### PR TITLE
Create module source and dependency graph during generation

### DIFF
--- a/cmake/FPrime.cmake
+++ b/cmake/FPrime.cmake
@@ -53,6 +53,7 @@ register_fprime_target("${CMAKE_CURRENT_LIST_DIR}/target/dict.cmake")
 register_fprime_target("${CMAKE_CURRENT_LIST_DIR}/target/impl.cmake")
 register_fprime_target("${CMAKE_CURRENT_LIST_DIR}/target/testimpl.cmake")
 register_fprime_target("${CMAKE_CURRENT_LIST_DIR}/target/package_gen.cmake")
+register_fprime_target("${CMAKE_CURRENT_LIST_DIR}/target/file_list.cmake")
 
 register_fprime_ut_target("${CMAKE_CURRENT_LIST_DIR}/target/coverage.cmake")
 

--- a/cmake/target/file_list.cmake
+++ b/cmake/target/file_list.cmake
@@ -1,0 +1,61 @@
+####
+# package_gen.cmake:
+#
+# Target for packaging and installing artifacts from modules. Defined as a standard target pattern.
+# This means that the following functions are defined:
+#
+# - `add_module_target`: adds sub-targets for '<MODULE_NAME>_package_gen'
+####
+
+####
+# Package function `add_module_target`:
+#
+# Adds a module level packaging target that packages module artifacts.
+#
+# - **MODULE_NAME:** name of the module
+# - **TARGET_NAME:** name of target to produce
+# - **GLOBAL_TARGET_NAME:** name of produced global target
+# - **AC_INPUTS:** list of autocoder inputs
+# - **SOURCE_FILES:** list of source file inputs
+# - **AC_OUTPUTS:** list of autocoder outputs
+# - **MOD_DEPS:** module dependencies of the target
+####
+function(add_module_target MODULE_NAME TARGET_NAME GLOBAL_TARGET_NAME AC_INPUTS SOURCE_FILES AC_OUTPUTS MOD_DEPS)
+    if (NOT CMAKE_BUILD_TYPE STREQUAL "RELEASE")
+        return()
+    endif()
+
+    set(ALL_FILES "")
+
+    if (NOT AC_INPUTS STREQUAL "")
+        list(APPEND ALL_FILES "${AC_INPUTS}")
+    endif()
+
+    if (NOT SOURCE_FILES STREQUAL "")
+        list(APPEND ALL_FILES "${SOURCE_FILES}")
+    endif()
+
+    if (NOT AC_OUTPUTS STREQUAL "")
+        list(APPEND ALL_FILES "${AC_OUTPUTS}")
+    endif()
+
+    string(REPLACE ";" "\n" ALL_FILES "${ALL_FILES}")
+
+    set(LISTING_FILE "${CMAKE_BINARY_DIR}/module_file_listings/${MODULE_NAME}.txt")
+    file(WRITE "${LISTING_FILE}" "${ALL_FILES}")
+
+    set(ALL_DEPS "")
+
+    if (NOT MODULE_DEPENDENCIES STREQUAL "")
+        list(APPEND ALL_DEPS "${MODULE_DEPENDENCIES}")
+    endif()
+
+    if (NOT MOD_DEPS STREQUAL "")
+        list(APPEND ALL_DEPS "${MOD_DEPS}")
+    endif()
+
+    string(REPLACE ";" "\n" ALL_DEPS "${ALL_DEPS}")
+
+    set(DEPS_FILE "${CMAKE_BINARY_DIR}/module_dependencies/${MODULE_NAME}.txt")
+    file(WRITE "${DEPS_FILE}" "${ALL_DEPS}")
+endfunction(add_module_target)


### PR DESCRIPTION
During cmake generation, every module will generate two file - a source file list and a dependency list.

These files can then be used by the metrics tool to generate source lines of code (SLOC) reports.

The SLOC tool will look for executable modules (denoted by ending in `_exe`). It will then start at the executable and generate a report by walking all the executables dependencies.

The tool will generate a per-module and overall SLOC report with the following data.

- Total lines of code
- Lines of xml code
- Lines of user-written C++ code (comments excluded)
- Lines of F' generated C++ code (comments excluded) (as matched by `*Ac.cpp|hpp`)
- Lines of code per file.

This needs a cmake unit test, but I wanted to get the design reviewed before writing tests.
