### PR TITLE
Fix fprime-util deployment flag and remove build cache flag

### DIFF
--- a/docs/UsersGuide/user/fprime-util.md
+++ b/docs/UsersGuide/user/fprime-util.md
@@ -72,11 +72,6 @@ behavior:
   this behavior to manually specify a deployment. Ex: `fprime-util build -d ~/fprime` will try to
   build the `~/fprime` deployment.
 
-Additionally, there are some advanced flags that can be useful in some situations:
-
-- `--build-dir`: This sets the cmake build cache directory. This is usually automatically determined
-  by the deployment and build type and setting this can cause unexpected results.
-
 ## Setting Build Platform
 
 Different F´ deployments will target different operating systems, architectures, and hardware. To


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| fprime-util |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| Resolves #285 |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

- Fixes fprime-util `--deployment` flag
- Removed fprime-util `--build-cache` flag

## Rationale

`--build-cache` is a very advanced option, users are better off using a combination of the `--deployment` and `--path` flags to automatically select a build cache instead. Users who want to use a custom build cache can directly use cmake. 

## Testing/Review Recommendations

Manually verify that the `--deployment` flag works.

## Future Work

None
