### PR TITLE
Added "F Prime" as an acceptable name in the docs

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -3,7 +3,7 @@ layout: default
 title: "F´ Features"
 ---
 
-F´ has the following key features that enable robust embedded system design. These features enable projects to quickly
+F´ (or F Prime) has the following key features that enable robust embedded system design. These features enable projects to quickly
 develop embedded systems applications from design through test.
 
 ### Reusability

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ title: "F´ A Flight Software and Embedded Systems Framework"
 layout: default
 ---
 
-F´ is a software framework for the rapid development and deployment of embedded systems and spaceflight applications.
+F´ (or F Prime) is a software framework for the rapid development and deployment of embedded systems and spaceflight applications.
 Originally developed at NASA's Jet Propulsion Laboratory, F´ is open-source software that has been successfully deployed
 for several space applications. It has been used for but is not limited to, CubeSats, SmallSats, instruments, and
 deployable.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**||
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**||
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**| y|

---
## Change Description

I added "F Prime" in brackets behind F´ in the docs on two occasions. I didn't do it behind every F´, as it would be repetitive. Doing this twice lets the reader know that F Prime is also an acceptable name.

## Rationale

This PR should "fix" what is mentioned in [this](https://github.com/nasa/fprime/issues/526) Issue. This is my first PR, so it seemed like a good place to start.

## Testing/Review Recommendations

This has no effect on the code.

## Future Work

None that I can think of. Let me know if this indication needs to be added elsewhere in the docs.
