### PR TITLE
Add the "Open in VS Code" badge to improve UX 

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1714,6 +1714,7 @@ virtualized
 vlist
 vm
 VMIN
+vscode
 vsnprintf
 VTIME
 vtype

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # F´: A Flight-Proven, Multi-Platform, Open-Source Flight Software Framework
 
+[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/nasa/fprime)
 [![Language grade: C++](https://img.shields.io/lgtm/grade/cpp/g/nasa/fprime.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nasa/fprime/context:cpp)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/nasa/fprime.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nasa/fprime/context:python)
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz  |
|**_Affected Component_**|  Development environment / UX |
|**_Affected Architectures(s)_**| N/A |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| N/A |
|**_Builds Without Errors (y/n)_**|  N/A |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR simply integrates the "Open in VS Code" badge into the README.md to further enhance the user experience with fprime.

[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/nasa/fprime)

## Rationale

The June 2021 release of Visual Studio Code includes the addition of the "Open in VS Code" badge (https://code.visualstudio.com/updates/v1_58) to allow visitors to quickly open a GitHub repo in the VS Code open source editor.

With this badge, visitors can either use the recently launched VS Code Remote Repositories extension or clone into a Dev Container.

By clicking on the badge, visitors will be directed to a page on https://open.vscode.dev/nasa/fprime, where they can choose how to continue in VS Code. An example is available on the VS Code GitHub repo: https://github.com/microsoft/vscode.

## Testing/Review Recommendations

Visitors will need to install the "Remote Repositories" extension of their Visual Studio Code (https://marketplace.visualstudio.com/items?itemName=GitHub.remotehub) which allows working with GitHub source code repositories quickly and safely in VS Code.

## Future Work

None
