### PR TITLE
lestarch: annotating the contributors document

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
 **NOTE:** a full list of contributors is here https://github.com/nasa/fprime/graphs/contributors.
 
-This file contains a list of contributors and authors prior to proper tracking using the publically available Github. The above link is a better representation 
+This file contains a list of contributors and authors prior to proper tracking using the publicly available GitHub. The above link is a better representation 
 of F´ contributors since the transition to open source.  This file will be removed in future releases.
 
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-**NOTE:** a full list of contriubtors is here https://github.com/nasa/fprime/graphs/contributors.
+**NOTE:** a full list of contributors is here https://github.com/nasa/fprime/graphs/contributors.
 
 This file contains a list of contributors and authors prior to proper tracking using the publically available Github. The above link is a better representation 
 of F´ contributors since the transition to open source.  This file will be removed in future releases.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,9 @@
+**NOTE:** a full list of contriubtors is here https://github.com/nasa/fprime/graphs/contributors.
+
+This file contains a list of contributors and authors prior to proper tracking using the publically available Github. The above link is a better representation 
+of F´ contributors since the transition to open source.  This file will be removed in future releases.
+
+
 JPL Contributors to the F' Software Framework:
 
 * Adams, Derek


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infra |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The CONTRIBUTORS.md document is not kept-up-to-date, and will be removed in favor of Github contributor lists....once we have a way to capture the contributors who aren't registered on public github.