### PR TITLE
Switch autodocs action to use VM instead of container

### DIFF
--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -8,12 +8,12 @@ jobs:
   build:
     name: Autodocumentation
     runs-on: ubuntu-latest
-    container:
-      image: nasafprime/fprime-base:latest
     steps:
     - name: checkout
       uses: actions/checkout@v2.0.0
-      with:
-        fetch-depth: 5
+    - name: Install fprime tools
+      run: pip3 install fprime-tools fprime-gds
+    - name: Setup Dependencies
+      run: sudo apt-get install doxygen
     - name: Autodocs
       run: .github/actions/autodoc.bash


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Switch autodocs workflow to use VM instead of docker container. Hopefully this will fix the current job errors.