### PR TITLE
mstarch: download GTest to gtest folder and only redownload if it is deleted not on purge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 build*/
+gtest/
 
 AutoXML/
 test_harness/src/test_harness-C/application.out

--- a/cmake/googletest-download/CMakeLists.txt.in
+++ b/cmake/googletest-download/CMakeLists.txt.in
@@ -7,7 +7,7 @@ ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           release-1.10.0
   SOURCE_DIR        "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-src"
-  BINARY_DIR        "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-build"
+  BINARY_DIR        "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-build-${PLATFORM}"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""

--- a/cmake/googletest-download/CMakeLists.txt.in
+++ b/cmake/googletest-download/CMakeLists.txt.in
@@ -6,8 +6,8 @@ include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           release-1.10.0
-  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
-  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  SOURCE_DIR        "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-src"
+  BINARY_DIR        "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-build"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""

--- a/cmake/googletest-download/googletest.cmake
+++ b/cmake/googletest-download/googletest.cmake
@@ -1,5 +1,5 @@
 # Download and unpack googletest at configure time if it doesn't exit already
-if (NOT IS_DIRECTORY "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-src/.git")
+if (NOT IS_DIRECTORY "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-build-${PLATFORM}/googletest")
     configure_file("${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in" googletest-download/CMakeLists.txt)
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
       RESULT_VARIABLE result
@@ -21,7 +21,7 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 # Add googletest directly to our build. This defines
 # the gtest and gtest_main targets.
 add_subdirectory(${FPRIME_FRAMEWORK_PATH}/gtest/googletest-src
-                 ${FPRIME_FRAMEWORK_PATH}/gtest/googletest-build
+	${FPRIME_FRAMEWORK_PATH}/gtest/googletest-build-${PLATFORM}
                  EXCLUDE_FROM_ALL)
 
 # The gtest/gtest_main targets carry header search path

--- a/cmake/googletest-download/googletest.cmake
+++ b/cmake/googletest-download/googletest.cmake
@@ -1,26 +1,27 @@
-# Download and unpack googletest at configure time
-configure_file("${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in" googletest-download/CMakeLists.txt)
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+# Download and unpack googletest at configure time if it doesn't exit already
+if (NOT IS_DIRECTORY "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-src/.git")
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in" googletest-download/CMakeLists.txt)
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+      RESULT_VARIABLE result
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+    if(result)
+      message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} --build .
+      RESULT_VARIABLE result
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+    if(result)
+      message(FATAL_ERROR "Build step for googletest failed: ${result}")
+    endif()
 endif()
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "Build step for googletest failed: ${result}")
-endif()
-
 # Prevent overriding the parent project's compiler/linker
 # settings on Windows
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # Add googletest directly to our build. This defines
 # the gtest and gtest_main targets.
-add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
-                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+add_subdirectory(${FPRIME_FRAMEWORK_PATH}/gtest/googletest-src
+                 ${FPRIME_FRAMEWORK_PATH}/gtest/googletest-build
                  EXCLUDE_FROM_ALL)
 
 # The gtest/gtest_main targets carry header search path


### PR DESCRIPTION
Fixes  #294.  Downloads GTest to framework install on first generation and doesn't redownload unless the directory is removed.