### PR TITLE
Rename misspelled private fields in Svc::ComLogger

### DIFF
--- a/Svc/ComLogger/ComLogger.cpp
+++ b/Svc/ComLogger/ComLogger.cpp
@@ -22,8 +22,8 @@ namespace Svc {
       maxFileSize(maxFileSize),
       fileMode(CLOSED), 
       byteCount(0),
-      writeErrorOccured(false),
-      openErrorOccured(false),
+      writeErrorOccurred(false),
+      openErrorOccurred(false),
       storeBufferLength(storeBufferLength)
   {
     if( this->storeBufferLength ) {
@@ -162,15 +162,15 @@ namespace Svc {
 
     Os::File::Status ret = file.open((char*) this->fileName, Os::File::OPEN_WRITE);
     if( Os::File::OP_OK != ret ) {
-      if( !this->openErrorOccured ) { // throttle this event, otherwise a positive
-                                // feedback event loop can occur!
+      if( !this->openErrorOccurred ) { // throttle this event, otherwise a positive
+                                       // feedback event loop can occur!
         Fw::LogStringArg logStringArg((char*) this->fileName);
         this->log_WARNING_HI_FileOpenError(ret, logStringArg);
       }
-      this->openErrorOccured = true;
+      this->openErrorOccurred = true;
     } else {
       // Reset event throttle:
-      this->openErrorOccured = false;
+      this->openErrorOccurred = false;
 
       // Reset byte count:
       this->byteCount = 0;
@@ -234,16 +234,16 @@ namespace Svc {
     NATIVE_INT_TYPE size = length;
     Os::File::Status ret = file.write(data, size);
     if( Os::File::OP_OK != ret || size != (NATIVE_INT_TYPE) length ) {
-      if( !this->writeErrorOccured ) { // throttle this event, otherwise a positive
-                                 // feedback event loop can occur!
+      if( !this->writeErrorOccurred ) { // throttle this event, otherwise a positive
+                                        // feedback event loop can occur!
         Fw::LogStringArg logStringArg((char*) this->fileName);
         this->log_WARNING_HI_FileWriteError(ret, size, length, logStringArg);
       }
-      this->writeErrorOccured = true;
+      this->writeErrorOccurred = true;
       return false;
     }
 
-    this->writeErrorOccured = false;
+    this->writeErrorOccurred = false;
     return true;
   }
 

--- a/Svc/ComLogger/ComLogger.hpp
+++ b/Svc/ComLogger/ComLogger.hpp
@@ -95,8 +95,8 @@ namespace Svc {
       U8 fileName[MAX_FILENAME_SIZE + MAX_PATH_SIZE];
       U8 hashFileName[MAX_FILENAME_SIZE + MAX_PATH_SIZE];
       U32 byteCount;
-      bool writeErrorOccured;
-      bool openErrorOccured;
+      bool writeErrorOccurred;
+      bool openErrorOccurred;
       bool storeBufferLength;
       
       // ----------------------------------------------------------------------


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Svc/ComLogger |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The names of two private class fields (`writeErrorOccured` and `openErrorOccured`) were misspelled in the header and source file. This commit fixes that.

## Rationale

Improve code readability, especially for for non-native English speakers.

## Testing/Review Recommendations

These fields do not appear to be accessed from unit tests. The code should compile cleanly.

## Future Work

None.
