### PR TITLE
Remove unused const qualifiers

### DIFF
--- a/Fw/FilePacket/PathName.cpp
+++ b/Fw/FilePacket/PathName.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  PathName.cpp
 // \author bocchino
 // \brief  cpp file for FilePacket::PathName
@@ -7,8 +7,8 @@
 // Copyright 2009-2016, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #include <string.h>
 
@@ -32,11 +32,11 @@ namespace Fw {
   }
 
   SerializeStatus FilePacket::PathName ::
-    fromSerialBuffer(SerialBuffer& serialBuffer) 
+    fromSerialBuffer(SerialBuffer& serialBuffer)
   {
 
     {
-      const SerializeStatus status = 
+      const SerializeStatus status =
         serialBuffer.deserialize(this->length);
       if (status != FW_SERIALIZE_OK)
         return status;
@@ -69,7 +69,7 @@ namespace Fw {
 
     {
       const SerializeStatus status = serialBuffer.pushBytes(
-          reinterpret_cast<const U8 *const>(this->value), 
+          reinterpret_cast<const U8 *>(this->value),
           this->length
       );
       if (status != FW_SERIALIZE_OK)

--- a/Fw/SerializableFile/SerializableFile.cpp
+++ b/Fw/SerializableFile/SerializableFile.cpp
@@ -1,14 +1,14 @@
-// ====================================================================== 
+// ======================================================================
 // \title  SerializableFile.cpp
-// \author dinkel 
-// \brief  cpp file for SerializableFile 
+// \author dinkel
+// \brief  cpp file for SerializableFile
 //
 // \copyright
 // Copyright 2009-2016, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #include "Fw/SerializableFile/SerializableFile.hpp"
 #include "Fw/Types/Assert.hpp"
@@ -20,7 +20,7 @@ namespace Fw {
     allocator(allocator),
     recoverable(false), // for compiler; not used
     actualSize(maxSerializedSize),
-    buffer( (U8 *const) this->allocator->allocate(0, actualSize, recoverable), actualSize)
+    buffer( (U8 *) this->allocator->allocate(0, actualSize, recoverable), actualSize)
   {
     // assert if allocator returns smaller size
     FW_ASSERT(maxSerializedSize == actualSize,maxSerializedSize,actualSize);
@@ -30,7 +30,7 @@ namespace Fw {
   SerializableFile::~SerializableFile() {
     this->allocator->deallocate(0, this->buffer.getBuffAddr());
   }
-  
+
   SerializableFile::Status SerializableFile::load(const char* fileName, Serializable& serializable) {
     Os::File file;
     Os::File::Status status;
@@ -76,7 +76,7 @@ namespace Fw {
     NATIVE_INT_TYPE size = length;
     status = file.write(this->buffer.getBuffAddr(), length);
     if( (Os::File::OP_OK != status) ||
-        (length != size) ) 
+        (length != size) )
     {
       file.close();
       return FILE_WRITE_ERROR;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

These const qualifiers were unused, triggering GCC warnings when compiling with -Wextra.
