### PR TITLE
Turn off pip caching for docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,9 +36,9 @@ ENTRYPOINT ["/bin/bash"]
 FROM fprime-base AS fprime-docker
 RUN     git clone --quiet https://github.com/nasa/fprime.git /opt/fprime && \
         python3 -m venv /opt/fprime-venv/ && . /opt/fprime-venv/bin/activate && \
-        pip install -U wheel setuptools pip && \
-        pip install /opt/fprime/Fw/Python/ && \
-        pip install /opt/fprime/Gds/ && \
+        pip install --no-cache-dir -U wheel setuptools pip && \
+        pip install --no-cache-dir /opt/fprime/Fw/Python/ && \
+        pip install --no-cache-dir /opt/fprime/Gds/ && \
         rm -r ~/.cache/pip && \
         chown -R fprime:fprime /opt/fprime-venv && \
         chmod -R 775 /opt/fprime-venv


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Matthew Gleich \<email@mattglei.ch> |
|**_Affected Component_**| F´Docker |
|**_Affected Architectures(s)_**| Anything that involves the docker build |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| N/A |
|**_Builds Without Errors (y/n)_**| N/A |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

Dependency installations via the pip package manager no longer utilize the caching feature in the docker build.

## Rationale

A best practice when working with dockerfiles is to effectively utilize the caching system. The pip install steps are already being cached by the docker build system. This means that the cached dependencies made by pip are being wasted and stored for no reason. A fatter image might not a concern here but it is always a good idea to follow the best practices.

## Testing/Review Recommendations

To ensure that the docker image still works you could run a simple test. From my end, the build still works.

## Future Work

N/A
