### PR TITLE
lestarch: add in ability to override telemetry time

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
@@ -890,22 +890,17 @@ namespace ${namespace} {
   // ----------------------------------------------------------------------
 
   #for $ids, $tlmname, $type, $size, $update, $comment, $typeinfo in $channels:
-  void ${class_name} ::
+    #set $tlm_type = $type
     #if $type == "string":
-    tlmWrite_${tlmname}(Fw::TlmString& arg)
+      #set $tlm_type = "Fw::TlmString&"
+    #else if $typeinfo == "user"
+      #set $tlm_type = $type + "&"
     #else
-      #if $typeinfo == "enum":
-    tlmWrite_${tlmname}(${type} arg)
-      #else
-        #if $typeinfo == "user":
-    tlmWrite_${tlmname}(${type}& arg)
-        #else
-    tlmWrite_${tlmname}(${type} arg)
-        #end if
-      #end if
+      #set $tlm_type = $type
     #end if
+  void ${class_name} ::
+    tlmWrite_${tlmname}(${tlm_type} arg, Fw::Time _tlmTime)
   {
-
     #if $update == "on_change"
     // Check to see if it is the first time
     if (not this->m_first_update_$tlmname) {
@@ -923,8 +918,7 @@ namespace ${namespace} {
 
     #end if
     if (this->m_${Tlm_Name}_OutputPort[0].isConnected()) {
-      Fw::Time _tlmTime;
-      if (this->m_${Time_Name}_OutputPort[0].isConnected()) {
+      if (this->m_${Time_Name}_OutputPort[0].isConnected() && _tlmTime ==  Fw::ZERO_TIME) {
          this->m_${Time_Name}_OutputPort[0].invoke( _tlmTime);
       }
       Fw::TlmBuffer _tlmBuff;

--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
@@ -813,32 +813,23 @@ $emit_non_port_params(8, $params)
     // ----------------------------------------------------------------------
 
   #for $ids, $name, $type, $size, $update, $comment, $typeinfo in $channels:
+    #set $tlm_type = $type
+    #if $type == "string":
+      #set $tlm_type = "Fw::TlmString&"
+    #else if $typeinfo == "user"
+      #set $tlm_type = $type + "&"
+    #else
+      #set $tlm_type = $type
+    #end if
     //! Write telemetry channel $name
     //!
     #if not $comment is None
     /* $comment */
     #end if
-    #if $type == "string":
     void tlmWrite_${name}(
-        Fw::TlmString& arg $doxygen_post_comment("The telemetry value")
+        ${tlm_type} arg $doxygen_post_comment("The telemetry value"),
+        Fw::Time _tlmTime=Fw::Time() $doxygen_post_comment("Timestamp. Default: unspecified, request from getTime port")
     );
-    #else:
-      #if $typeinfo == "enum":
-    void tlmWrite_${name}(
-        ${type} arg $doxygen_post_comment("The telemetry value")
-    );
-      #else:
-        #if $typeinfo == "user":
-    void tlmWrite_${name}(
-        ${type}& arg $doxygen_post_comment("The telemetry value")
-    );
-        #else:
-    void tlmWrite_${name}(
-        ${type} arg $doxygen_post_comment("The telemetry value")
-    );
-        #end if
-      #end if
-    #end if
 
   #end for
 #end if

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -85,6 +85,7 @@ namespace Fw {
             TimeBase m_timeBase; // !< basis of time (defined by system)
             FwTimeContextStoreType m_timeContext; // !< user settable value. Could be reboot count, node, etc
     };
+    const static Time ZERO_TIME = Time();
 
 }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| OWLS |
|**_Affected Component_**| Autocoder Template (Channels) |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Some use cases for sending telemetry include overriding the "time" the telemetry was taken.  This may have to do with hardware, a previously stored read, or the need to correlate across sample.  This currently can only be done crudely by copying AC code into one's user code.  This breaks the telemetry call into two polymorphic calls: one maintains current behavior and delegates internally to the second, which uses supplied time not calculated time.

## Future Work

Is there sufficient use cases enough to add this to Events?
