### PR TITLE
The six package is no longer a dependency.

### DIFF
--- a/Fw/Python/setup.py
+++ b/Fw/Python/setup.py
@@ -71,10 +71,9 @@ to interact with the data coming from the FSW.
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    # Requires Python 3.5+, and the 'six' Python package
+    # Requires Python 3.5+
     python_requires=">=3.5",
     install_requires=[
-        "six",
         "lxml",
         'enum34;python_version < "3.4"',
         "Markdown",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Bill Allen |
|**_Affected Component_**| Fw |
|**_Affected Architectures(s)_**| all |
|**_Related Issue(s)_**| #422 |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Removed the `six` package from the dependency listing in `setup.py`.

## Rationale

`six` is no longer referenced in Fw, plus Python 2 support has been dropped.

## Testing/Review Recommendations

Should run as before.

## Future Work

No other references to six were found in the project.