### PR TITLE
Remove test usage of 80 charater strings

### DIFF
--- a/Autocoders/Python/test/array_xml/ExampleArrayImpl.cpp
+++ b/Autocoders/Python/test/array_xml/ExampleArrayImpl.cpp
@@ -1,5 +1,6 @@
 #include <Autocoders/Python/test/array_xml/ExampleArrayImpl.hpp>
 #include <Fw/Types/BasicTypes.hpp>
+#include <Fw/Types/String.hpp>
 #include <iostream>
 #include <stdio.h>
 
@@ -19,7 +20,7 @@ namespace Example {
     }
 
     void ExampleArrayImpl::ExArrayIn_handler(NATIVE_INT_TYPE portNum, Example::ArrayType array1, Example::ArrSerial serial1) {
-        Fw::EightyCharString s;
+        Fw::String s;
         array1.toString(s);
 
         printf("%s Invoked ExArrayIn_handler();\n%s", this->getObjName(), s.toChar());
@@ -27,7 +28,7 @@ namespace Example {
     }
 
     void ExampleArrayImpl::ArrayIn_handler(NATIVE_INT_TYPE portNum, Example::ArrayType array1, Example::ArrSerial serial1) {
-        Fw::EightyCharString s;
+        Fw::String s;
         array1.toString(s);
 
         printf("%s Invoked ArrayIn_handler(%d);\n%s", this->getObjName(), portNum, s.toChar());

--- a/Autocoders/Python/test/array_xml/ExampleArrayImpl.hpp
+++ b/Autocoders/Python/test/array_xml/ExampleArrayImpl.hpp
@@ -1,7 +1,6 @@
 #ifndef EXAMPLE_ARRAY_IMPL_HPP
 #define EXAMPLE_ARRAY_IMPL_HPP
 
-#include <Fw/Types/EightyCharString.hpp>
 #include <Autocoders/Python/test/array_xml/Component1ComponentAc.hpp>
 
 namespace Example {

--- a/Autocoders/Python/test/array_xml/test/ut/main.cpp
+++ b/Autocoders/Python/test/array_xml/test/ut/main.cpp
@@ -10,7 +10,7 @@
 #include <Fw/Obj/SimpleObjRegistry.hpp>
 #include <Fw/Types/SerialBuffer.hpp>
 #include <Fw/Types/BasicTypes.hpp>
-#include <Fw/Types/EightyCharString.hpp>
+#include <Fw/Types/String.hpp>
 #include <Fw/Types/Assert.hpp>
 
 #include <bitset>
@@ -45,18 +45,18 @@ int main(int argc, char* argv[]) {
     InternalType array1 = InternalType(6,7,120,444);
     Example::ArrayType array2 = Example::ArrayType(array1);
     // Create string array for serializable
-    Fw::EightyCharString mem1 = "Member 1";
-    Fw::EightyCharString mem2 = "Member 2";
-    Fw::EightyCharString mem3 = "Member 3";
+    Fw::String mem1 = "Member 1";
+    Fw::String mem2 = "Member 2";
+    Fw::String mem3 = "Member 3";
     StringArray array3 = StringArray(mem1, mem2, mem3);
     Example::ArrSerial serial1;
 
     // Print toString outputs for each array
     cout << "Print toString for arrays" << endl;
 
-    Fw::EightyCharString tostring1;
-    Fw::EightyCharString tostring2;
-    Fw::EightyCharString tostring3;
+    Fw::String tostring1;
+    Fw::String tostring2;
+    Fw::String tostring3;
     array1.toString(tostring1);
     array2.toString(tostring2);
     array3.toString(tostring3);

--- a/Autocoders/Python/test/ext_dict/ExampleType.cpp
+++ b/Autocoders/Python/test/ext_dict/ExampleType.cpp
@@ -1,8 +1,6 @@
 #include <Autocoders/Python/test/ext_dict/ExampleType.hpp>
 #include <Fw/Types/Assert.hpp>
-#if FW_SERIALIZABLE_TO_STRING
-#include <Fw/Types/EightyCharString.hpp>
-#endif
+
 namespace ANameSpace {
 
 mytype::mytype(): Serializable() {

--- a/Autocoders/Python/test/interface1/UserSerializer.cpp
+++ b/Autocoders/Python/test/interface1/UserSerializer.cpp
@@ -2,10 +2,6 @@
 #include <Fw/Types/Assert.hpp>
 #include <cstdio>
 
-#if FW_SERIALIZABLE_TO_STRING
-#include <Fw/Types/EightyCharString.hpp>
-#endif
-
 namespace ANameSpace {
 
 UserSerializer::UserSerializer(): Serializable() {

--- a/Autocoders/Python/test/partition/DuckDuckImpl.cpp
+++ b/Autocoders/Python/test/partition/DuckDuckImpl.cpp
@@ -17,7 +17,7 @@ namespace Duck {
 
         // Internal call - implemented by hand.
         // downcall for input port externInputPort1
-        I32 DuckImpl::externInputPort1_Msg1_handler(U32 cmd, Fw::EightyCharString str) {
+        I32 DuckImpl::externInputPort1_Msg1_handler(U32 cmd, Fw::String str) {
             // User code is written here.
 			printf("\n\t*** %s: externInputPort1_Msg1_handler down-call\n", this->m_objName);
 			this->outputPort1_Msg1_out(cmd, str);
@@ -33,13 +33,13 @@ namespace Duck {
         }
 
         // downcall for input port inputPort1
-        I32 DuckImpl::inputPort1_Msg1_handler(U32 cmd, Fw::EightyCharString str) {
+        I32 DuckImpl::inputPort1_Msg1_handler(U32 cmd, Fw::String str) {
             // User code is written here.
             return 0;
         }
 
         // downcall for input port inputPort2
-        I32 DuckImpl::inputPort2_Msg1_handler(U32 cmd, Fw::EightyCharString str) {
+        I32 DuckImpl::inputPort2_Msg1_handler(U32 cmd, Fw::String str) {
             // User code is written here.
 			printf("\n\t*** %s: inputPort2_Msg1_handler(%d, %s) down-call\n", this->m_objName, cmd, str.toChar());
             return 0;

--- a/Autocoders/Python/test/partition/DuckDuckImpl.hpp
+++ b/Autocoders/Python/test/partition/DuckDuckImpl.hpp
@@ -14,10 +14,10 @@ namespace Duck {
 
     private:
         // downcall for input ports
-        I32 externInputPort1_Msg1_handler(U32 cmd, Fw::EightyCharString str);
+        I32 externInputPort1_Msg1_handler(U32 cmd, Fw::String str);
         I32 externInputPort3_Msg3_handler(U32 cmd);
-        I32 inputPort1_Msg1_handler(U32 cmd, Fw::EightyCharString str);
-        I32 inputPort2_Msg1_handler(U32 cmd, Fw::EightyCharString str);
+        I32 inputPort1_Msg1_handler(U32 cmd, Fw::String str);
+        I32 inputPort2_Msg1_handler(U32 cmd, Fw::String str);
         I32 inputPort3_Msg3_handler(U32 cmd);
     };
 };

--- a/Autocoders/Python/test/partition/Msg1InterfaceAi.xml
+++ b/Autocoders/Python/test/partition/Msg1InterfaceAi.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface name="Msg1" namespace="Ports">
-    <include_header>Fw/Types/FwStringType</include_header>
-    <include_header>Fw/Types/FwEightyCharString</include_header>
+    <include_header>Fw/Types/String.hpp</include_header>
     <comment>
     Msg 1 Interface to send cmd and stat arguments.
     </comment>
@@ -9,9 +8,8 @@
         <arg name="cmd" type="U32">
             <comment>The U32 cmd argument</comment>
         </arg>
-        <arg name="str" type="Fw::EightyCharString">
+        <arg name="str" type="Fw::String">
             <comment>The 80 character string str argument</comment>
         </arg>
 	</args>
 </interface>
-

--- a/Autocoders/Python/test/partition/Top.cpp
+++ b/Autocoders/Python/test/partition/Top.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[])  {
 	// Ask for input to huey or duey here.
 	char in[80];
 	U32 cmd;
-	Fw::EightyCharString *str;
+	Fw::String *str;
 	char str2[80];
 	//
 	while ( strcmp(in,"quit") != 0) {
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])  {
 			cout << "Enter short string: ";
 			cin >> str2;
 			cout << "The string 2 is: " << str2 << endl;
-			str = new Fw::EightyCharString(str2);
+			str = new Fw::String(str2);
 			cout << "hueyComp_ptr->getexternInputPort1InputPort()->msg_in(" << cmd << "," << str2 << ")" << endl;
 			hueyComp_ptr->getexternInputPort1Msg1InputPort()->msg_in(cmd,*str);
 		} else if (in[0] == '3') {

--- a/Autocoders/Python/test/port_loopback/ExampleType.cpp
+++ b/Autocoders/Python/test/port_loopback/ExampleType.cpp
@@ -1,8 +1,6 @@
 #include <Autocoders/Python/templates/ExampleType.hpp>
 #include <Fw/Types/Assert.hpp>
-#if FW_SERIALIZABLE_TO_STRING
-#include <Fw/Types/EightyCharString.hpp>
-#endif
+
 namespace ANameSpace {
 
 mytype::mytype(): Serializable() {

--- a/Autocoders/Python/test/port_nogen/ExampleType.cpp
+++ b/Autocoders/Python/test/port_nogen/ExampleType.cpp
@@ -1,8 +1,6 @@
 #include <Autocoders/Python/test/port_nogen/ExampleType.hpp>
 #include <Fw/Types/Assert.hpp>
-#if FW_SERIALIZABLE_TO_STRING
-#include <Fw/Types/EightyCharString.hpp>
-#endif
+
 namespace ANameSpace {
 
 mytype::mytype(): Serializable() {

--- a/Autocoders/Python/test/serialize_user/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/test/serialize_user/ExampleComponentImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/serialize_user/ExampleComponentImpl.hpp>
-#include <Fw/Types/EightyCharString.hpp>
+#include <Fw/Types/String.hpp>
 #include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
@@ -26,7 +26,7 @@ ExampleComponentImpl::~ExampleComponentImpl() {
 
 void ExampleComponentImpl::exampleInput_handler(NATIVE_INT_TYPE portNum, I32 arg1, ANameSpace::UserSerializer arg2) {
 
-    Fw::EightyCharString str;
+    Fw::String str;
     arg2.toString(str);
     printf("ARG: %s\n",str.toChar());
 }

--- a/Autocoders/Python/test/serialize_user/UserSerializer.cpp
+++ b/Autocoders/Python/test/serialize_user/UserSerializer.cpp
@@ -2,10 +2,6 @@
 #include <Fw/Types/Assert.hpp>
 #include <cstdio>
 
-#if FW_SERIALIZABLE_TO_STRING
-#include <Fw/Types/EightyCharString.hpp>
-#endif
-
 namespace ANameSpace {
 
 UserSerializer::UserSerializer(): Serializable() {

--- a/Autocoders/Python/test/stress/TestCommandImpl.cpp
+++ b/Autocoders/Python/test/stress/TestCommandImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/stress/TestCommandImpl.hpp>
-#include <Fw/Types/EightyCharString.hpp>
+#include <Fw/Types/String.hpp>
 #include <stdio.h>
 
 #if FW_OBJECT_NAMES == 1
@@ -29,7 +29,7 @@ void TestCommand1Impl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5
 }
 
 void TestCommand1Impl::aport2_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, Ref::Gnc::Quaternion arg6) {
-    Fw::EightyCharString str;
+    Fw::String str;
     arg6.toString(str);
     printf("Received aport2_Test2_handler call with %i %f %s\n",arg4,arg5,str.toChar());
 }

--- a/Autocoders/Python/test/stress/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/stress/TestTelemRecvImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/stress/TestTelemRecvImpl.hpp>
-#include <Fw/Types/EightyCharString.hpp>
+#include <Fw/Types/String.hpp>
 #include <Autocoders/Python/test/stress/QuaternionSerializableAc.hpp>
 #include <stdio.h>
 
@@ -25,7 +25,7 @@ TestTelemRecvImpl::~TestTelemRecvImpl() {
 void TestTelemRecvImpl::tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
     Ref::Gnc::Quaternion tlmVal;
     val.deserialize(tlmVal);
-    Fw::EightyCharString str;
+    Fw::String str;
 #if FW_SERIALIZABLE_TO_STRING
     tlmVal.toString(str);
 #endif

--- a/Autocoders/Python/test/tlm2/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm2/TestTelemRecvImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/tlm2/TestTelemRecvImpl.hpp>
-#include <Fw/Types/EightyCharString.hpp>
+#include <Fw/Types/String.hpp>
 #include <Autocoders/Python/test/tlm2/QuaternionSerializableAc.hpp>
 #include <stdio.h>
 
@@ -25,7 +25,7 @@ TestTelemRecvImpl::~TestTelemRecvImpl() {
 void TestTelemRecvImpl::tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
     Ref::Gnc::Quaternion tlmVal;
     val.deserialize(tlmVal);
-    Fw::EightyCharString str;
+    Fw::String str;
     tlmVal.toString(str);
     printf("ID: %d TLM value is %s. Time is %d:%d base: %d\n",id,str.toChar(),timeTag.getSeconds(),timeTag.getUSeconds(),timeTag.getTimeBase());
 }

--- a/Drv/Ip/test/ut/TestTcp.cpp
+++ b/Drv/Ip/test/ut/TestTcp.cpp
@@ -5,7 +5,6 @@
 #include <Drv/Ip/TcpClientSocket.hpp>
 #include <Drv/Ip/TcpServerSocket.hpp>
 #include <Drv/Ip/IpSocket.hpp>
-#include <Fw/Types/EightyCharString.hpp>
 #include <Os/Log.hpp>
 #include <Fw/Logger/Logger.hpp>
 #include <Drv/Ip/test/ut/PortSelector.hpp>

--- a/Drv/Ip/test/ut/TestUdp.cpp
+++ b/Drv/Ip/test/ut/TestUdp.cpp
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 #include <Drv/Ip/UdpSocket.hpp>
 #include <Drv/Ip/IpSocket.hpp>
-#include <Fw/Types/EightyCharString.hpp>
 #include <Os/Log.hpp>
 #include <Fw/Logger/Logger.hpp>
 #include <Drv/Ip/test/ut/PortSelector.hpp>

--- a/Fw/Logger/test/ut/LoggerRules.cpp
+++ b/Fw/Logger/test/ut/LoggerRules.cpp
@@ -17,7 +17,7 @@
 namespace LoggerRules {
 
     // Constructor
-    Register::Register(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
+    Register::Register(const Fw::String& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
 
     // Check for registration, always allowed
     bool Register::precondition(const MockLogging::FakeLogger& truth) {
@@ -40,7 +40,7 @@ namespace LoggerRules {
     }
 
     // Constructor
-    LogGood::LogGood(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
+    LogGood::LogGood(const Fw::String& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
 
     // Check for logging, only when not NULL
     bool LogGood::precondition(const MockLogging::FakeLogger& truth) {
@@ -113,7 +113,7 @@ namespace LoggerRules {
     }
 
     // Constructor
-    LogBad::LogBad(const Fw::EightyCharString& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
+    LogBad::LogBad(const Fw::String& name) : STest::Rule<MockLogging::FakeLogger>(name.toChar()) {}
 
     // Check for logging, only when not NULL
     bool LogBad::precondition(const MockLogging::FakeLogger& truth) {

--- a/Fw/Logger/test/ut/LoggerRules.hpp
+++ b/Fw/Logger/test/ut/LoggerRules.hpp
@@ -16,7 +16,7 @@
 #define FPRIME_LOGGERRULES_HPP
 
 #include <Fw/Types/BasicTypes.hpp>
-#include <Fw/Types/EightyCharString.hpp>
+#include <Fw/Types/String.hpp>
 #include <Fw/Logger/test/ut/FakeLogger.hpp>
 #include <STest/STest/Rule/Rule.hpp>
 #include <STest/STest/Pick/Pick.hpp>
@@ -32,7 +32,7 @@ namespace LoggerRules {
      */
     struct Register : public STest::Rule<MockLogging::FakeLogger> {
         // Constructor
-        Register(const Fw::EightyCharString& name);
+        Register(const Fw::String& name);
 
         // Check for registration, always allowed
         bool precondition(const MockLogging::FakeLogger& truth);
@@ -47,7 +47,7 @@ namespace LoggerRules {
      */
     struct LogGood : public STest::Rule<MockLogging::FakeLogger> {
         // Constructor
-        LogGood(const Fw::EightyCharString& name);
+        LogGood(const Fw::String& name);
 
         // Check for logging, only when not NULL
         bool precondition(const MockLogging::FakeLogger& truth);
@@ -63,7 +63,7 @@ namespace LoggerRules {
      */
     struct LogBad : public STest::Rule<MockLogging::FakeLogger> {
         // Constructor
-        LogBad(const Fw::EightyCharString& name);
+        LogBad(const Fw::String& name);
 
         // Check for logging, only when not NULL
         bool precondition(const MockLogging::FakeLogger& truth);

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -3,7 +3,7 @@
 #include <Os/IntervalTimer.hpp>
 #include <Os/InterruptLock.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <Fw/Types/EightyCharString.hpp>
+#include <Fw/Types/String.hpp>
 #include <Fw/Types/InternalInterfaceString.hpp>
 #include <Fw/Types/PolyType.hpp>
 #include <Fw/Types/MallocAllocator.hpp>
@@ -559,8 +559,8 @@ TEST(SerializationTest,Serialization1) {
     ASSERT_EQ(boolt1,boolt2);
 
     // serialize string
-    Fw::EightyCharString str1;
-    Fw::EightyCharString str2;
+    Fw::String str1;
+    Fw::String str2;
 
     str1 = "Foo";
     str2 = "BarBlat";
@@ -874,7 +874,7 @@ TEST(TypesTest, CheckAssertTest) {
 }
 
 TEST(TypesTest,PolyTest) {
-    Fw::EightyCharString str;
+    Fw::String str;
 
     // U8 Type  ===============================================================
     U8 in8 = 13;
@@ -1064,16 +1064,16 @@ TEST(TypesTest,PolyTest) {
 
 TEST(TypesTest,EightyCharTest) {
 
-    Fw::EightyCharString str;
+    Fw::String str;
     str = "foo";
-    Fw::EightyCharString str2;
+    Fw::String str2;
     str2 = "foo";
     ASSERT_EQ(str,str2);
     ASSERT_EQ(str,"foo");
     str2 = "doodie";
     ASSERT_NE(str,str2);
 
-    Fw::EightyCharString str3 = str;
+    Fw::String str3 = str;
     str3 += str2;
     ASSERT_EQ(str3,"foodoodie");
 
@@ -1081,15 +1081,15 @@ TEST(TypesTest,EightyCharTest) {
     ASSERT_EQ(str3,"foodoodiehoo");
 
 
-    Fw::EightyCharString copyStr("ASTRING");
+    Fw::String copyStr("ASTRING");
     ASSERT_EQ(copyStr,"ASTRING");
-    Fw::EightyCharString copyStr2 = "ASTRING";
+    Fw::String copyStr2 = "ASTRING";
     ASSERT_EQ(copyStr2,"ASTRING");
-    Fw::EightyCharString copyStr3(copyStr2);
+    Fw::String copyStr3(copyStr2);
     ASSERT_EQ(copyStr3,"ASTRING");
 
     Fw::InternalInterfaceString ifstr("IfString");
-    Fw::EightyCharString if2(ifstr);
+    Fw::String if2(ifstr);
 
     ASSERT_EQ(ifstr,if2);
     ASSERT_EQ(if2,"IfString");
@@ -1103,7 +1103,7 @@ TEST(TypesTest,EightyCharTest) {
 }
 
 TEST(TypesTest,StringFormatTest) {
-    Fw::EightyCharString str;
+    Fw::String str;
     str.format("Int %d String %s",10,"foo");
     ASSERT_STREQ(str.toChar(), "Int 10 String foo");
 }

--- a/Os/test/ut/OsQueueTest.cpp
+++ b/Os/test/ut/OsQueueTest.cpp
@@ -2,7 +2,6 @@
 #include <Os/Queue.hpp>
 #include <stdio.h>
 #include <string.h>
-#include <Fw/Types/EightyCharString.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <unistd.h>
 #include <signal.h>
@@ -37,7 +36,7 @@ class MyTestSerializedBuffer : public Fw::SerializeBufferBase {
 
 Os::Queue* createTestQueue(char *name, U32 size, I32 depth) {
     Os::Queue* testQueue = new Os::Queue();
-    Os::Queue::QueueStatus stat = testQueue->create(Fw::EightyCharString(name), depth, size);
+    Os::Queue::QueueStatus stat = testQueue->create(Os::QueueString(name), depth, size);
     EXPECT_EQ(stat,Os::Queue::QUEUE_OK);
 
     // Make sure the queue is of the correct size:

--- a/Os/test/ut/OsTaskTest.cpp
+++ b/Os/test/ut/OsTaskTest.cpp
@@ -1,7 +1,6 @@
 #include "gtest/gtest.h"
 #include <Os/Task.hpp>
 #include <stdio.h>
-#include <Fw/Types/EightyCharString.hpp>
 
 extern "C" {
     void startTestTask();
@@ -15,7 +14,7 @@ void someTask(void* ptr) {
 void startTestTask() {
     volatile bool taskRan = false;
     Os::Task testTask;
-    Fw::EightyCharString name("ATestTask");
+    Os::TaskString name("ATestTask");
     Os::Task::TaskStatus stat = testTask.start(name,12,100,10*1024,someTask,(void*) &taskRan);
     ASSERT_EQ(stat, Os::Task::TASK_OK);
     testTask.join(NULL);

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/CRCs.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/CRCs.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  CRCs.hpp
 // \author Rob Bocchino
 // \brief  AMPCS CRC files
@@ -7,10 +7,10 @@
 // Copyright (C) 2018 California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
-#include "Fw/Types/EightyCharString.hpp"
+#include "Fw/Types/String.hpp"
 #include "Fw/Types/SerialBuffer.hpp"
 #include "Os/File.hpp"
 #include "Os/FileSystem.hpp"
@@ -35,7 +35,7 @@ namespace Svc {
               const char *const fileName, //!< The file name
               const Os::File::Mode mode //!< The mode
           ) {
-            const Os::File::Status fileStatus = 
+            const Os::File::Status fileStatus =
               file.open(fileName, mode);
             ASSERT_EQ(Os::File::OP_OK, fileStatus);
           }
@@ -48,8 +48,8 @@ namespace Svc {
           ) {
             NATIVE_INT_TYPE sizeThenActualSize = size;
             const Os::File::Status status = file.write(
-                buffer, 
-                sizeThenActualSize, 
+                buffer,
+                sizeThenActualSize,
                 false
             );
             ASSERT_EQ(Os::File::OP_OK, status);
@@ -82,7 +82,7 @@ namespace Svc {
         void removeFile(
             const char *const fileName
         ) {
-          Fw::EightyCharString s("rm -f ");
+          Fw::String s("rm -f ");
           s += fileName;
           s += ".CRC32";
           int status = system(s.toChar());
@@ -98,7 +98,7 @@ namespace Svc {
           Fw::SerialBuffer serialBuffer(buffer, sizeof(buffer));
           serialBuffer.serialize(crc);
           const U8 *const addr = serialBuffer.getBuffAddr();
-          Fw::EightyCharString hashFileName(fileName);
+          Fw::String hashFileName(fileName);
           hashFileName += ".CRC32";
           openFile(file, hashFileName.toChar(), Os::File::OPEN_WRITE);
           writeFile(file, addr, sizeof(crc));

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/File.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/File.cpp
@@ -10,7 +10,7 @@
 //
 // ======================================================================
 
-#include "Fw/Types/EightyCharString.hpp"
+#include "Fw/Types/String.hpp"
 #include "Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/AMPCS.hpp"
 #include "Svc/CmdSequencer/test/ut/SequenceFiles/Buffers.hpp"
 #include "Svc/CmdSequencer/test/ut/SequenceFiles/File.hpp"
@@ -112,7 +112,7 @@ namespace Svc {
     void File ::
       remove()
     {
-      Fw::EightyCharString s("rm -f ");
+      Fw::String s("rm -f ");
       s += this->getName();
       int status = system(s.toChar());
       ASSERT_EQ(0, status);

--- a/Svc/GroundInterface/test/ut/GroundInterfaceRules.cpp
+++ b/Svc/GroundInterface/test/ut/GroundInterfaceRules.cpp
@@ -12,7 +12,7 @@
 
 namespace Svc {
     // Constructor
-    RandomizeRule :: RandomizeRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
+    RandomizeRule :: RandomizeRule(const Fw::String& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always randomize
     bool RandomizeRule :: precondition(const Svc::Tester &state) {
@@ -39,7 +39,7 @@ namespace Svc {
 
 
     // Constructor
-    DownlinkRule :: DownlinkRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
+    DownlinkRule :: DownlinkRule(const Fw::String& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always downlink
     bool DownlinkRule :: precondition(const Svc::Tester &state) {
@@ -57,7 +57,7 @@ namespace Svc {
     }
 
     // Constructor
-    FileDownlinkRule :: FileDownlinkRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
+    FileDownlinkRule :: FileDownlinkRule(const Fw::String& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always downlink
     bool FileDownlinkRule :: precondition(const Svc::Tester &state) {
@@ -80,7 +80,7 @@ namespace Svc {
     }
 
     // Constructor
-    SendAvailableRule :: SendAvailableRule(const Fw::EightyCharString& name) : STest::Rule<Tester>(name.toChar()) {}
+    SendAvailableRule :: SendAvailableRule(const Fw::String& name) : STest::Rule<Tester>(name.toChar()) {}
 
     // Can always downlink
     bool SendAvailableRule :: precondition(const Svc::Tester &state) {

--- a/Svc/GroundInterface/test/ut/GroundInterfaceRules.hpp
+++ b/Svc/GroundInterface/test/ut/GroundInterfaceRules.hpp
@@ -16,7 +16,7 @@
 #define FPRIME_SVC_GROUND_INTERFACE_HPP
 
 #include <Fw/Types/BasicTypes.hpp>
-#include <Fw/Types/EightyCharString.hpp>
+#include <Fw/Types/String.hpp>
 #include <Svc/GroundInterface/test/ut/Tester.hpp>
 #include <STest/STest/Rule/Rule.hpp>
 #include <STest/STest/Pick/Pick.hpp>
@@ -31,7 +31,7 @@ namespace Svc {
      */
     struct RandomizeRule : public STest::Rule<Tester> {
         // Constructor
-        RandomizeRule(const Fw::EightyCharString& name);
+        RandomizeRule(const Fw::String& name);
 
         // Always valid
         bool precondition(const Tester& state);
@@ -42,7 +42,7 @@ namespace Svc {
 
     struct DownlinkRule : public STest::Rule<Tester> {
         // Constructor
-        DownlinkRule(const Fw::EightyCharString& name);
+        DownlinkRule(const Fw::String& name);
 
         // Always valid
         bool precondition(const Tester& state);
@@ -53,7 +53,7 @@ namespace Svc {
 
     struct FileDownlinkRule : public STest::Rule<Tester> {
         // Constructor
-        FileDownlinkRule(const Fw::EightyCharString& name);
+        FileDownlinkRule(const Fw::String& name);
 
         // Always valid
         bool precondition(const Tester& state);
@@ -64,7 +64,7 @@ namespace Svc {
 
     struct SendAvailableRule : public STest::Rule<Tester> {
         // Constructor
-        SendAvailableRule(const Fw::EightyCharString& name);
+        SendAvailableRule(const Fw::String& name);
 
         // Always valid
         bool precondition(const Tester& state);

--- a/Utils/Types/test/ut/CircularBuffer/CircularRules.cpp
+++ b/Utils/Types/test/ut/CircularBuffer/CircularRules.cpp
@@ -15,7 +15,7 @@
 namespace Types {
 
 
-    RandomizeRule::RandomizeRule(const Fw::EightyCharString& name)
+    RandomizeRule::RandomizeRule(const Fw::String& name)
         : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
@@ -30,7 +30,7 @@ namespace Types {
 
 
 
-    SerializeOkRule::SerializeOkRule(const Fw::EightyCharString& name)
+    SerializeOkRule::SerializeOkRule(const Fw::String& name)
         : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
@@ -48,7 +48,7 @@ namespace Types {
 
 
 
-    SerializeOverflowRule::SerializeOverflowRule(const Fw::EightyCharString& name)
+    SerializeOverflowRule::SerializeOverflowRule(const Fw::String& name)
             : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
@@ -63,7 +63,7 @@ namespace Types {
     }
 
 
-    PeekOkRule::PeekOkRule(const Fw::EightyCharString& name)
+    PeekOkRule::PeekOkRule(const Fw::String& name)
             : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
@@ -128,7 +128,7 @@ namespace Types {
     }
 
 
-    PeekBadRule::PeekBadRule(const Fw::EightyCharString& name)
+    PeekBadRule::PeekBadRule(const Fw::String& name)
             : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
@@ -174,7 +174,7 @@ namespace Types {
     }
 
 
-    RotateOkRule::RotateOkRule(const Fw::EightyCharString& name)
+    RotateOkRule::RotateOkRule(const Fw::String& name)
             : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 
@@ -189,7 +189,7 @@ namespace Types {
     }
 
 
-    RotateBadRule::RotateBadRule(const Fw::EightyCharString& name)
+    RotateBadRule::RotateBadRule(const Fw::String& name)
             : STest::Rule<MockTypes::CircularState>(name.toChar()) {}
 
 

--- a/Utils/Types/test/ut/CircularBuffer/CircularRules.hpp
+++ b/Utils/Types/test/ut/CircularBuffer/CircularRules.hpp
@@ -20,7 +20,7 @@
 #define FPRIME_GROUNDINTERFACERULES_HPP
 
 #include <Fw/Types/BasicTypes.hpp>
-#include <Fw/Types/EightyCharString.hpp>
+#include <Fw/Types/String.hpp>
 #include <Utils/Types/test/ut/CircularBuffer/CircularState.hpp>
 #include <STest/STest/Rule/Rule.hpp>
 #include <STest/STest/Pick/Pick.hpp>
@@ -35,7 +35,7 @@ namespace Types {
      */
     struct RandomizeRule : public STest::Rule<MockTypes::CircularState> {
         // Constructor
-        RandomizeRule(const Fw::EightyCharString& name);
+        RandomizeRule(const Fw::String& name);
 
         // Always valid
         bool precondition(const MockTypes::CircularState& state);
@@ -51,7 +51,7 @@ namespace Types {
      */
     struct SerializeOkRule : public STest::Rule<MockTypes::CircularState> {
         // Constructor
-        SerializeOkRule(const Fw::EightyCharString& name);
+        SerializeOkRule(const Fw::String& name);
 
         // Valid precondition for when the buffer should accept data
         bool precondition(const MockTypes::CircularState& state);
@@ -67,7 +67,7 @@ namespace Types {
      */
     struct SerializeOverflowRule : public STest::Rule<MockTypes::CircularState> {
         // Constructor
-        SerializeOverflowRule(const Fw::EightyCharString& name);
+        SerializeOverflowRule(const Fw::String& name);
 
         // Valid precondition for when the buffer should reject data
         bool precondition(const MockTypes::CircularState& state);
@@ -83,7 +83,7 @@ namespace Types {
      */
     struct PeekOkRule : public STest::Rule<MockTypes::CircularState> {
         // Constructor
-        PeekOkRule(const Fw::EightyCharString& name);
+        PeekOkRule(const Fw::String& name);
 
         // Peek ok available for when buffer size - remaining size  - 1 <= peek size
         bool precondition(const MockTypes::CircularState& state);
@@ -99,7 +99,7 @@ namespace Types {
      */
     struct PeekBadRule : public STest::Rule<MockTypes::CircularState> {
         // Constructor
-        PeekBadRule(const Fw::EightyCharString& name);
+        PeekBadRule(const Fw::String& name);
 
         // Peek bad available for when buffer size - remaining size  - 1 > peek size
         bool precondition(const MockTypes::CircularState& state);
@@ -115,7 +115,7 @@ namespace Types {
      */
     struct RotateOkRule : public STest::Rule<MockTypes::CircularState> {
         // Constructor
-        RotateOkRule(const Fw::EightyCharString& name);
+        RotateOkRule(const Fw::String& name);
 
         // Rotate is ok when there is more data then rotational size
         bool precondition(const MockTypes::CircularState& state);
@@ -131,7 +131,7 @@ namespace Types {
      */
     struct RotateBadRule : public STest::Rule<MockTypes::CircularState> {
         // Constructor
-        RotateBadRule(const Fw::EightyCharString& name);
+        RotateBadRule(const Fw::String& name);
 
         // Rotate is bad when there is less data then rotational size
         bool precondition(const MockTypes::CircularState& state);

--- a/Utils/test/ut/LockGuardTester.cpp
+++ b/Utils/test/ut/LockGuardTester.cpp
@@ -14,7 +14,6 @@
 #include "LockGuardTester.hpp"
 #include <time.h>
 #include <Os/Task.hpp>
-#include <Fw/Types/EightyCharString.hpp>
 
 namespace Utils {
 
@@ -55,7 +54,7 @@ namespace Utils {
     data.i = 0;
     Os::Task testTask;
     Os::Task::TaskStatus stat;
-    Fw::EightyCharString name("TestTask");
+    Os::TaskString name("TestTask");
 
     {
       LockGuard guard(data.mutex);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Remaining usages of 80 character string have been replaces with the default String class