### PR TITLE
cmake: Only disable -Wstringop-truncation on GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,14 +11,18 @@ set(FPRIME_PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Root path of F p
 # This cmake project is only intended to be used by CI and developers to test F-prime
 # We enable -Wall on this particular project as a canary to warn about compilation errors without
 # impacting real projects, where a warning from an untested compiler could break the build.
-#
-# We test -Wall with -Wstringop-truncation turned off, which detects overflows when using strncpy and strncat.
-# Unfortunately, this warning is buggy in gcc. It triggers false positive warnings on some of our usages
-# of strncpy, despite the fact that we're explicitly NULL terminating the end of the buffer. Our usage
-# of strncpy should be refactored and eventually removed, but there's no drop-in replacement in the C stdlib,
-# so we will simply ignore the false positive warnings for now.
-set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-stringop-truncation -Werror")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-stringop-truncation -Werror")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+
+# We disable the buggy -Wstringop-truncation warning, which detects overflows when using strncpy and
+# strncat, for the gcc compiler. It triggers false positive warnings on some of our usages of strncpy,
+# despite the fact that we're explicitly NULL terminating the end of the buffer. Our usage of strncpy
+# should be refactored and eventually removed, but there's no drop-in replacement in the C stdlib, so
+# we will simply ignore the false positive warnings for now.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-stringop-truncation")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-stringop-truncation")
+endif()
 
 # Include the build for F prime.
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/FPrime.cmake")


### PR DESCRIPTION
This is a GCC only warning and it was causing Apple Clang to complain it was an unknown warning.