### PR TITLE
Fix GCC Compiler Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,18 @@ project(FPrime C CXX)
 set(FPRIME_FRAMEWORK_PATH "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Location of F prime framework" FORCE)
 set(FPRIME_PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Root path of F prime project" FORCE)
 
+# This cmake project is only intended to be used by CI and developers to test F-prime
+# We enable -Wall on this particular project as a canary to warn about compilation errors without
+# impacting real projects, where a warning from an untested compiler could break the build.
+#
+# We test -Wall with -Wstringop-truncation turned off, which detects overflows when using strncpy and strncat.
+# Unfortunately, this warning is buggy in gcc. It triggers false positive warnings on some of our usages
+# of strncpy, despite the fact that we're explicitly NULL terminating the end of the buffer. Our usage
+# of strncpy should be refactored and eventually removed, but there's no drop-in replacement in the C stdlib,
+# so we will simply ignore the false positive warnings for now.
+set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-stringop-truncation -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-stringop-truncation -Werror")
+
 # Include the build for F prime.
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/FPrime.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/FPrime-Code.cmake")

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
@@ -50,7 +50,11 @@ namespace Drv {
 
         // TODO check value of len
         len = snprintf(buf, sizeof(buf), "%d", gpio);
-        (void) write(fd, buf, len); // TODO check return value
+        if(write(fd, buf, len) != len) {
+            (void) close(fd);
+            DEBUG_PRINT("gpio/export error!\n");
+            return -1;
+        }
         (void) close(fd);
 
 	/* NOTE(mereweth) - this is to allow systemd udev to make
@@ -77,7 +81,11 @@ namespace Drv {
 
         // TODO check value of len
         len = snprintf(buf, sizeof(buf), "%d", gpio);
-        (void) write(fd, buf, len); // TODO check return value
+        if(write(fd, buf, len) != len) {
+            (void) close(fd);
+            DEBUG_PRINT("gpio/unexport error!\n");
+            return -1;
+        }
         (void) close(fd);
 
 	/* NOTE(mereweth) - this is to allow systemd udev to make
@@ -105,12 +113,13 @@ namespace Drv {
             return -1;
         }
 
-        // TODO check return value
-        if (out_flag) {
-            (void) write(fd, "out", 4);
-        }
-        else {
-            (void) write(fd, "in", 3);
+        const char *dir = out_flag ? "out" : "in";
+        len = strlen(dir);
+
+        if (write(fd, dir, len) != len) {
+            (void) close(fd);
+            DEBUG_PRINT("gpio/direction error!\n");
+            return -1;
         }
 
         (void) close(fd);
@@ -127,16 +136,15 @@ namespace Drv {
 
         // TODO make value a enum or check its value
 
-        // TODO check return value
-        if (value) {
-            (void) write(fd, "1", 1);
-        }
-        else {
-            (void) write(fd, "0", 1);
+        const char *val = value ? "1" : "0";
+        const int len = 1;
+
+        if(write(fd, val, len) != len) {
+            DEBUG_PRINT("gpio/set value error!\n");
+            return -1;
         }
 
         DEBUG_PRINT("GPIO fd %d value %d written\n",fd,value);
-
         return 0;
     }
 
@@ -191,8 +199,13 @@ namespace Drv {
             return -1;
         }
 
-        // TODO check return value of write and strlen()
-        (void) write(fd, edge, strlen(edge) + 1);
+        len = strlen(edge) + 1;
+        if(write(fd, edge, len) != len) {
+            (void) close(fd);
+            DEBUG_PRINT("gpio/set-edge error!\n");
+            return -1;
+        }
+
         (void) close(fd);
         return 0;
     }
@@ -311,64 +324,63 @@ namespace Drv {
   void LinuxGpioDriverComponentImpl ::
     intTaskEntry(void * ptr) {
 
-      FW_ASSERT(ptr);
-      LinuxGpioDriverComponentImpl* compPtr = (LinuxGpioDriverComponentImpl*) ptr;
+    FW_ASSERT(ptr);
+    LinuxGpioDriverComponentImpl* compPtr = (LinuxGpioDriverComponentImpl*) ptr;
+    FW_ASSERT(compPtr->m_fd != -1);
 
-      FW_ASSERT(compPtr->m_fd != -1);
+    // start GPIO interrupt
+    NATIVE_INT_TYPE stat;
+    stat = gpio_set_edge(compPtr->m_gpio, "rising");
+    if (-1 == stat) {
+      compPtr->log_WARNING_HI_GP_IntStartError(compPtr->m_gpio);
+      return;
+    }
 
-      // start GPIO interrupt
-      NATIVE_INT_TYPE stat;
-      stat = gpio_set_edge(compPtr->m_gpio, "rising");
-      if (-1 == stat) {
-          compPtr->log_WARNING_HI_GP_IntStartError(compPtr->m_gpio);
-          return;
-      }
+    // spin waiting for interrupt
+    while(not compPtr->m_quitThread) {
+        pollfd fdset[1];
+        NATIVE_INT_TYPE nfds = 1;
+        NATIVE_INT_TYPE timeout = 10000; // Timeout of 10 seconds
 
-      // spin waiting for interrupt
-      while(not compPtr->m_quitThread) {
-          pollfd fdset[1];
-          NATIVE_INT_TYPE nfds = 1;
-          NATIVE_INT_TYPE timeout = 10000; // Timeout of 10 seconds
+        memset((void*)fdset, 0, sizeof(fdset));
 
-          memset((void*)fdset, 0, sizeof(fdset));
+        fdset[0].fd = compPtr->m_fd;
+        fdset[0].events = POLLPRI;
+        stat = poll(fdset, nfds, timeout);
 
-          fdset[0].fd = compPtr->m_fd;
-          fdset[0].events = POLLPRI;
+        /*
+        * According to this link, poll will always have POLLERR set for the sys/class/gpio subsystem
+        * so cant check for it to look for error:
+        * http://stackoverflow.com/questions/27411013/poll-returns-both-pollpri-pollerr
+        */
+        if (stat < 0) {
+            DEBUG_PRINT("stat: %d, revents: 0x%x, POLLERR: 0x%x, POLLIN: 0x%x, POLLPRI: 0x%x\n",
+                    stat, fdset[0].revents, POLLERR, POLLIN, POLLPRI); // TODO remove
+            compPtr->log_WARNING_HI_GP_IntWaitError(compPtr->m_gpio);
+            return;
+        }
 
-          stat = poll(fdset, nfds, timeout);
+        if (stat == 0) {
+            // continue to poll
+            DEBUG_PRINT("Krait timed out waiting for GPIO interrupt\n");
+            continue;
+        }
 
-          /*
-           * According to this link, poll will always have POLLERR set for the sys/class/gpio subsystem
-           * so cant check for it to look for error:
-           * http://stackoverflow.com/questions/27411013/poll-returns-both-pollpri-pollerr
-           */
-          if (stat < 0) {
-              DEBUG_PRINT("stat: %d, revents: 0x%x, POLLERR: 0x%x, POLLIN: 0x%x, POLLPRI: 0x%x\n",
-                     stat, fdset[0].revents, POLLERR, POLLIN, POLLPRI); // TODO remove
-              compPtr->log_WARNING_HI_GP_IntWaitError(compPtr->m_gpio);
-              return;
-          }
+        // Asserting that number of fds w/ revents is 1:
+        FW_ASSERT(stat == 1, stat);  // TODO should i bother w/ this assert?
 
-          if (stat == 0) {
-              // continue to poll
-	          DEBUG_PRINT("Krait timed out waiting for GPIO interrupt\n");
-              continue;
-          }
+        // TODO what to do if POLLPRI not set?
 
-          // Asserting that number of fds w/ revents is 1:
-          FW_ASSERT(stat == 1, stat);  // TODO should i bother w/ this assert?
+        // TODO: if I take out the read then the poll just continually interrupts
+        // Read is only taking 22 usecs each time, so it is not blocking for long
+        if (fdset[0].revents & POLLPRI) {
 
-          // TODO what to do if POLLPRI not set?
-
-          // TODO: if I take out the read then the poll just continually interrupts
-          // Read is only taking 22 usecs each time, so it is not blocking for long
-          if (fdset[0].revents & POLLPRI) {
-
-              char *buf[MAX_BUF];
-              (void) lseek(fdset[0].fd, 0, SEEK_SET); // Must seek back to the starting
-              (void) read(fdset[0].fd, buf, MAX_BUF);
-              DEBUG_PRINT("\npoll() GPIO interrupt occurred w/ value: %c\n", buf[0]);
-          }
+            char *buf[MAX_BUF];
+            (void) lseek(fdset[0].fd, 0, SEEK_SET); // Must seek back to the starting
+            if(read(fdset[0].fd, buf, MAX_BUF) > 0) {
+                DEBUG_PRINT("\npoll() GPIO interrupt occurred w/ value: %c\n", buf[0]);
+            }
+        }
 
         // call interrupt ports
         Svc::TimerVal timerVal;

--- a/Svc/ComLogger/test/ut/Tester.cpp
+++ b/Svc/ComLogger/test/ut/Tester.cpp
@@ -304,7 +304,7 @@ namespace Svc {
   {
       // Construct illegal filePrefix, and set it via the friend:
       U8 filePrefix[2048];
-      U8 fileName[2048];
+      U8 fileName[2128];
       memset(fileName, 0, sizeof(fileName));
       memset(filePrefix, 0, sizeof(filePrefix));
       snprintf((char*) filePrefix, sizeof(filePrefix), "illegal/fname?;\\*");


### PR DESCRIPTION
I also enable '-Wall -Werror' on the root fprime project, which is only used
by CI and fprime developers to ensure that compiler warnings aren't accidentally
introduced in the future