### PR TITLE
Remove redundant use of void

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,2 @@
-Checks: "modernize-deprecated-headers,-clang-analyzer-security.insecureAPI.rand"
+Checks: "modernize-redundant-void-arg,modernize-deprecated-headers,-clang-analyzer-security.insecureAPI.rand"
 WarningsAsErrors: '*'

--- a/Autocoders/Python/src/fprime_ac/generators/templates/gtest/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/gtest/cpp.tmpl
@@ -41,7 +41,7 @@ $emit_cpp_params([ $param_maxHistorySize ])
   }
 
   $gtest_base ::
-    ~${gtest_base}(void)
+    ~${gtest_base}()
   {
 
   }

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -182,7 +182,7 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
         """
         length = len(params)
         if length == 0:
-            return self.emitIndent(indent) + "void"
+            return ""
         else:
             str = ""
             for i in range(0, length - 1):

--- a/Autocoders/Python/src/fprime_ac/models/ModelParser.py
+++ b/Autocoders/Python/src/fprime_ac/models/ModelParser.py
@@ -614,7 +614,8 @@ class ModelParser:
             if len(d[l]) > 0:
                 d2[l] = ", ".join(["{} {}".format(x[1], x[0]) for x in d[l]])
             else:
-                d2[l] = "void"
+                # If event has no arguments parameter string should be empty
+                d2[l] = ""
         return d2
 
     def getInternalInterfacesList(self, obj):

--- a/Fw/Types/StringType.cpp
+++ b/Fw/Types/StringType.cpp
@@ -116,7 +116,7 @@ namespace Fw {
         (void) strncat(const_cast<CHAR*>(this->toChar()), buff, remaining);
     }
 
-    NATIVE_UINT_TYPE StringBase::length(void) const {
+    NATIVE_UINT_TYPE StringBase::length() const {
         return static_cast<NATIVE_UINT_TYPE>(strnlen(this->toChar(),this->getCapacity()));
     }
 

--- a/Svc/PolyDb/test/ut/PolyDbComponentTestAc.cpp
+++ b/Svc/PolyDb/test/ut/PolyDbComponentTestAc.cpp
@@ -27,7 +27,7 @@ namespace Svc {
     }
 #endif
 
-    PolyDbTesterComponentBase::~PolyDbTesterComponentBase(void) {
+    PolyDbTesterComponentBase::~PolyDbTesterComponentBase() {
     }
 
     void PolyDbTesterComponentBase::init(NATIVE_INT_TYPE instance) {
@@ -71,10 +71,10 @@ namespace Svc {
         this->m_setValue_OutputPort[portNum].invoke(entry, status, time, val);
     }
 
-    NATIVE_INT_TYPE PolyDbTesterComponentBase::getNum_getValue_OutputPorts(void) {
+    NATIVE_INT_TYPE PolyDbTesterComponentBase::getNum_getValue_OutputPorts() {
         return (NATIVE_INT_TYPE) FW_NUM_ARRAY_ELEMENTS(this->m_getValue_OutputPort);
     }
-    NATIVE_INT_TYPE PolyDbTesterComponentBase::getNum_setValue_OutputPorts(void) {
+    NATIVE_INT_TYPE PolyDbTesterComponentBase::getNum_setValue_OutputPorts() {
         return (NATIVE_INT_TYPE) FW_NUM_ARRAY_ELEMENTS(this->m_setValue_OutputPort);
     }
     bool PolyDbTesterComponentBase::isConnected_getValue_OutputPort(NATIVE_INT_TYPE portNum) {

--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -65,7 +65,7 @@ namespace Svc {
   }
 
   TlmPacketizer ::
-    ~TlmPacketizer(void)
+    ~TlmPacketizer()
   {
 
   }

--- a/Svc/TlmPacketizer/test/ut/Tester.cpp
+++ b/Svc/TlmPacketizer/test/ut/Tester.cpp
@@ -23,7 +23,7 @@ namespace Svc {
   // ----------------------------------------------------------------------
 
   Tester ::
-    Tester(void) : 
+    Tester() : 
 #if FW_OBJECT_NAMES == 1
       TlmPacketizerGTestBase("Tester", MAX_HISTORY_SIZE),
       component("TlmPacketizer")
@@ -38,7 +38,7 @@ namespace Svc {
   }
 
   Tester ::
-    ~Tester(void) 
+    ~Tester() 
   {
     
   }
@@ -79,14 +79,14 @@ namespace Svc {
   TlmPacketizerPacket ignore = {ignoreList, 0, 0, FW_NUM_ARRAY_ELEMENTS(ignoreList)};
 
   void Tester ::
-    initTest(void)
+    initTest()
   {
       this->component.setPacketList(packetList,ignore,2);
 
   }
 
   void Tester ::
-    pushTlmTest(void)
+    pushTlmTest()
   {
       this->component.setPacketList(packetList,ignore,2);
       Fw::Time ts;
@@ -124,7 +124,7 @@ namespace Svc {
 
 
   void Tester ::
-    sendPacketsTest(void)
+    sendPacketsTest()
   {
       this->component.setPacketList(packetList,ignore,2);
       Fw::Time ts;
@@ -193,7 +193,7 @@ namespace Svc {
   }
 
   void Tester ::
-    sendPacketLevelsTest(void)
+    sendPacketLevelsTest()
   {
       this->component.setPacketList(packetList,ignore,1);
       Fw::Time ts;
@@ -262,7 +262,7 @@ namespace Svc {
   }
 
   void Tester ::
-    updatePacketsTest(void)
+    updatePacketsTest()
   {
       this->component.setPacketList(packetList,ignore,2);
       Fw::Time ts;
@@ -564,7 +564,7 @@ namespace Svc {
   }
 
   void Tester ::
-     ignoreTest(void)
+     ignoreTest()
   {
       this->component.setPacketList(packetList,ignore,2);
       Fw::Time ts;
@@ -631,7 +631,7 @@ namespace Svc {
   }
 
   void Tester ::
-     sendManualPacketTest(void)
+     sendManualPacketTest()
   {
       this->component.setPacketList(packetList,ignore,2);
       Fw::Time ts;
@@ -753,7 +753,7 @@ namespace Svc {
   }
 
   void Tester ::
-     setPacketLevelTest(void)
+     setPacketLevelTest()
   {
       this->component.setPacketList(packetList,ignore,0);
       Fw::Time ts;
@@ -890,7 +890,7 @@ return;
   }
 
   void Tester ::
-    nonPacketizedChannelTest(void) {
+    nonPacketizedChannelTest() {
 
       this->component.setPacketList(packetList,ignore,2);
       Fw::Time ts;
@@ -923,7 +923,7 @@ return;
   }
 
   void Tester ::
-    pingTest(void) {
+    pingTest() {
 
       this->component.setPacketList(packetList,ignore,2);
       // ping component
@@ -973,7 +973,7 @@ return;
   // ----------------------------------------------------------------------
 
   void Tester ::
-    connectPorts(void) 
+    connectPorts() 
   {
 
     // TlmRecv
@@ -1062,7 +1062,7 @@ return;
 
 
   void Tester ::
-    initComponents(void) 
+    initComponents() 
   {
     this->init();
     this->component.init(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Remove redundant usage of void (I.E. void for parameterless methods). Round 2, now backed by clang-tidy automation. Autocoder python changes were manual, all C++ code changes were autogenerated.