### PR TITLE
lestarch: adding options for stubbed drivers and baremetal scheduler

### DIFF
--- a/Drv/LinuxGpioDriver/CMakeLists.txt
+++ b/Drv/LinuxGpioDriver/CMakeLists.txt
@@ -5,37 +5,20 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
-
-
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImplStub.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImpl.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "CygWin")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImpl.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "arm-linux-gnueabihf")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImpl.cpp"
-	)
+if(NOT DEFINED FPRIME_USE_STUBBED_DRIVERS OR FPRIME_USE_STUBBED_DRIVERS)
+    set(SOURCE_FILES
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentAi.xml"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImplCommon.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImplStub.cpp"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "arm-linux-gnueabihf")
+    set(SOURCE_FILES
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentAi.xml"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImplCommon.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImpl.cpp"
+    )
 else()
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImplCommon.cpp"
-	)
+    message(FATAL_ERROR "Cannot use ${CMAKE_CURRENT_LIST_DIR} with platform ${CMAKE_SYSTEM_NAME}. Consider using -DFPRIME_USE_STUBBED_DRIVERS=ON")
 endif()
 
 register_fprime_module()

--- a/Drv/LinuxI2cDriver/CMakeLists.txt
+++ b/Drv/LinuxI2cDriver/CMakeLists.txt
@@ -5,26 +5,19 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-	add_definitions(-DSTUBBED_LINUX_I2C_DRIVER)
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImplStub.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImpl.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "arm-linux-gnueabihf")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImpl.cpp"
-	)
+if(NOT DEFINED FPRIME_USE_STUBBED_DRIVERS OR FPRIME_USE_STUBBED_DRIVERS)
+    add_definitions(-DSTUBBED_LINUX_I2C_DRIVER)
+    set(SOURCE_FILES
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImplStub.cpp"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "arm-linux-gnueabihf")
+    set(SOURCE_FILES
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentImpl.cpp"
+    )
 else()
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"
-	)
+    message(FATAL_ERROR "Cannot use ${CMAKE_CURRENT_LIST_DIR} with platform ${CMAKE_SYSTEM_NAME}. Consider using -DFPRIME_USE_STUBBED_DRIVERS=ON")
 endif()
 
 register_fprime_module()

--- a/Drv/LinuxSerialDriver/CMakeLists.txt
+++ b/Drv/LinuxSerialDriver/CMakeLists.txt
@@ -5,38 +5,16 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
-
-
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImpl.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImpl.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "CygWin")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImpl.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "arm-linux-gnueabihf")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImpl.cpp"
-	)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "arm-linux-gnueabihf" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    set(SOURCE_FILES
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentAi.xml"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImplCommon.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImpl.cpp"
+    )
 else()
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSerialDriverComponentImplCommon.cpp"
-	)
+    message(FATAL_ERROR "Cannot use ${CMAKE_CURRENT_LIST_DIR} with platform ${CMAKE_SYSTEM_NAME}.")
 endif()
+
 set(MOD_DEPS
     Os
 )

--- a/Drv/LinuxSpiDriver/CMakeLists.txt
+++ b/Drv/LinuxSpiDriver/CMakeLists.txt
@@ -5,37 +5,20 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
-
-
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImplStub.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImpl.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "CygWin")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImpl.cpp"
-	)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "arm-linux-gnueabihf")
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImplCommon.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImpl.cpp"
-	)
+if(NOT DEFINED FPRIME_USE_STUBBED_DRIVERS OR FPRIME_USE_STUBBED_DRIVERS)
+    set(SOURCE_FILES
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentAi.xml"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImplCommon.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImplStub.cpp"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "arm-linux-gnueabihf")
+    set(SOURCE_FILES
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentAi.xml"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImplCommon.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImpl.cpp"
+    )
 else()
-	set(SOURCE_FILES
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentAi.xml"
-		"${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImplCommon.cpp"
-	)
+    message(FATAL_ERROR "Cannot use ${CMAKE_CURRENT_LIST_DIR} with platform ${CMAKE_SYSTEM_NAME}. Consider using -DFPRIME_USE_STUBBED_DRIVERS=ON")
 endif()
 
 register_fprime_module()

--- a/Fw/Cfg/CMakeLists.txt
+++ b/Fw/Cfg/CMakeLists.txt
@@ -9,6 +9,8 @@ set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/ConfigCheck.cpp"
 )
 register_fprime_module()
-if (BAREMETAL_SCHEDULER)
+if (FPRIME_USE_BAREMETAL_SCHEDULE)
     target_compile_definitions(Fw_Cfg PUBLIC FW_BAREMETAL_SCHEDULER=1)
+else()
+    target_compile_definitions(Fw_Cfg PUBLIC FW_BAREMETAL_SCHEDULER=0)
 endif()

--- a/Os/CMakeLists.txt
+++ b/Os/CMakeLists.txt
@@ -72,9 +72,13 @@ endif()
 
 
 # If baremetal scheduler is set, remove the previous task files and add in the Baremetal variant
-if (BAREMETAL_SCHEDULER)
+if (FPRIME_USE_BAREMETAL_SCHEDULER)
     add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Baremetal/TaskRunner/")
-    list(FILTER SOURCE_FILES EXCLUDE REGEX "Task\.cpp")
+    foreach (ITER_ITEM IN LISTS SOURCE_FILES)
+        if (ITER_ITEM MATCHES "Task\.cpp$")
+            list(REMOVE_ITEM SOURCE_FILES "${ITER_ITEM}")
+        endif()
+    endforeach()
     list(APPEND SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/Baremetal/Task.cpp")
 endif()
 register_fprime_module()

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -18,6 +18,34 @@
 ####
 
 ####
+# `FPRIME_USE_STUBBED_DRIVERS:`
+#
+# Tells fprime to use the specific stubbed set of drivers as opposed to full implementation. This applies to drivers in
+# the Drv package with the exception of the serial and ipv4 drivers where a generic cross-platform solution is expected.
+#
+# If unspecified, it will be set in the platform file for the give architecture. If specified, may be set to ON to use
+# the stubbed drivers or OFF to used full driver implementations.
+###
+if (DEFINED FPRIME_USE_STUBBED_DRIVERS AND NOT "${FPRIME_USE_STUBBED_DRIVERS}" STREQUAL "ON" AND NOT "${FPRIME_USE_STUBBED_DRIVERS}" STREQUAL "OFF")
+    message(FATAL_ERROR "FPRIME_USE_STUBBED_DRIVERS must be set to ON, OFF, or not supplied at all")
+endif()
+
+####
+# `FPRIME_USE_BAREMETAL_SCHEDULER:`
+#
+# Tells fprime to use the baremetal scheduler. This scheduler replaces any OS scheduler with one that loops through
+# active components calling each one dispatch at a time. This is designed for use with baremetal (no-OS) system,
+# however; it may be set to limit execution to a single thread and or test the baremetal scheduler on a PC.
+#
+# If unspecified, it will be set in the platform file for the give architecture. If specified, may be set to ON to use
+# the scheduler or OFF to use the OS thread scheduler.
+###
+if (DEFINED FPRIME_USE_BAREMETAL_SCHEDULER AND NOT "${FPRIME_USE_BAREMETAL_SCHEDULER}" STREQUAL "ON" AND NOT "${FPRIME_USE_BAREMETAL_SCHEDULER}" STREQUAL "OFF")
+    message(FATAL_ERROR "FPRIME_USE_BAREMETAL_SCHEDULER must be set to ON, OFF, or not supplied at all")
+endif()
+
+
+####
 # `CMAKE_DEBUG_OUTPUT:`
 #
 # Turns on the reporting of debug output of the CMake build. Can help refine the CMake system, and repair errors. For

--- a/cmake/platform/Darwin.cmake
+++ b/cmake/platform/Darwin.cmake
@@ -6,10 +6,19 @@
 ####
 add_definitions(-DTGT_OS_TYPE_DARWIN)
 
-# Find an appropriate thread library
-message(STATUS "Requiring thread library")
-FIND_PACKAGE ( Threads REQUIRED )
 set(FPRIME_USE_POSIX ON)
+# Set platform default for stubbed drivers
+if (NOT DEFINED FPRIME_USE_STUBBED_DRIVERS)
+   set(FPRIME_USE_STUBBED_DRIVERS ON)
+endif()
+
+# Set platform default for baremetal scheduler drivers
+if (NOT DEFINED FPRIME_USE_BAREMETAL_SCHEDULER)
+   set(FPRIME_USE_BAREMETAL_SCHEDULER OFF)
+   message(STATUS "Requiring thread library")
+   FIND_PACKAGE ( Threads REQUIRED )
+endif()
+
 
 # Darwin specific flags: shared, C, and C++ settings
 set(DARWIN_COMMON

--- a/cmake/platform/Linux-common.cmake
+++ b/cmake/platform/Linux-common.cmake
@@ -8,9 +8,6 @@
 # Set linux target
 add_definitions(-DTGT_OS_TYPE_LINUX)
 set(FPRIME_USE_POSIX ON)
-# Requires threading library, use cmake to find appropriate library
-message(STATUS "Requiring thread library")
-FIND_PACKAGE ( Threads REQUIRED )
 
 # Add Linux specific headers into the system
 include_directories(SYSTEM "${FPRIME_FRAMEWORK_PATH}/Fw/Types/Linux")

--- a/cmake/platform/Linux.cmake
+++ b/cmake/platform/Linux.cmake
@@ -3,5 +3,18 @@
 #
 # Linux platform file for standard linux targets. Merely defers to [./Linux-common.cmake](Linux-common.cmake).
 ####
+
+# Set platform default for stubbed drivers
+if (NOT DEFINED FPRIME_USE_STUBBED_DRIVERS)
+   set(FPRIME_USE_STUBBED_DRIVERS ON)
+endif()
+
+# Set platform default for baremetal scheduler drivers
+if (NOT DEFINED FPRIME_USE_BAREMETAL_SCHEDULER)
+   set(FPRIME_USE_BAREMETAL_SCHEDULE OFF)
+   message(STATUS "Requiring thread library")
+   FIND_PACKAGE ( Threads REQUIRED )
+endif()
+
 # Use common linux setup
 include("${CMAKE_CURRENT_LIST_DIR}/Linux-common.cmake")

--- a/cmake/platform/arm-linux-gnueabihf.cmake
+++ b/cmake/platform/arm-linux-gnueabihf.cmake
@@ -5,5 +5,17 @@
 # toolchain file found at [../toolchain/raspberrypi.cmake](../toolchain/raspberrypi.cmake).
 ##
 
+# Set platform default for stubbed drivers
+if (NOT DEFINED FPRIME_USE_STUBBED_DRIVERS)
+   set(FPRIME_USE_STUBBED_DRIVERS OFF)
+endif()
+
+# Set platform default for baremetal scheduler drivers
+if (NOT DEFINED FPRIME_USE_BAREMETAL_SCHEDULER)
+   set(FPRIME_USE_BAREMETAL_SCHEDULER OFF)
+   message(STATUS "Requiring thread library")
+   FIND_PACKAGE ( Threads REQUIRED )
+endif()
+
 # RPI is Linux based, so include the common Linux items
 include("${CMAKE_CURRENT_LIST_DIR}/Linux-common.cmake")


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infrastructure |
|**_Affected Component_**| CMake |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Added switches to turn on/off the baremetal scheduler and stubbed drivers.  In this way these features can be enabled/disabled.  This allows breaks the hard-dependence on platform for drivers.

Documented switches in cmake/options.

## Rationale

"Big" features are nice to be able to throw a switch at the command line when generating.  "BIg" features mean items that have a build-system and C++ component to them.  

## Testing/Review Recommendations

Tested on darwin that all the defaulting and switching and error cases work.

