### PR TITLE
update: fix 343 GDS bool type issue

### DIFF
--- a/Gds/src/fprime_gds/common/data_types/cmd_data.py
+++ b/Gds/src/fprime_gds/common/data_types/cmd_data.py
@@ -159,10 +159,15 @@ class CmdData(sys_data.SysData):
                 "Argument value could not be converted to type object"
             )
         if isinstance(arg_type, BoolType):
-            if arg_val == "False":
+            value = str(arg_val).lower().strip()
+            if value in ("true", "yes"):
+                av = True
+            elif value in ("false", "no"):
                 av = False
             else:
-                av = True
+                raise CommandArgumentException(
+                    "Argument value is not a valid boolean"
+                )
             arg_type.val = av
         elif isinstance(arg_type, EnumType):
             arg_type.val = arg_val


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| FPrime |
|**_Affected Component_**|  GDS |
|**_Affected Architectures(s)_**|  1.5 > |
|**_Related Issue(s)_**|  #343 |
|**_Has Unit Tests (y/n)_**|  No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

The fix will make the GDS interpret `true`, `yes` as `True` and `false`, `no` as `False`. Values are not case sensitive. Trailing white spaces will be striped out. Any other value will raise `CommandArgumentException` exception.

## Rationale

In the previous implementation only `False` (case sensitive) was considered as boolean `False` and any other value as boolean `True`. No exception was raised on non-boolean values. This could cause confusion and problems. The new implementation has a limited set of valid boolean values (`true`, `yes`, `false`, `no`). Any other value will be rejected.

## Testing/Review Recommendations

Manually verified the change as shown below:

![image](https://user-images.githubusercontent.com/35859004/109615432-c02b5a00-7ae8-11eb-972b-f97c4cf0c538.png)


## Future Work
Need to add documentation to indicate valid boolean values in FPrime GDS.
