### PR TITLE
Add fprime-util warning when settings.ini doesn't match generated build cache

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -75,7 +75,7 @@ option(CMAKE_DEBUG_OUTPUT "Generate F prime's debug output while running CMake" 
 option(SKIP_TOOLS_CHECK "Skip the tools check for older clients." OFF)
 
 # Set build type, when it hasn't been set
-if(NOT CMAKE_BUILD_TYPE) 
+if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RELEASE)
 else()
     string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
@@ -211,13 +211,15 @@ endif()
 if (NOT DEFINED FPRIME_AC_CONSTANTS_FILE)
     set(FPRIME_AC_CONSTANTS_FILE "${FPRIME_FRAMEWORK_PATH}/config/AcConstants.ini" CACHE PATH "F prime AC constants.ini file" FORCE)
 endif()
+
 # Settings for F config directory
 if (NOT DEFINED FPRIME_CONFIG_DIR)
-    set(FPRIME_CONFIG_DIR "${FPRIME_FRAMEWORK_PATH}/config/" CACHE PATH "F prime configuration header directory" FORCE)
+    set(FPRIME_CONFIG_DIR "${FPRIME_FRAMEWORK_PATH}/config/")
 endif()
+set(FPRIME_CONFIG_DIR "${FPRIME_CONFIG_DIR}" CACHE PATH "F prime configuration header directory" FORCE)
 
 # Settings for F artifacts installation destination
 if (NOT DEFINED FPRIME_INSTALL_DEST)
-    set(FPRIME_INSTALL_DEST "${PROJECT_SOURCE_DIR}/build-artifacts/" CACHE PATH "F prime artifacts installation directory" FORCE)
+    set(FPRIME_INSTALL_DEST "${PROJECT_SOURCE_DIR}/build-artifacts/")
 endif()
-set(IGNORE_ME ${FPRIME_INSTALL_DEST}) # Prevent warning that FPRIME_INSTALL_DEST is unused
+set(FPRIME_INSTALL_DEST "${FPRIME_INSTALL_DEST}" CACHE PATH "F prime artifacts installation directory" FORCE)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| fprime-util  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| fixes #517  |
|**_Has Unit Tests (y/n)_**| n  |
|**_Builds Without Errors (y/n)_**|  y |
|**_Unit Tests Pass (y/n)_**| y  |
|**_Documentation Included (y/n)_**|  n |

---
## Change Description

Editing the settings.ini file requires a regeneration of any build caches, but nothing warns a user when they edit the settings.ini files and forget to regenerate.

## Rationale

settings.ini changes only take affect after regeneration, users may be surprised that they edit the settings.ini file and don't see their changes take affect when rebuilding.