### PR TITLE
Move string copyBuff from implmentation to string base class

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
@@ -1,7 +1,7 @@
 ##
 ## Template to stamp out serializable arrays .cpp file
 ##
-// ====================================================================== 
+// ======================================================================
 // \title  ${name}
 // \author Auto-generated
 // \brief  cpp file for ${name}
@@ -11,7 +11,7 @@
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged. Any commercial use must be negotiated with the Office
 // of Technology Transfer at the California Institute of Technology.
-// 
+//
 // This software may be subject to U.S. export control laws and
 // regulations.  By accepting this document, the user agrees to comply
 // with all U.S. export laws and regulations.  User has the
@@ -62,16 +62,6 @@ namespace ${namespace} {
 
     const char* ${name}::${name}String::toChar(void) const {
         return this->m_buf;
-    }
-
-    void ${name}::${name}String::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
     }
 
     Fw::SerializeStatus ${name}::${name}String::serialize(Fw::SerializeBufferBase& buffer) const {
@@ -127,8 +117,8 @@ namespace ${namespace} {
   #set $i = $i + 1
   #end for
   }
-  
-  ${name} :: 
+
+  ${name} ::
     ${name}(const ElementType (&a)[SIZE]) :
       Serializable()
   {
@@ -137,9 +127,9 @@ namespace ${namespace} {
       this->elements[index] = a[index];
     }
   }
-  
+
   #if $size != 1:
-  ${name} :: 
+  ${name} ::
     ${name}(const ElementType& e) :
       Serializable()
   {
@@ -149,8 +139,8 @@ namespace ${namespace} {
     }
   }
   #end if
-  
-  ${name} :: 
+
+  ${name} ::
     ${name}(
 #for $i in $range(1, $size + 1)
 #if $i != $size:
@@ -168,7 +158,7 @@ namespace ${namespace} {
 #set $k = $k + 1
 #end for
   }
-  
+
   ${name} ::
     ${name}(const ${name}& other) :
       Serializable()
@@ -178,27 +168,27 @@ namespace ${namespace} {
       this->elements[index] = other.elements[index];
     }
   }
-  
+
   // ----------------------------------------------------------------------
   // Public functions
   // ----------------------------------------------------------------------
-  
-  
+
+
   ${name}::ElementType& ${name} ::
     operator[](const U32 i)
   {
     FW_ASSERT(i < SIZE);
     return this->elements[i];
   }
-  
+
   const ${name}::ElementType& ${name} ::
     operator[](const U32 i) const
   {
     FW_ASSERT(i < SIZE);
     return this->elements[i];
   }
-  
-  
+
+
   const ${name}& ${name} ::
     operator=(const ${name}& other)
   {
@@ -207,7 +197,7 @@ namespace ${namespace} {
     }
     return *this;
   }
-  
+
   const ${name}& ${name} ::
     operator=(const ElementType (&a)[SIZE])
   {
@@ -216,7 +206,7 @@ namespace ${namespace} {
     }
     return *this;
   }
-  
+
   const ${name}& ${name} ::
     operator=(const ElementType& e)
   {
@@ -225,9 +215,9 @@ namespace ${namespace} {
     }
     return *this;
   }
-  
+
   bool ${name} ::
-    operator==(const ${name}& other) const 
+    operator==(const ${name}& other) const
   {
     for (U32 i = 0; i < SIZE; ++i) {
       if (!((*this)[i] == other[i])) {
@@ -236,9 +226,9 @@ namespace ${namespace} {
     }
     return true;
   }
-  
+
   bool ${name} ::
-    operator!=(const ${name}& other) const 
+    operator!=(const ${name}& other) const
   {
     return !(*this == other);
   }
@@ -288,7 +278,7 @@ void ${name}::toString(Fw::StringBase& text) const {
 }
 
 \#endif
-  
+
 \#ifdef BUILD_UT
   std::ostream& operator<<(std::ostream& os, const ${name}& obj) {
     Fw::EightyCharString temp;
@@ -298,7 +288,7 @@ void ${name}::toString(Fw::StringBase& text) const {
     return os;
   }
 \#endif
-  
+
   Fw::SerializeStatus ${name} ::
     serialize(Fw::SerializeBufferBase& buffer) const
   {
@@ -311,7 +301,7 @@ void ${name}::toString(Fw::StringBase& text) const {
     }
     return status;
   }
-  
+
   Fw::SerializeStatus ${name} ::
     deserialize(Fw::SerializeBufferBase& buffer)
   {

--- a/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_hpp.tmpl
@@ -2,7 +2,7 @@
 ## Template to stamp out serializable arrays .hpp file
 ##
 #import re
-// ====================================================================== 
+// ======================================================================
 // \title  ${name}.hpp
 // \author Auto-generated
 // \brief  hpp file for ${name}
@@ -12,7 +12,7 @@
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged. Any commercial use must be negotiated with the Office
 // of Technology Transfer at the California Institute of Technology.
-// 
+//
 // This software may be subject to U.S. export control laws and
 // regulations.  By accepting this document, the user agrees to comply
 // with all U.S. export laws and regulations.  User has the
@@ -73,7 +73,6 @@ namespace ${namespace} {
             Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer); //!< deserialization function
 
         private:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy a buffer, overwriting current contents
             NATIVE_UINT_TYPE getCapacity(void) const ;
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 
@@ -92,7 +91,7 @@ namespace ${namespace} {
 #else:
     typedef ${type} ElementType;
 #end if
-    
+
     enum {
         SIZE=${size},
         SERIALIZED_SIZE = SIZE *
@@ -106,28 +105,28 @@ namespace ${namespace} {
         sizeof($type)
 #end if
     }; //!< serializable size of ${name}
-  
+
     public:
-  
+
     // ----------------------------------------------------------------------
     // Constructors
     // ----------------------------------------------------------------------
-  
+
       //! Construct a ${name} with default initialization
       ${name}(void);
-  
+
       //! Construct a ${name} and initialize its elements from an array
       ${name}(
           const ElementType (&a)[SIZE] //!< The array
       );
 
- #if $size != 1: 
+ #if $size != 1:
       //! Construct a ${name} and initialize its elements from a single element
       ${name}(
           const ElementType& e //!< The element
       );
 #end if
-  
+
       //! Construct a ${name} and initialize its elements from elements
    ${name}(
 #for $i in $range(1, $size + 1):
@@ -138,53 +137,53 @@ namespace ${namespace} {
 #end if
 #end for
       );
-  
+
       //! Copy constructor
       ${name}(
           const ${name}& other //!< The other object
       );
-  
+
     public:
-  
+
       // ----------------------------------------------------------------------
       // Public operators
       // ----------------------------------------------------------------------
-  
+
       //! Subscript operator
       ElementType& operator[](
           const U32 i //!< The subscript index
       );
-  
+
       //! Const subscript operator
       const ElementType& operator[](
           const U32 i //!< The subscript index
       ) const;
-  
+
       //! Assignment operator
       const ${name}& operator=(
           const ${name}& other //!< The other object
       );
-  
+
       //! Assignment operator from array
       const ${name}& operator=(
           const ElementType (&a)[SIZE] //!< The array
       );
-  
+
       //! Assignment operator from element
       const ${name}& operator=(
           const ElementType& e //!< The element
       );
-  
+
       //! Equality operator
       bool operator==(
           const ${name}& other //!< The other object
       ) const;
-  
+
       //! Inequality operator
       bool operator!=(
           const ${name}& other //!< The other object
       ) const;
-  
+
 \#ifdef BUILD_UT
       //! Ostream operator
       friend std::ostream& operator<<(
@@ -192,18 +191,18 @@ namespace ${namespace} {
           const ${name}& obj //!< The object
       );
 \#endif
-  
+
     public:
-  
+
     // ----------------------------------------------------------------------
     // Public methods
     // ----------------------------------------------------------------------
-  
+
     //! Serialization
     Fw::SerializeStatus serialize(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
-  
+
     //! Deserialization
     Fw::SerializeStatus deserialize(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
@@ -218,16 +217,16 @@ namespace ${namespace} {
     enum {
         TYPE_ID = ${uuid} //!< type id
     };
-  
+
     private:
-  
+
     // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
-  
+
     //! The array elements
     ElementType elements[SIZE];
-  
+
   };
 
 #if $namespace

--- a/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortCpp.tmpl
@@ -34,16 +34,6 @@ namespace ${n} {
         return this->m_buf;
     }
 
-    void ${argname}String::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-
     Fw::SerializeStatus ${argname}String::serialize(Fw::SerializeBufferBase& buffer) const {
         NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
         // serialize string as buffer

--- a/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortH.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortH.tmpl
@@ -43,7 +43,6 @@ namespace ${namespace} {
             Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer); //!< serialization method
 
         private:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy buffer, overwriting old string
             NATIVE_UINT_TYPE getCapacity(void) const ;
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/namespaceSerialCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/namespaceSerialCpp.tmpl
@@ -37,16 +37,6 @@ namespace ${n} {
         return this->m_buf;
     }
 
-    void ${name}::${memname}String::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-
     Fw::SerializeStatus ${name}::${memname}String::serialize(Fw::SerializeBufferBase& buffer) const {
         NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
         // serialize string

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/namespaceSerialH.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/namespaceSerialH.tmpl
@@ -45,7 +45,6 @@ class ${name} : public Fw::Serializable {
             Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer); //!< deserialization function
 
         private:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy a buffer, overwriting current contents
             NATIVE_UINT_TYPE getCapacity(void) const ;
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Cmd/CmdString.cpp
+++ b/Fw/Cmd/CmdString.cpp
@@ -35,16 +35,6 @@ namespace Fw {
         return this->m_buf;
     }
 
-    void CmdStringArg::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-    
     const CmdStringArg& CmdStringArg::operator=(const CmdStringArg& other) {
         this->copyBuff(other.m_buf,this->getCapacity());
         return *this;
@@ -55,7 +45,7 @@ namespace Fw {
         // serialize string
         return buffer.serialize((U8*)this->m_buf,strSize);
     }
-    
+
     SerializeStatus CmdStringArg::deserialize(SerializeBufferBase& buffer) {
         NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
         // deserialize string
@@ -69,7 +59,7 @@ namespace Fw {
     NATIVE_UINT_TYPE CmdStringArg::getCapacity(void) const {
         return FW_CMD_STRING_MAX_SIZE;
     }
-    
+
     void CmdStringArg::terminate(NATIVE_UINT_TYPE size) {
         // null terminate the string
         this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;

--- a/Fw/Cmd/CmdString.hpp
+++ b/Fw/Cmd/CmdString.hpp
@@ -10,12 +10,12 @@ namespace Fw {
 
     class CmdStringArg : public Fw::StringBase {
         public:
-        
+
             enum {
                 SERIALIZED_TYPE_ID = FW_TYPEID_CMD_STR,
                 SERIALIZED_SIZE = FW_CMD_STRING_MAX_SIZE + sizeof(FwBuffSizeType)
             };
-        
+
             CmdStringArg(const char* src);
             CmdStringArg(const StringBase& src);
             CmdStringArg(const CmdStringArg& src);
@@ -25,12 +25,11 @@ namespace Fw {
             NATIVE_UINT_TYPE length(void) const;
 
             const CmdStringArg& operator=(const CmdStringArg& other); //!< equal operator for other strings
-            
+
             SerializeStatus serialize(SerializeBufferBase& buffer) const;
             SerializeStatus deserialize(SerializeBufferBase& buffer);
-            
+
         private:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy source buffer, overwriting
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Log/LogString.cpp
+++ b/Fw/Log/LogString.cpp
@@ -39,16 +39,6 @@ namespace Fw {
         return this->m_buf;
     }
 
-    void LogStringArg::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-    
     SerializeStatus LogStringArg::serialize(SerializeBufferBase& buffer) const {
         // serialize string
         NATIVE_UINT_TYPE strSize = FW_MIN(this->m_maxSer,static_cast<NATIVE_UINT_TYPE>(strnlen(this->m_buf,sizeof(this->m_buf))));
@@ -74,7 +64,7 @@ namespace Fw {
         return buffer.serialize((U8*)this->m_buf,strSize);
 #endif
     }
-    
+
     SerializeStatus LogStringArg::deserialize(SerializeBufferBase& buffer) {
         SerializeStatus stat;
 #if FW_AMPCS_COMPATIBLE

--- a/Fw/Log/LogString.hpp
+++ b/Fw/Log/LogString.hpp
@@ -10,12 +10,12 @@ namespace Fw {
 
     class LogStringArg : public Fw::StringBase {
         public:
-        
+
             enum {
                 SERIALIZED_TYPE_ID = FW_TYPEID_LOG_STR,
                 SERIALIZED_SIZE = FW_LOG_STRING_MAX_SIZE + sizeof(FwBuffSizeType) // size of buffer + storage of two size words
             };
-        
+
             LogStringArg(const char* src);
             LogStringArg(const StringBase& src);
             LogStringArg(const LogStringArg& src);
@@ -25,7 +25,7 @@ namespace Fw {
             NATIVE_UINT_TYPE length(void) const;
             // This method is set by the autocode to the max length specified in the XML declaration for a particular event.
             void setMaxSerialize(NATIVE_UINT_TYPE size); // limit amount serialized
-            
+
             const LogStringArg& operator=(const LogStringArg& other); //!< equal operator for other strings
 
             SerializeStatus serialize(SerializeBufferBase& buffer) const;
@@ -33,10 +33,9 @@ namespace Fw {
 #if FW_SERIALIZABLE_TO_STRING
             void toString(StringBase& text) const;
 #endif
-            
+
         private:
 
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy source buffer, overwriting
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Log/TextLogString.cpp
+++ b/Fw/Log/TextLogString.cpp
@@ -35,22 +35,12 @@ namespace Fw {
         return this->m_buf;
     }
 
-    void TextLogString::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-    
     SerializeStatus TextLogString::serialize(SerializeBufferBase& buffer) const {
         NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
         // serialize string
         return buffer.serialize((U8*)this->m_buf,strSize);
     }
-    
+
     SerializeStatus TextLogString::deserialize(SerializeBufferBase& buffer) {
         NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
         // deserialize string
@@ -64,7 +54,7 @@ namespace Fw {
     NATIVE_UINT_TYPE TextLogString::getCapacity(void) const {
         return FW_LOG_TEXT_BUFFER_SIZE;
     }
-    
+
     void TextLogString::terminate(NATIVE_UINT_TYPE size) {
         // null terminate the string
         this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;

--- a/Fw/Log/TextLogString.hpp
+++ b/Fw/Log/TextLogString.hpp
@@ -10,12 +10,12 @@ namespace Fw {
 
     class TextLogString : public Fw::StringBase {
         public:
-        
+
             enum {
                 SERIALIZED_TYPE_ID = FW_TYPEID_LOG_STR,
                 SERIALIZED_SIZE = FW_LOG_TEXT_BUFFER_SIZE + sizeof(FwBuffSizeType) // size of buffer + storage of two size words
             };
-        
+
             TextLogString(const char* src);
             TextLogString(const StringBase& src);
             TextLogString(const TextLogString& src);
@@ -23,14 +23,13 @@ namespace Fw {
             ~TextLogString(void);
             const char* toChar(void) const;
             NATIVE_UINT_TYPE length(void) const;
-            
+
             const TextLogString& operator=(const TextLogString& other); //!< equal operator for other strings
 
             SerializeStatus serialize(SerializeBufferBase& buffer) const;
             SerializeStatus deserialize(SerializeBufferBase& buffer);
-            
+
         private:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size);
             NATIVE_UINT_TYPE getCapacity(void) const ;
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Prm/PrmString.cpp
+++ b/Fw/Prm/PrmString.cpp
@@ -35,22 +35,12 @@ namespace Fw {
         return this->m_buf;
     }
 
-    void ParamString::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-    
     SerializeStatus ParamString::serialize(SerializeBufferBase& buffer) const {
         NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
         // serialize string as buffer
         return buffer.serialize((U8*)this->m_buf,strSize);
     }
-    
+
     SerializeStatus ParamString::deserialize(SerializeBufferBase& buffer) {
         NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
         // deserialize string

--- a/Fw/Prm/PrmString.hpp
+++ b/Fw/Prm/PrmString.hpp
@@ -10,12 +10,12 @@ namespace Fw {
 
     class ParamString : public Fw::StringBase {
         public:
-        
+
             enum {
                 SERIALIZED_TYPE_ID = FW_TYPEID_PRM_STR,
                 SERIALIZED_SIZE = FW_PARAM_STRING_MAX_SIZE + sizeof(FwBuffSizeType) // size of buffer + storage of two size words
             };
-        
+
             ParamString(const char* src);
             ParamString(const StringBase& src);
             ParamString(const ParamString& src);
@@ -23,14 +23,13 @@ namespace Fw {
             ~ParamString(void);
             const char* toChar(void) const;
             NATIVE_UINT_TYPE length(void) const;
-            
+
             const ParamString& operator=(const ParamString& other); //!< equal operator for other strings
 
             SerializeStatus serialize(SerializeBufferBase& buffer) const;
             SerializeStatus deserialize(SerializeBufferBase& buffer);
-            
+
         private:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size);
             NATIVE_UINT_TYPE getCapacity(void) const ;
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Test/String.cpp
+++ b/Fw/Test/String.cpp
@@ -35,16 +35,6 @@ namespace Test {
         return this->m_buf;
     }
 
-    void String::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-
     const String& String::operator=(const String& other) {
         this->copyBuff(other.m_buf,sizeof(this->m_buf));
         return *this;
@@ -69,7 +59,7 @@ namespace Test {
     NATIVE_UINT_TYPE String::getCapacity(void) const {
         return STRING_SIZE;
     }
-    
+
     void String::terminate(NATIVE_UINT_TYPE size) {
         // null terminate the string
         this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;

--- a/Fw/Test/String.hpp
+++ b/Fw/Test/String.hpp
@@ -10,12 +10,12 @@ namespace Test {
     //! A longer string for testing
     class String : public Fw::StringBase {
         public:
-        
+
             enum {
                 STRING_SIZE = 256, //!< Storage for string
                 SERIALIZED_SIZE = STRING_SIZE + sizeof(FwBuffSizeType) //!< Serialized size is size of buffer + size field
             };
-        
+
             String(const char* src); //!< char* source constructor
             String(const StringBase& src); //!< other string constructor
             String(const String& src); //!< String string constructor
@@ -25,12 +25,11 @@ namespace Test {
             NATIVE_UINT_TYPE length(void) const; //!< returns length of stored string
 
             const String& operator=(const String& other); //!< equal operator
-            
+
             Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const; //!< serialization function
             Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer); //!< deserialization function
-            
+
         PRIVATE:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy source buffer, overwriting
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Tlm/TlmString.cpp
+++ b/Fw/Tlm/TlmString.cpp
@@ -35,16 +35,6 @@ namespace Fw {
         return this->m_buf;
     }
 
-    void TlmString::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-    
     SerializeStatus TlmString::serialize(SerializeBufferBase& buffer) const {
         NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
 #if FW_AMPCS_COMPATIBLE
@@ -65,7 +55,7 @@ namespace Fw {
         return buffer.serialize((U8*)this->m_buf,strSize);
 #endif
     }
-    
+
     SerializeStatus TlmString::deserialize(SerializeBufferBase& buffer) {
         NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
         // deserialize string
@@ -99,7 +89,7 @@ namespace Fw {
     NATIVE_UINT_TYPE TlmString::getCapacity(void) const {
         return FW_TLM_STRING_MAX_SIZE;
     }
-    
+
     void TlmString::terminate(NATIVE_UINT_TYPE size) {
         // null terminate the string
         this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
@@ -115,5 +105,5 @@ namespace Fw {
     void TlmString::toString(StringBase& text) const {
         text = this->m_buf;
     }
-#endif    
+#endif
 }

--- a/Fw/Tlm/TlmString.hpp
+++ b/Fw/Tlm/TlmString.hpp
@@ -10,12 +10,12 @@ namespace Fw {
 
     class TlmString : public Fw::StringBase {
         public:
-        
+
             enum {
                 SERIALIZED_TYPE_ID = FW_TYPEID_TLM_STR,
                 SERIALIZED_SIZE = FW_TLM_STRING_MAX_SIZE + sizeof(FwBuffSizeType) // size of buffer + storage of size word
             };
-        
+
             TlmString(const char* src);
             TlmString(const StringBase& src);
             TlmString(const TlmString& src);
@@ -24,17 +24,16 @@ namespace Fw {
             const char* toChar(void) const;
             NATIVE_UINT_TYPE length(void) const;
             void setMaxSerialize(NATIVE_UINT_TYPE size); // limit amount serialized
-            
+
             const TlmString& operator=(const TlmString& other); //!< equal operator for other strings
 
             SerializeStatus serialize(SerializeBufferBase& buffer) const;
             SerializeStatus deserialize(SerializeBufferBase& buffer);
-            
+
 #if FW_SERIALIZABLE_TO_STRING
             void toString(StringBase& text) const;
 #endif
         PRIVATE:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size);
             NATIVE_UINT_TYPE getCapacity(void) const ;
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Types/EightyCharString.cpp
+++ b/Fw/Types/EightyCharString.cpp
@@ -35,16 +35,6 @@ namespace Fw {
         return this->m_buf;
     }
 
-    void EightyCharString::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-
     const EightyCharString& EightyCharString::operator=(const EightyCharString& other) {
         this->copyBuff(other.m_buf,sizeof(this->m_buf));
         return *this;
@@ -69,7 +59,7 @@ namespace Fw {
     NATIVE_UINT_TYPE EightyCharString::getCapacity(void) const {
         return STRING_SIZE;
     }
-    
+
     void EightyCharString::terminate(NATIVE_UINT_TYPE size) {
         // null terminate the string
         this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;

--- a/Fw/Types/EightyCharString.hpp
+++ b/Fw/Types/EightyCharString.hpp
@@ -9,13 +9,13 @@ namespace Fw {
 
     class EightyCharString : public Fw::StringBase {
         public:
-        
+
             enum {
                 SERIALIZED_TYPE_ID = FW_TYPEID_EIGHTY_CHAR_STRING, //!< typeid for string type
                 STRING_SIZE = 80, //!< Storage for string
                 SERIALIZED_SIZE = STRING_SIZE + sizeof(FwBuffSizeType) //!< Serialized size is size of buffer + size field
             };
-        
+
             EightyCharString(const char* src); //!< char* source constructor
             EightyCharString(const StringBase& src); //!< other string constructor
             EightyCharString(const EightyCharString& src); //!< EightyCharString string constructor
@@ -25,12 +25,11 @@ namespace Fw {
             NATIVE_UINT_TYPE length(void) const; //!< returns length of stored string
 
             const EightyCharString& operator=(const EightyCharString& other); //!< equal operator
-            
+
             SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
             SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
-            
+
         PRIVATE:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy source buffer, overwriting
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Types/FixedLengthString.cpp
+++ b/Fw/Types/FixedLengthString.cpp
@@ -35,16 +35,6 @@ namespace Fw {
         return this->m_buf;
     }
 
-    void FixedLengthString::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-
     const FixedLengthString& FixedLengthString::operator=(const FixedLengthString& other) {
         this->copyBuff(other.m_buf,sizeof(this->m_buf));
         return *this;
@@ -69,7 +59,7 @@ namespace Fw {
     NATIVE_UINT_TYPE FixedLengthString::getCapacity(void) const {
         return STRING_SIZE;
     }
-    
+
     void FixedLengthString::terminate(NATIVE_UINT_TYPE size) {
         // null terminate the string
         this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;

--- a/Fw/Types/FixedLengthString.hpp
+++ b/Fw/Types/FixedLengthString.hpp
@@ -9,13 +9,13 @@ namespace Fw {
 
     class FixedLengthString : public Fw::StringBase {
         public:
-        
+
             enum {
                 SERIALIZED_TYPE_ID = FW_TYPEID_FIXED_LENGTH_STRING, //!< typeid for string type
                 STRING_SIZE = FW_FIXED_LENGTH_STRING_SIZE, //!< Storage for string
                 SERIALIZED_SIZE = STRING_SIZE + sizeof(FwBuffSizeType) //!< Serialized size is size of buffer + size field
             };
-        
+
             FixedLengthString(const char* src); //!< char* source constructor
             FixedLengthString(const StringBase& src); //!< other string constructor
             FixedLengthString(const FixedLengthString& src); //!< FixedLengthString string constructor
@@ -25,12 +25,11 @@ namespace Fw {
             NATIVE_UINT_TYPE length(void) const; //!< returns length of stored string
 
             const FixedLengthString& operator=(const FixedLengthString& other); //!< equal operator
-            
+
             SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
             SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
-            
+
         PRIVATE:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy source buffer, overwriting
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Types/InternalInterfaceString.cpp
+++ b/Fw/Types/InternalInterfaceString.cpp
@@ -35,16 +35,6 @@ namespace Fw {
         return this->m_buf;
     }
 
-    void InternalInterfaceString::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-
     SerializeStatus InternalInterfaceString::serialize(SerializeBufferBase& buffer) const {
         NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
         // serialize string as buffer
@@ -64,7 +54,7 @@ namespace Fw {
     NATIVE_UINT_TYPE InternalInterfaceString::getCapacity(void) const {
         return FW_INTERNAL_INTERFACE_STRING_MAX_SIZE;
     }
-    
+
     const InternalInterfaceString& InternalInterfaceString::operator=(const InternalInterfaceString& other) {
         this->copyBuff(other.m_buf,this->getCapacity());
         return *this;

--- a/Fw/Types/InternalInterfaceString.hpp
+++ b/Fw/Types/InternalInterfaceString.hpp
@@ -10,12 +10,12 @@ namespace Fw {
 
     class InternalInterfaceString : public Fw::StringBase {
         public:
-        
+
             enum {
                 SERIALIZED_TYPE_ID = FW_TYPEID_INTERNAL_INTERFACE_STRING, //!< typeid for string type
                 SERIALIZED_SIZE = FW_INTERNAL_INTERFACE_STRING_MAX_SIZE + sizeof(FwBuffSizeType) //!< Serialized size is size of buffer + size field
             };
-        
+
             InternalInterfaceString(const char* src); //!< char* source constructor
             InternalInterfaceString(const StringBase& src); //!< other string constructor
             InternalInterfaceString(const InternalInterfaceString& src); //!< other string constructor
@@ -25,12 +25,11 @@ namespace Fw {
             NATIVE_UINT_TYPE length(void) const; //!< returns length of stored string
 
             const InternalInterfaceString& operator=(const InternalInterfaceString& other); //!< equal operator
-            
+
             SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
             SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
-            
+
         PRIVATE:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy source buffer, overwriting
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Types/StringType.cpp
+++ b/Fw/Types/StringType.cpp
@@ -11,12 +11,13 @@
  */
 
 #include <Fw/Types/StringType.hpp>
+#include <Fw/Types/Assert.hpp>
 #include <Fw/Types/BasicTypes.hpp>
+#include <Fw/Types/StringUtils.hpp>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
-#include <Fw/Types/Assert.hpp>
 
 namespace Fw {
 
@@ -102,6 +103,20 @@ namespace Fw {
     const char* StringBase::operator=(const char* other) { // lgtm[cpp/rule-of-two]
         this->copyBuff(other, this->getCapacity());
         return this->toChar();
+    }
+
+    void StringBase::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
+        FW_ASSERT(buff);
+
+        NATIVE_UINT_TYPE max = this->getCapacity();
+        if (size < max) {
+            max = size;
+        }
+
+        // check for self copy
+        if (buff != this->toChar()) {
+            Fw::StringUtils::string_copy((char*) this->toChar(),buff,max);
+        }
     }
 
     void StringBase::appendBuff(const char* buff, NATIVE_UINT_TYPE size) {

--- a/Fw/Types/StringType.hpp
+++ b/Fw/Types/StringType.hpp
@@ -35,6 +35,7 @@ namespace Fw {
             const StringBase& operator=(const StringBase& src); //!< Assign another StringBase
 
             void appendBuff(const char* buff, NATIVE_UINT_TYPE size);
+            void copyBuff(const char* buff, NATIVE_UINT_TYPE size);
 
             void format(const char* formatString, ...); //!< write formatted string to buffer
 #ifdef BUILD_UT
@@ -48,7 +49,6 @@ namespace Fw {
         protected:
             StringBase(void);
             virtual ~StringBase(void);
-            virtual void copyBuff(const char* buff, NATIVE_UINT_TYPE size) = 0;
             virtual NATIVE_UINT_TYPE getCapacity(void) const = 0; //!< return size of buffer
 
         PRIVATE:

--- a/Os/QueueString.cpp
+++ b/Os/QueueString.cpp
@@ -41,16 +41,6 @@ namespace Os {
         return this->m_buf;
     }
 
-    void QueueString::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-    
     NATIVE_UINT_TYPE QueueString::getCapacity(void) const {
         return FW_QUEUE_NAME_MAX_SIZE;
     }
@@ -59,5 +49,4 @@ namespace Os {
         // null terminate the string
         this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
     }
-    
 }

--- a/Os/QueueString.hpp
+++ b/Os/QueueString.hpp
@@ -9,7 +9,7 @@ namespace Os {
 
     class QueueString : public Fw::StringBase {
         public:
-        
+
             QueueString(const char* src); //!< char buffer constructor
             QueueString(const StringBase& src); //!< copy constructor
             QueueString(const QueueString& src); //!< copy constructor
@@ -23,7 +23,6 @@ namespace Os {
         private:
             Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const { return Fw::FW_SERIALIZE_NO_ROOM_LEFT; } //!< disabled
             Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer)  { return Fw::FW_SERIALIZE_NO_ROOM_LEFT; } //!< disabled
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy from a source buffer
             NATIVE_UINT_TYPE getCapacity(void) const ;
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
             char m_buf[FW_QUEUE_NAME_MAX_SIZE]; //!< buffer for string

--- a/Os/TaskString.cpp
+++ b/Os/TaskString.cpp
@@ -35,16 +35,6 @@ namespace Os {
         return this->m_buf;
     }
 
-    void TaskString::copyBuff(const char* buff, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buff);
-        // check for self copy
-        if (buff != this->m_buf) {
-            (void)strncpy(this->m_buf,buff,size);
-            // NULL terminate
-            this->terminate(sizeof(this->m_buf));
-        }
-    }
-    
     const TaskString& TaskString::operator=(const TaskString& other) {
         this->copyBuff(other.m_buf,this->getCapacity());
         return *this;
@@ -69,7 +59,7 @@ namespace Os {
 
         return stat;
     }
-    
+
     void TaskString::terminate(NATIVE_UINT_TYPE size) {
         // null terminate the string
         this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;

--- a/Os/TaskString.hpp
+++ b/Os/TaskString.hpp
@@ -9,7 +9,7 @@ namespace Os {
 
     class TaskString : public Fw::StringBase {
         public:
-        
+
             TaskString(const char* src); //!< char buffer constructor
             TaskString(const StringBase& src); //!< Copy constructor
             TaskString(const TaskString& src); //!< Copy constructor
@@ -22,9 +22,8 @@ namespace Os {
             Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer);
 
             const TaskString& operator=(const TaskString& other); //!< equal operator
-            
+
         private:
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size); //!< copy a char buffer into string
             NATIVE_UINT_TYPE getCapacity(void) const ;
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Convert string copyBuff from a virtual function that was implemented by string implementations to a method in the base string class.

## Rationale

Removes code duplication of the copyBuff function and reduces the chance of introducing an error when implementing a string class. It also was triggering clang-tidy warnings because calling a virtual function in a constructor is highly discouraged due to the chance of calling an unintended implementation of the virtual function.