### PR TITLE
Enabled exceptions for schematron validation failures.

### DIFF
--- a/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
@@ -1234,7 +1234,7 @@ class XmlComponentParser:
                     validator_type,
                     ROOTDIR + self.Config.get(validator_type, validator_name),
                 )
-                PRINT.info(msg)
+                raise FprimeXmlException(msg)
 
     def is_component(self):
         """


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Bill Allen |
|**_Affected Component_**| Autocoder |
|**_Affected Architectures(s)_**| all |
|**_Related Issue(s)_**| #325, #449, #450, #451, #452 |
|**_Has Unit Tests (y/n)_**| n (see notes) |
|**_Builds Without Errors (y/n)_**| n (see notes) |
|**_Unit Tests Pass (y/n)_**| n (see notes) |
|**_Documentation Included (y/n)_**| existing |

---
## Change Description

Enables exceptions when schematron validation fails.

## Rationale

Better awareness of invalid component schemas.

## Testing/Review Recommendations

Tests will not pass until the issues #449, #450, #451, and #452 are resolved.  They are `kind="active"` components, but they don't have `async_input` ports as required by the schematron spec.

## Future Work

None.
