### PR TITLE
Switch CI to run in VM instead of docker container

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,18 +12,13 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains 4 jobs. One for every CI test."
   Framework:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container:
-      image: nasafprime/fprime-base:latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-    # Runs the CI action internal to the repository
+    - name: Install fprime tools
+      run: pip3 install fprime-tools fprime-gds
     - name: F prime CI step
       run: ./ci/tests/Framework.bash
     # Archive the outputs
@@ -36,16 +31,12 @@ jobs:
         retention-days: 5
 
   Ref:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container:
-      image: nasafprime/fprime-base:latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-    # Runs the CI action internal to the repository
+    - name: Install fprime tools
+      run: pip3 install fprime-tools fprime-gds
     - name: F prime CI step
       run: ./ci/tests/Ref.bash
     # Archive the outputs
@@ -58,16 +49,14 @@ jobs:
         retention-days: 5
 
   RPI:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container:
-      image: nasafprime/fprime-base:latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-    # Runs the CI action internal to the repository
+    - name: Install fprime tools
+      run: pip3 install fprime-tools fprime-gds
+    - name: Install RPI Toolchain
+      run: sudo git clone https://github.com/raspberrypi/tools.git /opt/rpi/tools
     - name: F prime CI step
       run: ./ci/tests/RPI.bash
     # Archive the outputs
@@ -80,16 +69,14 @@ jobs:
         retention-days: 5
 
   Integration:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container:
-      image: nasafprime/fprime-base:latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-    # Runs the CI action internal to the repository
+    - name: Install fprime tools
+      run: pip3 install fprime-tools fprime-gds
+    - name: Setup Dependencies
+      run: sudo apt-get install valgrind
     - name: F prime CI step
       run: ./ci/tests/30-ints.bash
     # Archive the outputs
@@ -102,14 +89,12 @@ jobs:
         retention-days: 5
 
   CMake:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container:
-      image: nasafprime/fprime-base:latest
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-    # Runs CMake test cases
+    - name: Install fprime tools
+      run: pip3 install fprime-tools fprime-gds
     - name: CMake Tests
       working-directory: ./cmake/test
       run: pytest


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Instead of running CI steps inside of a docker container, run in the github provided 18.04 VM.

## Rationale

CI was the primary user of the fprime docker container and releasing new docker containers was a maintenance burden.
Since we were testing in ubuntu 18.04 anyway the docker container wasn't providing value.

## Future Work

This will enable the ability for us to more easily test against ubuntu 20.04 in the future without needing to release more docker containers.
