### PR TITLE
lestarch: allowing GTest to be disabled in UTs

### DIFF
--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -438,9 +438,16 @@ function(register_fprime_ut)
             message(STATUS "No extra 'MOD_DEPS' found in '${CMAKE_CURRENT_LIST_FILE}'.")
         endif()
     endif()
+
+    # Turn allow turning GTest on/off
+    set(INCLUDE_GTEST ON)
+    if (DEFINED UT_INCLUDE_GTEST)
+        set(INCLUDE_GTEST ${UT_INCLUDE_GTEST})
+    endif()
+
     get_nearest_build_root(${CMAKE_CURRENT_LIST_DIR})
     # Explicit call to module register
-    generate_ut("${UT_NAME}" "${SC_IFS}" "${MD_IFS}")
+    generate_ut("${UT_NAME}" "${SC_IFS}" "${MD_IFS}" "${INCLUDE_GTEST}")
     setup_all_module_targets(FPRIME_UT_TARGET_LIST ${MODULE_NAME} "" "${SOURCE_FILES}" "${AC_OUTPUTS}" "${MD_IFS}")
 endfunction(register_fprime_ut)
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infrastructure |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Allows users to disable GTest dependencies in UTs:

```
set(UT_INCLUDE_GTEST OFF)
fprime_register_ut(...
```

## Rationale

GTest was always intended to be an optional addition to our unit tests.  It helps the test, but should not be required.  Thus we have the ability to turn it off.

## Testing/Review Recommendations

None

## Future Work

Ensure this feature is not lost in the move to `v3.0.0`