### PR TITLE
saba-js: fixes 543 by freezing dependencies

### DIFF
--- a/Fw/Python/setup.py
+++ b/Fw/Python/setup.py
@@ -73,15 +73,15 @@ to interact with the data coming from the FSW.
     # Requires Python 3.6+
     python_requires=">=3.6",
     install_requires=[
-        "lxml",
-        "Markdown",
-        "pexpect",
-        "pytest",
-        "Cheetah3",
+        "lxml==4.6.3",
+        "Markdown==3.3.4",
+        "pexpect==4.8.0",
+        "pytest==6.2.4",
+        "Cheetah3==3.2.6.post2",
     ],
-    extras_require={"dev": ["black", "pylama", "pylint", "pre-commit"]},
+    extras_require={"dev": ["black==21.5b1", "pylama==7.7.1", "pylint==2.8.2", "pre-commit==2.12.1"]},
     # Setup and test requirements, not needed by normal install
-    setup_requires=["pytest-runner"],
+    setup_requires=["pytest-runner==5.3.0"],
     tests_require=["pytest"],
     # Create a set of executable entry-points for running directly from the package
     entry_points={

--- a/Gds/setup.py
+++ b/Gds/setup.py
@@ -108,17 +108,17 @@ integrated configuration with ground in-the-loop.
     ],
     python_requires=">=3.6",
     install_requires=[
-        "flask",
-        "pexpect",
-        "pytest",
-        "flask_restful",
+        "flask==1.1.2",
+        "pexpect==4.8.0",
+        "pytest==6.2.4",
+        "flask_restful==0.3.8",
         "fprime>=1.3.0",
         "flask_uploads @ git+https://github.com/maxcountryman/flask-uploads@f66d7dc93e684fa0a3a4350a38e41ae00483a796",
-        "argcomplete",
+        "argcomplete==1.12.3",
     ],
     extras_require={
         # I and T API
-        "uart-adapter": "pyserial",
-        "test-api-xls": "openpyxl",
+        "uart-adapter": "pyserial==3.5",
+        "test-api-xls": "openpyxl==3.0.7",
     },
 )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F Prime |
|**_Affected Component_**|  GDS, Fw/Python|
|**_Affected Architectures(s)_**| setup.py |
|**_Related Issue(s)_**|  #543|
|**_Has Unit Tests (y/n)_**| No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**|  NA |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

This PR freezes current dependency packages in GDS/setup.py and Fw/Python/setup.py to the latest version of working third party libraries.

## Rationale

Third-party libraries change frequently and some updates might not be backward compatible.
These dependencies should be updated periodically after thorough testing and verification by the maintainers.

As shown below Flask 2.0.0 was released to PyPI and on May 11 2021 and it is not compatible with current F Prime GDS.

https://pypi.org/project/Flask/#history
![image](https://user-images.githubusercontent.com/35859004/117911868-5b803e80-b293-11eb-8308-93dd8c717c70.png)


## Testing/Review Recommendations

Manually checked for build and execution of F Prime Ref

## Future Work

Find a way to be notified on the updates on the third party libraries and perform update whenever needed.
