### PR TITLE
Silence cycle slip event and added cycles between slips telemetry

### DIFF
--- a/Svc/ActiveRateGroup/ActiveRateGroupComponentAi.xml
+++ b/Svc/ActiveRateGroup/ActiveRateGroupComponentAi.xml
@@ -44,6 +44,11 @@
             Cycle slips for rate group
             </comment>
         </channel>
+        <channel id="2" name="RgSlipCycleDelta" data_type="U32" abbrev="S001-002" update="on_change">
+            <comment>
+            Number of cycles between slips, useful for determining a period between slips
+            </comment>
+        </channel>
     </telemetry>
     <events>
         <event id="0" name="RateGroupStarted" severity="DIAGNOSTIC" format_string = "Rate group started." >

--- a/Svc/ActiveRateGroup/ActiveRateGroupImpl.hpp
+++ b/Svc/ActiveRateGroup/ActiveRateGroupImpl.hpp
@@ -53,6 +53,11 @@ namespace Svc {
 
             void init(NATIVE_INT_TYPE queueDepth, NATIVE_INT_TYPE instance);
 
+            //! Call this function to silence the slip WARNING_HI
+            //! Useful when first getting a system up and running without
+            //! flooding the system with EVRs and bringing down GDS
+            void silenceSlipWarning();
+
             //!  \brief ActiveRateGroupImpl destructor
             //!
             //!  The destructor of the class is empty
@@ -105,6 +110,8 @@ namespace Svc {
             NATIVE_UINT_TYPE m_contexts[NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS]; //!< Must match number of output ports
             NATIVE_INT_TYPE m_overrunThrottle; //!< throttle value for overrun events
             U32 m_cycleSlips; //!< tracks number of cycle slips
+            U32 m_prevSlipCycle; //!< Used to calc the cycle delta between slips to telemetry
+            bool m_silenceSlipWarning; //!< Flag to set for silencing the slip WARNING_HI
     };
 
 }


### PR DESCRIPTION

| | |
|:---|:---|
|**_Originating Project/Creator_**| OWLS / bcmetz |
|**_Affected Component_**| Active Rate Group |
|**_Affected Architectures(s)_**| All |
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Added ability to silence the active rate groups cycle slip WARNING_HI event. Beneficial for when bringing up a new system and working all the kinks out without a constant stream of WARNING_HIs that make tracking other events difficult and slows GDS down to a crawl. 

Added a new telemetry channel which publishes the number of cycles between slips as a way to help determine the period of these slip events.

## Rationale

See change desc.

## Testing/Review Recommendations

Tested running locally on laptop and inducing cycle slips. Works as advertised.

## Future Work

None.