### PR TITLE
Fix behavior of --force flag with fprime-util purge

### DIFF
--- a/Fw/Python/src/fprime/util/build_helper.py
+++ b/Fw/Python/src/fprime/util/build_helper.py
@@ -376,7 +376,7 @@ def utility_entry(args):
                         parsed.command.title(), build.build_dir
                     )
                 )
-                if confirm() or parsed.force:
+                if parsed.force or confirm():
                     build.purge()
 
             build = Build(BuildType.BUILD_NORMAL, deployment, verbose=parsed.verbose)
@@ -395,7 +395,7 @@ def utility_entry(args):
                     parsed.command.title(), install_dir
                 )
             )
-            if confirm() or parsed.force:
+            if parsed.force or confirm():
                 build.purge_install()
         else:
             target = get_target(parsed)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| fprime-util |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| Resolves #310  |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Builds Without Errors (y/n)_**| y  |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n/a |

---
## Change Description

We were accidentally checking for confirmation before the force flag, so we were always
prompting for confirmation.

Thanks @jonathanmichel!

## Rationale

Fixes `fprime-util --force`

## Testing/Review Recommendations

N/A

## Future Work

We should add integration tests to cover the CLI. See #311
