### PR TITLE
Change signal raised by fatal event handling

### DIFF
--- a/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
+++ b/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
@@ -27,9 +27,9 @@ namespace Svc {
             FwEventIdType Id) {
         // for **nix, delay then exit with error code
         Fw::Logger::logMsg("FATAL %d handled.\n",(U32)Id,0,0,0,0,0);
+        (void)raise( SIGTERM );
         (void)Os::Task::delay(1000);
         Fw::Logger::logMsg("Exiting.\n",0,0,0,0,0,0);
-        (void)raise( SIGSEGV );
         exit(1);
     }
 

--- a/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
+++ b/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
@@ -27,9 +27,9 @@ namespace Svc {
             FwEventIdType Id) {
         // for **nix, delay then exit with error code
         Fw::Logger::logMsg("FATAL %d handled.\n",(U32)Id,0,0,0,0,0);
-        (void)raise( SIGTERM );
         (void)Os::Task::delay(1000);
-        Fw::Logger::logMsg("Exiting.\n",0,0,0,0,0,0);
+        Fw::Logger::logMsg("Exiting with segfault and core dump file.\n",0,0,0,0,0,0);
+        (void)raise( SIGSEGV );
         exit(1);
     }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Svc/FatalHandler |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| [#356](https://github.com/nasa/fprime/issues/356) |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Segmentation fault doesn't seem like an appropriate choice for handling Fatal events. SIGSEGV was replaced with SIGTERM.

## Rationale

Raising SIGTERM allows for cleaner exit on fatal event (if signal handler is implemented).

## Testing/Review Recommendations

None

## Future Work

None
