### PR TITLE
lestarch: fixing missing autocodes with time role port

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
@@ -973,7 +973,7 @@ namespace ${namespace} {
 
   #end for
 #end if
-#if $has_telemetry or $has_events
+#if $has_telemetry or $has_events or $has_time_get
   // ----------------------------------------------------------------------
   // Time
   // ----------------------------------------------------------------------

--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
@@ -842,7 +842,7 @@ $emit_non_port_params(8, $params)
 
   #end for
 #end if
-#if $has_telemetry or $has_events:
+#if $has_telemetry or $has_events or $has_time_get:
   PROTECTED:
 
     // ----------------------------------------------------------------------

--- a/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
@@ -475,7 +475,7 @@ $emit_cpp_port_params([ $param_callComp, $param_portNum] + $params)
 \#endif
 
   #end if
-  #if $has_events or $has_telemetry:
+  #if $has_events or $has_telemetry or $has_time_get:
   void ${tester_base} ::
     from_${Time_Name}_static(
         Fw::PassiveComponentBase *const component,
@@ -818,7 +818,7 @@ $emit_cpp_params([ $param_instance, $param_cmdSeq ] + $get_command_params($mnemo
   }
 
 #end if
-#if $has_telemetry or $has_events
+#if $has_telemetry or $has_events or $has_time_get
   // ----------------------------------------------------------------------
   // Time
   // ----------------------------------------------------------------------

--- a/Autocoders/Python/src/fprime_ac/generators/templates/test/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/test/hpp.tmpl
@@ -565,7 +565,7 @@ $emit_hpp_params([ $param_const_timeTag, $param_val ])
         *tlmHistory_${name};
 
 #end for
-#if $has_telemetry or $has_events
+#if $has_telemetry or $has_events or $has_time_get
     protected:
 
       // ----------------------------------------------------------------------
@@ -674,7 +674,7 @@ $emit_hpp_port_params([ $param_callComp, $param_portNum] + $params)
 
   #end for
 #end if
-#if $has_telemetry or $has_events
+#if $has_telemetry or $has_events or $has_time_get
     private:
 
       // ----------------------------------------------------------------------

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -442,6 +442,9 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
         c.has_output_ports = len(c.output_ports) > 0
         c.has_typed_output_ports = len(c.typed_output_ports) > 0
         c.has_serial_output_ports = len(c.serial_output_ports) > 0
+        roles = [role for name, ptype, sync, priority, role, max_number in c.output_ports]
+        c.has_time_get = "TimeGet" in roles
+
 
     def initPortIncludes(self, obj, c):
         c.port_includes = list()

--- a/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
@@ -446,6 +446,8 @@ class ComponentWriterBase(AbstractWriter.AbstractWriter):
         c.has_output_ports = len(c.output_ports) > 0
         c.has_typed_output_ports = len(c.typed_output_ports) > 0
         c.has_serial_output_ports = len(c.serial_output_ports) > 0
+        roles = [role for name, ptype, sync, priority, role, max_number in c.output_ports]
+        c.has_time_get = "TimeGet" in roles
 
     def initPortIncludes(self, obj, c):
         c.port_includes = list()

--- a/Autocoders/Python/test/CMakeLists.txt
+++ b/Autocoders/Python/test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/queued1")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/serial_passive")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/serialize_enum")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/serialize_stringbuffer")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/time_get")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/crisscross")
 
 # Template uses a malformed XML file

--- a/Autocoders/Python/test/time_get/CMakeLists.txt
+++ b/Autocoders/Python/test/time_get/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Default module cmake file
+# AUTOCODER_INPUT_FILES: Contains all Autocoder input files
+# SOURCE_FILES: Handcoded C++ source files)
+
+set(SOURCE_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/TimeGetComponentAi.xml"
+  "${CMAKE_CURRENT_LIST_DIR}/TestTimeGetImpl.cpp"
+)
+
+register_fprime_module()
+
+# Sets MODULE_NAME to unique name based on path
+get_module_name(${CMAKE_CURRENT_LIST_DIR})
+
+# Exclude test module from all build
+set_target_properties(
+  ${MODULE_NAME}
+  PROPERTIES
+  EXCLUDE_FROM_ALL TRUE
+)
+
+# Add unit test directory
+# UT_SOURCE_FILES: Sources for unit test
+set(UT_SOURCE_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/TimeGetComponentAi.xml"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/main.cpp"
+)
+register_fprime_ut()
+
+

--- a/Autocoders/Python/test/time_get/TestTimeGetImpl.cpp
+++ b/Autocoders/Python/test/time_get/TestTimeGetImpl.cpp
@@ -1,0 +1,26 @@
+/*
+ * TestCommand1Impl.cpp
+ *
+ *  Created on: Mar 28, 2014
+ *      Author: tcanham
+ */
+
+#include <stdio.h>
+#include "TestTimeGetImpl.hpp"
+
+TimeGetTesterImpl::TimeGetTesterImpl(const char* name) : TimeGet::TimeGetTesterComponentBase(name)
+{
+}
+
+TimeGetTesterImpl::~TimeGetTesterImpl() {
+}
+
+void TimeGetTesterImpl::init(void) {
+    TimeGet::TimeGetTesterComponentBase::init();
+}
+
+void TimeGetTesterImpl::test_time_get_handler() {
+    this->getTime();  // Tests independent getTime() function
+}
+
+

--- a/Autocoders/Python/test/time_get/TestTimeGetImpl.hpp
+++ b/Autocoders/Python/test/time_get/TestTimeGetImpl.hpp
@@ -1,0 +1,22 @@
+/*
+ * TestTelemRecvImpl.hpp
+ *
+ *  Created on: Mar 28, 2014
+ *      Author: tcanham
+ */
+
+#ifndef TESTTEXTLOGIMPL_HPP_
+#define TESTTEXTLOGIMPL_HPP_
+
+#include <Autocoders/Python/test/time_get/TimeGetComponentAc.hpp>
+
+class TimeGetTesterImpl: public TimeGet::TimeGetTesterComponentBase {
+    public:
+        TimeGetTesterImpl(const char* compName);
+        virtual ~TimeGetTesterImpl();
+        void init(void);
+    protected:
+        void test_time_get_handler();
+};
+
+#endif /* TESTTIMEIMPL_HPP_ */

--- a/Autocoders/Python/test/time_get/TimeGetComponentAi.xml
+++ b/Autocoders/Python/test/time_get/TimeGetComponentAi.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?oxygen RNGSchema="file:../xml/ISF_Component_Schema.rnc" type="compact"?>
+
+<component name="TimeGetTester" kind="passive" namespace="TimeGet">
+    <import_port_type>Fw/Time/TimePortAi.xml</import_port_type>
+
+    <comment>A component for testing telemetry</comment>
+    <ports>
+        <port name="Time" kind="output" data_type="Fw::Time" max_number="1" role="TimeGet" />
+    </ports>
+</component>

--- a/Autocoders/Python/test/time_get/test/ut/main.cpp
+++ b/Autocoders/Python/test/time_get/test/ut/main.cpp
@@ -1,0 +1,17 @@
+#include "GTestBase.hpp"
+#include <FpConfig.hpp>
+#include <Autocoders/Python/test/time_get/TestTimeGetImpl.hpp>
+
+// Very minimal to test autocoder. Some day they'll be actual unit test code
+// Here we test to ensure test harness generates correctly
+class ATester : public TimeGet::TimeGetTesterGTestBase {
+    public:
+        ATester(void) : TimeGet::TimeGetTesterGTestBase("comp",10) {}
+};
+
+int main(int argc, char* argv[]) {
+
+    ATester testBase;
+    TimeGetTesterImpl component("name");
+    component.getTime();
+}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| infrastructure |
|**_Affected Component_**| Autocoders |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y  |
|**_Documentation Included (y/n)_**| y  |

---
## Change Description

Adds in autocoding when a time role port is specified by-hand (not only calculated by existence of telemetry or events).

## Rationale

`this->timeGet();` should be available for use when without requiring events or channels such that users may easily request time for other purposes.


## Testing/Review Recommendations

## Future Work
