### PR TITLE
Fix ShellCommand to correctly calculate buffer size

### DIFF
--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  FileManager.hpp
 // \author bocchino
 // \brief  hpp file for FileManager component implementation class
@@ -7,8 +7,8 @@
 // Copyright 2009-2015, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -20,7 +20,7 @@
 namespace Svc {
 
   // ----------------------------------------------------------------------
-  // Construction, initialization, and destruction 
+  // Construction, initialization, and destruction
   // ----------------------------------------------------------------------
 
   FileManager ::
@@ -38,7 +38,7 @@ namespace Svc {
     init(
         const NATIVE_INT_TYPE queueDepth,
         const NATIVE_INT_TYPE instance
-    ) 
+    )
   {
     FileManagerComponentBase::init(queueDepth, instance);
   }
@@ -50,7 +50,7 @@ namespace Svc {
   }
 
   // ----------------------------------------------------------------------
-  // Command handler implementations 
+  // Command handler implementations
   // ----------------------------------------------------------------------
 
   void FileManager ::
@@ -62,7 +62,7 @@ namespace Svc {
   {
     Fw::LogStringArg logStringDirName(dirName.toChar());
     this->log_ACTIVITY_HI_CreateDirectoryStarted(logStringDirName);
-    const Os::FileSystem::Status status = 
+    const Os::FileSystem::Status status =
       Os::FileSystem::createDirectory(dirName.toChar());
     if (status != Os::FileSystem::OP_OK) {
       this->log_WARNING_HI_DirectoryCreateError(
@@ -110,9 +110,9 @@ namespace Svc {
     Fw::LogStringArg logStringSource(sourceFileName.toChar());
     Fw::LogStringArg logStringDest(destFileName.toChar());
     this->log_ACTIVITY_HI_MoveFileStarted(logStringSource, logStringDest);
-    const Os::FileSystem::Status status = 
+    const Os::FileSystem::Status status =
       Os::FileSystem::moveFile(
-          sourceFileName.toChar(), 
+          sourceFileName.toChar(),
           destFileName.toChar()
       );
     if (status != Os::FileSystem::OP_OK) {
@@ -161,7 +161,7 @@ namespace Svc {
     this->log_ACTIVITY_HI_ShellCommandStarted(
           logStringCommand
       );
-    NATIVE_INT_TYPE status = 
+    NATIVE_INT_TYPE status =
       this->systemCall(command, logFileName);
     if (status == 0) {
       this->log_ACTIVITY_HI_ShellCommandSucceeded(
@@ -176,8 +176,8 @@ namespace Svc {
         status == 0 ? Os::FileSystem::OP_OK : Os::FileSystem::OTHER_ERROR
     );
     this->sendCommandResponse(
-        opCode, 
-        cmdSeq, 
+        opCode,
+        cmdSeq,
         status == 0 ? Os::FileSystem::OP_OK : Os::FileSystem::OTHER_ERROR
     );
   }
@@ -223,7 +223,7 @@ namespace Svc {
       this->pingOut_out(0,key);
   }
   // ----------------------------------------------------------------------
-  // Helper methods 
+  // Helper methods
   // ----------------------------------------------------------------------
 
   NATIVE_INT_TYPE FileManager ::
@@ -232,11 +232,12 @@ namespace Svc {
         const Fw::CmdStringArg& logFileName
     ) const
   {
-    const U32 bufferSize = 10 + 2 * FW_CMD_STRING_MAX_SIZE;
+    const char evalStr[] = "eval '%s' 1>>%s 2>&1\n";
+    const U32 bufferSize = sizeof(evalStr) - 4 + 2 * FW_CMD_STRING_MAX_SIZE;
     char buffer[bufferSize];
     snprintf(
-        buffer, sizeof(buffer), "eval '%s' 1>>%s 2>&1\n", 
-        command.toChar(), 
+        buffer, sizeof(buffer), evalStr,
+        command.toChar(),
         logFileName.toChar()
     );
     const int status = system(buffer);
@@ -264,9 +265,9 @@ namespace Svc {
     )
   {
     this->cmdResponse_out(
-        opCode, 
-        cmdSeq, 
-        (status == Os::FileSystem::OP_OK) ? 
+        opCode,
+        cmdSeq,
+        (status == Os::FileSystem::OP_OK) ?
           Fw::COMMAND_OK : Fw::COMMAND_EXECUTION_ERROR
     );
   }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| FileManager |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n/a |

---
## Change Description

When executing a FileManager::ShellCommand command, We allocated 10 bytes to hold `eval '%s' 1>>%s 2>&1\n`, minus the string substitution. This string was actually 18 characters (including the null terminators), leading to potential truncation of the end of executed command if both the supplied command and the output logfile were at maximum length.

## Rationale

Removes a bug that could lead to unexpected behavior when running FileManager::ShellCommand. 

## Future Work

Run more static analysis on the F' framework, which would likely have caught this.
