### PR TITLE
Fix external enums "enum-compare" warning issue

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
@@ -66,9 +66,11 @@ namespace ${namespace} {
     // ----------------------------------------------------------------------
 
     enum {
-        SERIALIZED_SIZE = sizeof(FwEnumStoreType),
-        NUM_CONSTANTS = ${len($items_list)}
+        SERIALIZED_SIZE = sizeof(FwEnumStoreType)
         };
+
+    //! Number of items in ${name} enum 
+    const U32 NUM_CONSTANTS = ${len($items_list)};
 
     public:
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F Prime|
|**_Affected Component_**| Autocoder |
|**_Affected Architectures(s)_**| external enum |
|**_Related Issue(s)_**|  #471|
|**_Has Unit Tests (y/n)_**|  No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

This PR fixes an issue in PR #477.
`NUM_CONSTANTS` was provided as `enum`. This causes `enum-compare` warning when user performs comparison similar to the following:
```
valveId.e >= CommonEnum::ValveId::NUM_CONSTANTS
```

This pr resolves the issue by use const as shown below:
```
const U32 NUM_CONSTANTS = ${len($items_list)};
```

To make the comparison user can write a similar code as following:

```
valveId.e >= valveId.NUM_CONSTANTS
```

## Rationale

Comparison of external enum values with NUM_CONSTANTS should not cause any warning.

## Testing/Review Recommendations

Built and run with no issues.
An example output looks like the following:
```
//! Number of items in BpManagerState enum 
const U32 NUM_CONSTANTS = 4;
```

## Future Work

NA
