### PR TITLE
docs: Update Incorrect Ref Executable Path

### DIFF
--- a/docs/Tutorials/GettingStarted/Tutorial.md
+++ b/docs/Tutorials/GettingStarted/Tutorial.md
@@ -204,14 +204,7 @@ cd fprime/Ref
 fprime-util build raspberrypi
 ```
 
-## Installing the F´ Executable and Dictionaries
-
-Once the deployment is built, it would be nice to be able to install the binary and dictionaries. This will enable the users to
-quickly find and run the deployment. This installation can be run using the following command. Everything will be installed to
-the directory defining the deployment. i.e. `fprime/Ref/bin`. Install will also invoke `build` so users should use this in-place
-of build for deployments.
-
-**Installing the Ref Deployment and Running the Binary Assuming Linux**
+**Running the Binary Assuming Linux**
 ```
 cd fprime/Ref
 fprime-util build

--- a/docs/Tutorials/GettingStarted/Tutorial.md
+++ b/docs/Tutorials/GettingStarted/Tutorial.md
@@ -215,7 +215,7 @@ of build for deployments.
 ```
 cd fprime/Ref
 fprime-util build
-./bin/Linux/Ref # Run the deployment
+./build-artifacts/Linux/bin/Ref # Run the deployment
 CTRL-C # Exit the application
 ```
 Running the application as part of the development ground data system is shown below.


### PR DESCRIPTION
#864

| | |
|:---|:---|
|**_Originating Project/Creator_**|Esteban Duran|
|**_Affected Component_**| F' Tutorial.md |
|**_Affected Architectures(s)_**|F' Docs  |
|**_Related Issue(s)_**| |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Change the **Installing the Ref Deployment and Running the Binary Assuming Linux** section in _Tutorial.md_ to say:
```sh
cd fprime/Ref
fprime-util build
./build-artifacts/Linux/bin/Ref # Run the deployment
CTRL-C # Exit the application
```

## Rationale

The original documentation says to do the following:
```sh
cd fprime/Ref
fprime-util build
./bin/Linux/Ref # Run the deployment
CTRL-C # Exit the application
```
However, it does not create a bin directory at `fprime/Ref` nor does that `bin` directory exist anywhere inside of the project. This is misleading to individuals going through the tutorial.

## Testing/Review Recommendations

Fetch the latest `devel` branch and go through the tutorial.

## Future Work

None.
