### PR TITLE
Automate development setup

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -655,6 +655,7 @@ getuser
 gh
 ghprb
 github
+gitpod
 gjslint
 globals
 gmail
@@ -1230,6 +1231,7 @@ pport
 PQueue
 Prashanth
 prealloc
+prebuilds
 PREDEF
 preds
 pregen

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,30 @@
+tasks:
+  - init: |
+      pip install --upgrade fprime-tools fprime-gds
+      (
+        cd Ref
+        fprime-util generate
+        fprime-util build --jobs "$(nproc || printf '%s\n' 1)"
+      )
+    command: |
+      eval "$(register-python-argcomplete fprime-cli)"
+      fprime-gds -g html -r ./Ref/build-artifacts
+ports:
+  - port: 5000
+    onOpen: open-preview
+github:
+  prebuilds:
+    # enable for the default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: false
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,7 @@
 tasks:
   - init: |
-      pip install --upgrade fprime-tools fprime-gds
+      pip install --upgrade fprime-tools
+      pip install --upgrade fprime-gds
       (
         cd Ref
         fprime-util generate

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ F´ comprises several elements:
 
 To explore F´, you can start a development environment in your browser with the following button:
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mikenikles/fprime/tree/automate-development-setup)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/nasa/fprime)
 
 ### In your local environment
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ F´ comprises several elements:
 
 ## Quick Installation Guide
 
+### In a browser
+
+To explore F´, you can start a development environment in your browser with the following button:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mikenikles/fprime/tree/automate-development-setup)
+
+### In your local environment
+
 The following utilities are prerequisites to installing F´:
 
 - [cmake](https://cmake.org/)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @mikenikles |
|**_Affected Component_**| Development environment |
|**_Affected Architectures(s)_**| N/A |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

This PR introduces a `.gitpod.yml` configuration file to enable ephemeral, browser-based development environments based on www.gitpod.io. It automates the [INSTALL.md](docs/INSTALL.md) instructions and starts the Ref reference application automatically.

## Rationale

To reduce friction and lower the barrier for contributions to this project. The `README.md` file contains a new button for anyone to start a development environment with F´ configured and with the "Ref" Reference Application started automatically.

## Testing/Review Recommendations

Until this PR is merged, please use the following button to test what the development environment experience will be like:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mikenikles/fprime/tree/automate-development-setup)

The above button uses my own branch which has Gitpod Prebuilds configured. See the next session on how to enable that for `nasa/fprime` and why it is beneficial.

## Future Work

In order to get the best experience, the `nasa/fprime` repository will have to [enable Gitpod Prebuilds](https://www.gitpod.io/docs/prebuilds/#on-github) so that the development environment gets built every time there is a new commit pushed to the repository. With that enabled, anyone who starts a new development environment in their browser does not have to wait for any installation tasks to complete since they happened as part of a prebuild phase.
