### PR TITLE
Fix copy/paste error resulting in identical condition

### DIFF
--- a/Drv/SocketIpDriver/SocketHelper.cpp
+++ b/Drv/SocketIpDriver/SocketHelper.cpp
@@ -228,7 +228,7 @@ namespace Drv {
                 break;
             }
             // Error returned, and it wasn't an interrupt
-            else if (sent == -1 && errno == EINTR) {
+            else if (sent == -1 && errno != EINTR) {
                 Fw::Logger::logMsg("[ERROR] IP send failed ERRNO: %d UDP: %d\n", errno, m_sendUdp);
                 break;
             }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @LeStarch (I think) |
|**_Affected Component_**| `/Drv/SocketIpDriver/ |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| #497 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

As the comment suggests, the intent was to catch all /other/ errors.

## Rationale

This PR should fix a bug where a repeated condition caused most errors on `send()` and `sendto()` to be ignored and the contition itself could never be true on line 231.

## Testing/Review Recommendations

Hopefully I haven't missed anything and this bugfix is as easy as it looks.

## Future Work

None.
