### PR TITLE
fix: Autocoders: finishPortH.tmpl, clerical error

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/port/finishPortH.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/port/finishPortH.tmpl
@@ -1,4 +1,4 @@
-    /// Input $name port description
+    /// Output $name port description
     /// $desc
     
     class Output${name}Port : public Fw::OutputPortBase {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Autocoder|
|**_Affected Component_**| xxPortAc.hpp |
|**_Affected Architectures(s)_**| n |
|**_Related Issue(s)_**| n |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

The template "finishPortH.tmpl" for creating the last part of "[xx]PortAc.hpp", has an obvious comment error. It is not a functional error, but better to be corrected as well.

as an example:

The CyclePortAc.hpp likes this:

    /// Input Cycle port description
    /// 
    
    class OutputCyclePort : public Fw::OutputPortBase {
      public: 
        OutputCyclePort(void);

**After modification: ** (Comment has changed: /// Input --> /// Output)

    /// Output Cycle port description
    /// 
    
    class OutputCyclePort : public Fw::OutputPortBase {
      public: 
        OutputCyclePort(void);


## Rationale

A comment clerical error

## Testing/Review Recommendations

Not related specific feature for this

## Future Work

Review all templates in autocoder, check if there are other similar issues. 
