### PR TITLE
Fixed TypeError after error during code generation

### DIFF
--- a/Autocoders/Python/bin/codegen.py
+++ b/Autocoders/Python/bin/codegen.py
@@ -954,7 +954,7 @@ def generate_component_instance_dictionary(
         # can't have external non-xml members
         if len(xml_parser_obj.get_include_header_files()):
             PRINT.info(
-                "ERROR: Component include serializables cannot use user-defined types. file: "
+                "ERROR: Component include serializables cannot use user-defined types. file: %s"
                 % serializable_file
             )
             sys.exit(-1)
@@ -1129,7 +1129,7 @@ def generate_component(
         # can't have external non-xml members
         if len(xml_parser_obj.get_include_header_files()):
             PRINT.info(
-                "ERROR: Component include serializables cannot use user-defined types. file: "
+                "ERROR: Component include serializables cannot use user-defined types. file: %s"
                 % serializable_file
             )
             sys.exit(-1)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| Autocoders/Python/bin/codegen.py |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Fixed two TypeErrors which occurred when testing for the questions asked at: https://groups.google.com/g/fprime-community/c/FseVP1xcjSc

## Rationale

Fixes bug

## Testing/Review Recommendations

Create a serializable which has an `include_header` element and related member and is sent as telemetry, run `fprime-util build`, no exception should be thrown. Remove the member and the include and successfully compile the project. Add them back in and compile again. This hits both error statements.

## Future Work

None