### PR TITLE
fix 369: Include CmdPort on components with parameters only

### DIFF
--- a/cmake/support/parser/ai_parser.py
+++ b/cmake/support/parser/ai_parser.py
@@ -22,7 +22,7 @@ BASIC_DEPENDENCIES = {
     "commands": ["Fw_Cfg", "Fw_Types", "Fw_Time", "Fw_Com", "Fw_Cmd"],
     "events": ["Fw_Cfg", "Fw_Types", "Fw_Time", "Fw_Com", "Fw_Log"],
     "telemetry": ["Fw_Cfg", "Fw_Types", "Fw_Time", "Fw_Com", "Fw_Tlm"],
-    "parameters": ["Fw_Cfg", "Fw_Types", "Fw_Prm"],
+    "parameters": ["Fw_Cfg", "Fw_Types", "Fw_Prm", "Fw_Cmd"],
     "internal_interfaces": [],
     "enum": [],
     "array": [],


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| FPrime|
|**_Affected Component_**| cmake/support/parser/ai_parser.py|
|**_Affected Architectures(s)_**| GDS |
|**_Related Issue(s)_**|  #369 |
|**_Has Unit Tests (y/n)_**| N |
|**_Builds Without Errors (y/n)_**|  Y |
|**_Unit Tests Pass (y/n)_**| NA  |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

When *ComponentAi.xml only contains parameter and not any command the autocoder does not include
Fw/Cmd/CmdPortAc.hpp
This PR resolves the issue by adding `Fw_Cmd` as implicit dependency of `parameters` in cmake/support/parser/ai_parser.py

## Rationale

For the rational see https://github.com/nasa/fprime/issues/369#issuecomment-803435465

## Testing/Review Recommendations

After applying the change was able to successfully build and run the code as shown https://github.com/nasa/fprime/issues/369#issuecomment-803435465

## Future Work

It should be discussed if command port should implicitly be added to the components that only have parameters without having any command port.
