### PR TITLE
Fix missing RD_UartMsgOut in RPI Demo

### DIFF
--- a/RPI/RpiDemo/RpiDemoComponentImpl.cpp
+++ b/RPI/RpiDemo/RpiDemoComponentImpl.cpp
@@ -163,6 +163,11 @@ namespace Rpi {
       txt.setdata((U64)text.toChar());
       this->UartWrite_out(0,txt);
       this->m_uartWriteBytes += text.length();
+      
+      char* msg = (char*)txt.getdata();
+      Fw::LogStringArg arg = msg;
+      this->log_ACTIVITY_HI_RD_UartMsgOut(arg);
+      
       this->cmdResponse_out(opCode,cmdSeq,Fw::COMMAND_OK);
   }
 

--- a/RPI/RpiDemo/RpiDemoComponentImpl.cpp
+++ b/RPI/RpiDemo/RpiDemoComponentImpl.cpp
@@ -164,8 +164,7 @@ namespace Rpi {
       this->UartWrite_out(0,txt);
       this->m_uartWriteBytes += text.length();
       
-      char* msg = (char*)txt.getdata();
-      Fw::LogStringArg arg = msg;
+      Fw::LogStringArg arg = text;
       this->log_ACTIVITY_HI_RD_UartMsgOut(arg);
       
       this->cmdResponse_out(opCode,cmdSeq,Fw::COMMAND_OK);


### PR DESCRIPTION
In the RPI demo, the event `RD_UartMsgOut` is defined the XML, but never called (issue #156). Updated RpiDemoComponentImpl.cpp to actually log this event in `RD_SendString_cmdHandler`.