### PR TITLE
Fixed incorrect scheduler number in Math Component tutorial

### DIFF
--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -2102,7 +2102,7 @@ The `MathReceiver` component does not have a thread of its own, but relies on th
 ```xml
    <!-- Scheduler Connection -->
     <connection name = "MathReceiverRG">
-         <source component = "rateGroup1Comp" port = "RateGroupMemberOut" type = "Sched" num = "3"/>
+         <source component = "rateGroup1Comp" port = "RateGroupMemberOut" type = "Sched" num = "4"/>
          <target component = "mathReceiver" port = "SchedIn" type = "Sched" num = "0"/>
     </connection>
 ```


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Math Component Tutorial |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The number for the scheduler connection was incorrect and has been fixed

## Rationale

This needed to be fixed for the Math Component tutorial to work correctly

## Testing/Review Recommendations

To ensure this is correct, use it in the Math Component tutorial and make sure it works.