### PR TITLE
Make abstractmethods consistent in BaseType

### DIFF
--- a/Fw/Python/src/fprime/common/models/serialize/type_base.py
+++ b/Fw/Python/src/fprime/common/models/serialize/type_base.py
@@ -20,6 +20,7 @@ class BaseType(abc.ABC):
         """
         Serializes the current object type.
         """
+        raise AbstractMethodException("serialize")
 
     @abc.abstractmethod
     def deserialize(self, data, offset):
@@ -47,7 +48,7 @@ class BaseType(abc.ABC):
         raise AbstractMethodException("to_jsonable")
 
 
-class ValueType(BaseType, abc.ABC):
+class ValueType(BaseType):
     """
     An abstract base type used to represent a single value. This defines the value property, allowing for setting and
     reading from the .val member.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds the AbstractMethodException to `serialize` on BaseType to be consistent with the other `abstractmethod`s. Includes a new unit-test to validate the underlying behaviour of `BaseType`.

Also removed a superfluous multiple inheritance of `ABC` on `ValueType`. The intended behaviour of enforcing the `abstractmethod`s on `ValueType` is also now validated in the new unit-test, showing no behavioural changes.

## Rationale

All the other `abstractmethod` implementations on the BaseType ABC just `raise AbstractMethodException`. This PR makes a one-line change to add the same exception raise to `def serialize`.

However, these `AbstractMethodException` raises are only reachable by explicitly calling `super()` from a subclass, as the ABC machinery will stop users from instantiating a subclass which doesn't override the abstractmethods. As a result the unit-test validates each variant of this behaviour.

## Testing/Review Recommendations

Run the unit-test; there is a `Dummy` class to demonstrate the intended ABC behaviour of BaseType, which can be trivially modified to call `super()` to confirm the behavioural changes.

## Future Work

Maybe a wider discussion around whether `AbstractMethodException` is the right name/implementation for what it's being used for. The error message from AbstractMethodException says '%s must be implemented since it is abstract', however that's a given due to the ABC base class and `abstractmethod` decorator, so the only way to actually invoke the exception raise is to subclass and implement all required methods, and then call `super()`.

At the very least I think the message in AbstractMethodException could be changed to be more relevant to the only applicable failure scenario - maybe the string could be `f"you have just called an abstract method on the base class of {self.__class__.__name__}, which is a coding error"`, or similar.

