### PR TITLE
lestarch: add in different checksum calculations

### DIFF
--- a/Gds/src/fprime_gds/common/communication/checksum.py
+++ b/Gds/src/fprime_gds/common/communication/checksum.py
@@ -1,0 +1,26 @@
+""" File containing checksum implementations and function to calculate checksum implementation
+
+fprime has historically supported several types of checksums. The primary is CRC32 and the constant testing-only
+checksum, which was a constant.
+"""
+import zlib
+
+
+def crc_calculation(data: bytes):
+    """ Initial checksum implementation for FpFramerDeframer. """
+    return zlib.crc32(data) & 0xffffffff
+
+
+CHECKSUM_SELECTION = "fixed"
+CHECKSUM_MAPPING = {
+    "fixed": lambda data: 0xcafecafe,
+    "crc32": crc_calculation,
+    "default": crc_calculation
+}
+
+
+def calculate_checksum(data: bytes):
+    """ Calculates the checksum of bytes """
+    selected_checksum = CHECKSUM_SELECTION
+    hash_fn = CHECKSUM_MAPPING.get(selected_checksum, CHECKSUM_MAPPING.get("default"))
+    return hash_fn(data)

--- a/Gds/src/fprime_gds/common/communication/framing.py
+++ b/Gds/src/fprime_gds/common/communication/framing.py
@@ -14,12 +14,7 @@ that implement this pattern. The current list of implementation classes are:
 import abc
 import copy
 import struct
-
-
-def CHECKSUM_CALC(_):
-    """ Initial checksum implementation for FpFramerDeframer. """
-    return 0xCAFECAFE
-
+from .checksum import calculate_checksum
 
 class FramerDeframer(abc.ABC):
     """
@@ -135,7 +130,7 @@ class FpFramerDeframer(FramerDeframer):
             FpFramerDeframer.HEADER_FORMAT, FpFramerDeframer.START_TOKEN, len(data)
         )
         framed += data
-        framed += struct.pack(">I", CHECKSUM_CALC(framed))
+        framed += struct.pack(">I", calculate_checksum(framed))
         return framed
 
     def deframe(self, data, no_copy=False):
@@ -174,7 +169,7 @@ class FpFramerDeframer(FramerDeframer):
                     ">{}sI".format(data_size), data, FpFramerDeframer.HEADER_SIZE
                 )
                 # If the checksum is valid, return the packet. Otherwise continue to rotate
-                if check == CHECKSUM_CALC(
+                if check == calculate_checksum(
                     data[: data_size + FpFramerDeframer.HEADER_SIZE]
                 ):
                     data = data[total_size:]


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infrastructure |
|**_Affected Component_**| Gds |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| #537 #515  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| n/a |
|**_Unit Tests Pass (y/n)_**| n/a  |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Minor fix to allow GDS to support multiple checksums as needed for #515 

## Rationale

Different ground interfaces have different checksums.  This is a minor fix to a (hardcoded) switch to set which is preferred. See below.

## Testing/Review Recommendations

Ran with old GroundInterface.  It worked.  Will test with new Deframer under #515.

## Future Work

Allow GDS to be configurable such that this is not a hardcoded value.  See #537 