### PR TITLE
mstarch: fixes autocoder to allow component imports from other directories

### DIFF
--- a/Autocoders/Python/bin/codegen.py
+++ b/Autocoders/Python/bin/codegen.py
@@ -1699,7 +1699,6 @@ def main():
 
     for xml_filename in xml_filenames:
 
-        xml_filename = os.path.basename(xml_filename)
         xml_type = XmlParser.XmlParser(xml_filename)()
 
         if xml_type == "component":
@@ -1707,12 +1706,12 @@ def main():
             the_parsed_component_xml = XmlComponentParser.XmlComponentParser(
                 xml_filename
             )
-            generate_component(the_parsed_component_xml, xml_filename, opt)
+            generate_component(the_parsed_component_xml, os.path.basename(xml_filename), opt)
             dependency_parser = the_parsed_component_xml
         elif xml_type == "interface":
             DEBUG.info("Detected Port type XML so Generating Port type C++ Files...")
             the_parsed_port_xml = XmlPortsParser.XmlPortsParser(xml_filename)
-            generate_port(the_parsed_port_xml, xml_filename)
+            generate_port(the_parsed_port_xml, os.path.basename(xml_filename))
             dependency_parser = the_parsed_port_xml
         elif xml_type == "serializable":
             DEBUG.info(
@@ -1726,7 +1725,7 @@ def main():
             the_parsed_topology_xml = XmlTopologyParser.XmlTopologyParser(xml_filename)
             DEPLOYMENT = the_parsed_topology_xml.get_deployment()
             print("Found assembly or deployment named: %s\n" % DEPLOYMENT)
-            generate_topology(the_parsed_topology_xml, xml_filename, opt)
+            generate_topology(the_parsed_topology_xml, os.path.basename(xml_filename), opt)
             dependency_parser = the_parsed_topology_xml
         elif xml_type == "enum":
             DEBUG.info("Detected Enum XML so Generating hpp, cpp, and py files...")
@@ -1758,7 +1757,7 @@ def main():
             if opt.build_root_flag:
                 generate_dependency_file(
                     opt.dependency_file,
-                    xml_filename,
+                    os.path.basename(xml_filename),
                     list(get_build_roots())[0],
                     dependency_parser,
                     xml_type,

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -28,7 +28,6 @@ from fprime_ac.models import ModelParser
 # Python extention modules and custom interfaces
 #
 from fprime_ac.utils import ConfigManager
-from fprime_ac.utils.buildroot import get_nearest_build_root
 
 #
 # Global logger init. below.

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -783,11 +783,9 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
         """
         Include any headers for channel/parameter serializable includes
         """
-        ser_includes = [si.get_xml_filename() for si in obj.get_serializables()]
+        ser_includes = self.__model_parser.uniqueList(obj.get_xml_serializable_files())
         s_includes = [
-            sinc.replace("Ai.xml", "Ac.hpp").replace(
-                get_nearest_build_root(sinc) + "/", ""
-            )
+            sinc.replace("Ai.xml", "Ac.hpp")
             for sinc in ser_includes
         ]
         c.ser_includes = s_includes

--- a/Autocoders/Python/src/fprime_ac/models/CompFactory.py
+++ b/Autocoders/Python/src/fprime_ac/models/CompFactory.py
@@ -416,6 +416,7 @@ class CompFactory:
             comp_included_enums_list,
         )
         the_component.set_xml_port_files(comp_xml_port_files + parsed_array_list)
+        the_component.set_xml_serializable_files(the_parsed_component_xml.get_serializable_type_files())
         the_component.set_c_header_files(comp_c_header_files)
         if has_guarded_ports:
             the_component.set_has_guarded_ports()

--- a/Autocoders/Python/src/fprime_ac/models/Component.py
+++ b/Autocoders/Python/src/fprime_ac/models/Component.py
@@ -145,6 +145,9 @@ class Component:
     def set_serializables(self, serializables):
         self.__serializable_obj_list = serializables
 
+    def set_xml_serializable_files(self, x):
+        self.__xml_serializable_files = x
+
     def set_xml_port_files(self, x):
         self.__xml_port_files = x
 
@@ -153,6 +156,9 @@ class Component:
 
     def get_xml_port_files(self):
         return self.__xml_port_files
+
+    def get_xml_serializable_files(self):
+        return self.__xml_serializable_files
 
     def get_c_header_files(self):
         return self.__c_header_files

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlSerializeParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlSerializeParser.py
@@ -93,6 +93,7 @@ class XmlSerializeParser:
             stri = "ERROR: Could not find specified XML file %s." % xml_file
             raise OSError(stri)
         fd = open(xml_file)
+        xml_file = os.path.basename(xml_file)
         #        xml_file = os.path.basename(xml_file)
         self.__xml_filename = xml_file
 

--- a/Autocoders/Python/test/CMakeLists.txt
+++ b/Autocoders/Python/test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/queued1")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/serial_passive")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/serialize_enum")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/serialize_stringbuffer")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/crisscross")
 
 # Template uses a malformed XML file
 # add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/serialize_template")

--- a/Autocoders/Python/test/crisscross/CMakeLists.txt
+++ b/Autocoders/Python/test/crisscross/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Default module cmake file
+# AUTOCODER_INPUT_FILES: Contains all Autocoder input files
+# SOURCE_FILES: Handcoded C++ source files)
+
+set(SOURCE_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/../comp_diff_namespace/TestComponentAi.xml"
+  "${CMAKE_CURRENT_LIST_DIR}/../comp_diff_namespace/TestPortAi.xml"
+  "${CMAKE_CURRENT_LIST_DIR}/../comp_diff_namespace/QuaternionSerializableAi.xml"
+)
+
+register_fprime_module()
+
+# Sets MODULE_NAME to unique name based on path
+get_module_name(${CMAKE_CURRENT_LIST_DIR})
+
+# Exclude test module from all build
+set_target_properties(
+  ${MODULE_NAME}
+  PROPERTIES
+  EXCLUDE_FROM_ALL TRUE
+)
+
+# Add unit test directory
+# UT_SOURCE_FILES: Sources for unit test
+set(UT_SOURCE_FILES
+  "${FPRIME_FRAMEWORK_PATH}/Autocoders/Python/test/comp_diff_namespace/TestComponentAi.xml"
+  "${CMAKE_CURRENT_LIST_DIR}/../comp_diff_namespace/test/ut/main.cpp"
+)
+register_fprime_ut()
+
+


### PR DESCRIPTION
The PR improves the autocoder to allow for using XML models from other directories.

In short:
```
set(SOURCE_FILES
  ../SomeModel/SomeModelComponentAi.xml
)
```

Should now work.