### PR TITLE
Add Black Formatting

### DIFF
--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -1,0 +1,17 @@
+name: Format Python
+
+on: [push, pull_request]
+jobs:
+  format:
+      name: Format
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Check formatting
+        run: |
+          pip install black==21.6b0
+          black --check --diff ./

--- a/Autocoders/Python/bin/codegen.py
+++ b/Autocoders/Python/bin/codegen.py
@@ -412,7 +412,9 @@ def generate_topology(the_parsed_topology_xml, xml_filename, opt):
             topology_dict.attrib["topology"] = the_parsed_topology_xml.get_name()
             topology_dict.attrib["framework_version"] = get_fprime_version()
 
-            top_dict_gen = TopDictGenerator.TopDictGenerator(parsed_xml_dict, PRINT.debug)
+            top_dict_gen = TopDictGenerator.TopDictGenerator(
+                parsed_xml_dict, PRINT.debug
+            )
             for comp in the_parsed_topology_xml.get_instances():
                 comp_type = comp.get_type()
                 comp_name = comp.get_name()
@@ -1267,7 +1269,9 @@ def main():
             the_parsed_component_xml = XmlComponentParser.XmlComponentParser(
                 xml_filename
             )
-            generate_component(the_parsed_component_xml, os.path.basename(xml_filename), opt)
+            generate_component(
+                the_parsed_component_xml, os.path.basename(xml_filename), opt
+            )
             dependency_parser = the_parsed_component_xml
         elif xml_type == "interface":
             DEBUG.info("Detected Port type XML so Generating Port type C++ Files...")
@@ -1286,7 +1290,9 @@ def main():
             the_parsed_topology_xml = XmlTopologyParser.XmlTopologyParser(xml_filename)
             DEPLOYMENT = the_parsed_topology_xml.get_deployment()
             print("Found assembly or deployment named: %s\n" % DEPLOYMENT)
-            generate_topology(the_parsed_topology_xml, os.path.basename(xml_filename), opt)
+            generate_topology(
+                the_parsed_topology_xml, os.path.basename(xml_filename), opt
+            )
             dependency_parser = the_parsed_topology_xml
         elif xml_type == "enum":
             DEBUG.info("Detected Enum XML so Generating hpp, cpp, and py files...")

--- a/Autocoders/Python/bin/gds_dictgen.py
+++ b/Autocoders/Python/bin/gds_dictgen.py
@@ -132,7 +132,9 @@ def generate_xml_dict(the_parsed_topology_xml, xml_filename, opt):
     topology_dict.attrib["topology"] = the_parsed_topology_xml.get_name()
     topology_dict.attrib["framework_version"] = get_fprime_version()
 
-    top_dict_gen = TopDictGenerator.TopDictGenerator(parsed_xml_dict, print if VERBOSE else lambda _: None)
+    top_dict_gen = TopDictGenerator.TopDictGenerator(
+        parsed_xml_dict, print if VERBOSE else lambda _: None
+    )
     for comp in the_parsed_topology_xml.get_instances():
         comp_type = comp.get_type()
         comp_name = comp.get_name()

--- a/Autocoders/Python/schema/testSchemas.py
+++ b/Autocoders/Python/schema/testSchemas.py
@@ -235,7 +235,7 @@ def setup():
     channel_test.add_test(
         "Missing enum", "sample_XML_files/channel/missingEnum.xml", AssertionError
     )
-    
+
     command_test.add_test(
         "All working", "sample_XML_files/command/allWorking.xml", None
     )
@@ -259,7 +259,7 @@ def setup():
         "sample_XML_files/command/noStringSize.xml",
         AssertionError,
     )
-    
+
     component_test.add_test(
         "Base all working", "sample_XML_files/component/baseAllWorking.xml", None
     )
@@ -274,9 +274,9 @@ def setup():
         "sample_XML_files/component/interfaceOnly.xml",
         AssertionError,
     )
-    
+
     event_test.add_test("All working", "sample_XML_files/event/allWorking.xml", None)
-    
+
     event_test.add_test(
         "Event throttle negative",
         "sample_XML_files/event/negativeThrottle.xml",
@@ -392,17 +392,19 @@ def setup():
     topology_test.parse_and_add_directory(["deployment", "assembly"], "../test")
 
     # Add schemas to test_list
-    
-    test_list.extend((
-        topology_test,
-        component_test,
-        command_test,
-        parameter_test,
-        channel_test,
-        interface_test,
-        serializable_test,
-        event_test
-    ))
+
+    test_list.extend(
+        (
+            topology_test,
+            component_test,
+            command_test,
+            parameter_test,
+            channel_test,
+            interface_test,
+            serializable_test,
+            event_test,
+        )
+    )
 
     return test_list
 

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -68,7 +68,7 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
         """
         Make a list of args into a string
         """
-        return ', '.join(args)
+        return ", ".join(args)
 
     def buildFileName(self, obj):
         """
@@ -436,9 +436,10 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
         c.has_output_ports = len(c.output_ports) > 0
         c.has_typed_output_ports = len(c.typed_output_ports) > 0
         c.has_serial_output_ports = len(c.serial_output_ports) > 0
-        roles = [role for name, ptype, sync, priority, role, max_number in c.output_ports]
+        roles = [
+            role for name, ptype, sync, priority, role, max_number in c.output_ports
+        ]
         c.has_time_get = "TimeGet" in roles
-
 
     def initPortIncludes(self, obj, c):
         c.port_includes = list()
@@ -780,10 +781,7 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
         Include any headers for channel/parameter serializable includes
         """
         ser_includes = self.__model_parser.uniqueList(obj.get_xml_serializable_files())
-        s_includes = [
-            sinc.replace("Ai.xml", "Ac.hpp")
-            for sinc in ser_includes
-        ]
+        s_includes = [sinc.replace("Ai.xml", "Ac.hpp") for sinc in ser_includes]
         c.ser_includes = s_includes
 
     def initTelemetry(self, obj, c):

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyEventsHTMLVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyEventsHTMLVisitor.py
@@ -154,7 +154,7 @@ class InstanceTopologyEventsHTMLVisitor(AbstractVisitor.AbstractVisitor):
         """
         Make a list of args into a string
         """
-        return ', '.join(args)
+        return ", ".join(args)
 
     def eventArgsStr(self):
         """

--- a/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
@@ -446,7 +446,9 @@ class ComponentWriterBase(AbstractWriter.AbstractWriter):
         c.has_output_ports = len(c.output_ports) > 0
         c.has_typed_output_ports = len(c.typed_output_ports) > 0
         c.has_serial_output_ports = len(c.serial_output_ports) > 0
-        roles = [role for name, ptype, sync, priority, role, max_number in c.output_ports]
+        roles = [
+            role for name, ptype, sync, priority, role, max_number in c.output_ports
+        ]
         c.has_time_get = "TimeGet" in roles
 
     def initPortIncludes(self, obj, c):

--- a/Autocoders/Python/src/fprime_ac/models/Arg.py
+++ b/Autocoders/Python/src/fprime_ac/models/Arg.py
@@ -69,7 +69,7 @@ class Arg:
         return self.__comment
 
     def __eq__(self, other):
-        """ Equality checker """
+        """Equality checker"""
         if type(other) != type(self):
             return False
         return (

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlArrayParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlArrayParser.py
@@ -102,7 +102,7 @@ class XmlArrayParser(object):
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
-        fd.close() #Close the file, which is only used for the parsing above
+        fd.close()  # Close the file, which is only used for the parsing above
 
         # Validate against current schema. if more are imported later in the process, they will be reevaluated
         relax_file_handler = open(ROOTDIR + self.Config.get("schema", "array"), "r")

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
@@ -99,7 +99,7 @@ class XmlComponentParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
-        fd.close() #Close the file, which is only used for the parsing above
+        fd.close()  # Close the file, which is only used for the parsing above
 
         # Validate against current schema. if more are imported later in the process, they will be reevaluated
         relax_file_handler = open(ROOTDIR + self.Config.get("schema", "component"))

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlEnumParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlEnumParser.py
@@ -73,7 +73,7 @@ class XmlEnumParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
-        fd.close() #Close the file, which is only used for the parsing above
+        fd.close()  # Close the file, which is only used for the parsing above
 
         # Validate against current schema. if more are imported later in the process, they will be reevaluated
         relax_file_handler = open(ROOTDIR + self.Config.get("schema", "enum"))

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlPortsParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlPortsParser.py
@@ -73,7 +73,7 @@ class XmlPortsParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
-        fd.close() #Close the file, which is only used for the parsing above        
+        fd.close()  # Close the file, which is only used for the parsing above
 
         # Validate against schema
         relax_file_handler = open(ROOTDIR + self.__config.get("schema", "interface"))

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlSerializeParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlSerializeParser.py
@@ -103,7 +103,7 @@ class XmlSerializeParser:
 
         xml_parser = etree.XMLParser(remove_comments=True)
         element_tree = etree.parse(fd, parser=xml_parser)
-        fd.close() #Close the file, which is only used for the parsing above
+        fd.close()  # Close the file, which is only used for the parsing above
 
         # Validate new imports using their root tag as a key to find what schema to use
         rng_file = self.__config.get(

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlTopologyParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlTopologyParser.py
@@ -77,7 +77,7 @@ class XmlTopologyParser:
 
         self.__prepend_instance_name = False  # Used to turn off prepending instance name in the situation where instance dicts are being generated and only one instance of an object is created
         element_tree = etree.parse(fd)
-        fd.close() #Close the file, which is only used for the parsing above
+        fd.close()  # Close the file, which is only used for the parsing above
 
         # Validate against schema
         relax_file_handler = open(ROOTDIR + self.__config.get("schema", "assembly"))

--- a/Autocoders/Python/src/fprime_ac/utils/TopDictGenerator.py
+++ b/Autocoders/Python/src/fprime_ac/utils/TopDictGenerator.py
@@ -12,6 +12,7 @@ from fprime_ac.utils import (
 
 from fprime_ac.utils.buildroot import search_for_file
 
+
 class TopDictGenerator:
     def __init__(self, parsed_xml_dict, log):
         self.__log = log
@@ -37,12 +38,12 @@ class TopDictGenerator:
             self.__check_enum_files(enum_file_list)
 
     def check_for_serial_xml(self):
-        serializable_file_list = self.__parsed_xml_dict[self.__comp_type].get_serializable_type_files()
+        serializable_file_list = self.__parsed_xml_dict[
+            self.__comp_type
+        ].get_serializable_type_files()
         if serializable_file_list is not None:
             for serializable_file in serializable_file_list:
-                serializable_file = search_for_file(
-                    "Serializable", serializable_file
-                )
+                serializable_file = search_for_file("Serializable", serializable_file)
                 serializable_model = XmlSerializeParser.XmlSerializeParser(
                     serializable_file
                 )
@@ -74,9 +75,7 @@ class TopDictGenerator:
                 ) in serializable_model.get_members():
                     member_elem = etree.Element("member")
                     member_elem.attrib["name"] = member_name
-                    member_elem.attrib[
-                        "format_specifier"
-                    ] = member_format_specifier
+                    member_elem.attrib["format_specifier"] = member_format_specifier
                     if member_comment is not None:
                         member_elem.attrib["description"] = member_comment
                     if isinstance(member_type, tuple):
@@ -107,11 +106,7 @@ class TopDictGenerator:
             enum_file = search_for_file("Enum", enum_file)
             enum_model = XmlEnumParser.XmlEnumParser(enum_file)
             enum_elem = etree.Element("enum")
-            enum_type = (
-                enum_model.get_namespace()
-                + "::"
-                + enum_model.get_name()
-            )
+            enum_type = enum_model.get_namespace() + "::" + enum_model.get_name()
             enum_elem.attrib["type"] = enum_type
             enum_value = 0
             for (
@@ -144,9 +139,7 @@ class TopDictGenerator:
                     hex(int(command.get_opcodes()[0], base=0) + self.__comp_id)
                 )
                 if "comment" in list(command_elem.attrib.keys()):
-                    command_elem.attrib["description"] = command_elem.attrib[
-                        "comment"
-                    ]
+                    command_elem.attrib["description"] = command_elem.attrib["comment"]
                 args_elem = etree.Element("args")
                 for arg in command.get_args():
                     arg_elem = etree.Element("arg")
@@ -181,9 +174,7 @@ class TopDictGenerator:
                     hex(int(chan.get_ids()[0], base=0) + self.__comp_id)
                 )
                 if chan.get_format_string() is not None:
-                    channel_elem.attrib[
-                        "format_string"
-                    ] = chan.get_format_string()
+                    channel_elem.attrib["format_string"] = chan.get_format_string()
                 if chan.get_comment() is not None:
                     channel_elem.attrib["description"] = chan.get_comment()
 
@@ -191,9 +182,7 @@ class TopDictGenerator:
                     hex(int(chan.get_ids()[0], base=0) + self.__comp_id)
                 )
                 if "comment" in list(channel_elem.attrib.keys()):
-                    channel_elem.attrib["description"] = channel_elem.attrib[
-                        "comment"
-                    ]
+                    channel_elem.attrib["description"] = channel_elem.attrib["comment"]
                 channel_type = chan.get_type()
                 if isinstance(channel_type, tuple):
                     type_name = "{}::{}::{}".format(
@@ -238,9 +227,7 @@ class TopDictGenerator:
                 event_elem.attrib["severity"] = event.get_severity()
                 format_string = event.get_format_string()
                 if "comment" in list(event_elem.attrib.keys()):
-                    event_elem.attrib["description"] = event_elem.attrib[
-                        "comment"
-                    ]
+                    event_elem.attrib["description"] = event_elem.attrib["comment"]
                 args_elem = etree.Element("args")
                 arg_num = 0
                 for arg in event.get_args():
@@ -256,8 +243,10 @@ class TopDictGenerator:
                         enum_elem = self.__extract_enum_elem(type_name, arg_type[1])
                         self.__enum_list.append(enum_elem)
                         # replace enum format string %d with %s for ground system
-                        format_string = DictTypeConverter.DictTypeConverter().format_replace(
-                            format_string, arg_num, "d", "s"
+                        format_string = (
+                            DictTypeConverter.DictTypeConverter().format_replace(
+                                format_string, arg_num, "d", "s"
+                            )
                         )
                     else:
                         type_name = arg_type
@@ -298,9 +287,7 @@ class TopDictGenerator:
                 param_default = None
                 command_elem_set = etree.Element("command")
                 command_elem_set.attrib["component"] = self.__comp_name
-                command_elem_set.attrib["mnemonic"] = (
-                    parameter.get_name() + "_PRM_SET"
-                )
+                command_elem_set.attrib["mnemonic"] = parameter.get_name() + "_PRM_SET"
                 command_elem_set.attrib["opcode"] = "%s" % (
                     hex(int(parameter.get_set_opcodes()[0], base=0) + self.__comp_id)
                 )
@@ -387,16 +374,16 @@ class TopDictGenerator:
                 self.__parameter_list.append(param_elem)
 
     def check_for_arrays(self):
-        array_file_list = self.__parsed_xml_dict[self.__comp_type].get_array_type_files()
+        array_file_list = self.__parsed_xml_dict[
+            self.__comp_type
+        ].get_array_type_files()
         if array_file_list is not None:
             for array_file in array_file_list:
                 array_file = search_for_file("Array", array_file)
                 array_model = XmlArrayParser.XmlArrayParser(array_file)
                 array_elem = etree.Element("array")
 
-                array_name = (
-                    array_model.get_namespace() + "::" + array_model.get_name()
-                )
+                array_name = array_model.get_namespace() + "::" + array_model.get_name()
                 array_elem.attrib["name"] = array_name
 
                 array_type = array_model.get_type()
@@ -451,7 +438,8 @@ class TopDictGenerator:
                     i = 0
                     while i < len(children1) and i < len(children2):
                         if (
-                            not children1[i].attrib["name"] == children2[i].attrib["name"]
+                            not children1[i].attrib["name"]
+                            == children2[i].attrib["name"]
                             and should_remove
                         ):
                             should_remove = False
@@ -463,7 +451,7 @@ class TopDictGenerator:
 
     def get_enum_list(self):
         return self.__enum_list
-    
+
     def get_serializable_list(self):
         return self.__serializable_list
 

--- a/Autocoders/Python/src/fprime_ac/utils/buildroot.py
+++ b/Autocoders/Python/src/fprime_ac/utils/buildroot.py
@@ -46,7 +46,7 @@ def get_nearest_build_root(path):
     )
 
     def path_reducer(agg, item):
-        """ Reduces to the longest path """
+        """Reduces to the longest path"""
         common = os.path.commonpath([item, path])
         if agg is None or len(common) > len(agg):
             return common
@@ -120,7 +120,7 @@ class BuildRootMissingException(Exception):
     """
 
     def __init__(self, item):
-        """Initialize super exception """
+        """Initialize super exception"""
         super().__init__(
             "{} not found under any location: {}".format(
                 item, ",".join(get_build_roots())
@@ -134,7 +134,7 @@ class BuildRootCollisionException(Exception):
     """
 
     def __init__(self, occurrences):
-        """ Initialize super exception """
+        """Initialize super exception"""
         super().__init__(
             "Item found at multiple locations: {}".format(",".join(occurrences))
         )

--- a/Autocoders/Python/src/fprime_ac/utils/exceptions.py
+++ b/Autocoders/Python/src/fprime_ac/utils/exceptions.py
@@ -8,11 +8,11 @@ Exceptions defined for the Autocoder. This is active refactoring work, and may b
 
 
 class FprimeException(Exception):
-    """ Base Exception for FprimeException """
+    """Base Exception for FprimeException"""
 
 
 class FprimeRngXmlValidationException(FprimeException):
-    """ XML Exception from within the validation phase """
+    """XML Exception from within the validation phase"""
 
     def __init__(self, error_list):
         """
@@ -26,4 +26,4 @@ class FprimeRngXmlValidationException(FprimeException):
 
 
 class FprimeXmlException(FprimeException):
-    """ Generic XML error """
+    """Generic XML error"""

--- a/Autocoders/Python/src/fprime_ac/utils/version.py
+++ b/Autocoders/Python/src/fprime_ac/utils/version.py
@@ -2,13 +2,16 @@
 import os
 from setuptools_scm import get_version
 
-ROOT_PARENT_COUNT=5
+ROOT_PARENT_COUNT = 5
+
 
 def get_fprime_version():
-    """ Gets the fprime version using setuptools_scm  """
+    """Gets the fprime version using setuptools_scm"""
     # First try to read the SCM version
     try:
-        return get_version(root=os.sep.join([".."] * ROOT_PARENT_COUNT), relative_to=__file__)
+        return get_version(
+            root=os.sep.join([".."] * ROOT_PARENT_COUNT), relative_to=__file__
+        )
     # Fallback to a specified version when SCM is unavailable
     except LookupError:
-        return "1.5.4" # Must be kept up-to-date when tagging
+        return "1.5.4"  # Must be kept up-to-date when tagging

--- a/Ref/test/int/ref_integration_test.py
+++ b/Ref/test/int/ref_integration_test.py
@@ -264,7 +264,20 @@ class TestRefAppClass(object):
             self.set_default_filters()
 
     def test_seqgen(self):
-        """ Tests the seqgen code """
+        """Tests the seqgen code"""
         sequence = os.path.join(os.path.dirname(__file__), "test_seq.seq")
-        assert subprocess.run(["fprime-seqgen", "-d", self.dictionary, sequence, "/tmp/ref_test_int.bin"]).returncode == 0, "Failed to run fprime-seqgen"
-        self.assert_command("cmdSeq.CS_RUN", args=["/tmp/ref_test_int.bin"], max_delay=5)
+        assert (
+            subprocess.run(
+                [
+                    "fprime-seqgen",
+                    "-d",
+                    self.dictionary,
+                    sequence,
+                    "/tmp/ref_test_int.bin",
+                ]
+            ).returncode
+            == 0
+        ), "Failed to run fprime-seqgen"
+        self.assert_command(
+            "cmdSeq.CS_RUN", args=["/tmp/ref_test_int.bin"], max_delay=5
+        )

--- a/Utils/topologyTool.py
+++ b/Utils/topologyTool.py
@@ -35,8 +35,8 @@ def setup_opt_parse():
 
 def validate_xml(xml_list):
     """
-    Iterates through XML list, shows an error if an XML file is not an XML file or does not exist. 
-    
+    Iterates through XML list, shows an error if an XML file is not an XML file or does not exist.
+
     A list of valid XML files is returned (Not valid files are thrown out)
     """
 
@@ -55,7 +55,7 @@ def validate_xml(xml_list):
 def recursive_xml_parse(tree_obj):
     """
     returns a list of items
-    [tagName , [(argKey:argVal)] , [" " or [tagName , [] , []] ] ] 
+    [tagName , [(argKey:argVal)] , [" " or [tagName , [] , []] ] ]
     """
     out_obj = [tree_obj.tag, [], []]
 
@@ -96,7 +96,7 @@ def tag_object_to_string(tag_obj):
 def diff_files(xml_list):
     """
     Finds the difference between topology XML files, ignoring  ordering and names in "connection" tags
-    
+
     Iterate through root tag elements
     Create a dictionary with file_dict[tag] = [list of tag objects]
     """

--- a/cmake/docs/docs.py
+++ b/cmake/docs/docs.py
@@ -50,24 +50,30 @@ def main():
     os.chdir(sys.argv[1])
     for dirpath, dirnames, filenames in os.walk("."):
         for filename in filenames:
-            if ".cmake" in filename or filename == "CMakeLists.txt" or filename.endswith("CMakeLists.txt.template"):
+            if (
+                ".cmake" in filename
+                or filename == "CMakeLists.txt"
+                or filename.endswith("CMakeLists.txt.template")
+            ):
                 process_file(os.path.join(dirpath, filename), outdir)
 
 
 def process_file(file_name, outdir):
-    """ Process a file """
+    """Process a file"""
     # Read a line, and output it
     out_fn = file_name
     if os.path.basename(out_fn) == "CMakeLists.txt":
         out_fn = os.path.dirname(file_name)
-    out_fn = out_fn.replace(".cmake", "").replace(".template", "") + ("-template.md" if out_fn.endswith(".template") else ".md")
+    out_fn = out_fn.replace(".cmake", "").replace(".template", "") + (
+        "-template.md" if out_fn.endswith(".template") else ".md"
+    )
     if out_fn == file_name:
         raise AssertionError("File collision imminent")
     relative_fn = out_fn
     out_fn = os.path.join(outdir, out_fn)
     os.makedirs(os.path.dirname(out_fn), exist_ok=True)
     # Open both files, and loop over all the lines reading and writing each
-    print("[{}]({})".format(os.path.basename(out_fn).replace(".md",""), relative_fn))
+    print("[{}]({})".format(os.path.basename(out_fn).replace(".md", ""), relative_fn))
     with open(file_name, "r") as in_file_handle:
         with open(out_fn, "w") as out_file_handle:
             state = DocState.SEARCH

--- a/cmake/test/src/cmake.py
+++ b/cmake/test/src/cmake.py
@@ -110,7 +110,9 @@ def assert_exists(expected, install_dest, start_time):
         expect = expect.replace(
             "<FPRIME>", os.path.join(os.path.dirname(__file__), "..", "..", "..")
         )
-        expect = expect.replace("<FPRIME_INSTALL>", os.path.join(install_dest, platform.system()))
+        expect = expect.replace(
+            "<FPRIME_INSTALL>", os.path.join(install_dest, platform.system())
+        )
         assert os.path.exists(expect), "CMake build failed to generate '{0}'".format(
             expect
         )

--- a/cmake/test/src/test_install.py
+++ b/cmake/test/src/test_install.py
@@ -13,9 +13,7 @@ EXPECTED = [
     os.path.join("<FPRIME_INSTALL>", "dict", "RefTopologyAppDictionary.xml"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libDrv_BlockDriver.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_FileUplink.a"),
-    os.path.join(
-        "<FPRIME_INSTALL>", "lib", "static", "libSvc_CmdSequencer.a"
-    ),
+    os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_CmdSequencer.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Time.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_FileManager.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libRef_SendBuffApp.a"),
@@ -24,31 +22,21 @@ EXPECTED = [
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Types.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libUtils_Hash.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Port.a"),
-    os.path.join(
-        "<FPRIME_INSTALL>", "lib", "static", "libSvc_RateGroupDriver.a"
-    ),
-    os.path.join(
-        "<FPRIME_INSTALL>", "lib", "static", "libSvc_FatalHandler.a"
-    ),
+    os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_RateGroupDriver.a"),
+    os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_FatalHandler.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_TlmChan.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Obj.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Prm.a"),
-    os.path.join(
-        "<FPRIME_INSTALL>", "lib", "static", "libSvc_ActiveRateGroup.a"
-    ),
+    os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_ActiveRateGroup.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_Cycle.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_Health.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_LinuxTime.a"),
-    os.path.join(
-        "<FPRIME_INSTALL>", "lib", "static", "libRef_PingReceiver.a"
-    ),
+    os.path.join("<FPRIME_INSTALL>", "lib", "static", "libRef_PingReceiver.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Com.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libDrv_DataTypes.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Buffer.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Comp.a"),
-    os.path.join(
-        "<FPRIME_INSTALL>", "lib", "static", "libSvc_CmdDispatcher.a"
-    ),
+    os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_CmdDispatcher.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Log.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Tlm.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libOs.a"),
@@ -56,22 +44,14 @@ EXPECTED = [
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_Sched.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_Seq.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_WatchDog.a"),
-    os.path.join(
-        "<FPRIME_INSTALL>", "lib", "static", "libSvc_AssertFatalAdapter.a"
-    ),
-    os.path.join(
-        "<FPRIME_INSTALL>", "lib", "static", "libSvc_FileDownlink.a"
-    ),
+    os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_AssertFatalAdapter.a"),
+    os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_FileDownlink.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libRef_RecvBuffApp.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_Time.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Cfg.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_Fatal.a"),
-    os.path.join(
-        "<FPRIME_INSTALL>", "lib", "static", "libSvc_ActiveLogger.a"
-    ),
-    os.path.join(
-        "<FPRIME_INSTALL>", "lib", "static", "libSvc_BufferManager.a"
-    ),
+    os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_ActiveLogger.a"),
+    os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_BufferManager.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libFw_Cmd.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libCFDP_Checksum.a"),
     os.path.join("<FPRIME_INSTALL>", "lib", "static", "libSvc_PrmDb.a"),


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**| N  |

---
## Change Description

Adds the [black formatter](https://github.com/psf/black) as an additional action that checks the code style. 

## Rationale

It provides an easy-to-use and reliable tool to ensure that the code is formatted to Python PEP 8 guidelines.

See this [PR](https://github.com/fprime-community/fprime-tools/pull/6).
## Testing/Review Recommendations

The package can be installed with:
`pip install black`
Then it can be run on the entire directory with `black ./`

## Future Work
NA
