### PR TITLE
Fix typo

### DIFF
--- a/docs/UsersGuide/guide.md
+++ b/docs/UsersGuide/guide.md
@@ -30,7 +30,7 @@ The API documentation section contains the automatically generated documentation
 ## Table of Contents
 
 - Getting Started with F´
-    - [What is F´: a breif introduction](../index.md)
+    - [What is F´: a brief introduction](../index.md)
     - [Installing F´](../INSTALL.md)
     - [Installing F´ Console Autocomplete](./user/autocomplete.md)
     - [Tutorials: A Hands On Guide to F´](../Tutorials/README.md)


### PR DESCRIPTION
breif -> brief

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixed a typo ("_breif_" instead of "_brief-")