### PR TITLE
Remove usages of variable length arrays

### DIFF
--- a/Fw/FilePacket/PathName.cpp
+++ b/Fw/FilePacket/PathName.cpp
@@ -44,7 +44,7 @@ namespace Fw {
 
     {
       const U8* addrLeft = serialBuffer.getBuffAddrLeft();
-      U8 bytes[this->length];
+      U8 bytes[MAX_LENGTH];
       const SerializeStatus status =
         serialBuffer.popBytes(bytes, this->length);
       if (status != FW_SERIALIZE_OK)

--- a/Svc/BufferLogger/BufferLoggerFile.cpp
+++ b/Svc/BufferLogger/BufferLoggerFile.cpp
@@ -181,15 +181,16 @@ namespace Svc {
   bool BufferLogger::File ::
     writeSize(const U32 size)
   {
+    FW_ASSERT(this->sizeOfSize <= sizeof(U32));
+    U8 sizeBuffer[sizeof(U32)];
     U32 sizeRegister = size;
-    U8 sizeBuffer[this->sizeOfSize];
     for (U8 i = 0; i < this->sizeOfSize; ++i) {
       sizeBuffer[this->sizeOfSize - i - 1] = sizeRegister & 0xFF;
       sizeRegister >>= 8;
     }
     const bool status = this->writeBytes(
         sizeBuffer,
-        sizeof(sizeBuffer)
+        this->sizeOfSize
     );
     return status;
   }

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -402,7 +402,7 @@ namespace Svc {
     FW_ASSERT(byteOffset < this->endOffset);
     const U32 maxDataSize = FILEDOWNLINK_INTERNAL_BUFFER_SIZE - Fw::FilePacket::DataPacket::HEADERSIZE;
     const U32 dataSize = (byteOffset + maxDataSize > this->endOffset) ? (this->endOffset - byteOffset) : maxDataSize;
-    U8 buffer[dataSize];
+    U8 buffer[FILEDOWNLINK_INTERNAL_BUFFER_SIZE - Fw::FilePacket::DataPacket::HEADERSIZE];
     //This will be last data packet sent
     if (dataSize + byteOffset == this->endOffset) {
         this->lastCompletedType = Fw::FilePacket::T_DATA;

--- a/Svc/FileUplink/File.cpp
+++ b/Svc/FileUplink/File.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  File.cpp
 // \author bocchino
 // \brief  cpp file for FileUplink::File
@@ -7,11 +7,12 @@
 // Copyright 2009-2016, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #include <Svc/FileUplink/FileUplink.hpp>
 #include <Fw/Types/Assert.hpp>
+#include <Fw/Types/StringUtils.hpp>
 
 namespace Svc {
 
@@ -19,12 +20,12 @@ namespace Svc {
     open(const Fw::FilePacket::StartPacket& startPacket)
   {
     const U32 length = startPacket.destinationPath.length;
-    char path[length + 1];
+    char path[Fw::FilePacket::PathName::MAX_LENGTH + 1];
     memcpy(path, startPacket.destinationPath.value, length);
     path[length] = 0;
-    this->size = startPacket.fileSize;
     Fw::LogStringArg logStringArg(path);
     this->name = logStringArg;
+    this->size = startPacket.fileSize;
     CFDP::Checksum checksum;
     this->checksum = checksum;
     return this->osFile.open(path, Os::File::OPEN_WRITE);

--- a/Svc/GroundInterface/GroundInterface.cpp
+++ b/Svc/GroundInterface/GroundInterface.cpp
@@ -1,8 +1,8 @@
-// ====================================================================== 
+// ======================================================================
 // \title  GroundInterface.cpp
 // \author lestarch
 // \brief  cpp file for GroundInterface component implementation class
-// ====================================================================== 
+// ======================================================================
 
 #include <Fw/Com/ComPacket.hpp>
 #include <Svc/GroundInterface/GroundInterface.hpp>
@@ -16,7 +16,7 @@ namespace Svc {
   const U32 GroundInterfaceComponentImpl::END_WORD = static_cast<U32>(0xcafecafe);
 
   // ----------------------------------------------------------------------
-  // Construction, initialization, and destruction 
+  // Construction, initialization, and destruction
   // ----------------------------------------------------------------------
 
   GroundInterfaceComponentImpl ::
@@ -33,7 +33,7 @@ namespace Svc {
   void GroundInterfaceComponentImpl ::
     init(
         const NATIVE_INT_TYPE instance
-    ) 
+    )
   {
     GroundInterfaceComponentBase::init(instance);
   }
@@ -129,7 +129,7 @@ namespace Svc {
 
       //read packet descriptor in size agnostic way
       U8 packet_descriptor_size = sizeof(FwPacketDescriptorType);
-      U8 packet_type_bytes[packet_descriptor_size];
+      U8 packet_type_bytes[sizeof(FwPacketDescriptorType)];
       Fw::SerializeStatus stat = m_in_ring.peek(packet_type_bytes, packet_descriptor_size, HEADER_SIZE);
       //m_in_ring.peek(packet_type, HEADER_SIZE); // this way is only valid for 4byte packet descriptors
       if(stat == Fw::FW_SERIALIZE_OK)


### PR DESCRIPTION


| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Remove usages of variable length arrays

## Rationale

Variable length arrays are not part of the C++ standard and present a risk of
stack overflows in the case of an codeing error. Replace variable length arrays
with a statically sized array large enough to handle the maximum possible input.
