### PR TITLE
autodocs: check out entire history to avoid errors merging

### DIFF
--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -9,8 +9,9 @@ jobs:
     name: Autodocumentation
     runs-on: ubuntu-latest
     steps:
-    - name: checkout
-      uses: actions/checkout@v2.0.0
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Install fprime tools
       run: pip3 install fprime-tools fprime-gds
     - name: Setup Dependencies


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The autodocs workflow is currently failing because it cannot merge devel and the release/branch. Github by default only checks out the latest commit, so there's no commit history to use for the merge. Instead, checkout everything to ensure the merge succeeds. 
