### PR TITLE
Fix clang compiler warnings

### DIFF
--- a/Autocoders/Python/test/interface1/UserSerializer.cpp
+++ b/Autocoders/Python/test/interface1/UserSerializer.cpp
@@ -52,7 +52,7 @@ Fw::SerializeStatus UserSerializer::deserialize(Fw::SerializeBufferBase& buffer)
 
 #if FW_SERIALIZABLE_TO_STRING
 
-void UserSerializer::toString(Fw::StringBase& text) {
+void UserSerializer::toString(Fw::StringBase& text) const {
 
     // declare strings to hold any serializable toString() arguments
 

--- a/Autocoders/Python/test/interface1/UserSerializer.hpp
+++ b/Autocoders/Python/test/interface1/UserSerializer.hpp
@@ -32,7 +32,7 @@ namespace ANameSpace {
         Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const;
         Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer);
     #if FW_SERIALIZABLE_TO_STRING
-        void toString(Fw::StringBase& text); //!< generate text from serializable
+        void toString(Fw::StringBase& text) const; //!< generate text from serializable
     #endif
     protected:
 

--- a/Autocoders/Python/test/serialize_user/UserSerializer.cpp
+++ b/Autocoders/Python/test/serialize_user/UserSerializer.cpp
@@ -52,7 +52,7 @@ Fw::SerializeStatus UserSerializer::deserialize(Fw::SerializeBufferBase& buffer)
 
 #if FW_SERIALIZABLE_TO_STRING
 
-void UserSerializer::toString(Fw::StringBase& text) {
+void UserSerializer::toString(Fw::StringBase& text) const {
 
     // declare strings to hold any serializable toString() arguments
 

--- a/Autocoders/Python/test/serialize_user/UserSerializer.hpp
+++ b/Autocoders/Python/test/serialize_user/UserSerializer.hpp
@@ -32,7 +32,7 @@ namespace ANameSpace {
         Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const;
         Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer);
     #if FW_SERIALIZABLE_TO_STRING
-        void toString(Fw::StringBase& text); //!< generate text from serializable
+        void toString(Fw::StringBase& text) const; //!< generate text from serializable
     #endif
     protected:
 

--- a/Drv/LinuxI2cDriver/CMakeLists.txt
+++ b/Drv/LinuxI2cDriver/CMakeLists.txt
@@ -6,6 +6,7 @@
 #
 ####
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+	add_definitions(-DSTUBBED_LINUX_I2C_DRIVER)
 	set(SOURCE_FILES
 		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
 		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImplStub.cpp"

--- a/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImpl.hpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImpl.hpp
@@ -64,9 +64,10 @@ namespace Drv {
           Fw::Buffer &serBuffer 
       );
 
+      // Prevent unused field error when using stub
+      #ifndef STUBBED_LINUX_I2C_DRIVER
       NATIVE_INT_TYPE m_fd; //!< i2c file descriptor
-
-
+      #endif
     };
 
 } // end namespace Drv

--- a/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImplStub.cpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImplStub.cpp
@@ -26,8 +26,7 @@ namespace Drv {
   LinuxI2cDriverComponentImpl ::
     LinuxI2cDriverComponentImpl(
         const char *const compName
-    ) : LinuxI2cDriverComponentBase(compName),
-        m_fd(-1)
+    ) : LinuxI2cDriverComponentBase(compName)
   {
 
   }

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
@@ -10,19 +10,14 @@ namespace Svc {
 	public:
 
 		// Only called by derived class 
-	    ConsoleTextLoggerImpl(const char* compName);
-	    void init(void);
+		ConsoleTextLoggerImpl(const char* compName);
+		void init(void);
 		~ConsoleTextLoggerImpl(void);
 		
 	private:
 
 		// downcalls for input ports
-        void TextLogger_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, Fw::TextLogSeverity severity, Fw::TextLogString &text);
-        
-        // Track which line of the display we're on
-        NATIVE_INT_TYPE m_displayLine;
-        NATIVE_INT_TYPE m_pointerLine;
-        
+		void TextLogger_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, Fw::TextLogSeverity severity, Fw::TextLogString &text);
 	};
 	
 }

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
@@ -6,7 +6,7 @@
 namespace Svc {
 
     ConsoleTextLoggerImpl::ConsoleTextLoggerImpl(const char* compName) :
-        PassiveTextLoggerComponentBase(compName),m_displayLine(2),m_pointerLine(0) {
+        PassiveTextLoggerComponentBase(compName) {
     }
 
     void ConsoleTextLoggerImpl::init(void) {

--- a/Svc/PolyDb/test/ut/PolyDbImplTester.cpp
+++ b/Svc/PolyDb/test/ut/PolyDbImplTester.cpp
@@ -17,8 +17,7 @@ namespace Svc {
     }
 
     PolyDbImplTester::PolyDbImplTester(Svc::PolyDbImpl& inst) :
-        Svc::PolyDbTesterComponentBase("testerbase"),
-        m_impl(inst) {
+        Svc::PolyDbTesterComponentBase("testerbase") {
     }
 
     PolyDbImplTester::~PolyDbImplTester() {

--- a/Svc/PolyDb/test/ut/PolyDbImplTester.hpp
+++ b/Svc/PolyDb/test/ut/PolyDbImplTester.hpp
@@ -21,10 +21,6 @@ namespace Svc {
             void init(NATIVE_INT_TYPE instance = 0);
 
             void runNominalReadWrite(void);
-
-        private:
-            Svc::PolyDbImpl& m_impl;
-
     };
 
 } /* namespace Svc */


### PR DESCRIPTION
Fixes a variety of compiler warnings and causes running
`fprime build --all` and `fprime check --all` on macOs Catalina
to compile with the `-Wall` compiler flag added.