### PR TITLE
Remove unnecessary usages of PRIVATE macro

### DIFF
--- a/Autocoders/Python/test/array_xml/test/ut/main.cpp
+++ b/Autocoders/Python/test/array_xml/test/ut/main.cpp
@@ -50,7 +50,7 @@ void dumpobj(const char* objName) {
 
 void constructArchitecture(void) {
     Fw::PortBase::setTrace(true);
-    
+
     simpleReg_ptr = new Fw::SimpleObjRegistry();
 
     dumparch();
@@ -59,7 +59,7 @@ void constructArchitecture(void) {
 int main(int argc, char* argv[]) {
     // Construct the topology here.
     constructArchitecture();
-    
+
     setbuf(stdout, NULL);
 
     cout << "Initialize Arrays" << endl;
@@ -91,22 +91,22 @@ int main(int argc, char* argv[]) {
     cout << "Serialize arrays" << endl;
     U8 buffer1[1024];
     U8 buffer2[1024];
-    
-    Fw::SerialBuffer arraySerial1 = Fw::SerialBuffer(buffer1, sizeof(buffer1));
-    Fw::SerialBuffer arraySerial2 = Fw::SerialBuffer(buffer2, sizeof(buffer2));
-    
+
+    Fw::SerialBuffer arraySerial1(buffer1, sizeof(buffer1));
+    Fw::SerialBuffer arraySerial2(buffer2, sizeof(buffer2));
+
     if (arraySerial1.serialize(array1) != Fw::FW_SERIALIZE_OK) {
         cout << "ERROR: bad serialization array1." << endl;
     } else {
         cout << "Serialized array1" << endl;
     }
-                
+
     if (arraySerial2.serialize(array2) != Fw::FW_SERIALIZE_OK) {
         cout << "ERROR: bad serialization array2." << endl;
     } else {
         cout << "Serialized array2" << endl;
     }
-                
+
     cout << "Serialized arrays" << endl;
 
 
@@ -125,7 +125,7 @@ int main(int argc, char* argv[]) {
     } else {
         cout << "Deserialized array2" << endl;
     }
-            
+
     cout << "Deserialized arrays" << endl;
 
     if (array1 != array1Save) {
@@ -138,7 +138,7 @@ int main(int argc, char* argv[]) {
     } else {
         cout << "Successful array2 check" << endl;
     }
-            
+
     // Create serializable
     int integer1 = 100;
     int integer2 = 10000;
@@ -147,17 +147,17 @@ int main(int argc, char* argv[]) {
     serial1.setMember2(integer2);
     serial1.setMember3(array1);
     serial1.setMember4(array3);
-            
+
     cout << "Invoked ports" << endl;
 
     cout << "Quitting..." << endl;
-    
+
     cout << "Deleting components..." << endl;
     delete inst1;
     delete inst2;
     cout << "Delete registration objects..." << endl;
     delete simpleReg_ptr;
     cout << "Completed..." << endl;
-    
+
     return 0;
 }

--- a/Autocoders/Python/test/command2/TestCommandComponentImpl.hpp
+++ b/Autocoders/Python/test/command2/TestCommandComponentImpl.hpp
@@ -48,7 +48,7 @@ namespace AcTest {
       //!
       ~TestCommandComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -62,8 +62,6 @@ namespace AcTest {
           F32 arg5, /*!< The second argument*/
           U8 arg6 /*!< The third argument*/
       );
-
-    PRIVATE:
 
       // ----------------------------------------------------------------------
       // Command handler implementations

--- a/Autocoders/Python/test/command_res/Test1ComponentImpl.hpp
+++ b/Autocoders/Python/test/command_res/Test1ComponentImpl.hpp
@@ -48,7 +48,7 @@ namespace Cmd {
       //!
       ~Test1ComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -62,8 +62,6 @@ namespace Cmd {
           F32 arg5, /*!< The second argument*/
           U8 arg6 /*!< The third argument*/
       );
-
-    PRIVATE:
 
       // ----------------------------------------------------------------------
       // Command handler implementations

--- a/Autocoders/Python/test/enum_xml/build
+++ b/Autocoders/Python/test/enum_xml/build
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-fprime-util build --ut $@

--- a/Autocoders/Python/test/enum_xml/main.cpp
+++ b/Autocoders/Python/test/enum_xml/main.cpp
@@ -209,8 +209,8 @@ TEST(EnumXML, OK) {
     // Serialize enums
     U8 buffer1[1024];
     U8 buffer2[1024];
-    Fw::SerialBuffer enumSerial1 = Fw::SerialBuffer(buffer1, sizeof(buffer1));
-    Fw::SerialBuffer enumSerial2 = Fw::SerialBuffer(buffer2, sizeof(buffer2));
+    Fw::SerialBuffer enumSerial1(buffer1, sizeof(buffer1));
+    Fw::SerialBuffer enumSerial2(buffer2, sizeof(buffer2));
     ASSERT_EQ(enumSerial1.serialize(enum1), Fw::FW_SERIALIZE_OK);
     cout << "Serialized enum1" << endl;
 

--- a/Autocoders/Python/test/noargport/ExampleComponentImpl.hpp
+++ b/Autocoders/Python/test/noargport/ExampleComponentImpl.hpp
@@ -44,7 +44,7 @@ namespace ExampleComponents {
       //!
       ~ExampleComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports

--- a/Autocoders/Python/test/port_loopback/ExampleComponentImpl.hpp
+++ b/Autocoders/Python/test/port_loopback/ExampleComponentImpl.hpp
@@ -49,7 +49,7 @@ namespace ExampleComponents {
 
       void makePortCall(NATIVE_INT_TYPE port);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports

--- a/Autocoders/Python/test/serial_passive/TestSerialImpl.hpp
+++ b/Autocoders/Python/test/serial_passive/TestSerialImpl.hpp
@@ -49,7 +49,7 @@ namespace TestComponents {
       //!
       ~TestSerialImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined serial input ports

--- a/Autocoders/Python/test/testgen/MathSenderComponentImpl.hpp
+++ b/Autocoders/Python/test/testgen/MathSenderComponentImpl.hpp
@@ -48,7 +48,7 @@ namespace Ref {
       //!
       ~MathSenderComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -60,8 +60,6 @@ namespace Ref {
           const NATIVE_INT_TYPE portNum, /*!< The port number*/
           F32 result /*!< the result of the operation*/
       );
-
-    PRIVATE:
 
       // ----------------------------------------------------------------------
       // Command handler implementations

--- a/CFDP/Checksum/Checksum.hpp
+++ b/CFDP/Checksum/Checksum.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  CFDP/Checksum/Checksum.hpp
 // \author bocchino
 // \brief  hpp file for CFDP checksum class
@@ -7,8 +7,8 @@
 // Copyright 2009-2016, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef CFDP_Checksum_HPP
 #define CFDP_Checksum_HPP
@@ -18,20 +18,20 @@
 namespace CFDP {
 
   //! \class Checksum
-  //! \brief Class representing a CFDP checksum 
+  //! \brief Class representing a CFDP checksum
   //!
   class Checksum {
 
     public:
 
       // ----------------------------------------------------------------------
-      // Types 
+      // Types
       // ----------------------------------------------------------------------
 
     public:
 
       // ----------------------------------------------------------------------
-      // Construction and destruction 
+      // Construction and destruction
       // ----------------------------------------------------------------------
 
       //! Construct a fresh Checksum object
@@ -48,9 +48,9 @@ namespace CFDP {
 
     public:
 
-      // ---------------------------------------------------------------------- 
+      // ----------------------------------------------------------------------
       // Public instance methods
-      // ---------------------------------------------------------------------- 
+      // ----------------------------------------------------------------------
 
       //! Assign checksum to this
       const Checksum& operator=(const Checksum& checksum);
@@ -71,10 +71,10 @@ namespace CFDP {
       //! Get the checksum value
       U32 getValue(void) const;
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
-      // Private instance methods 
+      // Private instance methods
       // ----------------------------------------------------------------------
 
       //! Add a four-byte aligned word to the checksum value
@@ -95,10 +95,8 @@ namespace CFDP {
           const U8 offset //! The offset
       );
 
-    PRIVATE:
-
       // ----------------------------------------------------------------------
-      // Private member variables 
+      // Private member variables
       // ----------------------------------------------------------------------
 
       //! The accumulated checksum value

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.hpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.hpp
@@ -60,7 +60,7 @@ namespace Drv {
       //! exit thread
       void exitThread(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports

--- a/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImpl.hpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriverComponentImpl.hpp
@@ -42,7 +42,7 @@ namespace Drv {
       //!
       ~LinuxI2cDriverComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -52,16 +52,16 @@ namespace Drv {
       //!
       I2cStatus write_handler(
           const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          U32 addr, 
-          Fw::Buffer &serBuffer 
+          U32 addr,
+          Fw::Buffer &serBuffer
       );
 
       //! Handler implementation for read
       //!
       I2cStatus read_handler(
           const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          U32 addr, 
-          Fw::Buffer &serBuffer 
+          U32 addr,
+          Fw::Buffer &serBuffer
       );
 
       //! Handler implementation for writeRead

--- a/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.hpp
+++ b/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.hpp
@@ -79,7 +79,7 @@ namespace Drv {
       //!
       ~LinuxSerialDriverComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
@@ -61,7 +61,7 @@ namespace Drv {
                       NATIVE_INT_TYPE select,
                       SpiFrequency clock);
 
-        PRIVATE:
+        private:
 
             // ----------------------------------------------------------------------
             // Handler implementations for user-defined typed input ports

--- a/Drv/SocketIpDriver/SocketHelper.hpp
+++ b/Drv/SocketIpDriver/SocketHelper.hpp
@@ -35,7 +35,7 @@ namespace Drv {
             SocketIpStatus recv(U8* data, I32 &size);
             void close(void);
 
-        PRIVATE:
+        private:
 
             SocketIpStatus openProtocol(NATIVE_INT_TYPE protocol, bool isInput = true);
 

--- a/Drv/SocketIpDriver/SocketIpDriverComponentImpl.hpp
+++ b/Drv/SocketIpDriver/SocketIpDriverComponentImpl.hpp
@@ -81,7 +81,7 @@ namespace Drv {
               NATIVE_INT_TYPE cpuAffinity = -1 //!< CPU affinity of the task to start
       );
 
-      //! Task to join nondetached pthreads 
+      //! Task to join nondetached pthreads
       //!
       Os::Task::TaskStatus joinSocketTask(void** value_ptr);
 
@@ -89,7 +89,7 @@ namespace Drv {
       //!
       void exitSocketTask();
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -99,7 +99,7 @@ namespace Drv {
       //!
       void send_handler(
           const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          Fw::Buffer &fwBuffer 
+          Fw::Buffer &fwBuffer
       );
 
       // socket helper instance

--- a/Drv/TcpClient/TcpClientComponentImpl.hpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.hpp
@@ -103,7 +103,7 @@ class TcpClientComponentImpl : public ByteStreamDriverModelComponentBase, public
      */
     void sendBuffer(Fw::Buffer buffer, SocketIpStatus status);
 
-  PRIVATE:
+  private:
 
     // ----------------------------------------------------------------------
     // Handler implementations for user-defined typed input ports

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -123,7 +123,7 @@ class TcpServerComponentImpl : public ByteStreamDriverModelComponentBase, public
      */
     void sendBuffer(Fw::Buffer buffer, SocketIpStatus status);
 
-  PRIVATE:
+  private:
 
     // ----------------------------------------------------------------------
     // Handler implementations for user-defined typed input ports

--- a/Drv/Udp/UdpComponentImpl.hpp
+++ b/Drv/Udp/UdpComponentImpl.hpp
@@ -123,7 +123,7 @@ class UdpComponentImpl : public ByteStreamDriverModelComponentBase, public Socke
      */
     void sendBuffer(Fw::Buffer buffer, SocketIpStatus status);
 
-  PRIVATE:
+  private:
 
     // ----------------------------------------------------------------------
     // Handler implementations for user-defined typed input ports

--- a/Fw/Buffer/Buffer.hpp
+++ b/Fw/Buffer/Buffer.hpp
@@ -159,7 +159,7 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const Buffer& obj);
 #endif
 
-PRIVATE:
+private:
     Fw::ExternalSerializeBuffer m_serialize_repr; //<! Representation for serialization and deserialization functions
     U8* m_data; //<! data - A pointer to the data
     U32 m_size; //<! size - The data size in bytes

--- a/Fw/Buffer/test/ut/TestBuffer.cpp
+++ b/Fw/Buffer/test/ut/TestBuffer.cpp
@@ -11,7 +11,7 @@ void test_basic() {
     U8 faux[100];
     Fw::Buffer buffer;
     // Check basic guarantees
-    ASSERT_EQ(buffer.m_context, Fw::Buffer::NO_CONTEXT);
+    ASSERT_EQ(buffer.getContext(), Fw::Buffer::NO_CONTEXT);
     buffer.setData(data);
     buffer.setSize(sizeof(data));
     buffer.setContext(1234);
@@ -109,7 +109,7 @@ void test_serialization() {
 
     Fw::ExternalSerializeBuffer externalSerializeBuffer(wire, sizeof(wire));
     externalSerializeBuffer.serialize(buffer);
-    ASSERT_LT(externalSerializeBuffer.m_serLoc, sizeof(data));
+    ASSERT_LT(externalSerializeBuffer.getBuffLength(), sizeof(data));
 
     Fw::Buffer buffer_new;
     externalSerializeBuffer.deserialize(buffer_new);

--- a/Fw/Comp/ActiveComponentBase.hpp
+++ b/Fw/Comp/ActiveComponentBase.hpp
@@ -27,7 +27,7 @@ namespace Fw {
                 ACTIVE_COMPONENT_EXIT //!< message to exit active component task
             };
 
-        PROTECTED:
+        protected:
             ActiveComponentBase(const char* name); //!< Constructor
             virtual ~ActiveComponentBase(); //!< Destructor
             void init(NATIVE_INT_TYPE instance); //!< initialization code
@@ -38,7 +38,7 @@ namespace Fw {
 #if FW_OBJECT_TO_STRING == 1
             virtual void toString(char* str, NATIVE_INT_TYPE size); //!< create string description of component
 #endif
-        PRIVATE:
+        private:
             static void s_baseTask(void*); //!< function provided to task class for new thread.
             static void s_baseBareTask(void*); //!< function provided to task class for new thread.
     };

--- a/Fw/Comp/PassiveComponentBase.hpp
+++ b/Fw/Comp/PassiveComponentBase.hpp
@@ -16,8 +16,8 @@ namespace Fw {
             //! Get the ID base
             //! \return The ID base
             U32 getIdBase(void) const;
-            
-        PROTECTED:
+
+        protected:
             PassiveComponentBase(const char* name); //!< Named constructor
             virtual ~PassiveComponentBase(); //!< Destructor
             void init(NATIVE_INT_TYPE instance); //!< Initialization function
@@ -25,7 +25,7 @@ namespace Fw {
 #if FW_OBJECT_TO_STRING == 1
             virtual void toString(char* str, NATIVE_INT_TYPE size); //!< returns string description of component
 #endif
-        PRIVATE:
+        private:
             U32 m_idBase; //!< ID base for opcodes etc.
             NATIVE_INT_TYPE m_instance; //!< instance of component object
 

--- a/Fw/FilePacket/FilePacket.hpp
+++ b/Fw/FilePacket/FilePacket.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  FilePacket.hpp
 // \author bocchino
 // \brief  hpp file for FilePacket
@@ -7,8 +7,8 @@
 // Copyright 2009-2016, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef Fw_FilePacket_HPP
 #define Fw_FilePacket_HPP
@@ -51,15 +51,11 @@ namespace Fw {
           //! The maximum length of a path name
           enum { MAX_LENGTH = 255 };
 
-        public:
-          
           //! The length
           U8 length;
 
           //! Pointer to the path value
           const char *value;
-
-        public:
 
           //! Initialize a PathName
           void initialize(
@@ -69,7 +65,7 @@ namespace Fw {
           //! Compute the buffer size needed to hold this PathName
           U32 bufferSize(void) const;
 
-        PRIVATE:
+        private:
 
           //! Initialize this PathName from a SerialBuffer
           SerializeStatus fromSerialBuffer(SerialBuffer& serialBuffer);
@@ -91,11 +87,9 @@ namespace Fw {
 
           //! The sequence index
           U32 sequenceIndex;
-          
+
           //! Header size
           enum { HEADERSIZE = sizeof(U8) + sizeof(U32) };
-
-        PRIVATE:
 
           //! Initialize a file packet header
           void initialize(
@@ -105,6 +99,8 @@ namespace Fw {
 
           //! Compute the buffer size needed to hold this Header
           U32 bufferSize(void) const;
+
+        private:
 
           //! Initialize this Header from a SerialBuffer
           SerializeStatus fromSerialBuffer(SerialBuffer& serialBuffer);
@@ -133,8 +129,6 @@ namespace Fw {
           //! The destination path
           PathName destinationPath;
 
-        public:
-
           //! Initialize a StartPacket with sequence number 0
           void initialize(
               const U32 fileSize, //!< The file size
@@ -148,7 +142,7 @@ namespace Fw {
           //! Convert this StartPacket to a Buffer
           SerializeStatus toBuffer(Buffer& buffer) const;
 
-        PRIVATE:
+        private:
 
           //! Initialize this StartPacket from a SerialBuffer
           SerializeStatus fromSerialBuffer(SerialBuffer& serialBuffer);
@@ -182,9 +176,6 @@ namespace Fw {
               sizeof(U32) +
               sizeof(U16) };
 
-
-        public:
-
           //! Initialize a data packet
           void initialize(
               const U32 sequenceIndex, //!< The sequence index
@@ -199,14 +190,14 @@ namespace Fw {
           //! Convert this DataPacket to a Buffer
           SerializeStatus toBuffer(Buffer& buffer) const;
 
-        PRIVATE:
+        private:
 
           //! Initialize this DataPacket from a SerialBuffer
           SerializeStatus fromSerialBuffer(SerialBuffer& serialBuffer);
 
           //! Compute the fixed-length data size of a StartPacket
           U32 fixedLengthSize(void) const;
-          
+
           //! Write this DataPacket to a SerialBuffer
           SerializeStatus toSerialBuffer(SerialBuffer& serialBuffer) const;
 
@@ -234,15 +225,13 @@ namespace Fw {
           //! Convert this EndPacket to a Buffer
           SerializeStatus toBuffer(Buffer& buffer) const;
 
-        public:
-          
           //! Initialize an end packet
           void initialize(
               const U32 sequenceIndex, //!< The sequence index
               const CFDP::Checksum& checksum //!< The checksum
           );
 
-        PRIVATE:
+        private:
 
           //! The checksum
           U32 checksumValue;
@@ -265,8 +254,6 @@ namespace Fw {
           //! The packet header
           Header header;
 
-        public:
-
           //! Initialize a cancel packet
           void initialize(
               const U32 sequenceIndex //!< The sequence index
@@ -278,7 +265,7 @@ namespace Fw {
           //! Convert this CancelPacket to a Buffer
           SerializeStatus toBuffer(Buffer& buffer) const;
 
-        PRIVATE:
+        private:
 
           //! Initialize this CancelPacket from a SerialBuffer
           SerializeStatus fromSerialBuffer(SerialBuffer& serialBuffer);
@@ -292,8 +279,6 @@ namespace Fw {
       // ----------------------------------------------------------------------
 
       FilePacket(void) { this->header.type = T_NONE; }
-
-    public:
 
       // ----------------------------------------------------------------------
       // Public instance methods
@@ -347,7 +332,7 @@ namespace Fw {
       //!
       SerializeStatus toBuffer(Buffer& buffer) const;
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Private methods
@@ -357,10 +342,8 @@ namespace Fw {
       //!
       SerializeStatus fromSerialBuffer(SerialBuffer& serialBuffer);
 
-    PRIVATE:
-
       // ----------------------------------------------------------------------
-      // Private data 
+      // Private data
       // ----------------------------------------------------------------------
 
       //! this, seen as a header

--- a/Fw/FilePacket/test/ut/Main.cpp
+++ b/Fw/FilePacket/test/ut/Main.cpp
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------
-// Main.cpp 
+// Main.cpp
 // ----------------------------------------------------------------------
 
 #include <gtest/gtest.h>
@@ -10,33 +10,6 @@
 #include <Fw/Types/Assert.hpp>
 
 namespace Fw {
-
-  // Serialize and deserialize a file packet header
-  TEST(FilePacket, Header) {
-    const FilePacket::Header expected = {
-      FilePacket::T_DATA, // Packet type
-      10 // Sequence number
-    };
-    const U32 size = expected.bufferSize();
-    U8 bytes[size];
-    SerialBuffer serialBuffer(bytes, size);
-    {
-      const SerializeStatus status = 
-        expected.toSerialBuffer(serialBuffer);
-      FW_ASSERT(status == FW_SERIALIZE_OK);
-    }
-    FilePacket::Header actual;
-    {
-      const SerializeStatus status = 
-        actual.fromSerialBuffer(serialBuffer);
-      FW_ASSERT(status == FW_SERIALIZE_OK);
-    }
-    GTest::FilePackets::Header::compare(
-        expected, 
-        actual
-    );
-  }
-
 
   // Serialize and deserialize a start packet
   TEST(FilePacket, StartPacket) {
@@ -51,20 +24,20 @@ namespace Fw {
     Buffer buffer(bytes, size);
     SerialBuffer serialBuffer(bytes, size);
     {
-      const SerializeStatus status = 
+      const SerializeStatus status =
         expected.toBuffer(buffer);
       ASSERT_EQ(status, FW_SERIALIZE_OK);
     }
     FilePacket actual;
     {
-      const SerializeStatus status = 
+      const SerializeStatus status =
         actual.fromBuffer(buffer);
       ASSERT_EQ(status, FW_SERIALIZE_OK);
     }
     const FilePacket::StartPacket& actualStartPacket =
       actual.asStartPacket();
     GTest::FilePackets::StartPacket::compare(
-        expected, 
+        expected,
         actualStartPacket
     );
   }
@@ -85,20 +58,20 @@ namespace Fw {
     Buffer buffer(bytes, size);
     SerialBuffer serialBuffer(bytes, size);
     {
-      const SerializeStatus status = 
+      const SerializeStatus status =
         expected.toBuffer(buffer);
       FW_ASSERT(status == FW_SERIALIZE_OK);
     }
     FilePacket actual;
     {
-      const SerializeStatus status = 
+      const SerializeStatus status =
         actual.fromBuffer(buffer);
       FW_ASSERT(status == FW_SERIALIZE_OK);
     }
     const FilePacket::DataPacket& actualDataPacket =
       actual.asDataPacket();
     GTest::FilePackets::DataPacket::compare(
-        expected, 
+        expected,
         actualDataPacket
     );
   }
@@ -116,20 +89,20 @@ namespace Fw {
     Buffer buffer(bytes, size);
     SerialBuffer serialBuffer(bytes, size);
     {
-      const SerializeStatus status = 
+      const SerializeStatus status =
         expected.toBuffer(buffer);
       FW_ASSERT(status == FW_SERIALIZE_OK);
     }
     FilePacket actual;
     {
-      const SerializeStatus status = 
+      const SerializeStatus status =
         actual.fromBuffer(buffer);
       FW_ASSERT(status == FW_SERIALIZE_OK);
     }
     const FilePacket::EndPacket& actualEndPacket =
       actual.asEndPacket();
     GTest::FilePackets::EndPacket::compare(
-        expected, 
+        expected,
         actualEndPacket
     );
   }
@@ -146,20 +119,20 @@ namespace Fw {
     Buffer buffer(bytes, size);
     SerialBuffer serialBuffer(bytes, size);
     {
-      const SerializeStatus status = 
+      const SerializeStatus status =
         expected.toBuffer(buffer);
       FW_ASSERT(status == FW_SERIALIZE_OK);
     }
     FilePacket actual;
     {
-      const SerializeStatus status = 
+      const SerializeStatus status =
         actual.fromBuffer(buffer);
       FW_ASSERT(status == FW_SERIALIZE_OK);
     }
     const FilePacket::CancelPacket& actualCancelPacket =
       actual.asCancelPacket();
     GTest::FilePackets::CancelPacket::compare(
-        expected, 
+        expected,
         actualCancelPacket
     );
   }

--- a/Fw/Logger/test/ut/LoggerRules.cpp
+++ b/Fw/Logger/test/ut/LoggerRules.cpp
@@ -17,7 +17,7 @@
 namespace LoggerRules {
 
     // Constructor
-    Register::Register(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.m_buf) {}
+    Register::Register(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
 
     // Check for registration, always allowed
     bool Register::precondition(const MockLogging::FakeLogger& truth) {
@@ -40,7 +40,7 @@ namespace LoggerRules {
     }
 
     // Constructor
-    LogGood::LogGood(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.m_buf) {}
+    LogGood::LogGood(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
 
     // Check for logging, only when not NULL
     bool LogGood::precondition(const MockLogging::FakeLogger& truth) {
@@ -113,7 +113,7 @@ namespace LoggerRules {
     }
 
     // Constructor
-    LogBad::LogBad(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.m_buf) {}
+    LogBad::LogBad(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
 
     // Check for logging, only when not NULL
     bool LogBad::precondition(const MockLogging::FakeLogger& truth) {

--- a/Fw/SerializableFile/SerializableFile.hpp
+++ b/Fw/SerializableFile/SerializableFile.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  SerializableFile.hpp
 // \author dinkel
 // \brief  hpp file for SerializableFile
@@ -7,8 +7,8 @@
 // Copyright 2009-2016, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef Fw_SerializableFile_HPP
 #define Fw_SerializableFile_HPP
@@ -23,27 +23,27 @@ namespace Fw {
   class SerializableFile {
 
     public:
-    enum Status {
-      OP_OK,
-      FILE_OPEN_ERROR,
-      FILE_WRITE_ERROR,
-      FILE_READ_ERROR,
-      DESERIALIZATION_ERROR
-    };
+      enum Status {
+        OP_OK,
+        FILE_OPEN_ERROR,
+        FILE_WRITE_ERROR,
+        FILE_READ_ERROR,
+        DESERIALIZATION_ERROR
+      };
 
-    // NOTE!: This should not be used with an allocator that can return a smaller buffer than requested
-    SerializableFile(MemAllocator* allocator, NATIVE_UINT_TYPE maxSerializedSize);
-    ~SerializableFile();
-    
-    Status load(const char* fileName, Serializable& serializable);
-    Status save(const char* fileName, Serializable& serializable);
+      // NOTE!: This should not be used with an allocator that can return a smaller buffer than requested
+      SerializableFile(MemAllocator* allocator, NATIVE_UINT_TYPE maxSerializedSize);
+      ~SerializableFile();
 
-    PRIVATE:
-    void reset();
-    MemAllocator* allocator;
-    bool recoverable; // don't care; for allocator
-    NATIVE_UINT_TYPE actualSize; // for checking
-    SerialBuffer buffer;
+      Status load(const char* fileName, Serializable& serializable);
+      Status save(const char* fileName, Serializable& serializable);
+
+    private:
+      void reset();
+      MemAllocator* allocator;
+      bool recoverable; // don't care; for allocator
+      NATIVE_UINT_TYPE actualSize; // for checking
+      SerialBuffer buffer;
   };
 }
 

--- a/Fw/Test/String.hpp
+++ b/Fw/Test/String.hpp
@@ -29,7 +29,7 @@ namespace Test {
             Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const; //!< serialization function
             Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer); //!< deserialization function
 
-        PRIVATE:
+        private:
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -79,7 +79,7 @@ namespace Fw {
 #ifdef BUILD_UT // Stream operators to support Googletest
             friend std::ostream& operator<<(std::ostream& os,  const Time& val);
 #endif
-        PRIVATE:
+        private:
             U32 m_seconds; // !< seconds portion
             U32 m_useconds; // !< microseconds portion
             TimeBase m_timeBase; // !< basis of time (defined by system)

--- a/Fw/Time/test/ut/TimeTest.cpp
+++ b/Fw/Time/test/ut/TimeTest.cpp
@@ -12,10 +12,10 @@
 TEST(TimeTestNominal,InstantiateTest) {
 
     Fw::Time time(TB_NONE,1,2);
-    ASSERT_EQ(time.m_timeBase,TB_NONE);
-    ASSERT_EQ(time.m_timeContext,0);
-    ASSERT_EQ(time.m_seconds,1);
-    ASSERT_EQ(time.m_useconds,2);
+    ASSERT_EQ(time.getTimeBase(),TB_NONE);
+    ASSERT_EQ(time.getContext(),0);
+    ASSERT_EQ(time.getSeconds(),1);
+    ASSERT_EQ(time.getUSeconds(),2);
     std::cout << time << std::endl;
 }
 
@@ -36,19 +36,19 @@ TEST(TimeTestNominal,MathTest) {
 
     // normal subtract
     Fw::Time time3 = Fw::Time::sub(time2,time1);
-    ASSERT_EQ(time3.m_timeBase,TB_NONE);
-    ASSERT_EQ(time3.m_timeContext,0);
-    ASSERT_EQ(time3.m_seconds,3000);
-    ASSERT_EQ(time3.m_useconds,1000);
+    ASSERT_EQ(time3.getTimeBase(),TB_NONE);
+    ASSERT_EQ(time3.getContext(),0);
+    ASSERT_EQ(time3.getSeconds(),3000);
+    ASSERT_EQ(time3.getUSeconds(),1000);
 
     // rollover subtract
     time1.set(1,999999);
     time2.set(2,000001);
     time3 = Fw::Time::sub(time2,time1);
-    ASSERT_EQ(time3.m_timeBase,TB_NONE);
-    ASSERT_EQ(time3.m_timeContext,0);
-    EXPECT_EQ(time3.m_seconds,0);
-    EXPECT_EQ(time3.m_useconds,2);
+    ASSERT_EQ(time3.getTimeBase(),TB_NONE);
+    ASSERT_EQ(time3.getContext(),0);
+    EXPECT_EQ(time3.getSeconds(),0);
+    EXPECT_EQ(time3.getUSeconds(),2);
 
 }
 

--- a/Fw/Tlm/TlmBuffer.hpp
+++ b/Fw/Tlm/TlmBuffer.hpp
@@ -36,7 +36,7 @@ namespace Fw {
             U8* getBuffAddr(void);
             const U8* getBuffAddr(void) const;
 
-        PRIVATE:
+        private:
             U8 m_data[FW_TLM_BUFFER_MAX_SIZE]; // command argument buffer
     };
 

--- a/Fw/Tlm/TlmString.hpp
+++ b/Fw/Tlm/TlmString.hpp
@@ -33,7 +33,7 @@ namespace Fw {
 #if FW_SERIALIZABLE_TO_STRING
             void toString(StringBase& text) const;
 #endif
-        PRIVATE:
+        private:
             NATIVE_UINT_TYPE getCapacity(void) const ;
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Types/EightyCharString.hpp
+++ b/Fw/Types/EightyCharString.hpp
@@ -29,7 +29,7 @@ namespace Fw {
             SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
             SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
 
-        PRIVATE:
+        private:
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Types/FixedLengthString.hpp
+++ b/Fw/Types/FixedLengthString.hpp
@@ -29,7 +29,7 @@ namespace Fw {
             SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
             SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
 
-        PRIVATE:
+        private:
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Types/InternalInterfaceString.hpp
+++ b/Fw/Types/InternalInterfaceString.hpp
@@ -29,7 +29,7 @@ namespace Fw {
             SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
             SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
 
-        PRIVATE:
+        private:
             NATIVE_UINT_TYPE getCapacity(void) const ; //!< return buffer size
             void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
 

--- a/Fw/Types/PolyType.hpp
+++ b/Fw/Types/PolyType.hpp
@@ -36,7 +36,7 @@ namespace Fw {
             void get(I16& val); //!< I16 accessor
             bool isI16(void); //!< I16 checker
             PolyType& operator=(I16 val); //!< I16 operator=
-#endif            
+#endif
 #if FW_HAS_32_BIT
             PolyType(U32 val); //!< U32 constructor
             operator U32(); //!< U32 cast operator
@@ -108,7 +108,7 @@ namespace Fw {
             SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< Serialize function
             SerializeStatus deserialize(SerializeBufferBase& buffer); //!< Deserialize function
 
-        PRIVATE:
+        private:
 
             typedef enum {
                 TYPE_NOTYPE, // !< No type stored yet
@@ -138,7 +138,7 @@ namespace Fw {
 #if FW_HAS_32_BIT
                     U32 u32Val; //!< U32 data storage
                     I32 i32Val; //!< I32 data storage
-#endif                    
+#endif
 #if FW_HAS_64_BIT
                     U64 u64Val; //!< U64 data storage
                     I64 i64Val; //!< I64 data storage

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -137,11 +137,11 @@ namespace Fw {
             bool operator==(const SerializeBufferBase& other) const;
             friend std::ostream& operator<<(std::ostream& os, const SerializeBufferBase& buff);
 #endif
-        PROTECTED:
+        protected:
 
             SerializeBufferBase(); //!< default constructor
 
-        PRIVATE:
+        private:
             // A no-implementation copy constructor here will prevent the default copy constructor from being called
             // accidentally, and without an implementation it will create an error for the developer instead.
             SerializeBufferBase(const SerializeBufferBase &src); //!< constructor with buffer as source
@@ -165,7 +165,7 @@ namespace Fw {
             U8* getBuffAddr(void);
             const U8* getBuffAddr(void) const ;
 
-        PRIVATE:
+        private:
 
             // no copying
             ExternalSerializeBuffer(ExternalSerializeBuffer& other);

--- a/Fw/Types/StringType.hpp
+++ b/Fw/Types/StringType.hpp
@@ -51,7 +51,7 @@ namespace Fw {
             virtual ~StringBase(void);
             virtual NATIVE_UINT_TYPE getCapacity(void) const = 0; //!< return size of buffer
 
-        PRIVATE:
+        private:
             // A no-implementation copy constructor here will prevent the default copy constructor from being called
             // accidentally, and without an implementation it will create an error for the developer instead.
             StringBase(const StringBase &src); //!< constructor with buffer as source

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -58,10 +58,10 @@ TEST(SerializationTest,Serialization1) {
     stat1 = buff.serialize(u8t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
     ASSERT_EQ(0xAB,ptr[0]);
-    ASSERT_EQ(1,buff.m_serLoc);
+    ASSERT_EQ(1,buff.getBuffLength());
     stat2 = buff.deserialize(u8t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(1,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
     ASSERT_EQ(u8t2,u8t1);
 
@@ -72,25 +72,21 @@ TEST(SerializationTest,Serialization1) {
 #endif
 
     buff.resetSer();
-    ASSERT_EQ(0,buff.m_serLoc);
-    ASSERT_EQ(0,buff.m_deserLoc);
 
     I8 i8t1 = 0xFF;
     I8 i8t2 = 0;
 
     stat1 = buff.serialize(i8t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(1,buff.m_serLoc);
+    ASSERT_EQ(1,buff.getBuffLength());
     ASSERT_EQ(0xFF,ptr[0]);
     stat2 = buff.deserialize(i8t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
     ASSERT_EQ(i8t1,i8t2);
-    ASSERT_EQ(1,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
 
     buff.resetSer();
-    ASSERT_EQ(0,buff.m_serLoc);
-    ASSERT_EQ(0,buff.m_deserLoc);
 
     // double check negative numbers
     i8t1 = -100;
@@ -98,11 +94,11 @@ TEST(SerializationTest,Serialization1) {
 
     stat1 = buff.serialize(i8t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(1,buff.m_serLoc);
+    ASSERT_EQ(1,buff.getBuffLength());
     stat2 = buff.deserialize(i8t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
     ASSERT_EQ(i8t1,i8t2);
-    ASSERT_EQ(1,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
 
     #if DEBUG_VERBOSE
@@ -119,13 +115,13 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     stat1 = buff.serialize(u16t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(2,buff.m_serLoc);
+    ASSERT_EQ(2,buff.getBuffLength());
     ASSERT_EQ(0xAB,ptr[0]);
     ASSERT_EQ(0xCD,ptr[1]);
     stat2 = buff.deserialize(u16t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
     ASSERT_EQ(u16t1,u16t2);
-    ASSERT_EQ(2,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
 #if DEBUG_VERBOSE
     printf("Val: in: %d out: %d stat1: %d stat2: %d\n", u16t1, u16t2, stat1,
@@ -139,14 +135,14 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     stat1 = buff.serialize(i16t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(2,buff.m_serLoc);
+    ASSERT_EQ(2,buff.getBuffLength());
     // 2s complement
     ASSERT_EQ(0xAB,ptr[0]);
     ASSERT_EQ(0xCD,ptr[1]);
     stat2 = buff.deserialize(i16t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
     ASSERT_EQ(i16t1,i16t2);
-    ASSERT_EQ(2,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
     // double check negative number
     i16t1 = -1000;
@@ -155,11 +151,11 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     stat1 = buff.serialize(i16t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(2,buff.m_serLoc);
+    ASSERT_EQ(2,buff.getBuffLength());
     stat2 = buff.deserialize(i16t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
     ASSERT_EQ(i16t1,i16t2);
-    ASSERT_EQ(2,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
 
 #if DEBUG_VERBOSE
@@ -177,7 +173,7 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     stat1 = buff.serialize(u32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(4,buff.m_serLoc);
+    ASSERT_EQ(4,buff.getBuffLength());
     ASSERT_EQ(0xAB,ptr[0]);
     ASSERT_EQ(0xCD,ptr[1]);
     ASSERT_EQ(0xEF,ptr[2]);
@@ -185,7 +181,7 @@ TEST(SerializationTest,Serialization1) {
     stat2 = buff.deserialize(u32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
     ASSERT_EQ(u32t1,u32t2);
-    ASSERT_EQ(4,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
 #if DEBUG_VERBOSE
     printf("Val: in: %d out: %d stat1: %d stat2: %d\n", u32t1, u32t2, stat1,
@@ -199,14 +195,14 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     stat1 = buff.serialize(i32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(4,buff.m_serLoc);
+    ASSERT_EQ(4,buff.getBuffLength());
     ASSERT_EQ(0xAB,ptr[0]);
     ASSERT_EQ(0xCD,ptr[1]);
     ASSERT_EQ(0xEF,ptr[2]);
     ASSERT_EQ(0x12,ptr[3]);
     stat2 = buff.deserialize(i32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(4,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
     ASSERT_EQ(i32t1,i32t2);
 
     // double check negative number
@@ -216,10 +212,10 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     stat1 = buff.serialize(i32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(4,buff.m_serLoc);
+    ASSERT_EQ(4,buff.getBuffLength());
     stat2 = buff.deserialize(i32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(4,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
     ASSERT_EQ(i32t1,i32t2);
 
 
@@ -238,7 +234,7 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     stat1 = buff.serialize(u64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(8,buff.m_serLoc);
+    ASSERT_EQ(8,buff.getBuffLength());
     ASSERT_EQ(0x01,ptr[0]);
     ASSERT_EQ(0x23,ptr[1]);
     ASSERT_EQ(0x45,ptr[2]);
@@ -250,7 +246,7 @@ TEST(SerializationTest,Serialization1) {
     stat2 = buff.deserialize(u64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
     ASSERT_EQ(u64t1,u64t2);
-    ASSERT_EQ(8,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
 #if DEBUG_VERBOSE
     printf("Val: in: %lld out: %lld stat1: %d stat2: %d\n", u64t1, u64t2, stat1,
@@ -264,7 +260,7 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     stat1 = buff.serialize(i64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(8,buff.m_serLoc);
+    ASSERT_EQ(8,buff.getBuffLength());
     ASSERT_EQ(0x01,ptr[0]);
     ASSERT_EQ(0x23,ptr[1]);
     ASSERT_EQ(0x45,ptr[2]);
@@ -276,7 +272,7 @@ TEST(SerializationTest,Serialization1) {
     stat2 = buff.deserialize(i64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
     ASSERT_EQ(i64t1,i64t2);
-    ASSERT_EQ(8,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
     // double check negative number
     i64t1 = -1000000000000;
@@ -285,11 +281,11 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     stat1 = buff.serialize(i64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(8,buff.m_serLoc);
+    ASSERT_EQ(8,buff.getBuffLength());
     stat2 = buff.deserialize(i64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
     ASSERT_EQ(i64t1,i64t2);
-    ASSERT_EQ(8,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
 
 #if DEBUG_VERBOSE
@@ -307,7 +303,7 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     stat1 = buff.serialize(f32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(4,buff.m_serLoc);
+    ASSERT_EQ(4,buff.getBuffLength());
     ASSERT_EQ(0xBF,ptr[0]);
     ASSERT_EQ(0x9D,ptr[1]);
     ASSERT_EQ(0x70,ptr[2]);
@@ -315,7 +311,7 @@ TEST(SerializationTest,Serialization1) {
     stat2 = buff.deserialize(f32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
     ASSERT_FLOAT_EQ(f32t1,f32t2);
-    ASSERT_EQ(4,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
 #if DEBUG_VERBOSE
     printf("Val: in: %f out: %f stat1: %d stat2: %d\n", f32t1, f32t2, stat1,
@@ -329,7 +325,7 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     stat1 = buff.serialize(f64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(8,buff.m_serLoc);
+    ASSERT_EQ(8,buff.getBuffLength());
     ASSERT_EQ(0x40,ptr[0]);
     ASSERT_EQ(0x59,ptr[1]);
     ASSERT_EQ(0x0E,ptr[2]);
@@ -341,7 +337,7 @@ TEST(SerializationTest,Serialization1) {
     stat2 = buff.deserialize(f64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
     ASSERT_DOUBLE_EQ(f32t1,f32t2);
-    ASSERT_EQ(8,buff.m_deserLoc);
+    ASSERT_EQ(0,buff.getBuffLeft());
 
 #if DEBUG_VERBOSE
     printf("Val: in: %lf out: %lf stat1: %d stat2: %d\n", f64t1, f64t2, stat1,

--- a/Os/IntervalTimer.hpp
+++ b/Os/IntervalTimer.hpp
@@ -12,12 +12,12 @@
 namespace Os {
     class IntervalTimer {
         public:
-    		/**
-    		 * RawTime:
-    		 *
-    		 * Most time is stored as an upper and lower part of this raw time object. The
-    		 * semantic meaning of this "RawTime" is platform-dependent.
-    		 */
+            /**
+             * RawTime:
+             *
+             * Most time is stored as an upper and lower part of this raw time object. The
+             * semantic meaning of this "RawTime" is platform-dependent.
+             */
             typedef struct {
                 U32 upper;  //!< Upper 32-bits part of time value. Platform dependent.
                 U32 lower; //!< Lower 32-bits part of time value. Platform dependent.
@@ -64,9 +64,9 @@ namespace Os {
              * way.
              */
             static void getRawTime(RawTime& time);
-        PRIVATE:
+        private:
 
-		    //------------ Internal Member Variables ------------
+            //------------ Internal Member Variables ------------
             RawTime m_startTime; //!<  Stored start time
             RawTime m_stopTime; //!<  Stored end time
 

--- a/Os/ValidatedFile.hpp
+++ b/Os/ValidatedFile.hpp
@@ -53,7 +53,7 @@ namespace Os {
       //! \return The hash file buffer
       const Utils::HashBuffer& getHashBuffer(void) const;
 
-    PRIVATE:
+    private:
 
       //! The file name
       Fw::EightyCharString fileName;

--- a/Os/test/ut/OsQueueTest.cpp
+++ b/Os/test/ut/OsQueueTest.cpp
@@ -8,10 +8,10 @@
 #include <signal.h>
 #include <pthread.h>
 
-#if defined TGT_OS_TYPE_LINUX         
+#if defined TGT_OS_TYPE_LINUX
 #include <time.h>
 #endif
-#if defined TGT_OS_TYPE_DARWIN    
+#if defined TGT_OS_TYPE_DARWIN
 #include <sys/time.h>
 #endif
 
@@ -54,9 +54,8 @@ Os::Queue* createTestQueue(char *name, U32 size, I32 depth) {
     return testQueue;
 }
 
-MyTestSerializedBuffer getSendBuffer(I32 startByte) {
+void getSendBuffer(MyTestSerializedBuffer& sendBuff, I32 startByte) {
     Fw::SerializeStatus serStat;
-    MyTestSerializedBuffer sendBuff;
     NATIVE_UINT_TYPE size = sendBuff.getBuffCapacity() - sizeof(NATIVE_UINT_TYPE);
 
     // Fill serialized buffer with data:
@@ -68,7 +67,6 @@ MyTestSerializedBuffer getSendBuffer(I32 startByte) {
     }
     serStat = sendBuff.serialize(sendDataBuff, size);
     EXPECT_EQ(serStat,Fw::FW_SERIALIZE_OK);
-    return sendBuff;
 }
 
 void compareBuffers(MyTestSerializedBuffer& a, MyTestSerializedBuffer& b) {
@@ -94,7 +92,9 @@ void fillQueue(Os::Queue* queue) {
     // Note this loop should only need to go to QUEUE_SIZE,
     // but the SysV queues don't actually have a size, so
     // instead we loop until we get a queue full response:
-    MyTestSerializedBuffer sendBuff = getSendBuffer(0);
+    MyTestSerializedBuffer sendBuff;
+    getSendBuffer(sendBuff, 0);
+
     Os::Queue::QueueStatus stat;
     for( NATIVE_INT_TYPE ii = 0; ii < QUEUE_SIZE*100; ii++ ) {
         stat = queue->send(sendBuff, 0, Os::Queue::QUEUE_NONBLOCKING);
@@ -131,7 +131,8 @@ extern "C" {
 Os::Queue* globalQueue = NULL;
 void alarm_send_block(int sig)
 {
-    MyTestSerializedBuffer sendBuff = getSendBuffer(0);
+    MyTestSerializedBuffer sendBuff;
+    getSendBuffer(sendBuff, 0);
     Os::Queue::QueueStatus stat;
     stat = globalQueue->send(sendBuff, 0, Os::Queue::QUEUE_BLOCKING);
     EXPECT_EQ(stat, Os::Queue::QUEUE_OK);
@@ -139,7 +140,8 @@ void alarm_send_block(int sig)
 
 void alarm_send_nonblock(int sig)
 {
-    MyTestSerializedBuffer sendBuff = getSendBuffer(0);
+    MyTestSerializedBuffer sendBuff;
+    getSendBuffer(sendBuff, 0);
     Os::Queue::QueueStatus stat;
     stat = globalQueue->send(sendBuff, 0, Os::Queue::QUEUE_NONBLOCKING);
     EXPECT_EQ(stat, Os::Queue::QUEUE_OK);
@@ -178,7 +180,8 @@ void qtest_nonblock_send(void) {
     printf("-----------------------------\n");
     Os::Queue* testQueue = createTestQueue((char*)"TestQ",SER_BUFFER_SIZE,QUEUE_SIZE);
     Os::Queue::QueueStatus stat;
-    MyTestSerializedBuffer sendBuff = getSendBuffer(0);
+    MyTestSerializedBuffer sendBuff;
+    getSendBuffer(sendBuff, 0);
 
     // TEST 1
     printf("Testing non-blocking send on queue full...\n");
@@ -208,7 +211,8 @@ void qtest_block_send(void) {
     printf("-----------------------------\n");
     Os::Queue* testQueue = createTestQueue((char*)"TestQ",SER_BUFFER_SIZE,QUEUE_SIZE);
     Os::Queue::QueueStatus stat;
-    MyTestSerializedBuffer sendBuff = getSendBuffer(0);
+    MyTestSerializedBuffer sendBuff;
+    getSendBuffer(sendBuff, 0);
 
     // TEST 1
     printf("Testing blocking send on queue full with blocking receive...\n");
@@ -257,7 +261,8 @@ void qtest_block_receive(void) {
     Os::Queue* testQueue = createTestQueue((char*)"TestQ",SER_BUFFER_SIZE,QUEUE_SIZE);
     Os::Queue::QueueStatus stat;
     MyTestSerializedBuffer recvBuff;
-    MyTestSerializedBuffer sendBuff = getSendBuffer(0);
+    MyTestSerializedBuffer sendBuff;
+    getSendBuffer(sendBuff, 0);
     I32 prio; // not used
 
     // TEST 1
@@ -300,7 +305,8 @@ void qtest_block_receive(void) {
     NATIVE_INT_TYPE priorities[6] = {0, 50, 50, 99, 0, 16};
     for( I32 ii = 0; ii < 6; ii++ ) {
       // Generate a new send buffer for each enqueue:
-      MyTestSerializedBuffer sendBuff2 = getSendBuffer(sendBuffStart[ii]);
+      MyTestSerializedBuffer sendBuff2;
+      getSendBuffer(sendBuff2, sendBuffStart[ii]);
       stat = testQueue->send(sendBuff2, priorities[ii], Os::Queue::QUEUE_NONBLOCKING);
       EXPECT_EQ(stat,Os::Queue::QUEUE_OK);
     }
@@ -314,7 +320,8 @@ void qtest_block_receive(void) {
 #endif
     for( I32 ii = 0; ii < 6; ii++ ) {
       // Generate a new send buffer for each enqueue:
-      MyTestSerializedBuffer expectedSendBuff2 = getSendBuffer(expectedSendBuffStart[ii]);
+      MyTestSerializedBuffer expectedSendBuff2;
+      getSendBuffer(expectedSendBuff2, expectedSendBuffStart[ii]);
       stat = testQueue->receive(recvBuff, prio, Os::Queue::QUEUE_BLOCKING);
       EXPECT_EQ(stat,Os::Queue::QUEUE_OK);
       EXPECT_EQ(prio,expectedPriorities[ii]);
@@ -337,7 +344,8 @@ void qtest_nonblock_receive(void) {
     Os::Queue* testQueue = createTestQueue((char*)"TestQ", SER_BUFFER_SIZE, QUEUE_SIZE);
     Os::Queue::QueueStatus stat;
     MyTestSerializedBuffer recvBuff;
-    MyTestSerializedBuffer sendBuff = getSendBuffer(0);
+    MyTestSerializedBuffer sendBuff;
+    getSendBuffer(sendBuff, 0);
     I32 prio; // not used
 
     // TEST 1
@@ -364,7 +372,8 @@ void qtest_nonblock_receive(void) {
     NATIVE_INT_TYPE priorities[6] = {0, 50, 50, 99, 0, 16};
     for( I32 ii = 0; ii < 6; ii++ ) {
       // Generate a new send buffer for each enqueue:
-      MyTestSerializedBuffer sendBuff2 = getSendBuffer(sendBuffStart[ii]);
+      MyTestSerializedBuffer sendBuff2;
+      getSendBuffer(sendBuff2, sendBuffStart[ii]);
       stat = testQueue->send(sendBuff2, priorities[ii], Os::Queue::QUEUE_NONBLOCKING);
       EXPECT_EQ(stat,Os::Queue::QUEUE_OK);
     }
@@ -378,7 +387,8 @@ void qtest_nonblock_receive(void) {
 #endif
     for( I32 ii = 0; ii < 6; ii++ ) {
       // Generate a new send buffer for each enqueue:
-      MyTestSerializedBuffer expectedSendBuff2 = getSendBuffer(expectedSendBuffStart[ii]);
+      MyTestSerializedBuffer expectedSendBuff2;
+      getSendBuffer(expectedSendBuff2, expectedSendBuffStart[ii]);
       stat = testQueue->receive(recvBuff, prio, Os::Queue::QUEUE_NONBLOCKING);
       EXPECT_EQ(stat,Os::Queue::QUEUE_OK);
       EXPECT_EQ(prio,expectedPriorities[ii]);
@@ -400,26 +410,27 @@ void qtest_performance(void) {
     Os::Queue* testQueue = createTestQueue((char*)"TestQ", SER_BUFFER_SIZE, 10);
     Os::Queue::QueueStatus stat;
     MyTestSerializedBuffer recvBuff;
-    MyTestSerializedBuffer sendBuff = getSendBuffer(0);
+    MyTestSerializedBuffer sendBuff;
+    getSendBuffer(sendBuff, 0);
     I32 prio; // not used
     F64 elapsedTime;
     I32 numIterations;
 
-#if defined TGT_OS_TYPE_LINUX         
+#if defined TGT_OS_TYPE_LINUX
     timespec stime;
     timespec etime;
 #endif
-#if defined TGT_OS_TYPE_DARWIN    
+#if defined TGT_OS_TYPE_DARWIN
     timeval stime;
     timeval etime;
 #endif
 
     // TEST 1
     printf("Testing shallow queue...\n");
-#if defined TGT_OS_TYPE_LINUX         
+#if defined TGT_OS_TYPE_LINUX
     (void)clock_gettime(CLOCK_REALTIME,&stime);
 #endif
-#if defined TGT_OS_TYPE_DARWIN    
+#if defined TGT_OS_TYPE_DARWIN
     (void)gettimeofday(&stime,0);
 #endif
     numIterations = 1000000;
@@ -437,12 +448,12 @@ void qtest_performance(void) {
       stat = testQueue->receive(recvBuff, prio, Os::Queue::QUEUE_NONBLOCKING);
       EXPECT_EQ(stat,Os::Queue::QUEUE_OK);
     }
-#if defined TGT_OS_TYPE_LINUX         
+#if defined TGT_OS_TYPE_LINUX
     (void)clock_gettime(CLOCK_REALTIME,&etime);
     elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_nsec - stime.tv_nsec))/1000000000;
     printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);
 #endif
-#if defined TGT_OS_TYPE_DARWIN    
+#if defined TGT_OS_TYPE_DARWIN
     (void)gettimeofday(&etime,0);
     elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_usec - stime.tv_usec))/1000000;
     printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);
@@ -458,10 +469,10 @@ void qtest_performance(void) {
       if(stat == Os::Queue::QUEUE_FULL)
         break;
     }
-#if defined TGT_OS_TYPE_LINUX         
+#if defined TGT_OS_TYPE_LINUX
     (void)clock_gettime(CLOCK_REALTIME,&stime);
 #endif
-#if defined TGT_OS_TYPE_DARWIN    
+#if defined TGT_OS_TYPE_DARWIN
     (void)gettimeofday(&stime,0);
 #endif
     numIterations = 1000000;
@@ -479,12 +490,12 @@ void qtest_performance(void) {
       stat = testQueue->send(sendBuff, ii%4, Os::Queue::QUEUE_NONBLOCKING);
       EXPECT_EQ(stat,Os::Queue::QUEUE_OK);
     }
-#if defined TGT_OS_TYPE_LINUX         
+#if defined TGT_OS_TYPE_LINUX
     (void)clock_gettime(CLOCK_REALTIME,&etime);
     elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_nsec - stime.tv_nsec))/1000000000;
     printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);
 #endif
-#if defined TGT_OS_TYPE_DARWIN    
+#if defined TGT_OS_TYPE_DARWIN
     (void)gettimeofday(&etime,0);
     elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_usec - stime.tv_usec))/1000000;
     printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);
@@ -509,7 +520,8 @@ void *run_task(void *ptr)
   Os::Queue::QueueStatus stat;
   I32 prio; // not used
   MyTestSerializedBuffer recvBuff;
-  MyTestSerializedBuffer sendBuff = getSendBuffer(0);
+  MyTestSerializedBuffer sendBuff;
+  getSendBuffer(sendBuff, 0);
   for( NATIVE_INT_TYPE ii = 0; ii < numIterations; ii++ ) {
     stat = testQueue->receive(recvBuff, prio, Os::Queue::QUEUE_BLOCKING);
     EXPECT_EQ(stat,Os::Queue::QUEUE_OK);
@@ -536,14 +548,15 @@ void qtest_concurrent(void) {
     Os::Queue* testQueue = createTestQueue((char*)"TestQ", SER_BUFFER_SIZE, 10);
     Os::Queue::QueueStatus stat;
     MyTestSerializedBuffer recvBuff;
-    MyTestSerializedBuffer sendBuff = getSendBuffer(0);
+    MyTestSerializedBuffer sendBuff;
+    getSendBuffer(sendBuff, 0);
     F64 elapsedTime;
 
-#if defined TGT_OS_TYPE_LINUX         
+#if defined TGT_OS_TYPE_LINUX
     timespec stime;
     timespec etime;
 #endif
-#if defined TGT_OS_TYPE_DARWIN    
+#if defined TGT_OS_TYPE_DARWIN
     timeval stime;
     timeval etime;
 #endif
@@ -557,10 +570,10 @@ void qtest_concurrent(void) {
       if(stat == Os::Queue::QUEUE_FULL)
         break;
     }
-#if defined TGT_OS_TYPE_LINUX         
+#if defined TGT_OS_TYPE_LINUX
     (void)clock_gettime(CLOCK_REALTIME,&stime);
 #endif
-#if defined TGT_OS_TYPE_DARWIN    
+#if defined TGT_OS_TYPE_DARWIN
     (void)gettimeofday(&stime,0);
 #endif
 
@@ -572,20 +585,20 @@ void qtest_concurrent(void) {
         EXPECT_TRUE(0);
       }
     }
-    
+
     for(U32 ii = 0; ii < NUM_THREADS; ++ii) {
       if(pthread_join(thread[ii], NULL)) {
-        EXPECT_TRUE(0);      
+        EXPECT_TRUE(0);
       }
     }
 #endif
 
-#if defined TGT_OS_TYPE_LINUX         
+#if defined TGT_OS_TYPE_LINUX
     (void)clock_gettime(CLOCK_REALTIME,&etime);
     elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_nsec - stime.tv_nsec))/1000000000;
     printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);
 #endif
-#if defined TGT_OS_TYPE_DARWIN    
+#if defined TGT_OS_TYPE_DARWIN
     (void)gettimeofday(&etime,0);
     elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_usec - stime.tv_usec))/1000000;
     printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);

--- a/RPI/RpiDemo/RpiDemoComponentImpl.hpp
+++ b/RPI/RpiDemo/RpiDemoComponentImpl.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  RpiDemoImpl.hpp
 // \author tcanham
 // \brief  hpp file for RpiDemo component implementation class
@@ -7,8 +7,8 @@
 // Copyright 2009-2015, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef RpiDemo_HPP
 #define RpiDemo_HPP
@@ -49,7 +49,7 @@ namespace Rpi {
       //!
       ~RpiDemoComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -70,10 +70,8 @@ namespace Rpi {
           Drv::SerialReadStatus &status /*!< Status of read*/
       );
 
-    PRIVATE:
-
       // ----------------------------------------------------------------------
-      // Command handler implementations 
+      // Command handler implementations
       // ----------------------------------------------------------------------
 
       //! Implementation for RD_SendString command handler

--- a/Ref/PingReceiver/PingReceiverComponentImpl.hpp
+++ b/Ref/PingReceiver/PingReceiverComponentImpl.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  PingReceiverImpl.hpp
 // \author tim
 // \brief  hpp file for PingReceiver component implementation class
@@ -7,8 +7,8 @@
 // Copyright 2009-2015, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef PingReceiver_HPP
 #define PingReceiver_HPP
@@ -44,7 +44,7 @@ namespace Ref {
       //!
       ~PingReceiverComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports

--- a/Svc/ActiveLogger/ActiveLoggerImpl.hpp
+++ b/Svc/ActiveLogger/ActiveLoggerImpl.hpp
@@ -22,8 +22,8 @@ namespace Svc {
                     NATIVE_INT_TYPE queueDepth, /*!< The queue depth*/
                     NATIVE_INT_TYPE instance /*!< The instance number*/
                     ); //!< initialization function
-        PROTECTED:
-        PRIVATE:
+
+        private:
             void LogRecv_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, Fw::LogSeverity severity, Fw::LogBuffer &args);
             void loqQueue_internalInterfaceHandler(FwEventIdType id, Fw::Time &timeTag, Fw::LogSeverity& severity, Fw::LogBuffer &args);
 

--- a/Svc/ActiveRateGroup/test/ut/ActiveRateGroupImplTester.cpp
+++ b/Svc/ActiveRateGroup/test/ut/ActiveRateGroupImplTester.cpp
@@ -50,7 +50,7 @@ namespace Svc {
         // we can cause an overrun by calling the cycle port in the middle of the rate
         // group execution
         if (this->m_causeOverrun) {
-            TimerVal zero(0,0);
+            TimerVal zero(Os::IntervalTimer::RawTime{0,0});
             this->invoke_to_CycleIn(0,zero);
             this->m_causeOverrun = false;
         }
@@ -123,7 +123,7 @@ namespace Svc {
         ASSERT_EVENTS_SIZE(1);
         ASSERT_EVENTS_RateGroupStarted_SIZE(1);
 
-        Svc::TimerVal timer(1,2);
+        Svc::TimerVal timer(Os::IntervalTimer::RawTime{1,2});
 
         // run some more cycles to verify that event is sent and telemetry is updated
         for (NATIVE_INT_TYPE cycle = 0; cycle < ACTIVE_RATE_GROUP_OVERRUN_THROTTLE; cycle++) {

--- a/Svc/BufferAccumulator/BufferAccumulator.hpp
+++ b/Svc/BufferAccumulator/BufferAccumulator.hpp
@@ -23,7 +23,7 @@ namespace Svc {
     public BufferAccumulatorComponentBase
   {
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Types
@@ -64,7 +64,7 @@ namespace Svc {
             //! \return The capacity
             U32 getCapacity(void) const;
 
-        PRIVATE:
+        private:
 
           // ----------------------------------------------------------------------
           // Private member variables
@@ -125,7 +125,7 @@ namespace Svc {
       void deallocateQueue(Fw::MemAllocator& allocator);
 
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -159,8 +159,6 @@ namespace Svc {
           NATIVE_UINT_TYPE context /*!< The call order*/
       );
 
-    PRIVATE:
-
       // ----------------------------------------------------------------------
       // Command handler implementations
       // ----------------------------------------------------------------------
@@ -172,7 +170,6 @@ namespace Svc {
           const U32 cmdSeq, //!< The command sequence number
           OpState mode //!< The mode
       );
-    PRIVATE:
 
       // ----------------------------------------------------------------------
       // Private helper methods
@@ -180,8 +177,6 @@ namespace Svc {
 
       //! Send a stored buffer
       void sendStoredBuffer(void);
-
-    PRIVATE:
 
       // ----------------------------------------------------------------------
       // Private member variables

--- a/Svc/BufferLogger/test/ut/Health.cpp
+++ b/Svc/BufferLogger/test/ut/Health.cpp
@@ -23,7 +23,7 @@ namespace Svc {
       U32 key = 42;
 
       this->invoke_to_pingIn(0, key);
-      this->dispatchAll();
+      this->dispatchOne();
 
       ASSERT_EVENTS_SIZE(0);
       ASSERT_from_pingOut_SIZE(1);

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
@@ -53,7 +53,7 @@ namespace Svc {
             //!
             //!  The destructor for this component is empty
             virtual ~CommandDispatcherImpl();
-        PROTECTED:
+
         PRIVATE:
             //!  \brief component command status handler
             //!

--- a/Svc/CmdSequencer/formats/AMPCSSequence.hpp
+++ b/Svc/CmdSequencer/formats/AMPCSSequence.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  AMPCSSequence.hpp
 // \author Bocchino
 // \brief  AMPCSSequence interface
@@ -7,8 +7,8 @@
 // Copyright (C) 2009-2018 California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef Svc_AMPCSSequence_HPP
 #define Svc_AMPCSSequence_HPP
@@ -19,7 +19,7 @@ namespace Svc {
 
   //! \class AMPCSSequence
   //! \brief A sequence in AMPCS format
-  class AMPCSSequence : 
+  class AMPCSSequence :
     public CmdSequencerComponentImpl::Sequence
   {
 
@@ -88,14 +88,10 @@ namespace Svc {
 
       };
 
-    public:
-
       //! Construct an AMPCSSequence
       AMPCSSequence(
           CmdSequencerComponentImpl& component //!< The enclosing component
       );
-
-    public:
 
       //! Load a sequence file
       //! \return Success or failure
@@ -122,7 +118,7 @@ namespace Svc {
       //! After calling this, hasMoreRecords should return false.
       void clear(void);
 
-    PRIVATE:
+    private:
 
       //! Read a CRC file
       //! \return Success or failure
@@ -201,8 +197,6 @@ namespace Svc {
       //! Validate the sequence records in the buffer
       //! \return Success or failure
       bool validateRecords(void);
-
-    PRIVATE:
 
       //! The sequence header
       SequenceHeader::t m_sequenceHeader;

--- a/Svc/CmdSequencer/test/ut/Tester.cpp
+++ b/Svc/CmdSequencer/test/ut/Tester.cpp
@@ -43,13 +43,12 @@ namespace Svc {
         this->mallocator,
         BUFFER_SIZE
     );
-    this->component.preamble();
     this->component.setTimeout(TIMEOUT);
-    this->component.regCommands();  
+    this->component.regCommands();
   }
 
   Tester ::
-    ~Tester(void) 
+    ~Tester(void)
   {
     this->component.deallocateBuffer(this->mallocator);
   }
@@ -89,12 +88,12 @@ namespace Svc {
   }
 
   // ----------------------------------------------------------------------
-  // Virtual function interface 
+  // Virtual function interface
   // ----------------------------------------------------------------------
 
   void Tester ::
     executeCommandsAuto(
-        const char *const fileName, 
+        const char *const fileName,
         const U32 numCommands,
         const U32 bound,
         const CmdExecMode::t mode
@@ -105,7 +104,7 @@ namespace Svc {
 
   void Tester ::
     executeCommandsError(
-        const char *const fileName, 
+        const char *const fileName,
         const U32 numCommands
     )
   {
@@ -114,7 +113,7 @@ namespace Svc {
 
   void Tester ::
     executeCommandsManual(
-        const char *const fileName, 
+        const char *const fileName,
         const U32 numCommands
     )
   {
@@ -130,7 +129,7 @@ namespace Svc {
         SequenceFiles::File& file,
         const U32 numCommands,
         const U32 bound
-    ) 
+    )
   {
     ASSERT_TRUE(false) << "parameterizedAutoByCommand is not implemented\n";
   }
@@ -140,7 +139,7 @@ namespace Svc {
         SequenceFiles::File& file,
         const U32 numCommands,
         const U32 bound
-    ) 
+    )
   {
 
     REQUIREMENT("ISF-CMDS-005");
@@ -242,7 +241,7 @@ namespace Svc {
       // Assert command response
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
-          0, 
+          0,
           CmdSequencerComponentBase::OPCODE_CS_VALIDATE,
           validateCmdSeq,
           Fw::CmdResponse::EXECUTION_ERROR
@@ -686,7 +685,7 @@ namespace Svc {
     ASSERT_CMD_RESPONSE_SIZE(0);
     // Assert events
     ASSERT_EVENTS_SIZE(1);
-    const Fw::LogStringArg& fileName = 
+    const Fw::LogStringArg& fileName =
       this->component.m_sequence->getLogFileName();
     ASSERT_EVENTS_CS_PortSequenceStarted(0, fileName.toChar());
   }

--- a/Svc/Cycle/TimerVal.cpp
+++ b/Svc/Cycle/TimerVal.cpp
@@ -15,9 +15,8 @@ namespace Svc {
         this->m_timerVal.lower = 0;
     }
 
-    TimerVal::TimerVal(U32 upper, U32 lower)  {
-        this->m_timerVal.upper = upper;
-        this->m_timerVal.lower = lower;
+    TimerVal::TimerVal(Os::IntervalTimer::RawTime time)  {
+        this->m_timerVal = time;
     }
 
     TimerVal::TimerVal(const TimerVal& other) : Fw::Serializable() {

--- a/Svc/Cycle/TimerVal.hpp
+++ b/Svc/Cycle/TimerVal.hpp
@@ -27,6 +27,7 @@ namespace Svc {
             };
 
             TimerVal(); //!< Default constructor
+            TimerVal(Os::IntervalTimer::RawTime time); //!< Create TimerVal from RawTime
 
             //!  \brief Timer copy constructor
             //!
@@ -35,6 +36,7 @@ namespace Svc {
             //!  \param other source timer value
 
             TimerVal(const TimerVal& other); //!< copy constructor
+
 
             //!  \brief Timer equal operator
             //!
@@ -88,8 +90,7 @@ namespace Svc {
 
             U32 diffUSec(const TimerVal& time); //!< takes difference between stored time and passed time
 
-        PRIVATE:
-            TimerVal(U32 upper, U32 lower); //!< Private constructor for testing
+        private:
             Os::IntervalTimer::RawTime m_timerVal; //!< Stored timer value
     };
 

--- a/Svc/Deframer/DeframerComponentImpl.hpp
+++ b/Svc/Deframer/DeframerComponentImpl.hpp
@@ -58,7 +58,7 @@ class DeframerComponentImpl : public DeframerComponentBase, public DeframingProt
     );
 
 
-  PRIVATE:
+  private:
     // ----------------------------------------------------------------------
     // Handler implementations for user-defined typed input ports
     // ----------------------------------------------------------------------

--- a/Svc/FatalHandler/FatalHandlerComponentImpl.hpp
+++ b/Svc/FatalHandler/FatalHandlerComponentImpl.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  FatalHandlerImpl.hpp
 // \author tcanham
 // \brief  hpp file for FatalHandler component implementation class
@@ -7,8 +7,8 @@
 // Copyright 2009-2015, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef FatalHandler_HPP
 #define FatalHandler_HPP
@@ -43,7 +43,7 @@ namespace Svc {
       //!
       ~FatalHandlerComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  FileManager.hpp
 // \author bocchino
 // \brief  hpp file for FileManager component implementation class
@@ -7,8 +7,8 @@
 // Copyright 2009-2015, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef Svc_FileManager_HPP
 #define Svc_FileManager_HPP
@@ -45,10 +45,10 @@ namespace Svc {
       //!
       ~FileManager(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
-      // Command handler implementations 
+      // Command handler implementations
       // ----------------------------------------------------------------------
 
       //! Implementation for CreateDirectory command handler
@@ -109,10 +109,8 @@ namespace Svc {
           U32 key /*!< Value to return to pinger*/
       );
 
-    PRIVATE:
-
       // ----------------------------------------------------------------------
-      // Helper methods 
+      // Helper methods
       // ----------------------------------------------------------------------
 
       //! A system command with no arguments
@@ -135,8 +133,6 @@ namespace Svc {
           const U32 cmdSeq, //!< The command sequence value
           const Os::FileSystem::Status status //!< The status
       );
-
-    PRIVATE:
 
       // ----------------------------------------------------------------------
       // Variables

--- a/Svc/Framer/FramerComponentImpl.hpp
+++ b/Svc/Framer/FramerComponentImpl.hpp
@@ -62,7 +62,7 @@ class FramerComponentImpl : public FramerComponentBase, public FramingProtocolIn
     //! \return Fw::Buffer containing allocation to write into
     Fw::Buffer allocate(const U32 size);
 
-  PRIVATE:
+  private:
     // ----------------------------------------------------------------------
     // Handler implementations for user-defined typed input ports
     // ----------------------------------------------------------------------

--- a/Svc/GenericHub/GenericHubComponentImpl.hpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.hpp
@@ -49,7 +49,7 @@ class GenericHubComponentImpl : public GenericHubComponentBase {
     //!
     ~GenericHubComponentImpl(void);
 
-  PRIVATE:
+  private:
     // ----------------------------------------------------------------------
     // Handler implementations for user-defined typed input ports
     // ----------------------------------------------------------------------

--- a/Svc/GenericRepeater/GenericRepeaterComponentImpl.hpp
+++ b/Svc/GenericRepeater/GenericRepeaterComponentImpl.hpp
@@ -37,7 +37,7 @@ class GenericRepeaterComponentImpl : public GenericRepeaterComponentBase {
     //!
     ~GenericRepeaterComponentImpl(void);
 
-  PRIVATE:
+  private:
     // ----------------------------------------------------------------------
     // Handler implementations for user-defined serial input ports
     // ----------------------------------------------------------------------

--- a/Svc/GroundInterface/GroundInterface.hpp
+++ b/Svc/GroundInterface/GroundInterface.hpp
@@ -1,8 +1,8 @@
-// ====================================================================== 
+// ======================================================================
 // \title  GroundInterfaceImpl.hpp
 // \author lestarch
 // \brief  hpp file for GroundInterface component implementation class
-// ====================================================================== 
+// ======================================================================
 #include <Fw/Types/Serializable.hpp>
 #include "Svc/GroundInterface/GroundInterfaceComponentAc.hpp"
 #include "Utils/Types/CircularBuffer.hpp"
@@ -42,7 +42,7 @@ namespace Svc {
       //!
       ~GroundInterfaceComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -60,14 +60,14 @@ namespace Svc {
       //!
       void fileDownlinkBufferSendIn_handler(
           const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          Fw::Buffer &fwBuffer 
+          Fw::Buffer &fwBuffer
       );
 
       //! Handler implementation for readCallback
       //!
       void readCallback_handler(
           const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          Fw::Buffer &fwBuffer 
+          Fw::Buffer &fwBuffer
       );
 
       //! Handler implementation for schedIn

--- a/Svc/GroundInterface/test/ut/GroundInterfaceRules.cpp
+++ b/Svc/GroundInterface/test/ut/GroundInterfaceRules.cpp
@@ -12,7 +12,7 @@
 
 namespace Svc {
     // Constructor
-    RandomizeRule :: RandomizeRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.m_buf) {}
+    RandomizeRule :: RandomizeRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always randomize
     bool RandomizeRule :: precondition(const Svc::Tester &state) {
@@ -39,7 +39,7 @@ namespace Svc {
 
 
     // Constructor
-    DownlinkRule :: DownlinkRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.m_buf) {}
+    DownlinkRule :: DownlinkRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always downlink
     bool DownlinkRule :: precondition(const Svc::Tester &state) {
@@ -57,7 +57,7 @@ namespace Svc {
     }
 
     // Constructor
-    FileDownlinkRule :: FileDownlinkRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.m_buf) {}
+    FileDownlinkRule :: FileDownlinkRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always downlink
     bool FileDownlinkRule :: precondition(const Svc::Tester &state) {
@@ -80,7 +80,7 @@ namespace Svc {
     }
 
     // Constructor
-    SendAvailableRule :: SendAvailableRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.m_buf) {}
+    SendAvailableRule :: SendAvailableRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always downlink
     bool SendAvailableRule :: precondition(const Svc::Tester &state) {

--- a/Svc/UdpReceiver/UdpReceiverComponentImpl.hpp
+++ b/Svc/UdpReceiver/UdpReceiverComponentImpl.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  UdpReceiverImpl.hpp
 // \author tcanham
 // \brief  hpp file for UdpReceiver component implementation class
@@ -7,8 +7,8 @@
 // Copyright 2009-2015, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef UdpReceiver_HPP
 #define UdpReceiver_HPP
@@ -57,7 +57,7 @@ namespace Svc {
       );
 
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports

--- a/Svc/UdpSender/UdpSenderComponentImpl.hpp
+++ b/Svc/UdpSender/UdpSenderComponentImpl.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  UdpSenderImpl.hpp
 // \author tcanham
 // \brief  hpp file for UdpSender component implementation class
@@ -7,8 +7,8 @@
 // Copyright 2009-2015, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef UdpSender_HPP
 #define UdpSender_HPP
@@ -57,7 +57,7 @@ namespace Svc {
               const char* port /*!< server port */
       );
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -69,8 +69,6 @@ namespace Svc {
           const NATIVE_INT_TYPE portNum, /*!< The port number*/
           NATIVE_UINT_TYPE context /*!< The call order*/
       );
-
-    PRIVATE:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined serial input ports

--- a/Utils/Types/test/ut/CircularBuffer/CircularRules.cpp
+++ b/Utils/Types/test/ut/CircularBuffer/CircularRules.cpp
@@ -16,7 +16,7 @@ namespace Types {
 
 
     RandomizeRule::RandomizeRule(const Fw::EightyCharString& name)
-        : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+        : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool RandomizeRule::precondition(const MockTypes::CircularState& state) {
@@ -31,7 +31,7 @@ namespace Types {
 
 
     SerializeOkRule::SerializeOkRule(const Fw::EightyCharString& name)
-        : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+        : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool SerializeOkRule::precondition(const MockTypes::CircularState& state) {
@@ -49,7 +49,7 @@ namespace Types {
 
 
     SerializeOverflowRule::SerializeOverflowRule(const Fw::EightyCharString& name)
-            : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+            : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool SerializeOverflowRule::precondition(const MockTypes::CircularState& state) {
@@ -64,7 +64,7 @@ namespace Types {
 
 
     PeekOkRule::PeekOkRule(const Fw::EightyCharString& name)
-            : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+            : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool PeekOkRule::precondition(const MockTypes::CircularState& state) {
@@ -129,7 +129,7 @@ namespace Types {
 
 
     PeekBadRule::PeekBadRule(const Fw::EightyCharString& name)
-            : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+            : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool PeekBadRule::precondition(const MockTypes::CircularState& state) {
@@ -175,7 +175,7 @@ namespace Types {
 
 
     RotateOkRule::RotateOkRule(const Fw::EightyCharString& name)
-            : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+            : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool RotateOkRule::precondition(const MockTypes::CircularState& state) {
@@ -190,7 +190,7 @@ namespace Types {
 
 
     RotateBadRule::RotateBadRule(const Fw::EightyCharString& name)
-            : STest::Rule<MockTypes::CircularState>(name.m_buf) {}
+            : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
     bool RotateBadRule::precondition(const MockTypes::CircularState& state) {

--- a/docs/Tutorials/GpsTutorial/Tutorial.md
+++ b/docs/Tutorials/GpsTutorial/Tutorial.md
@@ -722,7 +722,7 @@ namespace GpsApp {
       //!
       ~GpsComponentImpl(void);
 
-    PRIVATE:
+    private:
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
       // ----------------------------------------------------------------------
@@ -734,8 +734,6 @@ namespace GpsApp {
           Fw::Buffer &serBuffer, /*!< Buffer containing data*/
           Drv::SerialReadStatus &serial_status /*!< Status of read*/
       );
-
-    PRIVATE:
 
       // ----------------------------------------------------------------------
       // Command handler implementations

--- a/docs/Tutorials/MathComponent/MathReceiver/MathReceiverComponentImpl.hpp
+++ b/docs/Tutorials/MathComponent/MathReceiver/MathReceiverComponentImpl.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  MathReceiverImpl.hpp
 // \author tcanham
 // \brief  hpp file for MathReceiver component implementation class
@@ -7,8 +7,8 @@
 // Copyright 2009-2015, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef MathReceiver_HPP
 #define MathReceiver_HPP
@@ -44,7 +44,7 @@ namespace Ref {
       //!
       ~MathReceiverComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -54,8 +54,8 @@ namespace Ref {
       //!
       void mathIn_handler(
           const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          F32 val1, 
-          F32 val2, 
+          F32 val1,
+          F32 val2,
           MathOperation operation /*!< operation argument*/
       );
 
@@ -66,10 +66,8 @@ namespace Ref {
           NATIVE_UINT_TYPE context /*!< The call order*/
       );
 
-    PRIVATE:
-
       // ----------------------------------------------------------------------
-      // Command handler implementations 
+      // Command handler implementations
       // ----------------------------------------------------------------------
 
       //! Implementation for MR_SET_FACTOR1 command handler

--- a/docs/Tutorials/MathComponent/MathSender/MathSenderComponentImpl.hpp
+++ b/docs/Tutorials/MathComponent/MathSender/MathSenderComponentImpl.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  MathSenderImpl.hpp
 // \author tcanham
 // \brief  hpp file for MathSender component implementation class
@@ -7,8 +7,8 @@
 // Copyright 2009-2015, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef MathSender_HPP
 #define MathSender_HPP
@@ -44,7 +44,7 @@ namespace Ref {
       //!
       ~MathSenderComponentImpl(void);
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -57,10 +57,8 @@ namespace Ref {
           F32 result /*!< the result of the operation*/
       );
 
-    PRIVATE:
-
       // ----------------------------------------------------------------------
-      // Command handler implementations 
+      // Command handler implementations
       // ----------------------------------------------------------------------
 
       //! Implementation for MS_DO_MATH command handler


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Remove unnecessary usages of PRIVATE macro in components not white box testing, particularly in the core framework (/Fw)

## Rationale

White box testing should be the exception, not the norm. Using the PRIVATE macro in particular has a few problems:

- Violates test as you fly. Changing method visibility for unit testing can trigger unexpected side affects. For example, SerialBuffer implicit copy constructors were enabled for unit tests only. Usually, they were marked private, preventing the creation of an implicit copy constructor, but using the macro enabled them while unit testing only, causing some unexpected copying of classes that shouldn't be copied.
- Enforces testing the public interface. There were unit tests in our code where we were validating the state of the class through internal variables and not testing the equivalent public getters.
- Breaks clang-format: Since clang format cannot evaluate macros, it improperly formats code that uses the PRIVATE macro.

While I would like to move away from using the PRIVATE macro in classes by default, there are cases where we do need to white box test components without observable side affects, like memory allocators. We should have a larger group discussion about whether we would like to continue using our current PRIVATE technique for testing them, switch to using friend classes, or expose the necessary observable state to properly test these components.