### PR TITLE
Cheetah compile py3 fix

### DIFF
--- a/cmake/support/AC_Utils.cmake
+++ b/cmake/support/AC_Utils.cmake
@@ -21,7 +21,7 @@ function(cheetah CHEETAH_TEMPLATES)
   # forces cheetah templates to be compiled and up-to-date before running the auto-coder.
   string(REPLACE ".tmpl" ".py" PYTHON_TEMPLATES "${CHEETAH_TEMPLATES}")
   # Setup the cheetah-compile command that runs the physical compile of the above statement. This
-  # controls the work to be done to create PYTHON_TEMPLATES from ${CHEETAH_TEMPLATES. 
+  # controls the work to be done to create PYTHON_TEMPLATES from ${CHEETAH_TEMPLATES.
   add_custom_command(
     OUTPUT ${PYTHON_TEMPLATES}
     COMMAND cheetah-compile ${CHEETAH_TEMPLATES}
@@ -54,7 +54,7 @@ function(serialns AI_XML)
     if (${ERR_RETURN})
         message(FATAL_ERROR "${FPRIME_CORE_DIR}/cmake/parser/serializable_xml_ns.py ${AI_XML} failed.")
     endif()
-    set(SERIAL_NS "${NS}" PARENT_SCOPE) 
+    set(SERIAL_NS "${NS}" PARENT_SCOPE)
 endfunction(serialns)
 
 
@@ -105,7 +105,7 @@ function(acwrap AC_TYPE AC_FINAL_SOURCE AC_FINAL_HEADER AI_XML)
       COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR}
       ${CMAKE_COMMAND} -E env PYTHONPATH=${PYTHON_AUTOCODER_DIR}/src:${PYTHON_AUTOCODER_DIR}/utils BUILD_ROOT=${FPRIME_CURRENT_BUILD_ROOT}
       PYTHON_AUTOCODER_DIR=${PYTHON_AUTOCODER_DIR} DICTIONARY_DIR=${DICTIONARY_DIR} FPRIME_CORE_DIR=${FPRIME_CORE_DIR}
-      ${FPRIME_CORE_DIR}/Autocoders/Python/bin/codegen.py ${GEN_ARGS} ${AI_XML} 
+      ${FPRIME_CORE_DIR}/Autocoders/Python/bin/codegen.py ${GEN_ARGS} ${AI_XML}
       DEPENDS ${AC_FINAL_XML}
     )
   else()

--- a/cmake/support/AC_Utils.cmake
+++ b/cmake/support/AC_Utils.cmake
@@ -22,9 +22,10 @@ function(cheetah CHEETAH_TEMPLATES)
   string(REPLACE ".tmpl" ".py" PYTHON_TEMPLATES "${CHEETAH_TEMPLATES}")
   # Setup the cheetah-compile command that runs the physical compile of the above statement. This
   # controls the work to be done to create PYTHON_TEMPLATES from ${CHEETAH_TEMPLATES.
+  find_program(CHEETAH_EXE NAMES "cheetah-compile" "cheetah-compile3")
   add_custom_command(
     OUTPUT ${PYTHON_TEMPLATES}
-    COMMAND cheetah-compile ${CHEETAH_TEMPLATES}
+    COMMAND ${CHEETAH_EXE} ${CHEETAH_TEMPLATES}
     DEPENDS ${CHEETAH_TEMPLATES}
   )
   # Add the above PYTHON_TEMPLATES to the list of sources for the CODEGEN_TARGET target. Thus they will be


### PR DESCRIPTION
This allows template code generation to occur using a system installation of `python-cheetah3`. 
We check if we are using python 2 or if we not using a system install of python, i.e. if we are using a venv. If that is satisfied then we use `cheetah-compile`. Else if we are using a system install of python3 then we use `cheetah-compile3`. This fixes build issues on Arch and Debian based systems.

One caveat is that if you are building `fprime` with python 3 outside a venv/virtualenv then you cannot use `pip`'s version of `cheetah3`. This is fine though, since using pip at the system wide level is not recommend in the first place. It should only be used in virtualenvs or at the user install level.

Confirmed with both system wide python3 install and virtualenv python3 install. Have not tested with python2, but I am sure it works.

Note: I could not think of a better way to check if the python interpreter was not a system one besides checking if the path starts at `/usr`. There is a CMake variable `Python_FIND_VIRTUALENV`, but that only works if you are already inside a virtualenv, defeating the purpose of the check in our case.

Resolves: #93 