### PR TITLE
lestarch: making CI log archive always run

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,7 +28,7 @@ jobs:
     # Archive the outputs
     - name: 'Archive Logs'
       uses: actions/upload-artifact@v2
-      if: ${{ always() }}
+      if: always()
       with:
         name: ci-logs
         path: ci-logs.tar.gz

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,6 +28,7 @@ jobs:
     # Archive the outputs
     - name: 'Archive Logs'
       uses: actions/upload-artifact@v2
+      if: ${{ always() }}
       with:
         name: ci-logs
         path: ci-logs.tar.gz


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infra |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description
Log always.