### PR TITLE
I2C return status enumeration into its own EnumAi.xml

### DIFF
--- a/Drv/I2cDriverPorts/CMakeLists.txt
+++ b/Drv/I2cDriverPorts/CMakeLists.txt
@@ -7,6 +7,7 @@
 ####
 set(SOURCE_FILES
 	"${CMAKE_CURRENT_LIST_DIR}/I2cPortAi.xml"
+	"${CMAKE_CURRENT_LIST_DIR}/I2cStatusEnumAi.xml"
 )
 
 register_fprime_module()

--- a/Drv/I2cDriverPorts/I2cPortAi.xml
+++ b/Drv/I2cDriverPorts/I2cPortAi.xml
@@ -2,6 +2,7 @@
 <?oxygen RNGSchema="file:../xml/ISF_Type_Schema.rnc" type="compact"?>
 
 <interface name="I2c" namespace="Drv">
+  <import_enum_type>Drv/I2cDriverPorts/I2cStatusEnumAi.xml</import_enum_type>
   <include_header>Fw/Buffer/Buffer.hpp</include_header>
     <args>
         <arg name="addr" type="U32">
@@ -11,13 +12,5 @@
             <comment>Buffer with data to read/write to/from</comment>
         </arg>
     </args>
-    <return type="ENUM" pass_by="value">
-       <enum name="I2cStatus">
-            <item name="I2C_OK" comment="Transaction okay"/>
-            <item name="I2C_ADDRESS_ERR" comment="I2C address invalid"/>           
-            <item name="I2C_WRITE_ERR" comment="I2C write failed"/>           
-            <item name="I2C_READ_ERR" comment="I2C read failed"/>           
-            <item name="I2C_OTHER_ERR" comment="Other errors that don't fit"/>           
-       </enum>
-   </return>
+    <return type="Drv::I2cStatus" pass_by="value"> </return>
 </interface>

--- a/Drv/I2cDriverPorts/I2cStatusEnumAi.xml
+++ b/Drv/I2cDriverPorts/I2cStatusEnumAi.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?oxygen RNGSchema="file:../../Autocoders/Python/schema/ISF_Type_Schema.rnc" type="compact"?>
+<enum namespace = "Drv" name="I2cStatus">
+    <comment>Enum of the status returns from the I2C Driver</comment>
+    <item name="I2C_OK" value="0" comment="Transaction okay"/>
+    <item name="I2C_ADDRESS_ERR" value="1" comment="I2C address invalid"/>
+    <item name="I2C_WRITE_ERR" value="2" comment="I2C write failed"/>
+    <item name="I2C_READ_ERR" value="3" comment="I2C read failed"/>
+    <item name="I2C_OTHER_ERR" value="4" comment="Other errors that don't fit"/>
+</enum>
+

--- a/Drv/LinuxI2cDriver/CMakeLists.txt
+++ b/Drv/LinuxI2cDriver/CMakeLists.txt
@@ -5,9 +5,26 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
-set(SOURCE_FILES
-	"${CMAKE_CURRENT_LIST_DIR}/I2cPortAi.xml"
-	"${CMAKE_CURRENT_LIST_DIR}/I2cStatusEnumAi.xml"
-)
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+	add_definitions(-DSTUBBED_LINUX_I2C_DRIVER)
+	set(SOURCE_FILES
+		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
+		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImplStub.cpp"
+	)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+	set(SOURCE_FILES
+		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
+		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImpl.cpp"
+	)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "arm-linux-gnueabihf")
+	set(SOURCE_FILES
+		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
+		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImpl.cpp"
+	)
+else()
+	set(SOURCE_FILES
+		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
+	)
+endif()
 
 register_fprime_module()

--- a/Drv/LinuxI2cDriver/CMakeLists.txt
+++ b/Drv/LinuxI2cDriver/CMakeLists.txt
@@ -5,26 +5,9 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-	add_definitions(-DSTUBBED_LINUX_I2C_DRIVER)
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImplStub.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImpl.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "arm-linux-gnueabihf")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImpl.cpp"
-	)
-else()
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
-	)
-endif()
+set(SOURCE_FILES
+	"${CMAKE_CURRENT_LIST_DIR}/I2cPortAi.xml"
+	"${CMAKE_CURRENT_LIST_DIR}/I2cStatusEnumAi.xml"
+)
 
 register_fprime_module()

--- a/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImpl.cpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImpl.cpp
@@ -92,7 +92,7 @@ namespace Drv {
 #if DEBUG_PRINT
           printf("Status: %d Errno: %d\n", stat, errno);
 #endif
-	  return Drv::I2C_ADDRESS_ERR;
+	  return I2cStatus::I2C_ADDRESS_ERR;
       }
       // make sure it isn't a null pointer
       FW_ASSERT(serBuffer.getData());
@@ -102,9 +102,9 @@ namespace Drv {
 #if DEBUG_PRINT
           printf("Status: %d Errno: %d\n", stat, errno);
 #endif
-	  return Drv::I2C_WRITE_ERR;
+	  return I2cStatus::I2C_WRITE_ERR;
       }
-      return Drv::I2C_OK;
+      return I2cStatus::I2C_OK;
   }
 
   Drv::I2cStatus LinuxI2cDriverComponentImpl ::
@@ -126,7 +126,7 @@ namespace Drv {
 #if DEBUG_PRINT
           printf("Status: %d Errno: %d\n", stat, errno);
 #endif
-	  return Drv::I2C_ADDRESS_ERR;
+	  return I2cStatus::I2C_ADDRESS_ERR;
       }
       // make sure it isn't a null pointer
       FW_ASSERT(serBuffer.getData());
@@ -136,7 +136,7 @@ namespace Drv {
 #if DEBUG_PRINT
           printf("Status: %d Errno: %d\n", stat, errno);
 #endif
-	  return Drv::I2C_READ_ERR;
+	  return I2cStatus::I2C_READ_ERR;
       }
 #if DEBUG_PRINT
       for (U32 byte = 0; byte < serBuffer.getSize(); byte++) {
@@ -145,7 +145,7 @@ namespace Drv {
       }
       printf("\n");
 #endif
-      return Drv::I2C_OK;
+      return I2cStatus::I2C_OK;
   }
 
 } // end namespace Drv

--- a/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImplStub.cpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImplStub.cpp
@@ -63,7 +63,7 @@ namespace Drv {
         Fw::Buffer &serBuffer
     )
   {
-    return I2C_OK;
+    return I2cStatus::I2C_OK;
   }
 
   Drv::I2cStatus LinuxI2cDriverComponentImpl ::
@@ -73,7 +73,7 @@ namespace Drv {
         Fw::Buffer &serBuffer
     )
   {
-    return I2C_OK;
+    return I2cStatus::I2C_OK;
   }
 
 } // end namespace Drv


### PR DESCRIPTION

| | |
|:---|:---|
|**_Originating Project/Creator_**|  OWLS / Brandon Metz|
|**_Affected Component_**| LinuxI2cDriver |
|**_Affected Architectures(s)_**| All |
|**_Related Issue(s)_**| None. |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| n/a |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Broke out the return status enumeration into its own EnumAi.xml, this allows us to use the status returned in EVRs along with all the other benefits. 

## Rationale

Would like to be able to use the i2c return status in EVRs and be able to assign it to a variable for later use. 

## Testing/Review Recommendations

None. 

## Future Work

None.