### PR TITLE
Remove usage of GCC switch range extension

### DIFF
--- a/Svc/CmdSequencer/FPrimeSequence.cpp
+++ b/Svc/CmdSequencer/FPrimeSequence.cpp
@@ -358,19 +358,18 @@ namespace Svc {
   {
     Fw::SerializeBufferBase& buffer = this->m_buffer;
     U8 descEntry;
+
     Fw::SerializeStatus status = buffer.deserialize(descEntry);
-    if (status == Fw::FW_SERIALIZE_OK) {
-      switch (descEntry) {
-        case Sequence::Record::ABSOLUTE...Sequence::Record::END_OF_SEQUENCE:
-          break;
-        default:
-          status = Fw::FW_DESERIALIZE_FORMAT_ERROR;
-      }
+    if (status != Fw::FW_SERIALIZE_OK) {
+      return status;
     }
-    if (status == Fw::FW_SERIALIZE_OK) {
-      descriptor = static_cast<Record::Descriptor>(descEntry);
+
+    if (descEntry > Sequence::Record::END_OF_SEQUENCE) {
+      return Fw::FW_DESERIALIZE_FORMAT_ERROR;
     }
-    return status;
+
+    descriptor = static_cast<Record::Descriptor>(descEntry);
+    return Fw::FW_SERIALIZE_OK;
   }
 
   Fw::SerializeStatus CmdSequencerComponentImpl::FPrimeSequence ::


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  CmdSeqencer |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Using a switch with a range case statement is a GCC extension and causes errors when compiling in pedantic mode.