### PR TITLE
Correct LGTM query selection

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -11,12 +11,13 @@ path_classifiers:
     docs:
       - docs
 queries:
-  - include: cpp/incorrect-not-operator-usage
-  - include:
-      tags:
-        - "correctness"
-        - "reliability"
-
+    - include: cpp/incorrect-not-operator-usage
+    - include:
+        tags:
+            - "correctness"
+    - include:
+        tags:
+            - "reliability"
 extraction:
     cpp:
         prepare:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This existing config selected queries tagged correctness AND reliability. I intended to select all queries tagged correctness OR reliability.

Unfortunately LGTM config only applies after being merged, so there's no great way to test this besides trial and error.
