### PR TITLE
Autocoder: Remove deprecated C style headers

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
@@ -20,8 +20,8 @@
 // countries or providing access to foreign persons.
 // ======================================================================
 
-\#include <string.h>
-\#include <stdio.h>
+\#include <cstring>
+\#include <cstdio>
 
 \#include "Fw/Types/Assert.hpp"
 \#include <Fw/Types/StringUtils.hpp>

--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
@@ -10,7 +10,7 @@
 //
 // ======================================================================
 
-\#include <stdio.h>
+\#include <cstdio>
 \#include <FpConfig.hpp>
 \#include <${comp_include_path}/${include_name}ComponentAc.hpp>
 \#include <Fw/Types/Assert.hpp>

--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
@@ -20,8 +20,8 @@
 // countries or providing access to foreign persons.
 // ======================================================================
 
-\#include <string.h>
-\#include <limits.h>
+\#include <cstring>
+\#include <limits>
 \#include "Fw/Types/Assert.hpp"
 \#include "${name}EnumAc.hpp"
 

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/includes1SerialH.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/includes1SerialH.tmpl
@@ -2,7 +2,7 @@
 \#include <Fw/Types/Serializable.hpp>
 \#if FW_SERIALIZABLE_TO_STRING
 \#include <Fw/Types/StringType.hpp>
-\#include <stdio.h> // snprintf
+\#include <cstdio> // snprintf
 \#ifdef BUILD_UT
 \#include <iostream>
 \#include <Fw/Types/String.hpp>

--- a/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
@@ -10,8 +10,8 @@
 //
 // ======================================================================
 
-\#include <stdlib.h>
-\#include <string.h>
+\#include <cstdlib>
+\#include <cstring>
 \#include "TesterBase.hpp"
 
 #if $namespace_list != None

--- a/Autocoders/Python/src/fprime_ac/generators/templates/test/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/test/hpp.tmpl
@@ -16,7 +16,7 @@
 \#include <${comp_include_path}/${include_name}ComponentAc.hpp>
 \#include <Fw/Types/Assert.hpp>
 \#include <Fw/Comp/PassiveComponentBase.hpp>
-\#include <stdio.h>
+\#include <cstdio>
 \#include <Fw/Port/InputSerializePort.hpp>
 
 #if $namespace_list != None

--- a/Autocoders/Python/src/fprime_ac/generators/templates/topology/includes1TopologyCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/topology/includes1TopologyCpp.tmpl
@@ -7,7 +7,7 @@
 #else
 \#include <$(name)TopologyAppAc.hpp>
 \#include <Fw/Obj/SimpleObjRegistry.hpp>
-\#include <string.h>
+\#include <cstring>
 
 //#for $p, $ns, $t in $component_header_list:
 //\#include <${p}/${ns}${t}Impl.hpp>

--- a/Autocoders/Python/src/fprime_ac/generators/templates/topology/includes1TopologyH.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/topology/includes1TopologyH.tmpl
@@ -2,7 +2,7 @@
 ## This template will contain the includes and starting static code
 ##
 \#include <Fw/Obj/SimpleObjRegistry.hpp>
-\#include <string.h>
+\#include <cstring>
 
 #for $xml_name in $component_import_list:
 \#include <${xml_name}>

--- a/Autocoders/Python/templates/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/templates/ExampleComponentImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/templates/ExampleComponentImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 namespace ExampleComponents {
 

--- a/Autocoders/Python/test/array_xml/ExampleArrayImpl.cpp
+++ b/Autocoders/Python/test/array_xml/ExampleArrayImpl.cpp
@@ -2,7 +2,7 @@
 #include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Types/String.hpp>
 #include <iostream>
-#include <stdio.h>
+#include <cstdio>
 
 using namespace std;
 

--- a/Autocoders/Python/test/array_xml/test/ut/main.cpp
+++ b/Autocoders/Python/test/array_xml/test/ut/main.cpp
@@ -15,7 +15,7 @@
 
 #include <bitset>
 #include <iostream>
-#include <string.h>
+#include <cstring>
 #include <unistd.h>
 #include <thread>
 #include <chrono>

--- a/Autocoders/Python/test/command1/TestCommand1Impl.cpp
+++ b/Autocoders/Python/test/command1/TestCommand1Impl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/command1/TestCommand1Impl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestCommand1Impl::TestCommand1Impl(const char* name) : Test1ComponentBase(name)

--- a/Autocoders/Python/test/command1/TestCommandSourceImpl.cpp
+++ b/Autocoders/Python/test/command1/TestCommandSourceImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/command1/TestCommandSourceImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestCommandSourceImpl::TestCommandSourceImpl(const char* name) : Cmd::CommandTesterComponentBase(name)

--- a/Autocoders/Python/test/command_multi_inst/TestCommand1Impl.cpp
+++ b/Autocoders/Python/test/command_multi_inst/TestCommand1Impl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/command_multi_inst/TestCommand1Impl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestCommand1Impl::TestCommand1Impl(const char* name) : Test1ComponentBase(name)

--- a/Autocoders/Python/test/command_multi_inst/TestCommandSourceImpl.cpp
+++ b/Autocoders/Python/test/command_multi_inst/TestCommandSourceImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/command1/TestCommandSourceImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestCommandSourceImpl::TestCommandSourceImpl(const char* name) : Cmd::CommandTesterComponentBase(name)

--- a/Autocoders/Python/test/command_string/TestCommandImpl.cpp
+++ b/Autocoders/Python/test/command_string/TestCommandImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/command_string/TestCommandImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestCommand1Impl::TestCommand1Impl(const char* name) :  AcTest::TestCommandComponentBase(name)

--- a/Autocoders/Python/test/command_string/TestCommandSourceImpl.cpp
+++ b/Autocoders/Python/test/command_string/TestCommandSourceImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/command_string/TestCommandSourceImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 
 #if FW_OBJECT_NAMES == 1

--- a/Autocoders/Python/test/enum_xml/Component1Impl.cpp
+++ b/Autocoders/Python/test/enum_xml/Component1Impl.cpp
@@ -1,7 +1,7 @@
 #include <Autocoders/Python/test/enum_xml/Component1Impl.hpp>
 #include <Fw/Types/BasicTypes.hpp>
 #include <iostream>
-#include <stdio.h>
+#include <cstdio>
 
 using namespace std;
 

--- a/Autocoders/Python/test/enum_xml/main.cpp
+++ b/Autocoders/Python/test/enum_xml/main.cpp
@@ -13,7 +13,7 @@
 #include "gtest/gtest.h"
 
 #include <iostream>
-#include <string.h>
+#include <cstring>
 
 using namespace std;
 

--- a/Autocoders/Python/test/event1/TestLogImpl.cpp
+++ b/Autocoders/Python/test/event1/TestLogImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/event1/TestLogImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestLogImpl::TestLogImpl(const char* name) : Somewhere::TestLogComponentBase(name)

--- a/Autocoders/Python/test/event1/TestLogRecvImpl.cpp
+++ b/Autocoders/Python/test/event1/TestLogRecvImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/event1/TestLogRecvImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestLogRecvImpl::TestLogRecvImpl(const char* name) : LogTextImpl(name)

--- a/Autocoders/Python/test/event_enum/TestLogImpl.cpp
+++ b/Autocoders/Python/test/event_enum/TestLogImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/event_enum/TestLogImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestLogImpl::TestLogImpl(const char* name) : Somewhere::TestLogComponentBase(name)

--- a/Autocoders/Python/test/event_enum/TestLogRecvImpl.cpp
+++ b/Autocoders/Python/test/event_enum/TestLogRecvImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/event_enum/TestLogRecvImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestLogRecvImpl::TestLogRecvImpl(const char* name) : LogTextImpl(name)

--- a/Autocoders/Python/test/event_multi_inst/TestLogImpl.cpp
+++ b/Autocoders/Python/test/event_multi_inst/TestLogImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/event_multi_inst/TestLogImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestLogImpl::TestLogImpl(const char* name) : Somewhere::TestLogComponentBase(name)

--- a/Autocoders/Python/test/event_multi_inst/TestLogRecvImpl.cpp
+++ b/Autocoders/Python/test/event_multi_inst/TestLogRecvImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/event1/TestLogRecvImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestLogRecvImpl::TestLogRecvImpl(const char* name) : LogTextImpl(name)

--- a/Autocoders/Python/test/event_string/TestLogImpl.cpp
+++ b/Autocoders/Python/test/event_string/TestLogImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/event_string/TestLogImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestLogImpl::TestLogImpl(const char* name) : Somewhere::TestLogComponentBase(name)

--- a/Autocoders/Python/test/event_string/TestLogRecvImpl.cpp
+++ b/Autocoders/Python/test/event_string/TestLogRecvImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/event_string/TestLogRecvImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 #include <Fw/Log/LogString.hpp>
 
 #if FW_OBJECT_NAMES == 1

--- a/Autocoders/Python/test/event_throttle/TestLogImpl.cpp
+++ b/Autocoders/Python/test/event_throttle/TestLogImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/event_throttle/TestLogImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestLogImpl::TestLogImpl(const char* name) : Somewhere::TestLogComponentBase(name)

--- a/Autocoders/Python/test/ext_dict/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/test/ext_dict/ExampleComponentImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/ext_dict/ExampleComponentImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 namespace ExampleComponents {
 

--- a/Autocoders/Python/test/interface1/TestComponentImpl.cpp
+++ b/Autocoders/Python/test/interface1/TestComponentImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/interface1/TestComponentImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestComponentImpl::TestComponentImpl(const char* name) : TestComponentBase(name)

--- a/Autocoders/Python/test/log_tester/TestTextLogImpl.cpp
+++ b/Autocoders/Python/test/log_tester/TestTextLogImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/log_tester/TestTextLogImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 LogTextImpl::LogTextImpl(const char* name) : Log::LogTesterComponentBase(name)

--- a/Autocoders/Python/test/param_enum/TestPrmImpl.cpp
+++ b/Autocoders/Python/test/param_enum/TestPrmImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/param_enum/TestPrmImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestPrmImpl::TestPrmImpl(const char* name) : Prm::TestPrmComponentBase(name)

--- a/Autocoders/Python/test/param_enum/TestPrmSourceImpl.cpp
+++ b/Autocoders/Python/test/param_enum/TestPrmSourceImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/param_enum/TestPrmSourceImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestParamSourceImpl::TestParamSourceImpl(const char* name) : Prm::ParamTesterComponentBase(name)

--- a/Autocoders/Python/test/param_multi_inst/TestPrmImpl.cpp
+++ b/Autocoders/Python/test/param_multi_inst/TestPrmImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/param_multi_inst/TestPrmImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestPrmImpl::TestPrmImpl(const char* name) : Prm::TestPrmComponentBase(name)

--- a/Autocoders/Python/test/param_multi_inst/TestPrmSourceImpl.cpp
+++ b/Autocoders/Python/test/param_multi_inst/TestPrmSourceImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/param_multi_inst/TestPrmSourceImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestParamSourceImpl::TestParamSourceImpl(const char* name) : Prm::ParamTesterComponentBase(name)

--- a/Autocoders/Python/test/param_string/TestPrmImpl.cpp
+++ b/Autocoders/Python/test/param_string/TestPrmImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/param_string/TestPrmImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestPrmImpl::TestPrmImpl(const char* name) : Prm::TestPrmComponentBase(name)

--- a/Autocoders/Python/test/param_string/TestPrmSourceImpl.cpp
+++ b/Autocoders/Python/test/param_string/TestPrmSourceImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/param_string/TestPrmSourceImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestParamSourceImpl::TestParamSourceImpl(const char* name) : Prm::ParamTesterComponentBase(name)

--- a/Autocoders/Python/test/port_loopback/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/test/port_loopback/ExampleComponentImpl.cpp
@@ -13,7 +13,7 @@
 
 #include <Autocoders/Python/test/port_loopback/ExampleComponentImpl.hpp>
 #include "Fw/Types/BasicTypes.hpp"
-#include <stdio.h>
+#include <cstdio>
 
 namespace ExampleComponents {
 

--- a/Autocoders/Python/test/port_nogen/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/test/port_nogen/ExampleComponentImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/port_nogen/ExampleComponentImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 namespace ExampleComponents {
 

--- a/Autocoders/Python/test/stress/TestCommandImpl.cpp
+++ b/Autocoders/Python/test/stress/TestCommandImpl.cpp
@@ -7,7 +7,7 @@
 
 #include <Autocoders/Python/test/stress/TestCommandImpl.hpp>
 #include <Fw/Types/String.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestCommand1Impl::TestCommand1Impl(const char* name) :  StressTest::TestCommandComponentBase(name)

--- a/Autocoders/Python/test/stress/TestCommandSourceImpl.cpp
+++ b/Autocoders/Python/test/stress/TestCommandSourceImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/stress/TestCommandSourceImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestCommandSourceImpl::TestCommandSourceImpl(const char* name) : Cmd::CommandTesterComponentBase(name)

--- a/Autocoders/Python/test/stress/TestLogRecvImpl.cpp
+++ b/Autocoders/Python/test/stress/TestLogRecvImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/stress/TestLogRecvImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestLogRecvImpl::TestLogRecvImpl(const char* name) : LogTextImpl(name)

--- a/Autocoders/Python/test/stress/TestPrmSourceImpl.cpp
+++ b/Autocoders/Python/test/stress/TestPrmSourceImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/stress/TestPrmSourceImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestParamSourceImpl::TestParamSourceImpl(const char* name) : Prm::ParamTesterComponentBase(name)

--- a/Autocoders/Python/test/stress/TestPtSourceImpl.cpp
+++ b/Autocoders/Python/test/stress/TestPtSourceImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/stress/TestPtSourceImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestPtSourceImpl::TestPtSourceImpl(const char* name) : StressTest::TestPortComponentBase(name)

--- a/Autocoders/Python/test/stress/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/stress/TestTelemRecvImpl.cpp
@@ -8,7 +8,7 @@
 #include <Autocoders/Python/test/stress/TestTelemRecvImpl.hpp>
 #include <Fw/Types/String.hpp>
 #include <Autocoders/Python/test/stress/QuaternionSerializableAc.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterComponentBase(name)

--- a/Autocoders/Python/test/time_get/TestTimeGetImpl.cpp
+++ b/Autocoders/Python/test/time_get/TestTimeGetImpl.cpp
@@ -5,7 +5,7 @@
  *      Author: tcanham
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include "TestTimeGetImpl.hpp"
 
 TimeGetTesterImpl::TimeGetTesterImpl(const char* name) : TimeGet::TimeGetTesterComponentBase(name)

--- a/Autocoders/Python/test/time_tester/TestTimeImpl.cpp
+++ b/Autocoders/Python/test/time_tester/TestTimeImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/time_tester/TestTimeImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTimeImpl::TestTimeImpl(const char* name) : Time::TimeTesterComponentBase(name)

--- a/Autocoders/Python/test/tlm1/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm1/TestTelemImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/tlm1/TestTelemImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTlmImpl::TestTlmImpl(const char* name) : Tlm::TestTlmComponentBase(name)

--- a/Autocoders/Python/test/tlm1/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm1/TestTelemRecvImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/tlm1/TestTelemRecvImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterComponentBase(name)

--- a/Autocoders/Python/test/tlm2/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm2/TestTelemImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/tlm2/TestTelemImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTlmImpl::TestTlmImpl(const char* name) : Tlm::TestTlmComponentBase(name)

--- a/Autocoders/Python/test/tlm2/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm2/TestTelemRecvImpl.cpp
@@ -8,7 +8,7 @@
 #include <Autocoders/Python/test/tlm2/TestTelemRecvImpl.hpp>
 #include <Fw/Types/String.hpp>
 #include <Autocoders/Python/test/tlm2/QuaternionSerializableAc.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterComponentBase(name)

--- a/Autocoders/Python/test/tlm_enum/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm_enum/TestTelemImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/tlm_enum/TestTelemImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTlmImpl::TestTlmImpl(const char* name) : Tlm::TestTlmComponentBase(name)

--- a/Autocoders/Python/test/tlm_enum/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm_enum/TestTelemRecvImpl.cpp
@@ -7,7 +7,7 @@
 
 
 #include <Autocoders/Python/test/tlm_enum/TestTelemRecvImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterComponentBase(name)

--- a/Autocoders/Python/test/tlm_multi_inst/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm_multi_inst/TestTelemImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/tlm_multi_inst/TestTelemImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTlmImpl::TestTlmImpl(const char* name) : Tlm::TestTlmComponentBase(name)

--- a/Autocoders/Python/test/tlm_multi_inst/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm_multi_inst/TestTelemRecvImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/tlm1/TestTelemRecvImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterComponentBase(name)

--- a/Autocoders/Python/test/tlm_onchange/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm_onchange/TestTelemImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/tlm_onchange/TestTelemImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTlmImpl::TestTlmImpl(const char* name) : Tlm::TestTlmComponentBase(name)

--- a/Autocoders/Python/test/tlm_onchange/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm_onchange/TestTelemRecvImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/tlm_onchange/TestTelemRecvImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterComponentBase(name)

--- a/Autocoders/Python/test/tlm_string/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm_string/TestTelemImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/tlm_string/TestTelemImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 #if FW_OBJECT_NAMES == 1
 TestTlmImpl::TestTlmImpl(const char* name) : Tlm::TestTlmComponentBase(name)

--- a/Autocoders/Python/test/tlm_string/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm_string/TestTelemRecvImpl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Autocoders/Python/test/tlm_string/TestTelemRecvImpl.hpp>
-#include <stdio.h>
+#include <cstdio>
 #include <Fw/Tlm/TlmString.hpp>
 
 #if FW_OBJECT_NAMES == 1


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Use clang-tidy to automatically replace deprecated C-style headers with their C++ equivalents.
Template headers were manually corrected.
