### PR TITLE
Pre-commit hook for black and python development guidelines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,9 @@ repos:
         rev: 19.3b0
         hooks:
         -   id: black
-            name: Format Python Code (black)
+            name: Format Python Code (black) in Fw/Python/
+            files: '^Fw/Python/'
+        -   id: black
+            name: Format Python Code (black) in Gds/
+            files: '^Gds/'
+            exclude: '^Gds/src/fprime_gds/wxgui/'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+    -   repo: https://github.com/psf/black
+        rev: 19.3b0
+        hooks:
+        -   id: black
+            name: Format Python Code (black)

--- a/Fw/Python/setup.py
+++ b/Fw/Python/setup.py
@@ -44,7 +44,7 @@ to interact with the data coming from the FSW.
     """,
     url="https://github.com/nasa/fprime",
     keywords=["fprime", "embedded", "nasa"],
-    project_urls={"Issue Tracker": "https://github.com/nasa/fprime/issues",},
+    project_urls={"Issue Tracker": "https://github.com/nasa/fprime/issues"},
     # Author of Python package, not F prime.
     author="Michael Starch",
     author_email="Michael.D.Starch@jpl.nasa.gov",
@@ -88,6 +88,7 @@ to interact with the data coming from the FSW.
         'Cheetah3;python_version >= "3.0"',
         'Cheetah;python_version < "3.0"',
     ],
+    extra_require={"dev": ["black", "pylama", "pylint", "pre-commit"]},
     # Setup and test requirments, not needed by normal install
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],

--- a/docs/py-dev.md
+++ b/docs/py-dev.md
@@ -1,17 +1,23 @@
 # F' Python Guidelines
 
-## Install For Development Instrucitons
+## Required Development Installs
 
-Setup the virtual enviroment per the isntall guide, but install the python packages using the following
+Setup the virtual enviroment per the install guide, but install the python packages using the following
 
 ```bash
 pip install -e fprime/Fw/Python[dev]
 pip install -e fprime/Gds/
 ```
 
+After you have installed the python packages you need to set up pre-commit hooks using the following command
+
+```bash
+pre-commit install
+```
+
 ## Unit Tests
 
-Probably one of the most important part of developing code. We use pytest
+Probably one of the most important parts of developing code. We use pytest
 
 ```bash
 cd fprime/Fw/Python/
@@ -38,7 +44,26 @@ black path/to/folder/
 
 ### Git Pre-commit hooks
 
-TODO
+If you followed the Development Install Instrucitons above you will have automatically set up pre-commit hooks.
+These will run automatically whenever you commit your code.
+Currently the only pre-commit hook we have is called 'black'. Black automatically formats your python code so that it is consistent with the rest of the FPrime python code. Here is roughly what it will look like.
+
+```bash
+$ git commit -m "Add new python code"
+Format Python Code (black)...............................................Passed
+[master 3415f7dd] Add new python code
+ 1 file changed, 30 insertions(+)
+```
+
+If black decides to format your code the commit will fail, meaning that you will have to stage the changes made by the formatter and run the commit again.
+
+If for some reason black's formatting introduces a bug into your code you can optionally skip the pre-commit hook by modifying the 'SKIP' environment variable in bash. For example...
+
+```bash
+SKIP=black git commit -m "foo"
+```
+
+However this should only be used in an emergency. If SKIP is used for all of your commits it will dramatically reduce code quality over time.
 
 ### Why did we choose black
 

--- a/docs/py-dev.md
+++ b/docs/py-dev.md
@@ -1,0 +1,64 @@
+# F' Python Guidelines
+
+## Install For Development Instrucitons
+
+Setup the virtual enviroment per the isntall guide, but install the python packages using the following
+
+```bash
+pip install -e fprime/Fw/Python[dev]
+pip install -e fprime/Gds/
+```
+
+## Unit Tests
+
+Probably one of the most important part of developing code. We use pytest
+
+```bash
+cd fprime/Fw/Python/
+pytest
+```
+
+```bash
+cd fprime/Gds/
+pytest
+```
+
+## When and How to Format Your Code
+
+Everyone has their own habits and style when writing code. We arent asking you to change your habits, we are only asking that you format your code so that reviewers and collaborators can more quickly comprehend what the code is doing. This can easily be done executing the 'black' formatter right before you commit and push your code.
+
+Here is how to run black
+
+```bash
+# format a single file
+black example-file.py
+# format an entire folder and subfolders
+black path/to/folder/
+```
+
+### Git Pre-commit hooks
+
+TODO
+
+### Why did we choose black
+
+Almost all of the python code that is part of FPrime is formatted with 'Black'
+Black is an automatic formatter that will format your code without any configuration or input from the programmer.
+
+Why did we choose an “opinionated” formatter? In short, convention is so much more efficient than configuration.  With convention, everyone just does what is dictated (in this case from the tool) and there is no room for choice, which causes entropy in the project (e.g. one developer chooses spaces, another chooses tabs, and chaos results).  Entropy increases learning curve, stifles automated tooling, and makes development overall more difficult. Hence, projects select coding styles, standards, best practices, etc. as a way to reduce entropy. By accepting an established opinion, we can gain the advantages of a well-ordered project via a tool.  Assuming the opinions of the tool are not too onerous, we’ll have a better project as a result.
+
+## Static Analysis
+
+While almost all projects require unit tests, not enough them consistently use static analysis to improve code quality.
+With a few simple commands static analysis will drastically reduce time wasted with simple errors or issues and increase the lifecycle of your code.
+
+FPrime uses Pylama to perform static analysis on our python code. Pylama contains pylint, pyflakes, pycodestyle(pep8), mccabe, pydocstyle, radon, gjslint, eradicate, and Mypy. Combining the output from the tools that you want into a single file.
+
+```bash
+# How to run pylama
+pylama -o path/to/fprime/pylama/setup.cfg path/to/directory/you/want/to/analyze/
+# the '-o' specifies the configuration file
+```
+
+Pylama can be configured within the setup.cfg file. This file can also go in the directory you are analyzing if you want a different configuration for the python files in that directory.
+Inside the configuration file you can configure both pylama as a whole and each of tools individually. There are examples on how to do this within the /fprime/pylama/setup.cfg.


### PR DESCRIPTION
## F´ Pull Request
|**Field**|**Value**|
|:---|:---|
|**_Submission Date_**| 2020-06-23 |
|**_Submitter_**| @hunterpaulson |
|**_Originating Project/Creator_**| F' |
|**_Base Branch_**| devel |
|**_Short Description_**| Adds Pre-commit hook for black and details how to use it  |
|**_Effected Component_**| Python code developed in the future |
|**_Effected Architectures(s)_**| Posix |
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Build Checked (y/n)_**| y |
|**_Unit Tests Run (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description
Adds pre-commit hooks to fprime. Currently the only pre-commit we run is an automatic python formatter (black). The instructions to install and run pre-commit hooks are in the Python development guide. They run automatically on modified files when you commit anything. These files are currently restricted to the /Fw/Python and Gds/ directories since we don't want to format other python code.

The python development guide also tells users how to run pytest and pylama.

## Rationale
We want to force people to format their python code so that it is consistent with the rest of F'.

## Testing Recommendations
Commit some python code in Fw/Python/ and Gds/
Or if you want to test without committing you can stage some files and then run
```bash
pre-commit run black
```
This is how I verified that only staged files within Fw/Python/ and Gds/ were formatted. 

## Future Work
Add other pre-commit hooks that accomplish other useful purposes.