### PR TITLE
Make serializable type getters as const functions

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialCpp.tmpl
@@ -44,13 +44,13 @@ void ${name}::set(${args_proto_string}) {
 
 #for ($member,$type,$size,$format,$comment,$typeinfo) in $members:
 #if $size == None:
-${type} ${name}::get${member}(void) {
+${type} ${name}::get${member}(void) const {
     return this->m_${member};
 #else if $typeinfo == 'string' or $typeinfo == 'extern':
-const ${type}& ${name}::get${member}(void) {
+const ${type}& ${name}::get${member}(void) const {
     return this->m_${member};
 #else
-const ${type}* ${name}::get${member}(NATIVE_INT_TYPE& size) {
+const ${type}* ${name}::get${member}(NATIVE_INT_TYPE& size) const {
     size = ${size};
     return this->m_${member};
 #end if

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialH.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialH.tmpl
@@ -40,11 +40,11 @@ public:
 
 #for name,type,size,format,comment,typeinfo in $members:
 #if $size == None:
-    ${type} get${name}(void); //!< get member $name
+    ${type} get${name}(void) const; //!< get member $name
 #else if $typeinfo == 'string' or $typeinfo == 'extern':
-    const ${type}& get${name}(void); //!< get member $name
+    const ${type}& get${name}(void) const; //!< get member $name
 #else
-    const ${type}* get${name}(NATIVE_INT_TYPE& size); //!< get member $name
+    const ${type}* get${name}(NATIVE_INT_TYPE& size) const; //!< get member $name
 #end if
 #end for
 

--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -186,9 +186,9 @@ namespace Fw {
 
     Time Time ::
       add(
-        Time& a,
-        Time& b
-      ) 
+        const Time& a,
+        const Time& b
+      )
     {
 #if FW_USE_TIME_BASE
       FW_ASSERT(a.getTimeBase() == b.getTimeBase(), a.getTimeBase(), b.getTimeBase() );
@@ -209,8 +209,8 @@ namespace Fw {
 
     Time Time ::
       sub(
-        Time& minuend, //!< Time minuend
-        Time& subtrahend //!< Time subtrahend
+        const Time& minuend, //!< Time minuend
+        const Time& subtrahend //!< Time subtrahend
     )
     {
 #if FW_USE_TIME_BASE

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -62,15 +62,15 @@ namespace Fw {
             //! Add two times
             //! \return The result
             static Time add(
-                Time& a, //!< Time a
-                Time& b //!< Time b
+                const Time& a, //!< Time a
+                const Time& b //!< Time b
             );
 
             //! Subtract subtrahend from minuend
             //! \return The result
             static Time sub(
-                Time& minuend, //!< Value being subtracted from
-                Time& subtrahend //!< Value being subtracted
+                const Time& minuend, //!< Value being subtracted from
+                const Time& subtrahend //!< Value being subtracted
             );
 
             // add seconds and microseconds to existing time


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| autocoder |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| already exist  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Make serializable type getters as const functions

## Rationale

Allows calling these getter functions on const serializable type instances.