### PR TITLE
Bugfix for `UnboundLocalError` in SerializableType

### DIFF
--- a/Fw/Python/src/fprime/common/models/serialize/serializable_type.py
+++ b/Fw/Python/src/fprime/common/models/serialize/serializable_type.py
@@ -32,6 +32,8 @@ class SerializableType(ValueType):
         if not isinstance(typename, str):
             raise TypeMismatchException(str, type(typename))
         self.__typename = typename
+
+        new_mem_list = []
         # If the member list is defined, stamp in None for any missing descriptions
         if mem_list:
             new_mem_list = [

--- a/Fw/Python/test/fprime/common/models/serialize/test_types.py
+++ b/Fw/Python/test/fprime/common/models/serialize/test_types.py
@@ -274,6 +274,10 @@ def test_serializable_type():
     memList = [(a, b, c, None) for a, b, c in memList]
     check_cloned_member_list(mem_list, memList)
 
+    serTypeEmpty = SerializableType("ASerType", [])
+    assert serTypeEmpty.val == {}
+    assert serTypeEmpty.mem_list == []
+
 
 # def test_array_type():
 #    """


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Bugfix for `UnboundLocalError` in SerializableType, including unit-test.

## Rationale

The docstring on SerializableType declares that 'the member descriptions can be None'.
However if you actually pass `None` (or don't pass the list at all, given that None is set
as the default kwarg), then you get an `UnboundLocalError: local variable 'new_mem_list' referenced before assignment`, due to the `if mem_list` branch hiding the creation of the `new_mem_list` local variable.

This change adds a default binding as `new_mem_list = []` so that in the case of an empty `mem_list`, or `mem_list=None`, then the object will always be initialised properly.

A check has been added to the existing SerializableType unit test verifying this behaviour. If you remove the change from the class constructor and run the updated test you will get the UnboundLocalError.

## Testing/Review Recommendations

Run the python tests, to verify the original bug, comment out the new line in the SerializableType constructor.

## Future Work

N/A
