### PR TITLE
specifiy python version for enum34 dep

### DIFF
--- a/Autocoders/Python/requirements.txt
+++ b/Autocoders/Python/requirements.txt
@@ -11,7 +11,8 @@
 ####
 # Independent requirements
 lxml
-enum34
+# Python < 3.4 enum version
+enum34; python_version <= '3.4'
 Markdown
 # Python 3 Cheetah version
 Cheetah3; python_version > '2.7'


### PR DESCRIPTION
Since `enum` is part of python for newer versions, checking for `enum34` breaks the cmake process if you have a newer python version. This PR ensures `enum34` is checked for only if it pertains to the correct python version, specifically python <= 3.4.

Resolves #89 