### PR TITLE
Fix to RPI example - sequencer

### DIFF
--- a/RPI/RpiDemo/docs/RpiDemo.md
+++ b/RPI/RpiDemo/docs/RpiDemo.md
@@ -6,19 +6,19 @@
 
 |Mnemonic|ID|Description|Arg Name|Arg Type|Comment
 |---|---|---|---|---|---|
-|RD_SendString|0 (0x0)|Command to send a string to the UART| | |   
-| | | |text|Fw::CmdStringArg|String to send|                    
-|RD_SetLed|1 (0x1)|Sets LED state| | |   
-| | | |value|LedState|GPIO value|                    
-|RD_SetLedDivider|2 (0x2)|Sets the divided rate of the LED| | |   
-| | | |divider|U32|Divide 10Hz by this number|                    
-|RD_SetGpio|3 (0x3)|Sets a GPIO port value| | |   
-| | | |output|GpioOutNum|Output GPIO|                    
-| | | |value|GpioOutVal|GPIO value|                    
-|RD_GetGpio|4 (0x4)|Gets a GPIO port value| | |   
-| | | |input|GpioInNum|Input GPIO|                    
-|RD_SendSpi|5 (0x5)|Sends SPI data, prints read data| | |   
-| | | |data|Fw::CmdStringArg|data to send|                    
+|RD_SendString|0 (0x0)|Command to send a string to the UART| | |
+| | | |text|Fw::CmdStringArg|String to send|
+|RD_SetLed|1 (0x1)|Sets LED state| | |
+| | | |value|LedState|GPIO value|
+|RD_SetLedDivider|2 (0x2)|Sets the divided rate of the LED| | |
+| | | |divider|U32|Divide 10Hz by this number|
+|RD_SetGpio|3 (0x3)|Sets a GPIO port value| | |
+| | | |output|GpioOutNum|Output GPIO|
+| | | |value|GpioOutVal|GPIO value|
+|RD_GetGpio|4 (0x4)|Gets a GPIO port value| | |
+| | | |input|GpioInNum|Input GPIO|
+|RD_SendSpi|5 (0x5)|Sends SPI data, prints read data| | |
+| | | |data|Fw::CmdStringArg|data to send|
 
 ## Telemetry Channel List
 
@@ -36,20 +36,20 @@
 |Event Name|ID|Description|Arg Name|Arg Type|Arg Size|Description
 |---|---|---|---|---|---|---|
 |RD_UartMsgOut|0 (0x0)|Message sent on UART| | | | |
-| | | |msg|Fw::LogStringArg&|40|The message|    
+| | | |msg|Fw::LogStringArg&|40|The message|
 |RD_UartMsgIn|1 (0x1)|Message received on UART| | | | |
-| | | |msg|Fw::LogStringArg&|40|The message|    
+| | | |msg|Fw::LogStringArg&|40|The message|
 |RD_GpioSetVal|2 (0x2)|GPIO set| | | | |
-| | | |output|U32||The output number|    
-| | | |value|GpioOutValEv||GPIO value|    
+| | | |output|U32||The output number|
+| | | |value|GpioOutValEv||GPIO value|
 |RD_GpioGetVal|3 (0x3)|GPIO get| | | | |
-| | | |output|U32||The output number|    
-| | | |value|GpioInValEv||GPIO value|    
+| | | |output|U32||The output number|
+| | | |value|GpioInValEv||GPIO value|
 |RD_SpiMsgIn|4 (0x4)|Message received on SPI| | | | |
-| | | |msg|Fw::LogStringArg&|40|The message bytes as text|    
+| | | |msg|Fw::LogStringArg&|40|The message bytes as text|
 |RD_InvalidGpio|5 (0x5)|Invalid GPIO requested| | | | |
-| | | |val|U32||The bad GPIO number|    
+| | | |val|U32||The bad GPIO number|
 |RD_InvalidDivider|6 (0x6)|Message received on UART| | | | |
-| | | |val|U32||The bad divider value|    
+| | | |val|U32||The bad divider value|
 |RD_LedBlinkState|7 (0x7)|Blink state set to new value| | | | |
-| | | |val|LedStatePrmEv||The blink state|    
+| | | |val|LedStatePrmEv||The blink state|

--- a/RPI/Top/RPITopologyAppAi.xml
+++ b/RPI/Top/RPITopologyAppAi.xml
@@ -523,6 +523,10 @@
        <source component = "rateGroup1HzComp" port = "RateGroupMemberOut" type = "Sched" num = "2"/>
         <target component = "rpiDemo" port = "Run" type = "Sched" num = "0"/>
    </connection>
+   <connection name = "cmdSeq">
+       <source component = "rateGroup1HzComp" port = "RateGroupMemberOut" type = "Sched" num = "3"/>
+        <target component = "cmdSeq" port = "schedIn" type = "Sched" num = "0"/>
+   </connection>
    
    <!-- Health Connections -->
    

--- a/RPI/Top/Topology.cpp
+++ b/RPI/Top/Topology.cpp
@@ -143,6 +143,9 @@ void constructApp(int port_number, char* hostname) {
     health.regCommands();
     rpiDemo.regCommands();
 
+    // set sequencer timeout
+    cmdSeq.setTimeout(30);
+
     // read parameters
     prmDb.readParamFile();
 


### PR DESCRIPTION
The sequencer did not have a rate group connection, so sequences stall. This adds the missing connection.