### PR TITLE
Correct clang-tidy detected warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: "-clang-analyzer-security.insecureAPI.rand"
+WarningsAsErrors: '*'

--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,5 @@ fprime-venv
 xml
 depend
 
-.*
-
 /.idea/
 /venv/

--- a/Drv/Ip/test/ut/SocketTestHelper.cpp
+++ b/Drv/Ip/test/ut/SocketTestHelper.cpp
@@ -49,8 +49,8 @@ void fill_random_buffer(Fw::Buffer &buffer) {
 
 void send_recv(Drv::IpSocket& sender, Drv::IpSocket& receiver) {
     I32 size = MAX_DRV_TEST_MESSAGE_SIZE;
-    U8 buffer_out[MAX_DRV_TEST_MESSAGE_SIZE];
-    U8 buffer_in[MAX_DRV_TEST_MESSAGE_SIZE];
+    U8 buffer_out[MAX_DRV_TEST_MESSAGE_SIZE] = {0};
+    U8 buffer_in[MAX_DRV_TEST_MESSAGE_SIZE] = {0};
 
     // Send receive validate block
     Drv::Test::fill_random_data(buffer_out, MAX_DRV_TEST_MESSAGE_SIZE);

--- a/Drv/LinuxI2cDriver/test/ut/main.cpp
+++ b/Drv/LinuxI2cDriver/test/ut/main.cpp
@@ -1,4 +1,5 @@
 #include <Tester.hpp>
+#include <Fw/Types/StringUtils.hpp>
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -29,7 +30,7 @@ int main(int argc, char* argv[]) {
                 addr = strtoul(optarg,0,0);
                 break;
             case 'd':
-                strcpy(device,optarg);
+                Fw::StringUtils::string_copy(device, optarg, sizeof(device));
                 break;
             default:
                 printf("test_ut %s\n",argv[0],help);

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -787,16 +787,16 @@ void AssertTest() {
 
         private:
 
-            FILE_NAME_ARG m_file;
-            NATIVE_UINT_TYPE m_lineNo;
-            NATIVE_UINT_TYPE m_numArgs;
-            AssertArg m_arg1;
-            AssertArg m_arg2;
-            AssertArg m_arg3;
-            AssertArg m_arg4;
-            AssertArg m_arg5;
-            AssertArg m_arg6;
-            bool m_asserted;
+            FILE_NAME_ARG m_file = nullptr;
+            NATIVE_UINT_TYPE m_lineNo = 0;
+            NATIVE_UINT_TYPE m_numArgs = 0;
+            AssertArg m_arg1 = 0;
+            AssertArg m_arg2 = 0;
+            AssertArg m_arg3 = 0;
+            AssertArg m_arg4 = 0;
+            AssertArg m_arg5 = 0;
+            AssertArg m_arg6 = 0;
+            bool m_asserted = false;
 
     };
 

--- a/Os/Pthreads/PriorityBufferQueue.cpp
+++ b/Os/Pthreads/PriorityBufferQueue.cpp
@@ -73,14 +73,18 @@ namespace Os {
       return false;
     }
     if( !heap->create(depth) ) {
+      delete heap;
       return false;
     }
     U8* data = new(std::nothrow) U8[depth*(sizeof(msgSize) + msgSize)];
     if (NULL == data) {
+      delete heap;
       return false;
     }
     NATIVE_UINT_TYPE* indexes = new(std::nothrow) NATIVE_UINT_TYPE[depth];
     if (NULL == indexes) {
+      delete heap;
+      delete[] data;
       return false;
     }
     for(NATIVE_UINT_TYPE ii = 0; ii < depth; ++ii) {
@@ -88,6 +92,9 @@ namespace Os {
     }
     PriorityQueue* priorityQueue = new(std::nothrow) PriorityQueue;
     if (NULL == priorityQueue) {
+      delete heap;
+      delete[] data;
+      delete[] indexes;
       return false;
     }
     priorityQueue->heap = heap;

--- a/Svc/ActiveTextLogger/test/ut/Tester.cpp
+++ b/Svc/ActiveTextLogger/test/ut/Tester.cpp
@@ -4,6 +4,7 @@
 // acknowledged.
 
 #include "Tester.hpp"
+#include "Fw/Types/StringUtils.hpp"
 #include <fstream>
 
 
@@ -111,7 +112,7 @@ namespace Svc {
                       "EVENT: (%d) (%d:%d,%d) %s: %s",
                        id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severityString,text.toChar());
               ASSERT_EQ(0,strcmp(textStr,buf));
-              strcpy(oldLine,buf);
+              Fw::StringUtils::string_copy(oldLine, buf, sizeof(oldLine));
           }
       }
       stream1.close();
@@ -214,7 +215,7 @@ namespace Svc {
                       "EVENT: (%d) (%d:%d,%d) %s: %s",
                        id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severityString,text.toChar());
               ASSERT_EQ(0,strcmp(textStr,buf));
-              strcpy(oldLine,buf);
+              Fw::StringUtils::string_copy(oldLine, buf, sizeof(oldLine));
           }
       }
       stream1.close();
@@ -293,8 +294,7 @@ namespace Svc {
       // Verify file not made:
       ASSERT_FALSE(stat);
       ASSERT_FALSE(this->component.m_log_file.m_openFile);
-      char longFileNameDupS[81];
-      strcat(longFileNameDupS,"0");
+      char longFileNameDupS[81] = "0";
       ASSERT_NE(Os::FileSystem::OP_OK,
               Os::FileSystem::getFileSize(longFileNameDupS,tmp));
 

--- a/Svc/FileDownlink/test/ut/Tester.cpp
+++ b/Svc/FileDownlink/test/ut/Tester.cpp
@@ -399,9 +399,9 @@ namespace Svc {
         Fw::Buffer& buffer
     )
   {
+    ASSERT_LT(buffers_index, FW_NUM_ARRAY_ELEMENTS(this->buffers));
     // Copy buffer before recycling
     U8* data = new U8[buffer.getSize()];
-    ASSERT_LT(buffers_index, FW_NUM_ARRAY_ELEMENTS(this->buffers));
     this->buffers[buffers_index] = data;
     buffers_index++;
     ::memcpy(data, buffer.getData(), buffer.getSize());


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Corrects a variety of minor issues detected by clang-tidy and adds a default clang-tidy config.
