### PR TITLE
adding included enum parsing for topology dictionary

### DIFF
--- a/Autocoders/Python/bin/codegen.py
+++ b/Autocoders/Python/bin/codegen.py
@@ -36,6 +36,7 @@ from fprime_ac.parsers import XmlComponentParser
 from fprime_ac.parsers import XmlPortsParser
 from fprime_ac.parsers import XmlSerializeParser
 from fprime_ac.parsers import XmlTopologyParser
+from fprime_ac.parsers import XmlEnumParser
 
 from lxml import etree
 
@@ -329,6 +330,30 @@ def generate_topology(the_parsed_topology_xml, xml_filename, opt):
                 comp_id = int(comp.get_base_id())
                 PRINT.debug("Processing %s [%s] (%s)"%(comp_name,comp_type,hex(comp_id)))
 
+                # check for included enum XML in referenced XML at top
+                if(parsed_xml_dict[comp_type].get_enum_type_files() != []):
+                    enum_file_list = parsed_xml_dict[comp_type].get_enum_type_files()
+                    for enum_file in enum_file_list:
+                        enum_file = search_for_file("Enum", enum_file)
+                        enum_model = XmlEnumParser.XmlEnumParser(enum_file)
+                        enum_elem = etree.Element("enum")
+                        enum_type = enum_model.get_namespace() + "::" + enum_model.get_name()
+                        enum_elem.attrib["type"] = enum_type
+                        members_elem = etree.Element("members")
+                        for (member_name, member_value, member_comment) in enum_model.get_items():
+                            enum_mem = etree.Element("item")
+                            enum_mem.attrib["name"] = member_name
+                            # keep track of incrementing enum value
+                            if member_value != None:
+                                enum_value = int(member_value)
+
+                            enum_mem.attrib["value"] = "%d"%enum_value
+                            enum_value = enum_value + 1
+                            if member_comment != None:
+                                enum_mem.attrib["description"] = member_comment
+                            enum_elem.append(enum_mem)
+                            enum_list.append(enum_elem)
+
                 # check for included serializable XML
                 if (parsed_xml_dict[comp_type].get_serializable_type_files() != None):
                     serializable_file_list = parsed_xml_dict[comp_type].get_serializable_type_files()
@@ -337,6 +362,31 @@ def generate_topology(the_parsed_topology_xml, xml_filename, opt):
                         serializable_model = XmlSerializeParser.XmlSerializeParser(serializable_file)
                         if (len(serializable_model.get_includes()) != 0):
                             raise Exception("%s: Can only include one level of serializable for dictionaries"%serializable_file)
+
+                        # check for included enum XML in included serializable XML
+                        if(len(serializable_model.get_include_enums()) != 0):
+                            enum_file_list = serializable_model.get_include_enums()
+                            for enum_file in enum_file_list:
+                                enum_file = search_for_file("Enum", enum_file)
+                                enum_model = XmlEnumParser.XmlEnumParser(enum_file)
+                                enum_elem = etree.Element("enum")
+                                enum_type = enum_model.get_namespace() + "::" + enum_model.get_name()
+                                enum_elem.attrib["type"] = enum_type
+                                members_elem = etree.Element("members")
+                                for (member_name, member_value, member_comment) in enum_model.get_items():
+                                    enum_mem = etree.Element("item")
+                                    enum_mem.attrib["name"] = member_name
+                                    # keep track of incrementing enum value
+                                    if member_value != None:
+                                        enum_value = int(member_value)
+
+                                    enum_mem.attrib["value"] = "%d"%enum_value
+                                    enum_value = enum_value + 1
+                                    if member_comment != None:
+                                        enum_mem.attrib["description"] = member_comment
+                                    enum_elem.append(enum_mem)
+                                    enum_list.append(enum_elem)
+
                         serializable_elem = etree.Element("serializable")
                         serializable_type = serializable_model.get_namespace() + "::" + serializable_model.get_name()
                         serializable_elem.attrib["type"] = serializable_type

--- a/Autocoders/Python/bin/codegen.py
+++ b/Autocoders/Python/bin/codegen.py
@@ -339,7 +339,6 @@ def generate_topology(the_parsed_topology_xml, xml_filename, opt):
                         enum_elem = etree.Element("enum")
                         enum_type = enum_model.get_namespace() + "::" + enum_model.get_name()
                         enum_elem.attrib["type"] = enum_type
-                        members_elem = etree.Element("members")
                         for (member_name, member_value, member_comment) in enum_model.get_items():
                             enum_mem = etree.Element("item")
                             enum_mem.attrib["name"] = member_name
@@ -372,7 +371,6 @@ def generate_topology(the_parsed_topology_xml, xml_filename, opt):
                                 enum_elem = etree.Element("enum")
                                 enum_type = enum_model.get_namespace() + "::" + enum_model.get_name()
                                 enum_elem.attrib["type"] = enum_type
-                                members_elem = etree.Element("members")
                                 for (member_name, member_value, member_comment) in enum_model.get_items():
                                     enum_mem = etree.Element("item")
                                     enum_mem.attrib["name"] = member_name


### PR DESCRIPTION
## F´ Pull Request
|**Field**|**Value**|
|:---|:---|
|**_Submission Date_**| July 20th, 2020 |
|**_Submitter_**| sommercharles |
|**_Originating Project/Creator_**| fprime |
|**_Base Branch_**| devel |
|**_Short Description_**| Adds parsing of included XML enum for topology dictionary |
|**_Effected Component_**| GDS XML Dictionary |
|**_Effected Architectures(s)_**| Linux |
|**_Related Issue(s)_**| #193 |
|**_Has Unit Tests (y/n)_**| n |
|**_Build Checked (y/n)_**| y |
|**_Unit Tests Run (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This adds included XML enums (*EnumAi.xml) to be parsed and added to the enums element when generating the topology dictionary (*TopologyAppDictionary.xml).

## Rationale

This fixes the issue where imported enums types were referenced in the topology dictionary but not described in the topology dictionary enums element, causing `Parsing error: Could not find type Namespace::enumName` when starting GDS.

## Testing Recommendations

Should implement an enum inclusion in a tutorial or else to showcase this works.
Fprime master branch Ref project compiles and runs fine with this.

## Future Work

Write a unit test?
Will open a new issue for non inclusion of generated autocoded enum header when importing and using an XML enum directly in a component (as opposed to through a serializable).