### PR TITLE
mstarch: fixing lgtm suggestions

### DIFF
--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -154,8 +154,8 @@ namespace Svc {
   Svc::SendFileResponse FileDownlink ::
     SendFile_handler(
         const NATIVE_INT_TYPE portNum,
-        sourceFileNameString sourceFilename,
-        destFileNameString destFilename,
+        sourceFileNameString sourceFilename, // lgtm[cpp/large-parameter] dictated by command architecture
+        destFileNameString destFilename, // lgtm[cpp/large-parameter] dictated by command architecture
         U32 offset,
         U32 length
     )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infra |
|**_Affected Component_**| FileDownlink | 
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Builds Without Errors (y/n)_**| n/a  |
|**_Unit Tests Pass (y/n)_**| n/a |
|**_Documentation Included (y/n)_**| n/a |

---
## Change Description

Added suppression comments to the large parameter arguments flagged by LGTM.

## Rationale

The pass-by-value is dictated by the commanding architecture and cannot be fixed/adjusted.  Thus we should suppress the recommendation.