### PR TITLE
update: fixes #335

### DIFF
--- a/docs/doxygen/generate_docs.bash
+++ b/docs/doxygen/generate_docs.bash
@@ -50,18 +50,18 @@ function clobber
     cd "${FPRIME}"
     clobber "${DOXY_OUTPUT}"
     (
-        mkdir -p "${FPRIME}/docs-build-for-docs"
-        cd "${FPRIME}/docs-build-for-docs"
+        mkdir -p "${FPRIME}/build-fprime-automatic-docs"
+        cd "${FPRIME}/build-fprime-automatic-docs"
         cmake "${FPRIME}" -DCMAKE_BUILD_TYPE=RELEASE
     )
-    fprime-util build -b "${FPRIME}/docs-build-for-docs" -j32
+    fprime-util build "docs" -j32
     if (( $? != 0 ))
     then
         echo "[ERROR] Failed to build fprime please generate build cache"
         exit 2 
     fi
     ${DOXYGEN} "${FPRIME}/docs/doxygen/Doxyfile"
-    rm -r "${FPRIME}/docs-build-for-docs"
+    rm -r "${FPRIME}/build-fprime-automatic-docs"
 ) || exit 1
 
 # CMake
@@ -75,6 +75,7 @@ function clobber
 # Python
 (
     clobber "${PY_OUTPUT}"
+    pip install sphinx sphinx-rtd-theme sphinx-autoapi sphinx-autoapi recommonmark sphinxcontrib.mermaid
     cd "${FPRIME}/Fw/Python/docs"
     "${FPRIME}/Fw/Python/docs/gendoc.bash"
     cd "${FPRIME}/Gds/docs"


### PR DESCRIPTION
## Change Description

Failing issue of generate_docs.bash when generating doxygen and sphinx is resolved. 

1. The script will use a temporary folder name with a prefix that is used by fprime-util build. 
2. Sphinx dependency packages are checked before attempting to run sphinx.