### PR TITLE
Fix #873, allow nullptr as an input with buffer constructor with an a…

### DIFF
--- a/Fw/Buffer/Buffer.cpp
+++ b/Fw/Buffer/Buffer.cpp
@@ -35,11 +35,15 @@ Buffer::Buffer(const Buffer& src) : Serializable(),
 {}
 
 Buffer::Buffer(U8* data, U32 size, U32 context) : Serializable(),
-    m_serialize_repr(data, size),
+    m_serialize_repr(),
     m_bufferData(data),
     m_size(size),
     m_context(context)
-{}
+{
+    if(m_bufferData != NULL){
+        this->m_serialize_repr.setExtBuffer(m_bufferData, m_size);
+    }
+}
 
 Buffer& Buffer::operator=(const Buffer& src) {
     // Ward against self-assignment

--- a/Fw/Buffer/test/ut/TestBuffer.cpp
+++ b/Fw/Buffer/test/ut/TestBuffer.cpp
@@ -31,6 +31,11 @@ void test_basic() {
     ASSERT_EQ(buffer_new.getContext(), 1234);
     ASSERT_EQ(buffer, buffer_new);
 
+    // Creating empty buffer
+    Fw::Buffer testBuffer(nullptr,0);
+    ASSERT_EQ(testBuffer.getData(), nullptr);
+    ASSERT_EQ(testBuffer.getSize(), 0);
+
     // Assignment operator with transitivity
     Fw::Buffer buffer_assignment1, buffer_assignment2;
     ASSERT_NE(buffer_assignment1.getData(), data);


### PR DESCRIPTION
| | |
|:---|:---|

|**_Affected Component_**|  |
Fw::Buffer
|**_Related Issue(s)_**|  |
#873 
|**_Has Unit Tests (y/n)_**|  |
y
|**_Builds Without Errors (y/n)_**|  |
y
|**_Unit Tests Pass (y/n)_**|  |
y
|**_Documentation Included (y/n)_**|  |
n

---
## Description

Allows data=nullptr and size=0 in Fw::Buffer

## Rationale
#873

## Testing/Review Recommendations
I added an assert inside the Buffer ut


