### PR TITLE
Add FixedLengthString Fw type

### DIFF
--- a/Fw/Cfg/SerIds.hpp
+++ b/Fw/Cfg/SerIds.hpp
@@ -56,6 +56,7 @@ namespace Fw {
 
         FW_TYPEID_EIGHTY_CHAR_STRING = 50, //!< 80 char string Buffer type id
         FW_TYPEID_INTERNAL_INTERFACE_STRING =   51, //!< interface string Buffer type id
+        FW_TYPEID_FIXED_LENGTH_STRING = 52, //!< 256 char string Buffer type id
     };
 }
 

--- a/Fw/Types/FixedLengthString.cpp
+++ b/Fw/Types/FixedLengthString.cpp
@@ -1,0 +1,78 @@
+#include <Fw/Types/StringType.hpp>
+#include <Fw/Types/BasicTypes.hpp>
+#include <Fw/Types/FixedLengthString.hpp>
+#include <Fw/Types/Assert.hpp>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+namespace Fw {
+
+    FixedLengthString::FixedLengthString(const char* src) : StringBase() {
+        this->copyBuff(src, sizeof(this->m_buf));
+    }
+
+    FixedLengthString::FixedLengthString(const StringBase& src) : StringBase() {
+        this->copyBuff(src.toChar(), sizeof(this->m_buf));
+    }
+
+    FixedLengthString::FixedLengthString(const FixedLengthString& src) : StringBase() {
+        this->copyBuff(src.m_buf, sizeof(this->m_buf));
+    }
+
+    FixedLengthString::FixedLengthString(void) : StringBase() {
+        this->m_buf[0] = 0;
+    }
+
+    FixedLengthString::~FixedLengthString(void) {
+    }
+
+    NATIVE_UINT_TYPE FixedLengthString::length(void) const {
+        return strnlen(this->m_buf,sizeof(this->m_buf));
+    }
+
+    const char* FixedLengthString::toChar(void) const {
+        return this->m_buf;
+    }
+
+    void FixedLengthString::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
+        FW_ASSERT(buff);
+        // check for self copy
+        if (buff != this->m_buf) {
+            (void)strncpy(this->m_buf,buff,size);
+            // NULL terminate
+            this->terminate(sizeof(this->m_buf));
+        }
+    }
+
+    const FixedLengthString& FixedLengthString::operator=(const FixedLengthString& other) {
+        this->copyBuff(other.m_buf,sizeof(this->m_buf));
+        return *this;
+    }
+
+    SerializeStatus FixedLengthString::serialize(SerializeBufferBase& buffer) const {
+        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
+        // serialize string as buffer
+        return buffer.serialize((U8*)this->m_buf,strSize);
+    }
+
+    SerializeStatus FixedLengthString::deserialize(SerializeBufferBase& buffer) {
+        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
+        // deserialize string
+        SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
+        // make sure it is null-terminated
+        this->terminate(maxSize);
+
+        return stat;
+    }
+
+    NATIVE_UINT_TYPE FixedLengthString::getCapacity(void) const {
+        return STRING_SIZE;
+    }
+    
+    void FixedLengthString::terminate(NATIVE_UINT_TYPE size) {
+        // null terminate the string
+        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
+    }
+
+}

--- a/Fw/Types/FixedLengthString.hpp
+++ b/Fw/Types/FixedLengthString.hpp
@@ -1,0 +1,41 @@
+#ifndef FW_FIXED_LENGTH_STRING_TYPE_HPP
+#define FW_FIXED_LENGTH_STRING_TYPE_HPP
+
+#include <Fw/Types/BasicTypes.hpp>
+#include <Fw/Types/StringType.hpp>
+#include <Fw/Cfg/SerIds.hpp>
+
+namespace Fw {
+
+    class FixedLengthString : public Fw::StringBase {
+        public:
+        
+            enum {
+                SERIALIZED_TYPE_ID = FW_TYPEID_FIXED_LENGTH_STRING, //!< typeid for string type
+                STRING_SIZE = FW_FIXED_LENGTH_STRING_SIZE, //!< Storage for string
+                SERIALIZED_SIZE = STRING_SIZE + sizeof(FwBuffSizeType) //!< Serialized size is size of buffer + size field
+            };
+        
+            FixedLengthString(const char* src); //!< char* source constructor
+            FixedLengthString(const StringBase& src); //!< other string constructor
+            FixedLengthString(const FixedLengthString& src); //!< FixedLengthString string constructor
+            FixedLengthString(void); //!< default constructor
+            ~FixedLengthString(void); //!< destructor
+            const char* toChar(void) const; //!< gets char buffer
+            NATIVE_UINT_TYPE length(void) const; //!< returns length of stored string
+
+            const FixedLengthString& operator=(const FixedLengthString& other); //!< equal operator
+            
+            SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
+            SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
+            
+        PRIVATE:
+            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy source buffer, overwriting
+            NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
+            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
+
+            char m_buf[STRING_SIZE]; //!< storage for string data
+    };
+}
+
+#endif

--- a/config/FpConfig.hpp
+++ b/config/FpConfig.hpp
@@ -347,6 +347,12 @@ enum TimeBase {
 #ifndef FW_USE_TIME_CONTEXT
 #define FW_USE_TIME_CONTEXT             1 //!< Whether or not to serialize the time context
 #endif
+//
+//These defines used for the FilepathCharString type
+
+#ifndef FW_FIXED_LENGTH_STRING_SIZE
+#define FW_FIXED_LENGTH_STRING_SIZE   256 //!< Character array size for the filepath character type
+#endif
 
 // *** NOTE configuration checks are in Fw/Cfg/ConfigCheck.cpp in order to have
 // the type definitions in Fw/Types/BasicTypes available.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description
Added a new type to be used a a fixed length string.  The length of the string can be modified by changing the constant FW_FIXED_LENGTH_STRING_SIZE in config/FpConfig.hpp


## Rationale
This new type was inspired by the EightyCharString but with the ability to change a single constant to change the size.  We plan to use this for file paths but can be used for other strings.

## Testing/Review Recommendations
The code is simply a rename of the EightCharString but the only change is the size of the string is defined in a #define.

## Future Work

None.
