### PR TITLE
lestarch: fixing schematron check for internal interfaces

### DIFF
--- a/Autocoders/Python/schema/default/active_comp_schematron.rng
+++ b/Autocoders/Python/schema/default/active_comp_schematron.rng
@@ -3,7 +3,7 @@
     xmlns="http://purl.oclc.org/dsdl/schematron">
 <pattern id = "ASYNC_PORT">
     <rule context="component">
-        <assert test="(//component/@kind = 'active' and count(//component/ports/port/@kind[. = 'async_input']) >= 1) or not (//component/@kind = 'active')">Active components should have at least 1 port of kind async_input.</assert>
+        <assert test="(//component/@kind = 'active' and (count(//component/ports/port/@kind[. = 'async_input']) + count(//component/internal_interfaces/internal_interface) ) >= 1) or not (//component/@kind = 'active')">Active components should have at least 1 port of kind async_input or internal_interface.</assert>
     </rule>
 </pattern>
 </schema>

--- a/Autocoders/Python/test/command_multi_inst/Test1ComponentAi.xml
+++ b/Autocoders/Python/test/command_multi_inst/Test1ComponentAi.xml
@@ -58,7 +58,7 @@
         </command>
     </commands>
     <ports>
-        <port name="CmdDisp" kind="input" data_type="Fw::Cmd" max_number="1" role="Cmd"/>
+        <port name="CmdDisp" kind="async_input" data_type="Fw::Cmd" max_number="1" role="Cmd"/>
         <port name="CmdReg" kind="output" data_type="Fw::CmdReg" max_number="1" role="CmdRegistration"/>
         <port name="CmdStatus" kind="output" data_type="Fw::CmdResponse" max_number="1" role="CmdResponse"/>
         <port name="aport" data_type="Another::Test2" kind="sync_input" >

--- a/Autocoders/Python/test/command_res/Test1ComponentAi.xml
+++ b/Autocoders/Python/test/command_res/Test1ComponentAi.xml
@@ -44,7 +44,7 @@
         </command>
     </commands>
     <ports>
-        <port name="CmdDisp" kind="input" data_type="Fw::Cmd" max_number="1" role="Cmd"/>
+        <port name="CmdDisp" kind="async_input" data_type="Fw::Cmd" max_number="1" role="Cmd"/>
         <port name="CmdReg" kind="output" data_type="Fw::CmdReg" max_number="1" role="CmdRegistration"/>
         <port name="CmdStatus" kind="output" data_type="Fw::CmdResponse" max_number="1" role="CmdResponse"/>
         <port name="aport" data_type="Another::Test2" kind="sync_input" >


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infrastructure |
|**_Affected Component_**|  Schmeatron |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n/a |

---
## Change Description

Change the active component rule in schematron.

## Rationale

It neglected internal interfaces.

## Testing/Review Recommendations

UTs should pass.
