### PR TITLE
lestarch: removing framework UTs by default

### DIFF
--- a/Autocoders/Python/test/stress/CMakeLists.txt
+++ b/Autocoders/Python/test/stress/CMakeLists.txt
@@ -44,7 +44,7 @@ set(UT_SOURCE_FILES
 register_fprime_ut()
 
 # ac.ini needs to be copied into Autocode directory
-if (CMAKE_BUILD_TYPE STREQUAL "TESTING")
+if (CMAKE_BUILD_TYPE STREQUAL "TESTING" AND NOT __FPRIME_NO_UT_GEN__)
   add_custom_target(py_ac_test_stress_ac_ini
      COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_LIST_DIR}/Autocode
      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/ac.ini ${CMAKE_CURRENT_LIST_DIR}/Autocode

--- a/ci/tests/20-fputil.bash
+++ b/ci/tests/20-fputil.bash
@@ -11,11 +11,17 @@ export SCRIPT_DIR="$(dirname ${BASH_SOURCE})/.."
 # Loop over deployments and targets
 for deployment in ${FPUTIL_DEPLOYS}
 do
+    export CMAKE_EXTRA_SETTINGS=""
     if [[ "${deployment}" == */RPI ]] && [ ! -d "/opt/rpi/tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf" ]
     then
         warn_and_cont "RPI tools not installed, refusing to test."
         continue
     fi
+    # Check not RPI and Ref deployment to enable FRAMEWORK UTS
+    if [[ "${deployment}" != */RPI ]] && [[ "${deployment}" != */Ref ]]
+    then
+        export CMAKE_EXTRA_SETTINGS="${CMAKE_EXTRA_SETTINGS} -DFPRIME_ENABLE_FRAMEWORK_UTS=ON"
+    fi 
     echo -e "${BLUE}Testing ${deployment} against fprime-util targets: ${FPUTIL_TARGETS[@]}${NOCOLOR}"
     export CHECK_TARGET_PLATFORM="native"
     for target in "${FPUTIL_TARGETS[@]}"

--- a/ci/tests/fputil.bash
+++ b/ci/tests/fputil.bash
@@ -29,7 +29,7 @@ function fputil_action {
         if [[ "${TARGET}" != "generate" ]] && [[ "${TEST_TYPE}" != "QUICK" ]]
         then
             echo "[INFO] Generating build cache before ${DEPLOYMENT//\//_} '${TARGET}' execution"
-            fprime-util "generate" ${PLATFORM} > "${LOG_DIR}/${DEPLOYMENT//\//_}_pregen.out.log" 2> "${LOG_DIR}/${DEPLOYMENT//\//_}_pregen.err.log" \
+            fprime-util "generate" ${PLATFORM} ${CMAKE_EXTRA_SETTINGS} > "${LOG_DIR}/${DEPLOYMENT//\//_}_pregen.out.log" 2> "${LOG_DIR}/${DEPLOYMENT//\//_}_pregen.err.log" \
                 || fail_and_stop "Failed to generate before ${DEPLOYMENT//\//_} '${TARGET}' execution"
         fi
         cd "${WORKDIR}"
@@ -40,7 +40,7 @@ function fputil_action {
                 || fail_and_stop "Failed to run '${TARGET}' in ${WORKDIR}"
         else
 	    echo "[INFO] FP Util in ${WORKDIR} running ${TARGET}"
-            fprime-util ${TARGET} ${PLATFORM} > "${LOG_DIR}/${WORKDIR//\//_}_${TARGET/ /}.out.log" 2> "${LOG_DIR}/${WORKDIR//\//_}_${TARGET/ /}.err.log" \
+            fprime-util ${TARGET} ${PLATFORM} ${CMAKE_EXTRA_SETTINGS} > "${LOG_DIR}/${WORKDIR//\//_}_${TARGET/ /}.out.log" 2> "${LOG_DIR}/${WORKDIR//\//_}_${TARGET/ /}.err.log" \
                 || fail_and_stop "Failed to run '${TARGET}' in ${WORKDIR}"
         fi
     ) || exit 1

--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -406,7 +406,7 @@ endfunction(register_fprime_executable)
 ####
 function(register_fprime_ut)
     #### CHECK UT BUILD ####
-    if (NOT CMAKE_BUILD_TYPE STREQUAL "TESTING")
+    if (NOT CMAKE_BUILD_TYPE STREQUAL "TESTING" OR __FPRIME_NO_UT_GEN__)
         return()
     endif()
     get_module_name(${CMAKE_CURRENT_LIST_DIR})

--- a/cmake/FPrime-Code.cmake
+++ b/cmake/FPrime-Code.cmake
@@ -13,10 +13,22 @@ if (${CMAKE_BUILD_TYPE} STREQUAL "TESTING")
     include("${FPRIME_FRAMEWORK_PATH}/cmake/googletest-download/googletest.cmake")
     add_subdirectory("${FPRIME_FRAMEWORK_PATH}/STest/" "${CMAKE_BINARY_DIR}/F-Prime/STest")
 endif()
+# By default we shutoff framework UTs
+set(__FPRIME_NO_UT_GEN__ ON)
+# Check for autocoder UTs
+if (FPRIME_ENABLE_FRAMEWORK_UTS AND FPRIME_ENABLE_AUTOCODER_UTS)
+    set(__FPRIME_NO_UT_GEN__ OFF)
+endif()
 add_subdirectory("${FPRIME_FRAMEWORK_PATH}/Autocoders/" "${CMAKE_BINARY_DIR}/F-Prime/Autocoders")
+# Check if we are allowing framework UTs
+if (FPRIME_ENABLE_FRAMEWORK_UTS)
+    set(__FPRIME_NO_UT_GEN__ OFF)
+endif()
 add_subdirectory("${FPRIME_FRAMEWORK_PATH}/Fw/" "${CMAKE_BINARY_DIR}/F-Prime/Fw")
 add_subdirectory("${FPRIME_FRAMEWORK_PATH}/Svc/" "${CMAKE_BINARY_DIR}/F-Prime/Svc")
 add_subdirectory("${FPRIME_FRAMEWORK_PATH}/Os/" "${CMAKE_BINARY_DIR}/F-Prime/Os")
 add_subdirectory("${FPRIME_FRAMEWORK_PATH}/Drv/" "${CMAKE_BINARY_DIR}/F-Prime/Drv")
 add_subdirectory("${FPRIME_FRAMEWORK_PATH}/CFDP/" "${CMAKE_BINARY_DIR}/F-Prime/CFDP")
 add_subdirectory("${FPRIME_FRAMEWORK_PATH}/Utils/" "${CMAKE_BINARY_DIR}/F-Prime/Utils")
+# Always enable UTs for a project
+set(__FPRIME_NO_UT_GEN__ OFF)

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -59,6 +59,33 @@ endif()
 ####
 option(CMAKE_DEBUG_OUTPUT "Generate F prime's debug output while running CMake" OFF)
 
+####
+# `FPRIME_ENABLE_FRAMEWORK_UTS:`
+#
+# Allow a project to to run fprime UTs from the core framework. Default: off, do not run fprime framework UTs. This
+# does not affect project specified UTs.
+#
+# **Values:**
+# - ON: adds framework UT targets to the total list of targets
+# - OFF: (default) do not add framework UTs to the target list
+#
+# e.g. `-DFPRIME_ENABLE_FRAMEWORK_UTS=ON`
+####
+option(FPRIME_ENABLE_FRAMEWORK_UTS "Enable framework UT generation" OFF)
+
+####
+# `FPRIME_ENABLE_AUTOCODER_UTS:`
+#
+# When FPRIME_ENABLE_FRAMEWORK_UTS is set, this allows a projects to also enable running the autocoder UTs which do not
+# represent the correctness of the C++/product software, but rather the operation of the autocoder tools.
+#
+# **Values:**
+# - ON: (default) retains the autocoder UTs in the target list
+# - OFF: removes autocoder UTs from the target list
+#
+# e.g. `-DFPRIME_ENABLE_AUTOCODER_UTS=OFF`
+####
+option(FPRIME_ENABLE_AUTOCODER_UTS "Enable autocoder UT generation" ON)
 
 ####
 # `SKIP_TOOLS_CHECK:`


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|  Infrastructure |
|**_Affected Component_**| UTs |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Projects can now turn on framework UTs meaning they don't by-default run all the framework UTs that are checked by CI here.