### PR TITLE
Use exceptionless variant of new to properly handle allocation errors

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1042,6 +1042,7 @@ nostdlib
 notask
 notchars
 NOTFOUND
+nothrow
 NOTYPE
 Nowicki
 npm

--- a/Autocoders/Python/test/array_xml/test/ut/main.cpp
+++ b/Autocoders/Python/test/array_xml/test/ut/main.cpp
@@ -22,17 +22,9 @@
 
 using namespace std;
 
-// Registry
-static Fw::SimpleObjRegistry* simpleReg_ptr = 0;
-
 // Component instance pointers
 Example::ExampleArrayImpl* inst1 = 0;
 Example::ExampleArrayImpl* inst2 = 0;
-
-extern "C" {
-    void dumparch();
-    void dumpobj(const char* objName);
-}
 
 #ifdef TGT_OS_TYPE_LINUX
 extern "C" {
@@ -40,25 +32,11 @@ extern "C" {
 };
 #endif
 
-void dumparch() {
-    simpleReg_ptr->dump();
-}
-
-void dumpobj(const char* objName) {
-    simpleReg_ptr->dump(objName);
-}
-
-void constructArchitecture() {
-    Fw::PortBase::setTrace(true);
-
-    simpleReg_ptr = new Fw::SimpleObjRegistry();
-
-    dumparch();
-}
-
 int main(int argc, char* argv[]) {
     // Construct the topology here.
-    constructArchitecture();
+    Fw::PortBase::setTrace(true);
+    Fw::SimpleObjRegistry simpleReg_ptr;
+    simpleReg_ptr.dump();
 
     setbuf(stdout, NULL);
 
@@ -156,7 +134,6 @@ int main(int argc, char* argv[]) {
     delete inst1;
     delete inst2;
     cout << "Delete registration objects..." << endl;
-    delete simpleReg_ptr;
     cout << "Completed..." << endl;
 
     return 0;

--- a/Drv/Ip/UdpSocket.cpp
+++ b/Drv/Ip/UdpSocket.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include <string.h>
+#include <new>
 
 namespace Drv {
 
@@ -49,7 +50,9 @@ struct SocketState {
     }
 };
 
-UdpSocket::UdpSocket() : IpSocket(), m_state(new SocketState), m_recv_port(0) {}
+UdpSocket::UdpSocket() : IpSocket(), m_state(new(std::nothrow) SocketState), m_recv_port(0) {
+    FW_ASSERT(m_state != NULL);
+}
 
 UdpSocket::~UdpSocket() {
     FW_ASSERT(m_state);

--- a/Os/Baremetal/Queue.cpp
+++ b/Os/Baremetal/Queue.cpp
@@ -10,6 +10,7 @@
 #include <Fw/Types/Assert.hpp>
 #include <Os/Queue.hpp>
 
+#include <new>
 #include <stdio.h>
 
 namespace Os {
@@ -46,7 +47,7 @@ Queue::QueueStatus Queue::createInternal(const Fw::StringBase &name, NATIVE_INT_
         handle = NULL;
     }
     //New queue handle, check for success or return error
-    handle = new BareQueueHandle;
+    handle = new(std::nothrow) BareQueueHandle;
     if (NULL == handle || !handle->create(depth, msgSize)) {
         return QUEUE_UNINITIALIZED;
     }

--- a/Os/Baremetal/Task.cpp
+++ b/Os/Baremetal/Task.cpp
@@ -3,6 +3,8 @@
 #include <Os/Baremetal/TaskRunner/BareTaskHandle.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <stdio.h>
+#include <new>
+
 namespace Os {
 
 Task::Task() :
@@ -15,7 +17,7 @@ Task::Task() :
 
 Task::TaskStatus Task::start(const Fw::StringBase &name, NATIVE_INT_TYPE identifier, NATIVE_INT_TYPE priority, NATIVE_INT_TYPE stackSize, taskRoutine routine, void* arg, NATIVE_INT_TYPE cpuAffinity) {
     //Get a task handle, and set it up
-    BareTaskHandle* handle = new BareTaskHandle();
+    BareTaskHandle* handle = new(std::nothrow) BareTaskHandle();
     if (handle == NULL) {
        return Task::TASK_UNKNOWN_ERROR;
     }

--- a/Os/MacOs/IPCQueueStub.cpp
+++ b/Os/MacOs/IPCQueueStub.cpp
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <new>
 
 namespace Os {
 
@@ -63,7 +64,7 @@ namespace Os {
     }
 
     // Create queue handle:
-    queueHandle = new QueueHandle;
+    queueHandle = new(std::nothrow) QueueHandle;
     if (NULL == queueHandle) {
       return QUEUE_UNINITIALIZED;
     }

--- a/Os/Posix/IPCQueue.cpp
+++ b/Os/Posix/IPCQueue.cpp
@@ -19,6 +19,7 @@
 #include <time.h>
 #include <sys/time.h>
 #include <pthread.h>
+#include <new>
 
 #define IPC_QUEUE_TIMEOUT_SEC (1)
 
@@ -84,7 +85,7 @@ namespace Os {
         }
 
         // Set up queue handle:
-        QueueHandle* queueHandle = new QueueHandle(handle);
+        QueueHandle* queueHandle = new(std::nothrow) QueueHandle(handle);
         if (NULL == queueHandle) {
           return QUEUE_UNINITIALIZED;
         }

--- a/Os/Posix/LocklessQueue.cpp
+++ b/Os/Posix/LocklessQueue.cpp
@@ -3,6 +3,7 @@
 
 #include <fcntl.h>
 #include <string.h>
+#include <new>
 
 #define CAS(a_ptr, a_oldVal, a_newVal) __sync_bool_compare_and_swap(a_ptr, a_oldVal, a_newVal)
 
@@ -19,8 +20,9 @@ namespace Os {
         // Must have at least 2 messages in the queue
         FW_ASSERT(maxmsg >= 2, maxmsg);
 
-        m_index = new QueueNode[maxmsg]; // Allocate an index entry for each msg
-        m_data = new U8[maxmsg * msgsize];  // Allocate data for each msg
+        m_index = new(std::nothrow) QueueNode[maxmsg]; // Allocate an index entry for each msg
+        m_data = new(std::nothrow) U8[maxmsg * msgsize];  // Allocate data for each msg
+        FW_ASSERT(m_index != NULL);
         FW_ASSERT(m_data != NULL);
 
         for (int i = 0, j = 1; i < maxmsg; i++, j++) {

--- a/Os/Posix/Mutex.cpp
+++ b/Os/Posix/Mutex.cpp
@@ -1,11 +1,14 @@
 #include <Os/Mutex.hpp>
 #include <pthread.h>
 #include <Fw/Types/Assert.hpp>
+#include <new>
 
 namespace Os {
 
     Mutex::Mutex() {
-        pthread_mutex_t* handle = new pthread_mutex_t;
+        pthread_mutex_t* handle = new(std::nothrow) pthread_mutex_t;
+        FW_ASSERT(handle != NULL);
+
         // set attributes
         pthread_mutexattr_t attr;
         pthread_mutexattr_init(&attr);
@@ -46,5 +49,3 @@ namespace Os {
     }
 
 }
-
-

--- a/Os/Posix/Queue.cpp
+++ b/Os/Posix/Queue.cpp
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <time.h>
 #include <pthread.h>
+#include <new>
 
 namespace Os {
 
@@ -90,7 +91,7 @@ namespace Os {
         }
 
         // Set up queue handle:
-        QueueHandle* queueHandle = new QueueHandle(handle);
+        QueueHandle* queueHandle = new(std::nothrow) QueueHandle(handle);
         if (NULL == queueHandle) {
           return QUEUE_UNINITIALIZED;
         }

--- a/Os/Posix/Task.cpp
+++ b/Os/Posix/Task.cpp
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <time.h>
 #include <stdio.h>
+#include <new>
 #include <Fw/Logger/Logger.hpp>
 
 typedef void* (*pthread_func_ptr)(void*);
@@ -120,7 +121,12 @@ namespace Os {
             Task::s_taskRegistry->addTask(this);
         }
 
-        pthread_t* tid = new pthread_t;
+        pthread_t* tid = new(std::nothrow) pthread_t;
+        if (tid == NULL) {
+            Fw::Logger::logMsg("failed to allocate pthread_t\n");
+            return TASK_UNKNOWN_ERROR;
+        }
+
         this->m_routineWrapper.routine = routine;
         this->m_routineWrapper.arg = arg;
 

--- a/Os/Posix/TaskRoot.cpp
+++ b/Os/Posix/TaskRoot.cpp
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <time.h>
 #include <stdio.h>
+#include <new>
 
 //#define DEBUG_PRINT(x,...) Fw::Logger::logMsg(x,##__VA_ARGS__);
 #define DEBUG_PRINT(x,...)
@@ -89,7 +90,11 @@ namespace Os {
             Task::s_taskRegistry->addTask(this);
         }
 
-        pthread_t* tid = new pthread_t;
+        pthread_t* tid = new(std::nothrow) pthread_t;
+        if (tid == NULL) {
+            Fw::Logger::logMsg("failed to allocate pthread_t\n");
+            return TASK_UNKNOWN_ERROR;
+        }
 
         stat = pthread_create(tid,&att,(pthread_func_ptr)routine,arg);
 

--- a/Os/Pthreads/FIFOBufferQueue.cpp
+++ b/Os/Pthreads/FIFOBufferQueue.cpp
@@ -1,7 +1,7 @@
 // ======================================================================
 // \title  FIFOBufferQueue.hpp
 // \author dinkel
-// \brief  An implementation of BufferQueue which uses a FIFO data 
+// \brief  An implementation of BufferQueue which uses a FIFO data
 //         structure for the queue. Priority is ignored.
 //
 // \copyright
@@ -13,7 +13,9 @@
 
 #include "Os/Pthreads/BufferQueue.hpp"
 #include <Fw/Types/Assert.hpp>
+
 #include <string.h>
+#include <new>
 
 // This is a simple FIFO queue implementation which ignores priority
 namespace Os {
@@ -33,11 +35,11 @@ namespace Os {
   /////////////////////////////////////////////////////
 
   bool BufferQueue::initialize(NATIVE_UINT_TYPE depth, NATIVE_UINT_TYPE msgSize) {
-    U8* data = new U8[depth*(sizeof(msgSize) + msgSize)];  
+    U8* data = new(std::nothrow) U8[depth*(sizeof(msgSize) + msgSize)];
     if (NULL == data) {
       return false;
     }
-    FIFOQueue* fifoQueue = new FIFOQueue;
+    FIFOQueue* fifoQueue = new(std::nothrow) FIFOQueue;
     if (NULL == fifoQueue) {
       return false;
     }
@@ -56,7 +58,7 @@ namespace Os {
       if (NULL != data) {
         delete [] data;
       }
-      delete fQueue; 
+      delete fQueue;
     }
     this->queue = NULL;
   }
@@ -75,20 +77,20 @@ namespace Os {
     ++fQueue->tail;
     return true;
   }
- 
+
   bool BufferQueue::dequeue(U8* buffer, NATIVE_UINT_TYPE& size, NATIVE_INT_TYPE &priority) {
     (void) priority;
 
     FIFOQueue* fQueue = static_cast<FIFOQueue*>(this->queue);
     U8* data = fQueue->data;
-    
+
     // Get the buffer from the queue:
     NATIVE_UINT_TYPE index = getBufferIndex(fQueue->head);
     bool ret = this->dequeueBuffer(buffer, size, data, index);
     if(!ret) {
       return false;
     }
-    
+
     // Increment head of fifo:
     ++fQueue->head;
     return true;

--- a/Os/Pthreads/MaxHeap/MaxHeap.cpp
+++ b/Os/Pthreads/MaxHeap/MaxHeap.cpp
@@ -1,10 +1,10 @@
 // ======================================================================
 // \title  MaxHeap.cpp
 // \author dinkel
-// \brief  An implementation of a stable max heap data structure. Items 
+// \brief  An implementation of a stable max heap data structure. Items
 //         popped off the heap are guaranteed to be in order of decreasing
-//         "value" (max removed first). Items of equal "value" will be 
-//         popped off in FIFO order. The performance of both push and pop 
+//         "value" (max removed first). Items of equal "value" will be
+//         popped off in FIFO order. The performance of both push and pop
 //         is O(log(n)).
 //
 // \copyright
@@ -17,16 +17,18 @@
 #include "Os/Pthreads/MaxHeap/MaxHeap.hpp"
 #include "Fw/Types/BasicTypes.hpp"
 #include "Fw/Types/Assert.hpp"
-#include <stdio.h>
 #include <Fw/Logger/Logger.hpp>
+
+#include <new>
+#include <stdio.h>
 
 // Macros for traversing the heap:
 #define LCHILD(x) (2 * x + 1)
 #define RCHILD(x) (2 * x + 2)
 #define PARENT(x) ((x - 1) / 2)
-  
+
 namespace Os {
-    
+
     MaxHeap::MaxHeap() {
       // Initialize the heap:
       this->capacity = 0;
@@ -34,7 +36,7 @@ namespace Os {
       this->size = 0;
       this->order = 0;
     }
-  
+
     MaxHeap::~MaxHeap() {
       delete [] this->heap;
       this->heap = NULL;
@@ -49,14 +51,14 @@ namespace Os {
         this->heap = NULL;
       }
 
-      this->heap = new Node[capacity];
+      this->heap = new(std::nothrow) Node[capacity];
       if( NULL == this->heap ) {
         return false;
       }
       this->capacity = capacity;
       return true;
     }
-  
+
     bool MaxHeap::push(NATIVE_INT_TYPE value, NATIVE_UINT_TYPE id) {
       // If the queue is full, return false:
       if(this->isFull()) {
@@ -72,16 +74,16 @@ namespace Os {
       NATIVE_UINT_TYPE maxCount = 0;
 
       // Start at the bottom of the heap and work our ways
-      // upwards until we find a parent that has a value 
+      // upwards until we find a parent that has a value
       // greater than ours.
       while(index && maxCount < maxIter) {
         // Get the parent index:
         parent = PARENT(index);
-        // The parent index should ALWAYS be less than the 
+        // The parent index should ALWAYS be less than the
         // current index. Let's verify that.
         FW_ASSERT(parent < index, parent, index);
         // If the current value is less than the parent,
-        // then the current index is in the correct place, 
+        // then the current index is in the correct place,
         // so break out of the loop:
         if(value <= this->heap[parent].value) {
           break;
@@ -119,15 +121,15 @@ namespace Os {
       id = this->heap[0].id;
 
       // Now place the last element on the heap in
-      // the root position, and resize the heap. 
-      // This will put the smallest value in the 
+      // the root position, and resize the heap.
+      // This will put the smallest value in the
       // heap on the top, violating the heap property.
       NATIVE_UINT_TYPE index = this->size-1;
       // Fw::Logger::logMsg("Putting on top: i: %u v: %d\n", index, this->heap[index].value);
       this->heap[0]= this->heap[index];
       --this->size;
 
-      // Now that the heap property is violated, we 
+      // Now that the heap property is violated, we
       // need to reorganize the heap to restore it's
       // heapy-ness.
       this->heapify();
@@ -143,7 +145,7 @@ namespace Os {
     bool MaxHeap::isEmpty() {
       return (this->size == 0);
     }
-    
+
     // Get the current size of the heap:
     NATIVE_UINT_TYPE MaxHeap::getSize() {
       return this->size;
@@ -200,21 +202,21 @@ namespace Os {
         }
 
         // Swap the largest node with the current node:
-        // Fw::Logger::logMsg("Swapping: i: %u v: %d with i: %u v: %d\n", 
+        // Fw::Logger::logMsg("Swapping: i: %u v: %d with i: %u v: %d\n",
         //   index, this->heap[index].value,
         //   largest, this->heap[largest].value);
         this->swap(index, largest);
 
         // Set the new index to whichever child was larger:
         index = largest;
-      }  
+      }
 
       // Check for programming errors or bit flips:
       FW_ASSERT(maxCount < maxIter, maxCount, maxIter);
       FW_ASSERT(index <= this->size, index);
     }
 
-    // Return the maximum priority index between two nodes. If their 
+    // Return the maximum priority index between two nodes. If their
     // priorities are equal, return the oldest to keep the heap stable
     NATIVE_UINT_TYPE MaxHeap::max(NATIVE_UINT_TYPE a, NATIVE_UINT_TYPE b) {
       FW_ASSERT(a < this->size, a, this->size);
@@ -223,7 +225,7 @@ namespace Os {
       // Extract the priorities:
       NATIVE_INT_TYPE aValue = this->heap[a].value;
       NATIVE_INT_TYPE bValue = this->heap[b].value;
-      
+
       // If the priorities are equal, the "larger" one will be
       // the "older" one as determined by order pushed on to the
       // heap. Using this secondary ordering technique makes the

--- a/Os/Pthreads/PriorityBufferQueue.cpp
+++ b/Os/Pthreads/PriorityBufferQueue.cpp
@@ -18,6 +18,7 @@
 #include <Fw/Types/Assert.hpp>
 #include <string.h>
 #include <stdio.h>
+#include <new>
 
 // This is a priority queue implementation implemented using a stable max heap.
 // Elements pushed onto the queue will be popped off in priority order.
@@ -67,25 +68,25 @@ namespace Os {
 
   bool BufferQueue::initialize(NATIVE_UINT_TYPE depth, NATIVE_UINT_TYPE msgSize) {
     // Create the priority queue data structure on the heap:
-    MaxHeap* heap = new MaxHeap;
+    MaxHeap* heap = new(std::nothrow) MaxHeap;
     if (NULL == heap) {
       return false;
     }
     if( !heap->create(depth) ) {
       return false;
     }
-    U8* data = new U8[depth*(sizeof(msgSize) + msgSize)];  
+    U8* data = new(std::nothrow) U8[depth*(sizeof(msgSize) + msgSize)];
     if (NULL == data) {
       return false;
     }
-    NATIVE_UINT_TYPE* indexes = new NATIVE_UINT_TYPE[depth];
+    NATIVE_UINT_TYPE* indexes = new(std::nothrow) NATIVE_UINT_TYPE[depth];
     if (NULL == indexes) {
       return false;
     }
     for(NATIVE_UINT_TYPE ii = 0; ii < depth; ++ii) {
         indexes[ii] = getBufferIndex(ii);
     }
-    PriorityQueue* priorityQueue = new PriorityQueue;
+    PriorityQueue* priorityQueue = new(std::nothrow) PriorityQueue;
     if (NULL == priorityQueue) {
       return false;
     }
@@ -104,18 +105,18 @@ namespace Os {
     {
       MaxHeap* heap = pQueue->heap;
       if (NULL != heap) {
-        delete heap; 
+        delete heap;
       }
       U8* data = pQueue->data;
       if (NULL != data) {
-        delete [] data; 
+        delete [] data;
       }
       NATIVE_UINT_TYPE* indexes = pQueue->indexes;
       if (NULL != indexes)
       {
-        delete [] indexes; 
+        delete [] indexes;
       }
-      delete pQueue; 
+      delete pQueue;
     }
     this->queue = NULL;
   }
@@ -129,7 +130,7 @@ namespace Os {
 
     // Get an available data index:
     NATIVE_UINT_TYPE index = checkoutIndex(pQueue, this->depth);
-    
+
     // Insert the data into the heap:
     bool ret = heap->push(priority, index);
     FW_ASSERT(ret, ret);
@@ -139,7 +140,7 @@ namespace Os {
 
     return true;
   }
- 
+
   bool BufferQueue::dequeue(U8* buffer, NATIVE_UINT_TYPE& size, NATIVE_INT_TYPE &priority) {
 
     // Extract queue handle variables:

--- a/Os/Pthreads/Queue.cpp
+++ b/Os/Pthreads/Queue.cpp
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <new>
 
 namespace Os {
 
@@ -64,7 +65,7 @@ namespace Os {
     }
 
     // Create queue handle:
-    queueHandle = new QueueHandle;
+    queueHandle = new(std::nothrow) QueueHandle;
     if (NULL == queueHandle) {
       return QUEUE_UNINITIALIZED;
     }

--- a/Os/test/ut/OsTaskTest.cpp
+++ b/Os/test/ut/OsTaskTest.cpp
@@ -4,25 +4,20 @@
 #include <Fw/Types/EightyCharString.hpp>
 
 extern "C" {
-    void startTestTask(int iters);
+    void startTestTask();
 }
-
-Os::Task* testTask = 0;
 
 void someTask(void* ptr) {
-    
-    long iters = (long) ptr;
-    
-    while (iters--) {
-        Os::Task::delay(1000);
-        printf("Tick %ld!\n",iters);
-    }
+    bool* ran = (bool*) ptr;
+    *ran = true;
 }
 
-void startTestTask(int iters) {
-    long localIter = iters;
-    testTask = new Os::Task();
+void startTestTask() {
+    volatile bool taskRan = false;
+    Os::Task testTask;
     Fw::EightyCharString name("ATestTask");
-    Os::Task::TaskStatus stat = testTask->start(name,12,100,10*1024,someTask,(void*) localIter);
+    Os::Task::TaskStatus stat = testTask.start(name,12,100,10*1024,someTask,(void*) &taskRan);
     ASSERT_EQ(stat, Os::Task::TASK_OK);
+    testTask.join(NULL);
+    ASSERT_EQ(taskRan, true);
 }

--- a/Os/test/ut/TestMain.cpp
+++ b/Os/test/ut/TestMain.cpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 extern "C" {
-  void startTestTask(int iters);
+  void startTestTask();
   void qtest_block_receive();
   void qtest_nonblock_receive();
   void qtest_nonblock_send();
@@ -17,8 +17,7 @@ extern "C" {
 }
 const char* filename;
 TEST(Nominal, StartTestTask) {
-   startTestTask(10);
-   sleep(15);
+   startTestTask();
 }
 TEST(Nominal, QTestBlockRecv) {
    qtest_block_receive();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| various |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n/a |

---
## Change Description

Switch F' from using `new` to `new (std::nothrow)`

## Rationale

`new` can throw an exception if allocation fails. When an exception is thrown but not handled it causes the current task to immediately halt. Switch to `new (std::nothrow)`, which returns  NULL on allocation failure.

I didn't update tests using `new` since for unit tests halting on memory allocation is the desired behavior.