### PR TITLE
[Docs] Fixes to unit testing, MathComponent tutorial

### DIFF
--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -2127,7 +2127,7 @@ If running on a different platform, you can specify the build target by typing `
 
 ## 4.1 Running the Ground System
 
-Once the `Ref` example has built successfully, you can run the ground system and executable by entering `cd fprime/Ref; fprime-gds`. The ground system GUI should appear.
+Once the `Ref` example has built successfully, you can run the ground system and executable by entering `fprime-gds -r fprime/Ref/build-artifacts`. The ground system GUI should appear.
 
 ### 4.1.1 Executing Commands
 

--- a/docs/UsersGuide/user/unit-testing.md
+++ b/docs/UsersGuide/user/unit-testing.md
@@ -200,27 +200,31 @@ leak | Check for memory leaks in unit tests.
 
 For example, to run all unit tests and check for code coverage, enter `fprime-util check --all,coverage`.
 
-Components that call into libraries have two ways to write tests: i)
-link against the library in the test, or ii) link against a mock or stub
-library. Selecting from either of these two options depend on the
-circumstances. If selecting the link against the library in the test,
-avoid writing the mock or stub library. This approach proves that the
-component code works with the actual library. If selecting the link
-against a mock or stub library, it will make it easier to induce the
-behaviors for testing, such as injecting faults. This approach may be
+### Choosing a test library
+
+Components that call into libraries have two ways to write tests:
+
+- Link against the library in the test
+- Link against a mock or stub library
+
+If you link against the library in the test, avoid linking against the
+mock or stub library. Linking against only the test library proves that the component code works with the actual library. 
+
+Linking against a mock or stub library makes it easier to induce 
+behaviors for testing, like injecting faults. This approach may be
 the only option on some platforms.
 
-Checking code coverage checks which lines were run at least once during
-a test. There are standard tools, such as *gcov*, that can perform this
-analysis by compiling and running the tests, and then produce a report.
+### Code coverage
+
+Code coverage checks which lines were run at least once during
+a test. Tools like *gcov* perform code coverage analysis by compiling and running the tests, then producing a report.
+
 Generally, code coverage checks close to 80% of lines. The remaining
 lines are usually off-nominal behaviors that may require additional
 effort to check by reverse reasoning from the desired behavior to
 synthesize the inputs, or by injecting faults into the library
-behaviors. However, 100% code coverage is not a complete solution to
-checking which system states were tested, or which paths through the
-code were tested, as this is not possible.
+behaviors.
 
-To review the analysis, go to the component directory and review the 
-summary output *\_gcov.txt* files. Next, go to the component directory to 
-review the coverage annotation *.hpp.gcov* and *.cpp.gcov* source files.
+Note that 100% code coverage does not check which system states were tested, nor which paths through the code were tested.
+
+To review code coverage analysis, go to the component directory and review the summary output *\_gcov.txt* files. Next, go to the component directory to review the coverage annotation *.hpp.gcov* and *.cpp.gcov* source files.

--- a/docs/UsersGuide/user/unit-testing.md
+++ b/docs/UsersGuide/user/unit-testing.md
@@ -187,12 +187,10 @@ The F′ Prime build system provides targets for building and running
 component unit tests.
 
 To build unit tests, go to the component directory (not the *test/ut*
-directory) and run *make ut* to build with code coverage enabled, or run
-*make ut\_nocov* to build with code coverage disabled.
+directory) and run `fprime-util generate --ut`.
 
 To run unit tests, go to the component directory (not the *test/ut*
-directory) and run *make run\_ut* to run with coverage enabled, or *make
-run\_ut\_nocov* to run with coverage disabled.
+directory) and run `fprime-util check --coverage` to run with coverage enabled.
 
 Components that call into libraries have two ways to write tests: i)
 link against the library in the test, or ii) link against a mock or stub
@@ -215,9 +213,6 @@ behaviors. However, 100% code coverage is not a complete solution to
 checking which system states were tested, or which paths through the
 code were tested, as this is not possible.
 
-To generate the analysis, go to the component directory (not the
-*test/ut* directory). After building and running the tests as outlined
-above, run *make cov*. The review the analysis, go to the *test/ut*
-directory (not the component director) and review the summary output
-*\_gcov.txt* files. Next, go to the component directory to review the
-coverage annotation *.hpp.gcov* and *.cpp.gcov* source files.
+To review the analysis, go to the component directory and review the 
+summary output *\_gcov.txt* files. Next, go to the component directory to 
+review the coverage annotation *.hpp.gcov* and *.cpp.gcov* source files.

--- a/docs/UsersGuide/user/unit-testing.md
+++ b/docs/UsersGuide/user/unit-testing.md
@@ -190,15 +190,15 @@ To build unit tests, go to the component directory (not the *test/ut*
 directory) and run `fprime-util generate --ut`.
 
 To run unit tests, go to the component directory (not the *test/ut*
-directory) and run `fprime-util check --<params>`. 
+directory) and run `fprime-util check [parameter flags]`. 
 
 Unit test check parameter | Description
 ---|---
-all | Run all unit tests. Combineable with `leak` or `coverage`.
-coverage | Check for code coverage in unit tests.
-leak | Check for memory leaks in unit tests.
+`--all` | Run all unit tests, combinable with `leak` or `coverage`
+`--coverage` | Check for code coverage in unit tests
+`--leak` | Check for memory leaks in unit tests
 
-For example, to run all unit tests and check for code coverage, enter `fprime-util check --all,coverage`.
+For example, to run all unit tests and check for code coverage, run `fprime-util check --all --coverage`.
 
 ### Choosing a test library
 

--- a/docs/UsersGuide/user/unit-testing.md
+++ b/docs/UsersGuide/user/unit-testing.md
@@ -190,7 +190,15 @@ To build unit tests, go to the component directory (not the *test/ut*
 directory) and run `fprime-util generate --ut`.
 
 To run unit tests, go to the component directory (not the *test/ut*
-directory) and run `fprime-util check --coverage` to run with coverage enabled.
+directory) and run `fprime-util check --<params>`. 
+
+Unit test check parameter | Description
+---|---
+all | Run all unit tests. Combineable with `leak` or `coverage`.
+coverage | Check for code coverage in unit tests.
+leak | Check for memory leaks in unit tests.
+
+For example, to run all unit tests and check for code coverage, enter `fprime-util check --all,coverage`.
 
 Components that call into libraries have two ways to write tests: i)
 link against the library in the test, or ii) link against a mock or stub


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Docs |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| #332, #382 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

This PR:
- fixes outstanding feedback about unit testing in https://github.com/nasa/fprime/issues/332#issuecomment-782578294
- tweaks syntax in the MathComponent tutorial based on https://github.com/nasa/fprime/pull/382#issuecomment-782481943
- Rewrites the unit testing doc for clarity about build flags, selecting libraries, and code coverage

## Rationale

This PR takes action on feedback in the originating issue (#332) and a partial fix to that issue (#382). 

## Testing/Review Recommendations

Sorry this took me a couple of weeks to get to. 😅 

@LeStarch Please verify that [this syntax](https://github.com/nasa/fprime/pull/445/files#diff-b5ac4d3af2fe521ce436dae727dbb974004de395712d123343695c7d55a30bd3R2130) is correct.

@saba-ja Some specific pieces to review:

1. [Adding flags](https://github.com/nasa/fprime/pull/445/files#diff-4113f0ae97457c9ff94d06e2e0fbc7575b6273e0f68ec0c00fe0b878590dc23cR193-R201) for `--all`, `--leak`, and `--coverage` to `fprime-util check`

   I populated a table with flags extrapolated from the [builder script](https://github.com/nasa/fprime/blob/5d631af802664719a2de61bf22cf0a1cf3b2dc9f/Fw/Python/src/fprime/fbuild/builder.py#L592-L618). I'm not convinced that a table is the best way to present these flags, but it _does_ get the content onto the page.

   Is [this syntax](https://github.com/nasa/fprime/pull/445/commits/5eb9655995d633cdf7995d98c17778b3f2f92cf5#diff-4113f0ae97457c9ff94d06e2e0fbc7575b6273e0f68ec0c00fe0b878590dc23cR201) correct:

   ```sh
   fprime-util check --all,coverage
   ```

   ...Or should there be whitespace between parameters? For example:
   ```sh
   fprime-util check --all, coverage
   ```

   Is the information on flags otherwise correct? Are any changes required?

2. Test libraries

   I separated content about libraries for testing and code coverage into separate sections. I also rewrote each section based on my best understanding. 

   Does the altered information architecture make sense?

   Is the updated text accurate? Are any changes required?

## Future Work

- Add more information and explanation about memory leaks in unit tests
- Rewrite the entire unit test page for clarity and consistency