### PR TITLE
initialized serializable_type.__val on initialization

### DIFF
--- a/Fw/Python/src/fprime/common/models/serialize/serializable_type.py
+++ b/Fw/Python/src/fprime/common/models/serialize/serializable_type.py
@@ -37,6 +37,7 @@ class SerializableType(type_base.BaseType):
             raise TypeMismatchException(type(str()),type(typename))
 
         self.__typename = typename
+        self.__val = []
         setattr(self, "mem_list", None)
 
         if mem_list == None or len(mem_list) == 0:


### PR DESCRIPTION
Fixed initialization of serializable_type, which caused issues in the MathComponent tutorial