### PR TITLE
Move enum duplicates removing to separate file

### DIFF
--- a/Autocoders/Python/README.md
+++ b/Autocoders/Python/README.md
@@ -102,7 +102,7 @@ Directory containing all python code for the autocoder tools. Codegen uses the v
 | XmlParser.py | Parent class of the rest of the XmlParser classes |
 | XmlPortsParser.py | Parses XML port description files |
 | XmlSerializeParser.py | Parses XML serialize description files |
-| XmlTopologyParser.py | Topology XML topology description files |
+| XmlTopologyParser.py | Parses XML topology description files |
 
 #### src/utils/
 | File | Description |
@@ -115,6 +115,7 @@ Directory containing all python code for the autocoder tools. Codegen uses the v
 | DiffAndRename.py | Mainly used for difference and rename routines |
 | DumpObj.py | Contains methods to print nicely formatted overviews of objects |
 | EnumDictCheck.py | A structure used to report enumeration size errors |
+| EnumDupRemover.py | Contains a function that removes duplicates from list of enums |
 | EnumGenerator.py | Generator to produce serializable enums |
 | Logger.py | Sets up the logging for all other scripts based on the Python logging module - not a standalone file |
 | ParseC.py | Contains a set of Python functions that parse C code |

--- a/Autocoders/Python/bin/codegen.py
+++ b/Autocoders/Python/bin/codegen.py
@@ -33,6 +33,7 @@ from fprime_ac.utils import (
     ArrayGenerator,
     ConfigManager,
     DictTypeConverter,
+    EnumDupRemover,
     EnumGenerator,
     Logger,
 )
@@ -746,7 +747,7 @@ def generate_topology(the_parsed_topology_xml, xml_filename, opt):
                 # check for parameters
                 if parsed_xml_dict[comp_type].get_parameters() is not None:
                     for parameter in parsed_xml_dict[comp_type].get_parameters():
-                        PRINT.debug("Processing Parameter %s" % chan.get_name())
+                        PRINT.debug("Processing Parameter %s" % parameter.get_name())
                         param_default = None
                         command_elem_set = etree.Element("command")
                         command_elem_set.attrib["component"] = comp_name
@@ -871,6 +872,8 @@ def generate_topology(the_parsed_topology_xml, xml_filename, opt):
 
                         array_elem.append(members_elem)
                         array_list.append(array_elem)
+
+            EnumDupRemover.remove_duplicates(enum_list)
 
             topology_dict.append(enum_list)
             topology_dict.append(serializable_list)

--- a/Autocoders/Python/src/fprime_ac/utils/EnumDupRemover.py
+++ b/Autocoders/Python/src/fprime_ac/utils/EnumDupRemover.py
@@ -1,0 +1,35 @@
+
+def remove_duplicates(enum_list):
+    temp_enum_list = []
+    for enum_elem in enum_list:
+        temp_enum_list.append(enum_elem)
+    for enum_elem in temp_enum_list:
+        should_remove = False
+        for temp_enum in enum_list:
+            # Skip over comparisons between same exact element
+            if id(enum_elem) == id(temp_enum):
+                continue
+
+            # Check all attributes
+            if temp_enum.attrib["type"] == enum_elem.attrib["type"]:
+                should_remove = True
+            if (
+                not len(temp_enum.getchildren()) == len(enum_elem.getchildren())
+                and should_remove
+            ):
+                should_remove = False
+            children1 = temp_enum.getchildren()
+            children2 = enum_elem.getchildren()
+            if children1 and children2:
+                i = 0
+                while i < len(children1) and i < len(children2):
+                    if (
+                        not children1[i].attrib["name"] == children2[i].attrib["name"]
+                        and should_remove
+                    ):
+                        should_remove = False
+                    i += 1
+            if should_remove:
+                break
+        if should_remove:
+            enum_list.remove(enum_elem)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Autocoders |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| #241 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Functionality to remove duplicates from list of enums was moved to
separate file to allow both gds_dictgen.py and codegen.py to use it
without duplicating code. Also a few typos were spotted and fixed.

## Rationale

Fixes #241 

## Testing/Review Recommendations

None

## Future Work

None
