### PR TITLE
fixed handling of redefined messages field types in Gds and GroundInterface

### DIFF
--- a/Gds/docs/README.md
+++ b/Gds/docs/README.md
@@ -9,9 +9,9 @@ This tool includes logging capability and can be connected to several adapters t
 
 Certain deployments may alter the fields of messsages for various reasons including memory conservation.
 To make the corresponding changes to the Gds for successful communication, 
-please edit the Gds/src/fprime_gds/common/utils/config_manager.py file accordingly. 
-Each field in the _set_defaults() function corresponds to a specific compile time flag for an FPrime deployment.
-Bellow is a table of corresponding fields that must match between deployment and Gds in order for successful communication to occur.
+please edit the `Gds/src/fprime_gds/common/utils/config_manager.py` file accordingly. 
+Each field in the `_set_defaults()` function corresponds to a specific compile time flag in the `/config/FpConfig.hpp` file for an FPrime deployment.
+Below is a table of corresponding fields that must match between deployment and Gds in order for successful communication to occur.
 
 Gds Field | FPrime Flag
 ----------- | ----------- |
@@ -23,4 +23,4 @@ self.__prop['types']['event_id'] | FwEventIdType
 self.__prop['types']['pkt_id'] | Unkown
 self.__prop['types']['key_val'] | unknown
 
-It is important to note that the default value of all of these fprime fields is U32, which is the behavior when none of these compile time flags are set in any CMakeLists.txt fields.
+It is important to note that the default value of all of these fprime fields is U32, which is the behavior when none of these compile time flags are changed in the `FpConfig.hpp` file.

--- a/Gds/docs/README.md
+++ b/Gds/docs/README.md
@@ -1,0 +1,26 @@
+# Gds Command and Control Tool
+
+## 1. Introduction
+
+This is a tool intended to be used with FPrime dpeloyments to exchange commands, telemetry, events and other messages.
+This tool includes logging capability and can be connected to several adapters to communicate with ground station equipment.
+
+## 2. Message Field Configuration
+
+Certain deployments may alter the fields of messsages for various reasons including memory conservation.
+To make the corresponding changes to the Gds for successful communication, 
+please edit the Gds/src/fprime_gds/common/utils/config_manager.py file accordingly. 
+Each field in the _set_defaults() function corresponds to a specific compile time flag for an FPrime deployment.
+Bellow is a table of corresponding fields that must match between deployment and Gds in order for successful communication to occur.
+
+Gds Field | FPrime Flag
+----------- | ----------- |
+self.__prop['types']['msg_len'] | TOKEN_TYPE
+self.__prop['types']['msg_desc'] | FwPacketDescriptorType
+self.__prop['types']['op_code'] | FwOpcodeType
+self.__prop['types']['ch_id'] | FwChanIdType
+self.__prop['types']['event_id'] | FwEventIdType
+self.__prop['types']['pkt_id'] | Unkown
+self.__prop['types']['key_val'] | unknown
+
+It is important to note that the default value of all of these fprime fields is U32, which is the behavior when none of these compile time flags are set in any CMakeLists.txt fields.

--- a/Gds/src/fprime_gds/common/decoders/ch_decoder.py
+++ b/Gds/src/fprime_gds/common/decoders/ch_decoder.py
@@ -20,15 +20,15 @@ Example data that would be sent to a decoder that parses channels:
 import copy
 
 from fprime.common.models.serialize.time_type import TimeType
-from fprime.common.models.serialize.numerical_types import U32Type
 from fprime_gds.common.data_types.ch_data import ChData
 from fprime_gds.common.decoders.decoder import Decoder
+from fprime_gds.common.utils import config_manager
 
 
 class ChDecoder(Decoder):
     """Decoder class for Channel data"""
 
-    def __init__(self, ch_dict):
+    def __init__(self, ch_dict, config):
         """
         ChDecoder class constructor
 
@@ -40,7 +40,13 @@ class ChDecoder(Decoder):
             An initialized channel decoder object.
         """
         super().__init__()
+
+        if config is None:
+            # Retrieve singleton for the configs
+            config = config_manager.ConfigManager().get_instance()
+
         self.__dict = ch_dict
+        self.id_obj = config.get_type("ch_id")
 
     def decode_api(self, data):
         """
@@ -59,10 +65,9 @@ class ChDecoder(Decoder):
         ptr = 0
 
         # Decode Ch ID here...
-        id_obj = U32Type()
-        id_obj.deserialize(data, ptr)
-        ptr += id_obj.getSize()
-        ch_id = id_obj.val
+        self.id_obj.deserialize(data, ptr)
+        ptr += self.id_obj.getSize()
+        ch_id = self.id_obj.val
 
         # Decode time...
         ch_time = TimeType()

--- a/Gds/src/fprime_gds/common/decoders/event_decoder.py
+++ b/Gds/src/fprime_gds/common/decoders/event_decoder.py
@@ -18,17 +18,17 @@ Example data structure:
 import copy
 import traceback
 
-import fprime.common.models.serialize.numerical_types
 from fprime.common.models.serialize import time_type
 from fprime.common.models.serialize.type_exceptions import TypeException
 from fprime_gds.common.data_types import event_data
 from fprime_gds.common.decoders import decoder
+from fprime_gds.common.utils import config_manager
 
 
 class EventDecoder(decoder.Decoder):
     """Decoder class for event data"""
 
-    def __init__(self, event_dict):
+    def __init__(self, event_dict, config=None):
         """
         EventDecoder class constructor
 
@@ -39,8 +39,14 @@ class EventDecoder(decoder.Decoder):
         Returns:
             An initialized EventDecoder object.
         """
-        super().__init__()
+        super(EventDecoder, self).__init__()
+
+        if config is None:
+            # Retrieve defaults for the configs
+            config = config_manager.ConfigManager().get_instance()
+
         self.__dict = event_dict
+        self.id_obj = config.get_type("event_id")
 
     def decode_api(self, data):
         """
@@ -59,10 +65,9 @@ class EventDecoder(decoder.Decoder):
         ptr = 0
 
         # Decode event ID here...
-        id_obj = fprime.common.models.serialize.numerical_types.U32Type()
-        id_obj.deserialize(data, ptr)
-        ptr += id_obj.getSize()
-        event_id = id_obj.val
+        self.id_obj.deserialize(data, ptr)
+        ptr += self.id_obj.getSize()
+        event_id = self.id_obj.val
 
         # Decode time...
         event_time = time_type.TimeType()

--- a/Gds/src/fprime_gds/common/decoders/pkt_decoder.py
+++ b/Gds/src/fprime_gds/common/decoders/pkt_decoder.py
@@ -18,16 +18,16 @@ Example data that would be sent to a decoder that parses events or channels:
 """
 
 from fprime.common.models.serialize.time_type import TimeType
-from fprime.common.models.serialize.numerical_types import U16Type
 from fprime_gds.common.data_types.ch_data import ChData
 from fprime_gds.common.data_types.pkt_data import PktData
 from fprime_gds.common.decoders.ch_decoder import ChDecoder
+from fprime_gds.common.utils import config_manager
 
 
 class PktDecoder(ChDecoder):
     """Decoder class for Packetized Telemetry data"""
 
-    def __init__(self, pkt_name_dict, ch_dict):
+    def __init__(self, pkt_name_dict, ch_dict, config=None):
         """
         Constructor
 
@@ -40,9 +40,12 @@ class PktDecoder(ChDecoder):
         Returns:
             An initialized PktDecoder object
         """
-        super().__init__(ch_dict)
+        if config is None:
+            config = config_manager.ConfigManager().get_instance()
+        super().__init__(ch_dict, config)
 
         self.__dict = pkt_name_dict
+        self.id_obj = config.get_type("pkt_id")
 
     def decode_api(self, data):
         """
@@ -61,10 +64,9 @@ class PktDecoder(ChDecoder):
         ptr = 0
 
         # Decode Pkt ID here...
-        id_obj = U16Type()
-        id_obj.deserialize(data, ptr)
-        ptr += id_obj.getSize()
-        pkt_id = id_obj.val
+        self.id_obj.deserialize(data, ptr)
+        ptr += self.id_obj.getSize()
+        pkt_id = self.id_obj.val
 
         # Decode time...
         pkt_time = TimeType()

--- a/Gds/src/fprime_gds/common/encoders/cmd_encoder.py
+++ b/Gds/src/fprime_gds/common/encoders/cmd_encoder.py
@@ -46,6 +46,7 @@ from . import encoder
 from fprime.common.models.serialize.numerical_types import U32Type
 from fprime_gds.common.data_types.cmd_data import CmdData
 from fprime_gds.common.utils.data_desc_type import DataDescType
+from fprime_gds.common.utils import config_manager
 
 
 class CmdEncoder(encoder.Encoder):
@@ -63,8 +64,15 @@ class CmdEncoder(encoder.Encoder):
         Returns:
             An initialized CmdEncoder object
         """
+
+        if config is None:
+            config = config_manager.ConfigManager().get_instance()
         super().__init__(config)
+
         self.len_obj = self.config.get_type("msg_len")
+        self.desc_obj = self.config.get_type("msg_desc")
+        self.opcode_obj = self.config.get_type("op_code")
+
 
     def encode_api(self, data):
         """
@@ -81,9 +89,11 @@ class CmdEncoder(encoder.Encoder):
 
         desc = U32Type(0x5A5A5A5A).serialize()
 
-        descriptor = U32Type(DataDescType["FW_PACKET_COMMAND"].value).serialize()
+        self.desc_obj.val = DataDescType["FW_PACKET_COMMAND"].value
+        descriptor = self.desc_obj.serialize()
 
-        op_code = U32Type(cmd_temp.get_op_code()).serialize()
+        self.opcode_obj.val = cmd_temp.get_op_code()
+        op_code = self.opcode_obj.serialize()
 
         arg_data = b""
         for arg in data.get_args():

--- a/Gds/src/fprime_gds/common/pipeline/encoding.py
+++ b/Gds/src/fprime_gds/common/pipeline/encoding.py
@@ -41,7 +41,7 @@ class EncodingDecoding:
         self.packet_decoder = None
         self.command_subscribers = []
 
-    def setup_coders(self, dictionaries, distributor, sender):
+    def setup_coders(self, dictionaries, distributor, sender, config):
         """
         Sets up the encoder and decoder layer of the GDS pipeline. This requires a dictionary set that has loaded the
         dictionaries needed for the decoders to work correctly. This will register then register the decoders with a
@@ -50,15 +50,19 @@ class EncodingDecoding:
 
         :param dictionaries: a dictionaries handling object holding dictionaries
         :param distributor: distributor of data to register to
+        :param sender: TODO
+        :param config: config object used to describe types used for different field encodings
         """
         # Create encoders and decoders using dictionaries
         self.file_encoder = fprime_gds.common.encoders.file_encoder.FileEncoder()
-        self.command_encoder = fprime_gds.common.encoders.cmd_encoder.CmdEncoder()
+        self.command_encoder = fprime_gds.common.encoders.cmd_encoder.CmdEncoder(
+            config=config
+        )
         self.event_decoder = fprime_gds.common.decoders.event_decoder.EventDecoder(
-            dictionaries.event_id
+            dictionaries.event_id, config=config
         )
         self.channel_decoder = fprime_gds.common.decoders.ch_decoder.ChDecoder(
-            dictionaries.channel_id
+            dictionaries.channel_id, config=config
         )
         self.file_decoder = fprime_gds.common.decoders.file_decoder.FileDecoder()
         self.packet_decoder = None

--- a/Gds/src/fprime_gds/common/pipeline/encoding.py
+++ b/Gds/src/fprime_gds/common/pipeline/encoding.py
@@ -50,7 +50,7 @@ class EncodingDecoding:
 
         :param dictionaries: a dictionaries handling object holding dictionaries
         :param distributor: distributor of data to register to
-        :param sender: TODO
+        :param sender: is used to send the bytes created by the command encoder
         :param config: config object used to describe types used for different field encodings
         """
         # Create encoders and decoders using dictionaries

--- a/Gds/src/fprime_gds/common/pipeline/standard.py
+++ b/Gds/src/fprime_gds/common/pipeline/standard.py
@@ -67,7 +67,7 @@ class StandardPipeline:
         # Setup dictionaries encoders and decoders
         self.dictionaries.load_dictionaries(dictionary, packet_spec)
         self.coders.setup_coders(
-            self.dictionaries, self.distributor, self.client_socket
+            self.dictionaries, self.distributor, self.client_socket, config
         )
         self.histories.setup_histories(self.coders)
         self.files.setup_file_handling(

--- a/Gds/src/fprime_gds/common/utils/config_manager.py
+++ b/Gds/src/fprime_gds/common/utils/config_manager.py
@@ -162,6 +162,7 @@ class ConfigManager(configparser.ConfigParser):
         self.__prop["types"]["msg_desc"] = "U32"
         self.__prop["types"]["ch_id"] = "U32"
         self.__prop["types"]["event_id"] = "U32"
+        self.__prop["types"]["op_code"] = "U32"
         self.__prop["types"]["pkt_id"] = "U16"
         self.__prop["types"]["key_val"] = "U16"
         self._set_section_defaults("types")


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|GT1/Georgia Tech |
|**_Affected Component_**| Svc/GroundInterface |
|**_Affected Architectures(s)_**| None |
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| N |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| Y |
|**_Documentation Included (y/n)_**| Y |

---
## Change Description

Edited the GroundInterface component to use the compilation flags defining the Packet Descriptor.
Edited the Gds to use the configuration manager's types when encoding and decoding commands, events, telemetry, parameters, and packet headers.

## Rationale

Fixes bug where configuring message fields in deployments causes the Gds to be unable to communicate with the deployment.
The compilation flags for configuring message fields are necessary on certain platforms with limited memory to reduce memory usage.

## Testing/Review Recommendations

A deployment should be made that edits the (compilation flag, config manager field) pairs described in the included Gds/docs/README.md file are changed. This deployment should be able to have successful exchanges of commands, events, parameters, and telemetry. There should also be builds containing individual changes to each flag to ensure that all fields are set correctly.

## Future Work

The `FwEnumStoreType` flag is confirmed to break the communications with the Gds when it is changed from an I32. I do not know how to change the way this type is serialized since it is defined in the `fprime/common/models/serialize/enum_type.py` file which I don't believe has access to the configuration manager from the Gds.
 
There may be additional fields that can be configured with compilation flags, but will still cause issues with encoding and decoding that will need to be handled correctly to avoid broken communications.
