### PR TITLE
Fix discreet vs discrete in docs

### DIFF
--- a/docs/UsersGuide/best/development-practice.md
+++ b/docs/UsersGuide/best/development-practice.md
@@ -21,7 +21,7 @@ The process:
 
 The first step of the development process is to establish the high-level design for the project.
 This involves specifying system-level requirements and a block diagram that represents the key
-system functionality. Once complete the project should break this functionality into discreet units
+system functionality. Once complete the project should break this functionality into discrete units
 of functionality that represent the system. In addition, the interface between these units should be
 defined. The units of functionality are Components and the interfaces are further broken down into
 discrete call or actions through that interface. These are F´ ports. The full design of the system

--- a/docs/UsersGuide/user/full-intro.md
+++ b/docs/UsersGuide/user/full-intro.md
@@ -43,7 +43,7 @@ What is a space system? For the purposes of this guide, it is any embedded syste
 compose the complete control and operation of a spacecraft to accomplish some mission.  At JPL these systems are
 typically conducting some aspect of scientific research.
 
-Since F´ is usually the complete software for one of these systems, F´ decomposes its projects into discreet
+Since F´ is usually the complete software for one of these systems, F´ decomposes its projects into discrete
 **Components** that each manage one part of the system. e.g. a Radio Component may control the radio hardware to
 facilitate communication. **Components** are connected to one another via **Ports**. **Ports** allow communication
 between **Components**.  The complete graph or network of **Components** connected via **Ports** is called a
@@ -65,7 +65,7 @@ framework.
 ## The Organization of F´ Deployments
 
 The core F′ software framework allows projects to be decomposed into a set of **Components** that are interconnected by
-**Ports**. Each **Component** represents one discreet piece of the system. e.g. the Command Dispatcher is a framework
+**Ports**. Each **Component** represents one discrete piece of the system. e.g. the Command Dispatcher is a framework
 component used to dispatch incoming commands to be handled by another component in the system. Its job is to receive a
 ground communication and translate that into an action, dispatch the action to another component, and await the
 completion of this action. It emits **Events** to signify when the action is dispatched, and when it has completed. It


### PR DESCRIPTION
I'm guessing from context that these cases should be "discrete" rather
than "discreet." This is a common word swap in English.

discreet: careful and circumspect in one's speech or actions, especially
in order to avoid causing offense or to gain an advantage.

discrete: individually separate and distinct.

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixed a likely mistake in wording in the docs (discreet vs discrete).

## Rationale

Docs are less confusing this way.

## Testing/Review Recommendations

(I am not sure what testing you require for changes like this, feel free to edit)