### PR TITLE
Correct link to autocomplete page

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -100,7 +100,7 @@ installation).
 
 ## (Optional) Installing Tab Completion
 
-Several of F´s command line utilities support tab completion. To enable these tools to use it, see the [instructions here](UsersGuide/user/AUTOCOMPLETE.md).
+Several of F´s command line utilities support tab completion. To enable these tools to use it, see the [instructions here](UsersGuide/user/autocomplete.md).
 
 ## Troubleshooting
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Simple update to link to the autocomplete page from the main INSTALL.md page.

## Rationale

Fixes broken link in docs

## Testing/Review Recommendations

N/A

## Future Work

N/A