### PR TITLE
lestarch: removing six from validation in pip setup

### DIFF
--- a/cmake/support/validation/pipsetup.py
+++ b/cmake/support/validation/pipsetup.py
@@ -10,11 +10,7 @@ from __future__ import print_function
 import sys
 
 # Migrated from setup.py in Fw/Python
-REQUIRED_PACKS = ["six", "lxml", "Markdown", "pexpect", "pytest"]
-if sys.version_info[0] >= 3:
-    REQUIRED_PACKS.append("Cheetah3")
-else:
-    REQUIRED_PACKS.extend(["Cheetah", "enum34"])
+REQUIRED_PACKS = ["lxml", "Markdown", "pexpect", "pytest", "Cheetah3"]
 
 
 def validate_python_setup():


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|  Infra |
|**_Affected Component_**| N/A |
|**_Affected Architectures(s)_**| Python |
|**_Related Issue(s)_**|  #440 |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

One last "six" removal along with #440.

## Rationale

Cleaning up to support #440 

## Testing/Review Recommendations

## Future Work

More python 2 cleanup as necessary.
