### PR TITLE
Close Xml files after parsing

### DIFF
--- a/Autocoders/Python/src/fprime_ac/parsers/XmlArrayParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlArrayParser.py
@@ -102,6 +102,7 @@ class XmlArrayParser(object):
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
+        fd.close()
 
         # Validate against current schema. if more are imported later in the process, they will be reevaluated
         relax_file_handler = open(ROOTDIR + self.Config.get("schema", "array"), "r")

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlArrayParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlArrayParser.py
@@ -102,7 +102,7 @@ class XmlArrayParser(object):
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
-        fd.close()
+        fd.close() #Close the file, which is only used for the parsing above
 
         # Validate against current schema. if more are imported later in the process, they will be reevaluated
         relax_file_handler = open(ROOTDIR + self.Config.get("schema", "array"), "r")

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
@@ -103,6 +103,7 @@ class XmlComponentParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
+        fd.close()
 
         # Validate against current schema. if more are imported later in the process, they will be reevaluated
         relax_file_handler = open(ROOTDIR + self.Config.get("schema", "component"))

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
@@ -103,7 +103,7 @@ class XmlComponentParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
-        fd.close()
+        fd.close() #Close the file, which is only used for the parsing above
 
         # Validate against current schema. if more are imported later in the process, they will be reevaluated
         relax_file_handler = open(ROOTDIR + self.Config.get("schema", "component"))

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlEnumParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlEnumParser.py
@@ -72,7 +72,7 @@ class XmlEnumParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
-        fd.close()
+        fd.close() #Close the file, which is only used for the parsing above
 
         # Validate against current schema. if more are imported later in the process, they will be reevaluated
         relax_file_handler = open(ROOTDIR + self.Config.get("schema", "enum"))

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlEnumParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlEnumParser.py
@@ -72,6 +72,7 @@ class XmlEnumParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
+        fd.close()
 
         # Validate against current schema. if more are imported later in the process, they will be reevaluated
         relax_file_handler = open(ROOTDIR + self.Config.get("schema", "enum"))

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlPortsParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlPortsParser.py
@@ -73,6 +73,7 @@ class XmlPortsParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
+        fd.close()
 
         # Validate against schema
         relax_file_handler = open(ROOTDIR + self.__config.get("schema", "interface"))

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlPortsParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlPortsParser.py
@@ -73,7 +73,7 @@ class XmlPortsParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
-        fd.close()
+        fd.close() #Close the file, which is only used for the parsing above        
 
         # Validate against schema
         relax_file_handler = open(ROOTDIR + self.__config.get("schema", "interface"))

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlSerializeParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlSerializeParser.py
@@ -103,7 +103,7 @@ class XmlSerializeParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
-        fd.close()
+        fd.close() #Close the file, which is only used for the parsing above
 
         # Validate new imports using their root tag as a key to find what schema to use
         rng_file = self.__config.get(

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlSerializeParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlSerializeParser.py
@@ -103,6 +103,7 @@ class XmlSerializeParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
+        fd.close()
 
         # Validate new imports using their root tag as a key to find what schema to use
         rng_file = self.__config.get(

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlTopologyParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlTopologyParser.py
@@ -77,6 +77,7 @@ class XmlTopologyParser:
 
         self.__prepend_instance_name = False  # Used to turn off prepending instance name in the situation where instance dicts are being generated and only one instance of an object is created
         element_tree = etree.parse(fd)
+        fd.close()
 
         # Validate against schema
         relax_file_handler = open(ROOTDIR + self.__config.get("schema", "assembly"))

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlTopologyParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlTopologyParser.py
@@ -77,7 +77,7 @@ class XmlTopologyParser:
 
         self.__prepend_instance_name = False  # Used to turn off prepending instance name in the situation where instance dicts are being generated and only one instance of an object is created
         element_tree = etree.parse(fd)
-        fd.close()
+        fd.close() #Close the file, which is only used for the parsing above
 
         # Validate against schema
         relax_file_handler = open(ROOTDIR + self.__config.get("schema", "assembly"))


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|infrastructure |
|**_Affected Component_**|  Autocoders |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**|  y |
|**_Unit Tests Pass (y/n)_**| y  |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Closing the files in the Xml parsers after usage. 

## Rationale

The parsers will otherwise print warnings such as: 
`ResourceWarning: unclosed file <_io.TextIOWrapper name='./test/example/QATopologyAi.xml' mode='r' encoding='cp1252'>
  model = XmlTopologyParser.XmlTopologyParser(topologyFile)
ResourceWarning: Enable tracemalloc to get the object allocation traceback`

## Testing/Review Recommendations

None

## Future Work

None
