### PR TITLE
Added return FILE_EXISTS error on OPEN_CREATE with O_EXCL enabled

### DIFF
--- a/Os/File.hpp
+++ b/Os/File.hpp
@@ -28,6 +28,7 @@ namespace Os {
                 NO_PERMISSION, //!<  No permission to read/write file
                 BAD_SIZE, //!<  Invalid size parameter
                 NOT_OPENED, //!<  file hasn't been opened yet
+                FILE_EXISTS, //!< file already exist (for CREATE with O_EXCL enabled)
                 OTHER_ERROR, //!<  A catch-all for other errors. Have to look in implementation-specific code
             } Status;
 

--- a/Os/Linux/File.cpp
+++ b/Os/Linux/File.cpp
@@ -98,6 +98,9 @@ namespace Os {
                 case EACCES:
                     stat = NO_PERMISSION;
                     break;
+                case EEXIST:
+                    stat = FILE_EXISTS;
+                    break;
                 default:
                     stat = OTHER_ERROR;
                     break;

--- a/Os/test/ut/OsFileSystemTest.cpp
+++ b/Os/test/ut/OsFileSystemTest.cpp
@@ -174,6 +174,35 @@ void testTestFileSystem() {
         char dir_buff[256];
         getcwd(dir_buff, 256);
 	printf("Current dir: %s\n", dir_buff);
+
+	//Create a file in OPEN_CREATE mode
+	printf("Creating test file (%s)\n", test_file_name1);
+	if ((file_status = test_file.open(test_file_name1, Os::File::OPEN_CREATE)) != Os::File::OP_OK) {
+		printf("\tFailed to OPEN_CREATE file: %s\n", test_file_name1);
+		printf("\tReturn status: %d\n", file_status);
+		FW_ASSERT(0);
+	}
+
+	//Close test file
+	test_file.close();
+
+	//Should not be able to OPEN_CREATE file since it already exist and we have
+	//include_excl enabled
+	printf("Creating test file (%s)\n", test_file_name1);
+	if ((file_status = test_file.open(test_file_name1, Os::File::OPEN_CREATE)) != Os::File::FILE_EXISTS) {
+		printf("\tFailed to not to overwrite existing file: %s\n", test_file_name1);
+		printf("\tReturn status: %d\n", file_status);
+		FW_ASSERT(0);
+	}
+
+	printf("Removing test file 1 (%s)\n", test_file_name1);
+	if ((file_sys_status = Os::FileSystem::removeFile(test_file_name1)) != Os::FileSystem::OP_OK) {
+		printf("\tFailed to remove file (%s)\n", test_file_name1);
+		printf("\tReturn status: %d\n", file_sys_status);
+		FW_ASSERT(0);
+	}
+	FW_ASSERT(stat(test_file_name1, &info) == -1);
+
 }
 
 extern "C" {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F Prime|
|**_Affected Component_**|  OS |
|**_Affected Architectures(s)_**| - |
|**_Related Issue(s)_**|  #698 |
|**_Has Unit Tests (y/n)_**|  Y |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| Y |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

This PR adds open file error `FILE_EXISTS` on `OPEN_CREATE` mode when `include_excl=true`

## Rationale

See #698 

## Testing/Review Recommendations

Added a unit test and verified the functionality with no issue.
Note: I did not enable Os unit tests since they need to be cleaned up which is out of scope for this PR.

## Future Work

Some of Os unit tests are broken and are currently disabled.
https://github.com/saba-ja/fprime/blob/5a9cf175339c60f0e24891b6466f239c68e7eccd/Os/CMakeLists.txt#L100-L101

Os unit tests are not in GTest format.