### PR TITLE
lestarch: fixes an overzealous string copy assert

### DIFF
--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -9,7 +9,7 @@ char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 nu
     }
 
     // Copying an overlapping range is undefined
-    FW_ASSERT(source + num <= destination || destination + num <= source);
+    FW_ASSERT(destination + num <= source);
 
     char* returned = strncpy(destination, source, num);
     destination[num - 1] = '\0';

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -9,7 +9,7 @@ char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 nu
     }
 
     // Copying an overlapping range is undefined
-    FW_ASSERT(destination + num <= source);
+    FW_ASSERT(source < destination || destination + num <= source);
 
     char* returned = strncpy(destination, source, num);
     destination[num - 1] = '\0';


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The destination must be large enough to hold the full copy without colliding with source...however; source is not required to  be that large and still not overlap (constant string on stack have this property).  This fixes the resulting bug.