### PR TITLE
In FprimeProtocol.cpp:deframe(), make buffer no larger than requested…

### DIFF
--- a/Svc/FramingProtocol/FprimeProtocol.cpp
+++ b/Svc/FramingProtocol/FprimeProtocol.cpp
@@ -109,6 +109,10 @@ DeframingProtocol::DeframingStatus FprimeDeframing::deframe(Types::CircularBuffe
         return DeframingProtocol::DEFRAMING_INVALID_CHECKSUM;
     }
     Fw::Buffer buffer = m_interface->allocate(size);
+    // some allocators may return buffers larger than requested
+    // that causes issues in routing. adjust size
+    FW_ASSERT(buffer.getSize() >= size);
+    buffer.setSize(size);
     ring.peek(buffer.getData(), size, FP_FRAME_HEADER_SIZE);
     m_interface->route(buffer);
     return DeframingProtocol::DEFRAMING_STATUS_SUCCESS;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| JPL COLDArm / Neil Abcouwer|
|**_Affected Component_**| FramingProtocol |
|**_Affected Architectures(s)_**| n/a |
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| y (no change to unit tests for this change, but unit tests still run successfully) |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

When Svc/FramingProtocol/FprimeProtocol.cpp:deframe() calls m_interface->allocate(), set the size of the returned buffer to be the requested size.

## Rationale

When Svc/FramingProtocol/FprimeProtocol.cpp:deframe() calls m_interface->allocate(), some allocators (StaticMemory) can return buffers that are larger than requested. In the case of uplink deframing, this size disparity makes it so commands can't be deframed successfully.

Alternatively, if returning a larger buffer than requested is bad, StaticMemory component could be changed instead. But should probably make allocation requests robust to bigger buffers due to alignment issues, etc.

## Testing/Review Recommendations

Worked properly in our deployment with a deframer and static memory component, but wouldn't have an effect on Reference deployment.

## Future Work

None
