### PR TITLE
fix: Borken GroundInterface UT

### DIFF
--- a/Svc/GroundInterface/test/ut/Tester.cpp
+++ b/Svc/GroundInterface/test/ut/Tester.cpp
@@ -194,6 +194,15 @@ namespace Svc {
     return Drv::POLL_OK;
   }
 
+  void Tester ::
+    from_readBufferReturn_handler(
+        const NATIVE_INT_TYPE portNum,
+        Fw::Buffer &fwBuffer
+    )
+  {
+    this->pushFromPortEntry_readBufferReturn(fwBuffer);
+  }
+
   // ----------------------------------------------------------------------
   // Helper methods 
   // ----------------------------------------------------------------------
@@ -279,7 +288,29 @@ namespace Svc {
         0, 
         this->get_from_readPoll(0)
     );
+// readBufferReturn
+    this->component.set_readBufferReturn_OutputPort(
+        0, 
+        this->get_from_readBufferReturn(0)
+    );
 
+    // Log
+    this->component.set_Log_OutputPort(
+        0, 
+        this->get_from_Log(0)
+    );
+
+    // LogText
+    this->component.set_LogText_OutputPort(
+        0, 
+        this->get_from_LogText(0)
+    );
+
+    // Time
+    this->component.set_Time_OutputPort(
+        0, 
+        this->get_from_Time(0)
+    );
   }
 
   void Tester ::

--- a/Svc/GroundInterface/test/ut/Tester.hpp
+++ b/Svc/GroundInterface/test/ut/Tester.hpp
@@ -104,6 +104,13 @@ namespace Svc {
           Fw::Buffer &fwBuffer 
       );
 
+      //! Handler for from_readBufferReturn
+      //!
+      void from_readBufferReturn_handler(
+          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          Fw::Buffer &fwBuffer 
+      );
+      
     private:
 
       // ----------------------------------------------------------------------


### PR DESCRIPTION
## Change Description

Ports readBufferReturn, Log, LogText, Time were added to GroundInterface
causing UT to break. UT is fix and tests pass now.