### PR TITLE
Fix a typo in guide.md

### DIFF
--- a/docs/UsersGuide/guide.md
+++ b/docs/UsersGuide/guide.md
@@ -124,7 +124,7 @@ are automatically generated from this design. These dictionaries are read into t
 
 ## F′ Utility Build Helper and CMake System
 
-F´ ships with a buoild system configured to build the F´ code. This build system is implemented using CMake and handles
+F´ ships with a build system configured to build the F´ code. This build system is implemented using CMake and handles
 the dependencies needed to run the Autocoder and assemble it with user written code. In order to support more standard
 development patterns with F´, the `fprime-util` was built. This tool maps simple commands into the make system in order
 to allow developer to follow set patterns easily.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix a typo in guide.md: “buoild” -> “build”

## Rationale

Documentation fix.

## Testing/Review Recommendations

None.

## Future Work

None.
