### PR TITLE
Default F' to C++11

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -127,24 +127,29 @@ endif()
 #
 # e.g. `-DCMAKE_BUILD_TYPE=TESTING`
 ####
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions" CACHE STRING "General C++ flags" FORCE)
-SET(CMAKE_CXX_FLAGS_RELEASE "-std=c++03" CACHE STRING "C++ flags." FORCE)
-SET(CMAKE_C_FLAGS_RELEASE "-std=c99" CACHE STRING "C flags." FORCE)
-# Raise C++ standard to C++11 while unit testing to support googletest
-SET(CMAKE_CXX_FLAGS_TESTING "-std=c++11 -g -DBUILD_UT -DPROTECTED=public -DPRIVATE=public -DSTATIC= -fprofile-arcs -ftest-coverage"
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+SET(CMAKE_CXX_FLAGS "-fno-exceptions" CACHE STRING "General C++ flags" FORCE)
+SET(CMAKE_CXX_FLAGS_TESTING "-g -DBUILD_UT -DPROTECTED=public -DPRIVATE=public -DSTATIC= -fprofile-arcs -ftest-coverage"
     CACHE STRING "Testing C++ flags." FORCE)
-SET(CMAKE_C_FLAGS_TESTING "-std=c99 -g -DBUILD_UT -DPROTECTED=public -DPRIVATE=public -DSTATIC= -fprofile-arcs -ftest-coverage"
+SET(CMAKE_C_FLAGS_TESTING "-g -DBUILD_UT -DPROTECTED=public -DPRIVATE=public -DSTATIC= -fprofile-arcs -ftest-coverage"
     CACHE STRING "Testing C flags." FORCE)
 SET(CMAKE_EXE_LINKER_FLAGS_TESTING "" CACHE STRING "Testing linker flags." FORCE)
 SET(CMAKE_SHARED_LINKER_FLAGS_TESTING "" CACHE STRING "Testing linker flags." FORCE)
 MARK_AS_ADVANCED(
     CMAKE_CXX_FLAGS
-    CMAKE_CXX_FLAGS_RELEASE
-    CMAKE_C_FLAGS_RELEASE
     CMAKE_CXX_FLAGS_TESTING
     CMAKE_C_FLAGS_TESTING
     CMAKE_EXE_LINKER_FLAGS_TESTING
     CMAKE_SHARED_LINKER_FLAGS_TESTING )
+
 # Testing setup for UT and coverage builds
 if (CMAKE_BUILD_TYPE STREQUAL "TESTING" )
     # These two lines allow for F prime style coverage. They are "unsupported" CMake features, so beware....


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| cmake |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

This updates the 3.0 release of F' to use C++11. CMake has been updated to set `--std=c++11` and to error when the compiler lacks C++11 support.
