### PR TITLE
Use ordinary char pointers for assert strings

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -328,6 +328,7 @@ deserializing
 dest
 DEVNULL
 dfdc
+DFL
 DFPRIME
 DGRAM
 DHTML

--- a/Fw/Logger/LogAssert.cpp
+++ b/Fw/Logger/LogAssert.cpp
@@ -67,7 +67,7 @@ namespace Fw {
 
     }
 
-    void LogAssertHook::printAssert(const I8* msg) {
+    void LogAssertHook::printAssert(const CHAR* msg) {
         // do nothing since reportAssert() sends message
     }
 

--- a/Fw/Logger/LogAssert.hpp
+++ b/Fw/Logger/LogAssert.hpp
@@ -29,7 +29,7 @@ namespace Fw {
                 AssertArg arg5,
                 AssertArg arg6
             );
-            void printAssert(const I8* msg);
+            void printAssert(const CHAR* msg);
             void doAssert();
     };
 

--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -7,6 +7,8 @@
 #include <taskLib.h>
 #endif
 
+#define FW_ASSERT_DFL_MSG_LEN 256
+
 #if FW_ASSERT_LEVEL == FW_NO_ASSERT
 
 #else
@@ -19,8 +21,8 @@
 
 namespace Fw {
 
-    void defaultPrintAssert(const I8* msg) {
-        (void)fprintf(stderr,"%s\n",reinterpret_cast<const char*>(msg));
+    void defaultPrintAssert(const CHAR* msg) {
+        (void)fprintf(stderr,"%s\n", msg);
     }
 
     void defaultReportAssert
@@ -34,36 +36,36 @@ namespace Fw {
             AssertArg arg4,
             AssertArg arg5,
             AssertArg arg6,
-            I8* destBuffer,
+            CHAR* destBuffer,
             NATIVE_INT_TYPE buffSize
             ) {
 
         switch (numArgs) {
             case 0:
-                (void)snprintf((char*)destBuffer,buffSize,fileIdFs,file,lineNo);
+                (void)snprintf(destBuffer,buffSize,fileIdFs,file,lineNo);
                 break;
             case 1:
-                (void)snprintf((char*)destBuffer,buffSize,fileIdFs "%d",file,lineNo,
+                (void)snprintf(destBuffer,buffSize,fileIdFs "%d",file,lineNo,
                         arg1);
                 break;
             case 2:
-                (void)snprintf((char*)destBuffer,buffSize,fileIdFs "%d %d",file,lineNo,
+                (void)snprintf(destBuffer,buffSize,fileIdFs "%d %d",file,lineNo,
                         arg1,arg2);
                 break;
             case 3:
-                (void)snprintf((char*)destBuffer,buffSize,fileIdFs "%d %d %d",file,lineNo,
+                (void)snprintf(destBuffer,buffSize,fileIdFs "%d %d %d",file,lineNo,
                         arg1,arg2,arg3);
                 break;
             case 4:
-                (void)snprintf((char*)destBuffer,buffSize,fileIdFs "%d %d %d %d",file,lineNo,
+                (void)snprintf(destBuffer,buffSize,fileIdFs "%d %d %d %d",file,lineNo,
                         arg1,arg2,arg3,arg4);
                 break;
             case 5:
-                (void)snprintf((char*)destBuffer,buffSize,fileIdFs "%d %d %d %d %d",file,lineNo,
+                (void)snprintf(destBuffer,buffSize,fileIdFs "%d %d %d %d %d",file,lineNo,
                         arg1,arg2,arg3,arg4,arg5);
                 break;
             case 6:
-                (void)snprintf((char*)destBuffer,buffSize,fileIdFs "%d %d %d %d %d %d",file,lineNo,
+                (void)snprintf(destBuffer,buffSize,fileIdFs "%d %d %d %d %d %d",file,lineNo,
                         arg1,arg2,arg3,arg4,arg5,arg6);
                 break;
             default: // in an assert already, what can we do?
@@ -75,7 +77,7 @@ namespace Fw {
 
     }
 
-    void AssertHook::printAssert(const I8* msg) {
+    void AssertHook::printAssert(const CHAR* msg) {
         defaultPrintAssert(msg);
     }
 
@@ -92,7 +94,7 @@ namespace Fw {
             AssertArg arg6
          )
     {
-        I8 destBuffer[256];
+        CHAR destBuffer[FW_ASSERT_DFL_MSG_LEN];
         defaultReportAssert
         (
             file,
@@ -128,7 +130,7 @@ namespace Fw {
 
     NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo) {
         if (NULL == s_assertHook) {
-            I8 assertMsg[256];
+            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
             defaultReportAssert(
                 file,
                 lineNo,
@@ -153,7 +155,7 @@ namespace Fw {
     NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo,
             AssertArg arg1) {
         if (NULL == s_assertHook) {
-            I8 assertMsg[256];
+            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
             defaultReportAssert(
                 file,
                 lineNo,
@@ -179,7 +181,7 @@ namespace Fw {
             AssertArg arg1,
             AssertArg arg2) {
         if (NULL == s_assertHook) {
-            I8 assertMsg[256];
+            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
             defaultReportAssert(
                 file,
                 lineNo,
@@ -205,7 +207,7 @@ namespace Fw {
             AssertArg arg2,
             AssertArg arg3) {
         if (NULL == s_assertHook) {
-            I8 assertMsg[256];
+            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
             defaultReportAssert(
                 file,
                 lineNo,
@@ -232,7 +234,7 @@ namespace Fw {
             AssertArg arg3,
             AssertArg arg4) {
         if (NULL == s_assertHook) {
-            I8 assertMsg[256];
+            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
             defaultReportAssert(
                 file,
                 lineNo,
@@ -260,7 +262,7 @@ namespace Fw {
             AssertArg arg4,
             AssertArg arg5) {
         if (NULL == s_assertHook) {
-            I8 assertMsg[256];
+            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
             defaultReportAssert(
                 file,
                 lineNo,
@@ -289,7 +291,7 @@ namespace Fw {
             AssertArg arg5,
             AssertArg arg6) {
         if (NULL == s_assertHook) {
-            I8 assertMsg[256];
+            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
             defaultReportAssert(
                 file,
                 lineNo,
@@ -318,7 +320,7 @@ extern "C" {
 
 NATIVE_INT_TYPE CAssert0(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo) {
     if (NULL == Fw::s_assertHook) {
-        I8 assertMsg[256];
+        CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
         Fw::defaultReportAssert(
             file,
             lineNo,

--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -21,10 +21,10 @@
     ((void) ((cond) ? (0) : \
     (Fw::SwAssert(ASSERT_FILE_ID, __LINE__, ##__VA_ARGS__))))
 #else
-#define FILE_NAME_ARG const U8*
+#define FILE_NAME_ARG const CHAR*
 #define FW_ASSERT(cond, ...) \
     ((void) ((cond) ? (0) : \
-    (Fw::SwAssert((U8*)__FILE__, __LINE__, ##__VA_ARGS__))))
+    (Fw::SwAssert(__FILE__, __LINE__, ##__VA_ARGS__))))
 #endif
 
 // F' Assertion functions can technically return even though the intention is for the assertion to terminate the program.
@@ -75,7 +75,7 @@ namespace Fw {
                     );
             // default reportAssert() will call this when the message is built
             // override it to do another kind of print. printf by default
-            virtual void printAssert(const I8* msg);
+            virtual void printAssert(const CHAR* msg);
             // do assert action. By default, calls assert.
             // Called after reportAssert()
             virtual void doAssert();

--- a/Fw/Types/BasicTypes.hpp
+++ b/Fw/Types/BasicTypes.hpp
@@ -90,11 +90,13 @@ typedef U8              BYTE; //!< byte type
  typedef int64_t        I64; //!< 64-bit signed integer
  typedef uint64_t       U64; //!< 64-bit unsigned integer
 #endif
- 
+
 typedef float   F32; //!< 32-bit floating point
 #if FW_HAS_F64
  typedef double  F64; //!< 64-bit floating point
 #endif
+
+typedef char CHAR;
 
 #ifndef NULL
 #define NULL  (0)  //!< NULL

--- a/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
+++ b/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
@@ -30,7 +30,7 @@ namespace Fw {
             AssertArg arg4,
             AssertArg arg5,
             AssertArg arg6,
-            I8* destBuffer,
+            CHAR* destBuffer,
             NATIVE_INT_TYPE buffSize
             );
 
@@ -121,12 +121,12 @@ namespace Svc {
       Fw::LogStringArg fileArg;
       fileArg.format("0x%08X",file);
 #else
-      Fw::LogStringArg fileArg((const char*)file);
+      Fw::LogStringArg fileArg(file);
 #endif
 
-      I8 msg[FW_ASSERT_TEXT_SIZE] = {0};
+      CHAR msg[FW_ASSERT_TEXT_SIZE] = {0};
       Fw::defaultReportAssert(file,lineNo,numArgs,arg1,arg2,arg3,arg4,arg5,arg6,msg,sizeof(msg));
-      fprintf(stderr, "%s\n",(const char*)msg);
+      fprintf(stderr, "%s\n", msg);
 
       switch (numArgs) {
           case 0:

--- a/Svc/AssertFatalAdapter/test/ut/Tester.cpp
+++ b/Svc/AssertFatalAdapter/test/ut/Tester.cpp
@@ -92,7 +92,7 @@ namespace Svc {
         ASSERT_EVENTS_AF_ASSERT_6(0,file,lineNo,1,2,3,4,5,6);
 
         // Test unexpected assert
-        this->component.reportAssert((U8*)"foo",1000,10,1,2,3,4,5,6);
+        this->component.reportAssert("foo",1000,10,1,2,3,4,5,6);
         ASSERT_EVENTS_AF_UNEXPECTED_ASSERT_SIZE(1);
         ASSERT_EVENTS_AF_UNEXPECTED_ASSERT(0,"foo",1000,10);
 

--- a/config/FpConfig.hpp
+++ b/config/FpConfig.hpp
@@ -160,6 +160,7 @@
 #define FW_NO_ASSERT                        1   //!< Asserts turned off
 #define FW_FILEID_ASSERT                    2   //!< File ID used - requires -DASSERT_FILE_ID=somevalue to be set on the compile command line
 #define FW_FILENAME_ASSERT                  3   //!< Uses the file name in the assert - image stores filenames
+#define FW_ASSERT_DFL_MSG_LEN               256 //!< Maximum assert message length when using the default assert handler
 
 #ifndef FW_ASSERT_LEVEL
 #define FW_ASSERT_LEVEL                     FW_FILENAME_ASSERT //!< Defines the type of assert used


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

As part of my C++ modernization work, I'm trying to replace all C-style typecasting with C++ casts.

The C++ treats chars, unsigned chars (U8), and signed chars (I8) as three unique types.
The assert subsystem uses both U8* and I8* to hold assert strings. This quickly becomes awkward when trying to work with const strings and the string handling methods. All string inputs to the assert system must be cast from char pointers to signed or unsigned pointers, then cast back to char pointers when displaying the assert. Since I didn't see any benefit to handling assert strings as U8* or I8* type, rather than replace all these C-style casts with C++ style casts, I just changed the assert system to use char* instead.
