### PR TITLE
update: fixes #335

### DIFF
--- a/Fw/Python/setup.py
+++ b/Fw/Python/setup.py
@@ -84,7 +84,18 @@ to interact with the data coming from the FSW.
         'Cheetah3;python_version >= "3.0"',
         'Cheetah;python_version < "3.0"',
     ],
-    extras_require={"dev": ["black", "pylama", "pylint", "pre-commit"]},
+    extras_require={"dev": [
+        "black", 
+        "pylama", 
+        "pylint", 
+        "pre-commit",
+        "sphinx",
+        "sphinx-rtd-theme", 
+        "sphinx-autoapi", 
+        "sphinx-autoapi", 
+        "recommonmark",
+        "sphinxcontrib.mermaid"
+    ]},
     # Setup and test requirments, not needed by normal install
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],

--- a/docs/doxygen/generate_docs.bash
+++ b/docs/doxygen/generate_docs.bash
@@ -50,18 +50,18 @@ function clobber
     cd "${FPRIME}"
     clobber "${DOXY_OUTPUT}"
     (
-        mkdir -p "${FPRIME}/docs-build-for-docs"
-        cd "${FPRIME}/docs-build-for-docs"
+        mkdir -p "${FPRIME}/build-fprime-automatic-docs"
+        cd "${FPRIME}/build-fprime-automatic-docs"
         cmake "${FPRIME}" -DCMAKE_BUILD_TYPE=RELEASE
     )
-    fprime-util build -b "${FPRIME}/docs-build-for-docs" -j32
+    fprime-util build "docs" -j32
     if (( $? != 0 ))
     then
         echo "[ERROR] Failed to build fprime please generate build cache"
         exit 2 
     fi
     ${DOXYGEN} "${FPRIME}/docs/doxygen/Doxyfile"
-    rm -r "${FPRIME}/docs-build-for-docs"
+    rm -r "${FPRIME}/build-fprime-automatic-docs"
 ) || exit 1
 
 # CMake


### PR DESCRIPTION
Failing issue of generate_docs.bash when generating doxygen and sphinx is resolved.
The script will use a temporary folder name with a prefix that is used by fprime-util build.

