### PR TITLE
GDS Stripchart Fixes

### DIFF
--- a/Gds/src/fprime_gds/tkgui/controllers/channel_listener.py
+++ b/Gds/src/fprime_gds/tkgui/controllers/channel_listener.py
@@ -142,6 +142,9 @@ class ChannelListener(consumer.Consumer):
       # Descriptor and length of message have already been decoded
       self.__status_bar_updater.put_data((8 + len(data), 0))
 
+      # Pass message to the stripchart panel
+      self.__stripchart_listener.update_telem(self.__current_ch_msg)
+
     def decode_ch(self, msg):
         """
         Decode channel telemetry item using Channel object dictionary.

--- a/Gds/src/fprime_gds/tkgui/utils/ConfigManager.py
+++ b/Gds/src/fprime_gds/tkgui/utils/ConfigManager.py
@@ -136,10 +136,10 @@ class ConfigManager(ConfigParser.SafeConfigParser):
 
         self.__prop['performance'] = dict()
         self.__prop['performance']['stripchart_update_period']  = 500 # Milliseconds
+        self.__prop['performance']['stripchart_update_rate']    = 500 # Milliseconds
         self.__prop['performance']['telem_table_update_period'] = 500 # Milliseconds
         self.__prop['performance']['event_table_update_period'] = 200 # Milliseconds
         self.__prop['performance']['status_bar_update_period']  = 1000 # Milliseconds
-        self.__prop['performance']['stripchart_update_period']  = 500 # Milliseconds
         self.__prop['performance']['status_light_deadband'] = 3 # Seconds
 
         self.__prop['severity_colors']=dict()

--- a/Gds/src/fprime_gds/tkgui/views/stripchart_panel.py
+++ b/Gds/src/fprime_gds/tkgui/views/stripchart_panel.py
@@ -172,9 +172,7 @@ class StripChartPanel(observer.Observer):
         # Get all figures
         fig_list = []
         for row in self.__axes_dict.values():
-            for a_frame in row.values():
-                fig_list.append(a_frame.get_fig())
-
+            fig_list.append(row.get_fig())
 
         d = tkFileDialog.askdirectory(initialdir = "/", \
                                       mustexist  = False,

--- a/Gds/src/fprime_gds/tkgui/views/stripchart_panel.py
+++ b/Gds/src/fprime_gds/tkgui/views/stripchart_panel.py
@@ -535,7 +535,7 @@ class AxesFrame(Tkinter.LabelFrame):
         self._canvas = FigureCanvasTkAgg(self._fig, master=self)
         # Attach canvas to self
         self._canvas.get_tk_widget().pack(side=Tkinter.TOP, expand=1, fill=Tkinter.X, padx=5, pady=5)
-        self._canvas.show()
+        self._canvas.draw()
 
         # Label Settings
         self.__settings_dialog = None

--- a/Gds/src/fprime_gds/tkgui/views/telemetry_filter_panel.py
+++ b/Gds/src/fprime_gds/tkgui/views/telemetry_filter_panel.py
@@ -53,8 +53,8 @@ class TelemetryFilterPanel(object):
         top.title("F Prime Channel Telemetry Filter Selection")
         top.focus()
         # Constrain size on window so geometry works.
-        top.maxsize(1000,400)
-        top.minsize(600,400)
+        top.maxsize(1000,450)
+        top.minsize(600,450)
         top.lift()
         self.__top = top
 


### PR DESCRIPTION
I've been experimenting with the Ref application, and ran across a few issues in the Stripchart section of GDS (TK Implementation). 

Here's the issues and steps taken to fix them: 

- Stripchart was not getting any message data.
  - Add message passing in the channel listener. A StripChartListener comment said it should be called from there.

- The "Channel Telemetry Filter Selection" GUI was cutting off buttons. 
  - Expand the window vertically to 450px.

- Clicking the Settings button caused an unhanded exception.
  -  A config field "stripchart_update_rate" wasn't initialized. Added the field and removed a duplicate field.  

- Clicking the Save All button caused an unhanded exception. 
  - Fixed the loop that gathered the graphs. It was digging too deeply into the data structure.

- Canvas.show() is depreciated.
  - Followed TK's warning and switched to canvas.draw().


Also, I don't see any contribution guidelines for this repository. Please let me know if you need any more information, would like to split the PR, create issues, switch target branches, etc. 