### PR TITLE
Fix uninitialized variable warnings

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
@@ -323,7 +323,7 @@ namespace ${namespace} {
 
     if (this->m_param_${prmname}_valid == Fw::PARAM_VALID) {
     #if $typeinfo == "enum":
-      FwEnumStoreType ${prmname}Val;
+      FwEnumStoreType ${prmname}Val = 0;
       stat = buff.deserialize(${prmname}Val);
       this->m_${prmname} = static_cast<$type>(${prmname}Val);
     #else
@@ -741,7 +741,7 @@ namespace ${namespace} {
         #for $arg_name, $arg_type, $comment, $is_enum in $args:
     $arg_type $arg_name;
           #if $is_enum == "enum":
-    FwEnumStoreType ${arg_name}Int;
+    FwEnumStoreType ${arg_name}Int = 0;
     _status = args.deserialize(${arg_name}Int);
     $arg_name = (${arg_type})${arg_name}Int;
           #else
@@ -1069,7 +1069,7 @@ namespace ${namespace} {
   {
 
     #if $typeinfo == "enum"
-    FwEnumStoreType _local_val;
+    FwEnumStoreType _local_val = 0;
     Fw::SerializeStatus _stat = val.deserialize(_local_val);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::COMMAND_VALIDATION_ERROR;
@@ -1743,7 +1743,7 @@ namespace ${namespace} {
 #else
     ComponentIpcSerializableBuffer msg;
 #end if
-    NATIVE_INT_TYPE priority;
+    NATIVE_INT_TYPE priority = 0;
 
   #if ($kind == "active")
     Os::Queue::QueueStatus msgStatus = this->m_queue.receive(msg,priority,Os::Queue::QUEUE_BLOCKING);
@@ -1766,7 +1766,7 @@ namespace ${namespace} {
     // Reset to beginning of buffer
     msg.resetDeser();
 
-    NATIVE_INT_TYPE desMsg;
+    NATIVE_INT_TYPE desMsg = 0;
     Fw::SerializeStatus deserStatus = msg.deserialize(desMsg);
     FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -1779,7 +1779,7 @@ namespace ${namespace} {
       return MSG_DISPATCH_EXIT;
     }
 
-    NATIVE_INT_TYPE portNum;
+    NATIVE_INT_TYPE portNum = 0;
     deserStatus = msg.deserialize(portNum);
     FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -1803,7 +1803,7 @@ namespace ${namespace} {
         $arg_name = static_cast<$arg_type*>(${arg_name}PtrTemp);
         #else if $arg_enum == "ENUM"
         $arg_type $arg_name;
-        FwEnumStoreType ${arg_name}Int;
+        FwEnumStoreType ${arg_name}Int = 0;
         deserStatus = msg.deserialize(${arg_name}Int);
         $arg_name = ($arg_type) ${arg_name}Int;
         #else
@@ -1859,7 +1859,7 @@ namespace ${namespace} {
       {
       #end if
         // Deserialize opcode
-        FwOpcodeType opCode;
+        FwOpcodeType opCode = 0;
         deserStatus = msg.deserialize(opCode);
         FW_ASSERT (
             deserStatus == Fw::FW_SERIALIZE_OK,
@@ -1867,7 +1867,7 @@ namespace ${namespace} {
         );
 
         // Deserialize command sequence
-        U32 cmdSeq;
+        U32 cmdSeq = 0;
         deserStatus = msg.deserialize(cmdSeq);
         FW_ASSERT (
             deserStatus == Fw::FW_SERIALIZE_OK,
@@ -1890,7 +1890,7 @@ namespace ${namespace} {
         // Deserialize argument $arg_name
         $arg_type $arg_name;
         #if $arg_enum == "enum"
-        FwEnumStoreType ${arg_name}Int;
+        FwEnumStoreType ${arg_name}Int = 0;
         deserStatus = args.deserialize(${arg_name}Int);
         $arg_name = (${arg_type})${arg_name}Int;
         #else
@@ -1946,7 +1946,7 @@ namespace ${namespace} {
     #for $arg_name, $arg_type, $comment, $typeinfo in $args:
         $arg_type $arg_name;
       #if $typeinfo == "enum"
-        FwEnumStoreType ${arg_name}Int;
+        FwEnumStoreType ${arg_name}Int = 0;
         deserStatus = msg.deserialize(${arg_name}Int);
         $arg_name = static_cast<${arg_type}>(${arg_name}Int);
       #else

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialCpp.tmpl
@@ -123,7 +123,7 @@ Fw::SerializeStatus ${name}::deserialize(Fw::SerializeBufferBase& buffer) {
 #for ($member,$type,$size,$format,$comment,$typeinfo) in $members:
 #if $size == None or $typeinfo == "string":
 #if $typeinfo == "enum"
-    FwEnumStoreType int${member};
+    FwEnumStoreType int${member} = 0;
     stat = buffer.deserialize(int${member});
     this->m_${member} = static_cast<$type>(int${member});
 #else

--- a/Os/Pthreads/PriorityBufferQueue.cpp
+++ b/Os/Pthreads/PriorityBufferQueue.cpp
@@ -148,7 +148,7 @@ namespace Os {
     U8* data = pQueue->data;
 
     // Get the highest priority data from the heap:
-    NATIVE_UINT_TYPE index;
+    NATIVE_UINT_TYPE index = 0;
     bool ret = heap->pop(priority, index);
     FW_ASSERT(ret, ret);
 

--- a/Os/ValidateFileCommon.cpp
+++ b/Os/ValidateFileCommon.cpp
@@ -29,7 +29,7 @@ namespace Os {
         Utils::Hash hash;
         hash.init();
         U8 buffer[VFILE_HASH_CHUNK_SIZE];
-        NATIVE_INT_TYPE size;
+        NATIVE_INT_TYPE size = 0;
         NATIVE_INT_TYPE cnt = 0;
         while( cnt <= max_itr ) {
             // Read out chunk from file:

--- a/Ref/RecvBuffApp/RecvBuffComponentImpl.cpp
+++ b/Ref/RecvBuffApp/RecvBuffComponentImpl.cpp
@@ -34,16 +34,16 @@ namespace Ref {
         // reset deserialization of buffer
         buff.resetDeser();
         // deserialize packet ID
-        U32 id;
+        U32 id = 0;
         Fw::SerializeStatus stat = buff.deserialize(id);
         FW_ASSERT(stat == Fw::FW_SERIALIZE_OK,static_cast<NATIVE_INT_TYPE>(stat));
         // deserialize data
-        U8 testData[24];
+        U8 testData[24] = {0};
         NATIVE_UINT_TYPE size = sizeof(testData);
         stat = buff.deserialize(testData,size);
         FW_ASSERT(stat == Fw::FW_SERIALIZE_OK,static_cast<NATIVE_INT_TYPE>(stat));
         // deserialize checksum
-        U32 csum;
+        U32 csum = 0;
         stat = buff.deserialize(csum);
         FW_ASSERT(stat == Fw::FW_SERIALIZE_OK,static_cast<NATIVE_INT_TYPE>(stat));
         // if first packet, send event

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -281,7 +281,7 @@ namespace Svc {
                 return;
             }
 
-            U32 recordSize;
+            U32 recordSize = 0;
             // read record size
             readSize = sizeof(recordSize);
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F Prime|
|**_Affected Component_**| Autocoders,  OS, Svc|
|**_Affected Architectures(s)_**| - |
|**_Related Issue(s)_**| #678 |
|**_Has Unit Tests (y/n)_**|  Y |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| Y |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

This PR resolved some of uninitialized variable security warnings from CodeSonar.

## Rationale

A variables should either be initialized or have a meaningful value assign to it before being used.

## Testing/Review Recommendations

Ran all Ref unit tests with no issues.

## Future Work

There are still about 40 more uninitialized variable warnings 

![Screen Shot 2021-06-07 at 12 12 05 AM](https://user-images.githubusercontent.com/35859004/120974486-0f56db80-c725-11eb-9251-4aae04169c8a.png)


due to the following lines in the autocoder:

https://github.com/nasa/fprime/blob/9a9fd99a757750b56da1a46930f48dd6cc43536b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl#L1810

https://github.com/nasa/fprime/blob/9a9fd99a757750b56da1a46930f48dd6cc43536b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl#L1891

https://github.com/nasa/fprime/blob/9a9fd99a757750b56da1a46930f48dd6cc43536b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl#L1947

The autocoder does not initialize the variable and it gets passed to the `deserialize()` function ([see here for list of deserialize functions](https://github.com/nasa/fprime/blob/devel/Fw/Types/Serializable.cpp)). If the condition is not correct the `deserialize()` does not assign any value to the variable, and returns a status other than `FW_SERIALIZE_OK` which gets asserted in the next lines. Since the code will not pass the the assert no further action will be done on the uninitialized variable.

There are other instances of the similar pattern in the autocoder so it might be better to resolve this issue in the `deserialize()` or in the autocoder component template.

Please advice if you have any idea how to resolve this issue.