### PR TITLE
Enable AddressSanitizer on CI builds

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -25,6 +25,7 @@ acwrap
 acxz
 addoffset
 addon
+AddressSanitizer
 adminlist
 aeiouy
 afterstatinfo
@@ -598,6 +599,7 @@ fputil
 frontend
 frox
 frsize
+fsanitize
 fscanf
 fstream
 fstrength
@@ -1239,10 +1241,10 @@ Prepends
 prepeneding
 pri
 PRId
-PRIu
 printables
 printf
 println
+PRIu
 prm
 PRMDB
 PRMDBFULL

--- a/Autocoders/Python/test/interface1/UserSerializer.cpp
+++ b/Autocoders/Python/test/interface1/UserSerializer.cpp
@@ -44,8 +44,9 @@ Fw::SerializeStatus UserSerializer::serialize(Fw::SerializeBufferBase& buffer) c
 
 Fw::SerializeStatus UserSerializer::deserialize(Fw::SerializeBufferBase& buffer) {
     NATIVE_UINT_TYPE serSize = sizeof(m_struct);
-    return buffer.deserialize((U8*)&m_struct,serSize);
+    Fw::SerializeStatus stat =  buffer.deserialize((U8*)&m_struct,serSize);
     FW_ASSERT(serSize == sizeof(m_struct));
+    return stat;
 }
 
 

--- a/Autocoders/Python/test/serialize_user/UserSerializer.cpp
+++ b/Autocoders/Python/test/serialize_user/UserSerializer.cpp
@@ -44,8 +44,9 @@ Fw::SerializeStatus UserSerializer::serialize(Fw::SerializeBufferBase& buffer) c
 
 Fw::SerializeStatus UserSerializer::deserialize(Fw::SerializeBufferBase& buffer) {
     NATIVE_UINT_TYPE serSize = sizeof(m_struct);
-    return buffer.deserialize((U8*)&m_struct,serSize);
+    Fw::SerializeStatus stat =  buffer.deserialize((U8*)&m_struct,serSize);
     FW_ASSERT(serSize == sizeof(m_struct));
+    return stat;
 }
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ set(FPRIME_PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Root path of F p
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wno-unused-parameter")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-unused-parameter")
 
+# For this testing cmake project, enable AddressSanitizer, a runtime memory sanitizer, on all unit tests
+set (CMAKE_C_FLAGS_TESTING "${CMAKE_C_FLAGS_TESTING} -fno-omit-frame-pointer -fsanitize=address")
+set (CMAKE_CXX_FLAGS_TESTING "${CMAKE_CXX_FLAGS_TESTING} -fno-omit-frame-pointer -fsanitize=address")
+set (CMAKE_LINKER_FLAGS_TESTING "${CMAKE_LINKER_FLAGS_TESTING} -fno-omit-frame-pointer -fsanitize=address")
+
 # Include the build for F prime.
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/FPrime.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/FPrime-Code.cmake")

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -130,9 +130,9 @@ endif()
 SET(CMAKE_CXX_FLAGS_RELEASE "-std=c++03" CACHE STRING "C++ flags." FORCE)
 SET(CMAKE_C_FLAGS_RELEASE "-std=c99" CACHE STRING "C flags." FORCE)
 # Raise C++ standard to C++11 while unit testing to support googletest
-SET(CMAKE_CXX_FLAGS_TESTING "-std=c++11 -g -DBUILD_UT -DPROTECTED=public -DPRIVATE=public -DSTATIC= -fprofile-arcs -ftest-coverage"
+SET(CMAKE_CXX_FLAGS_TESTING "${CMAKE_CXX_FLAGS_TESTING} -std=c++11 -g -DBUILD_UT -DPROTECTED=public -DPRIVATE=public -DSTATIC= -fprofile-arcs -ftest-coverage"
     CACHE STRING "Testing C++ flags." FORCE)
-SET(CMAKE_C_FLAGS_TESTING "-std=c99 -g -DBUILD_UT -DPROTECTED=public -DPRIVATE=public -DSTATIC= -fprofile-arcs -ftest-coverage"
+SET(CMAKE_C_FLAGS_TESTING "${CMAKE_C_FLAGS_TESTING} -std=c99 -g -DBUILD_UT -DPROTECTED=public -DPRIVATE=public -DSTATIC= -fprofile-arcs -ftest-coverage"
     CACHE STRING "Testing C flags." FORCE)
 SET(CMAKE_EXE_LINKER_FLAGS_TESTING "" CACHE STRING "Testing linker flags." FORCE)
 SET(CMAKE_SHARED_LINKER_FLAGS_TESTING "" CACHE STRING "Testing linker flags." FORCE)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

AddressSanitizer has been built into clang and gcc for some time and tracks out of bounds and use after free accesses. It has some overlap with valgrind, but its ability to track stack out of bounds is a valuable tool and has been a source of F' issues in the past. Comparison with valgrind [here](https://github.com/google/sanitizers/wiki/AddressSanitizerComparisonOfMemoryTools). It has a ~2x runtime performance hit, but in my experience testing locally it was even less than that.

The only people who should be using the root project are F' framework developers and CI, so we should be able to safely enable AddressSanitizer for all unit tests built by the project.


