### PR TITLE
Correct warnings raised by clang-analyze

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1086,6 +1086,7 @@ noncomma
 nondetached
 NONINFRINGEMENT
 Nop
+noreturn
 normalwidths
 normpath
 NOSEQUENCEACTIVE

--- a/Drv/Ip/IpSocket.cpp
+++ b/Drv/Ip/IpSocket.cpp
@@ -141,7 +141,6 @@ SocketIpStatus IpSocket::send(const U8* const data, const U32 size) {
     }
     // Attempt to send out data and retry as necessary
     for (U32 i = 0; (i < SOCKET_MAX_ITERATIONS) && (total < size); i++) {
-        sent = 0;
         // Send using my specific protocol
         sent = this->sendProtocol(data + total, size - total);
         // Error is EINTR or timeout just try again

--- a/Drv/TcpClient/test/ut/Tester.cpp
+++ b/Drv/TcpClient/test/ut/Tester.cpp
@@ -38,8 +38,8 @@ void Tester ::test_with_loop(U32 iterations, bool recv_thread) {
     Drv::TcpServerSocket server;
     server.configure("127.0.0.1", port, 0, 100);
     this->component.configure("127.0.0.1", port, 0, 100);
-    status2 = server.startup();
-    EXPECT_EQ(serverStat, SOCK_SUCCESS);
+    serverStat = server.startup();
+    ASSERT_EQ(serverStat, SOCK_SUCCESS);
 
     // Start up a receive thread
     if (recv_thread) {
@@ -48,7 +48,7 @@ void Tester ::test_with_loop(U32 iterations, bool recv_thread) {
     }
 
     // Loop through a bunch of client disconnects
-    for (U32 i = 0; i < iterations && serverStat == SOCK_SUCCESS; i++) {
+    for (U32 i = 0; i < iterations; i++) {
         I32 size = sizeof(m_data_storage);
 
         // Not testing with reconnect thread, we will need to open ourselves
@@ -172,7 +172,7 @@ Fw::Buffer Tester ::
 // ----------------------------------------------------------------------
 
   void Tester ::
-    connectPorts(void) 
+    connectPorts(void)
   {
 
     // send
@@ -189,19 +189,19 @@ Fw::Buffer Tester ::
 
     // recv
     this->component.set_recv_OutputPort(
-        0, 
+        0,
         this->get_from_recv(0)
     );
 
     // allocate
     this->component.set_allocate_OutputPort(
-        0, 
+        0,
         this->get_from_allocate(0)
     );
 
     // deallocate
     this->component.set_deallocate_OutputPort(
-        0, 
+        0,
         this->get_from_deallocate(0)
     );
 

--- a/Drv/TcpServer/test/ut/Tester.cpp
+++ b/Drv/TcpServer/test/ut/Tester.cpp
@@ -37,7 +37,7 @@ void Tester ::test_with_loop(U32 iterations, bool recv_thread) {
     ASSERT_NE(0, port);
 
     this->component.configure("127.0.0.1", port, 0, 100);
-    status2 = this->component.startup();
+    serverStat = this->component.startup();
     EXPECT_EQ(serverStat, SOCK_SUCCESS);
 
     // Start up a receive thread
@@ -169,7 +169,7 @@ Fw::Buffer Tester ::
 // ----------------------------------------------------------------------
 
 void Tester ::
-    connectPorts(void) 
+    connectPorts(void)
   {
 
     // send
@@ -186,19 +186,19 @@ void Tester ::
 
     // recv
     this->component.set_recv_OutputPort(
-        0, 
+        0,
         this->get_from_recv(0)
     );
 
     // allocate
     this->component.set_allocate_OutputPort(
-        0, 
+        0,
         this->get_from_allocate(0)
     );
 
     // deallocate
     this->component.set_deallocate_OutputPort(
-        0, 
+        0,
         this->get_from_deallocate(0)
     );
   }

--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -27,16 +27,28 @@
     (Fw::SwAssert((U8*)__FILE__, __LINE__, ##__VA_ARGS__))))
 #endif
 
+// F' Assertion functions can technically return even though the intention is for the assertion to terminate the program.
+// This breaks static analysis depending on assertions, since the analyzer has to assume the assertion will return.
+// When supported, annotate assertion functions as noreturn when statically analyzing.
+#ifndef CLANG_ANALYZER_NORETURN
+#ifndef __has_feature
+  #define __has_feature(x) 0  // Compatibility with non-clang compilers.
+#endif
+#if __has_feature(attribute_analyzer_noreturn)
+#define CLANG_ANALYZER_NORETURN __attribute__((analyzer_noreturn))
+#else
+#define CLANG_ANALYZER_NORETURN
+#endif
+#endif
 
 namespace Fw {
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo); //!< Assert with no arguments
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1); //!< Assert with one argument
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1, AssertArg arg2); //!< Assert with two arguments
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1, AssertArg arg2, AssertArg arg3); //!< Assert with three arguments
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1, AssertArg arg2, AssertArg arg3, AssertArg arg4); //!< Assert with four arguments
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1, AssertArg arg2, AssertArg arg3, AssertArg arg4, AssertArg arg5); //!< Assert with five arguments
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1, AssertArg arg2, AssertArg arg3, AssertArg arg4, AssertArg arg5, AssertArg arg6); //!< Assert with six arguments
-
+    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN; //!< Assert with no arguments
+    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1) CLANG_ANALYZER_NORETURN; //!< Assert with one argument
+    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1, AssertArg arg2) CLANG_ANALYZER_NORETURN; //!< Assert with two arguments
+    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1, AssertArg arg2, AssertArg arg3) CLANG_ANALYZER_NORETURN; //!< Assert with three arguments
+    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1, AssertArg arg2, AssertArg arg3, AssertArg arg4) CLANG_ANALYZER_NORETURN; //!< Assert with four arguments
+    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1, AssertArg arg2, AssertArg arg3, AssertArg arg4, AssertArg arg5) CLANG_ANALYZER_NORETURN; //!< Assert with five arguments
+    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, AssertArg arg1, AssertArg arg2, AssertArg arg3, AssertArg arg4, AssertArg arg5, AssertArg arg6) CLANG_ANALYZER_NORETURN; //!< Assert with six arguments
 }
 
 // Base class for declaring an assert hook

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -176,7 +176,7 @@ namespace Fw {
         return *this;
     }
 
-#endif    
+#endif
 #if FW_HAS_64_BIT
 
     // U64 methods
@@ -497,6 +497,9 @@ namespace Fw {
 
         // store type
         SerializeStatus stat = buffer.serialize(static_cast<FwEnumStoreType> (this->m_dataType));
+        if(stat != FW_SERIALIZE_OK) {
+            return stat;
+        }
 
         // switch on type
         switch (this->m_dataType) {
@@ -532,7 +535,7 @@ namespace Fw {
             case TYPE_F64:
                 stat = buffer.serialize(this->m_val.f64Val);
                 break;
-#endif				
+#endif
             case TYPE_F32:
                 stat = buffer.serialize(this->m_val.f32Val);
                 break;
@@ -546,7 +549,7 @@ namespace Fw {
                 stat = FW_SERIALIZE_FORMAT_ERROR;
                 break;
             }
-        
+
         return stat;
     }
 
@@ -570,13 +573,13 @@ namespace Fw {
                     return buffer.deserialize(this->m_val.u16Val);
                 case TYPE_I16:
                     return buffer.deserialize(this->m_val.i16Val);
-#endif                    
+#endif
 #if FW_HAS_32_BIT
                 case TYPE_U32:
                     return buffer.deserialize(this->m_val.u32Val);
                 case TYPE_I32:
                     return buffer.deserialize(this->m_val.i32Val);
-#endif                    
+#endif
 #if FW_HAS_64_BIT
                 case TYPE_U64:
                     return buffer.deserialize(this->m_val.u64Val);
@@ -584,7 +587,7 @@ namespace Fw {
                     return buffer.deserialize(this->m_val.i64Val);
                 case TYPE_F64:
                     return buffer.deserialize(this->m_val.f64Val);
-#endif              
+#endif
                 case TYPE_F32:
                     return buffer.deserialize(this->m_val.f32Val);
                 case TYPE_BOOL:
@@ -621,7 +624,7 @@ namespace Fw {
             case TYPE_I16:
             	(void) snprintf(valString, sizeof(valString), "%d ", this->m_val.i16Val);
                 break;
-#endif                
+#endif
 #if FW_HAS_32_BIT
             case TYPE_U32:
             	(void) snprintf(valString, sizeof(valString), "%d ", this->m_val.u32Val);
@@ -629,7 +632,7 @@ namespace Fw {
             case TYPE_I32:
             	(void) snprintf(valString, sizeof(valString), "%d ", this->m_val.i32Val);
                 break;
-#endif                
+#endif
 #if FW_HAS_64_BIT
             case TYPE_U64:
             	(void) snprintf(valString, sizeof(valString), "%llu ", (unsigned long long)this->m_val.u64Val);
@@ -656,7 +659,7 @@ namespace Fw {
             	(void) snprintf(valString, sizeof(valString), "%s ", "NT");
                 break;
         }
-        
+
         // NULL terminate
         valString[sizeof(valString)-1] = 0;
 

--- a/Os/Pthreads/test/ut/BufferQueueTest.cpp
+++ b/Os/Pthreads/test/ut/BufferQueueTest.cpp
@@ -104,6 +104,7 @@ int main() {
     count = queue2.getCount();
     maxCount = queue2.getMaxCount();
     FW_ASSERT(count == ii+1, count);
+    FW_ASSERT(maxCount == ii+1, maxCount);
   }
 
 #if PRIORITY_QUEUE
@@ -122,10 +123,9 @@ int main() {
     FW_ASSERT(ret, ret);
     FW_ASSERT(priority == orderedPriorities[ii], priority);
     FW_ASSERT(size == strlen(orderedMessages[ii]), strlen(orderedMessages[ii]));
-    printf("Popped '%s' at priority %d. Expected '%s' at priority %d.\n", 
+    printf("Popped '%s' at priority %d. Expected '%s' at priority %d.\n",
            temp, priority, orderedMessages[ii], orderedPriorities[ii]);
     FW_ASSERT(memcmp(temp, orderedMessages[ii], size) == 0, ii);
-    count = queue2.getCount();
     size = sizeof(temp) - 1; //Reset size
   }
 

--- a/Svc/PrmDb/test/ut/PrmDbImplTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbImplTester.cpp
@@ -574,6 +574,8 @@ void PrmDbImplTester::runFileReadError(void) {
         // dispatch command
         this->sendCmd_PRM_SAVE_FILE(0,12);
         Fw::QueuedComponentBase::MsgDispatchStatus stat = this->m_impl.doDispatch();
+        ASSERT_EQ(stat, Fw::QueuedComponentBase::MSG_DISPATCH_OK);
+
         // check for failed event
         ASSERT_EVENTS_SIZE(1);
         ASSERT_EVENTS_PrmFileWriteError_SIZE(1);

--- a/Svc/TlmChan/TlmChanImplRecv.cpp
+++ b/Svc/TlmChan/TlmChanImplRecv.cpp
@@ -38,6 +38,7 @@ namespace Svc {
                     FW_ASSERT(this->m_tlmEntries[this->m_activeBuffer].free < TLMCHAN_HASH_BUCKETS);
                     // add new bucket from free list
                     entryToUse = &this->m_tlmEntries[this->m_activeBuffer].buckets[this->m_tlmEntries[this->m_activeBuffer].free++];
+                    FW_ASSERT(prevEntry);
                     prevEntry->next = entryToUse;
                     // clear next pointer
                     entryToUse->next = 0;

--- a/Utils/test/ut/LockGuardTester.cpp
+++ b/Utils/test/ut/LockGuardTester.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  LockGuardTester.hpp
 // \author vwong
 // \brief  cpp file for LockGuard test harness implementation class
@@ -9,7 +9,7 @@
 //
 // ALL RIGHTS RESERVED. United States Government Sponsorship
 // acknowledged.
-// ====================================================================== 
+// ======================================================================
 
 #include "LockGuardTester.hpp"
 #include <time.h>
@@ -19,7 +19,7 @@
 namespace Utils {
 
   // ----------------------------------------------------------------------
-  // Construction and destruction 
+  // Construction and destruction
   // ----------------------------------------------------------------------
 
   LockGuardTester ::
@@ -28,13 +28,13 @@ namespace Utils {
   }
 
   LockGuardTester ::
-    ~LockGuardTester(void) 
+    ~LockGuardTester(void)
   {
-    
+
   }
 
   // ----------------------------------------------------------------------
-  // Tests 
+  // Tests
   // ----------------------------------------------------------------------
 
   struct TaskData {
@@ -49,7 +49,7 @@ namespace Utils {
   }
 
   void LockGuardTester ::
-    testLocking(void) 
+    testLocking(void)
   {
     TaskData data;
     data.i = 0;
@@ -70,15 +70,16 @@ namespace Utils {
       ASSERT_EQ(data.i, 1);
     }
     stat = testTask.join(NULL);
+    ASSERT_EQ(stat, Os::Task::TASK_OK);
   }
 
 
   // ----------------------------------------------------------------------
-  // Helper methods 
+  // Helper methods
   // ----------------------------------------------------------------------
 
   void LockGuardTester ::
-    initComponents(void) 
+    initComponents(void)
   {
   }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Corrects warnings raised by clang's static analyzer.

## Future Work

Ideally we could find some way to run clang's static analyzer in CI, but I haven't found any good github action integration options yet.