### PR TITLE
Fix 471: Adding a `MAX` enum item as the last item in the external enum

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
@@ -45,20 +45,19 @@ namespace ${namespace} {
 #for $item_name,$item_value,$item_comment in $items_list:
 #if not $item_value == ""
 #if not item_comment == ""
-        ${item_name} = ${item_value}, //!< ${item_comment}
+    ${item_name} = ${item_value}, //!< ${item_comment}
 #else
-        ${item_name} = ${item_value},
+    ${item_name} = ${item_value},
 #end if
 #else
 #if not item_comment == ""
-        ${item_name}, //!< ${item_comment}
+    ${item_name}, //!< ${item_comment}
 #else
-        ${item_name},
+    ${item_name},
 #end if
 #end if
 #end for
-        ${name}_MAX = ${int(item_value) + 1},
-    } t;
+        } t;
   
     public:
   
@@ -68,7 +67,7 @@ namespace ${namespace} {
 
     enum {
         SERIALIZED_SIZE = sizeof(FwEnumStoreType),
-        ENUM_LENGTH = ${len($items_list)}
+        LENGTH = ${len($items_list)}
         };
 
     public:

--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
@@ -45,19 +45,20 @@ namespace ${namespace} {
 #for $item_name,$item_value,$item_comment in $items_list:
 #if not $item_value == ""
 #if not item_comment == ""
-    ${item_name} = ${item_value}, //!< ${item_comment}
+        ${item_name} = ${item_value}, //!< ${item_comment}
 #else
-    ${item_name} = ${item_value},
+        ${item_name} = ${item_value},
 #end if
 #else
 #if not item_comment == ""
-    ${item_name}, //!< ${item_comment}
+        ${item_name}, //!< ${item_comment}
 #else
-    ${item_name},
+        ${item_name},
 #end if
 #end if
 #end for
-        } t;
+        ${name}_MAX = ${int(item_value) + 1},
+    } t;
   
     public:
   

--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
@@ -67,7 +67,8 @@ namespace ${namespace} {
     // ----------------------------------------------------------------------
 
     enum {
-        SERIALIZED_SIZE = sizeof(FwEnumStoreType)
+        SERIALIZED_SIZE = sizeof(FwEnumStoreType),
+        ENUM_LENGTH = ${len($items_list)}
         };
 
     public:

--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
@@ -67,7 +67,7 @@ namespace ${namespace} {
 
     enum {
         SERIALIZED_SIZE = sizeof(FwEnumStoreType),
-        LENGTH = ${len($items_list)}
+        NUM_CONSTANTS = ${len($items_list)}
         };
 
     public:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| FPrime |
|**_Affected Component_**|  External enum_hpp.tmpl |
|**_Affected Architectures(s)_**|  Autocoder |
|**_Related Issue(s)_**|  #471|
|**_Has Unit Tests (y/n)_**|  N|
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

This PR will add feature requested in #471 by adding a `MAX` enum item as the last item in the external enum.

## Rationale
The fix is adding `${name}_MAX = ${int(item_value) + 1},` after the end of template for loop as shown below:
```c++
    typedef enum {
#for $item_name,$item_value,$item_comment in $items_list:
#if not $item_value == ""
#if not item_comment == ""
        ${item_name} = ${item_value}, //!< ${item_comment}
#else
        ${item_name} = ${item_value},
#end if
#else
#if not item_comment == ""
        ${item_name}, //!< ${item_comment}
#else
        ${item_name},
#end if
#end if
#end for
        ${name}_MAX = ${int(item_value) + 1}, 
    } t;
```

The assumptions are 
1. External enums cannot have empty `value` (See `#if not $item_value == ""` in the code above).
2. External enums cannot have string value (Enforced by compiler).

In the code above the last `item_value` will be incremented by `1` and will be assigned to the last item of the enum with the name of external enum class concatenated to the word `_MAX` as shown in the last line of code above.

## Testing/Review Recommendations

Manually checked the autogenerated code on some external enums and verified that the `_MAX` item is added.
The followings are two examples of the result:

![image](https://user-images.githubusercontent.com/35859004/114429060-cbef4f00-9b71-11eb-87e1-cc34175054e7.png)

![image](https://user-images.githubusercontent.com/35859004/114429228-f7723980-9b71-11eb-9f2e-805512d37e42.png)

## Future Work

NA
