### PR TITLE
Cleanup string classes

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
@@ -24,6 +24,7 @@
 \#include <stdio.h>
 
 \#include "Fw/Types/Assert.hpp"
+\#include <Fw/Types/StringUtils.hpp>
 
 \#include "${name}ArrayAc.hpp"
 
@@ -34,64 +35,45 @@ namespace ${namespace} {
 #if $type == "string":
 
     ${name}::${name}String::${name}String(const char* src): StringBase() {
-        this->copyBuff(src,this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     ${name}::${name}String::${name}String(const Fw::StringBase& src): StringBase() {
-        this->copyBuff(src.toChar(),this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     ${name}::${name}String::${name}String(const ${name}String& src): StringBase() {
-        this->copyBuff(src.toChar(),this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     ${name}::${name}String::${name}String(void): StringBase() {
         this->m_buf[0] = 0;
     }
 
+    ${name}::${name}String& ${name}::${name}String::operator=(const ${name}String& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    ${name}::${name}String& ${name}::${name}String::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    ${name}::${name}String& ${name}::${name}String::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
     ${name}::${name}String::~${name}String(void) {
-    }
-
-    bool ${name}::${name}String::operator==(const ${name}String& src) const {
-        return (0 == strncmp(this->m_buf,src.m_buf,sizeof(this->m_buf)));
-    }
-
-    NATIVE_UINT_TYPE ${name}::${name}String::length(void) const {
-        return (NATIVE_UINT_TYPE)strnlen(this->m_buf,sizeof(this->m_buf));
     }
 
     const char* ${name}::${name}String::toChar(void) const {
         return this->m_buf;
     }
 
-    Fw::SerializeStatus ${name}::${name}String::serialize(Fw::SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-        // serialize string
-        return buffer.serialize((U8*)this->m_buf,strSize);
-    }
-
-    Fw::SerializeStatus ${name}::${name}String::deserialize(Fw::SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        Fw::SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
     NATIVE_UINT_TYPE ${name}::${name}String::getCapacity(void) const {
         return sizeof(this->m_buf);
-    }
-
-    void ${name}::${name}String::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
-    }
-
-    const ${name}::${name}String& ${name}::${name}String::operator=(const ${name}::${name}String& other) {
-        this->copyBuff(other.m_buf,this->getCapacity());
-        return *this;
     }
 
 #end if

--- a/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_hpp.tmpl
@@ -62,22 +62,17 @@ namespace ${namespace} {
             ${name}String(const Fw::StringBase& src); //!< string base constructor
             ${name}String(const ${name}String& src); //!< string base constructor
             ${name}String(void); //!< default constructor
-            virtual ~${name}String(void); //!< destructor
+            ${name}String& operator=(const ${name}String& other); //!< assignment operator
+            ${name}String& operator=(const Fw::StringBase& other); //!< other string assignment operator
+            ${name}String& operator=(const char* other); //!< char* assignment operator
+            ~${name}String(void); //!< destructor
+
             const char* toChar(void) const; //!< retrieves char buffer of string
-            NATIVE_UINT_TYPE length(void) const; //!< returns length of string
-            bool operator==(const ${name}String& src) const; //!< equality operator
-
-            const ${name}String& operator=(const ${name}String& other); //!< equal operator for other strings
-
-            Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const; //!< serialization function
-            Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer); //!< deserialization function
+            NATIVE_UINT_TYPE getCapacity(void) const ;
 
         private:
-            NATIVE_UINT_TYPE getCapacity(void) const ;
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 
             char m_buf[${string_size}]; //!< buffer for string storage
-
     };
 
 #end if

--- a/Autocoders/Python/src/fprime_ac/generators/templates/port/includes1PortCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/port/includes1PortCpp.tmpl
@@ -1,5 +1,6 @@
 \#include <FpConfig.hpp>
 \#include <Fw/Types/Assert.hpp>
 \#include <Fw/Types/Serializable.hpp>
+\#include <Fw/Types/StringUtils.hpp>
 
 \#include <${port_include_path}/${include_file}>

--- a/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortCpp.tmpl
@@ -8,60 +8,45 @@ namespace ${n} {
 #if $type == "string":
 
     ${argname}String::${argname}String(const char* src): StringBase() {
-        this->copyBuff(src,this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     ${argname}String::${argname}String(const Fw::StringBase& src): StringBase() {
-        this->copyBuff(src.toChar(),this->getCapacity());
+         Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     ${argname}String::${argname}String(const ${argname}String& src): StringBase() {
-        this->copyBuff(src.toChar(),this->getCapacity());
+         Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     ${argname}String::${argname}String(void): StringBase() {
         this->m_buf[0] = 0;
     }
 
-    ${argname}String::~${argname}String(void) {
+    ${argname}String& ${argname}String::operator=(const ${argname}String& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
     }
 
-    NATIVE_UINT_TYPE ${argname}String::length(void) const {
-        return (NATIVE_UINT_TYPE)strnlen(this->m_buf,sizeof(this->m_buf));
+    ${argname}String& ${argname}String::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    ${argname}String& ${argname}String::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    ${argname}String::~${argname}String(void) {
     }
 
     const char* ${argname}String::toChar(void) const {
         return this->m_buf;
     }
 
-    Fw::SerializeStatus ${argname}String::serialize(Fw::SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-        // serialize string as buffer
-        return buffer.serialize((U8*)this->m_buf,strSize);
-    }
-
-    Fw::SerializeStatus ${argname}String::deserialize(Fw::SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        Fw::SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
     NATIVE_UINT_TYPE ${argname}String::getCapacity(void) const {
         return sizeof(this->m_buf);
-    }
-
-    const ${argname}String& ${argname}String::operator=(const ${argname}String& other) {
-        this->copyBuff(other.m_buf,this->getCapacity());
-        return *this;
-    }
-
-    void ${argname}String::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
     }
 
 #end if

--- a/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortH.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortH.tmpl
@@ -33,18 +33,15 @@ namespace ${namespace} {
             ${argname}String(const Fw::StringBase& src); //!< other string constructor
             ${argname}String(const ${argname}String& src); //!< same type string constructor
             ${argname}String(void); //!< default constructor
-            virtual ~${argname}String(void); //!< destructor
+            ${argname}String& operator=(const ${argname}String& other); //!< assignment operator
+            ${argname}String& operator=(const Fw::StringBase& other); //!< other string assignment operator
+            ${argname}String& operator=(const char* other); //!< char* assignment operator
+            ~${argname}String(void); //!< destructor
+
             const char* toChar(void) const; //!< return internal buffer
-            NATIVE_UINT_TYPE length(void) const; //!< length of string
-
-            const ${argname}String& operator=(const ${argname}String& other); //!< equal operator for other strings
-
-            Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const; //!< deserialization method
-            Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer); //!< serialization method
+            NATIVE_UINT_TYPE getCapacity(void) const ;
 
         private:
-            NATIVE_UINT_TYPE getCapacity(void) const ;
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 
             char m_buf[${size}]; //!< buffer for string
     };

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/includes1SerialCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/includes1SerialCpp.tmpl
@@ -1,6 +1,7 @@
 \#include <${include_path}/${namespace}${name}SerializableAc.hpp>
 \#include <Fw/Types/Assert.hpp>
 \#include <Fw/Types/BasicTypes.hpp>
+\#include <Fw/Types/StringUtils.hpp>
 \#if FW_SERIALIZABLE_TO_STRING
 \#include <Fw/Types/EightyCharString.hpp>
 \#endif

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/namespaceSerialCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/namespaceSerialCpp.tmpl
@@ -7,64 +7,45 @@ namespace ${n} {
 #if $type == "string":
 
     ${name}::${memname}String::${memname}String(const char* src): StringBase() {
-        this->copyBuff(src,this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     ${name}::${memname}String::${memname}String(const Fw::StringBase& src): StringBase() {
-        this->copyBuff(src.toChar(),this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     ${name}::${memname}String::${memname}String(const ${memname}String& src): StringBase() {
-        this->copyBuff(src.toChar(),this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     ${name}::${memname}String::${memname}String(void): StringBase() {
         this->m_buf[0] = 0;
     }
 
+    ${name}::${memname}String& ${name}::${memname}String::operator=(const ${memname}String& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    ${name}::${memname}String& ${name}::${memname}String::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    ${name}::${memname}String& ${name}::${memname}String::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
     ${name}::${memname}String::~${memname}String(void) {
-    }
-
-    bool ${name}::${memname}String::operator==(const ${memname}String& src) const {
-        return (0 == strncmp(this->m_buf,src.m_buf,sizeof(this->m_buf)));
-    }
-
-    NATIVE_UINT_TYPE ${name}::${memname}String::length(void) const {
-        return (NATIVE_UINT_TYPE)strnlen(this->m_buf,sizeof(this->m_buf));
     }
 
     const char* ${name}::${memname}String::toChar(void) const {
         return this->m_buf;
     }
 
-    Fw::SerializeStatus ${name}::${memname}String::serialize(Fw::SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-        // serialize string
-        return buffer.serialize((U8*)this->m_buf,strSize);
-    }
-
-    Fw::SerializeStatus ${name}::${memname}String::deserialize(Fw::SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        Fw::SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
     NATIVE_UINT_TYPE ${name}::${memname}String::getCapacity(void) const {
         return sizeof(this->m_buf);
-    }
-
-    void ${name}::${memname}String::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
-    }
-
-    const ${name}::${memname}String& ${name}::${memname}String::operator=(const ${name}::${memname}String& other) {
-        this->copyBuff(other.m_buf,this->getCapacity());
-        return *this;
     }
 
 #end if

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/namespaceSerialH.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/namespaceSerialH.tmpl
@@ -34,22 +34,17 @@ class ${name} : public Fw::Serializable {
             ${memname}String(const Fw::StringBase& src); //!< string base constructor
             ${memname}String(const ${memname}String& src); //!< string base constructor
             ${memname}String(void); //!< default constructor
-            virtual ~${memname}String(void); //!< destructor
+            ${memname}String& operator=(const ${memname}String& other); //!< assignment operator
+            ${memname}String& operator=(const Fw::StringBase& other); //!< other string assignment operator
+            ${memname}String& operator=(const char* other); //!< char* assignment operator
+            ~${memname}String(void); //!< destructor
+
             const char* toChar(void) const; //!< retrieves char buffer of string
-            NATIVE_UINT_TYPE length(void) const; //!< returns length of string
-            bool operator==(const ${memname}String& src) const; //!< equality operator
-
-            const ${memname}String& operator=(const ${memname}String& other); //!< equal operator for other strings
-
-            Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const; //!< serialization function
-            Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer); //!< deserialization function
+            NATIVE_UINT_TYPE getCapacity(void) const ;
 
         private:
-            NATIVE_UINT_TYPE getCapacity(void) const ;
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 
             char m_buf[${size}]; //!< buffer for string storage
-
     };
 
 #end if

--- a/Fw/Cmd/CmdString.cpp
+++ b/Fw/Cmd/CmdString.cpp
@@ -1,68 +1,47 @@
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Cmd/CmdString.hpp>
-#include <Fw/Types/Assert.hpp>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <Fw/Types/StringUtils.hpp>
 
 namespace Fw {
 
     CmdStringArg::CmdStringArg(const char* src) : StringBase() {
-        this->copyBuff(src,this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     CmdStringArg::CmdStringArg(const StringBase& src) : StringBase()  {
-        this->copyBuff(src.toChar(),this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     CmdStringArg::CmdStringArg(const CmdStringArg& src) : StringBase()  {
-        this->copyBuff(src.m_buf,this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     CmdStringArg::CmdStringArg(void) : StringBase() {
         this->m_buf[0] = 0;
     }
 
-    CmdStringArg::~CmdStringArg(void) {
+    CmdStringArg& CmdStringArg::operator=(const CmdStringArg& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
     }
 
-    NATIVE_UINT_TYPE CmdStringArg::length(void) const {
-        return strnlen(this->m_buf,sizeof(this->m_buf));
+    CmdStringArg& CmdStringArg::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    CmdStringArg& CmdStringArg::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    CmdStringArg::~CmdStringArg(void) {
     }
 
     const char* CmdStringArg::toChar(void) const {
         return this->m_buf;
     }
 
-    const CmdStringArg& CmdStringArg::operator=(const CmdStringArg& other) {
-        this->copyBuff(other.m_buf,this->getCapacity());
-        return *this;
-    }
-
-    SerializeStatus CmdStringArg::serialize(SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-        // serialize string
-        return buffer.serialize((U8*)this->m_buf,strSize);
-    }
-
-    SerializeStatus CmdStringArg::deserialize(SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
     NATIVE_UINT_TYPE CmdStringArg::getCapacity(void) const {
         return FW_CMD_STRING_MAX_SIZE;
     }
-
-    void CmdStringArg::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
-    }
-
 }

--- a/Fw/Cmd/CmdString.hpp
+++ b/Fw/Cmd/CmdString.hpp
@@ -20,18 +20,15 @@ namespace Fw {
             CmdStringArg(const StringBase& src);
             CmdStringArg(const CmdStringArg& src);
             CmdStringArg(void);
+            CmdStringArg& operator=(const CmdStringArg& other);
+            CmdStringArg& operator=(const StringBase& other);
+            CmdStringArg& operator=(const char* other);
             ~CmdStringArg(void);
+
             const char* toChar(void) const;
-            NATIVE_UINT_TYPE length(void) const;
-
-            const CmdStringArg& operator=(const CmdStringArg& other); //!< equal operator for other strings
-
-            SerializeStatus serialize(SerializeBufferBase& buffer) const;
-            SerializeStatus deserialize(SerializeBufferBase& buffer);
+            NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
 
         private:
-            NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 
             char m_buf[FW_CMD_STRING_MAX_SIZE];
     };

--- a/Fw/Log/LogString.cpp
+++ b/Fw/Log/LogString.cpp
@@ -1,26 +1,22 @@
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Log/LogString.hpp>
-#include <Fw/Types/Assert.hpp>
+#include <Fw/Types/StringUtils.hpp>
 #include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 namespace Fw {
 
     LogStringArg::LogStringArg(const char* src)
             :  StringBase(), m_maxSer(FW_LOG_STRING_MAX_SIZE) {
-        this->copyBuff(src,sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     LogStringArg::LogStringArg(const StringBase& src)
             : StringBase(), m_maxSer(FW_LOG_STRING_MAX_SIZE) {
-        this->copyBuff(src.toChar(),sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     LogStringArg::LogStringArg(const LogStringArg& src)
             : StringBase(), m_maxSer(FW_LOG_STRING_MAX_SIZE) {
-        this->copyBuff(src.m_buf,sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     LogStringArg::LogStringArg(void)
@@ -107,7 +103,7 @@ namespace Fw {
     }
 
     const LogStringArg& LogStringArg::operator=(const LogStringArg& other) {
-        this->copyBuff(other.m_buf,this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 

--- a/Fw/Log/TextLogString.cpp
+++ b/Fw/Log/TextLogString.cpp
@@ -1,68 +1,46 @@
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Log/TextLogString.hpp>
-#include <Fw/Types/Assert.hpp>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-
+#include <Fw/Types/StringUtils.hpp>
 namespace Fw {
 
     TextLogString::TextLogString(const char* src) : StringBase() {
-        this->copyBuff(src,sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     TextLogString::TextLogString(const StringBase& src): StringBase()  {
-        this->copyBuff(src.toChar(),sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     TextLogString::TextLogString(const TextLogString& src): StringBase()  {
-        this->copyBuff(src.m_buf,sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     TextLogString::TextLogString(void): StringBase()  {
         this->m_buf[0] = 0;
     }
 
-    TextLogString::~TextLogString(void) {
+    TextLogString& TextLogString::operator=(const TextLogString& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
     }
 
-    NATIVE_UINT_TYPE TextLogString::length(void) const {
-        return (NATIVE_UINT_TYPE) strnlen(this->m_buf,sizeof(this->m_buf));
+    TextLogString& TextLogString::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    TextLogString& TextLogString::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    TextLogString::~TextLogString(void) {
     }
 
     const char* TextLogString::toChar(void) const {
         return this->m_buf;
     }
 
-    SerializeStatus TextLogString::serialize(SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-        // serialize string
-        return buffer.serialize((U8*)this->m_buf,strSize);
-    }
-
-    SerializeStatus TextLogString::deserialize(SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
     NATIVE_UINT_TYPE TextLogString::getCapacity(void) const {
         return FW_LOG_TEXT_BUFFER_SIZE;
     }
-
-    void TextLogString::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
-    }
-
-    const TextLogString& TextLogString::operator=(const TextLogString& other) {
-        this->copyBuff(other.m_buf,this->getCapacity());
-        return *this;
-    }
-
 }

--- a/Fw/Log/TextLogString.hpp
+++ b/Fw/Log/TextLogString.hpp
@@ -20,18 +20,15 @@ namespace Fw {
             TextLogString(const StringBase& src);
             TextLogString(const TextLogString& src);
             TextLogString(void);
+            TextLogString& operator=(const TextLogString& other);
+            TextLogString& operator=(const StringBase& other);
+            TextLogString& operator=(const char* other);
             ~TextLogString(void);
+
             const char* toChar(void) const;
-            NATIVE_UINT_TYPE length(void) const;
-
-            const TextLogString& operator=(const TextLogString& other); //!< equal operator for other strings
-
-            SerializeStatus serialize(SerializeBufferBase& buffer) const;
-            SerializeStatus deserialize(SerializeBufferBase& buffer);
+            NATIVE_UINT_TYPE getCapacity(void) const ;
 
         private:
-            NATIVE_UINT_TYPE getCapacity(void) const ;
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 
             char m_buf[FW_LOG_TEXT_BUFFER_SIZE];
     };

--- a/Fw/Logger/test/ut/LoggerRules.cpp
+++ b/Fw/Logger/test/ut/LoggerRules.cpp
@@ -17,7 +17,7 @@
 namespace LoggerRules {
 
     // Constructor
-    Register::Register(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.m_buf) {}
+    Register::Register(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
 
     // Check for registration, always allowed
     bool Register::precondition(const MockLogging::FakeLogger& truth) {
@@ -40,7 +40,7 @@ namespace LoggerRules {
     }
 
     // Constructor
-    LogGood::LogGood(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.m_buf) {}
+    LogGood::LogGood(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
 
     // Check for logging, only when not NULL
     bool LogGood::precondition(const MockLogging::FakeLogger& truth) {
@@ -113,7 +113,7 @@ namespace LoggerRules {
     }
 
     // Constructor
-    LogBad::LogBad(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.m_buf) {}
+    LogBad::LogBad(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
 
     // Check for logging, only when not NULL
     bool LogBad::precondition(const MockLogging::FakeLogger& truth) {

--- a/Fw/Prm/PrmString.cpp
+++ b/Fw/Prm/PrmString.cpp
@@ -1,68 +1,47 @@
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Prm/PrmString.hpp>
-#include <Fw/Types/Assert.hpp>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <Fw/Types/StringUtils.hpp>
 
 namespace Fw {
 
     ParamString::ParamString(const char* src) : StringBase()  {
-        this->copyBuff(src,this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     ParamString::ParamString(const StringBase& src) : StringBase()  {
-        this->copyBuff(src.toChar(),this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     ParamString::ParamString(const ParamString& src) : StringBase()  {
-        this->copyBuff(src.m_buf,this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     ParamString::ParamString(void) : StringBase()  {
         this->m_buf[0] = 0;
     }
 
-    ParamString::~ParamString(void) {
+    ParamString& ParamString::operator=(const ParamString& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
     }
 
-    NATIVE_UINT_TYPE ParamString::length(void) const {
-        return strnlen(this->m_buf,sizeof(this->m_buf));
+    ParamString& ParamString::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    ParamString& ParamString::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    ParamString::~ParamString(void) {
     }
 
     const char* ParamString::toChar(void) const {
         return this->m_buf;
     }
 
-    SerializeStatus ParamString::serialize(SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-        // serialize string as buffer
-        return buffer.serialize((U8*)this->m_buf,strSize);
-    }
-
-    SerializeStatus ParamString::deserialize(SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
     NATIVE_UINT_TYPE ParamString::getCapacity(void) const {
         return FW_PARAM_STRING_MAX_SIZE;
     }
-
-    void ParamString::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
-    }
-
-    const ParamString& ParamString::operator=(const ParamString& other) {
-        this->copyBuff(other.m_buf,this->getCapacity());
-        return *this;
-    }
-
 }

--- a/Fw/Prm/PrmString.hpp
+++ b/Fw/Prm/PrmString.hpp
@@ -20,18 +20,15 @@ namespace Fw {
             ParamString(const StringBase& src);
             ParamString(const ParamString& src);
             ParamString(void);
+            ParamString& operator=(const ParamString& other);
+            ParamString& operator=(const StringBase& other);
+            ParamString& operator=(const char* other);
             ~ParamString(void);
+
             const char* toChar(void) const;
-            NATIVE_UINT_TYPE length(void) const;
-
-            const ParamString& operator=(const ParamString& other); //!< equal operator for other strings
-
-            SerializeStatus serialize(SerializeBufferBase& buffer) const;
-            SerializeStatus deserialize(SerializeBufferBase& buffer);
+            NATIVE_UINT_TYPE getCapacity(void) const;
 
         private:
-            NATIVE_UINT_TYPE getCapacity(void) const ;
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 
             char m_buf[FW_PARAM_STRING_MAX_SIZE];
     };

--- a/Fw/Test/String.cpp
+++ b/Fw/Test/String.cpp
@@ -1,68 +1,47 @@
 #include <Fw/Test/String.hpp>
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/BasicTypes.hpp>
-#include <Fw/Types/Assert.hpp>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <Fw/Types/StringUtils.hpp>
 
 namespace Test {
 
     String::String(const char* src) : StringBase() {
-        this->copyBuff(src, sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     String::String(const StringBase& src) : StringBase() {
-        this->copyBuff(src.toChar(), sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     String::String(const String& src) : StringBase() {
-        this->copyBuff(src.m_buf, sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     String::String(void) : StringBase() {
         this->m_buf[0] = 0;
     }
 
-    String::~String(void) {
+    String& String::operator=(const String& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
     }
 
-    NATIVE_UINT_TYPE String::length(void) const {
-        return strnlen(this->m_buf,sizeof(this->m_buf));
+    String& String::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    String& String::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    String::~String(void) {
     }
 
     const char* String::toChar(void) const {
         return this->m_buf;
     }
 
-    const String& String::operator=(const String& other) {
-        this->copyBuff(other.m_buf,sizeof(this->m_buf));
-        return *this;
-    }
-
-    Fw::SerializeStatus String::serialize(Fw::SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-        // serialize string as buffer
-        return buffer.serialize((U8*)this->m_buf,strSize);
-    }
-
-    Fw::SerializeStatus String::deserialize(Fw::SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        Fw::SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
     NATIVE_UINT_TYPE String::getCapacity(void) const {
         return STRING_SIZE;
     }
-
-    void String::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
-    }
-
 }

--- a/Fw/Test/String.hpp
+++ b/Fw/Test/String.hpp
@@ -20,18 +20,15 @@ namespace Test {
             String(const StringBase& src); //!< other string constructor
             String(const String& src); //!< String string constructor
             String(void); //!< default constructor
+            String& operator=(const String& other); //!< assignment operator
+            String& operator=(const StringBase& other); //!< other string assignment operator
+            String& operator=(const char* other); //!< char* assignment operator
             ~String(void); //!< destructor
+
             const char* toChar(void) const; //!< gets char buffer
-            NATIVE_UINT_TYPE length(void) const; //!< returns length of stored string
-
-            const String& operator=(const String& other); //!< equal operator
-
-            Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const; //!< serialization function
-            Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer); //!< deserialization function
-
-        PRIVATE:
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
+
+        private:
 
             char m_buf[STRING_SIZE]; //!< storage for string data
     };

--- a/Fw/Tlm/TlmString.cpp
+++ b/Fw/Tlm/TlmString.cpp
@@ -1,23 +1,19 @@
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Tlm/TlmString.hpp>
-#include <Fw/Types/Assert.hpp>
+#include <Fw/Types/StringUtils.hpp>
 #include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 namespace Fw {
 
     TlmString::TlmString(const char* src) :  StringBase(), m_maxSer(FW_TLM_STRING_MAX_SIZE) {
-        this->copyBuff(src,sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     TlmString::TlmString(const StringBase& src) : StringBase(), m_maxSer(FW_TLM_STRING_MAX_SIZE) {
-        this->copyBuff(src.toChar(),sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     TlmString::TlmString(const TlmString& src) : StringBase(), m_maxSer(FW_TLM_STRING_MAX_SIZE) {
-        this->copyBuff(src.m_buf,sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     TlmString::TlmString(void) : StringBase(), m_maxSer(FW_TLM_STRING_MAX_SIZE) {
@@ -96,7 +92,7 @@ namespace Fw {
     }
 
     const TlmString& TlmString::operator=(const TlmString& other) {
-        this->copyBuff(other.m_buf,this->getCapacity());
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 

--- a/Fw/Types/EightyCharString.cpp
+++ b/Fw/Types/EightyCharString.cpp
@@ -1,68 +1,47 @@
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Types/EightyCharString.hpp>
-#include <Fw/Types/Assert.hpp>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <Fw/Types/StringUtils.hpp>
 
 namespace Fw {
 
     EightyCharString::EightyCharString(const char* src) : StringBase() {
-        this->copyBuff(src, sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     EightyCharString::EightyCharString(const StringBase& src) : StringBase() {
-        this->copyBuff(src.toChar(), sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     EightyCharString::EightyCharString(const EightyCharString& src) : StringBase() {
-        this->copyBuff(src.m_buf, sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     EightyCharString::EightyCharString(void) : StringBase() {
         this->m_buf[0] = 0;
     }
 
-    EightyCharString::~EightyCharString(void) {
+    EightyCharString& EightyCharString::operator=(const EightyCharString& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
     }
 
-    NATIVE_UINT_TYPE EightyCharString::length(void) const {
-        return strnlen(this->m_buf,sizeof(this->m_buf));
+    EightyCharString& EightyCharString::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    EightyCharString& EightyCharString::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    EightyCharString::~EightyCharString(void) {
     }
 
     const char* EightyCharString::toChar(void) const {
         return this->m_buf;
     }
 
-    const EightyCharString& EightyCharString::operator=(const EightyCharString& other) {
-        this->copyBuff(other.m_buf,sizeof(this->m_buf));
-        return *this;
-    }
-
-    SerializeStatus EightyCharString::serialize(SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-        // serialize string as buffer
-        return buffer.serialize((U8*)this->m_buf,strSize);
-    }
-
-    SerializeStatus EightyCharString::deserialize(SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
     NATIVE_UINT_TYPE EightyCharString::getCapacity(void) const {
         return STRING_SIZE;
     }
-
-    void EightyCharString::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
-    }
-
 }

--- a/Fw/Types/EightyCharString.hpp
+++ b/Fw/Types/EightyCharString.hpp
@@ -20,18 +20,15 @@ namespace Fw {
             EightyCharString(const StringBase& src); //!< other string constructor
             EightyCharString(const EightyCharString& src); //!< EightyCharString string constructor
             EightyCharString(void); //!< default constructor
+            EightyCharString& operator=(const EightyCharString& other); //!< assignment operator
+            EightyCharString& operator=(const StringBase& other); //!< other string assignment operator
+            EightyCharString& operator=(const char* other); //!< char* assignment operator
             ~EightyCharString(void); //!< destructor
+
             const char* toChar(void) const; //!< gets char buffer
-            NATIVE_UINT_TYPE length(void) const; //!< returns length of stored string
+            NATIVE_UINT_TYPE getCapacity(void) const; //!< return buffer size
 
-            const EightyCharString& operator=(const EightyCharString& other); //!< equal operator
-
-            SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
-            SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
-
-        PRIVATE:
-            NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
+        private:
 
             char m_buf[STRING_SIZE]; //!< storage for string data
     };

--- a/Fw/Types/FixedLengthString.cpp
+++ b/Fw/Types/FixedLengthString.cpp
@@ -1,68 +1,47 @@
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Types/FixedLengthString.hpp>
-#include <Fw/Types/Assert.hpp>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <Fw/Types/StringUtils.hpp>
 
 namespace Fw {
 
     FixedLengthString::FixedLengthString(const char* src) : StringBase() {
-        this->copyBuff(src, sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     FixedLengthString::FixedLengthString(const StringBase& src) : StringBase() {
-        this->copyBuff(src.toChar(), sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     FixedLengthString::FixedLengthString(const FixedLengthString& src) : StringBase() {
-        this->copyBuff(src.m_buf, sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     FixedLengthString::FixedLengthString(void) : StringBase() {
         this->m_buf[0] = 0;
     }
 
-    FixedLengthString::~FixedLengthString(void) {
+    FixedLengthString& FixedLengthString::operator=(const FixedLengthString& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
     }
 
-    NATIVE_UINT_TYPE FixedLengthString::length(void) const {
-        return strnlen(this->m_buf,sizeof(this->m_buf));
+    FixedLengthString& FixedLengthString::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    FixedLengthString& FixedLengthString::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    FixedLengthString::~FixedLengthString(void) {
     }
 
     const char* FixedLengthString::toChar(void) const {
         return this->m_buf;
     }
 
-    const FixedLengthString& FixedLengthString::operator=(const FixedLengthString& other) {
-        this->copyBuff(other.m_buf,sizeof(this->m_buf));
-        return *this;
-    }
-
-    SerializeStatus FixedLengthString::serialize(SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-        // serialize string as buffer
-        return buffer.serialize((U8*)this->m_buf,strSize);
-    }
-
-    SerializeStatus FixedLengthString::deserialize(SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
     NATIVE_UINT_TYPE FixedLengthString::getCapacity(void) const {
         return STRING_SIZE;
     }
-
-    void FixedLengthString::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
-    }
-
 }

--- a/Fw/Types/FixedLengthString.hpp
+++ b/Fw/Types/FixedLengthString.hpp
@@ -20,18 +20,15 @@ namespace Fw {
             FixedLengthString(const StringBase& src); //!< other string constructor
             FixedLengthString(const FixedLengthString& src); //!< FixedLengthString string constructor
             FixedLengthString(void); //!< default constructor
+            FixedLengthString& operator=(const FixedLengthString& other); //!< assignment operator
+            FixedLengthString& operator=(const StringBase& other); //!< other string assignment operator
+            FixedLengthString& operator=(const char* other); //!< char* assignment operator
             ~FixedLengthString(void); //!< destructor
+
             const char* toChar(void) const; //!< gets char buffer
-            NATIVE_UINT_TYPE length(void) const; //!< returns length of stored string
-
-            const FixedLengthString& operator=(const FixedLengthString& other); //!< equal operator
-
-            SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
-            SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
-
-        PRIVATE:
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
+
+        private:
 
             char m_buf[STRING_SIZE]; //!< storage for string data
     };

--- a/Fw/Types/InternalInterfaceString.cpp
+++ b/Fw/Types/InternalInterfaceString.cpp
@@ -1,68 +1,47 @@
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Types/InternalInterfaceString.hpp>
-#include <Fw/Types/Assert.hpp>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <Fw/Types/StringUtils.hpp>
 
 namespace Fw {
 
     InternalInterfaceString::InternalInterfaceString(const char* src) : StringBase()  {
-        this->copyBuff(src, sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     InternalInterfaceString::InternalInterfaceString(const StringBase& src) : StringBase()  {
-        this->copyBuff(src.toChar(), sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     InternalInterfaceString::InternalInterfaceString(const InternalInterfaceString& src) : StringBase()  {
-        this->copyBuff(src.m_buf, sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     InternalInterfaceString::InternalInterfaceString(void) : StringBase()  {
         this->m_buf[0] = 0;
     }
 
-    InternalInterfaceString::~InternalInterfaceString(void) {
+    InternalInterfaceString& InternalInterfaceString::operator=(const InternalInterfaceString& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
     }
 
-    NATIVE_UINT_TYPE InternalInterfaceString::length(void) const {
-        return strnlen(this->m_buf,sizeof(this->m_buf));
+    InternalInterfaceString& InternalInterfaceString::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    InternalInterfaceString& InternalInterfaceString::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    InternalInterfaceString::~InternalInterfaceString(void) {
     }
 
     const char* InternalInterfaceString::toChar(void) const {
         return this->m_buf;
     }
 
-    SerializeStatus InternalInterfaceString::serialize(SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-        // serialize string as buffer
-        return buffer.serialize((U8*)this->m_buf,strSize);
-    }
-
-    SerializeStatus InternalInterfaceString::deserialize(SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
     NATIVE_UINT_TYPE InternalInterfaceString::getCapacity(void) const {
         return FW_INTERNAL_INTERFACE_STRING_MAX_SIZE;
     }
-
-    const InternalInterfaceString& InternalInterfaceString::operator=(const InternalInterfaceString& other) {
-        this->copyBuff(other.m_buf,this->getCapacity());
-        return *this;
-    }
-
-    void InternalInterfaceString::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
-    }
-
 }

--- a/Fw/Types/InternalInterfaceString.hpp
+++ b/Fw/Types/InternalInterfaceString.hpp
@@ -20,21 +20,18 @@ namespace Fw {
             InternalInterfaceString(const StringBase& src); //!< other string constructor
             InternalInterfaceString(const InternalInterfaceString& src); //!< other string constructor
             InternalInterfaceString(void); //!< default constructor
+            InternalInterfaceString& operator=(const InternalInterfaceString& other); //!< assignment operator
+            InternalInterfaceString& operator=(const StringBase& other); //!< other string assignment operator
+            InternalInterfaceString& operator=(const char* other); //!< char* assignment operator
             ~InternalInterfaceString(void); //!< destructor
+
             const char* toChar(void) const; //!< gets char buffer
-            NATIVE_UINT_TYPE length(void) const; //!< returns length of stored string
-
-            const InternalInterfaceString& operator=(const InternalInterfaceString& other); //!< equal operator
-
-            SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
-            SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
-
-        PRIVATE:
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
+
+        private:
 
             char m_buf[FW_INTERNAL_INTERFACE_STRING_MAX_SIZE]; //!< storage for string data
-};
+    };
 }
 
 #endif // FW_INTERNAL_INTERFACE_STRING_TYPE_HPP

--- a/Fw/Types/StringType.hpp
+++ b/Fw/Types/StringType.hpp
@@ -23,21 +23,23 @@ namespace Fw {
     class StringBase : public Serializable {
         public:
             virtual const char* toChar(void) const = 0; //<! Convert to a C-style char*
-            virtual NATIVE_UINT_TYPE length(void) const = 0; //!< Get length of string
+            virtual NATIVE_UINT_TYPE getCapacity(void) const = 0; //!< return size of buffer
+            NATIVE_UINT_TYPE length(void) const;  //!< Get length of string
+
             const char* operator+=(const char* src); //!< Concatenate a char*
             const StringBase& operator+=(const StringBase& src); //!< Concatenate a StringBase
             bool operator==(const StringBase& other) const; //!< Check for equality with StringBase
             bool operator==(const char* other) const; //!< Check for equality with char*
             bool operator!=(const StringBase& other) const; //!< Inequality with StringBase
             bool operator!=(const char* other) const; //!< Inequality with char*
-
-            const char* operator=(const char* src); //!< Assign char*
-            const StringBase& operator=(const StringBase& src); //!< Assign another StringBase
-
-            void appendBuff(const char* buff, NATIVE_UINT_TYPE size);
-            void copyBuff(const char* buff, NATIVE_UINT_TYPE size);
+            StringBase& operator=(const char* src); //!< Assign char*
+            StringBase& operator=(const StringBase& src); //!< Assign another StringBase
 
             void format(const char* formatString, ...); //!< write formatted string to buffer
+
+            SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
+            SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
+
 #ifdef BUILD_UT
             // to support GoogleTest framework in unit tests
             friend std::ostream& operator<<(std::ostream& os, const StringBase& str);
@@ -49,9 +51,10 @@ namespace Fw {
         protected:
             StringBase(void);
             virtual ~StringBase(void);
-            virtual NATIVE_UINT_TYPE getCapacity(void) const = 0; //!< return size of buffer
 
-        PRIVATE:
+            void appendBuff(const char* buff, NATIVE_UINT_TYPE size);
+
+        private:
             // A no-implementation copy constructor here will prevent the default copy constructor from being called
             // accidentally, and without an implementation it will create an error for the developer instead.
             StringBase(const StringBase &src); //!< constructor with buffer as source

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -1,7 +1,16 @@
 #include "StringUtils.hpp"
+#include <Fw/Types/Assert.hpp>
 #include "string.h"
 
 char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 num) {
+    // Handle self-copy
+    if(destination == source) {
+        return destination;
+    }
+
+    // Copying an overlapping range is undefined
+    FW_ASSERT(source + num <= destination || destination + num <= source);
+
     char* returned = strncpy(destination, source, num);
     destination[num - 1] = '\0';
     return returned;

--- a/Os/QueueString.cpp
+++ b/Os/QueueString.cpp
@@ -1,40 +1,40 @@
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/BasicTypes.hpp>
 #include <Os/QueueString.hpp>
-#include <Fw/Types/Assert.hpp>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <Fw/Types/StringUtils.hpp>
 
 namespace Os {
 
-    QueueString::QueueString(const char* src) : StringBase()  {
-        this->copyBuff(src,sizeof(this->m_buf));
+    QueueString::QueueString(const char* src) : StringBase() {
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     QueueString::QueueString(const StringBase& src) : StringBase()  {
-        this->copyBuff(src.toChar(),sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     QueueString::QueueString(const QueueString& src)  : StringBase() {
-        this->copyBuff(src.m_buf,sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     QueueString::QueueString(void) : StringBase()  {
         this->m_buf[0] = 0;
     }
 
-    QueueString::~QueueString(void) {
-    }
-
-    const QueueString& QueueString::operator=(const QueueString& other) {
-        this->copyBuff(other.m_buf,this->getCapacity());
+    QueueString& QueueString::operator=(const QueueString& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
+    QueueString& QueueString::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
 
-    NATIVE_UINT_TYPE QueueString::length(void) const {
-        return strnlen(this->m_buf,sizeof(this->m_buf));
+    QueueString& QueueString::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    QueueString::~QueueString(void) {
     }
 
     const char* QueueString::toChar(void) const {
@@ -43,10 +43,5 @@ namespace Os {
 
     NATIVE_UINT_TYPE QueueString::getCapacity(void) const {
         return FW_QUEUE_NAME_MAX_SIZE;
-    }
-
-    void QueueString::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
     }
 }

--- a/Os/QueueString.hpp
+++ b/Os/QueueString.hpp
@@ -14,20 +14,18 @@ namespace Os {
             QueueString(const StringBase& src); //!< copy constructor
             QueueString(const QueueString& src); //!< copy constructor
             QueueString(void); //!< default constructor
+            QueueString& operator=(const QueueString& other); //!< assignment operator
+            QueueString& operator=(const StringBase& other); //!< other string assignment operator
+            QueueString& operator=(const char* other); //!< char* assignment operator
             ~QueueString(void); //!< destructor
-            const char* toChar(void) const; //!< get pointer to char buffer
-            NATIVE_UINT_TYPE length(void) const; //!< get current length of string
 
-            const QueueString& operator=(const QueueString& other); //!< equal operator
+            const char* toChar(void) const; //!< get pointer to char buffer
+            NATIVE_UINT_TYPE getCapacity(void) const ;
 
         private:
-            Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const { return Fw::FW_SERIALIZE_NO_ROOM_LEFT; } //!< disabled
-            Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer)  { return Fw::FW_SERIALIZE_NO_ROOM_LEFT; } //!< disabled
-            NATIVE_UINT_TYPE getCapacity(void) const ;
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
+
             char m_buf[FW_QUEUE_NAME_MAX_SIZE]; //!< buffer for string
     };
-
 }
 
 #endif

--- a/Os/TaskString.cpp
+++ b/Os/TaskString.cpp
@@ -1,68 +1,47 @@
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/BasicTypes.hpp>
 #include <Os/TaskString.hpp>
-#include <Fw/Types/Assert.hpp>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <Fw/Types/StringUtils.hpp>
 
 namespace Os {
 
     TaskString::TaskString(const char* src) : StringBase()  {
-        this->copyBuff(src,sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
     TaskString::TaskString(const StringBase& src) : StringBase()  {
-        this->copyBuff(src.toChar(),sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     TaskString::TaskString(const TaskString& src) : StringBase()  {
-        this->copyBuff(src.m_buf,sizeof(this->m_buf));
+        Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     TaskString::TaskString(void) {
         this->m_buf[0] = 0;
     }
 
-    TaskString::~TaskString(void) {
+    TaskString& TaskString::operator=(const TaskString& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
     }
 
-    NATIVE_UINT_TYPE TaskString::length(void) const {
-        return strnlen(this->m_buf,sizeof(this->m_buf));
+    TaskString& TaskString::operator=(const StringBase& other) {
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
+    }
+
+    TaskString& TaskString::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    TaskString::~TaskString(void) {
     }
 
     const char* TaskString::toChar(void) const {
         return this->m_buf;
     }
 
-    const TaskString& TaskString::operator=(const TaskString& other) {
-        this->copyBuff(other.m_buf,this->getCapacity());
-        return *this;
-    }
-
     NATIVE_UINT_TYPE TaskString::getCapacity(void) const {
         return FW_TASK_NAME_MAX_SIZE;
     }
-
-    Fw::SerializeStatus TaskString::serialize(Fw::SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-        // serialize string as buffer
-        return buffer.serialize((U8*)this->m_buf,strSize);
-    }
-
-    Fw::SerializeStatus TaskString::deserialize(Fw::SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        Fw::SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
-    void TaskString::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
-    }
-
 }

--- a/Os/TaskString.hpp
+++ b/Os/TaskString.hpp
@@ -14,18 +14,15 @@ namespace Os {
             TaskString(const StringBase& src); //!< Copy constructor
             TaskString(const TaskString& src); //!< Copy constructor
             TaskString(void); //!< default constructor
+            TaskString& operator=(const TaskString& other); //!< assignment operator
+            TaskString& operator=(const StringBase& other); //!< other string assignment operator
+            TaskString& operator=(const char* other); //!< char* assignment operator
             ~TaskString(void); //!< destructor
+
             const char* toChar(void) const; //!< get pointer to internal char buffer
-            NATIVE_UINT_TYPE length(void) const; //!< return current string length
-
-            Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const;
-            Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer);
-
-            const TaskString& operator=(const TaskString& other); //!< equal operator
+            NATIVE_UINT_TYPE getCapacity(void) const; //!< return buffer size
 
         private:
-            NATIVE_UINT_TYPE getCapacity(void) const ;
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 
             char m_buf[FW_TASK_NAME_MAX_SIZE]; //!< buffer for string
 

--- a/Svc/GroundInterface/test/ut/GroundInterfaceRules.cpp
+++ b/Svc/GroundInterface/test/ut/GroundInterfaceRules.cpp
@@ -12,7 +12,7 @@
 
 namespace Svc {
     // Constructor
-    RandomizeRule :: RandomizeRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.m_buf) {}
+    RandomizeRule :: RandomizeRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always randomize
     bool RandomizeRule :: precondition(const Svc::Tester &state) {
@@ -39,7 +39,7 @@ namespace Svc {
 
 
     // Constructor
-    DownlinkRule :: DownlinkRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.m_buf) {}
+    DownlinkRule :: DownlinkRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always downlink
     bool DownlinkRule :: precondition(const Svc::Tester &state) {
@@ -57,7 +57,7 @@ namespace Svc {
     }
 
     // Constructor
-    FileDownlinkRule :: FileDownlinkRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.m_buf) {}
+    FileDownlinkRule :: FileDownlinkRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always downlink
     bool FileDownlinkRule :: precondition(const Svc::Tester &state) {
@@ -80,7 +80,7 @@ namespace Svc {
     }
 
     // Constructor
-    SendAvailableRule :: SendAvailableRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.m_buf) {}
+    SendAvailableRule :: SendAvailableRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always downlink
     bool SendAvailableRule :: precondition(const Svc::Tester &state) {

--- a/Utils/Types/test/ut/CircularBuffer/CircularRules.cpp
+++ b/Utils/Types/test/ut/CircularBuffer/CircularRules.cpp
@@ -16,7 +16,7 @@ namespace Types {
 
 
     RandomizeRule::RandomizeRule(const Fw::EightyCharString& name)
-        : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+        : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool RandomizeRule::precondition(const MockTypes::CircularState& state) {
@@ -31,7 +31,7 @@ namespace Types {
 
 
     SerializeOkRule::SerializeOkRule(const Fw::EightyCharString& name)
-        : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+        : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool SerializeOkRule::precondition(const MockTypes::CircularState& state) {
@@ -49,7 +49,7 @@ namespace Types {
 
 
     SerializeOverflowRule::SerializeOverflowRule(const Fw::EightyCharString& name)
-            : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+            : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool SerializeOverflowRule::precondition(const MockTypes::CircularState& state) {
@@ -64,7 +64,7 @@ namespace Types {
 
 
     PeekOkRule::PeekOkRule(const Fw::EightyCharString& name)
-            : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+            : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool PeekOkRule::precondition(const MockTypes::CircularState& state) {
@@ -129,7 +129,7 @@ namespace Types {
 
 
     PeekBadRule::PeekBadRule(const Fw::EightyCharString& name)
-            : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+            : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool PeekBadRule::precondition(const MockTypes::CircularState& state) {
@@ -175,7 +175,7 @@ namespace Types {
 
 
     RotateOkRule::RotateOkRule(const Fw::EightyCharString& name)
-            : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+            : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool RotateOkRule::precondition(const MockTypes::CircularState& state) {
@@ -190,7 +190,7 @@ namespace Types {
 
 
     RotateBadRule::RotateBadRule(const Fw::EightyCharString& name)
-            : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+            : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool RotateBadRule::precondition(const MockTypes::CircularState& state) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Cleanup F' string classes

## Rationale

- Moves common functionality to StringBase, preventing code duplication
- Doesn't call the getCapacity virtual function on a class while it's being constructed, preventing clang tidy warnings
- Passing size of other string to function when calling copyBuffer

## Future Work

I wan't able to cleanup the LogStringArg and TlmString classes yet - they both have setMaxSerial methods that are theoretically used for per-telm channel and per-event string truncation, but we should have a discussion about if that functionality is necessary and if there's better ways to accomplish it.