### PR TITLE
feat: Add a Citation File

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -172,6 +172,7 @@ cdn
 cerrno
 cface
 CFDP
+cff
 cfg
 cflag
 cfsetispeed
@@ -342,7 +343,6 @@ diafile
 dictgen
 dicts
 dictvalue
-differend
 diffs
 diles
 dinkel
@@ -525,14 +525,12 @@ finalizer
 findall
 fio
 Firefox
-FIXME
 Fixme
 flist
 FNDELAY
 fnmatch
 fno
 fns
-followd
 FONTNAME
 FONTPATH
 FONTSIZE
@@ -893,7 +891,6 @@ LTIMER
 LTLT
 LVL
 lxml
-lxr
 MACROFILE
 magicdraw
 mailto
@@ -1646,8 +1643,8 @@ tt
 ttype
 Tuszynski
 TXD
-typedef
 typedef'ed
+typedef
 typeid
 typeinfo
 typelist

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Bocchino"
+  given-names: "Robert"
+- family-names: "Canham"
+  given-names: "Timothy"
+- family-names: "Watney"
+  given-names: "Garth"
+- family-names: "Reder"
+  given-names: "Leonard"
+- family-names: "Levison"
+  given-names: "Jeffrey"
+title: "F': A Flight-Proven, Multi-Platform, Open-Source Flight Software Framework"
+url: "https://github.com/nasa/fprime"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|@astroesteban |
|**_Affected Component_**| Repo Main Page |
|**_Affected Architectures(s)_**| None |
|**_Related Issue(s)_**| #946 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Add a _CITATION.cff_ file to the repo easily citing this repository in APA or BibTeX format

## Rationale

GitHub recently announced [support for citations](https://github.blog/2021-08-19-enhanced-support-citations-github/) using  `ruby-cff`. In order to add a citation for F' we just need to create a `CITATION.cff` file.

By adding this file we make it easier for users to cite F' thus bolstering the recognition of the project and boosting the reference count on sites like Google Scholar. This could have potential benefit when making a business case for F', recognizes the work made by contributors, and making it easier for people to reference the project is just nice.

## Testing/Review Recommendations

I added the authors listed [on this paper](https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=4140&context=smallsat). This section is up for debate. We could:

1. Add all the current contributors and keep updating this file as more contributors join the project.
2. Keep the current author list as is based on the paper.
3. Reduce the list of authors to the minimum of at least one. 

## Future Work

Note any additional work that will be done relating to this issue.
