### PR TITLE
Fix dictionary target dependencies

### DIFF
--- a/Ref/test/int/ref_integration_test.py
+++ b/Ref/test/int/ref_integration_test.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+import platform
 from enum import Enum
 
 filename = os.path.dirname(__file__)
@@ -22,7 +23,12 @@ class TestRefAppClass(object):
         cls.pipeline = StandardPipeline()
         config = ConfigManager()
         filename = os.path.dirname(__file__)
-        path = os.path.join(filename, "../../Top/RefTopologyAppDictionary.xml")
+        path = os.path.join(
+            filename,
+            "../../build-artifacts/{}/dict/RefTopologyAppDictionary.xml".format(
+                platform.system()
+            ),
+        )
         cls.pipeline.setup(config, path, "/tmp")
         cls.pipeline.connect("127.0.0.1", 50050)
         logpath = os.path.join(filename, "./logs")

--- a/cmake/target/dict.cmake
+++ b/cmake/target/dict.cmake
@@ -13,33 +13,37 @@
 #
 # Generate a dictionary from any *AppAi.xml file that we see
 ####
-function(dictgen MODULE_NAME AI_XML MOD_DEPS)
+function(dictgen MODULE_NAME AI_XML DEPS)
   string(REGEX REPLACE "Ai.xml" "Dictionary.xml" DICT_XML "${AI_XML}")
+  string(REGEX REPLACE "Ai.xml" "ID.csv" ID_CSV_XML "${AI_XML}")
+  string(REGEX REPLACE "Ai.xml" "Ai_IDTableLog.txt" ID_LOG_XML "${AI_XML}")
   string(REGEX REPLACE "Ai.xml" "Ac" AC_BASE "${AI_XML}")
   string(REPLACE ";" ":" FPRIME_BUILD_LOCATIONS_SEP "${FPRIME_BUILD_LOCATIONS}")
   get_filename_component(DICT_XML_NAME ${DICT_XML} NAME)
+  get_filename_component(ID_CSV_XML_NAME ${ID_CSV_XML} NAME)
+  get_filename_component(ID_LOG_XML_NAME ${ID_LOG_XML} NAME)
   set(DICT_ROOT "${FPRIME_INSTALL_DEST}/${PLATFORM}/dict")
   set(DICTIONARY_OUTPUT_FILE "${DICT_ROOT}/${DICT_XML_NAME}")
 
   add_custom_command(
-      OUTPUT "${DICTIONARY_OUTPUT_FILE}"
+      OUTPUT "${DICT_ROOT}/${DICT_XML_NAME}"
       COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR}
       ${CMAKE_COMMAND} -E env PYTHONPATH=${PYTHON_AUTOCODER_DIR}/src:${PYTHON_AUTOCODER_DIR}/utils BUILD_ROOT="${FPRIME_BUILD_LOCATIONS_SEP}"
       FPRIME_AC_CONSTANTS_FILE="${FPRIME_AC_CONSTANTS_FILE}"
       PYTHON_AUTOCODER_DIR=${PYTHON_AUTOCODER_DIR}
       ${FPRIME_FRAMEWORK_PATH}/Autocoders/Python/bin/codegen.py --build_root --xml_topology_dict ${AI_XML}
       COMMAND ${CMAKE_COMMAND} -E make_directory "${DICT_ROOT}"
-      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_COMMAND} -E copy ${DICT_XML_NAME} ${DICTIONARY_OUTPUT_FILE}
+      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_COMMAND} -E copy ${DICT_XML_NAME} ${ID_LOG_XML_NAME} ${ID_CSV_XML_NAME} ${DICT_ROOT}
       COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_COMMAND} -E copy_directory commands "${DICT_ROOT}/commands"
       COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_COMMAND} -E copy_directory channels "${DICT_ROOT}/channels"
       COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_COMMAND} -E copy_directory events "${DICT_ROOT}/events"
-      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_COMMAND} -E remove ${DICT_XML_NAME} ${AC_BASE}.cpp ${AC_BASE}.hpp
+      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_COMMAND} -E remove ${DICT_XML_NAME} ${ID_CSV_XML_NAME} ${ID_LOG_XML_NAME} ${AC_BASE}.cpp ${AC_BASE}.hpp
       # Workaround for older versions of cmake (~v3.10) that can only delete a single directory with "remove_directory" command.
       # When bumping cmake versions combine all deletions into a single "cmake -E rm -rf" command.
       COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_COMMAND} -E remove_directory commands
       COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_COMMAND} -E remove_directory channels
       COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_COMMAND} -E remove_directory events
-      DEPENDS ${MOD_DEPS}
+      DEPENDS ${DEPS}
   )
 
   # Return file for output
@@ -81,7 +85,7 @@ function(add_module_target MODULE_NAME TARGET_NAME GLOBAL_TARGET_NAME AC_INPUTS 
         # Only generate dictionaries on serializables or topologies
         if (AC_IN MATCHES ".*Topology.*\.xml$")
             fprime_ai_info("${AC_IN}" "${MODULE_NAME}")
-            dictgen("${MODULE_NAME}" "${AC_IN}" "${MODULE_DEPENDENCIES};${MOD_DEPS};${FILE_DEPENDENCIES}")
+            dictgen("${MODULE_NAME}" "${AC_IN}" "${AC_INPUTS};${MODULE_DEPENDENCIES};${MOD_DEPS};${FILE_DEPENDENCIES}")
             add_custom_target("${TARGET_NAME}" DEPENDS "${AC_IN}" "${DICTIONARY_OUTPUT_FILE}")
             add_dependencies("${MODULE_NAME}" "${TARGET_NAME}")
             add_dependencies("${GLOBAL_TARGET_NAME}" "${TARGET_NAME}")


### PR DESCRIPTION
The dictonary target wasn't depending on the topology xml file,
so changes to the topology weren't causing the dictionary to rebuild.

The autocoding step also generates dictionaries as a side affect of
generating the topology autocode (might be worth considering if we can
somehow combine these steps so we don't have to run the topology autocoder
twice). This could sometimes run after the dictionary generation step,
leading to leftover dictionary files in the source tree. Adding a dependency
on the modules autocoded files (including the autocoded topology files)
ensures that this step always runs after the topology autocode step
and can properly clean up.