### PR TITLE
Standardize assignment operator signature

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
@@ -171,7 +171,7 @@ namespace ${namespace} {
   }
 
 
-  const ${name}& ${name} ::
+  ${name}& ${name} ::
     operator=(const ${name}& other)
   {
     for(U32 index = 0; index < SIZE; index++) {
@@ -180,7 +180,7 @@ namespace ${namespace} {
     return *this;
   }
 
-  const ${name}& ${name} ::
+  ${name}& ${name} ::
     operator=(const ElementType (&a)[SIZE])
   {
     for(U32 index = 0; index < SIZE; index++) {
@@ -189,7 +189,7 @@ namespace ${namespace} {
     return *this;
   }
 
-  const ${name}& ${name} ::
+  ${name}& ${name} ::
     operator=(const ElementType& e)
   {
     for(U32 index = 0; index < SIZE; index++) {

--- a/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_hpp.tmpl
@@ -155,17 +155,17 @@ namespace ${namespace} {
       ) const;
 
       //! Assignment operator
-      const ${name}& operator=(
+      ${name}& operator=(
           const ${name}& other //!< The other object
       );
 
       //! Assignment operator from array
-      const ${name}& operator=(
+      ${name}& operator=(
           const ElementType (&a)[SIZE] //!< The array
       );
 
       //! Assignment operator from element
-      const ${name}& operator=(
+      ${name}& operator=(
           const ElementType& e //!< The element
       );
 

--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
@@ -56,13 +56,13 @@ namespace ${namespace} {
   // Instance methods
   // ----------------------------------------------------------------------
 
-  const ${name}& ${name} :: operator=(const ${name}& other)
+  ${name}& ${name} :: operator=(const ${name}& other)
   {
     this->e = other.e;
     return *this;
   }
 
-  const ${name}& ${name} :: operator=(const NATIVE_INT_TYPE a)
+  ${name}& ${name} :: operator=(const NATIVE_INT_TYPE a)
   {
 #for $item_name,$item_value,$item_comment in $items_list:
 #if not $item_value == ""
@@ -90,7 +90,7 @@ a == $item_value#slurp
     return *this;
   }
 
-  const ${name}& ${name} :: operator=(const NATIVE_UINT_TYPE a)
+  ${name}& ${name} :: operator=(const NATIVE_UINT_TYPE a)
   {
 #for $item_name,$item_value,$item_comment in $items_list:
 #if not $item_value == ""

--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
@@ -102,17 +102,17 @@ namespace ${namespace} {
     // ----------------------------------------------------------------------
 
     //! Assignment operator
-    const ${name}& operator=(
+    ${name}& operator=(
         const ${name}& other //!< The other object
         );
 
     //! Assignment operator
-    const ${name}& operator=(
+    ${name}& operator=(
         const NATIVE_INT_TYPE a //!< The integer to copy
         );
 
     //! Assignment operator
-    const ${name}& operator=(
+    ${name}& operator=(
         const NATIVE_UINT_TYPE a //!< The integer to copy
         );
 

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialCpp.tmpl
@@ -40,9 +40,9 @@ ${name}::${name}(${args_scalar_array_string}) : Serializable() {
 
 #end if
 
-const ${name}& ${name}::operator=(const ${name}& src) {
+${name}& ${name}::operator=(const ${name}& src) {
     this->set(${args_mstring});
-    return src;
+    return *this;
 }
 
 bool ${name}::operator==(const ${name}& src) const {

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialH.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialH.tmpl
@@ -32,7 +32,7 @@ public:
 #if $args_proto_scalar_init:
     ${name}($args_proto_scalar_init); //!< constructor with arguments with scalars for array arguments
 #end if
-    const ${name}& operator=(const ${name}& src); //!< equal operator
+    ${name}& operator=(const ${name}& src); //!< equal operator
     bool operator==(const ${name}& src) const; //!< equality operator
 #ifdef BUILD_UT
     // to support GoogleTest framework in unit tests

--- a/Autocoders/Python/templates/ExampleType.cpp
+++ b/Autocoders/Python/templates/ExampleType.cpp
@@ -20,9 +20,9 @@ mytype::mytype(U32 val) : Serializable() {
     this->setVal(val);
 }
 
-const mytype& mytype::operator=(const mytype& src) {
+mytype& mytype::operator=(const mytype& src) {
     this->setVal(src.m_val);
-    return src;
+    return *this;
 }
 
 bool mytype::operator==(const mytype& src) const {

--- a/Autocoders/Python/templates/ExampleType.hpp
+++ b/Autocoders/Python/templates/ExampleType.hpp
@@ -24,7 +24,7 @@ namespace ANameSpace {
         mytype(const mytype* src); // copy constructor
         mytype(const mytype& src); // copy constructor
         mytype(U32 arg); // constructor with arguments
-        const mytype& operator=(const mytype& src); // Equal operator
+        mytype& operator=(const mytype& src); // Equal operator
         bool operator==(const mytype& src) const;
 
         void setVal(U32 arg); // set values

--- a/Autocoders/Python/test/ext_dict/ExampleType.cpp
+++ b/Autocoders/Python/test/ext_dict/ExampleType.cpp
@@ -20,9 +20,9 @@ mytype::mytype(U32 val) : Serializable() {
     this->setVal(val);
 }
 
-const mytype& mytype::operator=(const mytype& src) {
+mytype& mytype::operator=(const mytype& src) {
     this->setVal(src.m_val);
-    return src;
+    return *this;
 }
 
 bool mytype::operator==(const mytype& src) const {

--- a/Autocoders/Python/test/ext_dict/ExampleType.hpp
+++ b/Autocoders/Python/test/ext_dict/ExampleType.hpp
@@ -24,7 +24,7 @@ namespace ANameSpace {
         mytype(const mytype* src); // copy constructor
         mytype(const mytype& src); // copy constructor
         mytype(U32 arg); // constructor with arguments
-        const mytype& operator=(const mytype& src); // Equal operator
+        mytype& operator=(const mytype& src); // Equal operator
         bool operator==(const mytype& src) const; // equality operator
 
         void setVal(U32 arg); // set values

--- a/Autocoders/Python/test/interface1/UserSerializer.cpp
+++ b/Autocoders/Python/test/interface1/UserSerializer.cpp
@@ -21,9 +21,9 @@ UserSerializer::UserSerializer(SomeUserStruct val) : Serializable() {
     this->setVal(val);
 }
 
-const SomeUserStruct& UserSerializer::operator=(const SomeUserStruct& src) {
+SomeUserStruct& UserSerializer::operator=(const SomeUserStruct& src) {
     this->setVal(src);
-    return src;
+    return this->m_struct;
 }
 
 void UserSerializer::getVal(SomeUserStruct& arg) {

--- a/Autocoders/Python/test/interface1/UserSerializer.hpp
+++ b/Autocoders/Python/test/interface1/UserSerializer.hpp
@@ -23,7 +23,7 @@ namespace ANameSpace {
         UserSerializer(const SomeUserStruct* src); // copy constructor
         UserSerializer(const SomeUserStruct& src); // copy constructor
         UserSerializer(SomeUserStruct arg); // constructor with arguments
-        const SomeUserStruct& operator=(const SomeUserStruct& src); // Equal operator
+        SomeUserStruct& operator=(const SomeUserStruct& src); // Equal operator
 
         void setVal(const SomeUserStruct& arg); // set values
 

--- a/Autocoders/Python/test/port_loopback/ExampleType.cpp
+++ b/Autocoders/Python/test/port_loopback/ExampleType.cpp
@@ -20,9 +20,9 @@ mytype::mytype(U32 val) : Serializable() {
     this->setVal(val);
 }
 
-const mytype& mytype::operator=(const mytype& src) {
+mytype& mytype::operator=(const mytype& src) {
     this->setVal(src.m_val);
-    return src;
+    return *this;
 }
 
 bool mytype::operator==(const mytype& src) const {

--- a/Autocoders/Python/test/port_loopback/ExampleType.hpp
+++ b/Autocoders/Python/test/port_loopback/ExampleType.hpp
@@ -24,7 +24,7 @@ namespace ANameSpace {
         mytype(const mytype* src); // copy constructor
         mytype(const mytype& src); // copy constructor
         mytype(U32 arg); // constructor with arguments
-        const mytype& operator=(const mytype& src); // Equal operator
+        mytype& operator=(const mytype& src); // Equal operator
         bool operator==(const mytype& src) const;
 
         void setVal(U32 arg); // set values

--- a/Autocoders/Python/test/port_nogen/ExampleType.cpp
+++ b/Autocoders/Python/test/port_nogen/ExampleType.cpp
@@ -20,9 +20,9 @@ mytype::mytype(U32 val) : Serializable() {
     this->setVal(val);
 }
 
-const mytype& mytype::operator=(const mytype& src) {
+mytype& mytype::operator=(const mytype& src) {
     this->setVal(src.m_val);
-    return src;
+    return *this;
 }
 
 bool mytype::operator==(const mytype& src) const {

--- a/Autocoders/Python/test/port_nogen/ExampleType.hpp
+++ b/Autocoders/Python/test/port_nogen/ExampleType.hpp
@@ -24,7 +24,7 @@ namespace ANameSpace {
         mytype(const mytype* src); // copy constructor
         mytype(const mytype& src); // copy constructor
         mytype(U32 arg); // constructor with arguments
-        const mytype& operator=(const mytype& src); // Equal operator
+        mytype& operator=(const mytype& src); // Equal operator
         bool operator==(const mytype& src) const; // equality operator
         void setVal(U32 arg); // set values
 

--- a/Autocoders/Python/test/serialize_user/UserSerializer.cpp
+++ b/Autocoders/Python/test/serialize_user/UserSerializer.cpp
@@ -21,9 +21,9 @@ UserSerializer::UserSerializer(SomeUserStruct val) : Serializable() {
     this->setVal(val);
 }
 
-const SomeUserStruct& UserSerializer::operator=(const SomeUserStruct& src) {
+SomeUserStruct& UserSerializer::operator=(const SomeUserStruct& src) {
     this->setVal(src);
-    return src;
+    return this->m_struct;
 }
 
 void UserSerializer::getVal(SomeUserStruct& arg) {

--- a/Autocoders/Python/test/serialize_user/UserSerializer.hpp
+++ b/Autocoders/Python/test/serialize_user/UserSerializer.hpp
@@ -23,7 +23,7 @@ namespace ANameSpace {
         UserSerializer(const SomeUserStruct* src); // copy constructor
         UserSerializer(const SomeUserStruct& src); // copy constructor
         UserSerializer(SomeUserStruct arg); // constructor with arguments
-        const SomeUserStruct& operator=(const SomeUserStruct& src); // Equal operator
+        SomeUserStruct& operator=(const SomeUserStruct& src); // Equal operator
 
         void setVal(const SomeUserStruct& arg); // set values
 

--- a/CFDP/Checksum/Checksum.cpp
+++ b/CFDP/Checksum/Checksum.cpp
@@ -43,7 +43,7 @@ namespace CFDP {
 
   }
 
-  const Checksum& Checksum ::
+  Checksum& Checksum ::
     operator=(const Checksum& checksum)
   {
     this->value = checksum.value;

--- a/CFDP/Checksum/Checksum.hpp
+++ b/CFDP/Checksum/Checksum.hpp
@@ -53,7 +53,7 @@ namespace CFDP {
       // ----------------------------------------------------------------------
 
       //! Assign checksum to this
-      const Checksum& operator=(const Checksum& checksum);
+      Checksum& operator=(const Checksum& checksum);
 
       //! Compare checksum and this for equality
       bool operator==(const Checksum& checksum) const;

--- a/Drv/DataTypes/DataBuffer.cpp
+++ b/Drv/DataTypes/DataBuffer.cpp
@@ -19,7 +19,7 @@ namespace Drv {
         FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
     }
 
-    const DataBuffer& DataBuffer::operator=(const DataBuffer& other) {
+    DataBuffer& DataBuffer::operator=(const DataBuffer& other) {
         Fw::SerializeStatus stat = Fw::SerializeBufferBase::setBuff(other.m_data,other.getBuffLength());
         FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;

--- a/Drv/DataTypes/DataBuffer.hpp
+++ b/Drv/DataTypes/DataBuffer.hpp
@@ -19,7 +19,7 @@ namespace Drv {
             DataBuffer();
             DataBuffer(const DataBuffer& other);
             virtual ~DataBuffer();
-            const DataBuffer& operator=(const DataBuffer& other);
+            DataBuffer& operator=(const DataBuffer& other);
 
             NATIVE_UINT_TYPE getBuffCapacity() const; // !< returns capacity, not current size, of buffer
             U8* getBuffAddr();

--- a/Fw/Cmd/CmdArgBuffer.cpp
+++ b/Fw/Cmd/CmdArgBuffer.cpp
@@ -19,7 +19,7 @@ namespace Fw {
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
     }
 
-    const CmdArgBuffer& CmdArgBuffer::operator=(const CmdArgBuffer& other) {
+    CmdArgBuffer& CmdArgBuffer::operator=(const CmdArgBuffer& other) {
         SerializeStatus stat = this->setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;

--- a/Fw/Cmd/CmdArgBuffer.hpp
+++ b/Fw/Cmd/CmdArgBuffer.hpp
@@ -31,7 +31,7 @@ namespace Fw {
             CmdArgBuffer();  //!< default constructor
             CmdArgBuffer(const CmdArgBuffer& other);  //!< other arg buffer constructor
             virtual ~CmdArgBuffer();  //!< destructor
-            const CmdArgBuffer& operator=(const CmdArgBuffer& other);  //!< Equal operator
+            CmdArgBuffer& operator=(const CmdArgBuffer& other);  //!< Equal operator
 
             NATIVE_UINT_TYPE getBuffCapacity() const;  //!< return capacity of buffer (how much it can hold)
             U8* getBuffAddr();  //!< return address of buffer (non const version)

--- a/Fw/Com/ComBuffer.cpp
+++ b/Fw/Com/ComBuffer.cpp
@@ -19,7 +19,7 @@ namespace Fw {
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
     }
 
-    const ComBuffer& ComBuffer::operator=(const ComBuffer& other) {
+    ComBuffer& ComBuffer::operator=(const ComBuffer& other) {
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;

--- a/Fw/Com/ComBuffer.hpp
+++ b/Fw/Com/ComBuffer.hpp
@@ -30,7 +30,7 @@ namespace Fw {
             ComBuffer();
             ComBuffer(const ComBuffer& other);
             virtual ~ComBuffer();
-            const ComBuffer& operator=(const ComBuffer& other);
+            ComBuffer& operator=(const ComBuffer& other);
 
             NATIVE_UINT_TYPE getBuffCapacity() const; // !< returns capacity, not current size, of buffer
             U8* getBuffAddr();

--- a/Fw/Log/LogBuffer.cpp
+++ b/Fw/Log/LogBuffer.cpp
@@ -19,7 +19,7 @@ namespace Fw {
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
     }
 
-    const LogBuffer& LogBuffer::operator=(const LogBuffer& other) {
+    LogBuffer& LogBuffer::operator=(const LogBuffer& other) {
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;

--- a/Fw/Log/LogBuffer.hpp
+++ b/Fw/Log/LogBuffer.hpp
@@ -31,7 +31,7 @@ namespace Fw {
             LogBuffer();
             LogBuffer(const LogBuffer& other);
             virtual ~LogBuffer();
-            const LogBuffer& operator=(const LogBuffer& other);
+            LogBuffer& operator=(const LogBuffer& other);
 
             NATIVE_UINT_TYPE getBuffCapacity() const; // !< returns capacity, not current size, of buffer
             U8* getBuffAddr();

--- a/Fw/Log/LogString.cpp
+++ b/Fw/Log/LogString.cpp
@@ -102,7 +102,7 @@ namespace Fw {
         this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
     }
 
-    const LogStringArg& LogStringArg::operator=(const LogStringArg& other) {
+    LogStringArg& LogStringArg::operator=(const LogStringArg& other) {
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Fw/Log/LogString.hpp
+++ b/Fw/Log/LogString.hpp
@@ -26,7 +26,7 @@ namespace Fw {
             // This method is set by the autocode to the max length specified in the XML declaration for a particular event.
             void setMaxSerialize(NATIVE_UINT_TYPE size); // limit amount serialized
 
-            const LogStringArg& operator=(const LogStringArg& other); //!< equal operator for other strings
+            LogStringArg& operator=(const LogStringArg& other); //!< equal operator for other strings
 
             SerializeStatus serialize(SerializeBufferBase& buffer) const;
             SerializeStatus deserialize(SerializeBufferBase& buffer);

--- a/Fw/Prm/PrmBuffer.cpp
+++ b/Fw/Prm/PrmBuffer.cpp
@@ -19,11 +19,11 @@ namespace Fw {
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
 	}
 
-	const ParamBuffer& ParamBuffer::operator=(const ParamBuffer& other) {
-	    SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
+    ParamBuffer& ParamBuffer::operator=(const ParamBuffer& other) {
+        SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;
-	}
+    }
 
     NATIVE_UINT_TYPE ParamBuffer::getBuffCapacity() const {
         return sizeof(this->m_bufferData);

--- a/Fw/Prm/PrmBuffer.hpp
+++ b/Fw/Prm/PrmBuffer.hpp
@@ -31,7 +31,7 @@ namespace Fw {
             ParamBuffer();
             ParamBuffer(const ParamBuffer& other);
             virtual ~ParamBuffer();
-            const ParamBuffer& operator=(const ParamBuffer& other);
+            ParamBuffer& operator=(const ParamBuffer& other);
 
             NATIVE_UINT_TYPE getBuffCapacity() const; // !< returns capacity, not current size, of buffer
             U8* getBuffAddr();

--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -40,7 +40,7 @@ namespace Fw {
         this->m_seconds = seconds;
     }
 
-    const Time& Time::operator=(const Time& other) {
+    Time& Time::operator=(const Time& other) {
         this->m_timeBase = other.m_timeBase;
         this->m_timeContext = other.m_timeContext;
         this->m_useconds = other.m_useconds;

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -39,7 +39,7 @@ namespace Fw {
             bool operator<(const Time& other) const;
             bool operator>=(const Time& other) const;
             bool operator<=(const Time& other) const;
-            const Time& operator=(const Time& other);
+            Time& operator=(const Time& other);
 
             // Static methods:
             //! The type of a comparison result

--- a/Fw/Tlm/TlmBuffer.cpp
+++ b/Fw/Tlm/TlmBuffer.cpp
@@ -19,7 +19,7 @@ namespace Fw {
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
     }
 
-    const TlmBuffer& TlmBuffer::operator=(const TlmBuffer& other) {
+    TlmBuffer& TlmBuffer::operator=(const TlmBuffer& other) {
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;

--- a/Fw/Tlm/TlmBuffer.hpp
+++ b/Fw/Tlm/TlmBuffer.hpp
@@ -30,7 +30,7 @@ namespace Fw {
             TlmBuffer();
             TlmBuffer(const TlmBuffer& other);
             virtual ~TlmBuffer();
-            const TlmBuffer& operator=(const TlmBuffer& other);
+            TlmBuffer& operator=(const TlmBuffer& other);
 
             NATIVE_UINT_TYPE getBuffCapacity() const; // !< returns capacity, not current size, of buffer
             U8* getBuffAddr();

--- a/Fw/Tlm/TlmString.cpp
+++ b/Fw/Tlm/TlmString.cpp
@@ -91,7 +91,7 @@ namespace Fw {
         this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
     }
 
-    const TlmString& TlmString::operator=(const TlmString& other) {
+    TlmString& TlmString::operator=(const TlmString& other) {
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Fw/Tlm/TlmString.hpp
+++ b/Fw/Tlm/TlmString.hpp
@@ -25,7 +25,7 @@ namespace Fw {
             NATIVE_UINT_TYPE length() const;
             void setMaxSerialize(NATIVE_UINT_TYPE size); // limit amount serialized
 
-            const TlmString& operator=(const TlmString& other); //!< equal operator for other strings
+            TlmString& operator=(const TlmString& other); //!< equal operator for other strings
 
             SerializeStatus serialize(SerializeBufferBase& buffer) const;
             SerializeStatus deserialize(SerializeBufferBase& buffer);

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -348,7 +348,7 @@ namespace Fw {
     PolyType::~PolyType() {
     }
 
-    const PolyType& PolyType::operator=(const PolyType &src) {
+    PolyType& PolyType::operator=(const PolyType &src) {
         this->m_dataType = src.m_dataType;
         this->m_val = src.m_val;
         return *this;

--- a/Fw/Types/PolyType.hpp
+++ b/Fw/Types/PolyType.hpp
@@ -98,7 +98,7 @@ namespace Fw {
             void toString(StringBase& dest) const; //!< get string representation
 #endif
 
-            const PolyType& operator=(const PolyType &src); //!< PolyType operator=
+            PolyType& operator=(const PolyType &src); //!< PolyType operator=
             bool operator<(const PolyType &other) const; //!< PolyType operator<
             bool operator>(const PolyType &other) const; //!< PolyType operator>
             bool operator>=(const PolyType &other) const; //!< PolyType operator>=

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -57,7 +57,7 @@ namespace Fw {
 
     // Copy constructor doesn't make sense in this virtual class as there is nothing to copy. Derived classes should
     // call the empty constructor and then call their own copy function
-    const SerializeBufferBase& SerializeBufferBase::operator=(const SerializeBufferBase &src) { // lgtm[cpp/rule-of-two]
+    SerializeBufferBase& SerializeBufferBase::operator=(const SerializeBufferBase &src) { // lgtm[cpp/rule-of-two]
         this->copyFrom(src);
         return *this;
     }

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -43,7 +43,7 @@ namespace Fw {
     class SerializeBufferBase {
         public:
 
-            const SerializeBufferBase& operator=(const SerializeBufferBase &src); //!< equal operator
+            SerializeBufferBase& operator=(const SerializeBufferBase &src); //!< equal operator
 
             virtual ~SerializeBufferBase(); //!< destructor
 

--- a/Svc/Cycle/TimerVal.cpp
+++ b/Svc/Cycle/TimerVal.cpp
@@ -25,9 +25,10 @@ namespace Svc {
         this->m_timerVal.lower = other.m_timerVal.lower;
     }
 
-    void TimerVal::operator=(const TimerVal& other) {
+    TimerVal& TimerVal::operator=(const TimerVal& other) {
         this->m_timerVal.upper = other.m_timerVal.upper;
         this->m_timerVal.lower = other.m_timerVal.lower;
+        return *this;
     }
 
     Os::IntervalTimer::RawTime TimerVal::getTimerVal() const {

--- a/Svc/Cycle/TimerVal.hpp
+++ b/Svc/Cycle/TimerVal.hpp
@@ -42,7 +42,7 @@ namespace Svc {
             //!
             //!  \param other source timer value
 
-            void operator=(const TimerVal& other); //!< equal operator
+            TimerVal& operator=(const TimerVal& other); //!< equal operator
 
             //!  \brief Destructor
             //!

--- a/Svc/UdpReceiver/UdpReceiverComponentImpl.cpp
+++ b/Svc/UdpReceiver/UdpReceiverComponentImpl.cpp
@@ -220,9 +220,10 @@ namespace Svc {
   }
 
 #ifdef BUILD_UT
-  void UdpReceiverComponentImpl::UdpSerialBuffer::operator=(const UdpReceiverComponentImpl::UdpSerialBuffer& other) {
+  UdpReceiverComponentImpl::UdpSerialBuffer& UdpReceiverComponentImpl::UdpSerialBuffer::operator=(const UdpReceiverComponentImpl::UdpSerialBuffer& other) {
       this->resetSer();
       this->serialize(other.getBuffAddr(),other.getBuffLength(),true);
+      return *this;
   }
 
   UdpReceiverComponentImpl::UdpSerialBuffer::UdpSerialBuffer(

--- a/Svc/UdpReceiver/UdpReceiverComponentImpl.hpp
+++ b/Svc/UdpReceiver/UdpReceiverComponentImpl.hpp
@@ -83,7 +83,7 @@ namespace Svc {
         public:
 
 #ifdef BUILD_UT
-          void operator=(const UdpSerialBuffer& other);
+          UdpSerialBuffer& operator=(const UdpSerialBuffer& other);
           UdpSerialBuffer(const Fw::SerializeBufferBase& other);
           UdpSerialBuffer(const UdpSerialBuffer& other);
           UdpSerialBuffer();

--- a/Svc/UdpSender/UdpSenderComponentImpl.cpp
+++ b/Svc/UdpSender/UdpSenderComponentImpl.cpp
@@ -147,9 +147,10 @@ namespace Svc {
   }
 
 #ifdef BUILD_UT
-  void UdpSenderComponentImpl::UdpSerialBuffer::operator=(const Svc::UdpSenderComponentImpl::UdpSerialBuffer& other) {
+  UdpSerialBuffer& UdpSenderComponentImpl::UdpSerialBuffer::operator=(const Svc::UdpSenderComponentImpl::UdpSerialBuffer& other) {
       this->resetSer();
       this->serialize(other.getBuffAddr(),other.getBuffLength(),true);
+      return *this;
   }
 
   UdpSenderComponentImpl::UdpSerialBuffer::UdpSerialBuffer(

--- a/Svc/UdpSender/UdpSenderComponentImpl.hpp
+++ b/Svc/UdpSender/UdpSenderComponentImpl.hpp
@@ -97,7 +97,7 @@ namespace Svc {
         public:
 
 #ifdef BUILD_UT
-          void operator=(const UdpSerialBuffer& other);
+          UdpSerialBuffer& operator=(const UdpSerialBuffer& other);
           UdpSerialBuffer(const Fw::SerializeBufferBase& other);
           UdpSerialBuffer(const UdpSerialBuffer& other);
           UdpSerialBuffer();

--- a/Utils/Hash/HashBuffer.hpp
+++ b/Utils/Hash/HashBuffer.hpp
@@ -45,7 +45,7 @@ namespace Utils {
 
             //! Assign a hash buffer from another hash buffer
             //!
-            const HashBuffer& operator=(const HashBuffer& other);
+            HashBuffer& operator=(const HashBuffer& other);
 
             //! Compare two hash buffers for equality
             //!

--- a/Utils/Hash/HashBufferCommon.cpp
+++ b/Utils/Hash/HashBufferCommon.cpp
@@ -19,7 +19,7 @@ namespace Utils {
         FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
     }
 
-    const HashBuffer& HashBuffer::operator=(const HashBuffer& other) {
+    HashBuffer& HashBuffer::operator=(const HashBuffer& other) {
         Fw::SerializeStatus stat = Fw::SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;


### PR DESCRIPTION
C++ assignment operators should not return const value to match behavior of primative types

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Standardize all C++ assignment operator signatures to: `class& operator=(const class& a)`

## Rationale

C++ assignment operators should not return const value to match behavior of primitive types
See http://courses.cms.caltech.edu/cs11/material/cpp/donnie/cpp-ops.html for more details
