### PR TITLE
Removed Python 2 support from Autocoder.

### DIFF
--- a/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
@@ -33,11 +33,7 @@ from fprime_ac.utils.exceptions import (
     FprimeXmlException,
 )
 
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
-# from __builtin__ import None
+import configparser
 
 # For Python determination
 

--- a/Autocoders/Python/src/fprime_ac/utils/ConfigManager.py
+++ b/Autocoders/Python/src/fprime_ac/utils/ConfigManager.py
@@ -21,16 +21,7 @@
 # ALL RIGHTS RESERVED. U.S. Government Sponsorship acknowledged.
 # ===============================================================================
 import os
-
-# For Python determination
-import six
-
-# 2/3 support
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
-
+import configparser
 
 parent = configparser.ConfigParser
 
@@ -48,8 +39,6 @@ class ConfigManager(parent):
         """
         Constructor.
         """
-        if six.PY2:
-            configparser.SafeConfigParser.__init__(self)
         configparser.ConfigParser.__init__(self)
         configparser.RawConfigParser.__init__(self)
         self.__prop = dict()

--- a/Autocoders/Python/src/fprime_ac/utils/ConfigManager.py
+++ b/Autocoders/Python/src/fprime_ac/utils/ConfigManager.py
@@ -40,7 +40,6 @@ class ConfigManager(parent):
         Constructor.
         """
         configparser.ConfigParser.__init__(self)
-        configparser.RawConfigParser.__init__(self)
         self.__prop = dict()
         self._setProps()
         # Now look for an ac.ini file within


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|Bill Allen |
|**_Affected Component_**| Autocoder |
|**_Affected Architectures(s)_**| all |
|**_Related Issue(s)_**| #422 |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Removed work-arounds for Python 2 support.

## Rationale

Python 2 reached end-of-life at the beginning of 2020.

## Testing/Review Recommendations

Existing tests pass as before.

## Future Work

Other components of F' might still have Python 2 workarounds, which will be removed as they are found.