### PR TITLE
Replace problematic term 'sanity check' with 'confidence check'

### DIFF
--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -303,7 +303,7 @@ namespace Svc {
             // deserialize, since record size is serialized in file
             FW_ASSERT(Fw::FW_SERIALIZE_OK == buff.deserialize(recordSize));
 
-            // sanity check value. It can't be larger than the maximum parameter buffer size + id
+            // confidence check value. It can't be larger than the maximum parameter buffer size + id
             // or smaller than the record id
             if ((recordSize > FW_PARAM_BUFFER_MAX_SIZE + sizeof(U32)) or (recordSize < sizeof(U32))) {
                 this->log_WARNING_HI_PrmFileReadError(PRM_READ_RECORD_SIZE_VALUE,recordNum,recordSize);

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -139,7 +139,7 @@ endif()
 get_filename_component(DETECTED_FRAMEWORK_PATH "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
 if (DEFINED FPRIME_FRAMEWORK_PATH)
      get_filename_component(FPRIME_FRAMEWORK_PATH "${FPRIME_FRAMEWORK_PATH}" ABSOLUTE)
-     # Sanity check the framework path as supplied
+     # Confidence check the framework path as supplied
      if (NOT FPRIME_FRAMEWORK_PATH STREQUAL DETECTED_FRAMEWORK_PATH)
          message(FATAL_ERROR "Inconsistent FPrime location: ${FPRIME_FRAMEWORK_PATH}. Check settings.ini")
      endif()

--- a/config/PrmDbImplCfg.hpp
+++ b/config/PrmDbImplCfg.hpp
@@ -13,7 +13,7 @@ namespace {
 
     enum {
         PRMDB_NUM_DB_ENTRIES = 25, // !< Number of entries in the parameter database
-        PRMDB_ENTRY_DELIMETER = 0xA5 // !< Byte value that should precede each parameter in file; sanity check against file integrity. Should match ground system.
+        PRMDB_ENTRY_DELIMETER = 0xA5 // !< Byte value that should precede each parameter in file; Confidence check against file integrity. Should match ground system.
     };
 
 }

--- a/docs/UsersGuide/dev/xml-specification.md
+++ b/docs/UsersGuide/dev/xml-specification.md
@@ -481,7 +481,7 @@ Autocoders/templates/ExampleType.hpp. The method is as follows:
    value of that member should be the sum of the sizes of all the
    members. It can be done with the sizeof() function that is available
    to all C/C++ compilers. Optionally, a type identifier can be added
-   so that a sanity check can be done when the data are deserialized.
+   so that a confidence check can be done when the data are deserialized.
    That type should be serialized, and then checked against the
    enumeration when it is deserialized.
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

As per the guidelines if the InclusingNaming project https://inclusivenaming.org/, replaces 'sanity check' with 'confidence check'.

## Rationale

The term 'sanity check' stigmatizes mental health issues.

## Testing/Review Recommendations

All changes are textual, and do not affect the functionality of the code. Thus, this change should have no impact on testing.

## Future Work

None anticipated.
