### PR TITLE
Bump GoogleTest version

### DIFF
--- a/cmake/googletest-download/CMakeLists.txt.in
+++ b/cmake/googletest-download/CMakeLists.txt.in
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           release-1.10.0
+  GIT_TAG           a3460d1
   SOURCE_DIR        "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-src"
   BINARY_DIR        "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-build-${PLATFORM}"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Bump googletest version to latest master branch commit.

## Rationale

GoogleTest has decided to go release less and encourage people to always use the master branch to avoid versioning problems. While they said they would do long term releases occasionally, the lastest LTS branch is 2 years old. Unfortunately in that time cmake 3.19 has been released and warns that google test supports a deprecated version of cmake (< 2.8.12). Switching to the GoogleTest master branch pulls in the fix for these warnings.

I propose that before a new release of F' we bump the googletest framework to the latest commit on master or switch to the latest long term support branch, whichever makes most sense at the time.
