### PR TITLE
Fix Ignored Return Value warnings

### DIFF
--- a/Svc/Deframer/DeframerComponentImpl.cpp
+++ b/Svc/Deframer/DeframerComponentImpl.cpp
@@ -73,7 +73,11 @@ void DeframerComponentImpl ::route(Fw::Buffer& data) {
     serial.setBuffLen(data.getSize());
     // Serialized packet type is explicitly an I32 (4 bytes)
     Fw::SerializeStatus status = serial.deserialize(packet_type);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    if (status != Fw::FW_SERIALIZE_OK) {
+        // In the case that the deserialize was unsuccessful we should deallocate the request
+        bufferDeallocate_out(0, data);
+        return;
+    }
 
     // Process variable type
     switch (packet_type) {

--- a/Svc/Deframer/DeframerComponentImpl.cpp
+++ b/Svc/Deframer/DeframerComponentImpl.cpp
@@ -72,7 +72,8 @@ void DeframerComponentImpl ::route(Fw::Buffer& data) {
     Fw::SerializeBufferBase& serial = data.getSerializeRepr();
     serial.setBuffLen(data.getSize());
     // Serialized packet type is explicitly an I32 (4 bytes)
-    serial.deserialize(packet_type);
+    Fw::SerializeStatus status = serial.deserialize(packet_type);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Process variable type
     switch (packet_type) {

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -236,12 +236,12 @@ namespace Svc {
     const U32 bufferSize = sizeof(evalStr) - 4 + 2 * FW_CMD_STRING_MAX_SIZE;
     char buffer[bufferSize];
     
-    I32 bytesCopied = snprintf(
+    NATIVE_INT_TYPE bytesCopied = snprintf(
         buffer, sizeof(buffer), evalStr,
         command.toChar(),
         logFileName.toChar()
     );
-    FW_ASSERT( bytesCopied >= 0 && bytesCopied < sizeof(buffer) );
+    FW_ASSERT(static_cast<NATIVE_UINT_TYPE>(bytesCopied) < sizeof(buffer));
     
     const int status = system(buffer);
     return status;

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -235,11 +235,14 @@ namespace Svc {
     const char evalStr[] = "eval '%s' 1>>%s 2>&1\n";
     const U32 bufferSize = sizeof(evalStr) - 4 + 2 * FW_CMD_STRING_MAX_SIZE;
     char buffer[bufferSize];
-    snprintf(
+    
+    I32 bytesCopied = snprintf(
         buffer, sizeof(buffer), evalStr,
         command.toChar(),
         logFileName.toChar()
     );
+    FW_ASSERT( bytesCopied >= 0 && bytesCopied < sizeof(buffer) );
+    
     const int status = system(buffer);
     return status;
   }

--- a/Svc/FramingProtocol/FprimeProtocol.cpp
+++ b/Svc/FramingProtocol/FprimeProtocol.cpp
@@ -32,17 +32,27 @@ void FprimeFraming::frame(const U8* const data, const U32 size, Fw::ComPacket::C
     Utils::HashBuffer hash;
 
     // Serialize data
-    serializer.serialize(START_WORD);
-    serializer.serialize(real_data_size);
+    Fw::SerializeStatus status;
+    status = serializer.serialize(START_WORD);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    
+    status = serializer.serialize(real_data_size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+
     // Serialize packet type if supplied, otherwise it *must* be present in the data
     if (packet_type != Fw::ComPacket::FW_PACKET_UNKNOWN) {
-        serializer.serialize(static_cast<I32>(packet_type)); // I32 used for enum storage
+        status = serializer.serialize(static_cast<I32>(packet_type)); // I32 used for enum storage
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     }
-    serializer.serialize(data, size, true);  // Serialize without length
+    
+    status = serializer.serialize(data, size, true);  // Serialize without length
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Calculate and add transmission hash
     Utils::Hash::hash(buffer.getData(), total - HASH_DIGEST_LENGTH, hash);
-    serializer.serialize(hash.getBuffAddr(), HASH_DIGEST_LENGTH, true);
+    status = serializer.serialize(hash.getBuffAddr(), HASH_DIGEST_LENGTH, true);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+
     buffer.setSize(total);
 
     m_interface->send(buffer);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F Prime|
|**_Affected Component_**| Svc|
|**_Affected Architectures(s)_**| - |
|**_Related Issue(s)_**| #678 |
|**_Has Unit Tests (y/n)_**|  Y |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| Y |
|**_Documentation Included (y/n)_**| N |


---
## Change Description

This PR resolved some of ignored return value reliability warnings from CodeSonar.
The proposed fixes are up to debate so please advise if there should be any changes.

## Rationale

The outputs of the following functions are not checked. If the returned value can indicate an error, the error will be ignored.

Also quote from CS output:
> The return value of snprintf() is checked or used 100% of the time in this project.
> The return value of Fw::SerializeBufferBase::serialize() is checked or used 99% of the time in this project.
> CodeSonar is configured to enforce Ignored Return Value checks for any function whose return value is checked at least 96% of the time, unless the function is used fewer than 20 times.

## Testing/Review Recommendations

Built and ran Ref with no issues. All UTs passed locally.

## Future Work
Output of the following is still not checked:
https://github.com/nasa/fprime/blob/eebef10711194f131128809ef9e6331acad8d733/Os/Linux/File.cpp#L334
