### PR TITLE
fixing generate_docs.bash to handle modern fprime-util

### DIFF
--- a/docs/doxygen/generate_docs.bash
+++ b/docs/doxygen/generate_docs.bash
@@ -50,18 +50,18 @@ function clobber
     cd "${FPRIME}"
     clobber "${DOXY_OUTPUT}"
     (
-        mkdir -p "${FPRIME}/docs-build-for-docs"
-        cd "${FPRIME}/docs-build-for-docs"
+        mkdir -p "${FPRIME}/build-fprime-automatic-docs"
+        cd "${FPRIME}/build-fprime-automatic-docs"
         cmake "${FPRIME}" -DCMAKE_BUILD_TYPE=RELEASE
     )
-    fprime-util build -b "${FPRIME}/docs-build-for-docs" -j32
+    fprime-util build "docs" -j32
     if (( $? != 0 ))
     then
         echo "[ERROR] Failed to build fprime please generate build cache"
         exit 2 
     fi
     ${DOXYGEN} "${FPRIME}/docs/doxygen/Doxyfile"
-    rm -r "${FPRIME}/docs-build-for-docs"
+    rm -r "${FPRIME}/build-fprime-automatic-docs"
 ) || exit 1
 
 # CMake


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infrastructure |
|**_Affected Component_**| docs |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Minor fix to documentation generation wrapper.

## Rationale



## Testing/Review Recommendations


## Future Work


