### PR TITLE
Added a missing break statement to the OPEN_SYNC_DIRECT case

### DIFF
--- a/Os/Stubs/Linux/FileStub.cpp
+++ b/Os/Stubs/Linux/FileStub.cpp
@@ -112,6 +112,7 @@ namespace Os {
 #else
                 ;
 #endif
+                break;
             case OPEN_CREATE:
                 flags = O_WRONLY | O_CREAT | O_TRUNC;
                 break;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F Prime |
|**_Affected Component_**| FileStub.cpp |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| #490 |
|**_Has Unit Tests (y/n)_**| N |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| N |

---
## Change Description
Closes #490.
A break statement was missing in one of the switch cases. Fixed it
by adding it.


## Rationale
Fixes the switch fall through issue mentioned in #490.

## Testing/Review Recommendations

General automation testing.

## Future Work

N/A
