### PR TITLE
lestarch: updating fprime-gds to check dictionary framework_version

### DIFF
--- a/Gds/src/fprime_gds/common/loaders/xml_loader.py
+++ b/Gds/src/fprime_gds/common/loaders/xml_loader.py
@@ -39,6 +39,7 @@ from fprime.common.models.serialize.numerical_types import (
 from fprime.common.models.serialize.serializable_type import SerializableType
 from fprime.common.models.serialize.string_type import StringType
 from fprime_gds.common.data_types import exceptions
+from fprime_gds.version import MINIMUM_SUPPORTED_FRAMEWORK_VERSION, MAXIMUM_SUPPORTED_FRAMEWORK_VERSION
 
 # Custom Python Modules
 from . import dict_loader
@@ -114,11 +115,21 @@ class XmlLoader(dict_loader.DictLoader):
         xml_parser = etree.XMLParser(remove_comments=True)
 
         with open(path) as fd:
-
             # Parse xml and get element tree object we can retrieve data from
             element_tree = etree.parse(fd, parser=xml_parser)
+        root = element_tree.getroot()
 
-        return element_tree.getroot()
+        # Check version of the XML before continuing. Versions weren't published before 1.5.4.  Only check major minor
+        # and point versions to allow for development versions to be allowed.
+        dict_version_string = root.attrib.get("framework_version", "1.5.4")
+        try:
+            dict_version = dict_version_string.split(".")
+            dict_version = tuple([int(item) for item in dict_version[0:3]])
+        except (ValueError, IndexError):
+                raise UnsupportedDictionaryVersionException(dict_version)
+        if dict_version < MINIMUM_SUPPORTED_FRAMEWORK_VERSION or dict_version > MAXIMUM_SUPPORTED_FRAMEWORK_VERSION:
+            raise UnsupportedDictionaryVersionException(dict_version)
+        return root
 
     @staticmethod
     def get_xml_section(section_name, xml_root):
@@ -389,3 +400,15 @@ class XmlLoader(dict_loader.DictLoader):
             raise exceptions.GseControllerParsingException(
                 "Could not find type %s" % type_name
             )
+
+
+class UnsupportedDictionaryVersionException(Exception):
+    """ Dictionary is of unsupported version """
+    def __init__(self, version):
+        """ Create a dictionary of a specific version """
+        def pretty(version_tuple):
+            """ Pretty print version """
+            return ".".join([str(item) for item in version_tuple])
+        super().__init__("Dictionary version {} is not in supported range: {}-{}. Please upgrade fprime-gds."
+                         .format(pretty(version), pretty(MINIMUM_SUPPORTED_FRAMEWORK_VERSION),
+                                 pretty(MAXIMUM_SUPPORTED_FRAMEWORK_VERSION)))

--- a/Gds/src/fprime_gds/flask/app.py
+++ b/Gds/src/fprime_gds/flask/app.py
@@ -7,6 +7,7 @@
 ####
 import logging
 import os
+import sys
 
 import flask
 import flask_restful
@@ -131,7 +132,12 @@ def construct_app():
     return app, api
 
 
-app, _ = construct_app()
+try:
+    app, _ = construct_app()
+except Exception as exc:
+    print("[ERROR] {}".format(exc), file=sys.stderr)
+    sys.exit(1)
+
 
 
 @app.route("/js/<path:path>")

--- a/Gds/src/fprime_gds/version.py
+++ b/Gds/src/fprime_gds/version.py
@@ -1,0 +1,9 @@
+''' Versioning information for the GDS
+
+This file contains versioning and compatibility definitions for the GDS tool set.
+'''
+
+# Currently the GDS is backwards compatible with all dictionaries. This MUST be bumped with each framework release to
+# ensure compatibility
+MINIMUM_SUPPORTED_FRAMEWORK_VERSION = (0,0,0)
+MAXIMUM_SUPPORTED_FRAMEWORK_VERSION = (1,5,4)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infrastructure |
|**_Affected Component_**| GDS |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y (error message w/ instructions) |

---
## Change Description

This adds version checking to the Gds.  This will error if a dictionary is out of the supported range preventing hidden errors from occurring.