### PR TITLE
mstarch: repairing seqgen

### DIFF
--- a/Gds/examples/simple_sequence.seq
+++ b/Gds/examples/simple_sequence.seq
@@ -6,18 +6,18 @@
 ; Commands in a sequence can either be timed absolutely or relative
 ; to the execution of the previous command. Here is an absolute NOOP
 ; command.
-A2015-075T22:32:40.123 CMD_NO_OP
+A2015-075T22:32:40.123 cmdDisp.CMD_NO_OP
 
 ; Here is a relative NOOP command, which will be run 1 second after
 ; the execution of the previous command
-R00:00:01 CMD_NO_OP; Send a no op command
+R00:00:01 cmdDisp.CMD_NO_OP; Send a no op command
 
 ; This command will run immediately after the previously executed command
 ; has completed
-R00:00:00 CMD_NO_OP
+R00:00:00 cmdDisp.CMD_NO_OP
 
 ; Let's try out some commands with arguments
-R01:00:01.050 CMD_NO_OP_STRING "Awesome string!";  <- cool argument right?
-R03:51:01.000 CMD_TEST_CMD_1 17, 3.2, 2; <- this command has 3 arguments
-R00:05:00 ALOG_SET_EVENT_REPORT_FILTER INPUT_COMMAND, INPUT_DISABLED; <- this command uses enum arguments
+R01:00:01.050 cmdDisp.CMD_NO_OP_STRING "Awesome string!";  <- cool argument right?
+R03:51:01.000 cmdDisp.CMD_TEST_CMD_1 17, 3.2, 2; <- this command has 3 arguments
+R00:05:00 eventLogger.ALOG_SET_EVENT_REPORT_FILTER INPUT_COMMAND, INPUT_DISABLED; <- this command uses enum arguments
 

--- a/Gds/setup.py
+++ b/Gds/setup.py
@@ -80,7 +80,8 @@ integrated configuration with ground in-the-loop.
     ####
     entry_points={
         "gui_scripts": ["fprime-gds = fprime_gds.executables.run_deployment:main"],
-        "console_scripts": ["fprime-cli = fprime_gds.executables.fprime_cli:main"],
+        "console_scripts": ["fprime-cli = fprime_gds.executables.fprime_cli:main", 
+                            "fprime-seqgen = fprime_gds.common.tools.seqgen:main"],
     },
     ####
     # Classifiers:

--- a/Ref/test/int/ref_integration_test.py
+++ b/Ref/test/int/ref_integration_test.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import platform
+import subprocess
 from enum import Enum
 
 filename = os.path.dirname(__file__)
@@ -34,6 +35,7 @@ class TestRefAppClass(object):
         logpath = os.path.join(filename, "./logs")
         cls.api = IntegrationTestAPI(cls.pipeline, logpath)
         cls.case_list = []  # TODO find a better way to do this.
+        cls.dictionary = path
 
     @classmethod
     def teardown_class(cls):
@@ -264,3 +266,9 @@ class TestRefAppClass(object):
             self.api.assert_event_count(pred, actHI_events)
         finally:
             self.set_default_filters()
+
+    def test_seqgen(self):
+        """ Tests the seqgen code """
+        sequence = os.path.join(os.path.dirname(__file__), "test_seq.seq")
+        assert subprocess.run(["fprime-seqgen", "-d", self.dictionary, sequence, "/tmp/ref_test_int.bin"]).returncode == 0, "Failed to run fprime-seqgen"
+        self.assert_command("cmdSeq.CS_RUN", args=["/tmp/ref_test_int.bin"], max_delay=5)

--- a/Ref/test/int/test_seq.seq
+++ b/Ref/test/int/test_seq.seq
@@ -1,0 +1,6 @@
+; A test sequence
+;
+R00:00:00 cmdDisp.CMD_NO_OP
+
+; Let's try out some commands with arguments
+R00:00:01.050 cmdDisp.CMD_NO_OP_STRING "Awesome string!";

--- a/docs/UsersGuide/gds/seqgen.md
+++ b/docs/UsersGuide/gds/seqgen.md
@@ -1,0 +1,58 @@
+# Sequencing In F´
+
+F´ supports a very basic sequence format that allows for executing F´ commands at absolute times and at times relative
+to previous commands. The sequence uses the F´ dictionary to translate the human readable sequence file into a minimized
+binary format for upload and running using the command sequencer.
+
+Compiling this sequence is done with the `fprime-seqgen` utility and can be run once uploaded by issuing the `*.CS_RUN`
+command of any command sequencer instance defined in the flight system.
+
+## Writing an F´ Sequence File
+
+F´ sequence files consist of lists of commands. These commands start with a time argument, followed by the command
+mnemonic, and lastly any arguments to command.  See the example below, which are all pulled from the example sequence
+file found here: [simple_sequence.seq](https://github.com/nasa/fprime/blob/devel/Gds/examples/simple_sequence.seq).
+
+```
+A2015-075T22:32:40.123 cmdDisp.CMD_NO_OP
+```
+
+Here an absolute command was chosen.  Times can be specified in in absolute or relative time format.  An absolute time
+starts with an `A` and specifies a calendar time. A relative command is specified starting with an `R`, which runs
+relative to the previous command or start of the sequence. A relative command with an argument is shown below.
+
+```
+R01:00:01.050 CMD_NO_OP_STRING "Awesome string!" ; And a nice comment too
+```
+
+A list of these commands can be specified in a text file typically ending with the `.seq` extension.  Comments start
+with a ;. The example file above goes into greater explaination of the sample commands.
+
+## Compiling A Sample Sequence
+
+The `fprime-seqgen` command can compile the sequence into a binary format that F´ flight software can execute. To do
+this the user should provide a path to the flight software dictionary and a path to the text file discussed above.
+Below is an example on how to run the sample example sequence with the Ref dictionary. Remember to build first or the
+dictionary will not be generated.
+
+```
+fprime-seqgen fprime/Gds/examples/simple_sequence.seq -d fprime/Ref/build-artifacts/*/dict/RefTopologyAppDictionary.xml 
+```
+
+Here the output file is not specified, so it will be a new file in the same directory as the sequence but ending with
+the `.bin` extension.
+
+This binary file should be uploaded to the flight software.  Given limitations on file path length, it should be copied
+to `/tmp` when running locally.
+
+## Running The Binary Sequence
+
+Once uploaded, the sequence can be run by executing the .CS_RUN command of any command sequencer. Here we will run the
+`cmdSeq` instance's .CS_RUN command using an upload location of /tmp/sample_sequence.bin. This should work in the `Ref`
+application.
+
+```
+cmdSeq.CS_RUN	"/tmp/sample_sequence.bin"
+```
+
+**Note:** the sample sequence will run for multiple hours due to the specification of the relative commands. 

--- a/docs/UsersGuide/gds/seqgen.md
+++ b/docs/UsersGuide/gds/seqgen.md
@@ -16,6 +16,7 @@ file found here: [simple_sequence.seq](https://github.com/nasa/fprime/blob/devel
 ```
 A2015-075T22:32:40.123 cmdDisp.CMD_NO_OP
 ```
+**Note:** see [Time Details](#time-details) for more on time formats and time bases.
 
 Here an absolute command was chosen.  Times can be specified in in absolute or relative time format.  An absolute time
 starts with an `A` and specifies a calendar time. A relative command is specified starting with an `R`, which runs
@@ -56,3 +57,36 @@ cmdSeq.CS_RUN	"/tmp/sample_sequence.bin"
 ```
 
 **Note:** the sample sequence will run for multiple hours due to the specification of the relative commands. 
+
+## Time Details
+
+Time is represented in the sequence file using several formats. Relative times are represented with ISO_8601 time with
+only subseconds being optional, see table below. Absolute times are represented in ISO_8601 using ordinal dates
+(day of year) and time with optional subseconds.
+
+| | Format | Description | Example |
+|---|---|---|---|
+| Relative Times | RHH:MM:SS[.sss] | 'R' followed by ISO_8601 hour minute section and optional subseconds | R23:02:01.010 |
+| Absolute Times | AYYYY-DDDTHH:MM:SS[.sss] | 'A' followed by ISO_8601 ordinal datetime format with optional subseconds | A2020-192T23:02:01.010 |
+
+**Note:** relative times cannot exceed 24 hours.
+
+Since sequences can specify absolute time it may be dangerous to run a sequence should the flight software time not be
+synchronized with a known source. For example, it may be dangerous to run a sequence near system boot before time has
+been polled from a hardware clock or system time source.
+
+A sequence can be built with an expected time base and said sequence will not run should the flight software report time
+system in a different time base. For example, a sequence using TB_SC_TIME (spacecraft time) could be prevented from
+running if the flight software is currently using raw processor time and has not synchronized time with a known time
+source.  Available time sources are below:
+
+| Timebase | Value | Explanation |
+|---|---|---|
+| TB_PROC_TIME | 1 | Sequence will run when only raw processor time is reported |
+| TB_WORKSTATION_TIME | 2 | Sequence will run when time is synchronized with test workstation (for testing) |
+| TB_SC_TIME | 3 | Sequence will run when time is synchronized with spacecraft time |
+| TB_FPGA_TIME | 4 | Sequence will run when time is synchronized with FPGA/hardware clock |
+| TB_DONT_CARE | 0xFFFF | Sequence will run regardless of flight software timebase |
+
+**Note:** the above discriptions represent typically usages of these time bases but are project specific i.e.
+TB_SC_TIME might derive time from an internet time source.

--- a/docs/UsersGuide/guide.md
+++ b/docs/UsersGuide/guide.md
@@ -51,6 +51,7 @@ The API documentation section contains the automatically generated documentation
     - [A Brief Guide to the F´ Ground Data System](./gds/gds-introduction.md)
     - [The Discerning User's Guide to the F´ GDS CLI](./gds/gds-cli.md)
     - [The GDS Dashboard](./gds/gds-custom-dashboards.md)
+    - [Sequencing in F´](./gds/seqgen.md)
 - Full Development Guides: technical details for full F´ implementations
     - [Configuring F´](./dev/configuring-fprime.md)
     - [A Tour of the Source Tree](./dev/source-tree.md)


### PR DESCRIPTION
Does the following:

1. Adds in `fprime-seqgen` tool to python environment
2. Corrects example files
3. Adds documentation
4. Adds an integration test to test sequences