### PR TITLE
fix 466: fprime-util ignores non-default UT executable names

### DIFF
--- a/cmake/support/Unit_Test.cmake
+++ b/cmake/support/Unit_Test.cmake
@@ -141,9 +141,16 @@ function(generate_ut UT_EXE_NAME UT_SOURCES_INPUT MOD_DEPS_INPUT)
                               --overwrite MemoryCheckCommandOptions=--leak-check=full --error-exitcode=100
                               --verbose -T MemCheck)
     endif()
+    
+    # Add top ut wrapper for this module
+    if (NOT TARGET "${MODULE_NAME}_ut_exe")
+      add_custom_target("${MODULE_NAME}_ut_exe")
+    endif()
+    
     add_dependencies("${MODULE_NAME}_check" ${UT_EXE_NAME})
     add_dependencies("${MODULE_NAME}_check_leak" ${UT_EXE_NAME})
-    
+    add_dependencies("${MODULE_NAME}_ut_exe" ${UT_EXE_NAME})
+
     # Link library list output on per-module basis
     if (CMAKE_DEBUG_OUTPUT)
 	    print_dependencies(${UT_EXE_NAME})


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| FPrime |
|**_Affected Component_**|  cmake/support/Unit_Test.cmake |
|**_Affected Architectures(s)_**|  cmake ut build|
|**_Related Issue(s)_**|  #466 |
|**_Has Unit Tests (y/n)_**|  N |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| NA  |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

`fprime-util generate --ut` assumes the `MODULE_NAME_ut_exe` as the default name for target executable UT.
This won't be an issue if the UT is registered with default name:
As an example line 24 of the following won't be a problem: 
https://github.com/nasa/fprime/blob/e1624fd8973284aec3a1c08c26732349620c2a6d/Svc/GenericHub/CMakeLists.txt#L14-L24

The problem arises when UTs are registered with an executable name.
For example line 38 of the following will raise the issue specified in #466 complaining `make: *** No rule to make target Fw_Types_ut_exe.  Stop.`

https://github.com/nasa/fprime/blob/e1624fd8973284aec3a1c08c26732349620c2a6d/Fw/Types/CMakeLists.txt#L35-L38

This PR resolves the issue by registering the default `MODULE_NAME_ut_exe` as target name and adding all UT executables of the module as the dependency of the `MODULE_NAME_ut_exe`.
 
## Rationale

`MODULE_NAME_ut_exe` is added as top wrapper for UT build so it could be called by fprime-util.

## Testing/Review Recommendations

Manually built and ran UT of `Fw/Types`, `Drv/Ip` and `Svr/GenericHub` with no issues.

## Future Work

Might need to optimize the cmake `generate` option to not include modules that are not related to the target UT.
