### PR TITLE
Added CPU Affinity support

### DIFF
--- a/Os/CMakeLists.txt
+++ b/Os/CMakeLists.txt
@@ -53,6 +53,27 @@ if (FPRIME_USE_POSIX)
         "${CMAKE_CURRENT_LIST_DIR}/Linux/Directory.cpp"
     )
 endif()
+
+# Posix systems typically share these
+if (FPRIME_USE_SU_LINUX_FOR_CPU_AFFINITY)
+    list(APPEND SOURCE_FILES
+        "${CMAKE_CURRENT_LIST_DIR}/LogPrintf.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Pthreads/Queue.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Pthreads/BufferQueueCommon.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Pthreads/PriorityBufferQueue.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Pthreads/MaxHeap/MaxHeap.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Linux/File.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Posix/Taskroot.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Linux/InterruptLock.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Linux/WatchdogTimer.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Posix/IntervalTimer.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Posix/Mutex.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Linux/FileSystem.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Posix/TaskId.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/Linux/Directory.cpp"
+    )
+endif()
+
 # Darwin IPC queue implementation
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
   list(APPEND SOURCE_FILES

--- a/Os/CMakeLists.txt
+++ b/Os/CMakeLists.txt
@@ -44,6 +44,8 @@ if (FPRIME_USE_POSIX)
         "${CMAKE_CURRENT_LIST_DIR}/Pthreads/MaxHeap/MaxHeap.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/Linux/File.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/Posix/Task.cpp"
+# On Linux for using CPU affinity, use TaskRoot instead of Task
+#        "${CMAKE_CURRENT_LIST_DIR}/Posix/TaskRoot.cpp" 
         "${CMAKE_CURRENT_LIST_DIR}/Linux/InterruptLock.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/Linux/WatchdogTimer.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/Posix/IntervalTimer.cpp"
@@ -53,27 +55,6 @@ if (FPRIME_USE_POSIX)
         "${CMAKE_CURRENT_LIST_DIR}/Linux/Directory.cpp"
     )
 endif()
-
-# Posix systems typically share these
-if (FPRIME_USE_SU_LINUX_FOR_CPU_AFFINITY)
-    list(APPEND SOURCE_FILES
-        "${CMAKE_CURRENT_LIST_DIR}/LogPrintf.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Pthreads/Queue.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Pthreads/BufferQueueCommon.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Pthreads/PriorityBufferQueue.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Pthreads/MaxHeap/MaxHeap.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Linux/File.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Posix/Taskroot.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Linux/InterruptLock.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Linux/WatchdogTimer.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Posix/IntervalTimer.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Posix/Mutex.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Linux/FileSystem.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Posix/TaskId.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/Linux/Directory.cpp"
-    )
-endif()
-
 # Darwin IPC queue implementation
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
   list(APPEND SOURCE_FILES

--- a/Os/Posix/TaskRoot.cpp
+++ b/Os/Posix/TaskRoot.cpp
@@ -41,34 +41,10 @@ namespace Os {
 
         I32 stat = pthread_attr_init(&att);
         if (stat != 0) {
-            Fw::Logger::logMsg("pthread_attr_init: (%d)(%d): %s\n",stat,errno,strerror(stat));
+            Fw::Logger::logMsg("pthread_attr_init: (%d)(%d): %s\n",stat,errno, reinterpret_cast<POINTER_CAST>(strerror(stat)));
         	return TASK_INVALID_PARAMS;
         }
 
-        stat = pthread_attr_setstacksize(&att,stackSize);
-        if (stat != 0) {
-            return TASK_INVALID_STACK;
-        }
-
-        stat = pthread_attr_setschedpolicy(&att,SCHED_RR);
-
-        if (stat != 0) {
-            Fw::Logger::logMsg("pthread_attr_setschedpolicy: %s\n",strerror(errno));
-            return TASK_INVALID_PARAMS;
-        }
-        stat = pthread_attr_setinheritsched(&att,PTHREAD_EXPLICIT_SCHED); // may not need this
-        if (stat != 0) {
-            Fw::Logger::logMsg("pthread_attr_setinheritsched: %s\n",strerror(errno));
-         	return TASK_INVALID_PARAMS;
-        }
-        sched_param schedParam;
-        memset(&schedParam,0,sizeof(sched_param));
-        schedParam.sched_priority = priority;
-        stat = pthread_attr_setschedparam(&att,&schedParam);
-        if (stat != 0) {
-            Fw::Logger::logMsg("pthread_attr_setschedparam: %s\n",strerror(errno));
-        	return TASK_INVALID_PARAMS;
-        }
 
         // Set affinity before creating thread:
         if (cpuAffinity != -1) {
@@ -79,7 +55,7 @@ namespace Os {
 
             stat = pthread_attr_setaffinity_np(&att, sizeof(cpu_set_t), &cpuset);
             if (stat != 0) {
-                Fw::Logger::logMsg("pthread_setaffinity_np: %i %s\n",cpuAffinity,strerror(stat));
+                Fw::Logger::logMsg("pthread_setaffinity_np: %i %s\n",cpuAffinity,reinterpret_cast<POINTER_CAST>(strerror(stat)));
                 return TASK_INVALID_PARAMS;
             }
         }
@@ -100,7 +76,7 @@ namespace Os {
                 break;
             case EINVAL:
                 delete tid;
-                Fw::Logger::logMsg("pthread_create: %s\n",strerror(errno));
+                Fw::Logger::logMsg("pthread_create: %s\n",reinterpret_cast<POINTER_CAST>(strerror(errno)));
                 tStat = TASK_INVALID_PARAMS;
                 break;
             default:
@@ -113,7 +89,7 @@ namespace Os {
 
             stat = pthread_setname_np(*tid,(char*)this->m_name.toChar());
             if (stat != 0) {
-                Fw::Logger::logMsg("pthread_setname_np: %s %s\n",this->m_name.toChar(),strerror(stat));
+                Fw::Logger::logMsg("pthread_setname_np: %s %s\n",reinterpret_cast<POINTER_CAST>(this->m_name.toChar()),reinterpret_cast<POINTER_CAST>(strerror(stat)));
                 delete tid;
                 tStat = TASK_INVALID_PARAMS;
             }


### PR DESCRIPTION
 Changes to be committed:
	modified:   Os/CMakeLists.txt
	modified:   Os/Posix/TaskRoot.cpp

| | |
|:---|:---|
|**_Dentopt_**| |
|**_FW/OS_**|  |
|**_Linux_**|  |
|**_Taskroot.cpp deprecated - CPU affinity_**|  |
|**_Has Unit Tests (y)_**|  |
|**_Builds Without Errors yes_**|  |
|**_Unit Tests Pass - not validated_**|  |
|**_Documentation Included n _**|  |

---
## Change Description

A description of the changes contained in the PR.

## Rationale

To assign CPU affinities under Linux OS/Posix/TaskRoot.cpp needs to be used instead of Task.cpp

## Testing/Review Recommendations

Running tests on TaskRoot.cpp

## Future Work

Note any additional work that will be done relating to this issue.
