### PR TITLE
Make NUM_CONSTANTS static

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
@@ -70,7 +70,7 @@ namespace ${namespace} {
         };
 
     //! Number of items in ${name} enum 
-    const U32 NUM_CONSTANTS = ${len($items_list)};
+    static const U32 NUM_CONSTANTS = ${len($items_list)};
 
     public:
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F Prime|
|**_Affected Component_**| Autocoder |
|**_Affected Architectures(s)_**| external enum |
|**_Related Issue(s)_**|  #471|
|**_Has Unit Tests (y/n)_**|  No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

This PR will make `NUM_CONSTANTS` statically accessible.

## Rationale

> NUM_CONSTANTS is a constant. It must be used statically and should be used NameSpace::Class::NUM_CONSTANTS to represent the number of the enum constants specified.

## Testing/Review Recommendations

Built and ran with no issue. Verified NUM_CONSTANTS can be accessed via static call.

## Future Work

`getMax()` and `getMin()` could be added as methods to return min and max value of the enums.
