### PR TITLE
Remove deprecated C style headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,2 @@
-Checks: "-clang-analyzer-security.insecureAPI.rand"
+Checks: "modernize-deprecated-headers,-clang-analyzer-security.insecureAPI.rand"
 WarningsAsErrors: '*'

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -188,6 +188,7 @@ chr
 chrono
 ci
 cin
+cinttypes
 CIRCULARSTATE
 classdiagram
 classdoc
@@ -269,6 +270,7 @@ crt
 CRTSCTS
 cryptsoft
 Csharp
+csignal
 CSIZE
 css
 cstat
@@ -521,8 +523,8 @@ finalizer
 findall
 fio
 Firefox
-FIXME
 Fixme
+FIXME
 flist
 FNDELAY
 fnmatch
@@ -541,9 +543,9 @@ foundin
 fpconfighpp
 FPGA
 fpl
+FPL
 fpp
 fppi
-FPL
 FPport
 fprim
 fprime

--- a/Drv/Ip/IpSocket.cpp
+++ b/Drv/Ip/IpSocket.cpp
@@ -9,7 +9,7 @@
 // acknowledged.
 //
 // ======================================================================
-#include <string.h>
+#include <cstring>
 #include <Drv/Ip/IpSocket.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/BasicTypes.hpp>
@@ -36,7 +36,7 @@
 #elif defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
 #include <sys/socket.h>
 #include <unistd.h>
-#include <errno.h>
+#include <cerrno>
 #include <arpa/inet.h>
 #else
 #error OS not supported for IP Socket Communications

--- a/Drv/Ip/SocketReadTask.cpp
+++ b/Drv/Ip/SocketReadTask.cpp
@@ -13,7 +13,7 @@
 #include <Drv/Ip/SocketReadTask.hpp>
 #include <Fw/Logger/Logger.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <errno.h>
+#include <cerrno>
 
 #define MAXIMUM_SIZE 0x7FFFFFFF
 

--- a/Drv/Ip/TcpClientSocket.cpp
+++ b/Drv/Ip/TcpClientSocket.cpp
@@ -34,8 +34,8 @@
     #error OS not supported for IP Socket Communications
 #endif
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 namespace Drv {
 

--- a/Drv/Ip/TcpServerSocket.cpp
+++ b/Drv/Ip/TcpServerSocket.cpp
@@ -34,7 +34,7 @@
     #error OS not supported for IP Socket Communications
 #endif
 
-#include <string.h>
+#include <cstring>
 
 namespace Drv {
 

--- a/Drv/Ip/UdpSocket.cpp
+++ b/Drv/Ip/UdpSocket.cpp
@@ -35,7 +35,7 @@
     #error OS not supported for IP Socket Communications
 #endif
 
-#include <string.h>
+#include <cstring>
 #include <new>
 
 namespace Drv {

--- a/Drv/Ip/test/ut/PortSelector.cpp
+++ b/Drv/Ip/test/ut/PortSelector.cpp
@@ -5,7 +5,7 @@
 #include "PortSelector.hpp"
 #include <sys/socket.h>
 #include <unistd.h>
-#include <errno.h>
+#include <cerrno>
 #include <arpa/inet.h>
 
 namespace Drv {

--- a/Drv/Ip/test/ut/SocketTestHelper.cpp
+++ b/Drv/Ip/test/ut/SocketTestHelper.cpp
@@ -8,7 +8,7 @@
 
 #include <sys/socket.h>
 #include <unistd.h>
-#include <errno.h>
+#include <cerrno>
 #include <arpa/inet.h>
 
 namespace Drv {

--- a/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.cpp
+++ b/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.cpp
@@ -14,16 +14,16 @@
 #include <Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.hpp>
 #include "Fw/Types/BasicTypes.hpp"
 #include <Os/TaskString.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
-#include <time.h>
+#include <ctime>
 
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <termios.h>
-#include <stdio.h>
-#include <errno.h>
+#include <cstdio>
+#include <cerrno>
 
 //#define DEBUG_PRINT(x,...) printf(x,##__VA_ARGS__); fflush(stdout)
 #define DEBUG_PRINT(x,...)

--- a/Drv/SocketIpDriver/SocketHelper.cpp
+++ b/Drv/SocketIpDriver/SocketHelper.cpp
@@ -33,14 +33,14 @@
     #include <sys/socket.h>
     #include <netdb.h>
     #include <unistd.h>
-    #include <errno.h>
+    #include <cerrno>
     #include <arpa/inet.h>
 #else
     #error OS not supported for IP Socket Communications
 #endif
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 
 namespace Drv {

--- a/Fw/Cmd/CmdPacket.cpp
+++ b/Fw/Cmd/CmdPacket.cpp
@@ -7,7 +7,7 @@
 
 #include <Fw/Cmd/CmdPacket.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 namespace Fw {
 

--- a/Fw/Comp/ActiveComponentBase.cpp
+++ b/Fw/Comp/ActiveComponentBase.cpp
@@ -2,7 +2,7 @@
 #include <Fw/Comp/ActiveComponentBase.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <Os/TaskString.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 //#define DEBUG_PRINT(x,...) printf(x,##__VA_ARGS__); fflush(stdout)
 #define DEBUG_PRINT(x,...)

--- a/Fw/Comp/PassiveComponentBase.cpp
+++ b/Fw/Comp/PassiveComponentBase.cpp
@@ -2,7 +2,7 @@
 #include <Fw/Types/Assert.hpp>
 #include <FpConfig.hpp>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace Fw {
 

--- a/Fw/Comp/QueuedComponentBase.cpp
+++ b/Fw/Comp/QueuedComponentBase.cpp
@@ -3,7 +3,7 @@
 #include <FpConfig.hpp>
 #include <Os/QueueString.hpp>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace Fw {
 

--- a/Fw/FilePacket/EndPacket.cpp
+++ b/Fw/FilePacket/EndPacket.cpp
@@ -10,7 +10,7 @@
 //
 // ======================================================================
 
-#include <string.h>
+#include <cstring>
 
 #include <Fw/FilePacket/FilePacket.hpp>
 #include <Fw/Types/Assert.hpp>

--- a/Fw/FilePacket/PathName.cpp
+++ b/Fw/FilePacket/PathName.cpp
@@ -10,7 +10,7 @@
 //
 // ======================================================================
 
-#include <string.h>
+#include <cstring>
 
 #include <Fw/FilePacket/FilePacket.hpp>
 #include <Fw/Types/Assert.hpp>

--- a/Fw/Log/LogString.cpp
+++ b/Fw/Log/LogString.cpp
@@ -1,6 +1,6 @@
 #include <Fw/Log/LogString.hpp>
 #include <Fw/Types/StringUtils.hpp>
-#include <string.h>
+#include <cstring>
 
 namespace Fw {
 

--- a/Fw/Logger/test/ut/FakeLogger.cpp
+++ b/Fw/Logger/test/ut/FakeLogger.cpp
@@ -10,7 +10,7 @@
 #include <Fw/Logger/test/ut/FakeLogger.hpp>
 
 extern "C" {
-    #include <string.h>
+    #include <cstring>
 }
 namespace MockLogging {
     Fw::Logger* FakeLogger::s_current = NULL;

--- a/Fw/Logger/test/ut/Main.cpp
+++ b/Fw/Logger/test/ut/Main.cpp
@@ -14,7 +14,7 @@
 #include <Fw/Logger/test/ut/LoggerRules.hpp>
 #include <gtest/gtest.h>
 
-#include <stdio.h>
+#include <cstdio>
 
 #define STEP_COUNT 10000
 

--- a/Fw/Obj/ObjBase.cpp
+++ b/Fw/Obj/ObjBase.cpp
@@ -1,7 +1,7 @@
 #include <FpConfig.hpp>
 #include <Fw/Obj/ObjBase.hpp>
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 
 namespace Fw {
 

--- a/Fw/Obj/SimpleObjRegistry.cpp
+++ b/Fw/Obj/SimpleObjRegistry.cpp
@@ -2,8 +2,8 @@
 #include <Fw/Obj/SimpleObjRegistry.hpp>
 #include <FpConfig.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #if FW_OBJECT_REGISTRATION == 1
 

--- a/Fw/Port/InputPortBase.cpp
+++ b/Fw/Port/InputPortBase.cpp
@@ -3,7 +3,7 @@
 #include <Fw/Port/InputPortBase.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/BasicTypes.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 namespace Fw {
 

--- a/Fw/Port/InputSerializePort.cpp
+++ b/Fw/Port/InputSerializePort.cpp
@@ -1,6 +1,6 @@
 #include <Fw/Port/InputSerializePort.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_PORT_SERIALIZATION == 1
 

--- a/Fw/Port/OutputPortBase.cpp
+++ b/Fw/Port/OutputPortBase.cpp
@@ -3,7 +3,7 @@
 #include <Fw/Port/OutputPortBase.hpp>
 #include <Fw/Types/BasicTypes.hpp>
 #include <Os/Log.hpp>
-#include <stdio.h>
+#include <cstdio>
 #include <Fw/Types/Assert.hpp>
 
 

--- a/Fw/Port/OutputSerializePort.cpp
+++ b/Fw/Port/OutputSerializePort.cpp
@@ -1,6 +1,6 @@
 #include <Fw/Port/OutputSerializePort.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_PORT_SERIALIZATION
 

--- a/Fw/Port/PortBase.cpp
+++ b/Fw/Port/PortBase.cpp
@@ -1,7 +1,7 @@
 #include <Fw/Port/PortBase.hpp>
 #include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Logger/Logger.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_PORT_TRACING
 void setConnTrace(bool trace) {

--- a/Fw/SerializableFile/test/ut/Test.cpp
+++ b/Fw/SerializableFile/test/ut/Test.cpp
@@ -2,8 +2,8 @@
 // Main.cpp 
 // ----------------------------------------------------------------------
 
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 #include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/MallocAllocator.hpp>

--- a/Fw/Test/UnitTestAssert.cpp
+++ b/Fw/Test/UnitTestAssert.cpp
@@ -8,8 +8,8 @@
  */
 
 #include <Fw/Test/UnitTestAssert.hpp>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 namespace Test {
 

--- a/Fw/Tlm/TlmString.cpp
+++ b/Fw/Tlm/TlmString.cpp
@@ -1,6 +1,6 @@
 #include <Fw/Tlm/TlmString.hpp>
 #include <Fw/Types/StringUtils.hpp>
-#include <string.h>
+#include <cstring>
 
 namespace Fw {
 

--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -1,7 +1,7 @@
 #include <FpConfig.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 
 #ifdef TGT_OS_TYPE_VXWORKS
 #include <taskLib.h>

--- a/Fw/Types/MallocAllocator.cpp
+++ b/Fw/Types/MallocAllocator.cpp
@@ -11,7 +11,7 @@
  */
 
 #include <Fw/Types/MallocAllocator.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 
 namespace Fw {
 

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -1,8 +1,8 @@
 #include <Fw/Types/PolyType.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <stdio.h>
+#include <cstdio>
 #define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+#include <cinttypes>
 
 namespace Fw {
 

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -1,8 +1,8 @@
 #include <Fw/Types/Serializable.hpp>
-#include <string.h> // memcpy
+#include <cstring> // memcpy
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/StringType.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #ifdef BUILD_UT
 #include <iomanip>

--- a/Fw/Types/StringType.cpp
+++ b/Fw/Types/StringType.cpp
@@ -13,9 +13,9 @@
 #include <Fw/Types/StringType.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/StringUtils.hpp>
-#include <string.h>
-#include <stdio.h>
-#include <stdarg.h>
+#include <cstring>
+#include <cstdio>
+#include <cstdarg>
 
 namespace Fw {
 

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -1,6 +1,6 @@
 #include "StringUtils.hpp"
 #include <Fw/Types/Assert.hpp>
-#include "string.h"
+#include <cstring>
 
 char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 num) {
     // Handle self-copy

--- a/Fw/Types/test/ut/TestStringUtils.cpp
+++ b/Fw/Types/test/ut/TestStringUtils.cpp
@@ -2,7 +2,7 @@
 // Created by mstarch on 12/7/20.
 //
 #include <gtest/gtest.h>
-#include <string.h>
+#include <cstring>
 #include <Fw/Types/StringUtils.hpp>
 
 TEST(Nominal, string_copy) {

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -8,8 +8,8 @@
 #include <Fw/Types/PolyType.hpp>
 #include <Fw/Types/MallocAllocator.hpp>
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 
 #include <iostream>

--- a/Os/IPCQueueCommon.cpp
+++ b/Os/IPCQueueCommon.cpp
@@ -1,5 +1,5 @@
 #include <Os/IPCQueue.hpp>
-#include <string.h>
+#include <cstring>
 
 namespace Os {
 

--- a/Os/IntervalTimerCommon.cpp
+++ b/Os/IntervalTimerCommon.cpp
@@ -12,7 +12,7 @@
 
 #include <Os/IntervalTimer.hpp>
 
-#include <string.h>
+#include <cstring>
 
 namespace Os {
 

--- a/Os/Linux/Directory.cpp
+++ b/Os/Linux/Directory.cpp
@@ -10,7 +10,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#include <string.h>
+#include <cstring>
 
 namespace Os {
 

--- a/Os/Linux/File.cpp
+++ b/Os/Linux/File.cpp
@@ -19,8 +19,8 @@ extern "C" {
 #include <fcntl.h>
 #include <unistd.h>
 #include <limits>
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 
 //#define DEBUG_PRINT(x,...) printf(x,##__VA_ARGS__); fflush(stdout)
 #define DEBUG_PRINT(x,...)

--- a/Os/Linux/FileSystem.cpp
+++ b/Os/Linux/FileSystem.cpp
@@ -8,8 +8,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <dirent.h>
-#include <stdio.h> // Needed for rename
-#include <string.h>
+#include <cstdio> // Needed for rename
+#include <cstring>
 #include <limits>
 #include <sys/statvfs.h>
 

--- a/Os/LogPrintf.cpp
+++ b/Os/LogPrintf.cpp
@@ -5,7 +5,7 @@
  */
 #include <Os/Log.hpp>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace Os {
     Log::Log() {

--- a/Os/MacOs/IPCQueueStub.cpp
+++ b/Os/MacOs/IPCQueueStub.cpp
@@ -16,9 +16,9 @@
 #include <Fw/Types/Assert.hpp>
 #include <Os/IPCQueue.hpp>
 
-#include <errno.h>
+#include <cerrno>
 #include <pthread.h>
-#include <stdio.h>
+#include <cstdio>
 #include <new>
 
 namespace Os {

--- a/Os/MemCommon.cpp
+++ b/Os/MemCommon.cpp
@@ -1,6 +1,6 @@
 #include <Os/Mem.hpp>
 
-#include <string.h>
+#include <cstring>
 
 namespace Os {
     

--- a/Os/Posix/IntervalTimer.cpp
+++ b/Os/Posix/IntervalTimer.cpp
@@ -8,8 +8,8 @@
  */
 #include <Os/IntervalTimer.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <time.h>
-#include <errno.h>
+#include <ctime>
+#include <cerrno>
 
 namespace Os {
     void IntervalTimer::getRawTime(RawTime& time) {

--- a/Os/Posix/Task.cpp
+++ b/Os/Posix/Task.cpp
@@ -11,10 +11,10 @@
 #endif
 
 #include <pthread.h>
-#include <errno.h>
-#include <string.h>
-#include <time.h>
-#include <stdio.h>
+#include <cerrno>
+#include <cstring>
+#include <ctime>
+#include <cstdio>
 #include <new>
 #include <Fw/Logger/Logger.hpp>
 

--- a/Os/Pthreads/BufferQueueCommon.cpp
+++ b/Os/Pthreads/BufferQueueCommon.cpp
@@ -14,7 +14,7 @@
 
 #include "Os/Pthreads/BufferQueue.hpp"
 #include <Fw/Types/Assert.hpp>
-#include <string.h>
+#include <cstring>
 
 namespace Os {
 

--- a/Os/Pthreads/MaxHeap/MaxHeap.cpp
+++ b/Os/Pthreads/MaxHeap/MaxHeap.cpp
@@ -20,7 +20,7 @@
 #include <Fw/Logger/Logger.hpp>
 
 #include <new>
-#include <stdio.h>
+#include <cstdio>
 
 // Macros for traversing the heap:
 #define LCHILD(x) (2 * x + 1)

--- a/Os/Pthreads/MaxHeap/test/ut/MaxHeapTest.cpp
+++ b/Os/Pthreads/MaxHeap/test/ut/MaxHeapTest.cpp
@@ -1,7 +1,7 @@
 #include "Os/Pthreads/MaxHeap/MaxHeap.hpp"
 #include <Fw/Types/Assert.hpp>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 using namespace Os;
 

--- a/Os/Pthreads/PriorityBufferQueue.cpp
+++ b/Os/Pthreads/PriorityBufferQueue.cpp
@@ -16,8 +16,8 @@
 #include "Os/Pthreads/BufferQueue.hpp"
 #include "Os/Pthreads/MaxHeap/MaxHeap.hpp"
 #include <Fw/Types/Assert.hpp>
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 #include <new>
 
 // This is a priority queue implementation implemented using a stable max heap.

--- a/Os/Pthreads/Queue.cpp
+++ b/Os/Pthreads/Queue.cpp
@@ -16,9 +16,9 @@
 #include <Fw/Types/Assert.hpp>
 #include <Os/Queue.hpp>
 
-#include <errno.h>
+#include <cerrno>
 #include <pthread.h>
-#include <stdio.h>
+#include <cstdio>
 #include <new>
 
 namespace Os {

--- a/Os/Pthreads/test/ut/BufferQueueTest.cpp
+++ b/Os/Pthreads/test/ut/BufferQueueTest.cpp
@@ -1,7 +1,7 @@
 #include "Os/Pthreads/BufferQueue.hpp"
 #include <Fw/Types/Assert.hpp>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 using namespace Os;
 

--- a/Os/QueueCommon.cpp
+++ b/Os/QueueCommon.cpp
@@ -1,6 +1,6 @@
 #include <Os/Queue.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <string.h>
+#include <cstring>
 
 namespace Os {
 

--- a/Os/Stubs/Linux/FileStub.cpp
+++ b/Os/Stubs/Linux/FileStub.cpp
@@ -10,8 +10,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 
 namespace Os {
 

--- a/Os/TaskCommon.cpp
+++ b/Os/TaskCommon.cpp
@@ -1,6 +1,6 @@
 #include <Os/Task.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <string.h>
+#include <cstring>
 
 namespace Os {
 

--- a/Os/test/ut/OsFileSystemTest.cpp
+++ b/Os/test/ut/OsFileSystemTest.cpp
@@ -5,8 +5,8 @@
 #include <Fw/Types/String.hpp>
 
 #include <unistd.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/Os/test/ut/OsQueueTest.cpp
+++ b/Os/test/ut/OsQueueTest.cpp
@@ -1,10 +1,10 @@
 #include "gtest/gtest.h"
 #include <Os/Queue.hpp>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <Fw/Types/Assert.hpp>
 #include <unistd.h>
-#include <signal.h>
+#include <csignal>
 #include <pthread.h>
 
 #if defined TGT_OS_TYPE_LINUX

--- a/Os/test/ut/OsTaskTest.cpp
+++ b/Os/test/ut/OsTaskTest.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 #include <Os/Task.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 extern "C" {
     void startTestTask();

--- a/Os/test/ut/OsValidateFileTest.cpp
+++ b/Os/test/ut/OsValidateFileTest.cpp
@@ -5,7 +5,7 @@
 #include <Utils/Hash/HashBuffer.hpp>
 #include <Fw/Types/Assert.hpp>
 
-#include <stdio.h>
+#include <cstdio>
 
 void testValidateFile(const char* fileName) {
 

--- a/Os/test/ut/TestMain.cpp
+++ b/Os/test/ut/TestMain.cpp
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
-#include <stdio.h>
+#include <cstdio>
 
 extern "C" {
   void startTestTask();

--- a/STest/STest/Random/Random.cpp
+++ b/STest/STest/Random/Random.cpp
@@ -9,8 +9,8 @@
 // acknowledged.
 // ======================================================================
 
-#include <assert.h>
-#include <time.h>
+#include <cassert>
+#include <ctime>
 
 #include "STest/Random/Random.hpp"
 

--- a/Svc/ActiveLogger/ActiveLoggerImpl.cpp
+++ b/Svc/ActiveLogger/ActiveLoggerImpl.cpp
@@ -5,7 +5,7 @@
  *      Author: tcanham
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <Svc/ActiveLogger/ActiveLoggerImpl.hpp>
 #include <Fw/Types/Assert.hpp>

--- a/Svc/ActiveTextLogger/ActiveTextLoggerImpl.cpp
+++ b/Svc/ActiveTextLogger/ActiveTextLoggerImpl.cpp
@@ -6,7 +6,7 @@
 #include <Svc/ActiveTextLogger/ActiveTextLoggerImpl.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Logger/Logger.hpp>
-#include <time.h>
+#include <ctime>
 
 namespace Svc {
 

--- a/Svc/ActiveTextLogger/LogFile.cpp
+++ b/Svc/ActiveTextLogger/LogFile.cpp
@@ -8,8 +8,8 @@
 #include <Os/File.hpp>
 #include <Os/FileSystem.hpp>
 #include <limits>
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 
 
 namespace Svc {

--- a/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
+++ b/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
@@ -15,8 +15,8 @@
 #include "Fw/Types/BasicTypes.hpp"
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Logger/Logger.hpp>
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 
 namespace Fw {
     void defaultReportAssert

--- a/Svc/BufferLogger/test/ut/Errors.cpp
+++ b/Svc/BufferLogger/test/ut/Errors.cpp
@@ -10,7 +10,7 @@
 //
 // ======================================================================
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "Errors.hpp"
 #include "Os/ValidatedFile.hpp"

--- a/Svc/BufferManager/test/ut/Tester.cpp
+++ b/Svc/BufferManager/test/ut/Tester.cpp
@@ -13,7 +13,7 @@
 #include "Tester.hpp"
 #include <Fw/Types/MallocAllocator.hpp>
 #include <Fw/Test/UnitTest.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 
 #define INSTANCE 0
 #define MAX_HISTORY_SIZE 100

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
@@ -8,7 +8,7 @@
 #include <Svc/CmdDispatcher/CommandDispatcherImpl.hpp>
 #include <Fw/Cmd/CmdPacket.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 namespace Svc {
     CommandDispatcherImpl::CommandDispatcherImpl(const char* name) :

--- a/Svc/ComLogger/ComLogger.cpp
+++ b/Svc/ComLogger/ComLogger.cpp
@@ -9,7 +9,7 @@
 #include <Fw/Types/SerialBuffer.hpp>
 #include <Fw/Types/StringUtils.hpp>
 #include <Os/ValidateFile.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 namespace Svc {
 

--- a/Svc/ComLogger/test/ut/Tester.cpp
+++ b/Svc/ComLogger/test/ut/Tester.cpp
@@ -2,7 +2,7 @@
 // CommandSequencer/test/ut/Tester.cpp
 // ----------------------------------------------------------------------
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "Tester.hpp"
 #include "Fw/Cmd/CmdPacket.hpp"

--- a/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
+++ b/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
@@ -10,8 +10,8 @@
 // 
 // ====================================================================== 
 
-#include <stdlib.h>
-#include <signal.h>
+#include <cstdlib>
+#include <csignal>
 #include <Fw/Logger/Logger.hpp>
 #include <Svc/FatalHandler/FatalHandlerComponentImpl.hpp>
 #include "Fw/Types/BasicTypes.hpp"

--- a/Svc/FileDownlink/test/ut/FileBuffer.cpp
+++ b/Svc/FileDownlink/test/ut/FileBuffer.cpp
@@ -9,7 +9,7 @@
 // acknowledged.
 // ====================================================================== 
 
-#include <string.h>
+#include <cstring>
 
 #include "Tester.hpp"
 

--- a/Svc/FileDownlink/test/ut/Tester.cpp
+++ b/Svc/FileDownlink/test/ut/Tester.cpp
@@ -9,7 +9,7 @@
 // acknowledged.
 // ======================================================================
 
-#include <errno.h>
+#include <cerrno>
 #include <unistd.h>
 
 #include "Tester.hpp"

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -10,8 +10,8 @@
 //
 // ======================================================================
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include "Svc/FileManager/FileManager.hpp"
 #include "Fw/Types/Assert.hpp"

--- a/Svc/FileUplink/test/ut/Tester.cpp
+++ b/Svc/FileUplink/test/ut/Tester.cpp
@@ -10,8 +10,8 @@
 //
 // ======================================================================
 
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
 
 #include "Tester.hpp"
 

--- a/Svc/GenericHub/GenericHubComponentImpl.cpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.cpp
@@ -14,7 +14,7 @@
 #include "Fw/Logger/Logger.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/BasicTypes.hpp"
-#include "string.h"
+#include <cstring>
 
 // Required port serialization or the hub cannot work
 FW_STATIC_ASSERT(FW_PORT_SERIALIZATION);

--- a/Svc/GroundInterface/GroundInterface.cpp
+++ b/Svc/GroundInterface/GroundInterface.cpp
@@ -7,7 +7,7 @@
 #include <Fw/Com/ComPacket.hpp>
 #include <Svc/GroundInterface/GroundInterface.hpp>
 #include "Fw/Types/BasicTypes.hpp"
-#include <string.h>
+#include <cstring>
 
 namespace Svc {
 

--- a/Svc/Health/Stub/HealthComponentStubChecks.cpp
+++ b/Svc/Health/Stub/HealthComponentStubChecks.cpp
@@ -12,7 +12,7 @@
 
 #include <Svc/Health/HealthComponentImpl.hpp>
 #include "Fw/Types/BasicTypes.hpp"
-#include <stdio.h>
+#include <cstdio>
 #include <Fw/Types/Assert.hpp>
 
 namespace Svc {

--- a/Svc/LinuxTime/LinuxTimeImpl.cpp
+++ b/Svc/LinuxTime/LinuxTimeImpl.cpp
@@ -7,7 +7,7 @@
 
 #include <Svc/LinuxTime/LinuxTimeImpl.hpp>
 #include <Fw/Time/Time.hpp>
-#include <time.h>
+#include <ctime>
 
 namespace Svc {
 

--- a/Svc/LinuxTime/test/ut/Tester.cpp
+++ b/Svc/LinuxTime/test/ut/Tester.cpp
@@ -2,7 +2,7 @@
 // LinuxTime/test/ut/Tester.cpp
 // ----------------------------------------------------------------------
 
-#include <stdio.h>
+#include <cstdio>
 #include <strings.h>
 
 #include "Tester.hpp"

--- a/Svc/PolyDb/test/ut/PolyDbComponentTestAc.cpp
+++ b/Svc/PolyDb/test/ut/PolyDbComponentTestAc.cpp
@@ -1,4 +1,4 @@
-#include <stdio.h>
+#include <cstdio>
 #include <FpConfig.hpp>
 // The following header will need to be modified when test code is moved
 // If the component tester is regenerated, this will need to be modified again.

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -11,7 +11,7 @@
 #include <Os/File.hpp>
 
 #include <cstring>
-#include <stdio.h>
+#include <cstdio>
 
 namespace Svc {
 

--- a/Svc/RateGroupDriver/RateGroupDriverImpl.cpp
+++ b/Svc/RateGroupDriver/RateGroupDriverImpl.cpp
@@ -2,7 +2,7 @@
 #include <Fw/Types/BasicTypes.hpp>
 #include <cstring>
 #include <Fw/Types/Assert.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 namespace Svc {
 

--- a/Svc/TlmChan/TlmChanImpl.cpp
+++ b/Svc/TlmChan/TlmChanImpl.cpp
@@ -15,7 +15,7 @@
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Com/ComBuffer.hpp>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace Svc {
 

--- a/Svc/TlmChan/TlmChanImplGet.cpp
+++ b/Svc/TlmChan/TlmChanImplGet.cpp
@@ -10,7 +10,7 @@
 #include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Types/Assert.hpp>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace Svc {
 

--- a/Svc/TlmChan/TlmChanImplRecv.cpp
+++ b/Svc/TlmChan/TlmChanImplRecv.cpp
@@ -10,7 +10,7 @@
 #include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Types/Assert.hpp>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace Svc {
 

--- a/Svc/TlmChan/TlmChanImplTask.cpp
+++ b/Svc/TlmChan/TlmChanImplTask.cpp
@@ -17,7 +17,7 @@
 #include <Fw/Tlm/TlmPacket.hpp>
 #include <Fw/Com/ComBuffer.hpp>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace Svc {
 

--- a/Utils/Hash/HashBufferCommon.cpp
+++ b/Utils/Hash/HashBufferCommon.cpp
@@ -1,5 +1,5 @@
 #include <Utils/Hash/HashBuffer.hpp>
-#include <string.h>
+#include <cstring>
 
 namespace Utils {
 

--- a/Utils/Types/CircularBuffer.cpp
+++ b/Utils/Types/CircularBuffer.cpp
@@ -18,7 +18,7 @@
     #include <Os/Log.hpp>
 #endif
 
-#include <stdio.h>
+#include <cstdio>
 
 
 namespace Types {

--- a/Utils/Types/test/ut/CircularBuffer/Main.cpp
+++ b/Utils/Types/test/ut/CircularBuffer/Main.cpp
@@ -14,8 +14,8 @@
 #include <Utils/Types/test/ut/CircularBuffer/CircularRules.hpp>
 #include <gtest/gtest.h>
 
-#include <stdio.h>
-#include <math.h>
+#include <cstdio>
+#include <cmath>
 
 #define STEP_COUNT 1000
 

--- a/Utils/test/ut/LockGuardTester.cpp
+++ b/Utils/test/ut/LockGuardTester.cpp
@@ -12,7 +12,7 @@
 // ======================================================================
 
 #include "LockGuardTester.hpp"
-#include <time.h>
+#include <ctime>
 #include <Os/Task.hpp>
 
 namespace Utils {

--- a/Utils/test/ut/RateLimiterTester.cpp
+++ b/Utils/test/ut/RateLimiterTester.cpp
@@ -12,7 +12,7 @@
 // ======================================================================
 
 #include "RateLimiterTester.hpp"
-#include <time.h>
+#include <ctime>
 
 namespace Utils {
 

--- a/Utils/test/ut/TokenBucketTester.cpp
+++ b/Utils/test/ut/TokenBucketTester.cpp
@@ -12,7 +12,7 @@
 // ======================================================================
 
 #include "TokenBucketTester.hpp"
-#include <time.h>
+#include <ctime>
 
 namespace Utils {
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Use clang-tidy to automatically replace deprecated C-style headers with their C++ equivalents. 