### PR TITLE
lestarch: making linux UART driver work on Darwin

### DIFF
--- a/Drv/LinuxSerialDriver/CMakeLists.txt
+++ b/Drv/LinuxSerialDriver/CMakeLists.txt
@@ -39,3 +39,14 @@ else()
 endif()
 
 register_fprime_module()
+
+### UTs ###
+set(UT_MOD_DEPS
+    Os
+)
+set(UT_SOURCE_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentAi.xml"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/main.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/Tester.cpp"
+)
+register_fprime_ut()

--- a/Drv/LinuxSerialDriver/CMakeLists.txt
+++ b/Drv/LinuxSerialDriver/CMakeLists.txt
@@ -11,7 +11,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 	set(SOURCE_FILES
 		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentAi.xml"
 		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImplStub.cpp"
+		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImpl.cpp"
 	)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 	set(SOURCE_FILES

--- a/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.cpp
+++ b/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.cpp
@@ -171,12 +171,14 @@ namespace Drv {
           case BAUD_230K:
               relayRate = B230400;
               break;
+#if defined TGT_OS_TYPE_LINUX
           case BAUD_460K:
               relayRate = B460800;
               break;
           case BAUD_921K:
               relayRate = B921600;
               break;
+#endif
           default:
               FW_ASSERT(0,baud);
               break;


### PR DESCRIPTION
## F´ Pull Request
|**Field**|**Value**|
|:---|:---|
|**_Submission Date_**| 2020-01-08 |
|**_Submitter_**| @lestarch |
|**_Originating Project/Creator_**| NASA-JPL Maintainers |
|**_Base Branch_**| devel |
|**_Short Description_**| Working OSX UART |
|**_Effected Component_**| LinuxSerialDriver  |
|**_Effected Architectures(s)_**| Darwin, Linux  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Build Checked (y/n)_**| y |
|**_Unit Tests Run (y/n)_**| n Note: UT requires some real serial port |
|**_Documentation Included (y/n)_**| n/a |

---
## Change Description

This makes UART compile for Mac OSX and Darwin.  That way Darwin is not just stubbed out, but a functional UART. 

## Rationale

UART for Darwin, easy win!

## Testing Recommendations

Tested in the GPS demo.  Everything is as expected.

## Future Work

Repair the UT for all systems.