### PR TITLE
Pass pointer rather than array to rategroup

### DIFF
--- a/RPI/Top/Topology.cpp
+++ b/RPI/Top/Topology.cpp
@@ -21,7 +21,7 @@ Svc::FprimeFraming framing;
 
 // Rate Group Dividers for 10Hz and 1Hz
 
-static NATIVE_INT_TYPE rgDivs[] = {1,10,0};
+static NATIVE_UINT_TYPE rgDivs[] = {1,10,0};
 Svc::RateGroupDriverImpl rateGroupDriverComp("RGDRV",rgDivs,FW_NUM_ARRAY_ELEMENTS(rgDivs));
 
 // Context array variables are passed to rate group members if needed to distinguish one call from another

--- a/Ref/Top/RefTopologyAc.cpp
+++ b/Ref/Top/RefTopologyAc.cpp
@@ -108,7 +108,7 @@ namespace Ref {
       }
 
       namespace rateGroupDriverComp {
-        NATIVE_INT_TYPE rgDivs[Svc::RateGroupDriverImpl::DIVIDER_SIZE] = { 1, 2, 4 };
+        NATIVE_UINT_TYPE rgDivs[Svc::RateGroupDriverImpl::DIVIDER_SIZE] = { 1, 2, 4 };
       }
 
       namespace uplink {

--- a/Svc/ActiveRateGroup/ActiveRateGroupImpl.cpp
+++ b/Svc/ActiveRateGroup/ActiveRateGroupImpl.cpp
@@ -20,7 +20,7 @@
 
 namespace Svc {
 
-    ActiveRateGroupImpl::ActiveRateGroupImpl(const char* compName, NATIVE_UINT_TYPE contexts[], NATIVE_UINT_TYPE numContexts) :
+    ActiveRateGroupImpl::ActiveRateGroupImpl(const char* compName, NATIVE_UINT_TYPE* contexts, NATIVE_UINT_TYPE numContexts) :
             ActiveRateGroupComponentBase(compName),
             m_cycles(0),
             m_maxTime(0),

--- a/Svc/ActiveRateGroup/ActiveRateGroupImpl.hpp
+++ b/Svc/ActiveRateGroup/ActiveRateGroupImpl.hpp
@@ -41,7 +41,7 @@ namespace Svc {
             //!         to each member component. The index of the array corresponds to the
             //!         output port number.
             //!  \param numContexts The number of elements in the context array.
-            ActiveRateGroupImpl(const char* compName, NATIVE_UINT_TYPE contexts[], NATIVE_UINT_TYPE numContexts);
+            ActiveRateGroupImpl(const char* compName, NATIVE_UINT_TYPE* contexts, NATIVE_UINT_TYPE numContexts);
 
             //!  \brief ActiveRateGroupImpl initialization function
             //!

--- a/Svc/RateGroupDriver/RateGroupDriverImpl.cpp
+++ b/Svc/RateGroupDriver/RateGroupDriverImpl.cpp
@@ -6,23 +6,23 @@
 
 namespace Svc {
 
-    RateGroupDriverImpl::RateGroupDriverImpl(const char* compName, I32 dividers[], I32 numDividers) :
+    RateGroupDriverImpl::RateGroupDriverImpl(const char* compName, NATIVE_UINT_TYPE* dividers, NATIVE_UINT_TYPE numDividers) :
         RateGroupDriverComponentBase(compName),
     m_ticks(0),m_rollover(1)
     {
 
         // double check arguments
         FW_ASSERT(dividers);
-        FW_ASSERT(numDividers <= static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)),
+        FW_ASSERT(numDividers <= static_cast<NATIVE_UINT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)),
                 numDividers,
-                static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)));
+                static_cast<NATIVE_UINT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)));
         // verify port/table size matches
         FW_ASSERT(FW_NUM_ARRAY_ELEMENTS(this->m_dividers) == this->getNum_CycleOut_OutputPorts(),
                 static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)),
                 this->getNum_CycleOut_OutputPorts());
         // clear table
         ::memset(this->m_dividers,0,sizeof(this->m_dividers));
-        for (NATIVE_INT_TYPE entry = 0; entry < numDividers; entry++) {
+        for (U32 entry = 0; entry < numDividers; entry++) {
             this->m_dividers[entry] = dividers[entry];
             // rollover value should be product of all dividers to make sure integer rollover doesn't jump cycles
             // only use non-zero dividers

--- a/Svc/RateGroupDriver/RateGroupDriverImpl.hpp
+++ b/Svc/RateGroupDriver/RateGroupDriverImpl.hpp
@@ -44,7 +44,7 @@ namespace Svc {
             //!  \param numDividers size of dividers array
             //!
             //!  \return return value description
-            RateGroupDriverImpl(const char* compName, NATIVE_INT_TYPE dividers[], NATIVE_INT_TYPE numDividers);
+            RateGroupDriverImpl(const char* compName, NATIVE_UINT_TYPE* dividers, NATIVE_UINT_TYPE numDividers);
 
             //!  \brief RateGroupDriverImpl initialization function
             //!
@@ -63,7 +63,7 @@ namespace Svc {
             void CycleIn_handler(NATIVE_INT_TYPE portNum, Svc::TimerVal& cycleStart);
 
             //! divider array
-            NATIVE_INT_TYPE m_dividers[NUM_CYCLEOUT_OUTPUT_PORTS];
+            NATIVE_UINT_TYPE m_dividers[NUM_CYCLEOUT_OUTPUT_PORTS];
 
             //! tick counter
             NATIVE_INT_TYPE m_ticks;

--- a/Svc/RateGroupDriver/test/ut/RateGroupDriverImplTester.cpp
+++ b/Svc/RateGroupDriver/test/ut/RateGroupDriverImplTester.cpp
@@ -37,7 +37,7 @@ namespace Svc {
         this->m_portCalls[portNum] = true;
     }
 
-    void RateGroupDriverImplTester::runSchedNominal(NATIVE_INT_TYPE dividers[], NATIVE_INT_TYPE numDividers) {
+    void RateGroupDriverImplTester::runSchedNominal(NATIVE_UINT_TYPE* dividers, NATIVE_UINT_TYPE numDividers) {
 
         TEST_CASE(106.1.1,"Nominal Execution");
         COMMENT(
@@ -47,7 +47,7 @@ namespace Svc {
 
         NATIVE_INT_TYPE expected_rollover = 1;
 
-        for (NATIVE_INT_TYPE div = 0; div < numDividers; div++) {
+        for (NATIVE_UINT_TYPE div = 0; div < numDividers; div++) {
             expected_rollover *= dividers[div];
         }
 
@@ -64,7 +64,7 @@ namespace Svc {
             // make sure ticks are counting correctly
             ASSERT_EQ((cycle+1)%expected_rollover,this->m_impl.m_ticks);
             // check for various intervals
-            for (NATIVE_INT_TYPE div = 0; div < numDividers; div++) {
+            for (NATIVE_UINT_TYPE div = 0; div < numDividers; div++) {
                 if (cycle % dividers[div] == 0) {
                     EXPECT_TRUE(this->m_portCalls[div]);
                 } else {

--- a/Svc/RateGroupDriver/test/ut/RateGroupDriverImplTester.hpp
+++ b/Svc/RateGroupDriver/test/ut/RateGroupDriverImplTester.hpp
@@ -20,7 +20,7 @@ namespace Svc {
 
             void init(NATIVE_INT_TYPE instance = 0);
 
-            void runSchedNominal(NATIVE_INT_TYPE dividers[], NATIVE_INT_TYPE numDividers);
+            void runSchedNominal(NATIVE_UINT_TYPE* dividers, NATIVE_UINT_TYPE numDividers);
 
         private:
 

--- a/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
+++ b/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
@@ -31,7 +31,7 @@ void connectPorts(Svc::RateGroupDriverImpl& impl, Svc::RateGroupDriverImplTester
 
 TEST(RateGroupDriverTest,NominalSchedule) {
 
-    NATIVE_INT_TYPE dividers[] = {1,2,3};
+    NATIVE_UINT_TYPE dividers[] = {1,2,3};
 
     Svc::RateGroupDriverImpl impl("RateGroupDriverImpl",dividers,FW_NUM_ARRAY_ELEMENTS(dividers));
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| RateGroup and ActiveRateGroup |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y  |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y  |

---
## Change Description

Removes linter warning by switching from passing a raw array to passing a point to rategroup drivers.
Switch make rategroup constructor consistent between header and definition - this is technically a breaking change because I switched the passive rategroup from taking a list of I32/NATIVE_INT_TYPE to taking a list of NATIVE_UINT_TYPE.