### PR TITLE
lestarch: fixing Fw::Time to allow comparisons across different time …

### DIFF
--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -161,10 +161,14 @@ namespace Fw {
       )
     {
 #if FW_USE_TIME_BASE
-      FW_ASSERT(time1.getTimeBase() == time2.getTimeBase(), time1.getTimeBase(), time2.getTimeBase() );
+      if (time1.getTimeBase() != time2.getTimeBase()) {
+          return INCOMPARABLE;
+      }
 #endif
 #if FW_USE_TIME_CONTEXT
-      FW_ASSERT(time1.getContext() == time2.getContext(), time1.getContext(), time2.getContext() );
+      if (time1.getContext() != time2.getContext()) {
+          return INCOMPARABLE;
+      }
 #endif
       const U32 s1 = time1.getSeconds();
       const U32 s2 = time2.getSeconds();

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -46,7 +46,8 @@ namespace Fw {
             typedef enum {
               LT = -1,
               EQ = 0,
-              GT = 1
+              GT = 1,
+              INCOMPARABLE = 2
             } Comparison;
 
             //! \return time zero

--- a/Fw/Time/test/ut/TimeTest.cpp
+++ b/Fw/Time/test/ut/TimeTest.cpp
@@ -90,7 +90,7 @@ TEST(TimeTestNominal,CopyTest) {
 }
 
 TEST(TimeTestNominal,ZeroTimeEquality) {
-    Fw::Time time(TB_DONT_CARE,1,2);
+    Fw::Time time(TB_PROC_TIME,1,2);
     ASSERT_NE(time, Fw::ZERO_TIME);
     Fw::Time time2;
     ASSERT_EQ(time2, Fw::ZERO_TIME);

--- a/Fw/Time/test/ut/TimeTest.cpp
+++ b/Fw/Time/test/ut/TimeTest.cpp
@@ -89,6 +89,13 @@ TEST(TimeTestNominal,CopyTest) {
 
 }
 
+TEST(TimeTestNominal,ZeroTimeEquality) {
+    Fw::Time time(TB_DONT_CARE,1,2);
+    ASSERT_NE(time, Fw::ZERO_TIME);
+    Fw::Time time2;
+    ASSERT_EQ(time2, Fw::ZERO_TIME);
+}
+
 int main(int argc, char* argv[]) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
…bases

| | |
|:---|:---|
|**_Originating Project/Creator_**| Infra |
|**_Affected Component_**| Fw::Time |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n/a |

---
## Change Description

Fw::Time doesn't assert when comparing across time bases, but returns INCOMPARABLE instead.  This allows comparing against ZERO_TIME.

## Rationale

Comparisons shouldn't crash the system. They should fail instead.

## Future Work

Look into add and subtract methods.  These are left for future work as it is less clear what to do in this case.