### PR TITLE
Set O_EXCL when opening file with include_excl

### DIFF
--- a/Os/Linux/File.cpp
+++ b/Os/Linux/File.cpp
@@ -66,6 +66,9 @@ namespace Os {
 #endif
             case OPEN_CREATE:
                 flags = O_WRONLY | O_CREAT | O_TRUNC;
+                if(include_excl) {
+                    flags |= O_EXCL;
+                }
                 break;
             case OPEN_APPEND:
                 flags = O_WRONLY | O_CREAT | O_APPEND;

--- a/Os/Stubs/Linux/FileStub.cpp
+++ b/Os/Stubs/Linux/FileStub.cpp
@@ -115,6 +115,9 @@ namespace Os {
                 break;
             case OPEN_CREATE:
                 flags = O_WRONLY | O_CREAT | O_TRUNC;
+                if(include_excl) {
+                    flags |= O_EXCL;
+                }
                 break;
             default:
                 FW_ASSERT(0,(NATIVE_INT_TYPE)mode);

--- a/Svc/ActiveTextLogger/LogFile.cpp
+++ b/Svc/ActiveTextLogger/LogFile.cpp
@@ -139,8 +139,7 @@ namespace Svc {
         }
 
         // Open the file (using CREATE so that it truncates an already existing file):
-        Os::File::Status stat = this->m_file.open(fileNameFinal,
-                                                  Os::File::OPEN_CREATE);
+        Os::File::Status stat = this->m_file.open(fileNameFinal, Os::File::OPEN_CREATE, false);
 
         // Bad status when trying to open the file:
         if (stat != Os::File::OP_OK) {

--- a/Svc/ActiveTextLogger/test/ut/Tester.cpp
+++ b/Svc/ActiveTextLogger/test/ut/Tester.cpp
@@ -14,11 +14,11 @@
 namespace Svc {
 
   // ----------------------------------------------------------------------
-  // Construction and destruction 
+  // Construction and destruction
   // ----------------------------------------------------------------------
 
   Tester ::
-    Tester(void) : 
+    Tester(void) :
 #if FW_OBJECT_NAMES == 1
       ActiveTextLoggerGTestBase("Tester", MAX_HISTORY_SIZE),
       component("ActiveTextLogger")
@@ -32,13 +32,13 @@ namespace Svc {
   }
 
   Tester ::
-    ~Tester(void) 
+    ~Tester(void)
   {
-    
+
   }
 
   // ----------------------------------------------------------------------
-  // Tests 
+  // Tests
   // ----------------------------------------------------------------------
 
   void Tester ::
@@ -181,7 +181,7 @@ namespace Svc {
 
       ASSERT_TRUE(stat);
       ASSERT_TRUE(this->component.m_log_file.m_openFile);
-      ASSERT_EQ(0,strcmp("test_file_max",this->component.m_log_file.m_fileName.toChar()));
+      ASSERT_STREQ("test_file_max",this->component.m_log_file.m_fileName.toChar());
       ASSERT_EQ(0U, this->component.m_log_file.m_currentFileSize);
       ASSERT_EQ(45U, this->component.m_log_file.m_maxFileSize);
       ASSERT_EQ(Os::FileSystem::OP_OK,
@@ -249,7 +249,7 @@ namespace Svc {
       // Verify made file with 0 suffix:
       ASSERT_TRUE(stat);
       ASSERT_TRUE(this->component.m_log_file.m_openFile);
-      ASSERT_EQ(0,strcmp("test_file_max0",this->component.m_log_file.m_fileName.toChar()));
+      ASSERT_STREQ("test_file_max0",this->component.m_log_file.m_fileName.toChar());
       ASSERT_EQ(0U, this->component.m_log_file.m_currentFileSize);
       ASSERT_EQ(50U, this->component.m_log_file.m_maxFileSize);
       ASSERT_EQ(Os::FileSystem::OP_OK,
@@ -353,11 +353,11 @@ namespace Svc {
   }
 
   // ----------------------------------------------------------------------
-  // Helper methods 
+  // Helper methods
   // ----------------------------------------------------------------------
 
   void Tester ::
-    connectPorts(void) 
+    connectPorts(void)
   {
 
     // TextLogger
@@ -372,7 +372,7 @@ namespace Svc {
   }
 
   void Tester ::
-    initComponents(void) 
+    initComponents(void)
   {
     this->init();
     this->component.init(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  Os |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| |

---
## Change Description

When `include_excl` is set, set the `O_EXCL` flag. Previously this argument was unused (caught through gcc's unused parameter warning).

⚠️  Warning: This is a breaking change that silently changes default behavior.

## Rationale

If we have an `include_excl` parameter, it should be respected. However, this does change the default behavior of `File::open(const char* fileName, File::Mode mode)`, since it defaults `include_excl` to true. Because `include_excl` was ignored this effectively is equivalent to `include_excl` = false.

I think the default of not overwriting a file if it already exists is wise. Personally, I believe the value of enforcing this safer default is greater than the impact of breaking projects upgrading to F' 2.0 that implicitly depending on the overwrite on create behavior. However, this is a serious breaking change and it may make sense to keep the current unintentional default and update `File::open(const char* fileName, File::Mode mode)` to set the `include_excl` flag to false.