### PR TITLE
lestarch: adding in Fw::StringUtils

### DIFF
--- a/Fw/Types/CMakeLists.txt
+++ b/Fw/Types/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/SerialBuffer.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/Serializable.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/StringType.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/StringUtils.cpp"
 )
 set(MOD_DEPS
   Fw/Cfg
@@ -30,6 +31,11 @@ set(UT_MOD_DEPS
   "${FPRIME_FRAMEWORK_PATH}/Os"
 )
 register_fprime_ut()
+
+set(UT_SOURCE_FILES
+    "${CMAKE_CURRENT_LIST_DIR}/test/ut/TestStringUtils.cpp"
+)
+register_fprime_ut("Fw_Types_StringUtils")
 
 # Non-test directory
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/GTest")

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -1,0 +1,8 @@
+#include "StringUtils.hpp"
+#include "string.h"
+
+char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 num) {
+    char* returned = strncpy(destination, source, num);
+    destination[num - 1] = '\0';
+    return returned;
+}

--- a/Fw/Types/StringUtils.hpp
+++ b/Fw/Types/StringUtils.hpp
@@ -1,0 +1,26 @@
+#ifndef FW_STRINGUTILS_HPP
+#define FW_STRINGUTILS_HPP
+#include "Fw/Types/BasicTypes.hpp"
+
+namespace Fw {
+namespace StringUtils {
+
+/**
+ * \brief copy string with null-termination guaranteed
+ *
+ * Standard implementations of strncpy fail to guarantee the termination of a
+ * string with the null terminator. This implementation guarantees the string is
+ * properly null-terminated at the possible expense of the last character of the
+ * copied string being lost. The user is responsible for providing a destination
+ * large enough for the content and a null-character. Other behavior retains the
+ * behavior of strncpy.
+ *
+ * \param destination: destination buffer to hold copied contents
+ * \param source: source buffer to read content to copy
+ * \param num: length of destination buffer
+ * \return destination buffer
+ */
+char* string_copy(char* destination, const char* source, U32 num);
+};      // namespace StringUtils
+};      // namespace Fw
+#endif  // FW_STRINGUTILS_HPP

--- a/Fw/Types/test/ut/TestStringUtils.cpp
+++ b/Fw/Types/test/ut/TestStringUtils.cpp
@@ -1,0 +1,61 @@
+//
+// Created by mstarch on 12/7/20.
+//
+#include <gtest/gtest.h>
+#include <string.h>
+#include <Fw/Types/StringUtils.hpp>
+
+TEST(Nominal, string_copy) {
+    const char* copy_string = "abc123\n";  // Length of 7
+    char buffer_out_test[10];
+    char buffer_out_truth[10];
+
+    char* out_truth = ::strncpy(buffer_out_truth, copy_string, sizeof(buffer_out_truth));
+    char* out_test = Fw::StringUtils::string_copy(buffer_out_test, copy_string, sizeof(buffer_out_test));
+
+    ASSERT_EQ(sizeof(buffer_out_truth), sizeof(buffer_out_test)) << "Buffer size mismatch";
+
+    // Check the outputs, both should return the input buffer
+    ASSERT_EQ(out_truth, buffer_out_truth) << "strncpy didn't return expected value";
+    ASSERT_EQ(out_test, buffer_out_test) << "string_copy didn't return expected value";
+
+    // Check string correct
+    ASSERT_STREQ(out_test, copy_string) << "Strings not equal from strncpy";
+    ASSERT_STREQ(out_test, out_truth) << "Copied strings differ from strncpy";
+
+    // Should output 0s for the remaining buffer
+    for (U32 i = ::strnlen(buffer_out_truth, sizeof(buffer_out_truth)); i < static_cast<U32>(sizeof(buffer_out_truth));
+         i++) {
+        ASSERT_EQ(buffer_out_truth[i], 0) << "strncpy didn't output 0 fill";
+        ASSERT_EQ(buffer_out_test[i], 0) << "string_copy didn't output 0 fill";
+    }
+}
+
+TEST(OffNominal, string_copy) {
+    const char* copy_string = "abc123\n";  // Length of 7
+    char buffer_out_test[sizeof(copy_string) - 1];
+    char buffer_out_truth[sizeof(copy_string) - 1];
+
+    char* out_truth = ::strncpy(buffer_out_truth, copy_string, sizeof(buffer_out_truth));
+    char* out_test = Fw::StringUtils::string_copy(buffer_out_test, copy_string, sizeof(buffer_out_test));
+
+    ASSERT_EQ(sizeof(buffer_out_truth), sizeof(buffer_out_test)) << "Buffer size mismatch";
+
+    // Check the outputs, both should return the input buffer
+    ASSERT_EQ(out_truth, buffer_out_truth) << "strncpy didn't return expected value";
+    ASSERT_EQ(out_test, buffer_out_test) << "string_copy didn't return expected value";
+
+    // Check string correct up to last digit
+    U32 i = 0;
+    ASSERT_STRNE(out_test, out_truth) << "Strings not equal";
+    for (i = 0; i < static_cast<U32>(sizeof(copy_string)) - 2; i++) {
+        ASSERT_EQ(out_test[i], out_truth[i]);
+    }
+    ASSERT_EQ(out_truth[i], '\n') << "strncpy did not error as expected";
+    ASSERT_EQ(out_test[i], 0) << "string_copy didn't properly null terminate";
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infrastructure |
|**_Affected Component_**| Fw |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Adds some improvements to Fw including:

1. Fw::StringUtils, a place holding common string code used in multiple places in the framework.


## Rationale


## Testing/Review Recommendations


## Future Work

Note: spinning `fprime-util new` into its own PR. 
