### PR TITLE
lestarch: formalizing Python 3.5+ support. Other versions are end-of-life, resolves nasa/fprime#103

### DIFF
--- a/Fw/Python/setup.py
+++ b/Fw/Python/setup.py
@@ -80,7 +80,7 @@ to interact with the data coming from the FSW.
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
-    # Requires Python 3.4+, and the 'six' Python package
+    # Requires Python 3.5+, and the 'six' Python package
     python_requires='>=3.5',
     install_requires=['six', "lxml", 'enum34;python_version < "3.4"', "Markdown", "pexpect", "pytest",
                   'Cheetah3;python_version >= "3.0"', 'Cheetah;python_version < "3.0"'],

--- a/Fw/Python/setup.py
+++ b/Fw/Python/setup.py
@@ -80,8 +80,8 @@ to interact with the data coming from the FSW.
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
-    # Requires Python 2.7, or 3.4+, and the 'six' Python package
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    # Requires Python 3.4+, and the 'six' Python package
+    python_requires='>=3.5',
     install_requires=['six', "lxml", 'enum34;python_version < "3.4"', "Markdown", "pexpect", "pytest",
                   'Cheetah3;python_version >= "3.0"', 'Cheetah;python_version < "3.0"'],
     # Setup and test requirments, not needed by normal install

--- a/Gds/setup.py
+++ b/Gds/setup.py
@@ -117,7 +117,7 @@ integrated configuration with ground in-the-loop.
         # 'Programming Language :: Python :: Implementation :: Jython',
         # 'Programming Language :: Python :: Implementation :: Stackless',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.5',
     install_requires=[
         'flask',
         'pexpect',

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ F´ comprises several elements:
 
 ## Quick Installation Guide
 
-F´ can be quickly install using the following instructions. F´ requires that the following utilities be installed: cmake, git, and Python 3 with pip. Once these have been installed, users are 
+F´ can be quickly install using the following instructions. F´ requires that the following utilities be installed: cmake, git, and Python 3.5+ with pip. Once these have been installed, users are 
 recommended to install F´ python dependencies. This is usually done in a Python virtual environment as this prevents issues at the system level, but is not required. Full installation instructions
-including virtual environment creation, installation verification, and support for Python 2 is available: [INSTALL.md](./docs/INSTALL.md). The following are the most basic steps for convenience.
+including virtual environment creation, and installation verification: [INSTALL.md](./docs/INSTALL.md). The following are the most basic steps for convenience.
 
 ```
 git clone https://github.com/nasa/fprime.git

--- a/cmake/support/validation/pipsetup.py
+++ b/cmake/support/validation/pipsetup.py
@@ -22,8 +22,8 @@ def validate_python_setup():
     Validates the python setup of the system to ensure that the CMake system, Autocoder, etc can run
     as expected.
     """
-    if sys.version_info[0] >= 3 and sys.version_info[1] <= 3:
-        print("Python 3.4+ required")
+    if sys.version_info[0] < 3 or sys.version_info[1] < 5:
+        print("Python 3.5+ required")
         return False
     import pkg_resources
     deps = REQUIRED_PACKS  

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -22,7 +22,7 @@ Requirements:
 2. CMake [https://cmake.org/download/](https://cmake.org/download/) available on the system path
 3. Bash or Bash compatible shell
 4. CLang or GCC compiler
-5. Python 3 and PIP [https://www.python.org/downloads/](https://www.python.org/downloads/)
+5. Python 3.5+ and PIP [https://www.python.org/downloads/](https://www.python.org/downloads/)
 6. Python Virtual Environment \* (pip install venv or pip install virtualenv)
 
 **Note:** it is possible to install and run F´ without a virtual environment, however; for
@@ -35,15 +35,9 @@ This will create a new virtual environment for F´ to be installed into. The fol
 will create a new virtual environment called `fprime-venv` and ensure that virtual environment
 is activated.
 
-**Python 3.3+:**
+**Python 3.5+:**
 ```
 python3 -m venv ./fprime-venv
-. ./fprime-venv/bin/activate
-```
-
-**Python 2.7 - 3.2:**
-```
-virtualenv ./fprime-venv
 . ./fprime-venv/bin/activate
 ```
 


### PR DESCRIPTION
This moves our requirement to Python 3.5+.  This is consistent with Python's end-of-lifed packages.

See: https://devguide.python.org/#status-of-python-branches