### PR TITLE
Disable interval timer test on Mac OS

### DIFF
--- a/Os/test/ut/TestMain.cpp
+++ b/Os/test/ut/TestMain.cpp
@@ -38,7 +38,17 @@ TEST(Nominal, QTestPerformance) {
 TEST(Nominal, QTestConcurrentTest) {
    qtest_concurrent();
 }
+
+// The interval timer unit test is timed off a 1 sec thread delay. Mac OS allows a large amount of
+// scheduling jitter to conserve energy, which rarely causes this sleep to be slightly shorter
+// (~0.99 s) or longer (~10 sec) than requested, causing the test to fail. The interval timer should
+// be rewritten to not directly utilize the OS clock, but in the mean time disabling this test on
+// Mac OS prevents intermittent unit test failures.
+#ifdef TGT_OS_TYPE_DARWIN
+TEST(Nominal, DISABLED_IntervalTimerTest) {
+#else
 TEST(Nominal, IntervalTimerTest) {
+#endif
    intervalTimerTest();
 }
 TEST(Nominal, FileSystemTest) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  Os |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| fixes #856 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The interval timer unit test is timed off a 1 sec thread delay. Mac OS allows a large amount of scheduling jitter to conserve energy, which rarely causes this sleep to be slightly shorter (~0.99 s) or longer (~10 sec) than requested, causing the test to fail. The interval timer should be rewritten to not directly utilize the OS clock, but in the mean time disabling this test on Mac OS prevents intermittent unit test failures.
