### PR TITLE
Fixes spelling error in documentation

### DIFF
--- a/docs/UsersGuide/user/cmd-evt-chn-prm.md
+++ b/docs/UsersGuide/user/cmd-evt-chn-prm.md
@@ -2,7 +2,7 @@
 
 Typically, spacecraft software is controlled through commands, and monitored using a set of events and telemetry
 channels. These are the critical data constructs supported directly by F´ and have built in autocoder support. In
-addition, the F´ `Svc` components handel these types making it easy to define and control an F´ system through commands,
+addition, the F´ `Svc` components handle these types making it easy to define and control an F´ system through commands,
 events, and telemetry channels.
 
 Parameters allow for controlling stored values that effect the operation of an F´ system. They have framework support


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes spelling error in documentation

## Rationale

Handel was a composer. Handle is a verb.

## Testing/Review Recommendations

Read docs, hum Handel.

## Future Work

None
