### PR TITLE
Fix 519: Repopulate cmd on double click

### DIFF
--- a/Gds/src/fprime_gds/flask/static/index.html
+++ b/Gds/src/fprime_gds/flask/static/index.html
@@ -155,6 +155,7 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
                               :filter-text="filterText"
                               :initial-views="itemsShown"
                               :compact="compact"
+                              :click-action="clickAction"
                     ></fp-table>
                 </div>
             </template>

--- a/Gds/src/fprime_gds/flask/static/js/vue-support/command.js
+++ b/Gds/src/fprime_gds/flask/static/js/vue-support/command.js
@@ -66,6 +66,10 @@ Vue.component("command-item", {
  * Input command form Vue object. This allows for sending commands from the GDS.
  */
 Vue.component("command-input", {
+    created: function() {
+        // Make command-input component accessible from other components
+        this.$root.$refs.command_input = this;
+    },
     data: function() {
         let keys = Object.keys(_datastore.commands).filter(command_name => {return command_name.indexOf("CMD_NO_OP") != -1;});
         let selected = (keys.length != 0) ? _datastore.commands[keys[0]] : Object.keys(_datastore.commands)[0];
@@ -124,6 +128,10 @@ Vue.component("command-input", {
                     }
                     _self.active = false;
                 });
+        },
+        selectCmd(cmd) {
+            // Change the selected command to the requested command
+            this.selected = cmd;
         }
     },
     computed: {
@@ -234,6 +242,15 @@ Vue.component("command-history", {
          */
         isItemHidden(item) {
             return listExistsAndItemNameNotInList(this.itemsShown, item);;
+        },
+        /**
+        * On double click on a row in command history table populate the 
+        * command and its arguments in the command input template
+        */
+        clickAction(item) {
+            let cmd = item;
+            cmd.full_name = item.template.full_name;
+            this.$root.$refs.command_input.selectCmd(cmd);
         }
     }
 });


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F Prime |
|**_Affected Component_**|  GDS |
|**_Affected Architectures(s)_**|  static/js |
|**_Related Issue(s)_**| #519  |
|**_Has Unit Tests (y/n)_**|  No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**|  NA |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

Added option to repopulate previous commands when user double clicks on a row in the command-history table.

## Rationale

> Double clicking on commands in the command history should repopulate the command-send box.

## Testing/Review Recommendations

Manually ran the GUI and checked the double click functionality with no issues.

![image](https://user-images.githubusercontent.com/35859004/119220029-319df780-ba9d-11eb-9bbf-06e461af5dd9.png)


## Future Work

NA
