### PR TITLE
Fix 474: Removed hardcoded cmdDisp.CMD_NO_OP from GDS GUI

### DIFF
--- a/Gds/src/fprime_gds/flask/static/js/vue-support/command.js
+++ b/Gds/src/fprime_gds/flask/static/js/vue-support/command.js
@@ -67,7 +67,8 @@ Vue.component("command-item", {
  */
 Vue.component("command-input", {
     data: function() {
-        let selected = _datastore.commands["cmdDisp.CMD_NO_OP"];
+        let keys = Object.keys(_datastore.commands).filter(command_name => {return command_name.indexOf("CMD_NO_OP") != -1;});
+        let selected = (keys.length != 0) ? _datastore.commands[keys[0]] : Object.keys(_datastore.commands)[0];
         return {
             "commands": _datastore.commands,
             "loader": _loader,


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| FPrime |
|**_Affected Component_**| vue-support/command.js |
|**_Affected Architectures(s)_**|  GDS |
|**_Related Issue(s)_**| #474 |
|**_Has Unit Tests (y/n)_**|  N |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

The following will fix issue #474 GDS hardcoded `cmdDisp.CMD_NO_OP` in command.js

## Rationale

GDS GUI should not break if user does not specify `cmdDisp.CMD_NO_OP`

## Testing/Review Recommendations

Manually checked the fix as shown below:

Changed the command `cmdDisp.CMD_NO_OP` to `cmdDisp.CMD_NO_OP_TEST`
As shown below GUI did not break:

![image](https://user-images.githubusercontent.com/35859004/114358141-71c99c00-9b27-11eb-840a-55e64dfeaffb.png)

Also events table was as expected:

![image](https://user-images.githubusercontent.com/35859004/114358255-902f9780-9b27-11eb-8d2e-dd5455856996.png)

Terminal output was as expected:

![image](https://user-images.githubusercontent.com/35859004/114358365-b05f5680-9b27-11eb-99d6-df4cb6f2b528.png)


## Future Work

NA
