### PR TITLE
Add one-liner command for installing pre-requisites

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -122,6 +122,7 @@ autoraise
 autosectionlabel
 awt
 AYYYY
+arijitdas
 backend
 backface
 backport

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1394,6 +1394,7 @@ outdir
 outout
 outputfile
 overridable
+OS'es
 packetization
 packetized
 PACKETOUTOFBOUNDS
@@ -1663,6 +1664,7 @@ runtest
 rx
 RXD
 rxor
+RHEL
 saaj
 saddr
 sadl

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -59,3 +59,4 @@ Non-JPL Contributors to the F' Software Framework:
 * keck-in-space
 * sommercharles
 * SterlingPeet
+* arijitdas123student

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ The following utilities are prerequisites to installing F´:
 - git
 - Python 3.5+ with pip
 
+You can install them using this one-liner command :
+
+```
+sudo apt-get -y install cmake git python3-pip
+```
+
 Once these utilities are installed, you can install F´ Python dependencies. Installing dependencies in a Python virtual environment prevents issues at the system level, but installing in a virtual environment is not required. 
 
 To install F´ quickly, enter:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ The following utilities are prerequisites to installing F´:
 - git
 - Python 3.5+ with pip
 
-
 Once these utilities are installed, you can install F´ Python dependencies. Installing dependencies in a Python virtual environment prevents issues at the system level, but installing in a virtual environment is not required. 
 
 To install F´ quickly, enter:

--- a/README.md
+++ b/README.md
@@ -24,11 +24,6 @@ The following utilities are prerequisites to installing F´:
 - git
 - Python 3.5+ with pip
 
-You can install them using this one-liner command :
-
-```
-sudo apt-get -y install cmake git python3-pip
-```
 
 Once these utilities are installed, you can install F´ Python dependencies. Installing dependencies in a Python virtual environment prevents issues at the system level, but installing in a virtual environment is not required. 
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -25,6 +25,10 @@ Requirements:
 5. Python 3.5+ and PIP [https://www.python.org/downloads/](https://www.python.org/downloads/)
 6. Python Virtual Environment \* (pip install venv or pip install virtualenv)
 
+You can install them using this one-liner command :
+
+```sudo apt-get -y install cmake git python3-pip```
+
 **Note:** it is possible to install and run F´ without a virtual environment, however; for
 individuals and researchers, this is the recommended approach.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -27,7 +27,7 @@ Requirements:
 
 You can install them using this one-liner command :
 
-```sudo apt-get update && -y install cmake git python3-pip``` (for Debian based OS'es)
+```sudo apt-get update && sudo apt-get -y install cmake git python3-pip``` (for Debian based OS'es)
 
 OR
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -27,7 +27,11 @@ Requirements:
 
 You can install them using this one-liner command :
 
-```sudo apt-get update && -y install cmake git python3-pip```
+```sudo apt-get update && -y install cmake git python3-pip``` (for Debian based OS'es)
+
+OR
+
+``` yum install cmake git python3-pip ``` (for RHEL OS)
 
 **Note:** it is possible to install and run F´ without a virtual environment, however; for
 individuals and researchers, this is the recommended approach.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -27,7 +27,7 @@ Requirements:
 
 You can install them using this one-liner command :
 
-```sudo apt-get -y install cmake git python3-pip```
+```sudo apt-get update && -y install cmake git python3-pip```
 
 **Note:** it is possible to install and run F´ without a virtual environment, however; for
 individuals and researchers, this is the recommended approach.


### PR DESCRIPTION

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

I added a one-liner command :
```
sudo apt-get -y install cmake git python3-pip
```
that will ease the install of pre-requisites.

## Rationale

A rationale for this change. e.g. fixes bug, or most projects need XYZ feature.

## Testing/Review Recommendations

I have already tested this one-liner and it lays out the proper results.

## Future Work

Note any additional work that will be done relating to this issue.
