### PR TITLE
Added option to impl templates to check for return type of user defined functions.

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/impl/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/impl/cpp.tmpl
@@ -58,12 +58,17 @@ $emit_non_port_params($params_init_cpp)
   // ----------------------------------------------------------------------
 
   #for $instance, $type, $sync, $priority, $full, $role, $max_num in $typed_user_input_ports:
-  void ${name}ComponentImpl ::
+  #set $return_type = $port_return_type_strs[$instance]
+  ${return_type}${name}ComponentImpl ::
     ${instance}_handler(
 $emit_port_params([ $param_portNum ] + $port_params[instance])
     )
   {
+    #if $return_type[:4] == "void":    
     // TODO
+    #else:
+    // TODO return
+    #end if
   }
 
   #end for

--- a/Autocoders/Python/src/fprime_ac/generators/templates/impl/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/impl/cpp.tmpl
@@ -64,7 +64,7 @@ $emit_non_port_params($params_init_cpp)
 $emit_port_params([ $param_portNum ] + $port_params[instance])
     )
   {
-    #if $return_type[:4] == "void":    
+    #if $return_type[:-1] == "void":    
     // TODO
     #else:
     // TODO return

--- a/Autocoders/Python/src/fprime_ac/generators/templates/impl/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/impl/hpp.tmpl
@@ -55,9 +55,10 @@ $emit_non_port_params($params_init_hpp)
       // ----------------------------------------------------------------------
 
   #for $instance, $type, $sync, $priority, $full, $role, $max_num in $typed_user_input_ports:
+  #set $return_type = $port_return_type_strs[$instance]
       //! Handler implementation for $instance
       //!
-      void ${instance}_handler(
+      ${return_type}${instance}_handler(
 $emit_port_params([ $param_portNum ] + $port_params[$instance])
       );
 


### PR DESCRIPTION
Added option to impl templates to check for return type of user defined
functions.

| | |
|:---|:---|
|**_Originating Project/Creator_**| Fprime |
|**_Affected Component_**|  autocoder impl template|
|**_Affected Architectures(s)_**|  1.5 >|
|**_Related Issue(s)_**|  #419 |
|**_Has Unit Tests (y/n)_**|  No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

Added option to check for the return type of user-defined ports. The previous template only returned `void` without checking for user-defined return types causing the generated template inconsistent with the user definition of the port return type.

## Rationale

Now the fprime-util impl will generate the correct return type for each function. 

## Testing/Review Recommendations

Manually tested the change on one of FileDownlink Component which had a port with return type. The result is shown below:

Svc/FileDownlink/FileDownlinkComponentImpl.hpp-template
![image](https://user-images.githubusercontent.com/35859004/109341765-b7ecc980-781f-11eb-979e-39cc2c47fa4c.png)


Svc/FileDownlink/FileDownlinkComponentImpl.cpp-template
![image](https://user-images.githubusercontent.com/35859004/109341748-b28f7f00-781f-11eb-811a-fd6766f4f0a0.png)


## Future Work

Note: The user still needs to add the return statement manually after the template is generated.
