### PR TITLE
fix: typo spelling grammar

### DIFF
--- a/Autocoders/Python/src/fprime_ac/utils/ParseC.py
+++ b/Autocoders/Python/src/fprime_ac/utils/ParseC.py
@@ -177,7 +177,7 @@ def ParseTypedefEnum(typename, filename, loadfile=True):
     #
     # Configure a parser to pickoff a typedef enumeration. This only works
     # for named typedefs of enumerations. We are looking for 'typedef enum'
-    # followd by the typename.
+    # followed by the typename.
 
     _ = Forward()
 

--- a/Os/Pthreads/MaxHeap/test/ut/MaxHeapTest.cpp
+++ b/Os/Pthreads/MaxHeap/test/ut/MaxHeapTest.cpp
@@ -153,7 +153,7 @@ int main() {
   printf("Testing mixed priority...\n");
   // For this test we expect things to come in fifo order
   // for things of the same priority and in priority
-  // order for things of differend priorities.
+  // order for things of different priorities.
   NATIVE_INT_TYPE pries[DEPTH] = {1, 7, 100, 1, 7};
   NATIVE_INT_TYPE data2[DEPTH] = {4, 22, 99, 12344, 33};
   NATIVE_INT_TYPE orderedPries[DEPTH] = {100, 7, 7, 1, 1};


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|  [slowy07](github.com/slowy07)|
|**_Affected Component_**| ``parseC.py``  ``MaxHeapTest.cpp``|
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| not include because just replace typo fixing |
|**_Builds Without Errors (y/n)_**| not include because just replace typo fixing |
|**_Unit Tests Pass (y/n)_**| not include because just replace typo fixing |
|**_Documentation Included (y/n)_**| **y** |

---
## Change Description
fixing typo and replace to correct words

## Rationale
for more readable code comments