### PR TITLE
Bugfix GDS logging function call

### DIFF
--- a/Gds/src/fprime_gds/common/communication/updown.py
+++ b/Gds/src/fprime_gds/common/communication/updown.py
@@ -194,7 +194,7 @@ class Uplinker:
                     else:
                         UP_LOGGER.warning(
                             "Uplink failed to send %d bytes of data after %d retries",
-                            (len(framed), Uplinker.RETRY_COUNT),
+                            len(framed), Uplinker.RETRY_COUNT 
                         )
         # An OSError might occur during shutdown and is harmless. If we are not shutting down, this error should be
         # propagated up the stack.


### PR DESCRIPTION

## F´ Pull Request
|**Field**|**Value**|
|:---|:---|
|**_Submission Date_**|2020.12.07 |
|**_Submitter_**|[@jonathanmichel](https://github.com/jonathanmichel) |
|**_Originating Project/Creator_**| |
|**_Base Branch_**|devel |
|**_Short Description_**| Python log format error bugfix |
|**_Affected Component_**| GDS simulator |
|**_Affected Architectures(s)_**| - |
|**_Related Issue(s)_**| - |
|**_Has Unit Tests (y/n)_**| n |
|**_Build Checked (y/n)_**| y |
|**_Unit Tests Run (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description
Function call change to fix error when running GDS

## Rationale
Bugfix `TypeError: %d format: a number is required, not tupple` in [Updown.py:195](https://github.com/nasa/fprime/blob/d224c98e19345a089d8503d1cbd8714ac3cd8b94/Gds/src/fprime_gds/common/communication/updown.py#L195) when uplink error printing with GDS. 

## Testing Recommendations
Start GDS without an F' application runnig and try to send a command.

## Future Work
No future work expected based on this request.
