### PR TITLE
fix 349: GDS decoding ENUM events incorrectly

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -47,6 +47,7 @@ ANamespace
 anotherchan
 ANOTHEREVENT
 anotherparam
+Anps
 aop
 apad
 api
@@ -217,6 +218,7 @@ ccsparc
 cdata
 cdefs
 CDH
+Cdioux
 cdn
 cdt
 cerrno
@@ -532,7 +534,6 @@ Dxyz
 dylib
 EACCES
 EAGAIN
-eas
 eay
 eb
 EBADF
@@ -546,6 +547,7 @@ edu
 EEXIST
 EFAULT
 EFBIG
+Efg
 EGB
 EHAs
 EINPROGRESS
@@ -1088,6 +1090,7 @@ LINUXTIMEIMPL
 listbox
 listdir
 Listst
+LIw
 LJR
 ljust
 lkd
@@ -1283,7 +1286,6 @@ noapp
 noargport
 NOBUFFERS
 NOCOLOR
-nocov
 NOCTTY
 nogen
 nolog
@@ -1902,6 +1904,7 @@ synopsys
 sys
 SYSFS
 systemd
+SZ
 tabbedwidths
 tabccitt
 tabdnp

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -47,7 +47,6 @@ ANamespace
 anotherchan
 ANOTHEREVENT
 anotherparam
-Anps
 aop
 apad
 api
@@ -218,7 +217,6 @@ ccsparc
 cdata
 cdefs
 CDH
-Cdioux
 cdn
 cdt
 cerrno
@@ -534,6 +532,7 @@ Dxyz
 dylib
 EACCES
 EAGAIN
+eas
 eay
 eb
 EBADF
@@ -547,7 +546,6 @@ edu
 EEXIST
 EFAULT
 EFBIG
-Efg
 EGB
 EHAs
 EINPROGRESS
@@ -1090,7 +1088,6 @@ LINUXTIMEIMPL
 listbox
 listdir
 Listst
-LIw
 LJR
 ljust
 lkd
@@ -1286,6 +1283,7 @@ noapp
 noargport
 NOBUFFERS
 NOCOLOR
+nocov
 NOCTTY
 nogen
 nolog
@@ -1904,7 +1902,6 @@ synopsys
 sys
 SYSFS
 systemd
-SZ
 tabbedwidths
 tabccitt
 tabdnp

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -35,8 +35,8 @@ value="(?:[0-9a-f]{1,2} )*"
 # ignore long runs of a single character:
 \b([A-Za-z])\g{-1}{3,}\b
 
-# Ignore any text between block of back-ticks
-(([ \t]*`{3,4})([^\n]*)([\s\S]+?)(^[ \t]*\2))
+# Ignore string sequence if it is assigned to a variable and has special symbols | \ / % * & %
+=\s*["'].*[\|\\\/\#\*\&\%].*["']
 
 # Ignore any text between inline back-ticks
 `(.*?)`

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -34,3 +34,9 @@ value="(?:[0-9a-f]{1,2} )*"
 
 # ignore long runs of a single character:
 \b([A-Za-z])\g{-1}{3,}\b
+
+# Ignore any text between block of back-ticks
+(([ \t]*`{3,4})([^\n]*)([\s\S]+?)(^[ \t]*\2))
+
+# Ignore any text between inline back-ticks
+`(.*?)`

--- a/Gds/src/fprime_gds/common/data_types/event_data.py
+++ b/Gds/src/fprime_gds/common/data_types/event_data.py
@@ -9,6 +9,7 @@
 
 from fprime.common.models.serialize import time_type
 from fprime_gds.common.data_types import sys_data
+from fprime_gds.common.utils.string_util import format_string
 
 
 class EventData(sys_data.SysData):
@@ -102,7 +103,7 @@ class EventData(sys_data.SysData):
             # used to fill in a format string. Convert them to values that can be
             arg_val_list = [arg_obj.val for arg_obj in self.args]
 
-            arg_str = format_str % tuple(arg_val_list)
+            arg_str = format_string(format_str, tuple(arg_val_list))
 
         if verbose and csv:
             return "%s,%s,%s,%d,%s,%s" % (

--- a/Gds/src/fprime_gds/common/utils/string_util.py
+++ b/Gds/src/fprime_gds/common/utils/string_util.py
@@ -1,0 +1,44 @@
+"""
+string_util.py
+
+Utility functions to process strings to be used in FPrime GDS
+
+@Created March 18, 2021
+@janamian
+"""
+
+import re
+
+def format_string(format_str, values):
+    """
+    Function to convert C-string style to python format
+    without using python interpolation
+    Considered the following format for C-string:
+    %[flags][width][.precision][length]type
+
+    %:           (?<!%)(?:%%)*%
+    flags:       ([\-\+0\ \#])?
+    width:       (\d+|\*)?
+    .precision:  (\.\*|\.\d+)?
+    length:      ([hLIw]|l{1,2}|I32|I64)?
+    type:        ([cCdiouxXeEfgGaAnpsSZ])
+
+    Note:
+    This function will keep the flags, widht, .percision and length of C-string
+    template. It will remove all types so they could be ducktyped by python 
+    interpreter except for hex type X or x.
+    """
+    def convert(match_obj):
+        if match_obj.group() is not None:
+            template = "{:" + match_obj.group()[1:-1]
+            if match_obj.group()[-1].lower() == 'x':
+                template += match_obj.group()[-1]
+            template += "}"
+            return template
+        return match_obj
+
+    pattern = "(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])"
+    match = re.compile(pattern) 
+    formated_str = re.sub(match, convert, format_str)
+    result = formated_str.format(*values)
+    return result

--- a/Gds/src/fprime_gds/common/utils/string_util.py
+++ b/Gds/src/fprime_gds/common/utils/string_util.py
@@ -24,8 +24,8 @@ def format_string(format_str, values):
     type:        ([cCdiouxXeEfgGaAnpsSZ])
 
     Note:
-    This function will keep the flags, widht, .percision and length of C-string
-    template. It will remove all types so they could be ducktyped by python 
+    This function will keep the flags, width, .precision and length of C-string
+    template. It will remove all types so they could be duck-typed by python 
     interpreter except for hex type X or x.
     """
     def convert(match_obj):

--- a/Gds/src/fprime_gds/common/utils/string_util.py
+++ b/Gds/src/fprime_gds/common/utils/string_util.py
@@ -15,14 +15,14 @@ def format_string(format_str, values):
     without using python interpolation
     Considered the following format for C-string:
     %[flags][width][.precision][length]type
-
+    ```
     %:           (?<!%)(?:%%)*%
     flags:       ([\-\+0\ \#])?
     width:       (\d+|\*)?
     .precision:  (\.\*|\.\d+)?
     length:      ([hLIw]|l{1,2}|I32|I64)?
     type:        ([cCdiouxXeEfgGaAnpsSZ])
-
+    ```
     Note:
     This function will keep the flags, width, .precision and length of C-string
     template. It will remove all types so they could be duck-typed by python 

--- a/Gds/src/fprime_gds/common/utils/string_util.py
+++ b/Gds/src/fprime_gds/common/utils/string_util.py
@@ -15,14 +15,14 @@ def format_string(format_str, values):
     without using python interpolation
     Considered the following format for C-string:
     %[flags][width][.precision][length]type
-    ```
+    
     %:           (?<!%)(?:%%)*%
     flags:       ([\-\+0\ \#])?
     width:       (\d+|\*)?
     .precision:  (\.\*|\.\d+)?
-    length:      ([hLIw]|l{1,2}|I32|I64)?
-    type:        ([cCdiouxXeEfgGaAnpsSZ])
-    ```
+    length:      `([hLIw]|l{1,2}|I32|I64)?`
+    type:        `([cCdiouxXeEfgGaAnpsSZ])`
+    
     Note:
     This function will keep the flags, width, .precision and length of C-string
     template. It will remove all types so they could be duck-typed by python 

--- a/Gds/src/fprime_gds/flask/events.py
+++ b/Gds/src/fprime_gds/flask/events.py
@@ -13,6 +13,7 @@ import types
 
 import flask_restful
 import flask_restful.reqparse
+from fprime_gds.common.utils.string_util import format_string
 
 
 class EventDictionary(flask_restful.Resource):
@@ -63,7 +64,7 @@ class EventHistory(flask_restful.Resource):
             setattr(
                 event,
                 "display_text",
-                event.template.format_str % tuple([arg.val for arg in event.args]),
+                format_string(event.template.format_str, tuple([arg.val for arg in event.args])),
             )
             func = lambda this: this.display_text
             setattr(event, "get_display_text", types.MethodType(func, event))

--- a/Gds/test/fprime_gds/common/utils/test_string_util.py
+++ b/Gds/test/fprime_gds/common/utils/test_string_util.py
@@ -1,0 +1,41 @@
+"""
+Tests format_string util
+
+@Created on March 18, 2021
+@janamian
+"""
+
+import unittest
+from fprime_gds.common.utils.string_util import format_string
+
+class TestFormatString(unittest.TestCase):
+
+    def test_format_with_no_issue(self):
+        template = 'Opcode 0x%04X dispatched to port %d and value %f'
+        values = (181, 8, 1.234)
+        expected = 'Opcode 0x00B5 dispatched to port 8 and value 1.234'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_value_with_string_input_as_other_types(self):
+        template = 'Opcode 0x%04X dispatched to port %d and value %f'
+        values = (181, "8", "1.234")
+        expected = 'Opcode 0x00B5 dispatched to port 8 and value 1.234'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_with_format_spec(self):
+        template = 'Opcode 0x%04X dispatched to port %04d and value %0.02f'
+        values = (181, 8, 1.234)
+        expected = 'Opcode 0x00B5 dispatched to port 0008 and value 1.2'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_bad_case(self):
+        template = 'Opcode 0x%04X dispatched with value %f'
+        values = ("181", "0.123")
+        with self.assertRaises(ValueError):
+            self.assertEqual(format_string(template, values))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| FPrime|
|**_Affected Component_**| events |
|**_Affected Architectures(s)_**| GDS |
|**_Related Issue(s)_**|  #349 |
|**_Has Unit Tests (y/n)_**| Y |
|**_Builds Without Errors (y/n)_**|  Y |
|**_Unit Tests Pass (y/n)_**| Y  |
|**_Documentation Included (y/n)_**| Y |

---
## Change Description

Old style Python %-formatting string interpolation is removed from the `events`.
GDS Python code could throw an exception when the string format defined in the componentEventAi.xml did not have the expected string format value.
For example, the following event format_string could potentially break the GDS Python code since %-formatting expects an integer, but Enum in the form of string is passed to GDS:

![image](https://user-images.githubusercontent.com/35859004/111595686-98472200-8789-11eb-879e-154f7443efa9.png)

## Rationale

Python code should not break if user defines Enum as %d in the event string format.
With this fix using %d as the placeholder for Enum will not break the Python code. The correct string value of Enum will be shown in the event page and event log in GDS.

Note 1: The fix still expects correct Hex format (e.g. %04X) and will raise a ValueError if a string is proved in place of expected Hex value.

Note 2: This function will keep the flags, width, .precision and length of C-string template. It will remove all types so they could be duck-typed by the Python interpreter except for hex type X or x.

## Testing/Review Recommendations

Mutated fprime/Ref/SignalGen/Events.xml to have:
```C++
format_string="Set Frequency(Hz) %d, Amplitude %f, Phase %f, Signal Type %d"
```

Tested the output as shown below with expected values:
![image](https://user-images.githubusercontent.com/35859004/111597236-35ef2100-878b-11eb-89d0-98b75614f918.png)

![image](https://user-images.githubusercontent.com/35859004/111597267-3be50200-878b-11eb-8e9d-76163b0d6109.png)

The unit test can be found here: fprime/Gds/test/fprime_gds/common/utils/test_string_util.py 

## Future Work

This update will not fix the std out to show the Enum string if %d is used as string format.

If we have the following:
```C++
format_string="Set Frequency(Hz) %d, Amplitude %f, Phase %f, Signal Type %d"
```
The output will still show this:
![image](https://user-images.githubusercontent.com/35859004/111597015-050eec00-878b-11eb-9883-1c9d72489ccf.png)

Instead of this:
![image](https://user-images.githubusercontent.com/35859004/111597039-0a6c3680-878b-11eb-89ad-3ec1df62a2ed.png)


