### PR TITLE
Fw: Convert C style casts to C++ style casts

### DIFF
--- a/Fw/Buffer/Buffer.cpp
+++ b/Fw/Buffer/Buffer.cpp
@@ -103,7 +103,7 @@ Fw::SerializeBufferBase& Buffer::getSerializeRepr() {
 Fw::SerializeStatus Buffer::serialize(Fw::SerializeBufferBase& buffer) const {
     Fw::SerializeStatus stat;
 #if FW_SERIALIZATION_TYPE_ID
-    stat = buffer.serialize((U32)Buffer::TYPE_ID);
+    stat = buffer.serialize(static_cast<U32>(Buffer::TYPE_ID));
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }

--- a/Fw/Comp/ActiveComponentBase.cpp
+++ b/Fw/Comp/ActiveComponentBase.cpp
@@ -67,12 +67,12 @@ namespace Fw {
 #else
         Os::Task::TaskStatus status = this->m_task.start(taskName, identifier, priority, stackSize, this->s_baseTask, this, cpuAffinity);
 #endif
-        FW_ASSERT(status == Os::Task::TASK_OK,(NATIVE_INT_TYPE)status);
+        FW_ASSERT(status == Os::Task::TASK_OK,static_cast<NATIVE_INT_TYPE>(status));
     }
 
     void ActiveComponentBase::exit() {
         ActiveComponentExitSerializableBuffer exitBuff;
-        SerializeStatus stat = exitBuff.serialize((I32)ACTIVE_COMPONENT_EXIT);
+        SerializeStatus stat = exitBuff.serialize(static_cast<I32>(ACTIVE_COMPONENT_EXIT));
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         (void)this->m_queue.send(exitBuff,0,Os::Queue::QUEUE_NONBLOCKING);
         DEBUG_PRINT("exit %s\n", this->getObjName());
@@ -104,7 +104,7 @@ namespace Fw {
                 comp->m_task.setStarted(false);
                 break;
             default:
-                FW_ASSERT(0,(NATIVE_INT_TYPE)loopStatus);
+                FW_ASSERT(0,static_cast<NATIVE_INT_TYPE>(loopStatus));
         }
     }
     void ActiveComponentBase::s_baseTask(void* ptr) {
@@ -134,7 +134,7 @@ namespace Fw {
                     quitLoop = true;
                     break;
                 default:
-                    FW_ASSERT(0,(NATIVE_INT_TYPE)loopStatus);
+                    FW_ASSERT(0,static_cast<NATIVE_INT_TYPE>(loopStatus));
             }
         }
 

--- a/Fw/Log/AmpcsEvrLogPacket.cpp
+++ b/Fw/Log/AmpcsEvrLogPacket.cpp
@@ -55,7 +55,7 @@ namespace Fw {
         SerializeStatus stat;
 
         len = AMPCS_EVR_TASK_NAME_LEN;
-        stat = buffer.deserialize((U8*)this->m_taskName, len, true);
+        stat = buffer.deserialize(this->m_taskName, len, true);
         if (stat != FW_SERIALIZE_OK) {
             return stat;
         }

--- a/Fw/Log/LogString.cpp
+++ b/Fw/Log/LogString.cpp
@@ -28,7 +28,7 @@ namespace Fw {
     }
 
     NATIVE_UINT_TYPE LogStringArg::length() const {
-        return (NATIVE_UINT_TYPE) strnlen(this->m_buf,sizeof(m_buf));
+        return static_cast<NATIVE_UINT_TYPE>(strnlen(this->m_buf,sizeof(m_buf)));
     }
 
     const char* LogStringArg::toChar() const {
@@ -55,9 +55,9 @@ namespace Fw {
         if (stat != FW_SERIALIZE_OK) {
             return stat;
         }
-        return buffer.serialize((U8*)this->m_buf,strSize,true);
+        return buffer.serialize(reinterpret_cast<const U8*>(this->m_buf),strSize,true);
 #else
-        return buffer.serialize((U8*)this->m_buf,strSize);
+        return buffer.serialize(reinterpret_cast<const U8*>(this->m_buf),strSize);
 #endif
     }
 
@@ -75,13 +75,13 @@ namespace Fw {
         }
 
         NATIVE_UINT_TYPE deserSize_native = static_cast<NATIVE_UINT_TYPE>(deserSize);
-        buffer.deserialize((U8*)this->m_buf,deserSize_native,true);
+        buffer.deserialize(reinterpret_cast<U8*>(this->m_buf),deserSize_native,true);
         this->m_buf[deserSize_native] = 0;
         return stat;
 #else
         NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
         // deserialize string
-        stat = buffer.deserialize((U8*)this->m_buf,maxSize);
+        stat = buffer.deserialize(reinterpret_cast<U8*>(this->m_buf),maxSize);
         // make sure it is null-terminated
         this->terminate(maxSize);
 

--- a/Fw/Log/test/ut/LogTest.cpp
+++ b/Fw/Log/test/ut/LogTest.cpp
@@ -9,7 +9,7 @@ TEST(FwLogTest,LogPacketSerialize) {
 
     Fw::LogPacket pktIn;
     Fw::LogBuffer buffIn;
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,buffIn.serialize((U32)12));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK,buffIn.serialize(static_cast<U32>(12)));
     Fw::Time timeIn(TB_WORKSTATION_TIME,10,11);
 
     pktIn.setId(10);
@@ -25,13 +25,13 @@ TEST(FwLogTest,LogPacketSerialize) {
     Fw::Time timeOut(TB_WORKSTATION_TIME,10,11);
 
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.deserialize(pktOut));
-    ASSERT_EQ(pktOut.getId(),(FwChanIdType)10);
+    ASSERT_EQ(pktOut.getId(),10u);
     ASSERT_EQ(pktOut.getTimeTag(),timeOut);
     U32 valOut = 0;
     buffOut = pktOut.getLogBuffer();
     buffOut.resetDeser();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,buffOut.deserialize(valOut));
-    ASSERT_EQ(valOut,(U32)12);
+    ASSERT_EQ(valOut,12u);
 
     // serialize string
     Fw::LogStringArg str1;

--- a/Fw/Port/PortBase.cpp
+++ b/Fw/Port/PortBase.cpp
@@ -56,9 +56,9 @@ namespace Fw {
 
         if (do_trace) {
 #if FW_OBJECT_NAMES == 1
-            Fw::Logger::logMsg("Trace: %s\n", (POINTER_CAST)this->m_objName, 0, 0, 0, 0, 0);
+            Fw::Logger::logMsg("Trace: %s\n", reinterpret_cast<POINTER_CAST>(this->m_objName), 0, 0, 0, 0, 0);
 #else
-            Fw::Logger::logMsg("Trace: %p\n", (POINTER_CAST)this, 0, 0, 0, 0, 0);
+            Fw::Logger::logMsg("Trace: %p\n", reinterpret_cast<POINTER_CAST>(this), 0, 0, 0, 0, 0);
 #endif
         }
     }

--- a/Fw/SerializableFile/SerializableFile.cpp
+++ b/Fw/SerializableFile/SerializableFile.cpp
@@ -20,7 +20,7 @@ namespace Fw {
     allocator(allocator),
     recoverable(false), // for compiler; not used
     actualSize(maxSerializedSize),
-    buffer( (U8 *) this->allocator->allocate(0, actualSize, recoverable), actualSize)
+    buffer(static_cast<U8*>(this->allocator->allocate(0, actualSize, recoverable)), actualSize)
   {
     // assert if allocator returns smaller size
     FW_ASSERT(maxSerializedSize == actualSize,maxSerializedSize,actualSize);

--- a/Fw/Tlm/TlmString.cpp
+++ b/Fw/Tlm/TlmString.cpp
@@ -24,7 +24,7 @@ namespace Fw {
     }
 
     NATIVE_UINT_TYPE TlmString::length() const {
-        return strnlen(this->m_buf,sizeof(this->m_buf));
+        return static_cast<NATIVE_UINT_TYPE>(strnlen(this->m_buf,sizeof(this->m_buf)));
     }
 
     const char* TlmString::toChar() const {
@@ -46,9 +46,9 @@ namespace Fw {
         if (stat != FW_SERIALIZE_OK) {
             return stat;
         }
-        return buffer.serialize((U8*)this->m_buf,strSize,true);
+        return buffer.serialize(reinterpret_cast<const U8*>(this->m_buf),strSize,true);
 #else
-        return buffer.serialize((U8*)this->m_buf,strSize);
+        return buffer.serialize(reinterpret_cast<const U8*>(this->m_buf),strSize);
 #endif
     }
 
@@ -66,11 +66,11 @@ namespace Fw {
         // To make sure there is space when we add the null terminator
         // which was omitted in the serialization of this buffer
         strSize++;
-        stat = buffer.deserialize((U8*)this->m_buf,buffSize,true);
+        stat = buffer.deserialize(reinterpret_cast<U8*>(this->m_buf),buffSize,true);
         this->m_buf[strSize-1] = 0;
 #else
         // deserialize string
-        SerializeStatus stat = buffer.deserialize((U8*)this->m_buf,maxSize);
+        SerializeStatus stat = buffer.deserialize(reinterpret_cast<U8*>(this->m_buf),maxSize);
 #endif
         // make sure it is null-terminated
         this->terminate(maxSize);

--- a/Fw/Tlm/test/ut/TlmTest.cpp
+++ b/Fw/Tlm/test/ut/TlmTest.cpp
@@ -8,7 +8,7 @@ TEST(FwTlmTest,TlmPacketSerialize) {
 
     Fw::TlmPacket pktIn;
     Fw::TlmBuffer buffIn;
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,buffIn.serialize((U32)12));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK,buffIn.serialize(static_cast<U32>(12)));
     Fw::Time timeIn(TB_WORKSTATION_TIME,10,11);
 
     pktIn.setId(10);
@@ -24,13 +24,13 @@ TEST(FwTlmTest,TlmPacketSerialize) {
     Fw::Time timeOut(TB_WORKSTATION_TIME,10,11);
 
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.deserialize(pktOut));
-    ASSERT_EQ(pktOut.getId(),(FwChanIdType)10);
+    ASSERT_EQ(pktOut.getId(),10u);
     ASSERT_EQ(pktOut.getTimeTag(),timeOut);
     U32 valOut = 0;
     buffOut = pktOut.getTlmBuffer();
     buffOut.resetDeser();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,buffOut.deserialize(valOut));
-    ASSERT_EQ(valOut,(U32)12);
+    ASSERT_EQ(valOut,12u);
 
 }
 

--- a/Fw/Types/BasicTypes.hpp
+++ b/Fw/Types/BasicTypes.hpp
@@ -104,56 +104,56 @@ typedef char CHAR;
 
 
 #ifndef I8_MAX
-#define I8_MAX (I8)(127)
+#define I8_MAX static_cast<I8>(127)
 #endif
 
 #ifndef I8_MIN
-#define I8_MIN (I8)(-128)
+#define I8_MIN static_cast<I8>(-128)
 #endif
 
 #ifndef U8_MAX
-#define U8_MAX (U8)(255)
+#define U8_MAX static_cast<U8>(255u)
 #endif
 
 #if FW_HAS_16_BIT
 #ifndef I16_MAX
-#define I16_MAX (I16)(32767)
+#define I16_MAX static_cast<I16>(32767)
 #endif
 
 #ifndef I16_MIN
-#define I16_MIN (I16)(-32768)
+#define I16_MIN static_cast<I16>(-32768)
 #endif
 
 #ifndef U16_MAX
-#define U16_MAX (U16)(65535)
+#define U16_MAX static_cast<U16>(65535u)
 #endif
 #endif
 
 #if FW_HAS_32_BIT
 #ifndef I32_MAX
-#define I32_MAX (I32)(2147483647)
+#define I32_MAX static_cast<I32>(2147483647)
 #endif
 
 #ifndef I32_MIN
-#define I32_MIN (I32)(-2147483648)
+#define I32_MIN static_cast<I32>(-2147483648)
 #endif
 
 #ifndef U32_MAX
-#define U32_MAX (U32)(4294967295)
+#define U32_MAX static_cast<U32>(4294967295u)
 #endif
 #endif
 
 #if FW_HAS_64_BIT
 #ifndef I64_MAX
-#define I64_MAX (I64)(9223372036854775807)
+#define I64_MAX static_cast<I64>(9223372036854775807)
 #endif
 
 #ifndef I64_MIN
-#define I64_MIN (I64)(-9223372036854775808)
+#define I64_MIN static_cast<I64>(-9223372036854775808)
 #endif
 
 #ifndef U64_MAX
-#define U64_MAX (U64)(18446744073709551615)
+#define U64_MAX static_cast<U64>(18446744073709551615u)
 #endif
 #endif
 

--- a/Fw/Types/CAssert.hpp
+++ b/Fw/Types/CAssert.hpp
@@ -26,7 +26,7 @@
 #define FILE_NAME_ARG const U8*
 #define FW_CASSERT(cond) \
     ((void) ((cond) ? (0) : \
-    (CAssert0((U8*)__FILE__, __LINE__))))
+    (CAssert0(reinterpret_cast<FILE_NAME_ARG>(__FILE__), __LINE__))))
 #endif
 
 #ifdef __cplusplus

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -65,7 +65,7 @@ namespace Fw {
     // serialization routines
 
     SerializeStatus SerializeBufferBase::serialize(U8 val) {
-        if (this->m_serLoc + (NATIVE_UINT_TYPE) sizeof(val) - 1 >= this->getBuffCapacity()) {
+        if (this->m_serLoc + static_cast<NATIVE_UINT_TYPE>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
             return FW_SERIALIZE_NO_ROOM_LEFT;
         }
         FW_ASSERT(this->getBuffAddr());
@@ -77,7 +77,7 @@ namespace Fw {
     }
 
     SerializeStatus SerializeBufferBase::serialize(I8 val) {
-        if (this->m_serLoc + (NATIVE_UINT_TYPE) sizeof(val) - 1 >= this->getBuffCapacity()) {
+        if (this->m_serLoc + static_cast<NATIVE_UINT_TYPE>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
             return FW_SERIALIZE_NO_ROOM_LEFT;
         }
         FW_ASSERT(this->getBuffAddr());
@@ -89,7 +89,7 @@ namespace Fw {
 
 #if FW_HAS_16_BIT==1
     SerializeStatus SerializeBufferBase::serialize(U16 val) {
-        if (this->m_serLoc + (NATIVE_UINT_TYPE) sizeof(val) - 1 >= this->getBuffCapacity()) {
+        if (this->m_serLoc + static_cast<NATIVE_UINT_TYPE>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
             return FW_SERIALIZE_NO_ROOM_LEFT;
         }
         FW_ASSERT(this->getBuffAddr());
@@ -102,7 +102,7 @@ namespace Fw {
     }
 
     SerializeStatus SerializeBufferBase::serialize(I16 val) {
-        if (this->m_serLoc + (NATIVE_UINT_TYPE) sizeof(val) - 1 >= this->getBuffCapacity()) {
+        if (this->m_serLoc + static_cast<NATIVE_UINT_TYPE>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
             return FW_SERIALIZE_NO_ROOM_LEFT;
         }
         FW_ASSERT(this->getBuffAddr());
@@ -116,7 +116,7 @@ namespace Fw {
 #endif
 #if FW_HAS_32_BIT==1
     SerializeStatus SerializeBufferBase::serialize(U32 val) {
-        if (this->m_serLoc + (NATIVE_UINT_TYPE) sizeof(val) - 1 >= this->getBuffCapacity()) {
+        if (this->m_serLoc + static_cast<NATIVE_UINT_TYPE>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
             return FW_SERIALIZE_NO_ROOM_LEFT;
         }
         FW_ASSERT(this->getBuffAddr());
@@ -131,7 +131,7 @@ namespace Fw {
     }
 
     SerializeStatus SerializeBufferBase::serialize(I32 val) {
-        if (this->m_serLoc + (NATIVE_UINT_TYPE) sizeof(val) - 1 >= this->getBuffCapacity()) {
+        if (this->m_serLoc + static_cast<NATIVE_UINT_TYPE>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
             return FW_SERIALIZE_NO_ROOM_LEFT;
         }
         FW_ASSERT(this->getBuffAddr());
@@ -148,7 +148,7 @@ namespace Fw {
 
 #if FW_HAS_64_BIT==1
     SerializeStatus SerializeBufferBase::serialize(U64 val) {
-        if (this->m_serLoc + (NATIVE_UINT_TYPE) sizeof(val) - 1 >= this->getBuffCapacity()) {
+        if (this->m_serLoc + static_cast<NATIVE_UINT_TYPE>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
             return FW_SERIALIZE_NO_ROOM_LEFT;
         }
         FW_ASSERT(this->getBuffAddr());
@@ -167,7 +167,7 @@ namespace Fw {
     }
 
     SerializeStatus SerializeBufferBase::serialize(I64 val) {
-        if (this->m_serLoc + (NATIVE_UINT_TYPE) sizeof(val) - 1 >= this->getBuffCapacity()) {
+        if (this->m_serLoc + static_cast<NATIVE_UINT_TYPE>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
             return FW_SERIALIZE_NO_ROOM_LEFT;
         }
         FW_ASSERT(this->getBuffAddr());
@@ -208,7 +208,7 @@ namespace Fw {
     }
 
     SerializeStatus SerializeBufferBase::serialize(bool val) {
-        if (this->m_serLoc + (NATIVE_UINT_TYPE) sizeof(U8) - 1 >= this->getBuffCapacity()) {
+        if (this->m_serLoc + static_cast<NATIVE_UINT_TYPE>(sizeof(U8)) - 1 >= this->getBuffCapacity()) {
             return FW_SERIALIZE_NO_ROOM_LEFT;
         }
 
@@ -225,12 +225,12 @@ namespace Fw {
     }
 
     SerializeStatus SerializeBufferBase::serialize(const void* val) {
-        if (this->m_serLoc + (NATIVE_UINT_TYPE) sizeof(void*) - 1
+        if (this->m_serLoc + static_cast<NATIVE_UINT_TYPE>(sizeof(void*)) - 1
                 >= this->getBuffCapacity()) {
             return FW_SERIALIZE_NO_ROOM_LEFT;
         }
 
-        return this->serialize((POINTER_CAST) val);
+        return this->serialize(reinterpret_cast<POINTER_CAST>(val));
 
     }
 
@@ -264,13 +264,13 @@ namespace Fw {
     SerializeStatus SerializeBufferBase::serialize(
             const SerializeBufferBase& val) {
         NATIVE_UINT_TYPE size = val.getBuffLength();
-        if (this->m_serLoc + size + (NATIVE_UINT_TYPE) sizeof(FwBuffSizeType)
+        if (this->m_serLoc + size + static_cast<NATIVE_UINT_TYPE>(sizeof(FwBuffSizeType))
                 > this->getBuffCapacity()) {
             return FW_SERIALIZE_NO_ROOM_LEFT;
         }
 
         // First, serialize size
-        SerializeStatus stat = this->serialize((FwBuffSizeType)size);
+        SerializeStatus stat = this->serialize(static_cast<FwBuffSizeType>(size));
         if (stat != FW_SERIALIZE_OK) {
             return stat;
         }
@@ -291,7 +291,7 @@ namespace Fw {
         // check for room
         if (this->getBuffLength() == this->m_deserLoc) {
             return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < (NATIVE_UINT_TYPE)sizeof(val)) {
+        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<NATIVE_UINT_TYPE>(sizeof(val))) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
         // read from current location
@@ -305,12 +305,12 @@ namespace Fw {
         // check for room
         if (this->getBuffLength() == this->m_deserLoc) {
             return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < (NATIVE_UINT_TYPE)sizeof(val)) {
+        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<NATIVE_UINT_TYPE>(sizeof(val))) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
         // read from current location
         FW_ASSERT(this->getBuffAddr());
-        val = (I8) this->getBuffAddr()[this->m_deserLoc + 0];
+        val = static_cast<I8>(this->getBuffAddr()[this->m_deserLoc + 0]);
         this->m_deserLoc += sizeof(val);
         return FW_SERIALIZE_OK;
     }
@@ -320,14 +320,14 @@ namespace Fw {
         // check for room
         if (this->getBuffLength() == this->m_deserLoc) {
             return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < (NATIVE_UINT_TYPE)sizeof(val)) {
+        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<NATIVE_UINT_TYPE>(sizeof(val))) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
         // read from current location
         FW_ASSERT(this->getBuffAddr());
         // MSB first
-        val = (U16) (this->getBuffAddr()[this->m_deserLoc + 1] << 0)
-                | (U16) (this->getBuffAddr()[this->m_deserLoc + 0] << 8);
+        val = (static_cast<U16>(this->getBuffAddr()[this->m_deserLoc + 1]) << 0)
+                | (static_cast<U16>(this->getBuffAddr()[this->m_deserLoc + 0]) << 8);
         this->m_deserLoc += sizeof(val);
         return FW_SERIALIZE_OK;
     }
@@ -336,14 +336,14 @@ namespace Fw {
         // check for room
         if (this->getBuffLength() == this->m_deserLoc) {
             return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < (NATIVE_UINT_TYPE)sizeof(val)) {
+        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<NATIVE_UINT_TYPE>(sizeof(val))) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
         // read from current location
         FW_ASSERT(this->getBuffAddr());
         // MSB first
-        val = (I16) (this->getBuffAddr()[this->m_deserLoc + 1] << 0)
-                | (I16) (this->getBuffAddr()[this->m_deserLoc + 0] << 8);
+        val = (static_cast<I16>(this->getBuffAddr()[this->m_deserLoc + 1]) << 0)
+                | (static_cast<I16>(this->getBuffAddr()[this->m_deserLoc + 0]) << 8);
         this->m_deserLoc += sizeof(val);
         return FW_SERIALIZE_OK;
     }
@@ -353,16 +353,16 @@ namespace Fw {
         // check for room
         if (this->getBuffLength() == this->m_deserLoc) {
             return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < (NATIVE_UINT_TYPE)sizeof(val)) {
+        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<NATIVE_UINT_TYPE>(sizeof(val))) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
         // read from current location
         FW_ASSERT(this->getBuffAddr());
         // MSB first
-        val = ((U32) this->getBuffAddr()[this->m_deserLoc + 3] << 0)
-                | ((U32) this->getBuffAddr()[this->m_deserLoc + 2] << 8)
-                | ((U32) this->getBuffAddr()[this->m_deserLoc + 1] << 16)
-                | ((U32) this->getBuffAddr()[this->m_deserLoc + 0] << 24);
+        val = (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 0)
+                | (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8)
+                | (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16)
+                | (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
         this->m_deserLoc += sizeof(val);
         return FW_SERIALIZE_OK;
     }
@@ -371,16 +371,16 @@ namespace Fw {
         // check for room
         if (this->getBuffLength() == this->m_deserLoc) {
             return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < (NATIVE_UINT_TYPE)sizeof(val)) {
+        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<NATIVE_UINT_TYPE>(sizeof(val))) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
         // read from current location
         FW_ASSERT(this->getBuffAddr());
         // MSB first
-        val = ((U32) this->getBuffAddr()[this->m_deserLoc + 3] << 0)
-                | ((U32) this->getBuffAddr()[this->m_deserLoc + 2] << 8)
-                | ((U32) this->getBuffAddr()[this->m_deserLoc + 1] << 16)
-                | ((U32) this->getBuffAddr()[this->m_deserLoc + 0] << 24);
+        val = (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 0)
+                | (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8)
+                | (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16)
+                | (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
         this->m_deserLoc += sizeof(val);
         return FW_SERIALIZE_OK;
     }
@@ -392,20 +392,20 @@ namespace Fw {
         // check for room
         if (this->getBuffLength() == this->m_deserLoc) {
             return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < (NATIVE_UINT_TYPE)sizeof(val)) {
+        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<NATIVE_UINT_TYPE>(sizeof(val))) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
         // read from current location
         FW_ASSERT(this->getBuffAddr());
         // MSB first
-        val = ((U64) this->getBuffAddr()[this->m_deserLoc + 7] << 0)
-                | ((U64) this->getBuffAddr()[this->m_deserLoc + 6] << 8)
-                | ((U64) this->getBuffAddr()[this->m_deserLoc + 5] << 16)
-                | ((U64) this->getBuffAddr()[this->m_deserLoc + 4] << 24)
-                | ((U64) this->getBuffAddr()[this->m_deserLoc + 3] << 32)
-                | ((U64) this->getBuffAddr()[this->m_deserLoc + 2] << 40)
-                | ((U64) this->getBuffAddr()[this->m_deserLoc + 1] << 48)
-                | ((U64) this->getBuffAddr()[this->m_deserLoc + 0] << 56);
+        val = (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 0)
+                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8)
+                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 16)
+                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 24)
+                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 32)
+                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 40)
+                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48)
+                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
 
         this->m_deserLoc += sizeof(val);
         return FW_SERIALIZE_OK;
@@ -415,20 +415,20 @@ namespace Fw {
         // check for room
         if (this->getBuffLength() == this->m_deserLoc) {
             return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < (NATIVE_UINT_TYPE)sizeof(val)) {
+        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<NATIVE_UINT_TYPE>(sizeof(val))) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
         // read from current location
         FW_ASSERT(this->getBuffAddr());
         // MSB first
-        val = ((I64) this->getBuffAddr()[this->m_deserLoc + 7] << 0)
-                | ((I64) this->getBuffAddr()[this->m_deserLoc + 6] << 8)
-                | ((I64) this->getBuffAddr()[this->m_deserLoc + 5] << 16)
-                | ((I64) this->getBuffAddr()[this->m_deserLoc + 4] << 24)
-                | ((I64) this->getBuffAddr()[this->m_deserLoc + 3] << 32)
-                | ((I64) this->getBuffAddr()[this->m_deserLoc + 2] << 40)
-                | ((I64) this->getBuffAddr()[this->m_deserLoc + 1] << 48)
-                | ((I64) this->getBuffAddr()[this->m_deserLoc + 0] << 56);
+        val = (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 0)
+                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8)
+                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 16)
+                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 24)
+                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 32)
+                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 40)
+                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48)
+                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
         this->m_deserLoc += sizeof(val);
         return FW_SERIALIZE_OK;
     }
@@ -445,7 +445,7 @@ namespace Fw {
             return stat;
         }
         // copy to argument
-        (void) memcpy(&val, &tempVal, (NATIVE_UINT_TYPE)sizeof(val));
+        (void) memcpy(&val, &tempVal, sizeof(val));
 
         return FW_SERIALIZE_OK;
     }
@@ -456,7 +456,7 @@ namespace Fw {
         // check for room
         if (this->getBuffLength() == this->m_deserLoc) {
             return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < (NATIVE_UINT_TYPE)sizeof(U8)) {
+        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<NATIVE_UINT_TYPE>(sizeof(U8))) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
         // read from current location
@@ -474,7 +474,7 @@ namespace Fw {
     }
 
     SerializeStatus SerializeBufferBase::deserialize(void*& val) {
-        return this->deserialize((POINTER_CAST&) val);
+        return this->deserialize(reinterpret_cast<POINTER_CAST&>(val));
     }
 
     SerializeStatus SerializeBufferBase::deserialize(F32 &val) {
@@ -687,7 +687,7 @@ namespace Fw {
         FW_ASSERT(us);
 
         for (NATIVE_UINT_TYPE byte = 0; byte < buff.getBuffLength(); byte++) {
-            os << "[" << std::setw(2) << std::hex << std::setfill('0') << (NATIVE_UINT_TYPE)us[byte] << "]" << std::dec;
+            os << "[" << std::setw(2) << std::hex << std::setfill('0') << us[byte] << "]" << std::dec;
         }
 
         return os;

--- a/Fw/Types/StringType.cpp
+++ b/Fw/Types/StringType.cpp
@@ -25,7 +25,7 @@ namespace Fw {
     StringBase::~StringBase() {
     }
 
-    const char* StringBase::operator+=(const char* src) {
+    const CHAR* StringBase::operator+=(const CHAR* src) {
         this->appendBuff(src, strnlen(src, this->getCapacity()));
         return this->toChar();
     }
@@ -44,9 +44,9 @@ namespace Fw {
         }
     }
 
-    bool StringBase::operator==(const char* other) const {
+    bool StringBase::operator==(const CHAR* other) const {
 
-        const char *const us = this->toChar();
+        const CHAR *const us = this->toChar();
         if ((us == NULL) or (other == NULL)) {
             return false;
         }
@@ -57,8 +57,8 @@ namespace Fw {
 
     }
 
-    void StringBase::format(const char* formatString, ...) {
-        char* us = (char*) this->toChar();
+    void StringBase::format(const CHAR* formatString, ...) {
+        CHAR* us = const_cast<CHAR*>(this->toChar());
         NATIVE_UINT_TYPE cap = this->getCapacity();
         FW_ASSERT(us);
         va_list args;
@@ -73,7 +73,7 @@ namespace Fw {
         return !operator==(other);
     }
 
-    bool StringBase::operator!=(const char* other) const {
+    bool StringBase::operator!=(const CHAR* other) const {
         return !operator==(other);
     }
 
@@ -98,12 +98,12 @@ namespace Fw {
 
     // Copy constructor doesn't make sense in this virtual class as there is nothing to copy. Derived classes should
     // call the empty constructor and then call their own copy function
-    StringBase& StringBase::operator=(const char* other) { // lgtm[cpp/rule-of-two]
+    StringBase& StringBase::operator=(const CHAR* other) { // lgtm[cpp/rule-of-two]
         Fw::StringUtils::string_copy(const_cast<char *>(this->toChar()), other, this->getCapacity());
         return *this;
     }
 
-    void StringBase::appendBuff(const char* buff, NATIVE_UINT_TYPE size) {
+    void StringBase::appendBuff(const CHAR* buff, NATIVE_UINT_TYPE size) {
         const U32 capacity = this->getCapacity();
         const U32 length = this->length();
         FW_ASSERT(capacity > length, capacity, length);
@@ -113,11 +113,11 @@ namespace Fw {
             remaining = size;
         }
         FW_ASSERT(remaining < capacity, remaining, capacity);
-        (void) strncat(const_cast<char *>(this->toChar()), buff, remaining);
+        (void) strncat(const_cast<CHAR*>(this->toChar()), buff, remaining);
     }
 
     NATIVE_UINT_TYPE StringBase::length(void) const {
-        return strnlen(this->toChar(),this->getCapacity());
+        return static_cast<NATIVE_UINT_TYPE>(strnlen(this->toChar(),this->getCapacity()));
     }
 
     SerializeStatus StringBase::serialize(SerializeBufferBase& buffer) const {
@@ -126,7 +126,7 @@ namespace Fw {
 
     SerializeStatus StringBase::deserialize(SerializeBufferBase& buffer) {
         NATIVE_UINT_TYPE maxSize = this->getCapacity() - 1;
-        char *raw = const_cast<char *>(this->toChar());
+        CHAR* raw = const_cast<CHAR*>(this->toChar());
         SerializeStatus stat = buffer.deserialize(reinterpret_cast<U8*>(raw),maxSize);
         // Null terminate deserialized string
         raw[maxSize] = 0;

--- a/Fw/Types/StringType.hpp
+++ b/Fw/Types/StringType.hpp
@@ -22,20 +22,20 @@
 namespace Fw {
     class StringBase : public Serializable {
         public:
-            virtual const char* toChar() const = 0; //<! Convert to a C-style char*
+            virtual const CHAR* toChar() const = 0; //<! Convert to a C-style char*
             virtual NATIVE_UINT_TYPE getCapacity() const = 0; //!< return size of buffer
             NATIVE_UINT_TYPE length() const;  //!< Get length of string
 
-            const char* operator+=(const char* src); //!< Concatenate a char*
+            const CHAR* operator+=(const CHAR* src); //!< Concatenate a CHAR*
             const StringBase& operator+=(const StringBase& src); //!< Concatenate a StringBase
             bool operator==(const StringBase& other) const; //!< Check for equality with StringBase
-            bool operator==(const char* other) const; //!< Check for equality with char*
+            bool operator==(const CHAR* other) const; //!< Check for equality with CHAR*
             bool operator!=(const StringBase& other) const; //!< Inequality with StringBase
-            bool operator!=(const char* other) const; //!< Inequality with char*
-            StringBase& operator=(const char* src); //!< Assign char*
+            bool operator!=(const CHAR* other) const; //!< Inequality with CHAR*
+            StringBase& operator=(const CHAR* src); //!< Assign CHAR*
             StringBase& operator=(const StringBase& src); //!< Assign another StringBase
 
-            void format(const char* formatString, ...); //!< write formatted string to buffer
+            void format(const CHAR* formatString, ...); //!< write formatted string to buffer
 
             SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
             SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
@@ -52,7 +52,7 @@ namespace Fw {
             StringBase();
             virtual ~StringBase();
 
-            void appendBuff(const char* buff, NATIVE_UINT_TYPE size);
+            void appendBuff(const CHAR* buff, NATIVE_UINT_TYPE size);
 
         private:
             // A no-implementation copy constructor here will prevent the default copy constructor from being called

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -627,7 +627,7 @@ TEST(PerformanceTest, SerPerfTest) {
 
     printf("%d iterations took %d us (%f each).\n", iterations,
             timer.getDiffUsec(),
-            (F32) (timer.getDiffUsec()) / (F32) iterations);
+            static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iterations));
 
 }
 
@@ -660,7 +660,7 @@ TEST(PerformanceTest, StructCopyTest) {
 
     printf("%d iterations took %d us (%f each).\n", iterations,
             timer.getDiffUsec(),
-            (F32) (timer.getDiffUsec()) / (F32) iterations);
+            static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iterations));
 
 }
 
@@ -686,7 +686,7 @@ TEST(PerformanceTest, ClassCopyTest) {
 
     printf("%d iterations took %d us (%f each).\n", iterations,
             timer.getDiffUsec(),
-            (F32) (timer.getDiffUsec()) / (F32) iterations);
+            static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iterations));
 
 }
 
@@ -808,64 +808,64 @@ void AssertTest() {
     FW_ASSERT(0);
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ((NATIVE_UINT_TYPE)0,hook.getNumArgs());
+    ASSERT_EQ(0u,hook.getNumArgs());
 
     // issue an assert
     FW_ASSERT(0,1);
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ((NATIVE_UINT_TYPE)1,hook.getNumArgs());
-    ASSERT_EQ((NATIVE_UINT_TYPE)1,hook.getArg1());
+    ASSERT_EQ(1u,hook.getNumArgs());
+    ASSERT_EQ(1u,hook.getArg1());
 
     // issue an assert
     FW_ASSERT(0,1,2);
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ((NATIVE_UINT_TYPE)2,hook.getNumArgs());
-    ASSERT_EQ((NATIVE_UINT_TYPE)1,hook.getArg1());
-    ASSERT_EQ((NATIVE_UINT_TYPE)2,hook.getArg2());
+    ASSERT_EQ(2u,hook.getNumArgs());
+    ASSERT_EQ(1u,hook.getArg1());
+    ASSERT_EQ(2u,hook.getArg2());
 
     // issue an assert
     FW_ASSERT(0,1,2,3);
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ((NATIVE_UINT_TYPE)3,hook.getNumArgs());
-    ASSERT_EQ((NATIVE_UINT_TYPE)1,hook.getArg1());
-    ASSERT_EQ((NATIVE_UINT_TYPE)2,hook.getArg2());
-    ASSERT_EQ((NATIVE_UINT_TYPE)3,hook.getArg3());
+    ASSERT_EQ(3u,hook.getNumArgs());
+    ASSERT_EQ(1u,hook.getArg1());
+    ASSERT_EQ(2u,hook.getArg2());
+    ASSERT_EQ(3u,hook.getArg3());
 
     // issue an assert
     FW_ASSERT(0,1,2,3,4);
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ((NATIVE_UINT_TYPE)4,hook.getNumArgs());
-    ASSERT_EQ((NATIVE_UINT_TYPE)1,hook.getArg1());
-    ASSERT_EQ((NATIVE_UINT_TYPE)2,hook.getArg2());
-    ASSERT_EQ((NATIVE_UINT_TYPE)3,hook.getArg3());
-    ASSERT_EQ((NATIVE_UINT_TYPE)4,hook.getArg4());
+    ASSERT_EQ(4u,hook.getNumArgs());
+    ASSERT_EQ(1u,hook.getArg1());
+    ASSERT_EQ(2u,hook.getArg2());
+    ASSERT_EQ(3u,hook.getArg3());
+    ASSERT_EQ(4u,hook.getArg4());
 
     // issue an assert
     FW_ASSERT(0,1,2,3,4,5);
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ((NATIVE_UINT_TYPE)5,hook.getNumArgs());
-    ASSERT_EQ((NATIVE_UINT_TYPE)1,hook.getArg1());
-    ASSERT_EQ((NATIVE_UINT_TYPE)2,hook.getArg2());
-    ASSERT_EQ((NATIVE_UINT_TYPE)3,hook.getArg3());
-    ASSERT_EQ((NATIVE_UINT_TYPE)4,hook.getArg4());
-    ASSERT_EQ((NATIVE_UINT_TYPE)5,hook.getArg5());
+    ASSERT_EQ(5u,hook.getNumArgs());
+    ASSERT_EQ(1u,hook.getArg1());
+    ASSERT_EQ(2u,hook.getArg2());
+    ASSERT_EQ(3u,hook.getArg3());
+    ASSERT_EQ(4u,hook.getArg4());
+    ASSERT_EQ(5u,hook.getArg5());
 
     // issue an assert
     FW_ASSERT(0,1,2,3,4,5,6);
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ((NATIVE_UINT_TYPE)6,hook.getNumArgs());
-    ASSERT_EQ((NATIVE_UINT_TYPE)1,hook.getArg1());
-    ASSERT_EQ((NATIVE_UINT_TYPE)2,hook.getArg2());
-    ASSERT_EQ((NATIVE_UINT_TYPE)3,hook.getArg3());
-    ASSERT_EQ((NATIVE_UINT_TYPE)4,hook.getArg4());
-    ASSERT_EQ((NATIVE_UINT_TYPE)5,hook.getArg5());
-    ASSERT_EQ((NATIVE_UINT_TYPE)6,hook.getArg6());
+    ASSERT_EQ(6u,hook.getNumArgs());
+    ASSERT_EQ(1u,hook.getArg1());
+    ASSERT_EQ(2u,hook.getArg2());
+    ASSERT_EQ(3u,hook.getArg3());
+    ASSERT_EQ(4u,hook.getArg4());
+    ASSERT_EQ(5u,hook.getArg5());
+    ASSERT_EQ(6u,hook.getArg6());
 
 }
 
@@ -882,15 +882,15 @@ TEST(TypesTest,PolyTest) {
 
     Fw::PolyType pt(in8);
 
-    out8 = (U8) pt;
+    out8 = static_cast<U8>(pt);
     ASSERT_EQ(in8, out8);
 
     // Test assigning to polytype and return type of assignment
     in8 = 218;
     // Can assign Polytype to U8 via overridden cast operator
     out8 = (pt = in8);
-    ASSERT_EQ((U8) pt, (U8) 218);
-    ASSERT_EQ((U8) pt, in8);
+    ASSERT_EQ(static_cast<U8>(pt), 218u);
+    ASSERT_EQ(static_cast<U8>(pt), in8);
     ASSERT_EQ(out8, in8);
 
     pt.toString(str);
@@ -901,12 +901,12 @@ TEST(TypesTest,PolyTest) {
     U16 outU16;
     Fw::PolyType ptU16(inU16);
 
-    outU16 = (U16) ptU16;
+    outU16 = static_cast<U16>(ptU16);
     ASSERT_EQ(inU16, outU16);
 
     inU16 = 45000;
     outU16 = (ptU16 = inU16);
-    ASSERT_EQ((U16) ptU16, inU16);
+    ASSERT_EQ(static_cast<U16>(ptU16), inU16);
     ASSERT_EQ(outU16, inU16);
 
     ptU16.toString(str);
@@ -917,12 +917,12 @@ TEST(TypesTest,PolyTest) {
     U32 outU32;
     Fw::PolyType ptU32(inU32);
 
-    outU32 = (U32) ptU32;
+    outU32 = static_cast<U32>(ptU32);
     ASSERT_EQ(inU32, outU32);
 
     inU32 = 3222111000;
     outU32 = (ptU32 = inU32);
-    ASSERT_EQ((U32) ptU32, inU32);
+    ASSERT_EQ(static_cast<U32>(ptU32), inU32);
     ASSERT_EQ(outU32, inU32);
 
     ptU32.toString(str);
@@ -933,12 +933,12 @@ TEST(TypesTest,PolyTest) {
     U64 outU64;
     Fw::PolyType ptU64(inU64);
 
-    outU64 = (U64) ptU64;
+    outU64 = static_cast<U64>(ptU64);
     ASSERT_EQ(inU64, outU64);
 
     inU64 = 555444333222111;
     outU64 = (ptU64 = inU64);
-    ASSERT_EQ((U64) ptU64, inU64);
+    ASSERT_EQ(static_cast<U64>(ptU64), inU64);
     ASSERT_EQ(outU64, inU64);
 
     ptU64.toString(str);
@@ -949,12 +949,12 @@ TEST(TypesTest,PolyTest) {
     I8 outI8;
     Fw::PolyType ptI8(inI8);
 
-    outI8 = (I8) ptI8;
+    outI8 = static_cast<I8>(ptI8);
     ASSERT_EQ(inI8, outI8);
 
     inI8 = -3;
     outI8 = (ptI8 = inI8);
-    ASSERT_EQ((I8) ptI8, inI8);
+    ASSERT_EQ(static_cast<I8>(ptI8), inI8);
     ASSERT_EQ(outI8, inI8);
 
     ptI8.toString(str);
@@ -965,12 +965,12 @@ TEST(TypesTest,PolyTest) {
     I16 outI16;
     Fw::PolyType ptI16(inI16);
 
-    outI16 = (I16) ptI16;
+    outI16 = static_cast<I16>(ptI16);
     ASSERT_EQ(inI16, outI16);
 
     inI16 = -7;
     outI16 = (ptI16 = inI16);
-    ASSERT_EQ((I16) ptI16, inI16);
+    ASSERT_EQ(static_cast<I16>(ptI16), inI16);
     ASSERT_EQ(outI16, inI16);
 
     ptI16.toString(str);
@@ -981,12 +981,12 @@ TEST(TypesTest,PolyTest) {
     I32 outI32;
     Fw::PolyType ptI32(inI32);
 
-    outI32 = (I32) ptI32;
+    outI32 = static_cast<I32>(ptI32);
     ASSERT_EQ(inI32, outI32);
 
     inI32 = -13;
     outI32 = (ptI32 = inI32);
-    ASSERT_EQ((I32) ptI32, inI32);
+    ASSERT_EQ(static_cast<I32>(ptI32), inI32);
     ASSERT_EQ(outI32, inI32);
 
     ptI32.toString(str);
@@ -997,12 +997,12 @@ TEST(TypesTest,PolyTest) {
     I64 outI64;
     Fw::PolyType ptI64(inI64);
 
-    outI64 = (I64) ptI64;
+    outI64 = static_cast<I64>(ptI64);
     ASSERT_EQ(inI64, outI64);
 
     inI64 = -19;
     outI64 = (ptI64 = inI64);
-    ASSERT_EQ((I64) ptI64, inI64);
+    ASSERT_EQ(static_cast<I64>(ptI64), inI64);
     ASSERT_EQ(outI64, inI64);
 
     ptI64.toString(str);
@@ -1013,12 +1013,12 @@ TEST(TypesTest,PolyTest) {
     F32 outF32;
     Fw::PolyType ptF32(inF32);
 
-    outF32 = (F32) ptF32;
+    outF32 = static_cast<F32>(ptF32);
     ASSERT_EQ(inF32, outF32);
 
     inF32 = 29.92;
     outF32 = (ptF32 = inF32);
-    ASSERT_EQ((F32) ptF32, inF32);
+    ASSERT_EQ(static_cast<F32>(ptF32), inF32);
     ASSERT_EQ(outF32, inF32);
 
     // F64 Type  ==============================================================
@@ -1026,12 +1026,12 @@ TEST(TypesTest,PolyTest) {
     F64 outF64;
     Fw::PolyType ptF64(inF64);
 
-    outF64 = (F64) ptF64;
+    outF64 = static_cast<F64>(ptF64);
     ASSERT_EQ(inF64, outF64);
 
     inF64 = 37.73;
     outF64 = (ptF64 = inF64);
-    ASSERT_EQ((F64) ptF64, inF64);
+    ASSERT_EQ(static_cast<F64>(ptF64), inF64);
     ASSERT_EQ(outF64, inF64);
 
     // bool Type  =============================================================
@@ -1039,12 +1039,12 @@ TEST(TypesTest,PolyTest) {
     bool outbool;
     Fw::PolyType ptbool(inbool);
 
-    outbool = (bool) ptbool;
+    outbool = static_cast<bool>(ptbool);
     ASSERT_EQ(inbool, outbool);
 
     inbool = false;
     outbool = (ptbool = inbool);
-    ASSERT_EQ((bool) ptbool, inbool);
+    ASSERT_EQ(static_cast<bool>(ptbool), inbool);
     ASSERT_EQ(outbool, inbool);
 
     // ptr Type  ==============================================================
@@ -1052,12 +1052,12 @@ TEST(TypesTest,PolyTest) {
     void* outPtr;
     Fw::PolyType ptPtr(inPtr);
 
-    outPtr = (void*) ptPtr;
+    outPtr = static_cast<void*>(ptPtr);
     ASSERT_EQ(inPtr, outPtr);
 
     inPtr = &ptF64;
     outPtr = (ptPtr = inPtr);
-    ASSERT_EQ((void*) ptPtr, inPtr);
+    ASSERT_EQ(static_cast<void*>(ptPtr), inPtr);
     ASSERT_EQ(outPtr, inPtr);
 
 }
@@ -1136,7 +1136,7 @@ TEST(PerformanceTest, F64SerPerfTest) {
 
     printf("%d iterations took %d us (%f us each).\n", iters,
             timer.getDiffUsec(),
-            (F32) (timer.getDiffUsec()) / (F32) iters);
+            static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iters));
 
 }
 
@@ -1148,7 +1148,7 @@ TEST(AllocatorTest,MallocAllocatorTest) {
     bool recoverable;
     void *ptr = allocator.allocate(10,size,recoverable);
     ASSERT_EQ(100,size);
-    ASSERT_NE(ptr,(void*)NULL);
+    ASSERT_NE(ptr,nullptr);
     ASSERT_FALSE(recoverable);
     // deallocate memory
     allocator.deallocate(100,ptr);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Fw |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Breaking changes in #955 into smaller chuncks. This PR is just the modifications to the Fw directory.

Switch fprime from using a mix of C/C++ style casts to C++ style casts only. Add compiler warning to core framework project to error on use of C style casts. Note, using a c-style cast to cast return value to void and signal that the return value is ignored is still permitted.



## Rationale

C++ style static, const, and reinterpret casts are safer than C style casts by forcing developers to be explicit about how they intend to typecast a value. This brings fprime inline with the C++ best practice of avoiding C style casts.