### PR TITLE
Remove TIMSP standard types

### DIFF
--- a/Fw/Types/TIMSP/StandardTypes.hpp
+++ b/Fw/Types/TIMSP/StandardTypes.hpp
@@ -1,1 +1,0 @@
-#include <stdint.h>


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

I'm not sure what platform this was supposed to be used for, but it doesn't seem to be actively used in the current codebase. Platforms that aren't supported by core F' can now supply their own standard types header with their external cmake toolchain.

@timcanham Are you okay with removing this?