### PR TITLE
CLEAN/DOC: fix typos

### DIFF
--- a/Fw/Buffer/Buffer.hpp
+++ b/Fw/Buffer/Buffer.hpp
@@ -99,7 +99,7 @@ public:
     //! serializes the pointer to said data, the size, and context. This is done for efficiency in moving around data,
     //! and is the primary usage of Fw::Buffer. To serialize the wrapped data, use either the data pointer accessor
     //! or the serialize buffer base representation and serialize from that.
-    //! \param serialBuffer: serialze buffer to write data into
+    //! \param serialBuffer: serialize buffer to write data into
     //! \return: status of serialization
     Fw::SerializeStatus serialize(Fw::SerializeBufferBase& serialBuffer) const;
 
@@ -109,7 +109,7 @@ public:
     //! deserializes the pointer to said data, the size, and context. This is done for efficiency in moving around data,
     //! and is the primary usage of Fw::Buffer. To deserialize the wrapped data, use either the data pointer accessor
     //! or the serialize buffer base representation and deserialize from that.
-    //! \param serialBuffer: serialze buffer to read data into
+    //! \param serialBuffer: serialize buffer to read data into
     //! \return: status of serialization
     Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer);
 
@@ -154,7 +154,7 @@ public:
 #endif
 
 #ifdef BUILD_UT
-    //! Supports GTest framework for outputing this type to a stream
+    //! Supports GTest framework for outputting this type to a stream
     //!
     friend std::ostream& operator<<(std::ostream& os, const Buffer& obj);
 #endif

--- a/Fw/Log/docs/sdd.md
+++ b/Fw/Log/docs/sdd.md
@@ -3,7 +3,7 @@
 
 ## 1. Introduction
 
-The `Fw::Log` port is used to pass a serialzed form of an ISF Event. It passes the ID, a time tag, the severity, and a buffer
+The `Fw::Log` port is used to pass a serialized form of an ISF Event. It passes the ID, a time tag, the severity, and a buffer
 containing the serialized arguments of the event. 
 
 The `Fw::LogText` port is used to pass a printable text representation of an ISF Event. It passes the ID, a time tag, 

--- a/Fw/Python/docs/index.rst
+++ b/Fw/Python/docs/index.rst
@@ -3,7 +3,7 @@
 =======================
 
 A flight software and embedded systems framework. This is the automatically generated API
-documentation for the `fprime` python package. This package contains the necesssary types and setup
+documentation for the `fprime` python package. This package contains the necessary types and setup
 to write support code for F´ including both Autocoder functions and Ground Data System packages.
 
 This package also provides the `fprime-util` command line utility used to help build F´ following

--- a/Fw/Python/pylama.cfg
+++ b/Fw/Python/pylama.cfg
@@ -8,7 +8,7 @@ linters = pylint,pyflakes,radon
 
 # You can configure the options for each of the tools pylama includes
 [pylama:pylint]
-# Conventions and Refactor recomendations are disabled for the CI system, but should be turned on when developing code
+# Conventions and Refactor recommendations are disabled for the CI system, but should be turned on when developing code
 # C0301 is line length, as long as you use black to format your code it will be perfect
 # C0330 is incorrect hanging indent, this conflicts with black so we ignore it
 # W0612 is for unused variables, pyflakes reports if a variable is assigned to and still unused which is more useful

--- a/Fw/Python/setup.py
+++ b/Fw/Python/setup.py
@@ -26,7 +26,7 @@ setup(
     # Package Description:
     #
     # Basic package information. Describes the package and the data contained inside. This
-    # information should match the F prime decription information.
+    # information should match the F prime description information.
     ####
     name="fprime",
     version="1.5.3",

--- a/Fw/Python/src/fprime/common/models/serialize/type_exceptions.py
+++ b/Fw/Python/src/fprime/common/models/serialize/type_exceptions.py
@@ -86,7 +86,7 @@ class ArgNotFoundException(TypeException):
 
 
 class NotInitializedException(TypeException):
-    """ Did not intialize types """
+    """ Did not initialize types """
 
     def __init__(self, message):
         super().__init__("Instance %s not initialized!" % message)

--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -40,7 +40,7 @@ namespace Fw {
 }
 
 // Base class for declaring an assert hook
-// Each of the base class functions can be overriden
+// Each of the base class functions can be overridden
 // or used by derived classes.
 
 namespace Fw {

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -886,7 +886,7 @@ TEST(TypesTest,PolyTest) {
 
     // Test assigning to polytype and return type of assignment
     in8 = 21;
-    // Can assign Polytype to U8 via overriden cast operator
+    // Can assign Polytype to U8 via overridden cast operator
     out8 = (pt = in8);
     ASSERT_EQ((U8) pt, (U8) 21);
     ASSERT_EQ((U8) pt, in8);

--- a/Gds/docs/index.rst
+++ b/Gds/docs/index.rst
@@ -3,7 +3,7 @@
 =======================
 
 A flight software and embedded systems framework. This is the automatically generated API
-documentation for the `fprime` python package. This package contains the necesssary types and setup
+documentation for the `fprime` python package. This package contains the necessary types and setup
 to write support code for F´ including both Autocoder functions and Ground Data System packages.
 
 This package also provides the `fprime-util` command line utility used to help build F´ following

--- a/Gds/setup.py
+++ b/Gds/setup.py
@@ -41,7 +41,7 @@ setup(
     # Package Description:
     #
     # Basic package information. Describes the package and the data contained inside. This
-    # information should match the F prime decription information.
+    # information should match the F prime description information.
     ####
     name="fprime_gds",
     version="1.5.0",

--- a/Gds/src/fprime_gds/common/data_types/sys_data.py
+++ b/Gds/src/fprime_gds/common/data_types/sys_data.py
@@ -68,7 +68,7 @@ class SysData:
 
     def to_jsonable(self):
         """
-        Converts to a JSONable object (primatives, anon-objects, lists)
+        Converts to a JSONable object (primitives, anon-objects, lists)
         """
         return fprime_gds.common.utils.jsonable.fprime_to_jsonable(self)
 

--- a/Gds/src/fprime_gds/common/files/downlinker.py
+++ b/Gds/src/fprime_gds/common/files/downlinker.py
@@ -150,7 +150,7 @@ class FileDownlinker(fprime_gds.common.handlers.DataHandler):
         :param data: end packet
         """
         # Initialize all relevant END packet attributes into variables from file_data
-        # hashValue attribute is not relevent right now, but might be in the future
+        # hashValue attribute is not relevant right now, but might be in the future
         if self.state != FileStates.RUNNING:
             LOGGER.warning("Received unexpected END packet")
         else:

--- a/Gds/src/fprime_gds/common/models/common/event.py
+++ b/Gds/src/fprime_gds/common/models/common/event.py
@@ -97,7 +97,7 @@ class Event:
 
     def stringify(self, event_args_list):
         """
-        Return a formated string of event args.
+        Return a formatted string of event args.
         """
         # print event_args_list
         return self.__format_string % tuple(event_args_list[1:])

--- a/Gds/src/fprime_gds/common/parsers/seq_file_parser.py
+++ b/Gds/src/fprime_gds/common/parsers/seq_file_parser.py
@@ -28,7 +28,7 @@ class SeqFileParser:
 
         def removeTrailingComments(string):
             """
-            Remove any trailing comments (proceded by ';') in a string
+            Remove any trailing comments (preceded by ';') in a string
             @param string: the string to perform comment removal on
             @return the string without trailing comments
             """

--- a/Gds/src/fprime_gds/common/templates/data_template.py
+++ b/Gds/src/fprime_gds/common/templates/data_template.py
@@ -35,6 +35,6 @@ class DataTemplate:
 
     def to_jsonable(self):
         """
-        Converts to a JSONable object (primatives, anon-objects, lists)
+        Converts to a JSONable object (primitives, anon-objects, lists)
         """
         return fprime_gds.common.utils.jsonable.fprime_to_jsonable(self)

--- a/Gds/src/fprime_gds/common/testing_fw/api.py
+++ b/Gds/src/fprime_gds/common/testing_fw/api.py
@@ -562,7 +562,7 @@ class IntegrationTestAPI(DataHandler):
         the sequence is completed. The user can specify that await also searches the history by
         specifying a value for start. On timeout, the search will return the list of found
         channel updates regardless of whether the sequence is complete.
-        Note: It is reccomended (but not enforced) not to specify timestamps for this assert.
+        Note: It is recommended (but not enforced) not to specify timestamps for this assert.
         Note: This function will always return a list of updates. The user should check if the
         sequence was completed.
 
@@ -652,7 +652,7 @@ class IntegrationTestAPI(DataHandler):
         A search for a sing sequence of telemetry updates messages. If the history doesn't have the
         complete sequence, the call will await until the sequence is completed or the timeout, at
         which point it will return the list of found channel updates.
-        Note: It is reccomended (but not enforced) not to specify timestamps for this assert.
+        Note: It is recommended (but not enforced) not to specify timestamps for this assert.
         Note: This function will always return a list of updates the user should check if the
         sequence was completed.
 
@@ -801,7 +801,7 @@ class IntegrationTestAPI(DataHandler):
         the sequence is completed. The user can specify that await also searches the history by
         specifying a value for start. On timeout, the search will return the list of found
         event messages regardless of whether the sequence is complete.
-        Note: It is reccomended (but not enforced) not to specify timestamps for this assert.
+        Note: It is recommended (but not enforced) not to specify timestamps for this assert.
         Note: This function will always return a list of events the user should check if the
         sequence was completed.
 
@@ -899,7 +899,7 @@ class IntegrationTestAPI(DataHandler):
         An assert that a sequence of event messages is received. If the history doesn't have the
         complete sequence, the call will await until the sequence is completed or the timeout, at
         which point it will assert failure.
-        Note: It is reccomended (but not enforced) not to specify timestamps for this assert.
+        Note: It is recommended (but not enforced) not to specify timestamps for this assert.
 
         Args:
             events: an ordered list of event specifiers (mnemonic, id, or predicate)

--- a/Gds/src/fprime_gds/flask/static/index.html
+++ b/Gds/src/fprime_gds/flask/static/index.html
@@ -56,7 +56,7 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
             The tabbed component has to primary sections:
 
             1. Navigation, allowing for the changing of tabs in the system
-            2. Tab components only one visable at a time.
+            2. Tab components only one visible at a time.
             -->
             <template id="tabetc-template">
                 <div class="fp-flex-repeater">

--- a/Gds/test/fprime_gds/common/gds_cli/utils_test.py
+++ b/Gds/test/fprime_gds/common/gds_cli/utils_test.py
@@ -162,7 +162,7 @@ def item_template_dictionary():
 
 def t2d(template: DataTemplate) -> SysData:
     """
-    Convers a DataTemplate object to a SysData object
+    Convert a DataTemplate object to a SysData object
     """
     # Currently unable to instantiate SysData, so instantiating PktData instead
     return PktData([], None, template)

--- a/Ref/SignalGen/SignalGen.hpp
+++ b/Ref/SignalGen/SignalGen.hpp
@@ -76,7 +76,7 @@ namespace Ref {
         // Generate the next sample internal helper
         F32 generateSample(U32 ticks);
 
-        // Memeber variables
+        // Member variables
         U32 sampleFrequency;
         U32 signalFrequency;
         F32 signalAmplitude;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN groupadd fprime && \
     mkdir -p /opt/ && chown fprime:fprime /opt/ && \
     git clone --quiet https://github.com/raspberrypi/tools.git /opt/rpi/tools && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-# Change user and group of the virtual environemnt
+# Change user and group of the virtual environment
 # Make fprime user default user
 ENV HOST fprime
 ENV USER fprime

--- a/docs/Tutorials/GettingStarted/Tutorial.md
+++ b/docs/Tutorials/GettingStarted/Tutorial.md
@@ -95,7 +95,7 @@ is a setup step and isn't formally part of the F´ development process.
 
 To run this tool, the developer will use the `generate` subcommand.  It take one optional argument: the toolchain file
 used in CMake to compile for a specific platform.  If not supplied, the `native` toolchain will be used and F´ will be
-setup to run on the current platform (typically Mac OS, or Linux depending on the developer's choosen OS).
+setup to run on the current platform (typically Mac OS, or Linux depending on the developer's chosen OS).
 
 **Generate the Ref Application for Native Compilation**
 

--- a/docs/Tutorials/GpsTutorial/Tutorial.md
+++ b/docs/Tutorials/GpsTutorial/Tutorial.md
@@ -126,7 +126,7 @@ serial driver.
         </port>
         <port name="cmdResponseOut" data_type="Fw::CmdResponse" kind="output" role="CmdResponse" max_number="1">
         </port>
-        <!-- Event ports: send events, and text formated events -->
+        <!-- Event ports: send events, and text formatted events -->
         <port name="eventOut" data_type="Fw::Log"  kind="output" role="LogEvent"  max_number="1">
         </port>
         <port name="textEventOut" data_type="Fw::LogText" kind="output" role="LogTextEvent" max_number="1">
@@ -547,7 +547,7 @@ namespace GpsApp {
           this->serialBufferOut_out(0, serBuffer);
           return;
       }
-      // If not enough data is available for a full messsage, return the buffer and abort.
+      // If not enough data is available for a full message, return the buffer and abort.
       else if (buffsize < 24) {
           // We MUST return the buffer or the serial driver won't be able to reuse it. The same buffer send call is used
           // as we did in "preamble".  Since the buffer's size was overwritten to hold the actual data size, we need to

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -1803,7 +1803,7 @@ Ref::MathSenderComponentImpl mathSender(FW_OPTIONAL_NAME("mathSender"));
 Ref::MathReceiverComponentImpl mathReceiver(FW_OPTIONAL_NAME("mathReceiver"));
 ```
 
-Where the other components are initialzed, add `MathSender` and `MathReceiver`:
+Where the other components are initialized, add `MathSender` and `MathReceiver`:
 
 `Ref/Top/Topology.cpp`, line 286:
 

--- a/docs/UsersGuide/api/python/fprime-gds/html/index.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/index.html
@@ -157,7 +157,7 @@
   <div class="section" id="project-documentation">
 <h1>Fprime-Gds Documentation<a class="headerlink" href="#project-documentation" title="Permalink to this headline">¶</a></h1>
 <p>A flight software and embedded systems framework. This is the automatically generated API
-documentation for the <cite>fprime</cite> python package. This package contains the necesssary types and setup
+documentation for the <cite>fprime</cite> python package. This package contains the necessary types and setup
 to write support code for F´ including both Autocoder functions and Ground Data System packages.</p>
 <p>This package also provides the <cite>fprime-util</cite> command line utility used to help build F´ following
 the recommended development process. This tool simplifies the CMake setup for general use cases

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/GDSChannelFilterDialog.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/GDSChannelFilterDialog.html
@@ -410,7 +410,7 @@
 <div class="viewcode-block" id="ChannelFilterDialog.__del__"><a class="viewcode-back" href="../api/GDSChannelFilterDialog/index.html#GDSChannelFilterDialog.ChannelFilterDialog.__del__">[docs]</a>    <span class="k">def</span> <span class="fm">__del__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="k">pass</span></div>
 
-    <span class="c1"># Virtual event handlers, overide them in your derived class</span>
+    <span class="c1"># Virtual event handlers, override them in your derived class</span>
 <div class="viewcode-block" id="ChannelFilterDialog.onCloseChannelFilterDialog"><a class="viewcode-back" href="../api/GDSChannelFilterDialog/index.html#GDSChannelFilterDialog.ChannelFilterDialog.onCloseChannelFilterDialog">[docs]</a>    <span class="k">def</span> <span class="nf">onCloseChannelFilterDialog</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">event</span><span class="p">):</span>
         <span class="n">event</span><span class="o">.</span><span class="n">Skip</span><span class="p">()</span></div>
 

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/GDSChannelTelemetryPanelGUI.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/GDSChannelTelemetryPanelGUI.html
@@ -279,7 +279,7 @@
 <div class="viewcode-block" id="ChannelTelemetry.__del__"><a class="viewcode-back" href="../api/GDSChannelTelemetryPanelGUI/index.html#GDSChannelTelemetryPanelGUI.ChannelTelemetry.__del__">[docs]</a>    <span class="k">def</span> <span class="fm">__del__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="k">pass</span></div>
 
-    <span class="c1"># Virtual event handlers, overide them in your derived class</span>
+    <span class="c1"># Virtual event handlers, override them in your derived class</span>
 <div class="viewcode-block" id="ChannelTelemetry.onChannelTelemContextMenu"><a class="viewcode-back" href="../api/GDSChannelTelemetryPanelGUI/index.html#GDSChannelTelemetryPanelGUI.ChannelTelemetry.onChannelTelemContextMenu">[docs]</a>    <span class="k">def</span> <span class="nf">onChannelTelemContextMenu</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">event</span><span class="p">):</span>
         <span class="n">event</span><span class="o">.</span><span class="n">Skip</span><span class="p">()</span></div>
 

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/GDSCommandPanelGUI.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/GDSCommandPanelGUI.html
@@ -396,7 +396,7 @@
 <div class="viewcode-block" id="Commands.__del__"><a class="viewcode-back" href="../api/GDSCommandPanelGUI/index.html#GDSCommandPanelGUI.Commands.__del__">[docs]</a>    <span class="k">def</span> <span class="fm">__del__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="k">pass</span></div>
 
-    <span class="c1"># Virtual event handlers, overide them in your derived class</span>
+    <span class="c1"># Virtual event handlers, override them in your derived class</span>
 <div class="viewcode-block" id="Commands.onCharCmdComboBox"><a class="viewcode-back" href="../api/GDSCommandPanelGUI/index.html#GDSCommandPanelGUI.Commands.onCharCmdComboBox">[docs]</a>    <span class="k">def</span> <span class="nf">onCharCmdComboBox</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">event</span><span class="p">):</span>
         <span class="n">event</span><span class="o">.</span><span class="n">Skip</span><span class="p">()</span></div>
 

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/GDSLogEventPanelGUI.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/GDSLogEventPanelGUI.html
@@ -315,7 +315,7 @@
 <div class="viewcode-block" id="LogEvents.__del__"><a class="viewcode-back" href="../api/GDSLogEventPanelGUI/index.html#GDSLogEventPanelGUI.LogEvents.__del__">[docs]</a>    <span class="k">def</span> <span class="fm">__del__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="k">pass</span></div>
 
-    <span class="c1"># Virtual event handlers, overide them in your derived class</span>
+    <span class="c1"># Virtual event handlers, override them in your derived class</span>
 <div class="viewcode-block" id="LogEvents.onLogEventDataViewContextMenu"><a class="viewcode-back" href="../api/GDSLogEventPanelGUI/index.html#GDSLogEventPanelGUI.LogEvents.onLogEventDataViewContextMenu">[docs]</a>    <span class="k">def</span> <span class="nf">onLogEventDataViewContextMenu</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">event</span><span class="p">):</span>
         <span class="n">event</span><span class="o">.</span><span class="n">Skip</span><span class="p">()</span></div>
 

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/GDSMainFrameGUI.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/GDSMainFrameGUI.html
@@ -263,7 +263,7 @@
 <div class="viewcode-block" id="MainFrame.__del__"><a class="viewcode-back" href="../api/GDSMainFrameGUI/index.html#GDSMainFrameGUI.MainFrame.__del__">[docs]</a>    <span class="k">def</span> <span class="fm">__del__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="k">pass</span></div>
 
-    <span class="c1"># Virtual event handlers, overide them in your derived class</span>
+    <span class="c1"># Virtual event handlers, override them in your derived class</span>
 <div class="viewcode-block" id="MainFrame.onNewMenuItemClick"><a class="viewcode-back" href="../api/GDSMainFrameGUI/index.html#GDSMainFrameGUI.MainFrame.onNewMenuItemClick">[docs]</a>    <span class="k">def</span> <span class="nf">onNewMenuItemClick</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">event</span><span class="p">):</span>
         <span class="n">event</span><span class="o">.</span><span class="n">Skip</span><span class="p">()</span></div>
 

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/PexpectRunnerConsol.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/PexpectRunnerConsol.html
@@ -205,7 +205,7 @@
 <div class="viewcode-block" id="PexpectRunnerGUI.__del__"><a class="viewcode-back" href="../api/PexpectRunnerConsol/index.html#PexpectRunnerConsol.PexpectRunnerGUI.__del__">[docs]</a>    <span class="k">def</span> <span class="fm">__del__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="k">pass</span></div>
 
-    <span class="c1"># Virtual event handlers, overide them in your derived class</span>
+    <span class="c1"># Virtual event handlers, override them in your derived class</span>
 <div class="viewcode-block" id="PexpectRunnerGUI.onWindowClose"><a class="viewcode-back" href="../api/PexpectRunnerConsol/index.html#PexpectRunnerConsol.PexpectRunnerGUI.onWindowClose">[docs]</a>    <span class="k">def</span> <span class="nf">onWindowClose</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">event</span><span class="p">):</span>
         <span class="n">event</span><span class="o">.</span><span class="n">Skip</span><span class="p">()</span></div>
 

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/data_types/sys_data.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/data_types/sys_data.html
@@ -224,7 +224,7 @@
 
 <div class="viewcode-block" id="SysData.to_jsonable"><a class="viewcode-back" href="../../../../api/fprime_gds/common/data_types/sys_data/index.html#fprime_gds.common.data_types.sys_data.SysData.to_jsonable">[docs]</a>    <span class="k">def</span> <span class="nf">to_jsonable</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Converts to a JSONable object (primatives, anon-objects, lists)</span>
+<span class="sd">        Converts to a JSONable object (primitives, anon-objects, lists)</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="k">return</span> <span class="n">fprime_gds</span><span class="o">.</span><span class="n">common</span><span class="o">.</span><span class="n">utils</span><span class="o">.</span><span class="n">jsonable</span><span class="o">.</span><span class="n">fprime_to_jsonable</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span></div>
 

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/decoders/pkt_decoder.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/decoders/pkt_decoder.html
@@ -190,7 +190,7 @@
 <span class="sd">        Args:</span>
 <span class="sd">            pkt_name_dict: (dict) Packet dictionary. Pkt names should be keys</span>
 <span class="sd">                                  and PktTemplate objects should be values</span>
-<span class="sd">            ch_dict: (dict) Channel dictionary. Channel ids shoudl be keys and</span>
+<span class="sd">            ch_dict: (dict) Channel dictionary. Channel ids should be keys and</span>
 <span class="sd">                            ChTemplate objects should be values</span>
 
 <span class="sd">        Returns:</span>

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/files/downlinker.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/files/downlinker.html
@@ -306,7 +306,7 @@
 <span class="sd">        :param data: end packet</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="c1"># Initialize all relevant END packet attributes into varibles from file_data</span>
-        <span class="c1"># hashValue attribute is not relevent right now, but might be in the future</span>
+        <span class="c1"># hashValue attribute is not relevant right now, but might be in the future</span>
         <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">state</span> <span class="o">!=</span> <span class="n">FileStates</span><span class="o">.</span><span class="n">RUNNING</span><span class="p">:</span>
             <span class="n">LOGGER</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Received unexpected END packet&quot;</span><span class="p">)</span>
         <span class="k">else</span><span class="p">:</span>

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/files/uplinker.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/files/uplinker.html
@@ -266,7 +266,7 @@
                 <span class="k">if</span> <span class="n">file_obj</span> <span class="ow">is</span> <span class="kc">None</span> <span class="ow">or</span> <span class="ow">not</span> <span class="bp">self</span><span class="o">.</span><span class="n">running</span><span class="p">:</span>
                     <span class="bp">self</span><span class="o">.</span><span class="n">queue</span><span class="o">.</span><span class="n">put</span><span class="p">(</span><span class="n">file_obj</span><span class="p">)</span>
                     <span class="k">break</span>
-                <span class="c1"># Once a file is obtained from the queue, aquire the busy lock before starting. This prevents a in-use</span>
+                <span class="c1"># Once a file is obtained from the queue, acquire the busy lock before starting. This prevents a in-use</span>
                 <span class="c1"># or paused queue from uplinking.</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">busy</span><span class="o">.</span><span class="n">acquire</span><span class="p">()</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">uplinker</span><span class="o">.</span><span class="n">start</span><span class="p">(</span><span class="n">file_obj</span><span class="p">)</span>

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/models/common/command.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/models/common/command.html
@@ -296,7 +296,7 @@
 <span class="sd">        Method to set up an argument value of any</span>
 <span class="sd">        of the types specified in serialize package.</span>
 <span class="sd">        @param arg_name: string name of the argument.</span>
-<span class="sd">        @param arg_type: object type to store arugment value in.</span>
+<span class="sd">        @param arg_type: object type to store argument value in.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="c1">### double check argument types</span>
         <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">arg_name</span><span class="p">,</span> <span class="nb">str</span><span class="p">):</span>

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/models/common/event.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/models/common/event.html
@@ -253,7 +253,7 @@
 
 <div class="viewcode-block" id="Event.stringify"><a class="viewcode-back" href="../../../../../api/fprime_gds/common/models/common/event/index.html#fprime_gds.common.models.common.event.Event.stringify">[docs]</a>    <span class="k">def</span> <span class="nf">stringify</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">event_args_list</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Return a formated string of event args.</span>
+<span class="sd">        Return a formatted string of event args.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="c1"># print event_args_list</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__format_string</span> <span class="o">%</span> <span class="nb">tuple</span><span class="p">(</span><span class="n">event_args_list</span><span class="p">[</span><span class="mi">1</span><span class="p">:])</span></div>

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/parsers/seq_file_parser.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/parsers/seq_file_parser.html
@@ -184,7 +184,7 @@
 
         <span class="k">def</span> <span class="nf">removeTrailingComments</span><span class="p">(</span><span class="n">string</span><span class="p">):</span>
             <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Remove any trailing comments (proceded by &#39;;&#39;) in a string</span>
+<span class="sd">            Remove any trailing comments (preceded by &#39;;&#39;) in a string</span>
 <span class="sd">            @param string: the string to perform comment removal on</span>
 <span class="sd">            @return the string without trailing comments</span>
 <span class="sd">            &quot;&quot;&quot;</span>

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/pipeline/router.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/pipeline/router.html
@@ -185,7 +185,7 @@
 <div class="viewcode-block" id="OutgoingRouter.data_callback"><a class="viewcode-back" href="../../../../api/fprime_gds/common/pipeline/router/index.html#fprime_gds.common.pipeline.router.OutgoingRouter.data_callback">[docs]</a>    <span class="k">def</span> <span class="nf">data_callback</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">data</span><span class="p">,</span> <span class="n">sender</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Handles incoming data by stamping on a handshake token to be passed back in the handshake packet. This reads</span>
-<span class="sd">        from the sender parameter to creat this token, otherwise &quot;0000&quot; is sent out.</span>
+<span class="sd">        from the sender parameter to create this token, otherwise &quot;0000&quot; is sent out.</span>
 
 <span class="sd">        :param data: encoded data to be prepended to</span>
 <span class="sd">        :param sender: sender to append to.</span>
@@ -209,7 +209,7 @@
 <div class="viewcode-block" id="IncomingRouter.data_callback"><a class="viewcode-back" href="../../../../api/fprime_gds/common/pipeline/router/index.html#fprime_gds.common.pipeline.router.IncomingRouter.data_callback">[docs]</a>    <span class="k">def</span> <span class="nf">data_callback</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">data</span><span class="p">,</span> <span class="n">sender</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Handles incoming data by stamping on a handshake token to be passed back in the handshake packet. This reads</span>
-<span class="sd">        from the sender parameter to creat this token, otherwise &quot;0000&quot; is sent out.</span>
+<span class="sd">        from the sender parameter to create this token, otherwise &quot;0000&quot; is sent out.</span>
 
 <span class="sd">        :param data: encoded data to be prepended to</span>
 <span class="sd">        :param sender: sender id to append to.</span>

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/templates/data_template.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/common/templates/data_template.html
@@ -191,7 +191,7 @@
 
 <div class="viewcode-block" id="DataTemplate.to_jsonable"><a class="viewcode-back" href="../../../../api/fprime_gds/common/templates/data_template/index.html#fprime_gds.common.templates.data_template.DataTemplate.to_jsonable">[docs]</a>    <span class="k">def</span> <span class="nf">to_jsonable</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Converts to a JSONable object (primatives, anon-objects, lists)</span>
+<span class="sd">        Converts to a JSONable object (primitives, anon-objects, lists)</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="k">return</span> <span class="n">fprime_gds</span><span class="o">.</span><span class="n">common</span><span class="o">.</span><span class="n">utils</span><span class="o">.</span><span class="n">jsonable</span><span class="o">.</span><span class="n">fprime_to_jsonable</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span></div></div>
 </pre></div>

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/executables/tcpserver.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/executables/tcpserver.html
@@ -201,7 +201,7 @@
 <div class="viewcode-block" id="ThreadedTCPRequestHandler"><a class="viewcode-back" href="../../../api/fprime_gds/executables/tcpserver/index.html#fprime_gds.executables.tcpserver.ThreadedTCPRequestHandler">[docs]</a><span class="k">class</span> <span class="nc">ThreadedTCPRequestHandler</span><span class="p">(</span><span class="n">socketserver</span><span class="o">.</span><span class="n">StreamRequestHandler</span><span class="p">):</span>
     <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">    Derived from original Stable demo during R&amp;TD and adapted</span>
-<span class="sd">    for use in new FSW gse.py applicaiton.</span>
+<span class="sd">    for use in new FSW gse.py application.</span>
 
 <span class="sd">    TCP socket server for commands, log events, and telemetry data.</span>
 <span class="sd">    Later this will handle other things such as sequence files and parameters.</span>
@@ -484,7 +484,7 @@
 <div class="viewcode-block" id="ThreadedUDPRequestHandler"><a class="viewcode-back" href="../../../api/fprime_gds/executables/tcpserver/index.html#fprime_gds.executables.tcpserver.ThreadedUDPRequestHandler">[docs]</a><span class="k">class</span> <span class="nc">ThreadedUDPRequestHandler</span><span class="p">(</span><span class="n">socketserver</span><span class="o">.</span><span class="n">BaseRequestHandler</span><span class="p">):</span>
     <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">    Derived from original Stable demo during R&amp;TD and adapted</span>
-<span class="sd">    for use in new FSW gse.py applicaiton.</span>
+<span class="sd">    for use in new FSW gse.py application.</span>
 
 <span class="sd">    TCP socket server for commands, log events, and telemetry data.</span>
 <span class="sd">    Later this will handle other things such as sequence files and parameters.</span>

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/wxgui/src/GDSArgItemComboBox.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/wxgui/src/GDSArgItemComboBox.html
@@ -159,7 +159,7 @@
 
 <div class="viewcode-block" id="ArgItemComboBox"><a class="viewcode-back" href="../../../../api/fprime_gds/wxgui/src/GDSArgItemComboBox/index.html#fprime_gds.wxgui.src.GDSArgItemComboBox.ArgItemComboBox">[docs]</a><span class="k">class</span> <span class="nc">ArgItemComboBox</span><span class="p">(</span><span class="n">wx</span><span class="o">.</span><span class="n">Panel</span><span class="p">):</span>
 
-    <span class="sd">&quot;&quot;&quot;Defines the GUI and funcitonality for the GUI element which accepts command arguments with a wx.ComboBox&quot;&quot;&quot;</span>
+    <span class="sd">&quot;&quot;&quot;Defines the GUI and functionality for the GUI element which accepts command arguments with a wx.ComboBox&quot;&quot;&quot;</span>
 
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">parent</span><span class="p">,</span> <span class="n">combo_options</span><span class="p">,</span> <span class="n">label</span><span class="p">,</span> <span class="n">validator</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;ArgItemComboBox constructor</span>

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/wxgui/src/GDSArgItemTextCtl.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/wxgui/src/GDSArgItemTextCtl.html
@@ -158,14 +158,14 @@
 
 
 <div class="viewcode-block" id="ArgItemTextCtl"><a class="viewcode-back" href="../../../../api/fprime_gds/wxgui/src/GDSArgItemTextCtl/index.html#fprime_gds.wxgui.src.GDSArgItemTextCtl.ArgItemTextCtl">[docs]</a><span class="k">class</span> <span class="nc">ArgItemTextCtl</span><span class="p">(</span><span class="n">wx</span><span class="o">.</span><span class="n">Panel</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;Defines the GUI and funcitonality for the GUI element which accepts command arguments with a wx.TextCtrl&quot;&quot;&quot;</span>
+    <span class="sd">&quot;&quot;&quot;Defines the GUI and functionality for the GUI element which accepts command arguments with a wx.TextCtrl&quot;&quot;&quot;</span>
 
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">parent</span><span class="p">,</span> <span class="n">validator</span><span class="p">,</span> <span class="n">label</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;ArgItemTextCtl constructor</span>
 
 <span class="sd">        Arguments:</span>
 <span class="sd">                parent {wx.Window} -- The parent window for this UI element</span>
-<span class="sd">                validator {wx.Validator} -- Validator object that will check if the TextCtrl entry is formated correctly</span>
+<span class="sd">                validator {wx.Validator} -- Validator object that will check if the TextCtrl entry is formatted correctly</span>
 <span class="sd">                label {string} -- Label for this GUI element. Usually the name of the argument.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
 

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/wxgui/src/GDSCommandPanelGUI.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/wxgui/src/GDSCommandPanelGUI.html
@@ -397,7 +397,7 @@
 <div class="viewcode-block" id="Commands.__del__"><a class="viewcode-back" href="../../../../api/fprime_gds/wxgui/src/GDSCommandPanelGUI/index.html#fprime_gds.wxgui.src.GDSCommandPanelGUI.Commands.__del__">[docs]</a>    <span class="k">def</span> <span class="fm">__del__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="k">pass</span></div>
 
-    <span class="c1"># Virtual event handlers, overide them in your derived class</span>
+    <span class="c1"># Virtual event handlers, override them in your derived class</span>
 <div class="viewcode-block" id="Commands.onCharCmdComboBox"><a class="viewcode-back" href="../../../../api/fprime_gds/wxgui/src/GDSCommandPanelGUI/index.html#fprime_gds.wxgui.src.GDSCommandPanelGUI.Commands.onCharCmdComboBox">[docs]</a>    <span class="k">def</span> <span class="nf">onCharCmdComboBox</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">event</span><span class="p">):</span>
         <span class="n">event</span><span class="o">.</span><span class="n">Skip</span><span class="p">()</span></div>
 

--- a/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/wxgui/tools/PexpectRunnerConsolGUI.html
+++ b/docs/UsersGuide/api/python/fprime-gds/html/modules/fprime_gds/wxgui/tools/PexpectRunnerConsolGUI.html
@@ -209,7 +209,7 @@
 <div class="viewcode-block" id="PexpectRunnerGUI.__del__"><a class="viewcode-back" href="../../../../api/fprime_gds/wxgui/tools/PexpectRunnerConsolGUI/index.html#fprime_gds.wxgui.tools.PexpectRunnerConsolGUI.PexpectRunnerGUI.__del__">[docs]</a>    <span class="k">def</span> <span class="fm">__del__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="k">pass</span></div>
 
-    <span class="c1"># Virtual event handlers, overide them in your derived class</span>
+    <span class="c1"># Virtual event handlers, override them in your derived class</span>
 <div class="viewcode-block" id="PexpectRunnerGUI.onWindowClose"><a class="viewcode-back" href="../../../../api/fprime_gds/wxgui/tools/PexpectRunnerConsolGUI/index.html#fprime_gds.wxgui.tools.PexpectRunnerConsolGUI.PexpectRunnerGUI.onWindowClose">[docs]</a>    <span class="k">def</span> <span class="nf">onWindowClose</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">event</span><span class="p">):</span>
         <span class="n">event</span><span class="o">.</span><span class="n">Skip</span><span class="p">()</span></div>
 

--- a/docs/UsersGuide/api/python/fprime/html/api/fprime/common/models/serialize/type_exceptions/index.html
+++ b/docs/UsersGuide/api/python/fprime/html/api/fprime/common/models/serialize/type_exceptions/index.html
@@ -257,7 +257,7 @@
 <dt id="fprime.common.models.serialize.type_exceptions.NotInitializedException">
 <em class="property">exception </em><code class="sig-prename descclassname">fprime.common.models.serialize.type_exceptions.</code><code class="sig-name descname">NotInitializedException</code><span class="sig-paren">(</span><em class="sig-param"><span class="n">message</span></em><span class="sig-paren">)</span><a class="reference internal" href="../../../../../../modules/fprime/common/models/serialize/type_exceptions.html#NotInitializedException"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#fprime.common.models.serialize.type_exceptions.NotInitializedException" title="Permalink to this definition">¶</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#fprime.common.models.serialize.type_exceptions.TypeException" title="fprime.common.models.serialize.type_exceptions.TypeException"><code class="xref py py-class docutils literal notranslate"><span class="pre">fprime.common.models.serialize.type_exceptions.TypeException</span></code></a></p>
-<p>Did not intialize types</p>
+<p>Did not initialize types</p>
 </dd></dl>
 
 <dl class="py exception">

--- a/docs/UsersGuide/api/python/fprime/html/index.html
+++ b/docs/UsersGuide/api/python/fprime/html/index.html
@@ -157,7 +157,7 @@
   <div class="section" id="project-documentation">
 <h1>Fprime Documentation<a class="headerlink" href="#project-documentation" title="Permalink to this headline">¶</a></h1>
 <p>A flight software and embedded systems framework. This is the automatically generated API
-documentation for the <cite>fprime</cite> python package. This package contains the necesssary types and setup
+documentation for the <cite>fprime</cite> python package. This package contains the necessary types and setup
 to write support code for F´ including both Autocoder functions and Ground Data System packages.</p>
 <p>This package also provides the <cite>fprime-util</cite> command line utility used to help build F´ following
 the recommended development process. This tool simplifies the CMake setup for general use cases

--- a/docs/UsersGuide/api/python/fprime/html/modules/fprime/common/models/serialize/type_exceptions.html
+++ b/docs/UsersGuide/api/python/fprime/html/modules/fprime/common/models/serialize/type_exceptions.html
@@ -240,7 +240,7 @@
 
 
 <div class="viewcode-block" id="NotInitializedException"><a class="viewcode-back" href="../../../../../api/fprime/common/models/serialize/type_exceptions/index.html#fprime.common.models.serialize.type_exceptions.NotInitializedException">[docs]</a><span class="k">class</span> <span class="nc">NotInitializedException</span><span class="p">(</span><span class="n">TypeException</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot; Did not intialize types &quot;&quot;&quot;</span>
+    <span class="sd">&quot;&quot;&quot; Did not initialize types &quot;&quot;&quot;</span>
 
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">message</span><span class="p">):</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="s2">&quot;Instance </span><span class="si">%s</span><span class="s2"> not initialized!&quot;</span> <span class="o">%</span> <span class="n">message</span><span class="p">)</span></div>

--- a/docs/UsersGuide/api/python/fprime/html/sources/api/fprime/common/models/serialize/type_exceptions/index.rst.txt
+++ b/docs/UsersGuide/api/python/fprime/html/sources/api/fprime/common/models/serialize/type_exceptions/index.rst.txt
@@ -87,7 +87,7 @@ Module Contents
 
    Bases: :class:`fprime.common.models.serialize.type_exceptions.TypeException`
 
-   Did not intialize types
+   Did not initialize types
 
 
 .. py:exception:: NotOverridenException(message)

--- a/docs/UsersGuide/api/python/fprime/html/sources/index.rst.txt
+++ b/docs/UsersGuide/api/python/fprime/html/sources/index.rst.txt
@@ -3,7 +3,7 @@
 =======================
 
 A flight software and embedded systems framework. This is the automatically generated API
-documentation for the `fprime` python package. This package contains the necesssary types and setup
+documentation for the `fprime` python package. This package contains the necessary types and setup
 to write support code for F´ including both Autocoder functions and Ground Data System packages.
 
 This package also provides the `fprime-util` command line utility used to help build F´ following

--- a/docs/UsersGuide/cmake/Customization.md
+++ b/docs/UsersGuide/cmake/Customization.md
@@ -8,7 +8,7 @@ advice on how to configure standard customization items as part of this CMake sy
 can be done using standard CMake patterns. Thus, the user is encouraged to study CMake if advice
 cannot be found herein.
 
-## Build F Prime Utilites
+## Build F Prime Utilities
 
 Adding a utility executable that dependns on F prime code is easy. Just perform a standard call to
 `register_fprime_executable`. Care should be taken to set the variable `EXECUTABLE_NAME` before

--- a/docs/UsersGuide/cmake/Migration.md
+++ b/docs/UsersGuide/cmake/Migration.md
@@ -43,7 +43,7 @@ A guide to the API function calls is found here: [API](API.md)
 
 ## Creating Deployments
 
-Deployments in the new F prime system must now specifiy a `CMakeLists.txt` following a specific
+Deployments in the new F prime system must now specify a `CMakeLists.txt` following a specific
 format in order to act as a build entry point. This file includes the F prime make system, acts as
 a target for the CMake command, and sets up basic project information. This file may also add other
 subdirectories to pull in deployment specific modules, and is placed at top-level in the deployment

--- a/docs/UsersGuide/dev/configuring-fprime.md
+++ b/docs/UsersGuide/dev/configuring-fprime.md
@@ -64,7 +64,7 @@ setting = 123; Comment
 
 Some configurations may be changed during compilation time. The F′ framework has a number of optional features that can
 be enabled or disabled by editing the `config/FpConfig.hpp` file.  These changes affect of the whole of the F´
-deployment. Users can change or override defined *C* macro values that activate or disable code by using complier flags
+deployment. Users can change or override defined *C* macro values that activate or disable code by using compiler flags
 for different deployment settings. During flight software (FSW) execution, disabling unnecessary features saves memory
 and CPU cycles.
 

--- a/docs/UsersGuide/dev/os-docs.md
+++ b/docs/UsersGuide/dev/os-docs.md
@@ -211,7 +211,7 @@ remove  directories etc.
 This class definition can be found in **Os/Log.hpp**. It is an interface to
 a system logging facility. It is meant to abstract the VxWorks logging
 facility.  It is a subclass of `Fw::Logger` and thus must be registered after construction.  Compiling in
-**Os/LogDefault.cpp** into your deployment will automatically creat an **Os::Log** and register it.
+**Os/LogDefault.cpp** into your deployment will automatically create an **Os::Log** and register it.
 Table 30 provides the methods and their descriptions.
 
 **Table 30.** Log method descriptions.

--- a/docs/UsersGuide/dev/testAPI/markdown/integration_test_api.md
+++ b/docs/UsersGuide/dev/testAPI/markdown/integration_test_api.md
@@ -345,7 +345,7 @@ A search for a sequence of telemetry updates. By default, the call will only awa
 the sequence is completed. The user can specify that await also searches the history by
 specifying a value for start. On timeout, the search will return the list of found
 channel updates regardless of whether the sequence is complete.
-Note: It is reccomended (but not enforced) not to specify timestamps for this assert.
+Note: It is recommended (but not enforced) not to specify timestamps for this assert.
 Note: This function will always return a list of updates. The user should check if the
 sequence was completed.
 
@@ -405,7 +405,7 @@ Returns:
 A search for a sing sequence of telemetry updates messages. If the history doesn’t have the
 complete sequence, the call will await until the sequence is completed or the timeout, at
 which point it will return the list of found channel updates.
-Note: It is reccomended (but not enforced) not to specify timestamps for this assert.
+Note: It is recommended (but not enforced) not to specify timestamps for this assert.
 Note: This function will always return a list of updates the user should check if the
 sequence was completed.
 
@@ -499,7 +499,7 @@ A search for a sequence of event messages. By default, the call will only await 
 the sequence is completed. The user can specify that await also searches the history by
 specifying a value for start. On timeout, the search will return the list of found
 event messages regardless of whether the sequence is complete.
-Note: It is reccomended (but not enforced) not to specify timestamps for this assert.
+Note: It is recommended (but not enforced) not to specify timestamps for this assert.
 Note: This function will always return a list of events the user should check if the
 sequence was completed.
 
@@ -560,7 +560,7 @@ Returns:
 An assert that a sequence of event messages is received. If the history doesn’t have the
 complete sequence, the call will await until the sequence is completed or the timeout, at
 which point it will assert failure.
-Note: It is reccomended (but not enforced) not to specify timestamps for this assert.
+Note: It is recommended (but not enforced) not to specify timestamps for this assert.
 
 Args:
 

--- a/docs/UsersGuide/gds/gds-cli.md
+++ b/docs/UsersGuide/gds/gds-cli.md
@@ -208,7 +208,7 @@ completion enabled, you can also double-tap tab to view a list of potential comm
 
 ## Command Details
 
-Each command's available interface is shown below for referece.  When in doubt use the `--help`  flag with the command
+Each command's available interface is shown below for reference.  When in doubt use the `--help`  flag with the command
 directly.
 
 ### `channels`
@@ -353,4 +353,4 @@ optional arguments:
 ## Conclusion
 
 The user should now be able to successfully use the GDS cli to connect to a running GDS, send commands, receive events
-and telemetry, and filter the results to be managable.  All this is done through the command line using this tool.
+and telemetry, and filter the results to be manageable.  All this is done through the command line using this tool.

--- a/docs/UsersGuide/gds/gds-custom-addons.md
+++ b/docs/UsersGuide/gds/gds-custom-addons.md
@@ -74,7 +74,7 @@ Available data from `_datastore` is described in the following table
 
 | Item | Type | Description |
 |---|---|---|
-| events    | list | List of events recieved |
+| events    | list | List of events received |
 | channels  | dict | Channel id to last received reading |
 | upfiles   | list | List of uplinked file objects |
 | downfiles | list | List of downlinked file objects |

--- a/docs/UsersGuide/gds/gds-introduction.md
+++ b/docs/UsersGuide/gds/gds-introduction.md
@@ -207,7 +207,7 @@ click that button. This new window will connect to the same backend as the first
 At the very top-right, there should be a green circle or a red X representing the GUI's connection status. A green
 circle means that data is still flowing from the embedded system, while a red X means the embedded system is currently
 disconnected and not sending/receiving any data. This is reset to an X via timeout, so you may need to configure that
-timeout in the `config.js` file.  This widget is fondly refered to as "the orb" as it quickly shows if there is data
+timeout in the `config.js` file.  This widget is fondly referred to as "the orb" as it quickly shows if there is data
 flow from the embedded F´ system.
 
 There's also a NASA logo on the far left. It doesn't do anything right now, but hopefully the meatball continues to

--- a/docs/UsersGuide/gds/seqgen.md
+++ b/docs/UsersGuide/gds/seqgen.md
@@ -27,7 +27,7 @@ R01:00:01.050 CMD_NO_OP_STRING "Awesome string!" ; And a nice comment too
 ```
 
 A list of these commands can be specified in a text file typically ending with the `.seq` extension.  Comments start
-with a ;. The example file above goes into greater explaination of the sample commands.
+with a ;. The example file above goes into greater explanation of the sample commands.
 
 ## Compiling A Sample Sequence
 

--- a/docs/UsersGuide/user/fprime-util.md
+++ b/docs/UsersGuide/user/fprime-util.md
@@ -26,7 +26,7 @@ subcommands:
 ```
 
 The `fprime-util` helper is driven by a series of subcommands listed above. Each perform one aspect
-of the development process and are breifly described below.  The following sections will go into
+of the development process and are briefly described below.  The following sections will go into
 each command's usage in more detail.
 
 1. `generate`: generates build cache directories. It defaults to generating the build cache for


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Fw,Gds,Ref,docker,docs |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes (guided by https://github.com/bwignall/typochecker) some typos I found. I have not fixed everything; submitting now to see if there is interest before I spend too much time. Another reason to submit with the given set was to solicit advice on which folders should{, not} be looked through, which are auto-generated, etc.

Should be non-semantic.

## Rationale

Fixes typos.

## Testing/Review Recommendations

Should be non-semantic (ie, affecting only comments and documentation).

## Future Work

If interest, can continue.
