### PR TITLE
python3.6 is now lower bound

### DIFF
--- a/Fw/Python/setup.py
+++ b/Fw/Python/setup.py
@@ -75,12 +75,10 @@ to interact with the data coming from the FSW.
     python_requires=">=3.5",
     install_requires=[
         "lxml",
-        'enum34;python_version < "3.4"',
         "Markdown",
         "pexpect",
         "pytest",
-        'Cheetah3;python_version >= "3.0"',
-        'Cheetah;python_version < "3.0"',
+        "Cheetah3",
     ],
     extras_require={"dev": ["black", "pylama", "pylint", "pre-commit"]},
     # Setup and test requirements, not needed by normal install

--- a/Fw/Python/setup.py
+++ b/Fw/Python/setup.py
@@ -65,14 +65,13 @@ to interact with the data coming from the FSW.
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    # Requires Python 3.5+
-    python_requires=">=3.5",
+    # Requires Python 3.6+
+    python_requires=">=3.6",
     install_requires=[
         "lxml",
         "Markdown",

--- a/Gds/setup.py
+++ b/Gds/setup.py
@@ -97,7 +97,6 @@ integrated configuration with ground in-the-loop.
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
@@ -107,7 +106,7 @@ integrated configuration with ground in-the-loop.
         # 'Programming Language :: Python :: Implementation :: Jython',
         # 'Programming Language :: Python :: Implementation :: Stackless',
     ],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=[
         "flask",
         "pexpect",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following utilities are prerequisites to installing F´:
 
 - [cmake](https://cmake.org/)
 - [git](https://git-scm.com/)
-- [Python](https://www.python.org/) 3.5+ with pip
+- [Python](https://www.python.org/) 3.6+ with pip
 
 Once these utilities are installed, you can install F´ Python dependencies. Installing dependencies in a Python virtual environment prevents issues at the system level, but installing in a virtual environment is not required. 
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -22,7 +22,7 @@ Requirements:
 2. CMake 3.5 or newer [https://cmake.org/download/](https://cmake.org/download/). CLI tool must be available on the system path.
 3. Bash or Bash compatible shell
 4. CLang or GCC compiler
-5. Python 3.5+ and PIP [https://www.python.org/downloads/](https://www.python.org/downloads/)
+5. Python 3.6+ and PIP [https://www.python.org/downloads/](https://www.python.org/downloads/)
 6. Python Virtual Environment \* (pip install venv or pip install virtualenv)
 
 **Note:** it is possible to install and run F´ without a virtual environment, however; for
@@ -34,7 +34,7 @@ This will create a new virtual environment for F´ to be installed into. The fol
 will create a new virtual environment called `fprime-venv` and ensure that the virtual environment
 is activated.
 
-**Python 3.5+:**
+**Python 3.6+:**
 
 ```
 python3 -m venv ./fprime-venv

--- a/docs/UsersGuide/dev/gds-cli-dev.md
+++ b/docs/UsersGuide/dev/gds-cli-dev.md
@@ -25,7 +25,7 @@ This guide is for programmers who intend to maintain and develop code for the Gr
     -   At a minimum, the CLI tools should allow for receiving all events/telemetry data from the GDS and sending commands to the spacecraft
 -   The CLI tools' output must be usable with existing UNIX utilities through piping/file output/BASH scripting/etc.
 -   The CLI tools should be multi-platform, supporting (at a minimum) Linux, Mac, and Windows systems
--   If implemented in Python, must support Python 3.5+
+-   If implemented in Python, must support Python 3.6+
 
 ### Secondary Requirements
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Python |
|**_Affected Architectures(s)_**| |
|**_Related Issue(s)_**| #422 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

A description of the changes contained in the PR.

python3.6 is now lower bound

## Rationale

A rationale for this change. e.g. fixes bug, or most projects need XYZ feature.

python3.5 is EOL

## Testing/Review Recommendations

Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality.

## Future Work

Note any additional work that will be done relating to this issue.

Not 100% related but I was wondering if there are any plans to bring the packages to PyPI as I was thinking about porting this to conda-forge (Which can either pull from GitHub or PyPI with the latter one being the recommended approach).
#405 exists but hasn't gotten much traction yet.