### PR TITLE
Fix/gds cli missing events

### DIFF
--- a/Gds/src/fprime_gds/common/gds_cli/base_commands.py
+++ b/Gds/src/fprime_gds/common/gds_cli/base_commands.py
@@ -195,12 +195,16 @@ class QueryHistoryCommand(BaseCommand):
             item = cls._get_upcoming_item(api, search_filter, "NOW", timeout)
             cls._log(cls._get_item_string(item, json))
         else:
+
             def print_upcoming_item(min_start_time="NOW"):
                 item = cls._get_upcoming_item(api, search_filter, min_start_time)
                 cls._log(cls._get_item_string(item, json))
                 # Update time so we catch the next item since the last one
                 if item:
                     min_start_time = predicates.greater_than(item.get_time())
+                    min_start_time = filtering_utils.time_to_data_predicate(
+                        min_start_time
+                    )
                 return (min_start_time,)
 
             misc_utils.repeat_until_interrupt(print_upcoming_item, "NOW")

--- a/Gds/src/fprime_gds/common/gds_cli/base_commands.py
+++ b/Gds/src/fprime_gds/common/gds_cli/base_commands.py
@@ -5,6 +5,7 @@ CLI commands
 
 import abc
 from typing import Iterable
+import sys
 
 import fprime_gds.common.gds_cli.filtering_utils as filtering_utils
 import fprime_gds.common.gds_cli.misc_utils as misc_utils
@@ -30,6 +31,8 @@ class BaseCommand(abc.ABC):
         """
         if log_text:
             print(log_text)
+            sys.stdout.flush()
+
 
     @classmethod
     @abc.abstractmethod

--- a/Gds/src/fprime_gds/common/gds_cli/filtering_utils.py
+++ b/Gds/src/fprime_gds/common/gds_cli/filtering_utils.py
@@ -6,6 +6,7 @@ to the user in the GDS CLI
 from typing import Any, Callable, Iterable
 
 from fprime_gds.common.data_types.cmd_data import CmdData
+from fprime_gds.common.data_types.sys_data import SysData
 from fprime_gds.common.testing_fw import predicates
 
 
@@ -192,3 +193,28 @@ class cmd_predicate(predicates.predicate):
         Returns a string outlining the evaluation done by the predicate.
         """
         return "True IFF: x is a CmdData object"
+
+
+class time_to_data_predicate(predicates.predicate):
+    def __init__(self, time_predicate: predicates.predicate):
+        """
+        Converts the given predicate from one called on an F' TimeType to one
+        that can be called on a SysData type
+        :param time_predicate: a predicate that expects a TimeType object to be
+            passed in
+        """
+        self.time_pred = time_predicate
+
+    def __call__(self, item: SysData):
+        """
+        Gets the given item's time and checks it using the passed-in predicate
+
+        :param item: an object to check for being a CmdData object
+        """
+        return self.time_pred(item.get_time())
+
+    def __str__(self):
+        """
+        Returns a string outlining the evaluation done by the predicate.
+        """
+        return "x = x.get_time(), {}".format(self.time_pred)

--- a/Gds/src/fprime_gds/common/pipeline/standard.py
+++ b/Gds/src/fprime_gds/common/pipeline/standard.py
@@ -59,11 +59,9 @@ class StandardPipeline(object):
         :param config: config object used when constructing the pipeline.
         :param dictionary: dictionary path. Used to setup loading of dictionaries.
         :param down_store: downlink storage directory
-        :param logging_prefix: logging prefix. Logs will be placed in a dated directory under this prefix
+        :param logging_prefix: logging prefix. Defaults to not logging at all.
         :param packet_spec: location of packetized telemetry XML specification.
         """
-        if logging_prefix is None:
-            logging_prefix = StandardPipeline.get_dated_logging_dir()
         # Loads the distributor and client socket
         self.distributor = fprime_gds.common.distributor.distributor.Distributor(config)
         self.client_socket = (
@@ -85,14 +83,15 @@ class StandardPipeline(object):
         # Register distributor to client socket
         self.client_socket.register_distributor(self.distributor)
         # Final setup step is to make a logging directory, and register in the logger
-        self.setup_logging(logging_prefix)
+        if logging_prefix:
+            self.setup_logging(logging_prefix)
 
     @classmethod
     def get_dated_logging_dir(cls, prefix=os.path.expanduser("~")):
         """
         Sets up the dated subdirectory based upon a given prefix
         :param prefix:
-        :return:
+        :return: Path to new directory where logs will be stored for this pipeline
         """
         # Setup log file location
         dts = datetime.datetime.now()


### PR DESCRIPTION
## F´ Pull Request
|**Field**|**Value**|
|:---|:---|
|**_Submission Date_**| 7/1/2020 |
|**_Submitter_**| JHDeerin |
|**_Originating Project/Creator_**| fprime|
|**_Base Branch_**| devel |
|**_Short Description_**| Fixed a bug in the GDS CLI where some data wasn't printed |
|**_Effected Component_**| GDS CLI |
|**_Effected Architectures(s)_**| N/A |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| y |
|**_Build Checked (y/n)_**| y |
|**_Unit Tests Run (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Fixed a bug where the GDS CLI would miss some events by adding a new predicate type (for comparing another predicate against a `SysData` object's `TimeType`) and wrapping the time-updating check in `base_commands.py` in this predicate, making the comparisons valid.

I also updated some broken unit tests for the GDS CLI while I was at it (a previous commit had added a flag that wasn't represented in the parsing tests), and created a few new ones to make sure this change worked.

## Rationale

This bug was originally reported by Aadil Rizvi, who noticed an issue when doing the following:

1. `cd` into the `Ref` folder and run it normally via `fprime-gds`
2. In another terminal, run the command `fprime-cli events`
3. Send a `cmdDisp.CMD_NO_OP` command to the GDS
4. Note that the GUI Events window shows 3 new events after sending this command, but only 1 of them is printed in the terminal

After debugging, it seems this error was caused in `base_commands.py` by creating a `predicates.greater_than` that expected to be passed in a `TimeType`, when the Test API actually passed in `SysData` objects to this predicate, meaning there was an invalid comparison occurring (which didn't throw an error for some reason, possibly because of the implementation of `__ge__` on `TimeType`). The new predicate wraps this comparison by only using `SysData.get_time()`, making the comparison valid.

Keeping information parity between the CLI tools and the GUI is clearly important to avoid getting confusing, contradictory outputs, and to make sure test results stay consistent regardless of which tool is used. Doubly-so when this difference in output was clearly a bug.

## Testing Recommendations

Besides running the unit tests, follow the above bug-reproducing steps and verify the console/GUI output now matches. Check the `channel` output for similar issues.

## Future Work

N/A (Assuming the bug is truly fixed)