### PR TITLE
Remove uneccessary snprintf error handling from ActiveTextlogger

### DIFF
--- a/Svc/ActiveTextLogger/ActiveTextLoggerImpl.cpp
+++ b/Svc/ActiveTextLogger/ActiveTextLoggerImpl.cpp
@@ -79,7 +79,6 @@ namespace Svc {
 
         // TODO: Add calling task id to format string
         char textStr[FW_INTERNAL_INTERFACE_STRING_MAX_SIZE];
-        NATIVE_INT_TYPE stat;
 
         if (timeTag.getTimeBase() == TB_WORKSTATION_TIME) {
 
@@ -92,7 +91,7 @@ namespace Svc {
                 return;
             }
 
-            stat = snprintf(textStr,
+            (void) snprintf(textStr,
                             FW_INTERNAL_INTERFACE_STRING_MAX_SIZE,
                             "EVENT: (%d) (%04d-%02d-%02dT%02d:%02d:%02d.%03u) %s: %s\n",
                             id, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour,
@@ -101,19 +100,10 @@ namespace Svc {
         }
         else {
 
-            stat = snprintf(textStr,
+            (void) snprintf(textStr,
                             FW_INTERNAL_INTERFACE_STRING_MAX_SIZE,
                             "EVENT: (%d) (%d:%d,%d) %s: %s\n",
                             id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severityString,text.toChar());
-        }
-
-        // If there was a error then just return:
-        if (stat <= 0) {
-            return;
-        }
-        // If there was string text truncation:
-        else if (stat >= FW_INTERNAL_INTERFACE_STRING_MAX_SIZE) {
-            // Do nothing
         }
 
         // Call internal interface so that everything else is done on component thread,


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Removed unused snprintf error handling.

## Rationale

LGTM was warning that the else if conditional was unused so I cleaned up the unused string truncation case. If the format string is correct I don't think snprintf can return an error, so I removed the other error case as well. Rather than silently failing if snprintf errors we're probably better off trying to print whatever it generated.