### PR TITLE
I2C Driver Update - Repeated Start Functionality

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1073,6 +1073,7 @@ Nicolich
 ninjaaron
 nio
 NMEA
+nmsgs
 noargport
 NOBUFFERS
 NOCOLOR

--- a/Drv/I2cDriverPorts/CMakeLists.txt
+++ b/Drv/I2cDriverPorts/CMakeLists.txt
@@ -7,6 +7,7 @@
 ####
 set(SOURCE_FILES
 	"${CMAKE_CURRENT_LIST_DIR}/I2cPortAi.xml"
+	"${CMAKE_CURRENT_LIST_DIR}/I2cWriteReadPortAi.xml"
 	"${CMAKE_CURRENT_LIST_DIR}/I2cStatusEnumAi.xml"
 )
 

--- a/Drv/I2cDriverPorts/I2cWriteReadPortAi.xml
+++ b/Drv/I2cDriverPorts/I2cWriteReadPortAi.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?oxygen RNGSchema="file:../xml/ISF_Type_Schema.rnc" type="compact"?>
+
+<interface name="I2cWriteRead" namespace="Drv">
+  <import_enum_type>Drv/I2cDriverPorts/I2cStatusEnumAi.xml</import_enum_type>
+  <include_header>Fw/Buffer/Buffer.hpp</include_header>
+    <comment>Write a set of bytes then read a set of bytes using the repeated start option</comment>
+    <args>
+        <arg name="addr" type="U32">
+            <comment>I2C slave device address</comment>
+        </arg>
+        <arg name="writeBuffer" type="Fw::Buffer" pass_by="reference">
+            <comment>Buffer to write data to the i2c device</comment>
+        </arg>
+        <arg name="readBuffer" type="Fw::Buffer" pass_by="reference">
+            <comment>Buffer to read back data from the i2c device, must set size when passing in read buffer</comment>
+        </arg>
+    </args>
+    <return type="Drv::I2cStatus" pass_by="value"> </return>
+</interface>

--- a/Drv/I2cDriverPorts/I2cWriteReadPortAi.xml
+++ b/Drv/I2cDriverPorts/I2cWriteReadPortAi.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?oxygen RNGSchema="file:../xml/ISF_Type_Schema.rnc" type="compact"?>
 
 <interface name="I2cWriteRead" namespace="Drv">
   <import_enum_type>Drv/I2cDriverPorts/I2cStatusEnumAi.xml</import_enum_type>

--- a/Drv/LinuxI2cDriver/LinuxI2cDriverComponentAi.xml
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriverComponentAi.xml
@@ -3,10 +3,13 @@
 <component name="LinuxI2cDriver" kind="passive" namespace="Drv">
 
     <import_port_type>Drv/I2cDriverPorts/I2cPortAi.xml</import_port_type>
+    <import_port_type>Drv/I2cDriverPorts/I2cWriteReadPortAi.xml</import_port_type>
     <ports>
         <port name="write" data_type="Drv::I2c"  kind="guarded_input">
         </port>
         <port name="read" data_type="Drv::I2c"  kind="guarded_input">
+        </port>
+        <port name="writeRead" data_type="Drv::I2cWriteRead"  kind="guarded_input">
         </port>
     </ports>
 

--- a/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImpl.cpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImpl.cpp
@@ -12,14 +12,15 @@
 
 
 #include <Drv/LinuxI2cDriver/LinuxI2cDriverComponentImpl.hpp>
+#include <Fw/Logger/Logger.hpp>
 #include "Fw/Types/BasicTypes.hpp"
 #include "Fw/Types/Assert.hpp"
 
 #include <unistd.h> // required for I2C device access
 #include <fcntl.h>  // required for I2C device configuration
 #include <sys/ioctl.h> // required for I2C device usage
+#include <linux/i2c.h> // required for struct / constant definitions
 #include <linux/i2c-dev.h> // required for constant definitions
-#include <stdio.h>  // required for printf statements
 #include <errno.h>
 
 #define DEBUG_PRINT 0
@@ -79,18 +80,18 @@ namespace Drv {
       FW_ASSERT(-1 != this->m_fd);
 
 #if DEBUG_PRINT
-      printf("I2c addr: 0x%02X\n",addr);
+      Fw::Logger::logMsg("I2c addr: 0x%02X\n",addr);
       for (U32 byte = 0; byte < serBuffer.getSize(); byte++) {
-    	  printf("0x%02X ",serBuffer.getData()[byte]);
+    	  Fw::Logger::logMsg("0x%02X ",serBuffer.getData()[byte]);
 
       }
-      printf("\n");
+      Fw::Logger::logMsg("\n");
 #endif
       // select slave address
       int stat = ioctl(this->m_fd, I2C_SLAVE, addr);
       if (stat == -1) {
 #if DEBUG_PRINT
-          printf("Status: %d Errno: %d\n", stat, errno);
+          Fw::Logger::logMsg("Status: %d Errno: %d\n", stat, errno);
 #endif
 	  return I2cStatus::I2C_ADDRESS_ERR;
       }
@@ -100,7 +101,7 @@ namespace Drv {
       stat = write(this->m_fd, serBuffer.getData(), serBuffer.getSize());
       if (stat == -1) {
 #if DEBUG_PRINT
-          printf("Status: %d Errno: %d\n", stat, errno);
+          Fw::Logger::logMsg("Status: %d Errno: %d\n", stat, errno);
 #endif
 	  return I2cStatus::I2C_WRITE_ERR;
       }
@@ -118,13 +119,13 @@ namespace Drv {
       FW_ASSERT(-1 != this->m_fd);
 
 #if DEBUG_PRINT
-      printf("I2c addr: 0x%02X\n",addr);
+      Fw::Logger::logMsg("I2c addr: 0x%02X\n",addr);
 #endif
       // select slave address
       int stat = ioctl(this->m_fd, I2C_SLAVE, addr);
       if (stat == -1) {
 #if DEBUG_PRINT
-          printf("Status: %d Errno: %d\n", stat, errno);
+          Fw::Logger::logMsg("Status: %d Errno: %d\n", stat, errno);
 #endif
 	  return I2cStatus::I2C_ADDRESS_ERR;
       }
@@ -134,18 +135,86 @@ namespace Drv {
       stat = read(this->m_fd, serBuffer.getData(), serBuffer.getSize());
       if (stat == -1) {
 #if DEBUG_PRINT
-          printf("Status: %d Errno: %d\n", stat, errno);
+          Fw::Logger::logMsg("Status: %d Errno: %d\n", stat, errno);
 #endif
 	  return I2cStatus::I2C_READ_ERR;
       }
 #if DEBUG_PRINT
       for (U32 byte = 0; byte < serBuffer.getSize(); byte++) {
-    	  printf("0x%02X ",serBuffer.getData()[byte]);
+    	  Fw::Logger::logMsg("0x%02X ",serBuffer.getData()[byte]);
 
       }
-      printf("\n");
+      Fw::Logger::logMsg("\n");
 #endif
       return I2cStatus::I2C_OK;
+  }
+
+  Drv::I2cStatus LinuxI2cDriverComponentImpl ::
+    writeRead_handler(
+      const NATIVE_INT_TYPE portNum, /*!< The port number*/
+      U32 addr,
+      Fw::Buffer &writeBuffer,
+      Fw::Buffer &readBuffer
+  ){
+
+    // Make sure file has been opened
+    FW_ASSERT(-1 != this->m_fd);
+
+    // make sure they are not null pointers
+    FW_ASSERT(writeBuffer.getData());
+    FW_ASSERT(readBuffer.getData());
+
+    #if DEBUG_PRINT
+      Fw::Logger::logMsg("I2c addr: 0x%02X\n",addr);
+    #endif
+
+    struct i2c_msg rdwr_msgs[2] = {
+        {  // Start address
+            .addr = static_cast<U16>(addr),
+            .flags = 0, // write
+            .len = static_cast<U16>(writeBuffer.getSize()),
+            .buf = writeBuffer.getData()
+        },
+        { // Read buffer
+            .addr = static_cast<U16>(addr),
+            .flags = I2C_M_RD, // read
+            .len = static_cast<U16>(readBuffer.getSize()),
+            .buf = readBuffer.getData()
+        }
+    };
+
+    struct i2c_rdwr_ioctl_data rdwr_data = {
+        .msgs = rdwr_msgs,
+        .nmsgs = 2
+    };
+
+    //Use ioctl to perform the combined write/read transaction
+    NATIVE_INT_TYPE stat = ioctl(this->m_fd, I2C_RDWR, &rdwr_data);
+
+    if(stat == -1){
+      #if DEBUG_PRINT
+        Fw::Logger::logMsg("Status: %d Errno: %d\n", stat, errno);
+      #endif
+      //Because we're using ioctl to perform the transaction we dont know exactly the type of error that occurred
+      return Drv::I2cStatus::I2C_OTHER_ERR;
+    }
+
+#if DEBUG_PRINT
+    Fw::Logger::logMsg("Wrote:\n");
+    for (U32 byte = 0; byte < writeBuffer.getSize(); byte++) {
+    	  Fw::Logger::logMsg("0x%02X ",writeBuffer.getData()[byte]);
+
+    }
+    Fw::Logger::logMsg("\n");
+    Fw::Logger::logMsg("Read:\n");
+    for (U32 byte = 0; byte < readBuffer.getSize(); byte++) {
+    	  Fw::Logger::logMsg("0x%02X ",readBuffer.getData()[byte]);
+
+    }
+    Fw::Logger::logMsg("\n");
+#endif
+
+    return I2cStatus::I2C_OK;
   }
 
 } // end namespace Drv

--- a/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImpl.hpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImpl.hpp
@@ -64,6 +64,15 @@ namespace Drv {
           Fw::Buffer &serBuffer 
       );
 
+      //! Handler implementation for writeRead
+      //!
+      Drv::I2cStatus  writeRead_handler(
+          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          U32 addr,
+          Fw::Buffer &writeBuffer,
+          Fw::Buffer &readBuffer
+      );
+
       // Prevent unused field error when using stub
       #ifndef STUBBED_LINUX_I2C_DRIVER
       NATIVE_INT_TYPE m_fd; //!< i2c file descriptor

--- a/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImplStub.cpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImplStub.cpp
@@ -76,4 +76,14 @@ namespace Drv {
     return I2cStatus::I2C_OK;
   }
 
+  Drv::I2cStatus LinuxI2cDriverComponentImpl ::
+    writeRead_handler(
+      const NATIVE_INT_TYPE portNum, /*!< The port number*/
+      U32 addr,
+      Fw::Buffer &writeBuffer,
+      Fw::Buffer &readBuffer
+  ){
+    return I2cStatus::I2C_OK;
+  }
+
 } // end namespace Drv


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| OWLS / Brandon Metz |
|**_Affected Component_**| LinuxI2cDriver |
|**_Affected Architectures(s)_**| All |
|**_Related Issue(s)_**| None. |
|**_Has Unit Tests (y/n)_**| N |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

Adds a new port interface to the LinuxI2cDriver to allow a write and then read with repeated start bit.

I also changed all the printfs as part of the DEBUG_PRINT over to `Fw::Logger::logMsg`

## Rationale

Certain I2C devices (memory chips for example) require writing a set of bytes and then reading a set of bytes instantly with no stop bit in between. This is called a "repeated start". https://www.i2c-bus.org/repeated-start-condition/

Example from the ADS1119 ADC:
![image](https://user-images.githubusercontent.com/2592986/120726607-532fb380-c48d-11eb-89a0-19754828d513.png)
![image](https://user-images.githubusercontent.com/2592986/120726617-5aef5800-c48d-11eb-8dc0-2f9399856cba.png)


## Testing/Review Recommendations

Testing was performed on a Zynq 7020 Processor/FPGA. The I2C device was using the Xilinx AXI-to-I2C IP core and so using the Xilinx Axi I2C linux driver.

Test data was collected via logic analyzer to see the repeated start.

Here is an example of setting a register to `0x0D` and then reading it back with the repeated start:
Last byte in the chain is the value we want to set:
![image](https://user-images.githubusercontent.com/2592986/120727094-8292f000-c48e-11eb-91ba-8887bc3c8241.png)
Here we are reading it back (`0x0D`), the green dots represent the start bit:
![image](https://user-images.githubusercontent.com/2592986/120727139-a1918200-c48e-11eb-9156-f4159d726373.png)


Another example of reading two bytes back from the ADS1119 ADC:
![image](https://user-images.githubusercontent.com/2592986/120727231-d8679800-c48e-11eb-84f7-3345467f72ba.png)


## Future Work

None.