### PR TITLE
Fix unit test autocode for serial ports

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
@@ -328,7 +328,7 @@ $emit_cpp_port_params([ $param_portNum ] + $port_params[$instance])
 
   #end for
 #end if
-#if $has_from_ports:
+#if $has_output_ports:
   // ----------------------------------------------------------------------
   // Static functions for from ports
   // ----------------------------------------------------------------------

--- a/Autocoders/Python/test/CMakeLists.txt
+++ b/Autocoders/Python/test/CMakeLists.txt
@@ -42,8 +42,7 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/port_loopback")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/port_nogen")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/port_return_type")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/queued1")
-#Note: AC broken, does not generate from_SerialOut_static in TesterBase.cpp
-#add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/serial_passive")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/serial_passive")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/serialize_enum")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/serialize_stringbuffer")
 

--- a/Autocoders/Python/test/serial_passive/CMakeLists.txt
+++ b/Autocoders/Python/test/serial_passive/CMakeLists.txt
@@ -27,7 +27,11 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/Tester.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/main.cpp"
 )
-#TODO: ULTRA FIX 
-#register_fprime_ut()
+
+set(UT_MOD_DEPS
+    Autocoders/Python/test/port_loopback
+)
+
+register_fprime_ut()
 
 

--- a/Autocoders/Python/test/serial_passive/test/ut/main.cpp
+++ b/Autocoders/Python/test/serial_passive/test/ut/main.cpp
@@ -21,6 +21,7 @@ int main(int argc, char* argv[]) {
 
     Os::Task::delay(500);
     serImpl.exit();
+    serImpl.ActiveComponentBase::join(NULL);
 
     return 0;
 


### PR DESCRIPTION
Autocoder was skipping generating TestBase code for output serial ports
if there were not other typed output ports.

Also renables test that was broken due to this bug.