### PR TITLE
lestarch: installation and utility bug fixes

### DIFF
--- a/Fw/Python/src/fprime/fbuild/cmake.py
+++ b/Fw/Python/src/fprime/fbuild/cmake.py
@@ -62,6 +62,10 @@ class CMakeHandler(object):
         """
         self.build_cache = CMakeBuildCache()
         self.verbose = False
+        try:
+            self._run_cmake([])
+        except Exception as exc:
+            raise CMakeExecutionException("CMake executable 'cmake' not found", str(exc))
 
     def set_verbose(self, verbose):
         """ Sets verbosity """

--- a/Fw/Python/src/fprime/util/build_helper.py
+++ b/Fw/Python/src/fprime/util/build_helper.py
@@ -21,6 +21,7 @@ import shutil
 
 import fprime.fbuild
 
+
 UT_SUFFIX = "-ut"
 ACTION_MAP = {
     "generate": {
@@ -176,6 +177,12 @@ def parse_args(args):
     hparser.add_argument("hash", type=lambda x: int(x, 0), help="F prime assert hash to associate with a file.")
     hparser.add_argument("-t", "--unittest", default=False, action="store_true",
                          help="Use F prime ut build, not regular build")
+    # Check for a valid builder first
+    try:
+        fprime.fbuild.builder()
+    except Exception as exc:
+        print("[ERROR]", exc, exc.stderr, file=sys.stderr)
+        sys.exit()
     # Parse and prepare to run
     parsed = parser.parse_args(args)
     if not hasattr(parsed, "command") or parsed.command is None:
@@ -193,7 +200,13 @@ def confirm():
     """
     # Loop "forever"
     while True:
-        confirm = input("Purge this directory (yes/no)?")
+        # Py 2/3
+        prompter = input
+        try:
+            prompter = raw_input
+        except NameError:
+            pass
+        confirm = prompter("Purge this directory (yes/no)?")
         if confirm.lower() in ["y", "yes"]:
             return True
         elif confirm.lower() in ["n", "no"]:

--- a/Gds/setup.py
+++ b/Gds/setup.py
@@ -135,7 +135,6 @@ integrated configuration with ground in-the-loop.
              'multiprocess',
              'Pmw',
              'tkintertable==1.2',
-             'numpy',
              'scipy',
              'scimath',
              'matplotlib'],


### PR DESCRIPTION
This adds quick fixes for installation and running on fresh systems.  Namely it does the following:

1. `fprime-util` checks for `cmake` before trying to run.  Corrects a confusing error when cmake is not installed.

2. Fixes python 2.7 install to fix scipy errors.