### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/Autocoders/MagicDrawCompPlugin/Demos/isfpluginexec.sh
+++ b/Autocoders/MagicDrawCompPlugin/Demos/isfpluginexec.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while [[ $# > 0 ]]
+while [[ $# -gt 0 ]]
 do
         key="$1"
 
@@ -57,4 +57,4 @@ if [ -z "$BUILD_ROOT" ]; then
         echo WARNING: Environmental variable BUILD_ROOT is not defined
 fi
 
-eval $run
+eval "$run"

--- a/Autocoders/MagicDrawCompPlugin/isfpluginexec.sh
+++ b/Autocoders/MagicDrawCompPlugin/isfpluginexec.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while [[ $# > 0 ]]
+while [[ $# -gt 0 ]]
 do
         key="$1"
 
@@ -57,4 +57,4 @@ if [ -z "$BUILD_ROOT" ]; then
         echo WARNING: Environmental variable BUILD_ROOT is not defined
 fi
 
-eval $run
+eval "$run"

--- a/Autocoders/Python/bin/run_JSONDict.sh
+++ b/Autocoders/Python/bin/run_JSONDict.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../../.." || exit; pwd)"
+    export BUILD_ROOT
 fi
 echo "BUILD_ROOT is: ${BUILD_ROOT}"
 

--- a/Gds/bin/helpers/run_tool.sh
+++ b/Gds/bin/helpers/run_tool.sh
@@ -19,18 +19,21 @@
 ####
 TOOL="$1"
 shift
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../../.." || exit; pwd)"
+    export BUILD_ROOT
 fi
 echo "BUILD_ROOT is: ${BUILD_ROOT}"
 
 # Get binary output path
-export NATIVE_BUILD="`make -f ${BUILD_ROOT}/mk/makefiles/build_vars.mk print_native_build`"
+NATIVE_BUILD="$(make -f "${BUILD_ROOT}/mk/makefiles/build_vars.mk print_native_build")"
+export NATIVE_BUILD
 echo "NATIVE_BUILD: ${NATIVE_BUILD}"
-export OUTPUT_DIR="`make -f ${BUILD_ROOT}/mk/makefiles/build_vars.mk BUILD=$NATIVE_BUILD print_output_dir`"
+OUTPUT_DIR="$(make -f "${BUILD_ROOT}/mk/makefiles/build_vars.mk BUILD=${NATIVE_BUILD} print_output_dir")"
+export OUTPUT_DIR
 echo "OUTPUT_DIR: ${OUTPUT_DIR}"
 
 export PYTHONPATH="${BUILD_ROOT}/Fw/Python/src:${BUILD_ROOT}/Gds/src"

--- a/Gds/bin/run_deployment.sh
+++ b/Gds/bin/run_deployment.sh
@@ -4,11 +4,12 @@
 # * ALL RIGHTS RESERVED. United States Government Sponsorship
 # * acknowledged.
 # *
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../.." || exit; pwd)"
+    export BUILD_ROOT
 fi
 export PYTHONPATH="${BUILD_ROOT}/Fw/Python/src:${BUILD_ROOT}/Gds/src"
 python -m fprime_gds.executables.run_deployment "$@"

--- a/Gds/bin/run_seqgen.sh
+++ b/Gds/bin/run_seqgen.sh
@@ -11,5 +11,5 @@
 # * information to foreign countries or providing access to foreign
 # * persons.
 # *
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 "${DIRNAME}/helpers/run_tool.sh" seqgen "$@"

--- a/Gds/bin/tkgui/run_cmds.sh
+++ b/Gds/bin/tkgui/run_cmds.sh
@@ -11,5 +11,5 @@
 # * information to foreign countries or providing access to foreign
 # * persons.
 # *
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 "${DIRNAME}/run_tool.sh" run_cmds "$@"

--- a/Gds/bin/tkgui/run_seqgen.sh
+++ b/Gds/bin/tkgui/run_seqgen.sh
@@ -11,5 +11,5 @@
 # * information to foreign countries or providing access to foreign
 # * persons.
 # *
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 "${DIRNAME}/run_tool.sh" seqgen "$@"

--- a/Gds/bin/tkgui/run_tlmeditor.sh
+++ b/Gds/bin/tkgui/run_tlmeditor.sh
@@ -11,5 +11,5 @@
 # * information to foreign countries or providing access to foreign
 # * persons.
 # *
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 "${DIRNAME}/run_tool.sh" TlmPacketEditor "$@"

--- a/Gds/bin/tkgui/run_tool.sh
+++ b/Gds/bin/tkgui/run_tool.sh
@@ -19,19 +19,21 @@
 ####
 TOOL="$1"
 shift
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../../.." || exit; pwd)"
+    export BUILD_ROOT
 fi
 echo "BUILD_ROOT is: ${BUILD_ROOT}"
 
 # Get binary output path
-export NATIVE_BUILD="`make -f ${BUILD_ROOT}/mk/makefiles/build_vars.mk print_native_build`"
+NATIVE_BUILD="$(make -f "${BUILD_ROOT}/mk/makefiles/build_vars.mk print_native_build")"
+export NATIVE_BUILD
 echo "NATIVE_BUILD: ${NATIVE_BUILD}"
-export OUTPUT_DIR="`make -f ${BUILD_ROOT}/mk/makefiles/build_vars.mk BUILD=$NATIVE_BUILD print_output_dir`"
-echo "OUTPUT_DIR: ${OUTPUT_DIR}"
+OUTPUT_DIR="$(make -f "${BUILD_ROOT}/mk/makefiles/build_vars.mk BUILD=${NATIVE_BUILD} print_output_dir")"
+export OUTPUT_DIR
 
 export PYTHONPATH="${BUILD_ROOT}/Fw/Python/src:${BUILD_ROOT}/Gds/src"
 python -m fprime_gds.tkgui.tools."${TOOL}" "$@"

--- a/Gds/bin/wxgui/run_cmds.sh
+++ b/Gds/bin/wxgui/run_cmds.sh
@@ -17,19 +17,23 @@
 # Helper script that runs one of the tools associated with the tkgui
 # layer. 
 ####
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../../.." || exit; pwd)"
+    export
 fi
 echo "BUILD_ROOT is: ${BUILD_ROOT}"
 
 # Get binary output path
-export NATIVE_BUILD="`make -f ${BUILD_ROOT}/mk/makefiles/build_vars.mk print_native_build`"
+NATIVE_BUILD="$(make -f "${BUILD_ROOT}/mk/makefiles/build_vars.mk print_native_build")"
+export NATIVE_BUILD
 echo "NATIVE_BUILD: ${NATIVE_BUILD}"
-export OUTPUT_DIR="`make -f ${BUILD_ROOT}/mk/makefiles/build_vars.mk BUILD=$NATIVE_BUILD print_output_dir`"
+OUTPUT_DIR="$(make -f "${BUILD_ROOT}/mk/makefiles/build_vars.mk BUILD=${NATIVE_BUILD} print_output_dir")"
+export OUTPUT_DIR
 echo "OUTPUT_DIR: ${OUTPUT_DIR}"
 
-export PYTHONPATH="${BUILD_ROOT}/Fw/Python/src:${BUILD_ROOT}/Gds/src"
+PYTHONPATH="${BUILD_ROOT}/Fw/Python/src:${BUILD_ROOT}/Gds/src"
+export PYTHONPATH
 python -m fprime_gds.wxgui.tools.run_cmds "$@"

--- a/RPI/scripts/run_rpi_cross.sh
+++ b/RPI/scripts/run_rpi_cross.sh
@@ -4,12 +4,13 @@
 # * ALL RIGHTS RESERVED. United States Government Sponsorship
 # * acknowledged.
 # *
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../.." || exit ; pwd)"
+    export BUILD_ROOT
 fi
-DEPLOY=`cd ${DIRNAME}/..; pwd;`
-${BUILD_ROOT}/Gds/bin/run_deployment.sh --deploy "${DEPLOY}" --no-app "$@"
+DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd;)
+"${BUILD_ROOT}/Gds/bin/run_deployment.sh" --deploy "${DEPLOY}" --no-app "$@"
 

--- a/RPI/scripts/run_rpi_cross.sh
+++ b/RPI/scripts/run_rpi_cross.sh
@@ -11,6 +11,6 @@ then
     BUILD_ROOT="$(cd "${DIRNAME}/../.." || exit ; pwd)"
     export BUILD_ROOT
 fi
-DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd;)
+DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd)
 "${BUILD_ROOT}/Gds/bin/run_deployment.sh" --deploy "${DEPLOY}" --no-app "$@"
 

--- a/RPI/scripts/run_rpi_cross_gds.sh
+++ b/RPI/scripts/run_rpi_cross_gds.sh
@@ -11,6 +11,6 @@ then
     BUILD_ROOT="$(cd "${DIRNAME}/../.." || exit ; pwd)"
     export BUILD_ROOT
 fi
-DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd;)
+DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd)
 "${BUILD_ROOT}/Gds/bin/run_deployment.sh"--deploy "${DEPLOY}" -g wx --no-app "$@"
 

--- a/RPI/scripts/run_rpi_cross_gds.sh
+++ b/RPI/scripts/run_rpi_cross_gds.sh
@@ -4,12 +4,13 @@
 # * ALL RIGHTS RESERVED. United States Government Sponsorship
 # * acknowledged.
 # *
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../.." || exit ; pwd)"
+    export BUILD_ROOT
 fi
-DEPLOY=`cd ${DIRNAME}/..; pwd;`
-${BUILD_ROOT}/Gds/bin/run_deployment.sh --deploy "${DEPLOY}" -g wx --no-app "$@"
+DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd;)
+"${BUILD_ROOT}/Gds/bin/run_deployment.sh"--deploy "${DEPLOY}" -g wx --no-app "$@"
 

--- a/Ref/scripts/compile_ref_sequence.sh
+++ b/Ref/scripts/compile_ref_sequence.sh
@@ -11,12 +11,13 @@
 # * information to foreign countries or providing access to foreign
 # * persons.
 # *
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../.." || exit ; pwd)"
+    export BUILD_ROOT
 fi
 echo "BUILD_ROOT is: ${BUILD_ROOT}"
 export PYTHONPATH="${BUILD_ROOT}/Fw/Python/src:${BUILD_ROOT}/Gds/src"
-python "${BUILD_ROOT}/Gds/src/fprime_gds/tkgui/tools/seqgen.py" -g ${BUILD_ROOT}/Ref/py_dict "$@"
+python "${BUILD_ROOT}/Gds/src/fprime_gds/tkgui/tools/seqgen.py" -g "${BUILD_ROOT}/Ref/py_dict" "$@"

--- a/Ref/scripts/run_ref.sh
+++ b/Ref/scripts/run_ref.sh
@@ -11,12 +11,13 @@
 # * information to foreign countries or providing access to foreign
 # * persons.
 # *
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../../.." || exit; pwd)"
+    export BUILD_ROOT
 fi
-DEPLOY=`cd ${DIRNAME}/..; pwd;`
-${BUILD_ROOT}/Gds/bin/run_deployment.sh --deploy "${DEPLOY}"
+DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd;)
+"${BUILD_ROOT}/Gds/bin/run_deployment.sh" --deploy "${DEPLOY}"
 

--- a/Ref/scripts/run_ref.sh
+++ b/Ref/scripts/run_ref.sh
@@ -18,6 +18,6 @@ then
     BUILD_ROOT="$(cd "${DIRNAME}/../../.." || exit; pwd)"
     export BUILD_ROOT
 fi
-DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd;)
+DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd)
 "${BUILD_ROOT}/Gds/bin/run_deployment.sh" --deploy "${DEPLOY}"
 

--- a/Ref/scripts/run_ref_cmds.sh
+++ b/Ref/scripts/run_ref_cmds.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../.." || exit ; pwd)"
+    export BUILD_ROOT
 fi
 echo "BUILD_ROOT is: ${BUILD_ROOT}"
 
-${BUILD_ROOT}/Gds/bin/tkgui/run_cmds.sh --addr localhost --port 50000 --dictionary ${BUILD_ROOT}/Ref/py_dict "$@"
+"${BUILD_ROOT}/Gds/bin/tkgui/run_cmds.sh" --addr localhost --port 50000 --dictionary "${BUILD_ROOT}/Ref/py_dict" "$@"

--- a/Ref/scripts/run_ref_for_int_test.sh
+++ b/Ref/scripts/run_ref_for_int_test.sh
@@ -11,12 +11,13 @@
 # * information to foreign countries or providing access to foreign
 # * persons.
 # *
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../.." || exit; pwd)"
+    export BUILD_ROOT
 fi
-DEPLOY=`cd ${DIRNAME}/..; pwd;`
-DICTIONARY=`cd ${DIRNAME}/../Top/; pwd;`
-${BUILD_ROOT}/Gds/bin/run_deployment.sh --dictionary "${DICTIONARY}" --deploy "${DEPLOY}" -g none
+DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd;)
+DICTIONARY=$(cd "${DIRNAME}/../Top/" || exit; pwd;)
+"${BUILD_ROOT}/Gds/bin/run_deployment.sh"--dictionary "${DICTIONARY}" --deploy "${DEPLOY}" -g none

--- a/Ref/scripts/run_ref_for_int_test.sh
+++ b/Ref/scripts/run_ref_for_int_test.sh
@@ -18,6 +18,6 @@ then
     BUILD_ROOT="$(cd "${DIRNAME}/../.." || exit; pwd)"
     export BUILD_ROOT
 fi
-DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd;)
-DICTIONARY=$(cd "${DIRNAME}/../Top/" || exit; pwd;)
+DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd)
+DICTIONARY=$(cd "${DIRNAME}/../Top/" || exit; pwd)
 "${BUILD_ROOT}/Gds/bin/run_deployment.sh"--dictionary "${DICTIONARY}" --deploy "${DEPLOY}" -g none

--- a/Ref/scripts/run_ref_gds.sh
+++ b/Ref/scripts/run_ref_gds.sh
@@ -18,6 +18,6 @@ then
     BUILD_ROOT="$(cd "${DIRNAME}/../.." || exit; pwd)"
     export BUILD_ROOT
 fi
-DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd;)
+DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd)
 "${BUILD_ROOT}/Gds/bin/run_deployment.sh" --deploy "${DEPLOY}" -g wx
 

--- a/Ref/scripts/run_ref_gds.sh
+++ b/Ref/scripts/run_ref_gds.sh
@@ -11,12 +11,13 @@
 # * information to foreign countries or providing access to foreign
 # * persons.
 # *
-DIRNAME="`dirname $0`"
+DIRNAME="$(dirname "$0")"
 # Set BUILD_ROOT if unset or "" set the BUILD_ROOT to be the above dir
-if [ -z ${BUILD_ROOT} ]
+if [ -z "${BUILD_ROOT}" ]
 then
-    export BUILD_ROOT="`cd ${DIRNAME}/../..; pwd`"
+    BUILD_ROOT="$(cd "${DIRNAME}/../.." || exit; pwd)"
+    export BUILD_ROOT
 fi
-DEPLOY=`cd ${DIRNAME}/..; pwd;`
-${BUILD_ROOT}/Gds/bin/run_deployment.sh --deploy "${DEPLOY}" -g wx
+DEPLOY=$(cd "${DIRNAME}/.." || exit; pwd;)
+"${BUILD_ROOT}/Gds/bin/run_deployment.sh" --deploy "${DEPLOY}" -g wx
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes several warnings reported by shellcheck to avoid that shell behaves strangely and counter-intuitively or giving cryptic error messages.

## Rationale

Shellcheck reported ~143 warnings, mostly 
  * https://www.shellcheck.net/wiki/SC2071 -- ">" is for string comparisons
  * https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately
  * https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
  * https://www.shellcheck.net/wiki/SC2006 -- Use $(...) notation instead of legacy backticked `...`
  * https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing and word splitting

## Testing/Review Recommendations

[Shellcheck](https://github.com/koalaman/shellcheck) is a shell script static analysis tool reporting warnings and suggestions for bash/sh shell scripts.

Reproduce warnings by `docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable $(find . -name "*.sh")`

## Future Work

None
