### PR TITLE
Wrap raw task routine with an platform specific wrapper

### DIFF
--- a/Os/Posix/Task.cpp
+++ b/Os/Posix/Task.cpp
@@ -19,14 +19,20 @@
 
 typedef void* (*pthread_func_ptr)(void*);
 
-//#define DEBUG_PRINT(x,...) Fw::Logger::logMsg(x,##__VA_ARGS__);
-#define DEBUG_PRINT(x,...)
+void* pthread_entry_wrapper(void* arg) {
+    FW_ASSERT(arg);
+    Os::Task::TaskRoutineWrapper *task = reinterpret_cast<Os::Task::TaskRoutineWrapper*>(arg);
+    FW_ASSERT(task->routine);
+    task->routine(task->arg);
+    return NULL;
+}
 
 namespace Os {
-    Task::Task() : m_handle(0), m_identifier(0), m_affinity(-1), m_started(false), m_suspendedOnPurpose(false) {
+    Task::Task() : m_handle(0), m_identifier(0), m_affinity(-1), m_started(false), m_suspendedOnPurpose(false), m_routineWrapper() {
     }
 
     Task::TaskStatus Task::start(const Fw::StringBase &name, NATIVE_INT_TYPE identifier, NATIVE_INT_TYPE priority, NATIVE_INT_TYPE stackSize, taskRoutine routine, void* arg, NATIVE_INT_TYPE cpuAffinity) {
+        FW_ASSERT(routine);
 
         this->m_name = "TP_";
         this->m_name += name;
@@ -37,7 +43,6 @@ namespace Os {
         this->m_name += pid;
 #endif
         this->m_identifier = identifier;
-
         Task::TaskStatus tStat = TASK_OK;
 
         pthread_attr_t att;
@@ -116,7 +121,8 @@ namespace Os {
         }
 
         pthread_t* tid = new pthread_t;
-        stat = pthread_create(tid,&att,(pthread_func_ptr)routine,arg);
+        this->m_routineWrapper = {.routine = routine, .arg = arg};
+        stat = pthread_create(tid,&att,pthread_entry_wrapper,&this->m_routineWrapper);
 
         switch (stat) {
             case 0:
@@ -214,7 +220,6 @@ namespace Os {
         stat = pthread_join(*((pthread_t*) this->m_handle), value_ptr);
 
         if (stat != 0) {
-            DEBUG_PRINT("join: %s\n", strerror(errno));
             return TASK_JOIN_ERROR;
         }
         else {

--- a/Os/Task.hpp
+++ b/Os/Task.hpp
@@ -11,7 +11,6 @@
 namespace Os {
 
     class TaskRegistry; //!< forward declaration
-
     class Task {
         public:
 
@@ -26,6 +25,11 @@ namespace Os {
             } TaskStatus ;
 
             typedef void (*taskRoutine)(void* ptr); //!< prototype for task routine started in task context
+
+            struct TaskRoutineWrapper {
+                taskRoutine routine; //!< contains the task entrypoint
+                void* arg; //!< contains the task entrypoint pointer
+            };
 
             Task(); //!< constructor
             virtual ~Task(); //!< destructor
@@ -61,6 +65,7 @@ namespace Os {
             void toString(char* buf, NATIVE_INT_TYPE buffSize); //!< print a string of the state of the task
             bool m_started; //!< set when task has reached entry point
             bool m_suspendedOnPurpose; //!< set when task was suspended in purpose (i.e. simulation)
+            TaskRoutineWrapper m_routineWrapper; //! Contains task entrypoint and argument for task wrapper
 
             static TaskRegistry* s_taskRegistry; //!< pointer to registered task
             static NATIVE_INT_TYPE s_numTasks; //!< stores the number of tasks created.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Os/Tasks |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| fixes #661 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Instead of calling a user provided task routine directly, call the routine from a platform specific task wrapper function.

## Rationale

Different platforms have different function definitions for task routines.

- Pthreads are `void * task(void *)`
- VxWorks is `int task(int arg1, ..., int arg10)`

F' provides a generic task definition: `void task(void *)`. Right now we're force casting this function to the OS specific function definition. However, casting a function with a void return value to functions with non-void return values is undefined behavior that should be avoided (and is also triggering static analysis warnings). A platform-specific wrapper is used as the task entrypoint, which then calls the F' task entrypoint.

## Future Work

The VxWorks task implmentation should be updated to use this new pattern.
For consistency, we may want to update the bare metal schedule to use the execRoutine function.
