### PR TITLE
Fix 473: GDS updating orb status when client connection drops

### DIFF
--- a/Gds/src/fprime_gds/flask/static/js/datastore.js
+++ b/Gds/src/fprime_gds/flask/static/js/datastore.js
@@ -128,6 +128,8 @@ export class DataStore {
             this.active.splice(index, 1, true);
             clearTimeout(this.active_timeout);
             this.active_timeout = setTimeout(() => _self.active.splice(index, 1, false), timeout);
+        } else {
+            this.active.splice(index, 1, false);
         }
     }
 };


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| FPrime|
|**_Affected Component_**|  datastore.js|
|**_Affected Architectures(s)_**| GDS |
|**_Related Issue(s)_**|  #473 |
|**_Has Unit Tests (y/n)_**|  N |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**|  NA |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

The following will fix issue #473 GDS Orb does not change when client connection drops.

## Rationale

GDS orb should show status of data communication by changing state when there is no data from client for a period of time  defined by `active_timeout` in config file or when client connection is dropped.

## Testing/Review Recommendations

Manually verified the functionality as shown below:

1. Started GDS GUI with client connected and sent few NO_OP commands:

![Screen Shot 2021-04-12 at 12 02 56 AM](https://user-images.githubusercontent.com/35859004/114355051-e0a4f600-9b23-11eb-9620-8adf9afd857f.png)

2. Dropped client connection:

![image](https://user-images.githubusercontent.com/35859004/114355174-003c1e80-9b24-11eb-9035-f5222ce52a76.png)

3. Status of orb changed as shown below:

![image](https://user-images.githubusercontent.com/35859004/114355222-0f22d100-9b24-11eb-9c51-5130b0bf8f63.png)
 

## Future Work

NA
