### PR TITLE
Fix fprime-util impl for components including serializables

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
@@ -32,7 +32,6 @@ from fprime_ac.utils import ConfigManager
 from fprime_ac.utils.buildroot import (
     BuildRootMissingException,
     build_root_relative_path,
-    get_nearest_build_root,
 )
 
 #
@@ -353,7 +352,6 @@ class ComponentWriterBase(AbstractWriter.AbstractWriter):
     def initIncludes(self, obj, c):
         self.initTypeIncludes(obj, c)
         self.initPortIncludes(obj, c)
-        self.initSerialIncludes(obj, c)
         self.initIncludeName(obj, c)
         self.initCompIncludePath(obj, c)
 
@@ -785,19 +783,6 @@ class ComponentWriterBase(AbstractWriter.AbstractWriter):
         )
         c.param_msgSize = ("msgSize", "const NATIVE_INT_TYPE", "The message size")
         c.param_queueDepth = ("queueDepth", "const NATIVE_INT_TYPE", "The queue depth")
-
-    def initSerialIncludes(self, obj, c):
-        """
-        Include any headers for channel/parameter serializable includes
-        """
-        ser_includes = [si.get_xml_filename() for si in obj.get_serializables()]
-        s_includes = [
-            sinc.replace("Ai.xml", "Ac.hpp")
-            .replace(get_nearest_build_root(sinc) + "/", "")
-            .replace("/test/ut", "")
-            for sinc in ser_includes
-        ]
-        c.ser_includes = s_includes
 
     def initTelemetry(self, obj, c):
         """


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Autocoder |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| Fixes #327 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Components including serializable types would explode include paths when running 'fprime-util impl'
Since impl doesn't need include paths for serialized components, we can remove this
logic from the ComponentWriter class.

## Rationale

This was introduced in another autocoder bugfix, #309, to fix importing components from other directories.
The ComponentVisitor was updated for this new functionality, but the ComponentWriter, a duplicated copy of
the same class wasn't updated, since it wasn't using this field. It turns out that even though the attribute wasn't
used by the ComponentWriter it was still calculated.

Instead of trying to keep the two files in sync, which is easy to forget, I think it's better to strip out unused logic
from the ComponentWriter class. In the future we should consider re-combining the visitor and writer classes.

## Testing/Review Recommendations

1. With devel branch, run `fprime-util impl` in Ref/SignalGen and confirm an exception.
2. Re-run `fprime-util impl` with these changes in Ref/SignalGen and confirm successful template generation.

## Future Work

A total autocoder refactor... :cry: