### PR TITLE
Array U8 autocoder fix

### DIFF
--- a/Autocoders/Python/src/fprime_ac/parsers/XmlArrayParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlArrayParser.py
@@ -77,7 +77,7 @@ class XmlArrayParser(object):
         self.Config = ConfigManager.ConfigManager.getInstance()
 
         typeslist = [
-            "I8",
+            "U8",
             "I8",
             "BYTE",
             "I16",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Brandon Metz |
|**_Affected Component_**| Array Autocoder |
|**_Affected Architectures(s)_**| All |
|**_Related Issue(s)_**| None. |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| na |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

A description of the changes contained in the PR.

## Rationale

When trying to create an array with type U8:
```
<array name="SpikeDuration" namespace="Backplane">
    <type>U8</type>
    <size>16</size>
    <format>%d</format>
...
```

You'll get the following build error:

```
error: â€˜U8â€™ is not a class, namespace, or enumeration
U8::SERIALIZED_SIZE
```
and points inside the the autocoded array class at the following line:
![image](https://user-images.githubusercontent.com/2592986/117869568-ce67c600-b24f-11eb-8cef-3e947c162c34.png)


## Testing/Review Recommendations

@LeStarch investigated and found the duplicate line of `I8`, upon renaming the first `I8` to `U8` the project was able to build successfully. 

## Future Work

None.