### PR TITLE
Fix enum vxworks macro conflict

### DIFF
--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -140,7 +140,7 @@ namespace Svc {
           this->curTimer = 0;
           this->log_WARNING_HI_DownlinkTimeout(this->file.sourceName, this->file.destName);
           this->enterCooldown();
-          this->sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::OK : SendFileStatus::ERROR);
+          this->sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR);
         } else { //Otherwise update the current counter
           this->curTimer += cycleTime;
         }
@@ -179,9 +179,9 @@ namespace Svc {
     Os::Queue::QueueStatus status = fileQueue.send((U8 *) &entry, sizeof(entry), 0, Os::Queue::QUEUE_NONBLOCKING);
 
     if(status != Os::Queue::QUEUE_OK) {
-      return SendFileResponse(SendFileStatus::ERROR, __UINT32_MAX__);
+      return SendFileResponse(SendFileStatus::STATUS_ERROR, __UINT32_MAX__);
     }
-    return SendFileResponse(SendFileStatus::OK, entry.context);
+    return SendFileResponse(SendFileStatus::STATUS_OK, entry.context);
   }
 
   void FileDownlink ::
@@ -310,13 +310,13 @@ namespace Svc {
     statusToCmdResp(SendFileStatus status)
   {
     switch(status.e) {
-    case SendFileStatus::OK:
+    case SendFileStatus::STATUS_OK:
       return Fw::COMMAND_OK;
-    case SendFileStatus::ERROR:
+    case SendFileStatus::STATUS_ERROR:
       return Fw::COMMAND_EXECUTION_ERROR;
-    case SendFileStatus::INVALID:
+    case SendFileStatus::STATUS_INVALID:
       return Fw::COMMAND_VALIDATION_ERROR;
-    case SendFileStatus::BUSY:
+    case SendFileStatus::STATUS_BUSY:
         return Fw::COMMAND_BUSY;
     default:
         // Trigger assertion if given unknown status
@@ -359,7 +359,7 @@ namespace Svc {
     if (status != Os::File::OP_OK) {
       this->mode.set(Mode::IDLE);
       this->warnings.fileOpenError();
-      sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::OK : SendFileStatus::ERROR);
+      sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR);
       return;
     }
 
@@ -367,7 +367,7 @@ namespace Svc {
     if (startOffset >= this->file.size) {
         this->enterCooldown();
         this->log_WARNING_HI_DownlinkPartialFail(this->file.sourceName, this->file.destName, startOffset, this->file.size);
-        sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::OK : SendFileStatus::INVALID);
+        sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_INVALID);
         return;
     } else if (startOffset + length > this->file.size) {
         // If the amount to downlink is greater than the file size, emit a Warning and then allow
@@ -526,7 +526,7 @@ namespace Svc {
           if (status != Os::File::OP_OK) {
               this->log_WARNING_HI_SendDataFail(this->file.sourceName, this->byteOffset);
               this->enterCooldown();
-              this->sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::OK : SendFileStatus::ERROR);
+              this->sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR);
               //Don't go to wait state
               return;
           }
@@ -551,7 +551,7 @@ namespace Svc {
           this->log_ACTIVITY_HI_DownlinkCanceled(this->file.sourceName, this->file.destName);
       }
       this->enterCooldown();
-      sendResponse(SendFileStatus::OK);
+      sendResponse(SendFileStatus::STATUS_OK);
   }
 
   void FileDownlink ::

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -160,16 +160,15 @@ namespace Svc {
         U32 length
     )
   {
-    struct FileEntry entry = {
-      .srcFilename = {0},
-      .destFilename = {0},
-      .offset = offset,
-      .length = length,
-      .source = FileDownlink::PORT,
-      .opCode = 0,
-      .cmdSeq = 0,
-      .context = cntxId++
-    };
+    struct FileEntry entry;
+    entry.srcFilename[0] = 0;
+    entry.destFilename[0] = 0;
+    entry.offset = offset;
+    entry.length = length;
+    entry.source = FileDownlink::PORT;
+    entry.opCode = 0;
+    entry.cmdSeq = 0;
+    entry.context = cntxId++;
 
     FW_ASSERT(sourceFilename.length() < sizeof(entry.srcFilename));
     FW_ASSERT(destFilename.length() < sizeof(entry.destFilename));
@@ -233,16 +232,15 @@ namespace Svc {
         const Fw::CmdStringArg& destFilename
     )
   {
-    struct FileEntry entry = {
-      .srcFilename = {0},
-      .destFilename = {0},
-      .offset = 0,
-      .length = 0,
-      .source = FileDownlink::COMMAND,
-      .opCode = opCode,
-      .cmdSeq = cmdSeq,
-      .context =__UINT32_MAX__
-    };
+    struct FileEntry entry;
+    entry.srcFilename[0] = 0;
+    entry.destFilename[0] = 0;
+    entry.offset = 0;
+    entry.length = 0;
+    entry.source = FileDownlink::COMMAND;
+    entry.opCode = opCode;
+    entry.cmdSeq = cmdSeq;
+    entry.context = __UINT32_MAX__;
 
     FW_ASSERT(sourceFilename.length() < sizeof(entry.srcFilename));
     FW_ASSERT(destFilename.length() < sizeof(entry.destFilename));
@@ -266,16 +264,15 @@ namespace Svc {
       U32 length
    )
   {
-    struct FileEntry entry = {
-      .srcFilename = {0},
-      .destFilename = {0},
-      .offset = startOffset,
-      .length = length,
-      .source = FileDownlink::COMMAND,
-      .opCode = opCode,
-      .cmdSeq = cmdSeq,
-      .context = __UINT32_MAX__
-    };
+    struct FileEntry entry;
+    entry.srcFilename[0] = 0;
+    entry.destFilename[0] = 0;
+    entry.offset = startOffset;
+    entry.length = length;
+    entry.source = FileDownlink::COMMAND;
+    entry.opCode = opCode;
+    entry.cmdSeq = cmdSeq;
+    entry.context = __UINT32_MAX__;
 
     FW_ASSERT(sourceFilename.length() < sizeof(entry.srcFilename));
     FW_ASSERT(destFilename.length() < sizeof(entry.destFilename));

--- a/Svc/FileDownlink/SendFileStatusEnumAi.xml
+++ b/Svc/FileDownlink/SendFileStatusEnumAi.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <enum namespace = "Svc" name="SendFileStatus">
     <comment>Status of file transfer.</comment>
-    <item name="OK" value="0"/>
-    <item name="ERROR" value="1"/>
-    <item name="INVALID" value="2"/>
-    <item name="BUSY" value="3"/>
+    <item name="STATUS_OK" value="0"/>
+    <item name="STATUS_ERROR" value="1"/>
+    <item name="STATUS_INVALID" value="2"/>
+    <item name="STATUS_BUSY" value="3"/>
 </enum>

--- a/Svc/FileDownlink/test/ut/Tester.cpp
+++ b/Svc/FileDownlink/test/ut/Tester.cpp
@@ -338,7 +338,7 @@ namespace Svc {
     destFileNameString  destFileArg(destFileName);
     Svc::SendFileResponse resp = this->invoke_to_SendFile(0, srcFileArg, destFileArg, 0, 0);
 
-    ASSERT_EQ(resp.getstatus(), SendFileStatus::OK);
+    ASSERT_EQ(resp.getstatus(), SendFileStatus::STATUS_OK);
     ASSERT_EQ(resp.getcontext(), 0);
 
     this->component.Run_handler(0,0); // Dequeue file downlink request
@@ -350,7 +350,7 @@ namespace Svc {
     }
 
     ASSERT_from_FileComplete_SIZE(1);
-    ASSERT_from_FileComplete(0, Svc::SendFileResponse(SendFileStatus(SendFileStatus::OK), 0));
+    ASSERT_from_FileComplete(0, Svc::SendFileResponse(SendFileStatus(SendFileStatus::STATUS_OK), 0));
 
     // Assert telemetry
     ASSERT_TLM_SIZE(4);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Svc::FileDownlink |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  n|
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Changed enum element's name and instantiation of struct. 

## Rationale

MACRO conflicts and compilation errors with older compilers.

## Testing/Review Recommendations

Re-run unit tests.

## Future Work

None.
