### PR TITLE
Correct errors in PolyType toString method

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1238,6 +1238,8 @@ preparse
 Prepends
 prepeneding
 pri
+PRId
+PRIu
 printables
 printf
 println
@@ -1557,6 +1559,7 @@ startword
 staticmethod
 statvfs
 stdarg
+STDC
 stddef
 stderr
 stdin

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -1,6 +1,8 @@
 #include <Fw/Types/PolyType.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <stdio.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 namespace Fw {
 
@@ -612,51 +614,51 @@ namespace Fw {
 
         switch (this->m_dataType) {
             case TYPE_U8:
-                (void) snprintf(valString, sizeof(valString), "%d ", this->m_val.u8Val);
+                (void) snprintf(valString, sizeof(valString), "%" PRIu8 " ", this->m_val.u8Val);
                 break;
             case TYPE_I8:
-            	(void) snprintf(valString, sizeof(valString), "%d ", this->m_val.i8Val);
+                (void) snprintf(valString, sizeof(valString), "%" PRId8 " ", this->m_val.i8Val);
                 break;
 #if FW_HAS_16_BIT
             case TYPE_U16:
-            	(void) snprintf(valString, sizeof(valString), "%d ", this->m_val.u16Val);
+                (void) snprintf(valString, sizeof(valString), "%" PRIu16 " ", this->m_val.u16Val);
                 break;
             case TYPE_I16:
-            	(void) snprintf(valString, sizeof(valString), "%d ", this->m_val.i16Val);
+                (void) snprintf(valString, sizeof(valString), "%" PRId16 " ", this->m_val.i16Val);
                 break;
 #endif
 #if FW_HAS_32_BIT
             case TYPE_U32:
-            	(void) snprintf(valString, sizeof(valString), "%d ", this->m_val.u32Val);
+                (void) snprintf(valString, sizeof(valString), "%" PRIu32 " ", this->m_val.u32Val);
                 break;
             case TYPE_I32:
-            	(void) snprintf(valString, sizeof(valString), "%d ", this->m_val.i32Val);
+                (void) snprintf(valString, sizeof(valString), "%" PRId32 " ", this->m_val.i32Val);
                 break;
 #endif
 #if FW_HAS_64_BIT
             case TYPE_U64:
-            	(void) snprintf(valString, sizeof(valString), "%llu ", (unsigned long long)this->m_val.u64Val);
+                (void) snprintf(valString, sizeof(valString), "%" PRIu64 " ", this->m_val.u64Val);
                 break;
             case TYPE_I64:
-            	(void) snprintf(valString, sizeof(valString), "%lld ", (long long)this->m_val.i64Val);
+            	(void) snprintf(valString, sizeof(valString), "%" PRId64 " ", this->m_val.i64Val);
                 break;
 #endif
 #if FW_HAS_F64
             case TYPE_F64:
-            	(void) snprintf(valString, sizeof(valString), "%lg ", this->m_val.f64Val);
+                (void) snprintf(valString, sizeof(valString), "%lg ", this->m_val.f64Val);
                 break;
 #endif
             case TYPE_F32:
-            	(void) snprintf(valString, sizeof(valString), "%g ", this->m_val.f32Val);
+                (void) snprintf(valString, sizeof(valString), "%g ", this->m_val.f32Val);
                 break;
             case TYPE_BOOL:
-            	(void) snprintf(valString, sizeof(valString), "%s ", this->m_val.boolVal?"T":"F");
+                (void) snprintf(valString, sizeof(valString), "%s ", this->m_val.boolVal?"T":"F");
                 break;
             case TYPE_PTR:
-            	(void) snprintf(valString, sizeof(valString), "%p ", this->m_val.ptrVal);
+                (void) snprintf(valString, sizeof(valString), "%p ", this->m_val.ptrVal);
                 break;
             default:
-            	(void) snprintf(valString, sizeof(valString), "%s ", "NT");
+                (void) snprintf(valString, sizeof(valString), "%s ", "NT");
                 break;
         }
 

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -874,6 +874,7 @@ TEST(TypesTest, CheckAssertTest) {
 }
 
 TEST(TypesTest,PolyTest) {
+    Fw::EightyCharString str;
 
     // U8 Type  ===============================================================
     U8 in8 = 13;
@@ -885,12 +886,15 @@ TEST(TypesTest,PolyTest) {
     ASSERT_EQ(in8, out8);
 
     // Test assigning to polytype and return type of assignment
-    in8 = 21;
+    in8 = 218;
     // Can assign Polytype to U8 via overridden cast operator
     out8 = (pt = in8);
-    ASSERT_EQ((U8) pt, (U8) 21);
+    ASSERT_EQ((U8) pt, (U8) 218);
     ASSERT_EQ((U8) pt, in8);
     ASSERT_EQ(out8, in8);
+
+    pt.toString(str);
+    ASSERT_STREQ(str.toChar(), "218 ");
 
     // U16 Type  ==============================================================
     U16 inU16 = 34;
@@ -900,10 +904,13 @@ TEST(TypesTest,PolyTest) {
     outU16 = (U16) ptU16;
     ASSERT_EQ(inU16, outU16);
 
-    inU16 = 55;
+    inU16 = 45000;
     outU16 = (ptU16 = inU16);
     ASSERT_EQ((U16) ptU16, inU16);
     ASSERT_EQ(outU16, inU16);
+
+    ptU16.toString(str);
+    ASSERT_STREQ(str.toChar(), "45000 ");
 
     // U32 Type  ==============================================================
     U32 inU32 = 89;
@@ -913,10 +920,13 @@ TEST(TypesTest,PolyTest) {
     outU32 = (U32) ptU32;
     ASSERT_EQ(inU32, outU32);
 
-    inU32 = 144;
+    inU32 = 3222111000;
     outU32 = (ptU32 = inU32);
     ASSERT_EQ((U32) ptU32, inU32);
     ASSERT_EQ(outU32, inU32);
+
+    ptU32.toString(str);
+    ASSERT_STREQ(str.toChar(), "3222111000 ");
 
     // U64 Type  ==============================================================
     U64 inU64 = 233;
@@ -926,10 +936,13 @@ TEST(TypesTest,PolyTest) {
     outU64 = (U64) ptU64;
     ASSERT_EQ(inU64, outU64);
 
-    inU64 = 377;
+    inU64 = 555444333222111;
     outU64 = (ptU64 = inU64);
     ASSERT_EQ((U64) ptU64, inU64);
     ASSERT_EQ(outU64, inU64);
+
+    ptU64.toString(str);
+    ASSERT_STREQ(str.toChar(), "555444333222111 ");
 
     // I8 Type  ===============================================================
     I8 inI8 = 2;
@@ -939,10 +952,13 @@ TEST(TypesTest,PolyTest) {
     outI8 = (I8) ptI8;
     ASSERT_EQ(inI8, outI8);
 
-    inI8 = 3;
+    inI8 = -3;
     outI8 = (ptI8 = inI8);
     ASSERT_EQ((I8) ptI8, inI8);
     ASSERT_EQ(outI8, inI8);
+
+    ptI8.toString(str);
+    ASSERT_STREQ(str.toChar(), "-3 ");
 
     // I16 Type  ==============================================================
     I16 inI16 = 5;
@@ -952,10 +968,13 @@ TEST(TypesTest,PolyTest) {
     outI16 = (I16) ptI16;
     ASSERT_EQ(inI16, outI16);
 
-    inI16 = 7;
+    inI16 = -7;
     outI16 = (ptI16 = inI16);
     ASSERT_EQ((I16) ptI16, inI16);
     ASSERT_EQ(outI16, inI16);
+
+    ptI16.toString(str);
+    ASSERT_STREQ(str.toChar(), "-7 ");
 
     // I32 Type  ==============================================================
     I32 inI32 = 11;
@@ -965,10 +984,13 @@ TEST(TypesTest,PolyTest) {
     outI32 = (I32) ptI32;
     ASSERT_EQ(inI32, outI32);
 
-    inI32 = 13;
+    inI32 = -13;
     outI32 = (ptI32 = inI32);
     ASSERT_EQ((I32) ptI32, inI32);
     ASSERT_EQ(outI32, inI32);
+
+    ptI32.toString(str);
+    ASSERT_STREQ(str.toChar(), "-13 ");
 
     // I64 Type  ==============================================================
     I64 inI64 = 17;
@@ -978,10 +1000,13 @@ TEST(TypesTest,PolyTest) {
     outI64 = (I64) ptI64;
     ASSERT_EQ(inI64, outI64);
 
-    inI64 = 19;
+    inI64 = -19;
     outI64 = (ptI64 = inI64);
     ASSERT_EQ((I64) ptI64, inI64);
     ASSERT_EQ(outI64, inI64);
+
+    ptI64.toString(str);
+    ASSERT_STREQ(str.toChar(), "-19 ");
 
     // F32 Type  ==============================================================
     F32 inF32 = 23.32;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Correct errors in PolyType toString method:

- Properly print unsigned types
- Don't cast 64 bit values to long long, which is C++11 only.

I used the inttypes header to help generate the correct format specifiers, which can vary per-platform. 