### PR TITLE
lestarch: reverting enable UTs to OFF and a deprecation warning

### DIFF
--- a/ci/tests/20-fputil.bash
+++ b/ci/tests/20-fputil.bash
@@ -17,10 +17,10 @@ do
         warn_and_cont "RPI tools not installed, refusing to test."
         continue
     fi
-    # Check not RPI and Ref deployment to enable FRAMEWORK UTS
-    if [[ "${deployment}" != */RPI ]] && [[ "${deployment}" != */Ref ]]
+    # Check if RPI or Ref deployment to disable FRAMEWORK UTS
+    if [[ "${deployment}" == */RPI ]] || [[ "${deployment}" == */Ref ]]
     then
-        export CMAKE_EXTRA_SETTINGS="${CMAKE_EXTRA_SETTINGS} -DFPRIME_ENABLE_FRAMEWORK_UTS=ON"
+        export CMAKE_EXTRA_SETTINGS="${CMAKE_EXTRA_SETTINGS} -DFPRIME_ENABLE_FRAMEWORK_UTS=OFF"
     fi 
     echo -e "${BLUE}Testing ${deployment} against fprime-util targets: ${FPUTIL_TARGETS[@]}${NOCOLOR}"
     export CHECK_TARGET_PLATFORM="native"

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -66,12 +66,15 @@ option(CMAKE_DEBUG_OUTPUT "Generate F prime's debug output while running CMake" 
 # does not affect project specified UTs.
 #
 # **Values:**
-# - ON: adds framework UT targets to the total list of targets
-# - OFF: (default) do not add framework UTs to the target list
+# - ON: (default) adds framework UT targets to the total list of targets
+# - OFF: do not add framework UTs to the target list
 #
-# e.g. `-DFPRIME_ENABLE_FRAMEWORK_UTS=ON`
+# e.g. `-DFPRIME_ENABLE_FRAMEWORK_UTS=OFF`
 ####
-option(FPRIME_ENABLE_FRAMEWORK_UTS "Enable framework UT generation" OFF)
+option(FPRIME_ENABLE_FRAMEWORK_UTS "Enable framework UT generation" ON)
+if (NOT FPRIME_ENABLE_FRAMEWORK_UTS)
+    message(WARNING "-DFPRIME_ENABLE_FRAMEWORK_UTS=OFF will be deprecated in a future release")
+endif() 
 
 ####
 # `FPRIME_ENABLE_AUTOCODER_UTS:`
@@ -86,6 +89,9 @@ option(FPRIME_ENABLE_FRAMEWORK_UTS "Enable framework UT generation" OFF)
 # e.g. `-DFPRIME_ENABLE_AUTOCODER_UTS=OFF`
 ####
 option(FPRIME_ENABLE_AUTOCODER_UTS "Enable autocoder UT generation" ON)
+if (NOT FPRIME_ENABLE_AUTOCODER_UTS)
+    message(WARNING "-DFPRIME_ENABLE_AUTOCODER_UTS=OFF will be deprecated in a future release")
+endif() 
 
 ####
 # `SKIP_TOOLS_CHECK:`


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infrastructure |
|**_Affected Component_**| UTs |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Make framework UTs enabled by default.

## Rationale

Projects pointed out that framework UTs "are" UTs and thus should be run by default. Since this is not the best long-term way to handle this, we are also adding a deprecation warning.
