### PR TITLE
Separate fprime-util generate for different build types

### DIFF
--- a/ci/tests/fputil.bash
+++ b/ci/tests/fputil.bash
@@ -4,7 +4,7 @@
 #
 # Helpers to test via FP util
 ####
-export FPUTIL_TARGETS=("generate" "build" "build --all" "check --all")
+export FPUTIL_TARGETS=("generate" "generate --ut" "build" "build --all" "check --all")
 export FPUTIL_DEPLOYS="${FPRIME_DIR} ${FPRIME_DIR}/Ref ${FPRIME_DIR}/RPI"
 
 export INT_DEPLOYS="${FPRIME_DIR}/Ref"
@@ -31,7 +31,7 @@ function fputil_action {
                 if [[ "${TEST_TYPE}" == "QUICK" ]]
                 then
                     echo "[INFO] Generating build cache before ${DEPLOYMENT//\//_} '${TARGET}' execution"
-                    fprime-util "generate" ${PLATFORM} > "${LOG_DIR}/${DEPLOYMENT//\//_}_pregen.out.log" 2> "${LOG_DIR}/${DEPLOYMENT//\//_}_pregen.err.log" \
+                    fprime-util generate --ut ${PLATFORM} > "${LOG_DIR}/${DEPLOYMENT//\//_}_pregen.out.log" 2> "${LOG_DIR}/${DEPLOYMENT//\//_}_pregen.err.log" \
                         || fail_and_stop "Failed to generate before ${DEPLOYMENT//\//_} '${TARGET}' execution"
                 fi
         fi
@@ -44,7 +44,7 @@ function fputil_action {
                 || fail_and_stop "Failed to generate before ${DEPLOYMENT//\//_} '${TARGET}' execution"
         fi
         cd "${WORKDIR}"
-        if [[ "${TARGET}" != "generate" ]]
+        if [[ "${TARGET}" != "generate" ]] && [[ "${TARGET}" != "generate --ut" ]]
         then
 	    echo "[INFO] FP Util in ${WORKDIR} running ${TARGET} with ${JOBS} jobs"
             fprime-util ${TARGET} --jobs "${JOBS}" ${PLATFORM} > "${LOG_DIR}/${WORKDIR//\//_}_${TARGET/ /}.out.log" 2> "${LOG_DIR}/${WORKDIR//\//_}_${TARGET/ /}.err.log" \

--- a/docs/Tutorials/GettingStarted/Tutorial.md
+++ b/docs/Tutorials/GettingStarted/Tutorial.md
@@ -229,8 +229,14 @@ fprime-util build raspberrypi
 ## Building and Running Unit Tests
 
 Unit tests can be build using the the `build --ut` command of the `fprime-util`. This will allow us to build the unit tests
-in preparation to run them.  The user can also just run "check" to build and run the unit tests.  **Note: no unit tests
-are currently supplied with the Ref application, and thus these commands may error.**
+in preparation to run them.  The user can also just run "check" to build and run the unit tests.
+
+Before building unit tests, the unit test build cache must be generated:
+
+```
+cd fprime/Ref
+fprime-util generate --ut
+```
 
 **Building Unit Test of SignalGen**
 ```

--- a/docs/UsersGuide/user/fprime-util.md
+++ b/docs/UsersGuide/user/fprime-util.md
@@ -29,9 +29,10 @@ The `fprime-util` helper is driven by a series of subcommands listed above. Each
 of the development process and are breifly described below.  The following sections will go into
 each command's usage in more detail.
 
-1. `generate`: generates build caches, one for development, and one with unit test flags enabled.
-   This is the required first step to using the F´ build system. This should be executed once int
-   the deployment directory before developing.  It can be run again after the user runs `purge`.
+1. `generate`: generates build cache directories. It defaults to generating the build cache for
+   release builds, but adding the `--ut` flag will generate a unit testing build cache. This is the
+   required first step to using the F´ build system and must be run before building an F´ deployment
+   or running unit tests. The `purge` command can be used to delete all existing build caches.
 2. `purge`: removes the build caches created with generate. This should be used when the build
    system has not properly detected changes and need to be redone from the beginning.
 3. `hash-to-file`: If F´ assertions are setup to output file hashes instead of file paths (i.e. when
@@ -73,8 +74,6 @@ behavior:
 
 Additionally, there are some advanced flags that can be useful in some situations:
 
-- `--build-type {Release,Testing}`: Manually set the Cmake built type. This is usually automatically
-  determined by `fprime-util` and setting this can cause unexpected behavior.
 - `--build-dir`: This sets the cmake build cache directory. This is usually automatically determined
   by the deployment and build type and setting this can cause unexpected results.
 


### PR DESCRIPTION
As part of this, I got rid of the `--build-type` flag and instead had the build type default to RELEASE unless the `--ut` flag is passed, in which case the build type is set to TESTING. This should allow us to add a `--debug` flag in the future and support a DEBUG build type.

This plays a little strangely with the fprime-util cmake targets. I thought about having the cmake targets use the global build type, but ran into some obstacles:

- Most targets only make sense for a single build type. I.E. `check` will only run on TESTING build types.
- Even for targets that make sense to run in multiple build types, I.E. build, by using the global build type we lose the ability to show all the potential target configurations in `fprime-util info`. So if you listed targets you'd only see `build` and not `build` + `build --ut`.

Instead, I figured the simplest solution was to never use the global build type when building a cmake target. Instead, every cmake target has a specific build type it can run against (as opposed to a list as before). The downside of this is that we have to specifically to list every potential target and build type configuration, but due to the limited number of build types and the fact that most targets only run against a single build type I don't see this as a major obstacle.

Resolves #295