### PR TITLE
Add default_ut_toolchain settings option

### DIFF
--- a/Fw/Python/src/fprime/fbuild/builder.py
+++ b/Fw/Python/src/fprime/fbuild/builder.py
@@ -529,11 +529,14 @@ class Build:
         assert self.build_dir is None, "Already setup it is invalid to re-setup"
 
         self.settings = IniSettings.load(self.deployment / "settings.ini", cwd)
-        self.platform = (
-            platform
-            if platform is not None and platform != "default"
-            else self.settings.get("default_toolchain", "native")
-        )
+
+        if platform is not None and platform != "default":
+            self.platform = platform
+        elif self.build_type == BuildType.BUILD_TESTING:
+            self.platform = self.settings.get("default_ut_toolchain", "native")
+        else:
+            self.platform = self.settings.get("default_toolchain", "native")
+
         self.build_dir = build_dir if build_dir is not None else self.get_build_cache()
 
 

--- a/Fw/Python/src/fprime/fbuild/settings.py
+++ b/Fw/Python/src/fprime/fbuild/settings.py
@@ -142,6 +142,9 @@ class IniSettings:
             "default_toolchain": confparse.get(
                 "fprime", "default_toolchain", fallback="native"
             ),
+            "default_ut_toolchain": confparse.get(
+                "fprime", "default_ut_toolchain", fallback="native"
+            ),
             "install_dest": install_dest,
             "environment_file": env_file,
             "environment": environment,

--- a/Fw/Python/test/fprime/fbuild/settings-data/settings-custom-toolchain.ini
+++ b/Fw/Python/test/fprime/fbuild/settings-data/settings-custom-toolchain.ini
@@ -1,0 +1,3 @@
+[fprime]
+default_toolchain: custom1
+default_ut_toolchain: custom2

--- a/Fw/Python/test/fprime/fbuild/test_settings.py
+++ b/Fw/Python/test/fprime/fbuild/test_settings.py
@@ -33,6 +33,7 @@ def test_settings():
             "expected": {
                 "settings_file": full_path("settings-data/settings-empty.ini"),
                 "default_toolchain": "native",
+                "default_ut_toolchain": "native",
                 "framework_path": full_path("../../../../.."),
                 "install_dest": full_path("settings-data/build-artifacts"),
                 "library_locations": [],
@@ -45,11 +46,27 @@ def test_settings():
             "expected": {
                 "settings_file": full_path("settings-data/settings-custom-install.ini"),
                 "default_toolchain": "native",
+                "default_ut_toolchain": "native",
                 "framework_path": full_path("../../../../.."),
                 "install_dest": full_path("test"),
                 "library_locations": [],
                 "environment_file": full_path(
                     "settings-data/settings-custom-install.ini"
+                ),
+                "environment": {},
+            },
+        },
+        {
+            "file": "settings-custom-toolchain.ini",
+            "expected": {
+                "settings_file": full_path("settings-data/settings-custom-toolchain.ini"),
+                "default_toolchain": "custom1",
+                "default_ut_toolchain": "custom2",
+                "framework_path": full_path("../../../../.."),
+                "install_dest": full_path("settings-data/build-artifacts"),
+                "library_locations": [],
+                "environment_file": full_path(
+                    "settings-data/settings-custom-toolchain.ini"
                 ),
                 "environment": {},
             },

--- a/ci/tests/fputil.bash
+++ b/ci/tests/fputil.bash
@@ -24,18 +24,7 @@ function fputil_action {
     (
         cd "${DEPLOYMENT}"
         PLATFORM=""
-        # Setup special platform for check/check-all
-        if [[ "${TARGET}" == check* ]] && [[ "${DEPLOYMENT}" == */RPI ]]
-        then
-                PLATFORM="${CHECK_TARGET_PLATFORM}"
-                if [[ "${TEST_TYPE}" == "QUICK" ]]
-                then
-                    echo "[INFO] Generating build cache before ${DEPLOYMENT//\//_} '${TARGET}' execution"
-                    fprime-util generate --ut ${PLATFORM} > "${LOG_DIR}/${DEPLOYMENT//\//_}_pregen.out.log" 2> "${LOG_DIR}/${DEPLOYMENT//\//_}_pregen.err.log" \
-                        || fail_and_stop "Failed to generate before ${DEPLOYMENT//\//_} '${TARGET}' execution"
-                fi
-        fi
-  
+
         # Generate is only needed when it isn't being tested
         if [[ "${TARGET}" != "generate" ]] && [[ "${TEST_TYPE}" != "QUICK" ]]
         then
@@ -97,7 +86,7 @@ function integration_test {
         # Run integration tests
         (
             cd "${WORKDIR}/test"
-            echo "[INFO] Running ${WORKDIR}/test's pytest integration tests" 
+            echo "[INFO] Running ${WORKDIR}/test's pytest integration tests"
             timeout --kill-after=10s 180s pytest
         )
         RET_PYTEST=$?
@@ -110,7 +99,7 @@ function integration_test {
         wait $VALGRIND_PID
         RET_MEMTEST=$?
         # Report memory leaks if they occurred and the pytests were successful
-        if [ ${RET_MEMTEST} -ne 0 ] && [ ${RET_PYTEST} -eq 0 ]; then 
+        if [ ${RET_MEMTEST} -ne 0 ] && [ ${RET_PYTEST} -eq 0 ]; then
             cat "${LOG_DIR}/gds-logs/valgrind.log"
             fail_and_stop "Integration tests on ${WORKDIR} contain memory leaks"
         fi

--- a/docs/UsersGuide/user/settings.md
+++ b/docs/UsersGuide/user/settings.md
@@ -44,6 +44,8 @@ These settings include:
   specified with the `:` separator. Ex: `../library1:../library2`
 - `default_toolchain`: Default platform to build against. Defaults to `native`, or the host
   computer platform.
+- `default_ut_toolchain`: Default platform to build unit tests against. Defaults to `native`, or the host
+  computer platform.
 - `environment_file`: An ini file that can be used to set environmental variables during the build
   process.
 - `ac_constants`: Path to autocode constants ini file.


### PR DESCRIPTION

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| fprime-util |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y  |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y  |

---
## Change Description

Adds a `default_ut_toolchain` option to settings.ini file

## Rationale

Right now, setting a default toolchain also would also set your default toolchain for building/running units tests.
Most of the time however, users build their unit tests for a platform different than they target their normal builds.

For example, a user may target an embedded system for the deployment but design the unit tests to run natively on linux.

Because of this split between target toolchain and unit test toolchain, the user will always need to override the platform
when building either the target or the unit tests.

This change allows users to separately configure the target and unit test toolchain.
Setting the default_toolchain has no effect on the default unit test toolchain and vice versa.
If either default toolchain is unset, it will default to a native platform build.

## Testing/Review Recommendations

Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality.

## Future Work

Note any additional work that will be done relating to this issue.
