### PR TITLE
Properly bound size when concatenating strings

### DIFF
--- a/Fw/Types/StringType.cpp
+++ b/Fw/Types/StringType.cpp
@@ -109,7 +109,10 @@ namespace Fw {
         const U32 length = this->length();
         FW_ASSERT(capacity > length, capacity, length);
         // Subtract 1 to leave space for null terminator
-        const U32 remaining = capacity - length - 1;
+        U32 remaining = capacity - length - 1;
+        if(size < remaining) {
+            remaining = size;
+        }
         FW_ASSERT(remaining < capacity, remaining, capacity);
         (void) strncat((char*) this->toChar(), buff, remaining);
     }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Fw |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Use the size argument, rather than the end of string null terminator to bound StringBase::appendBuff

## Rationale

GCC flagged this by highlighting that the size argument was unused. Technically `strncat` will stop at the null terminator of the provided string, but respecting size allows handling the use case that a user only wants to append a partial string, as well as not crash when a string buffer isn't null terminated.