### PR TITLE
lestarch: adding a ready port to bytestreamdriver and the tcp implementors

### DIFF
--- a/Drv/ByteStreamDriverModel/ByteStreamDriverComponentAi.xml
+++ b/Drv/ByteStreamDriverModel/ByteStreamDriverComponentAi.xml
@@ -6,6 +6,7 @@
     <import_port_type>Drv/ByteStreamDriverModel/ByteStreamSendPortAi.xml</import_port_type>
     <import_port_type>Drv/ByteStreamDriverModel/ByteStreamRecvPortAi.xml</import_port_type>
     <import_port_type>Drv/ByteStreamDriverModel/ByteStreamPollPortAi.xml</import_port_type>
+    <import_port_type>Drv/ByteStreamDriverModel/ByteStreamReadyPortAi.xml</import_port_type>
     <import_port_type>Fw/Log/LogPortAi.xml</import_port_type>
     <import_port_type>Fw/Log/LogTextPortAi.xml</import_port_type>
     <import_port_type>Fw/Time/TimePortAi.xml</import_port_type>
@@ -19,6 +20,9 @@
         </port>
 
         <port name="poll" data_type="Drv::ByteStreamPoll" kind="guarded_input" max_number="1">
+        </port>
+
+        <port name="ready" data_type="Drv::ByteStreamReady" kind="output" max_number="1">
         </port>
 
         <!-- Buffer request port used for incoming data -->

--- a/Drv/ByteStreamDriverModel/ByteStreamReadyPortAi.xml
+++ b/Drv/ByteStreamDriverModel/ByteStreamReadyPortAi.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<interface name="ByteStreamReady" namespace="Drv">
+</interface>

--- a/Drv/ByteStreamDriverModel/CMakeLists.txt
+++ b/Drv/ByteStreamDriverModel/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCE_FILES
     "${CMAKE_CURRENT_LIST_DIR}/ByteStreamRecvPortAi.xml"
     "${CMAKE_CURRENT_LIST_DIR}/ByteStreamSendPortAi.xml"
     "${CMAKE_CURRENT_LIST_DIR}/ByteStreamPollPortAi.xml"
+    "${CMAKE_CURRENT_LIST_DIR}/ByteStreamReadyPortAi.xml"
     "${CMAKE_CURRENT_LIST_DIR}/ByteStreamDriverComponentAi.xml"
 )
 

--- a/Drv/Ip/SocketReadTask.cpp
+++ b/Drv/Ip/SocketReadTask.cpp
@@ -37,7 +37,12 @@ void SocketReadTask::startSocketTask(const Fw::StringBase &name,
 }
 
 SocketIpStatus SocketReadTask::open() {
-    return this->getSocketHandler().open();
+    SocketIpStatus status = this->getSocketHandler().open();
+    // Call connected any time the open is successful
+    if (Drv::SOCK_SUCCESS == status) {
+        this->connected();
+    }
+    return status;
 }
 
 void SocketReadTask::close() {
@@ -60,7 +65,7 @@ void SocketReadTask::readTask(void* pointer) {
     do {
         // Open a network connection if it has not already been open
         if ((not self->getSocketHandler().isOpened()) and (not self->m_stop) and
-            ((status = self->getSocketHandler().open()) != SOCK_SUCCESS)) {
+            ((status = self->open()) != SOCK_SUCCESS)) {
             Fw::Logger::logMsg("[WARNING] Failed to open port with status %d and errno %d\n", status, errno);
             Os::Task::delay(SOCKET_RETRY_INTERVAL_MS);
         }

--- a/Drv/Ip/SocketReadTask.hpp
+++ b/Drv/Ip/SocketReadTask.hpp
@@ -134,6 +134,11 @@ class SocketReadTask {
     virtual void sendBuffer(Fw::Buffer buffer, SocketIpStatus status) = 0;
 
     /**
+     * \brief called when the IPv4 system has been connected
+     */
+    virtual void connected() = 0;
+
+    /**
      * \brief a task designed to read from the socket and output incoming data
      *
      * \param pointer: pointer to "this" component

--- a/Drv/TcpClient/TcpClientComponentImpl.cpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.cpp
@@ -53,6 +53,13 @@ void TcpClientComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status
     this->recv_out(0, buffer, (status == SOCK_SUCCESS) ? RECV_OK : RECV_ERROR);
 }
 
+void TcpClientComponentImpl::connected() {
+    if (isConnected_ready_OutputPort(0)) {
+        this->ready_out(0);
+    }
+
+}
+
 // ----------------------------------------------------------------------
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------

--- a/Drv/TcpClient/TcpClientComponentImpl.hpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.hpp
@@ -103,6 +103,12 @@ class TcpClientComponentImpl : public ByteStreamDriverModelComponentBase, public
      */
     void sendBuffer(Fw::Buffer buffer, SocketIpStatus status);
 
+    /**
+     * \brief called when the IPv4 system has been connected
+    */
+    void connected();
+
+
   PRIVATE:
 
     // ----------------------------------------------------------------------

--- a/Drv/TcpClient/test/ut/Tester.hpp
+++ b/Drv/TcpClient/test/ut/Tester.hpp
@@ -69,6 +69,12 @@ namespace Drv {
           RecvStatus recvStatus 
       );
 
+      //! Handler for from_ready
+      //!
+      void from_ready_handler(
+          const NATIVE_INT_TYPE portNum /*!< The port number*/
+      );
+
       //! Handler for from_allocate
       //!
       Fw::Buffer from_allocate_handler(

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -60,6 +60,13 @@ void TcpServerComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status
     this->recv_out(0, buffer, (status == SOCK_SUCCESS) ? RECV_OK : RECV_ERROR);
 }
 
+void TcpServerComponentImpl::connected() {
+    if (isConnected_ready_OutputPort(0)) {
+        this->ready_out(0);
+    }
+
+}
+
 // ----------------------------------------------------------------------
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -123,6 +123,12 @@ class TcpServerComponentImpl : public ByteStreamDriverModelComponentBase, public
      */
     void sendBuffer(Fw::Buffer buffer, SocketIpStatus status);
 
+    /**
+     * \brief called when the IPv4 system has been connected
+    */
+    void connected();
+
+
   PRIVATE:
 
     // ----------------------------------------------------------------------

--- a/Drv/TcpServer/test/ut/Tester.hpp
+++ b/Drv/TcpServer/test/ut/Tester.hpp
@@ -79,6 +79,12 @@ namespace Drv {
           RecvStatus recvStatus 
       );
 
+      //! Handler for from_ready
+      //!
+      void from_ready_handler(
+          const NATIVE_INT_TYPE portNum /*!< The port number*/
+      );
+
       //! Handler for from_allocate
       //!
       Fw::Buffer from_allocate_handler(

--- a/Drv/Udp/UdpComponentImpl.cpp
+++ b/Drv/Udp/UdpComponentImpl.cpp
@@ -58,6 +58,12 @@ void UdpComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status) {
     this->recv_out(0, buffer, (status == SOCK_SUCCESS) ? RECV_OK : RECV_ERROR);
 }
 
+void UdpComponentImpl::connected() {
+    if (isConnected_ready_OutputPort(0)) {
+        this->ready_out(0);
+    }
+}
+
 // ----------------------------------------------------------------------
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------

--- a/Drv/Udp/UdpComponentImpl.hpp
+++ b/Drv/Udp/UdpComponentImpl.hpp
@@ -123,6 +123,11 @@ class UdpComponentImpl : public ByteStreamDriverModelComponentBase, public Socke
      */
     void sendBuffer(Fw::Buffer buffer, SocketIpStatus status);
 
+    /**
+     * \brief called when the IPv4 system has been connected
+    */
+    void connected();
+
   PRIVATE:
 
     // ----------------------------------------------------------------------

--- a/Drv/Udp/test/ut/Tester.cpp
+++ b/Drv/Udp/test/ut/Tester.cpp
@@ -90,14 +90,16 @@ void Tester::test_with_loop(U32 iterations, bool recv_thread) {
                 while (not m_spinner) {}
             }
         }
-        this->component.close();
+        // Properly stop the client on the last iteration
+        if ((1 + i) == iterations && recv_thread) {
+            this->component.stopSocketTask();
+            this->component.joinSocketTask(NULL);
+        } else {
+            this->component.close();
+        }
         udp2.close();
     }
-    // Wait for the receiver to shutdown
-    if (recv_thread) {
-        this->component.stopSocketTask();
-        this->component.joinSocketTask(NULL);
-    }
+    ASSERT_from_ready_SIZE(iterations);
 }
 
 Tester ::Tester(void)
@@ -142,6 +144,10 @@ void Tester ::from_recv_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& recvB
     Drv::Test::validate_random_buffer(m_data_buffer, recvBuffer.getData());
     m_spinner = true;
     delete[] recvBuffer.getData();
+}
+
+void Tester ::from_ready_handler(const NATIVE_INT_TYPE portNum) {
+    this->pushFromPortEntry_ready();
 }
 
 Fw::Buffer Tester ::
@@ -189,6 +195,12 @@ void Tester ::
     this->component.set_recv_OutputPort(
         0, 
         this->get_from_recv(0)
+    );
+
+    // recv
+    this->component.set_ready_OutputPort(
+      0,
+      this->get_from_ready(0)
     );
 
     // allocate

--- a/Drv/Udp/test/ut/Tester.hpp
+++ b/Drv/Udp/test/ut/Tester.hpp
@@ -80,6 +80,12 @@ namespace Drv {
           RecvStatus recvStatus 
       );
 
+      //! Handler for from_ready
+      //!
+      void from_ready_handler(
+          const NATIVE_INT_TYPE portNum /*!< The port number*/
+      );
+
       //! Handler for from_allocate
       //!
       Fw::Buffer from_allocate_handler(


### PR DESCRIPTION


| | |
|:---|:---|
|**_Originating Project/Creator_**| OWLS |
|**_Affected Component_**| Tcp IP and ByteStreamDriver |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Adds a "ready" port signaling the byte stream driver has connected.

## Rationale

Downlink queues, retry connection code, and more needs to know when a connection was established.

## Testing/Review Recommendations

None.

## Future Work

None.  