### PR TITLE
Replace 32 with total cpu thread(s)

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -87,7 +87,7 @@ layer components. Should the user not have installed the given component, the co
 ```
 cd Ref
 fprime-util generate
-fprime-util build --jobs 32
+fprime-util build --jobs "$(nproc || printf '%s\n' 1)"
 ```
 
 **Testing F´ GDS Installation Via Running HTML GUI**


### PR DESCRIPTION
`"$(nproc || printf '%s\n' 1)"` will return total number of cpu thread(s) if it returns `0` else `1`.