### PR TITLE
mstarch: fixing GenericHub UT to account for non-stock sizes

### DIFF
--- a/Svc/ActiveRateGroup/test/ut/ActiveRateGroupTester.cpp
+++ b/Svc/ActiveRateGroup/test/ut/ActiveRateGroupTester.cpp
@@ -51,7 +51,10 @@ TEST(ActiveRateGroupTest,NominalSchedule) {
 
     for (NATIVE_INT_TYPE inst = 0; inst < 3; inst++) {
 
-        NATIVE_UINT_TYPE contexts[] = {1,2,3,4,5,6,7,8,9,10};
+        NATIVE_UINT_TYPE contexts[Svc::ActiveRateGroupComponentBase::NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS];
+        for (U32 i = 0; i < Svc::ActiveRateGroupComponentBase::NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS; i++) {
+            contexts[i] = i + 1;
+        }
 
         Svc::ActiveRateGroupImpl impl("ActiveRateGroupImpl",contexts,FW_NUM_ARRAY_ELEMENTS(contexts));
 
@@ -73,7 +76,10 @@ TEST(ActiveRateGroupTest,CycleOverrun) {
 
     for (NATIVE_INT_TYPE inst = 0; inst < 3; inst++) {
 
-        NATIVE_UINT_TYPE contexts[] = {1,2,3,4,5,6,7,8,9,10};
+        NATIVE_UINT_TYPE contexts[Svc::ActiveRateGroupComponentBase::NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS];
+        for (U32 i = 0; i < Svc::ActiveRateGroupComponentBase::NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS; i++) {
+            contexts[i] = i + 1;
+        }
 
         Svc::ActiveRateGroupImpl impl("ActiveRateGroupImpl",contexts,FW_NUM_ARRAY_ELEMENTS(contexts));
 
@@ -92,7 +98,10 @@ TEST(ActiveRateGroupTest,CycleOverrun) {
 
 TEST(ActiveRateGroupTest,PingPort) {
 
-    NATIVE_UINT_TYPE contexts[] = {1,2,3,4,5,6,7,8,9,10};
+    NATIVE_UINT_TYPE contexts[Svc::ActiveRateGroupComponentBase::NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS];
+    for (U32 i = 0; i < Svc::ActiveRateGroupComponentBase::NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS; i++) {
+        contexts[i] = i + 1;
+    }
 
     Svc::ActiveRateGroupImpl impl("ActiveRateGroupImpl",contexts,FW_NUM_ARRAY_ELEMENTS(contexts));
     Svc::ActiveRateGroupImplTester tester(impl);

--- a/Svc/GenericHub/test/ut/Tester.cpp
+++ b/Svc/GenericHub/test/ut/Tester.cpp
@@ -184,7 +184,8 @@ void Tester ::from_dataInDeallocate_handler(const NATIVE_INT_TYPE portNum, Fw::B
 
 void Tester ::connectPorts(void) {
     // buffersIn
-    for (NATIVE_INT_TYPE i = 0; i < 10; ++i) {
+    U32 max = std::min(this->componentIn.getNum_buffersIn_InputPorts(), this->componentOut.getNum_buffersOut_OutputPorts());
+    for (U32 i = 0; i < max; ++i) {
         this->connect_to_buffersIn(i, this->componentIn.get_buffersIn_InputPort(i));
     }
 
@@ -192,7 +193,7 @@ void Tester ::connectPorts(void) {
     this->connect_to_dataIn(0, this->componentOut.get_dataIn_InputPort(0));
 
     // buffersOut
-    for (NATIVE_INT_TYPE i = 0; i < 10; ++i) {
+    for (U32 i = 0; i < max; ++i) {
         this->componentOut.set_buffersOut_OutputPort(i, this->get_from_buffersOut(i));
     }
 
@@ -211,7 +212,8 @@ void Tester ::connectPorts(void) {
     // ----------------------------------------------------------------------
     // Connect serial output ports
     // ----------------------------------------------------------------------
-    for (NATIVE_INT_TYPE i = 0; i < 10; ++i) {
+    max = std::min(this->componentIn.getNum_portIn_InputPorts(), this->componentOut.getNum_portOut_OutputPorts());
+    for (U32 i = 0; i < max; ++i) {
         this->componentOut.set_portOut_OutputPort(i, this->get_from_portOut(i));
     }
 
@@ -219,7 +221,7 @@ void Tester ::connectPorts(void) {
     // Connect serial input ports
     // ----------------------------------------------------------------------
     // portIn
-    for (NATIVE_INT_TYPE i = 0; i < 10; ++i) {
+    for (U32 i = 0; i < max; ++i) {
         this->connect_to_portIn(i, this->componentIn.get_portIn_InputPort(i));
     }
 }

--- a/Svc/StaticMemory/test/ut/Tester.cpp
+++ b/Svc/StaticMemory/test/ut/Tester.cpp
@@ -70,7 +70,7 @@ namespace Svc {
   {
 
     // bufferDeallocate
-    for (NATIVE_INT_TYPE i = 0; i < 4; ++i) {
+    for (NATIVE_INT_TYPE i = 0; i < StaticMemoryComponentBase::NUM_BUFFERALLOCATE_INPUT_PORTS; ++i) {
       this->connect_to_bufferDeallocate(
           i,
           this->component.get_bufferDeallocate_InputPort(i)
@@ -78,7 +78,7 @@ namespace Svc {
     }
 
     // bufferAllocate
-    for (NATIVE_INT_TYPE i = 0; i < 4; ++i) {
+    for (NATIVE_INT_TYPE i = 0; i < StaticMemoryComponentBase::NUM_BUFFERALLOCATE_INPUT_PORTS; ++i) {
       this->connect_to_bufferAllocate(
           i,
           this->component.get_bufferAllocate_InputPort(i)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infrastructure |
|**_Affected Component_**| GenericHub  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n/a |

---
## Change Description

Fixed GH unit test.