### PR TITLE
Fix stack buffer overflow in Types

### DIFF
--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -52,7 +52,7 @@ namespace Fw {
         FW_ASSERT(this->getBuffAddr());
         // destination has to be same or bigger
         FW_ASSERT(src.getBuffLength() <= this->getBuffCapacity(),src.getBuffLength(),this->getBuffLength());
-        (void) memcpy(this->getBuffAddr(),src.getBuffAddr(),this->m_serLoc+1);
+        (void) memcpy(this->getBuffAddr(),src.getBuffAddr(),this->m_serLoc);
     }
 
     // Copy constructor doesn't make sense in this virtual class as there is nothing to copy. Derived classes should


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Types  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| #429  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix stack-buffer-overflow error in Serializable.cpp line 55
