### PR TITLE
fprime-util: fix --path argument

### DIFF
--- a/Fw/Python/src/fprime/fbuild/builder.py
+++ b/Fw/Python/src/fprime/fbuild/builder.py
@@ -213,7 +213,7 @@ class Build:
         self.cmake = CMakeHandler()
         self.cmake.set_verbose(verbose)
 
-    def invent(self, platform: str = None, build_dir: Path = None):
+    def invent(self, cwd: Path, platform: str = None, build_dir: Path = None):
         """Invents a build path from a given platform
 
         Sets this build up as a new build that would be used as as part of a generate step. This directory must not
@@ -232,13 +232,13 @@ class Build:
         Raises:
             InvalidBuildCacheException: a build cache already exists as it should not
         """
-        self.__setup_default(platform, build_dir)
+        self.__setup_default(cwd, platform, build_dir)
         if self.build_dir.exists():
             raise InvalidBuildCacheException(
                 "{} already exists.".format(self.build_dir)
             )
 
-    def load(self, platform: str = None, build_dir: Path = None):
+    def load(self, cwd: Path, platform: str = None, build_dir: Path = None):
         """Load an existing build cache
 
         Sets this build up from an existing build cache. This can be used after a previous run that has generated a
@@ -252,7 +252,7 @@ class Build:
         Raises:
             InvalidBuildCacheException: the build cache does not exist as it must
         """
-        self.__setup_default(platform, build_dir)
+        self.__setup_default(cwd, platform, build_dir)
         if (
             not self.build_dir.exists()
             or not (self.build_dir / "CMakeCache.txt").exists()
@@ -428,7 +428,7 @@ class Build:
             context.absolute(),
             make_args=make_args,
             top_target=isinstance(target, GlobalTarget),
-            environment=self.settings.get("environment", None)
+            environment=self.settings.get("environment", None),
         )
 
     def generate(self, cmake_args):
@@ -465,7 +465,7 @@ class Build:
                 self.deployment,
                 self.build_dir,
                 cmake_args,
-                environment=self.settings.get("environment", None)
+                environment=self.settings.get("environment", None),
             )
         except CMakeException as cexc:
             raise GenerateException(str(cexc)) from cexc
@@ -514,7 +514,7 @@ class Build:
                 return full_path
         return Build.find_nearest_deployment(full_path.parent)
 
-    def __setup_default(self, platform: str = None, build_dir: Path = None):
+    def __setup_default(self, cwd: Path, platform: str = None, build_dir: Path = None):
         """Sets up default build
 
         Sets this build up before determining if it is a pre-generated, or post-generated build.
@@ -531,7 +531,7 @@ class Build:
         assert self.platform is None, "Already setup it is invalid to re-setup"
         assert self.build_dir is None, "Already setup it is invalid to re-setup"
 
-        self.settings = IniSettings.load(self.deployment / "settings.ini")
+        self.settings = IniSettings.load(self.deployment / "settings.ini", cwd)
         self.platform = (
             platform
             if platform is not None and platform != "default"

--- a/Fw/Python/src/fprime/fbuild/cmake.py
+++ b/Fw/Python/src/fprime/fbuild/cmake.py
@@ -52,7 +52,14 @@ class CMakeHandler:
         self.verbose = verbose
 
     def execute_known_target(
-        self, target, build_dir, path, cmake_args=None, make_args=None, top_target=False, environment=None
+        self,
+        target,
+        build_dir,
+        path,
+        cmake_args=None,
+        make_args=None,
+        top_target=False,
+        environment=None,
     ):
         """
         Executes a known target for a given build_dir. Path will default to a known path.
@@ -209,7 +216,9 @@ class CMakeHandler:
         self._cmake_validate_build_dir(cmake_dir)  # Validate the dir
         return self._read_values_from_cache(fields, build_dir=cmake_dir)
 
-    def generate_build(self, source_dir, build_dir, args=None, ignore_output=False, environment=None):
+    def generate_build(
+        self, source_dir, build_dir, args=None, ignore_output=False, environment=None
+    ):
         """Generate a build directory for purposes of the build.
 
         :param source_dir: source directory to generate from
@@ -240,7 +249,7 @@ class CMakeHandler:
             workdir=build_dir,
             print_output=not ignore_output,
             write_override=True,
-            environment=environment
+            environment=environment,
         )
 
     def get_cmake_module(self, path, build_dir):

--- a/Fw/Python/src/fprime/fbuild/settings.py
+++ b/Fw/Python/src/fprime/fbuild/settings.py
@@ -19,12 +19,12 @@ class IniSettings:
     SET_ENV = "FPRIME_SETTINGS_FILE"
 
     @staticmethod
-    def find_fprime():
+    def find_fprime(cwd: Path) -> Path:
         """
         Finds F prime by recursing parent to parent until a matching directory is found.
         """
         needle = Path("cmake/FPrime.cmake")
-        path = Path.cwd().resolve()
+        path = cwd.resolve()
         while path != path.parent:
             if Path(path, needle).is_file():
                 return path
@@ -67,7 +67,7 @@ class IniSettings:
         return expanded
 
     @staticmethod
-    def load(settings_file: Path):
+    def load(settings_file: Path, cwd: Path):
         """
         Load settings from specified file or from specified build directory. Either a specific file or the build
         directory must be not None.
@@ -85,7 +85,7 @@ class IniSettings:
         # Check file existence if specified
         if not os.path.exists(settings_file):
             print("[WARNING] Failed to find settings file: {}".format(settings_file))
-            fprime_location = IniSettings.find_fprime()
+            fprime_location = IniSettings.find_fprime(cwd)
             return {
                 "framework_path": fprime_location,
                 "install_dest": dfl_install_dest,
@@ -97,7 +97,7 @@ class IniSettings:
             confparse, "fprime", "framework_path", settings_file
         )
         if not fprime_location:
-            fprime_location = IniSettings.find_fprime()
+            fprime_location = IniSettings.find_fprime(cwd)
         else:
             fprime_location = Path(fprime_location[0])
         # Read project root if it is available

--- a/Fw/Python/test/fprime/fbuild/test_build.py
+++ b/Fw/Python/test/fprime/fbuild/test_build.py
@@ -51,7 +51,7 @@ def test_hash_finder():
     builder = fprime.fbuild.builder.Build(
         fprime.fbuild.builder.BuildType.BUILD_NORMAL, dep_dir
     )
-    builder.load(build_dir=dep_dir / "build-fprime-automatic-native")
+    builder.load(local, build_dir=dep_dir / "build-fprime-automatic-native")
 
     assert builder.find_hashed_file(0xDEADBEEF) == ["Abc: 0xdeadbeef\n"]
     assert builder.find_hashed_file(0xC0DEC0DE) == ["HJK: 0xc0dec0de\n"]

--- a/Fw/Python/test/fprime/fbuild/test_settings.py
+++ b/Fw/Python/test/fprime/fbuild/test_settings.py
@@ -11,9 +11,11 @@ from pathlib import Path
 
 from fprime.fbuild.settings import IniSettings
 
+LOCAL_PATH = Path(__file__).parent
+
 
 def full_path(path):
-    path = Path(__file__).parent / Path(path)
+    path = LOCAL_PATH / Path(path)
     return path.resolve()
 
 
@@ -54,13 +56,10 @@ def test_settings():
         },
     ]
 
-    # Setting chdir so that test is unaffected from working directory pytest is run from
-    os.chdir(full_path("."))
-
     for case in test_cases:
         fp = full_path("settings-data/" + case["file"])
         print(fp)
-        results = IniSettings.load(fp)
+        results = IniSettings.load(fp, LOCAL_PATH)
         assert case["expected"] == results, "{}: Expected {}, got {}".format(
             fp, case["expected"], results
         )


### PR DESCRIPTION
Because `settings.py` was explicitly using the `cwd`, setting the path manually on the command line didn't change where fprime-util looked for the framework path. 