### PR TITLE
Docker update venv

### DIFF
--- a/mk/ci/bootstrap.bash
+++ b/mk/ci/bootstrap.bash
@@ -9,6 +9,7 @@
 ####
 export USABLE_VENV="${FPRIME_DIR}/ci-venv"
 echo -e "${BLUE}Preparing VENV at: ${USABLE_VENV}${NOCOLOR}"
+deactivate
 rm -r "${USABLE_VENV}"
 python3 -m venv "${USABLE_VENV}" || fail_and_stop "Failed to create VENV"
 . "${USABLE_VENV}/bin/activate" || fail_and_stop "Failed to source VENV"

--- a/mk/docker/Dockerfile
+++ b/mk/docker/Dockerfile
@@ -35,7 +35,7 @@ ENTRYPOINT ["/bin/bash"]
 FROM fprime-base AS fprime-docker
 RUN     git clone --quiet https://github.com/nasa/fprime.git /opt/fprime && \
         python3 -m venv /opt/fprime-venv/ && . /opt/fprime-venv/bin/activate && \
-        pip install wheel && \
+        pip install -U wheel setuptools pip && \
         pip install /opt/fprime/Fw/Python/ && \
         pip install /opt/fprime/Gds/ && \
         rm -r ~/.cache/pip && \

--- a/mk/docker/Dockerfile
+++ b/mk/docker/Dockerfile
@@ -62,8 +62,8 @@ RUN groupadd jenkins && \
     usermod -a -G fprime jenkins
 ENV HOST jenkins
 ENV USER jenkins
-# Paths and entrypoinys
-ENV PATH "/opt/fprime-venv/bin:/opt/fprime-venv/bin/python:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+# Paths and entrypoints
+ENV PATH "/opt/fprime-venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 ENV CI_CLEAN_REPO "NO_REALLY_I_WANT_TO_NUKE_ALL_YOUR_BASE"


### PR DESCRIPTION
Allows docker to begin with the fprime-venv launched. fprime-util displays the expected message and in opt/fprime/Ref the generate and build commands can be run.