### PR TITLE
Update fprime-gds option and path being used in INSTALL.md

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -92,7 +92,7 @@ fprime-util build --jobs 32
 
 **Testing F´ GDS Installation Via Running HTML GUI**
 ```
-fprime-gds -g html -d <path to fprime checkout>/Ref
+fprime-gds -g html -r <path to fprime checkout>/Ref/build-artifacts
 ```
 **Note:** `Ref` should contain pre-built dictionaries and binaries for the user's system. This can
 be achieved by running the Autocoder installation test (the user must have a working Autocoder


### PR DESCRIPTION
## Change Description

It's just an update to the INSTALL.md file. `fprime-gds -g html -d <path to fprime checkout>/Ref` does not work. The option -d doesn't exist, I'm currently using -r instead. Additionally, the path I've used to successfully run the gds has been <path to prime checkout>/Ref/build-artifacts.