### PR TITLE
LinuxSerialDriver: Check for errors when setting interface speed

### DIFF
--- a/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.cpp
+++ b/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.cpp
@@ -231,7 +231,23 @@ namespace Drv {
 
       // Set baud rate:
       stat = cfsetispeed(&newtio, relayRate);
+      if (stat) {
+          DEBUG_PRINT("cfsetispeed failed\n");
+          close(fd);
+          Fw::LogStringArg _arg = device;
+          Fw::LogStringArg _err = strerror(errno);
+          this->log_WARNING_HI_DR_OpenError(_arg,fd,_err);
+          return false;
+      }
       stat = cfsetospeed(&newtio, relayRate);
+      if (stat) {
+          DEBUG_PRINT("cfsetospeed failed\n");
+          close(fd);
+          Fw::LogStringArg _arg = device;
+          Fw::LogStringArg _err = strerror(errno);
+          this->log_WARNING_HI_DR_OpenError(_arg,fd,_err);
+          return false;
+      }
 
       // Raw output:
       newtio.c_oflag = 0;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Backport #981 from 3.0 to the development branch for testing.
