### PR TITLE
mstarch: fixing build environment from settings.ini

### DIFF
--- a/Fw/Python/setup.py
+++ b/Fw/Python/setup.py
@@ -29,7 +29,7 @@ setup(
     # information should match the F prime decription information.
     ####
     name="fprime",
-    version="1.5.2",
+    version="1.5.3",
     license="Apache 2.0 License",
     description="F Prime Flight Software core data types",
     long_description="""

--- a/Fw/Python/src/fprime/fbuild/builder.py
+++ b/Fw/Python/src/fprime/fbuild/builder.py
@@ -428,6 +428,7 @@ class Build:
             context.absolute(),
             make_args=make_args,
             top_target=isinstance(target, GlobalTarget),
+            environment=self.settings.get("environment", None)
         )
 
     def generate(self, cmake_args):
@@ -459,7 +460,12 @@ class Build:
             cmake_args.update(
                 {"CMAKE_BUILD_TYPE": self.build_type.get_cmake_build_type()}
             )
-            self.cmake.generate_build(self.deployment, self.build_dir, cmake_args)
+            self.cmake.generate_build(
+                self.deployment,
+                self.build_dir,
+                cmake_args,
+                environment=self.settings.get("environment", None)
+            )
         except CMakeException as cexc:
             raise GenerateException(str(cexc)) from cexc
 


### PR DESCRIPTION
This fixes the issue where `fprime-util` is not setting up the environment as loaded from settings.ini and any referenced environment file.