### PR TITLE
lestarch: baremetal compilation fixes

### DIFF
--- a/Fw/Cfg/CMakeLists.txt
+++ b/Fw/Cfg/CMakeLists.txt
@@ -9,3 +9,6 @@ set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/ConfigCheck.cpp"
 )
 register_fprime_module()
+if (BAREMETAL_SCHEDULER)
+    target_compile_definitions(Fw_Cfg PUBLIC FW_BAREMETAL_SCHEDULER=1)
+endif()

--- a/Fw/Comp/ActiveComponentBase.cpp
+++ b/Fw/Comp/ActiveComponentBase.cpp
@@ -68,7 +68,7 @@ namespace Fw {
 // If running with the baremetal scheduler, use a variant of the task-loop that
 // does not loop internal, but waits for an external eiteration call.
 #if FW_BAREMETAL_SCHEDULER == 1
-        Os::Task::TaskStatus status = this->m_task.start(taskName, identifier, priority, stackSize, this->s_baseBareTask, this, cpuAffinity);
+	Os::Task::TaskStatus status = this->m_task.start(taskName, identifier, priority, stackSize, this->s_baseBareTask, this, cpuAffinity);
 #else
         Os::Task::TaskStatus status = this->m_task.start(taskName, identifier, priority, stackSize, this->s_baseTask, this, cpuAffinity);
 #endif

--- a/Os/CMakeLists.txt
+++ b/Os/CMakeLists.txt
@@ -169,7 +169,6 @@ endif()
 # If baremetal scheduler is set, remove the previouse task files and add in the Baremetal variant
 if (BAREMETAL_SCHEDULER)
     add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Baremetal/TaskRunner/")
-    add_definitions("-DFW_BAREMETAL_SCHEDULER")
     list(FILTER SOURCE_FILES EXCLUDE REGEX "Task\.cpp")
     list(APPEND SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/Baremetal/Task.cpp")
 endif()


### PR DESCRIPTION
This corrects the setting of the FW_BAREMETAL_SCHEDULER flag.  @SterlingPeet this is the fix is suggested.

For those following the Teensyduino toolchain, you'll need to add `<DEFINES>` to your toolchain file as seen here: https://github.com/LeStarch/fprime/commit/46f756594f1e3ac71b2bf9602d7a0841dbc32fb5