### PR TITLE
Don't generate zero size array for argumentless ports

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortCpp.tmpl
@@ -92,20 +92,30 @@ namespace ${n} {
 
             public:
                 NATIVE_UINT_TYPE getBuffCapacity() const {
-                    return sizeof(m_buff);
+                    return Input${name}Port::SERIALIZED_SIZE;
                 }
 
                 U8* getBuffAddr() {
+#if len($arg_list) > 0:
                     return m_buff;
+#else
+                    return nullptr;
+#end if
                 }
 
                 const U8* getBuffAddr() const {
+#if len($arg_list) > 0:
                     return m_buff;
+#else
+                    return nullptr;
+#end if
                 }
 
         private:
 
+#if len($arg_list) > 0:
             U8 m_buff[Input${name}Port::SERIALIZED_SIZE];
+#end if
 
         };
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Autocoder |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

When ports have no arguments, their serialized size is zero. The autocoder was generating zero sized arrays for the backing serial buffer, which isn't valid ISO C++ and produced compilation errors when compiling with `-pedantic`.
