### PR TITLE
Allow GroundInterface and QueuedComponentBase to work with FW_OBJECT_NAMES disabled

### DIFF
--- a/Fw/Comp/QueuedComponentBase.cpp
+++ b/Fw/Comp/QueuedComponentBase.cpp
@@ -33,7 +33,7 @@ namespace Fw {
         queueName = this->m_objName;
 #else
         char queueNameChar[FW_QUEUE_NAME_MAX_SIZE];
-        (void)snprintf(queueNameChar,sizeof(queueNameChar),"CompQ_%d",Os::Queue::getNumQueues());
+        (void)snprintf(queueNameChar,sizeof(queueNameChar),"CompQ_%d",this->m_queue.getNumQueues());
         queueName = queueNameChar;
 #endif
     	return this->m_queue.create(queueName, depth, msgSize);


### PR DESCRIPTION
There are currently a couple of issues which cause F Prime to not compile when FW_OBJECT_NAMES is disabled. I have patched 2 issues below.

GroundInterfaceComponent currently has a malformed constructor definition when FW_OBJECT_NAMES is disabled. The first commit patches this issue.

QueuedComponentBase tries to call `Os::Queue::getNumQueues()` without using an object, which is not allowed and leads to this error:

>error: cannot call member function 'NATIVE_INT_TYPE Os::Queue::getNumQueues()' without object

The second commit fixes this issue by calling `getNumQueues()` via the `m_queue` object.