### PR TITLE
lestarch: fixing defaults for linux drivers (default build)

### DIFF
--- a/Drv/LinuxGpioDriver/CMakeLists.txt
+++ b/Drv/LinuxGpioDriver/CMakeLists.txt
@@ -5,7 +5,7 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
-if(NOT DEFINED FPRIME_USE_STUBBED_DRIVERS OR FPRIME_USE_STUBBED_DRIVERS)
+if(FPRIME_USE_STUBBED_DRIVERS)
     set(SOURCE_FILES
         "${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentAi.xml"
         "${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImplCommon.cpp"

--- a/Drv/LinuxI2cDriver/CMakeLists.txt
+++ b/Drv/LinuxI2cDriver/CMakeLists.txt
@@ -5,7 +5,7 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
-if(NOT DEFINED FPRIME_USE_STUBBED_DRIVERS OR FPRIME_USE_STUBBED_DRIVERS)
+if(FPRIME_USE_STUBBED_DRIVERS)
     add_definitions(-DSTUBBED_LINUX_I2C_DRIVER)
     set(SOURCE_FILES
         "${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriverComponentAi.xml"

--- a/Drv/LinuxSpiDriver/CMakeLists.txt
+++ b/Drv/LinuxSpiDriver/CMakeLists.txt
@@ -5,7 +5,7 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
-if(NOT DEFINED FPRIME_USE_STUBBED_DRIVERS OR FPRIME_USE_STUBBED_DRIVERS)
+if(FPRIME_USE_STUBBED_DRIVERS)
     set(SOURCE_FILES
         "${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentAi.xml"
         "${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImplCommon.cpp"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infra |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The linux drivers were intended to default to operational, but didn't.  This makes the linux drivers (on linux) not be stubbed.
