### PR TITLE
Documentation updates for issue 332

### DIFF
--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -1428,13 +1428,19 @@ Next, the test checks for the expected telemetry and events:
 
 The other test cases are similarly implemented for the other operations. See the tutorial code for their implementation.
 
-To build the unit test, type:
+You must first generate the unit test before you can build it. Enter:
+
+```
+fprime-util generate --ut
+```
+
+Once you generate the unit test, you can build the unit test by entering:
 
 ```
 fprime-util build --ut
 ```
 
-The unit test can be run by typing the following in the `MathSender` (not `test/ut`) directory:
+You can run the unit test by typing the following in the `MathSender` (not `test/ut`) directory:
 
 ```shell
 $ fprime-util check

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -2127,7 +2127,7 @@ If running on a different platform, you can specify the build target by typing `
 
 ## 4.1 Running the Ground System
 
-Once the `Ref` example has built successfully, you can run the ground system and executable by entering `fprime-gds -r fprime/Ref`. The ground system GUI should appear.
+Once the `Ref` example has built successfully, you can run the ground system and executable by entering `cd fprime/Ref; fprime-gds`. The ground system GUI should appear.
 
 ### 4.1.1 Executing Commands
 

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -1905,7 +1905,8 @@ The component XML definitions must be imported into the topology file:
 `Ref/Top/RefTopologyAppAi.xml`, line 32:
 
 ```xml
-	<import_component_type>Svc/PassiveTextLogger/PassiveTextLoggerComponentAi.xml</import_component_type>
+	<import_component_type>Svc/PassiveConsoleTextLogger/PassiveTextLoggerComponentAi.xml</import_component_type>
+
 
     <import_component_type>Ref/MathSender/MathSenderComponentAi.xml</import_component_type>
     <import_component_type>Ref/MathReceiver/MathReceiverComponentAi.xml</import_component_type>

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -2127,7 +2127,7 @@ If running on a different platform, you can specify the build target by typing `
 
 ## 4.1 Running the Ground System
 
-Once the `Ref` example has successfully built, the ground system and executable can be run by typing `fprime-gds -d fprime/Ref`. The ground system GUI should appear:
+Once the `Ref` example has built successfully, you can run the ground system and executable by entering `fprime-gds -r fprime/Ref`. The ground system GUI should appear.
 
 ### 4.1.1 Executing Commands
 

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -2119,7 +2119,7 @@ The final connection is the connection that performs the math operation. It goes
    
 ```
 
-Once all the updates to the topology file have been made, the module can be built by typing `fprime-util build` at the command line in the `Ref/Top` directory. 
+Once all the updates to the topology file have been made, the module can be built by typing `fprime-util build` at the command line in the `Ref/` directory. 
 If the updates were correct, the module should compile with no errors. 
 The overall `Ref` deployment can be built by changing to the `Ref` directory and typing `fprime-util build`.
 

--- a/docs/UsersGuide/user/port-comp-top.md
+++ b/docs/UsersGuide/user/port-comp-top.md
@@ -24,7 +24,7 @@ represent the data being conveyed across the port.
 
 A port supports passing arguments across the port's connection in order to pass data to the receiving
 **Component** of an invocation. Some ports may also return data from the receiving **Component** to the invoking
-**Component**. A port may specify zero or more arguments of any D´ data type or primitive (int, float, U8, etc.).
+**Component**. A port may specify zero or more arguments of any F´ data type or primitive (int, float, U8, etc.).
 Pointers and references are allowed as arguments to the port as well (for performance purposes), but care should be
 taken to ensure correct memory management as the ownership of the underlying memory is effectively shared when the
 port is invoked.  The port's type is synonymous with the port invocations' "data_type" when used on a **Component**.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Docs |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| #332, #362, #324 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

This PR aims to resolve all but one outstanding documentation issue in #332. 

## Rationale

@saba-ja 👋🏻 Some updates and questions for you:

1. The broken link was fixed in `devel` by #362.

2. What specific information needs to change for the unit testing tutorial to be accurate?

3. Fix added in this PR.

4. The text appears sufficiently similar between `devel` and `update/ground-prototype` that I've added a fix to `devel` in this PR. Specifically, I added a generate command based on order of operations in the [Ref tutorial](https://github.com/nasa/fprime/blob/devel/Ref/README.md). Please verify for accuracy. 🙇🏻 

5. Fix added in this PR.

6. A [fix](https://github.com/nasa/fprime/issues/171#issuecomment-640099588) doesn't appear in [`devel`](https://github.com/nasa/fprime/blob/devel/docs/Tutorials/MathComponent/Tutorial.md#329-the-math-operation-connection) yet either, so I've added it here.

7. Based on #324, it looks like `-d` was replaced with `-r`. However, unlike #324, substitution fails here:

```sh
fprime/Ref (devel) $ fprime-gds -r
usage: fprime-gds [-h] [-l LOGS] [--log-directly] [-g {none,html}]
                  [--dictionary DICTIONARY] [-c CONFIG] [--tts-port TTS_PORT]
                  [--tts-addr TTS_ADDR] [-n] [--app APP] [-r ROOT_DIR]
                  [--ip-address ADDRESS] [--ip-port PORT]
                  [--comm-adapter {ip}]
fprime-gds: error: argument -r/--root: expected one argument
```
Subsequently:
```sh
fprime/Ref (devel) $ fprime-gds -r .
[ERROR] binary location Darwin/bin does not exist
```
Likewise:
```sh
fprime/Ref (devel) $ cd ..
fprime (devel) $ fprime-gds -r Ref/
[ERROR] binary location Ref/Darwin/bin does not exist
```

Note that `fprime/Ref (devel) $ fprime-gds` appears to work as intended.

Given errors on `Darwin/bin`, it seems like there are non-obvious things happening under the hood. @Joshua-Anderson 👋🏻 Can you please verify whether [this particular command](https://github.com/nasa/fprime/pull/382/files#diff-b5ac4d3af2fe521ce436dae727dbb974004de395712d123343695c7d55a30bd3R2130) requires a flag; and if so, what that flag and syntax should be?

## Testing/Review Recommendations

1. Verify that the [`fprime-util generate --ut` command](https://github.com/nasa/fprime/pull/382/files#diff-b5ac4d3af2fe521ce436dae727dbb974004de395712d123343695c7d55a30bd3R1431-R1435) is correct, and that the overall build procedure succeeds.

2. Verify that a change [inferred](https://github.com/nasa/fprime/pull/382/files#diff-b5ac4d3af2fe521ce436dae727dbb974004de395712d123343695c7d55a30bd3R2122) from #171 is correct for `devel`.

3. Verify the correct syntax for the [ground system build command](https://github.com/nasa/fprime/pull/382/files#diff-b5ac4d3af2fe521ce436dae727dbb974004de395712d123343695c7d55a30bd3R2130).

## Future Work

Rewrite for general clarity and adherence to style guide.
