### PR TITLE
don't try to commit build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+build
+build*
+
 AutoXML/
 test_harness/src/test_harness-C/application.out
 /.project
@@ -54,7 +57,7 @@ core
 ./Gds/docs/doxy
 
 *AppDictionary.xml
-*TopologyAppID.csv 
+*TopologyAppID.csv
 *TopologyAppAi_IDTableLog.txt
 
 .vscode


### PR DESCRIPTION
This change adds the standard cmake ``build`` or ``build-and_some_other_stuff`` formatted folders to the ``.gitignore``, which makes it harder to accidentally commit artifacts back into the repository.

Most people who are even marginally familiar with the cmake build process, even if all they have done is just build and install a project, use this convention.  This is a convenience to avoid having to sort through a large number of files in your git status for files that actually need to be committed.