### PR TITLE
lestarch: fixing several bugs with `fprime-util`

### DIFF
--- a/Fw/Python/src/fprime/fbuild/cmake.py
+++ b/Fw/Python/src/fprime/fbuild/cmake.py
@@ -228,6 +228,8 @@ class CMakeHandler(object):
         """
         if not os.path.exists(build_dir):
             os.makedirs(build_dir)
+        # We will CD for build, so this path must become absolute
+        source_dir = os.path.abspath(source_dir)
         args = {} if args is None else args
         fleshed_args = map(lambda key: ("{}={}" if key.startswith("--") else "-D{}={}")
                            .format(key, args[key]), args.keys())

--- a/Fw/Python/src/fprime/util/build_helper.py
+++ b/Fw/Python/src/fprime/util/build_helper.py
@@ -130,7 +130,7 @@ def validate(parsed):
             toolchains = list(filter(os.path.exists, toolchains_paths))
             if not toolchains:
                 print("[ERROR] Toolchain file {} does not exist at any of {}"
-                      .format(toolchains + ".cmake", ", ".join(list(toolchains_paths))))
+                      .format(toolchain + ".cmake", ", ".join(list(toolchains_paths))))
                 sys.exit(-1)
             print("[INFO] Using toolchain file {} for platform {}".format(toolchains[0], parsed.platform))
             cmake_args.update({"CMAKE_TOOLCHAIN_FILE": toolchains[0]})

--- a/Fw/Python/src/fprime/util/build_helper.py
+++ b/Fw/Python/src/fprime/util/build_helper.py
@@ -90,7 +90,7 @@ def validate(parsed):
         # Generation validation
         elif parsed.build_dir is None:
             build_inst_name = fprime.fbuild.cmake.CMakeHandler.CMAKE_DEFAULT_BUILD_NAME.format(parsed.platform)
-            parsed.build_dir = os.path.join(os.getcwd(), build_inst_name)
+            parsed.build_dir = os.path.join(parsed.path, build_inst_name)
     except fprime.fbuild.cmake.CMakeProjectException as exc:
         print("[ERROR] {}".format(exc))
         sys.exit(1)


### PR DESCRIPTION
This fixes several minor bugs in the `fprime-util`. This includes the following bugs:

1. Cleaning up error when an invalid Toolchain is used
2. Fixing the ability to supply a non-CWD directory to `generate`
3. Better error printing from CMake.