### PR TITLE
add offset option for rate groups allowing different trigger patterns

### DIFF
--- a/RPI/Top/Topology.cpp
+++ b/RPI/Top/Topology.cpp
@@ -22,7 +22,8 @@ Svc::FprimeFraming framing;
 // Rate Group Dividers for 10Hz and 1Hz
 
 static NATIVE_INT_TYPE rgDivs[] = {1,10,0};
-Svc::RateGroupDriverImpl rateGroupDriverComp("RGDRV",rgDivs,FW_NUM_ARRAY_ELEMENTS(rgDivs));
+static NATIVE_INT_TYPE rgOffs[] = {0,0,0};
+Svc::RateGroupDriverImpl rateGroupDriverComp("RGDRV",rgDivs,rgOffs,FW_NUM_ARRAY_ELEMENTS(rgDivs));
 
 // Context array variables are passed to rate group members if needed to distinguish one call from another
 // These context must match the rate group members connected in RPITopologyAi.xml

--- a/Ref/Top/Topology.cpp
+++ b/Ref/Top/Topology.cpp
@@ -31,7 +31,8 @@ static Fw::SimpleObjRegistry simpleReg;
 
 // Component instance pointers
 static NATIVE_INT_TYPE rgDivs[Svc::RateGroupDriverImpl::DIVIDER_SIZE] = {1,2,4};
-Svc::RateGroupDriverImpl rateGroupDriverComp(FW_OPTIONAL_NAME("RGDvr"),rgDivs,FW_NUM_ARRAY_ELEMENTS(rgDivs));
+static NATIVE_INT_TYPE rgOffs[Svc::RateGroupDriverImpl::DIVIDER_SIZE] = {0,0,0};
+Svc::RateGroupDriverImpl rateGroupDriverComp(FW_OPTIONAL_NAME("RGDvr"),rgDivs,rgOffs,FW_NUM_ARRAY_ELEMENTS(rgDivs));
 
 static NATIVE_UINT_TYPE rg1Context[] = {0,0,0,0,0,0,0,0,0,0};
 Svc::ActiveRateGroupImpl rateGroup1Comp(FW_OPTIONAL_NAME("RG1"),rg1Context,FW_NUM_ARRAY_ELEMENTS(rg1Context));

--- a/Svc/RateGroupDriver/README
+++ b/Svc/RateGroupDriver/README
@@ -1,6 +1,8 @@
 This component takes a primary clock tick in the system and divides it down to drive output ports. 
-Constructor arguments define the divisors for each port. The output ports are meant to be connected 
-to the input ports of rate groups to drive them at the correct rate.
+Constructor arguments define the divisors for each port as well as an offset to allow the triggering
+for the rate group to be offset from each other, only necessary on a system without a thread scheduler.
+The output ports are meant to be connected to the input ports of rate groups to drive them at the
+correct rate.
 
 RateGroupDriverComponentAi.xml - XML definition of rate group driver component
 RateGroupDriverImpl.hpp(.cpp) - Implementation for rate group driver 

--- a/Svc/RateGroupDriver/RateGroupDriverImpl.hpp
+++ b/Svc/RateGroupDriver/RateGroupDriverImpl.hpp
@@ -44,7 +44,7 @@ namespace Svc {
             //!  \param numDividers size of dividers array
             //!
             //!  \return return value description
-            RateGroupDriverImpl(const char* compName, NATIVE_INT_TYPE dividers[], NATIVE_INT_TYPE numDividers);
+            RateGroupDriverImpl(const char* compName, NATIVE_INT_TYPE dividers[], NATIVE_INT_TYPE offsets[], NATIVE_INT_TYPE numDividers);
 
             //!  \brief RateGroupDriverImpl initialization function
             //!
@@ -64,6 +64,9 @@ namespace Svc {
 
             //! divider array
             NATIVE_INT_TYPE m_dividers[NUM_CYCLEOUT_OUTPUT_PORTS];
+
+            //! offset array
+            NATIVE_INT_TYPE m_offsets[NUM_CYCLEOUT_OUTPUT_PORTS];
 
             //! tick counter
             NATIVE_INT_TYPE m_ticks;

--- a/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
+++ b/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
@@ -32,8 +32,9 @@ void connectPorts(Svc::RateGroupDriverImpl& impl, Svc::RateGroupDriverImplTester
 TEST(RateGroupDriverTest,NominalSchedule) {
 
     NATIVE_INT_TYPE dividers[] = {1,2,3};
+    NATIVE_INT_TYPE offsets[] = {0,0,0};
 
-    Svc::RateGroupDriverImpl impl("RateGroupDriverImpl",dividers,FW_NUM_ARRAY_ELEMENTS(dividers));
+    Svc::RateGroupDriverImpl impl("RateGroupDriverImpl",dividers,offsets,FW_NUM_ARRAY_ELEMENTS(dividers));
 
     Svc::RateGroupDriverImplTester tester(impl);
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| LFPS |
|**_Affected Component_**| RateGroupDriver  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y  |
|**_Documentation Included (y/n)_**| y  |

---
## Change Description

This PR allows deployments to specify offsets to stagger RG firings, this is useful when a thread scheduler is not present

## Rationale

This was used on the LFPS firmware and cut our rate group times almost in half preventing major rate group slipping.  The image below shows an example of how the current rate group would fire off vs how the proposed change could be used to fire them off.   
<img width="668" alt="Rate Group Offset Visualization" src="https://user-images.githubusercontent.com/63731123/125321169-6b0b1a80-e30a-11eb-89fc-058b851726d4.png">

## Future Work

Testing on the Ref/RPI deployments as well as notifying users that they will have to update their rate group driver declarations to account for the new argument.  
