### PR TITLE
Mark tlmWrite argument const for user types

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
@@ -894,7 +894,7 @@ namespace ${namespace} {
     #if $type == "string":
       #set $tlm_type = "Fw::TlmString&"
     #else if $typeinfo == "user"
-      #set $tlm_type = $type + "&"
+      #set $tlm_type = "const " + $type + "&"
     #else
       #set $tlm_type = $type
     #end if

--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
@@ -817,7 +817,7 @@ $emit_non_port_params(8, $params)
     #if $type == "string":
       #set $tlm_type = "Fw::TlmString&"
     #else if $typeinfo == "user"
-      #set $tlm_type = $type + "&"
+      #set $tlm_type = "const " + $type + "&"
     #else
       #set $tlm_type = $type
     #end if

--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -186,9 +186,9 @@ namespace Fw {
 
     Time Time ::
       add(
-        Time& a,
-        Time& b
-      ) 
+        const Time& a,
+        const Time& b
+      )
     {
 #if FW_USE_TIME_BASE
       FW_ASSERT(a.getTimeBase() == b.getTimeBase(), a.getTimeBase(), b.getTimeBase() );
@@ -209,8 +209,8 @@ namespace Fw {
 
     Time Time ::
       sub(
-        Time& minuend, //!< Time minuend
-        Time& subtrahend //!< Time subtrahend
+        const Time& minuend, //!< Time minuend
+        const Time& subtrahend //!< Time subtrahend
     )
     {
 #if FW_USE_TIME_BASE

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -62,15 +62,15 @@ namespace Fw {
             //! Add two times
             //! \return The result
             static Time add(
-                Time& a, //!< Time a
-                Time& b //!< Time b
+                const Time& a, //!< Time a
+                const Time& b //!< Time b
             );
 
             //! Subtract subtrahend from minuend
             //! \return The result
             static Time sub(
-                Time& minuend, //!< Value being subtracted from
-                Time& subtrahend //!< Value being subtracted
+                const Time& minuend, //!< Value being subtracted from
+                const Time& subtrahend //!< Value being subtracted
             );
 
             // add seconds and microseconds to existing time


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Mark tlmWrite argument const for user types.

Note, tlmStrings cannot be marked const - yet. TlmWrite modifies the tlmString in an attempt to truncate the string to the user provided string max length. However, the truncation operation is nonfunctional - effectively no-oping. We need to revisit this in more depth in the future.