### PR TITLE
Fixed reference to seqgen.py [issue #25]

### DIFF
--- a/Ref/scripts/compile_ref_sequence.sh
+++ b/Ref/scripts/compile_ref_sequence.sh
@@ -19,4 +19,4 @@ then
 fi
 echo "BUILD_ROOT is: ${BUILD_ROOT}"
 export PYTHONPATH="${BUILD_ROOT}/Fw/Python/src:${BUILD_ROOT}/Gds/src"
-python "${BUILD_ROOT}/Gds/bin/tkgui/seqgen.py" -g ${BUILD_ROOT}/Ref/py_dict "$@"
+python "${BUILD_ROOT}/Gds/src/fprime_gds/tkgui/tools/seqgen.py" -g ${BUILD_ROOT}/Ref/py_dict "$@"


### PR DESCRIPTION
* fixed the outdated reference location of seqgen.py in compile_ref_sequence.sh 