### PR TITLE
Fix 487: Adding option to `fprime-gds` to set Flask host and port number

### DIFF
--- a/Gds/src/fprime_gds/executables/cli.py
+++ b/Gds/src/fprime_gds/executables/cli.py
@@ -410,6 +410,25 @@ class GdsParser(ParserBase):
             type=str,
             help="Configuration for wx GUI. Ignored if not using wx.",
         )
+        parser.add_argument(
+            "--gui-addr",
+            dest="gui_addr",
+            action="store",
+            default="127.0.0.1",
+            required=False,
+            type=str,
+            help="Set the GUI server address [default: %(default)s]",
+        )
+        parser.add_argument(
+            "--gui-port",
+            dest="gui_port",
+            action="store",
+            default="5000",
+            required=False,
+            type=str,
+            help="Set the GUI server address [default: %(default)s]",
+        )
+
         return parser
 
     @classmethod

--- a/Gds/src/fprime_gds/executables/run_deployment.py
+++ b/Gds/src/fprime_gds/executables/run_deployment.py
@@ -256,7 +256,7 @@ def launch_wx(port, dictionary, connect_address, log_dir, config, **_):
     return launch_process(gse_args, name="WX GUI")
 
 
-def launch_html(tts_port, dictionary, connect_address, logs, **extras):
+def launch_html(tts_port, dictionary, connect_address, logs, gui_addr, gui_port, **extras):
     """
     Launch the flask server and a browser pointed at the HTML page.
 
@@ -264,6 +264,8 @@ def launch_html(tts_port, dictionary, connect_address, logs, **extras):
     :param dictionary: dictionary to look at
     :param connect_address: address to connect to
     :param logs: directory to place logs
+    :param gui_addr: Flask server host IP address
+    :param gui_port: Flask server port number
     :return: process
     """
     gse_env = os.environ.copy()
@@ -277,10 +279,12 @@ def launch_html(tts_port, dictionary, connect_address, logs, **extras):
             "SERVE_LOGS": "YES",
         }
     )
-    gse_args = [sys.executable, "-u", "-m", "flask", "run"]
+    gse_args = [sys.executable, "-u", "-m", "flask", "run", 
+                "--host", str(gui_addr), 
+                "--port", str(gui_port)]
     ret = launch_process(gse_args, name="HTML GUI", env=gse_env, launch_time=2)
     if extras["gui"] == "html":
-        webbrowser.open("http://localhost:5000/", new=0, autoraise=True)
+        webbrowser.open(f"http://localhost:{str(gui_port)}/", new=0, autoraise=True)
     return ret
 
 

--- a/Gds/src/fprime_gds/executables/run_deployment.py
+++ b/Gds/src/fprime_gds/executables/run_deployment.py
@@ -284,7 +284,7 @@ def launch_html(tts_port, dictionary, connect_address, logs, gui_addr, gui_port,
                 "--port", str(gui_port)]
     ret = launch_process(gse_args, name="HTML GUI", env=gse_env, launch_time=2)
     if extras["gui"] == "html":
-        webbrowser.open(f"http://localhost:{str(gui_port)}/", new=0, autoraise=True)
+        webbrowser.open(f"http://{str(gui_addr)}:{str(gui_port)}/", new=0, autoraise=True)
     return ret
 
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F Prime |
|**_Affected Component_**|  run_deployment.py |
|**_Affected Architectures(s)_**|  GDS |
|**_Related Issue(s)_**|  #487 |
|**_Has Unit Tests (y/n)_**|  N |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**|  NA |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

Adds options to `fprime-gds` for setting Flask server host address and port number.
The new options are:
```
--gui-addr: Set the GUI server address [default: 127.0.0.1]
--gui-port: Set the GUI server address [default: 5000]
```
## Rationale

As described in #487 there was no option in `fprime-gds` to set the host and port number of Flask server. Changing these options might be needed when running GDS GUI from a containerized environment such as docker.

## Testing/Review Recommendations

Manually tested the functionality on both Darwin and Linux platforms as shown below:

From Darwin ran `fprime-gds -n --gui-addr localhost --gui-port 4000`

![image](https://user-images.githubusercontent.com/35859004/115411967-c9f84200-a1a8-11eb-809c-5c0c7da08d2a.png)

From Linux ran `fprime-gds -n --gui-addr 0.0.0.0 --gui-port 8000`

![image](https://user-images.githubusercontent.com/35859004/115416020-3d4f8300-a1ac-11eb-93a9-d9523436ad19.png)

## Future Work

NA
