### PR TITLE
lestarch: deframer fix

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -326,6 +326,7 @@ delitem
 deployables
 DEPRECATEDLIST
 deps
+deque
 deregistration
 deser
 deserialization

--- a/Os/test/ut/TestMain.cpp
+++ b/Os/test/ut/TestMain.cpp
@@ -38,10 +38,6 @@ TEST(Nominal, QTestPerformance) {
 TEST(Nominal, QTestConcurrentTest) { 
    qtest_concurrent();
 }
-// Disabled for macOS known issue
-//TEST(Nominal, IntervalTimerTest) { 
-//   intervalTimerTest();
-//}
 TEST(Nominal, FileSystemTest) { 
    fileSystemTest();
 }

--- a/Os/test/ut/TestMain.cpp
+++ b/Os/test/ut/TestMain.cpp
@@ -38,9 +38,10 @@ TEST(Nominal, QTestPerformance) {
 TEST(Nominal, QTestConcurrentTest) { 
    qtest_concurrent();
 }
-TEST(Nominal, IntervalTimerTest) { 
-   intervalTimerTest();
-}
+// Disabled for macOS known issue
+//TEST(Nominal, IntervalTimerTest) { 
+//   intervalTimerTest();
+//}
 TEST(Nominal, FileSystemTest) { 
    fileSystemTest();
 }

--- a/Svc/Deframer/CMakeLists.txt
+++ b/Svc/Deframer/CMakeLists.txt
@@ -24,4 +24,13 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/Tester.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/TestMain.cpp"
 )
-register_fprime_ut()
+#register_fprime_ut()
+
+set(UT_SOURCE_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/DeframerComponentAi.xml"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut-unified/DeframerRules.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut-unified/Tester.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut-unified/TestMain.cpp"
+)
+set(UT_MOD_DEPS STest)
+register_fprime_ut() #(Svc_Deframer_unified)

--- a/Svc/Deframer/CMakeLists.txt
+++ b/Svc/Deframer/CMakeLists.txt
@@ -24,7 +24,7 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/Tester.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/TestMain.cpp"
 )
-#register_fprime_ut()
+register_fprime_ut()
 
 set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/DeframerComponentAi.xml"
@@ -33,4 +33,4 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut-unified/TestMain.cpp"
 )
 set(UT_MOD_DEPS STest)
-register_fprime_ut() #(Svc_Deframer_unified)
+register_fprime_ut(Svc_Deframer_with_fprime)

--- a/Svc/Deframer/DeframerComponentImpl.cpp
+++ b/Svc/Deframer/DeframerComponentImpl.cpp
@@ -108,7 +108,7 @@ void DeframerComponentImpl ::route(Fw::Buffer& data) {
 
 void DeframerComponentImpl ::processRing() {
     FW_ASSERT(m_protocol != NULL);
-    // Maximum limit to to the loop as at least one byte is process per iteration unless needed > remaining size
+    // Maximum limit to the loop as at least one byte is process per iteration unless needed > remaining size
     const U32 loop_limit = m_in_ring.get_capacity() + 1;
 
     // Inner-loop, process ring buffer looking for at least the header

--- a/Svc/Deframer/DeframerComponentImpl.cpp
+++ b/Svc/Deframer/DeframerComponentImpl.cpp
@@ -117,6 +117,7 @@ void DeframerComponentImpl ::processRing() {
         // Successful deframing consumes messages
         if (status == DeframingProtocol::DEFRAMING_STATUS_SUCCESS) {
             m_in_ring.rotate(needed);
+            needed = 0; // Must reset needed after a successful deframe
         }
         // Error statuses  reset needed and rotate away 1 byte
         else if (status != DeframingProtocol::DEFRAMING_MORE_NEEDED) {

--- a/Svc/Deframer/DeframerComponentImpl.cpp
+++ b/Svc/Deframer/DeframerComponentImpl.cpp
@@ -106,32 +106,42 @@ void DeframerComponentImpl ::route(Fw::Buffer& data) {
     }
 }
 
-
 void DeframerComponentImpl ::processRing() {
     FW_ASSERT(m_protocol != NULL);
+    // Maximum limit to to the loop as at least one byte is process per iteration unless needed > remaining size
+    const U32 loop_limit = m_in_ring.get_capacity() + 1;
+
     // Inner-loop, process ring buffer looking for at least the header
     U32 i = 0;
-    U32 needed = 0;
-    for (i = 0; (i < (m_in_ring.get_capacity() + 1)) and (m_in_ring.get_remaining_size() >= needed); i++) {
+    for (i = 0; (m_in_ring.get_remaining_size() > 0) and (i < loop_limit); i++) {
+        const U32 remaining = m_in_ring.get_remaining_size();
+        U32 needed = 0; // Needed is an out-only variable, and should be reset each loop
         DeframingProtocol::DeframingStatus status = m_protocol->deframe(m_in_ring, needed);
+        FW_ASSERT(needed != 0); //Deframing protocol must always set needed to a non-zero value
+        FW_ASSERT(remaining == m_in_ring.get_remaining_size()); // Deframing protocol must not consume data only view it
         // Successful deframing consumes messages
         if (status == DeframingProtocol::DEFRAMING_STATUS_SUCCESS) {
             m_in_ring.rotate(needed);
-            needed = 0; // Must reset needed after a successful deframe
+        }
+        // Break on the condition that more is needed
+        else if (status == DeframingProtocol::DEFRAMING_MORE_NEEDED) {
+            // Deframing protocol reported inconsistent "more is needed" and needed size
+            FW_ASSERT(needed > m_in_ring.get_remaining_size(), needed, m_in_ring.get_remaining_size());
+            break;
         }
         // Error statuses  reset needed and rotate away 1 byte
-        else if (status != DeframingProtocol::DEFRAMING_MORE_NEEDED) {
+        else {
             m_in_ring.rotate(1);
-            needed = 0;
             // Checksum errors get logged as it is unlikely to get to a checksum check on random data
             if (status == DeframingProtocol::DEFRAMING_INVALID_CHECKSUM) {
                 Fw::Logger::logMsg("[ERROR] Deframing checksum validation failed\n");
             }
         }
     }
-    // Note: this assert can trip when "more is needed" from the circular buffer and the circular buffer
-    // reports that it has enough for what is needed. This would constitute a hard failure
-    FW_ASSERT(i <= m_in_ring.get_capacity(), m_in_ring.get_capacity());
+    // In every iteration of the loop above data is removed from the buffer, or we break from the loop due. Thus at
+    // worst case the loop should be called m_in_ring.get_capacity() times before exiting due an empty buffer. If it hits
+    // the limit, something went horribly wrong.
+    FW_ASSERT(i < loop_limit);
 }
 
 void DeframerComponentImpl ::processBuffer(Fw::Buffer& buffer) {

--- a/Svc/Deframer/test/ut-unified/DeframerRules.cpp
+++ b/Svc/Deframer/test/ut-unified/DeframerRules.cpp
@@ -1,0 +1,85 @@
+/**
+ * DeframerRules.cpp:
+ *
+ * This file specifies Rule classes for testing of the Svc::Deframer. These rules can then be used by the main
+ * testing program to test the code.
+ *
+ *
+ * @author mstarch
+ */
+#include "DeframerRules.hpp"
+#include <STest/Pick/Pick.hpp>
+#include <stdio.h>
+namespace Svc {
+    // Constructor
+    RandomizeRule :: RandomizeRule(const Fw::String& name) : STest::Rule<Tester>(name.toChar()) {}
+
+    // Can always randomize
+    bool RandomizeRule :: precondition(const Svc::Tester &state) {
+        return true;
+    }
+    // Randomize
+    void RandomizeRule :: action(Svc::Tester &state) {
+        state.m_uplink_type = STest::Pick::lowerUpper(0, 1);
+        state.m_uplink_size = STest::Pick::lowerUpper(0, sizeof(state.m_uplink_data) - 1);
+        // Reset or not sent allows randomization
+        if (state.m_uplink_type == 2 || state.m_uplink_point == 0) {
+            state.m_uplink_type = STest::Pick::lowerUpper(0, 1);
+            state.m_uplink_used = STest::Pick::lowerUpper(4, FW_COM_BUFFER_MAX_SIZE);
+            state.m_uplink_com_type = static_cast<Fw::ComPacket::ComPacketType>(
+                    STest::Pick::lowerUpper(Fw::ComPacket::FW_PACKET_COMMAND,Fw::ComPacket::FW_PACKET_FILE));
+            U32 i = 0;
+            for (i = 0; i < state.m_uplink_used; i++) {
+                state.m_uplink_data[(sizeof(FP_FRAME_TOKEN_TYPE) * 2) + i] =
+                        static_cast<U8>(STest::Pick::lowerUpper(0, 255));
+            }
+            for (; i < sizeof(state.m_uplink_data); i++) {
+                state.m_uplink_data[i] = 0;
+            }
+            // Garbage may only be set if we refreshed the data
+            state.m_garbage = !STest::Pick::lowerUpper(0, 9); // One part failure in 10
+            // Correct header info for items
+            state.update_header_info(STest::Pick::lowerUpper(0,sizeof(U32) + 2 * sizeof(FP_FRAME_TOKEN_TYPE) + state.m_uplink_used - 1),
+                                     STest::Pick::lowerUpper(1,255));
+        }
+
+    }
+
+    // Constructor
+    SendAvailableRule :: SendAvailableRule(const Fw::String& name) : STest::Rule<Tester>(name.toChar()) {}
+
+    // Can always downlink
+    bool SendAvailableRule :: precondition(const Svc::Tester &state) {
+        return true;
+    }
+
+    // Pick a rule and downlink
+    void SendAvailableRule :: action(Svc::Tester &state) {
+        U32 total_used = state.m_uplink_used + FP_FRAME_HEADER_SIZE + sizeof(U32);
+        U8* up_ptr = state.m_uplink_data + state.m_uplink_point;
+        U32 size = ((state.m_uplink_point + state.m_uplink_size) >= total_used) ?
+                    (total_used - state.m_uplink_point) : state.m_uplink_size;
+        state.m_uplink_point = (state.m_uplink_point + size >= total_used) ? 0 : (state.m_uplink_point + size);
+        Fw::Buffer buffer(up_ptr, size);
+        // Uplink based on uplink type
+        if (state.m_uplink_type) {
+            state.invoke_to_framedIn(0, buffer, Drv::RecvStatus::RECV_OK);
+        } else {
+            state.m_incoming_buffer = buffer;
+            state.invoke_to_schedIn(0, 0);
+        }
+        // Finished current uplink, check that the uplink was handled
+        if (state.m_uplink_point == 0 && size > 0 && !state.m_garbage) {
+            // Check uplink type
+            if (state.m_uplink_com_type == Fw::ComPacket::FW_PACKET_COMMAND) {
+                state.assert_from_comOut_size(__FILE__, __LINE__, 1);
+            } else if (state.m_uplink_com_type == Fw::ComPacket::FW_PACKET_FILE) {
+                state.assert_from_bufferOut_size(__FILE__, __LINE__, 1);
+            }
+            state.clearFromPortHistory();
+        } else {
+            state.assert_from_comOut_size(__FILE__, __LINE__, 0);
+            state.assert_from_bufferOut_size(__FILE__, __LINE__, 0);
+        }
+    }
+};

--- a/Svc/Deframer/test/ut-unified/DeframerRules.cpp
+++ b/Svc/Deframer/test/ut-unified/DeframerRules.cpp
@@ -9,8 +9,39 @@
  */
 #include "DeframerRules.hpp"
 #include <STest/Pick/Pick.hpp>
-#include <stdio.h>
+#include <Utils/Hash/Hash.hpp>
+
 namespace Svc {
+
+    void update_header_info(Tester::UplinkData& data, U32 garbage_index, U8 garbage_byte) {
+        const U32 full_size = FP_FRAME_HEADER_SIZE + data.size + sizeof(U32);
+        data.full_size = full_size;
+        // Write token types
+        for (U32 i = 0; i < sizeof(FP_FRAME_TOKEN_TYPE); i++) {
+            data.data[i] = (FprimeFraming::START_WORD >> ((sizeof(FP_FRAME_TOKEN_TYPE) - 1 - i) * 8)) & 0xFF;
+            data.data[i + sizeof(FP_FRAME_TOKEN_TYPE)] =
+                    (data.size >> ((sizeof(FP_FRAME_TOKEN_TYPE) - 1 - i) * 8)) & 0xFF;
+        }
+        // Packet type
+        data.data[2 * sizeof(FP_FRAME_TOKEN_TYPE) + 0] = (static_cast<U32>(data.type) >> 24) & 0xFF;
+        data.data[2 * sizeof(FP_FRAME_TOKEN_TYPE) + 1] = (static_cast<U32>(data.type) >> 16) & 0xFF;
+        data.data[2 * sizeof(FP_FRAME_TOKEN_TYPE) + 2] = (static_cast<U32>(data.type) >> 8) & 0xFF;
+        data.data[2 * sizeof(FP_FRAME_TOKEN_TYPE) + 3] = (static_cast<U32>(data.type) >> 0) & 0xFF;
+
+        Utils::Hash hash;
+        Utils::HashBuffer hashBuffer;
+        hash.update(data.data,  FP_FRAME_HEADER_SIZE + data.size);
+        hash.final(hashBuffer);
+
+        for (U32 i = 0; i < sizeof(U32); i++) {
+            data.data[i + full_size - sizeof(U32)] = hashBuffer.getBuffAddr()[i] & 0xFF;
+        }
+        if (data.corrupted) {
+            data.data[garbage_index] += garbage_byte;
+        }
+    }
+
+
     // Constructor
     RandomizeRule :: RandomizeRule(const Fw::String& name) : STest::Rule<Tester>(name.toChar()) {}
 
@@ -20,29 +51,25 @@ namespace Svc {
     }
     // Randomize
     void RandomizeRule :: action(Svc::Tester &state) {
-        state.m_uplink_type = STest::Pick::lowerUpper(0, 1);
-        state.m_uplink_size = STest::Pick::lowerUpper(0, sizeof(state.m_uplink_data) - 1);
-        // Reset or not sent allows randomization
-        if (state.m_uplink_type == 2 || state.m_uplink_point == 0) {
-            state.m_uplink_type = STest::Pick::lowerUpper(0, 1);
-            state.m_uplink_used = STest::Pick::lowerUpper(4, FW_COM_BUFFER_MAX_SIZE);
-            state.m_uplink_com_type = static_cast<Fw::ComPacket::ComPacketType>(
-                    STest::Pick::lowerUpper(Fw::ComPacket::FW_PACKET_COMMAND,Fw::ComPacket::FW_PACKET_FILE));
+        for (U32 j = 0; j < STest::Pick::lowerUpper(1, 100); j++) {
+            Tester::UplinkData data;
+            ::memset(&data, 0, sizeof(data));
+            data.partial = 0;
+            data.size = STest::Pick::lowerUpper(4, sizeof(data.data) - FP_FRAME_HEADER_SIZE - sizeof(U32) - 1);
+            data.type = static_cast<Fw::ComPacket::ComPacketType>(
+                    STest::Pick::lowerUpper(Fw::ComPacket::FW_PACKET_COMMAND, Fw::ComPacket::FW_PACKET_FILE));
+            // Fill in randomized data
             U32 i = 0;
-            for (i = 0; i < state.m_uplink_used; i++) {
-                state.m_uplink_data[(sizeof(FP_FRAME_TOKEN_TYPE) * 2) + i] =
-                        static_cast<U8>(STest::Pick::lowerUpper(0, 255));
-            }
-            for (; i < sizeof(state.m_uplink_data); i++) {
-                state.m_uplink_data[i] = 0;
+            for (i = 0; i < data.size; i++) {
+                data.data[FP_FRAME_HEADER_SIZE + i] = static_cast<U8>(STest::Pick::lowerUpper(0, 255));
             }
             // Garbage may only be set if we refreshed the data
-            state.m_garbage = !STest::Pick::lowerUpper(0, 9); // One part failure in 10
+            data.corrupted = !STest::Pick::lowerUpper(0, 9); // One part failure in 10
             // Correct header info for items
-            state.update_header_info(STest::Pick::lowerUpper(0,sizeof(U32) + 2 * sizeof(FP_FRAME_TOKEN_TYPE) + state.m_uplink_used - 1),
-                                     STest::Pick::lowerUpper(1,255));
+            update_header_info(data, STest::Pick::lowerUpper(0, sizeof(U32) + FP_FRAME_HEADER_SIZE + data.size - 1),
+                               STest::Pick::lowerUpper(1, 255));
+            state.m_sending.push_back(data);
         }
-
     }
 
     // Constructor
@@ -55,31 +82,67 @@ namespace Svc {
 
     // Pick a rule and downlink
     void SendAvailableRule :: action(Svc::Tester &state) {
-        U32 total_used = state.m_uplink_used + FP_FRAME_HEADER_SIZE + sizeof(U32);
-        U8* up_ptr = state.m_uplink_data + state.m_uplink_point;
-        U32 size = ((state.m_uplink_point + state.m_uplink_size) >= total_used) ?
-                    (total_used - state.m_uplink_point) : state.m_uplink_size;
-        state.m_uplink_point = (state.m_uplink_point + size >= total_used) ? 0 : (state.m_uplink_point + size);
-        Fw::Buffer buffer(up_ptr, size);
-        // Uplink based on uplink type
-        if (state.m_uplink_type) {
-            state.invoke_to_framedIn(0, buffer, Drv::RecvStatus::RECV_OK);
+        const U32 incoming_buffer_size = (state.m_polling) ? sizeof(state.component.m_poll_buffer) : STest::Pick::lowerUpper(1, 10240);
+        U8* incoming_buffer = new U8[incoming_buffer_size];
+        state.m_incoming_buffer.set(incoming_buffer, incoming_buffer_size);
+        state.m_incoming_buffer.getSerializeRepr().resetSer();
+        state.m_incoming_buffer.getSerializeRepr().resetDeser();
+        U32 expected_com_count = 0;
+        U32 expected_buf_count = 0;
+
+        // Loop through all available packets
+        U32 i = 0;
+        while (state.m_sending.size() > 0 && i < incoming_buffer_size) {
+            Tester::UplinkData data = state.m_sending.front();
+
+            U32 available = std::min(data.full_size, (incoming_buffer_size - i));
+            // Put in as much data as we can
+            state.m_incoming_buffer.getSerializeRepr().serialize(data.data + data.partial, available, true);
+            data.partial += available;
+            i += available;
+
+            // If we have sent the whole packet, consume it and add it to the receiving queue
+            if (data.partial == data.full_size) {
+                state.m_sending.pop_front();
+                if (!data.corrupted) {
+                    state.m_receiving.push_back(data);
+                    expected_com_count += (data.type == Fw::ComPacket::FW_PACKET_COMMAND) ? 1 : 0;
+                    expected_buf_count += (data.type == Fw::ComPacket::FW_PACKET_FILE) ? 1 : 0;
+                }
+            }
+        }
+        state.m_incoming_buffer.setSize(i);
+
+
+        // Send based on polling or not
+        if (!state.m_polling) {
+            state.invoke_to_framedIn(0, state.m_incoming_buffer, Drv::RecvStatus::RECV_OK);
         } else {
-            state.m_incoming_buffer = buffer;
             state.invoke_to_schedIn(0, 0);
         }
-        // Finished current uplink, check that the uplink was handled
-        if (state.m_uplink_point == 0 && size > 0 && !state.m_garbage) {
-            // Check uplink type
-            if (state.m_uplink_com_type == Fw::ComPacket::FW_PACKET_COMMAND) {
-                state.assert_from_comOut_size(__FILE__, __LINE__, 1);
-            } else if (state.m_uplink_com_type == Fw::ComPacket::FW_PACKET_FILE) {
-                state.assert_from_bufferOut_size(__FILE__, __LINE__, 1);
-            }
-            state.clearFromPortHistory();
-        } else {
-            state.assert_from_comOut_size(__FILE__, __LINE__, 0);
-            state.assert_from_bufferOut_size(__FILE__, __LINE__, 0);
+
+        // If corruption hits a size byte to a valid size, it must wait until more data.  This will flush the buffer.
+        const U32 flush_buffer_size = (state.m_polling) ? sizeof(state.component.m_poll_buffer) : state.component.m_in_ring.get_capacity();
+        U8* flush_buffer = new U8[flush_buffer_size];
+        state.m_incoming_buffer.set(flush_buffer, incoming_buffer_size);
+        state.m_incoming_buffer.getSerializeRepr().resetSer();
+        state.m_incoming_buffer.getSerializeRepr().resetDeser();
+
+
+        for (i = 0; i < flush_buffer_size; i++) {
+            state.m_incoming_buffer.getData()[i] = static_cast<U8>(STest::Pick::lowerUpper(0, 255));
         }
+        state.m_incoming_buffer.setSize(flush_buffer_size);
+        // Flush it
+        if (!state.m_polling) {
+            state.invoke_to_framedIn(0, state.m_incoming_buffer, Drv::RecvStatus::RECV_OK);
+        } else {
+            state.invoke_to_schedIn(0, 0);
+        }
+
+        state.assert_from_comOut_size(__FILE__, __LINE__, expected_com_count);
+        state.assert_from_bufferOut_size(__FILE__, __LINE__, expected_buf_count);
+        state.clearFromPortHistory();
+
     }
 };

--- a/Svc/Deframer/test/ut-unified/DeframerRules.hpp
+++ b/Svc/Deframer/test/ut-unified/DeframerRules.hpp
@@ -1,0 +1,47 @@
+/**
+ * GroundInterfaceRules.hpp:
+ *
+ * This file specifies Rule classes for testing of the Svc::GroundInterface. These rules can then be used by the main
+ * testing program to test the code. These rules support rule-based random testing.
+ *
+ * GroundInterface rules:
+ *
+ * 1. On read-callback of sufficient parts, an uplink-out is produced
+ * @author lestarch
+ */
+#ifndef SVC_DEFRAMER_UT_UNIFIED
+#define SVC_DEFRAMER_UT_UNIFIED
+
+#include <Fw/Types/BasicTypes.hpp>
+#include <Fw/Types/StringType.hpp>
+#include <Svc/Deframer/test/ut-unified/Tester.hpp>
+#include <STest/STest/Rule/Rule.hpp>
+#include <STest/STest/Pick/Pick.hpp>
+
+
+namespace Svc {
+
+    struct RandomizeRule : public STest::Rule<Tester> {
+        // Constructor
+        RandomizeRule(const Fw::String& name);
+
+        // Always valid
+        bool precondition(const Tester& state);
+
+        // Will randomize the test state
+        void action(Tester& truth);
+    };
+
+    struct SendAvailableRule : public STest::Rule<Tester> {
+        // Constructor
+        SendAvailableRule(const Fw::String& name);
+
+        // Always valid
+        bool precondition(const Tester& state);
+
+        // Will randomize the test state
+        void action(Tester& truth);
+    };
+
+};
+#endif //SVC_DEFRAMER_UT_UNIFIED

--- a/Svc/Deframer/test/ut-unified/TestMain.cpp
+++ b/Svc/Deframer/test/ut-unified/TestMain.cpp
@@ -1,0 +1,49 @@
+// ----------------------------------------------------------------------
+// TestMain.cpp
+// ----------------------------------------------------------------------
+
+#include "Tester.hpp"
+#include <gtest/gtest.h>
+#include <Svc/GroundInterface/test/ut/GroundInterfaceRules.hpp>
+#include <STest/Scenario/Scenario.hpp>
+#include <STest/Scenario/RandomScenario.hpp>
+#include <STest/Scenario/BoundedScenario.hpp>
+
+#define STEP_COUNT 10000
+
+/**
+ * A random hopper for rules. Apply STEP_COUNT times.
+ */
+TEST(Nominal, RandomizedDeframer) {
+    Svc::Tester tester;
+
+    // Create rules, and assign them into the array
+    Svc::RandomizeRule randomize("Randomize");
+    Svc::SendAvailableRule sendup("");
+
+    // Setup a list of rules to choose from
+    STest::Rule<Svc::Tester>* rules[] = {
+            &randomize,
+            &sendup
+    };
+    // Construct the random scenario and run it with the defined bounds
+    STest::RandomScenario<Svc::Tester> random("Random Rules", rules, FW_NUM_ARRAY_ELEMENTS(rules));
+
+    // Setup a bounded scenario to run rules a set number of times
+    STest::BoundedScenario<Svc::Tester> bounded("Bounded Random Rules Scenario", random, STEP_COUNT);
+    // Run!
+    const U32 numSteps = bounded.run(tester);
+    printf("Ran %u steps.\n", numSteps);
+}
+
+
+TEST(Nominal, BasicUplink) {
+    Svc::Tester tester;
+    Svc::SendAvailableRule rule("Uplink Rule");
+    rule.apply(tester);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/Svc/Deframer/test/ut-unified/TestMain.cpp
+++ b/Svc/Deframer/test/ut-unified/TestMain.cpp
@@ -19,7 +19,7 @@ TEST(Nominal, RandomizedDeframer) {
 
     // Create rules, and assign them into the array
     Svc::RandomizeRule randomize("Randomize");
-    Svc::SendAvailableRule sendup("");
+    Svc::SendAvailableRule sendup("Send");
 
     // Setup a list of rules to choose from
     STest::Rule<Svc::Tester>* rules[] = {
@@ -36,11 +36,44 @@ TEST(Nominal, RandomizedDeframer) {
     printf("Ran %u steps.\n", numSteps);
 }
 
+TEST(Nominal, RandomizedPollingDeframer) {
+    Svc::Tester tester(true);
+
+    // Create rules, and assign them into the array
+    Svc::RandomizeRule randomize("Randomize");
+    Svc::SendAvailableRule sendup("Send");
+
+    // Setup a list of rules to choose from
+    STest::Rule<Svc::Tester>* rules[] = {
+            &randomize,
+            &sendup
+    };
+    // Construct the random scenario and run it with the defined bounds
+    STest::RandomScenario<Svc::Tester> random("Random Rules", rules, FW_NUM_ARRAY_ELEMENTS(rules));
+
+    // Setup a bounded scenario to run rules a set number of times
+    STest::BoundedScenario<Svc::Tester> bounded("Bounded Random Rules Scenario", random, STEP_COUNT);
+    // Run!
+    const U32 numSteps = bounded.run(tester);
+    printf("Ran %u steps.\n", numSteps);
+}
 
 TEST(Nominal, BasicUplink) {
-    Svc::Tester tester;
-    Svc::SendAvailableRule rule("Uplink Rule");
-    rule.apply(tester);
+    Svc::Tester tester(false);
+    Svc::RandomizeRule setup("Randomize");
+    Svc::SendAvailableRule send("Uplink Rule");
+
+    setup.apply(tester);
+    send.apply(tester);
+}
+
+TEST(Nominal, BasicPollUplink) {
+    Svc::Tester tester(false);
+    Svc::RandomizeRule setup("Randomize");
+    Svc::SendAvailableRule send("Uplink Rule");
+
+    setup.apply(tester);
+    send.apply(tester);
 }
 
 int main(int argc, char **argv) {

--- a/Svc/Deframer/test/ut-unified/Tester.cpp
+++ b/Svc/Deframer/test/ut-unified/Tester.cpp
@@ -1,0 +1,158 @@
+// ======================================================================
+// \title  Tester.cpp
+// \author mstarch
+// \brief  cpp file for Deframer test harness implementation class
+//
+// \copyright
+// Copyright 2009-2015, by the California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+//
+// ======================================================================
+
+#include "Tester.hpp"
+#include "Utils/Hash/Hash.hpp"
+#include "Utils/Hash/HashBuffer.hpp"
+
+#define INSTANCE 0
+#define MAX_HISTORY_SIZE 10000
+
+namespace Svc {
+// ----------------------------------------------------------------------
+// Construction and destruction
+// ----------------------------------------------------------------------
+
+Tester ::Tester(void)
+    : DeframerGTestBase("Tester", MAX_HISTORY_SIZE),
+      component("Deframer"),
+      m_buffer(NULL),
+      m_uplink_type(1),
+      m_uplink_used(30),
+      m_uplink_size(sizeof(FP_FRAME_TOKEN_TYPE) * 2 + sizeof(U32) + m_uplink_used),
+      m_uplink_point(0),
+      m_garbage(false),
+      m_uplink_com_type(Fw::ComPacket::FW_PACKET_COMMAND) {
+    this->initComponents();
+    this->connectPorts();
+    component.setup(protocol);
+    update_header_info(0, 0);
+}
+
+Tester ::~Tester(void) {}
+
+// ----------------------------------------------------------------------
+// Tests State Adjustments
+// ----------------------------------------------------------------------
+
+void Tester ::update_header_info(U32 garbage_index, U8 garbage_byte) {
+    // Write token types
+    for (U32 i = 0; i < sizeof(FP_FRAME_TOKEN_TYPE); i++) {
+        m_uplink_data[i] = (FprimeFraming::START_WORD >> ((sizeof(FP_FRAME_TOKEN_TYPE) - 1 - i) * 8)) & 0xFF;
+        m_uplink_data[i + sizeof(FP_FRAME_TOKEN_TYPE)] =
+            (m_uplink_used >> ((sizeof(FP_FRAME_TOKEN_TYPE) - 1 - i) * 8)) & 0xFF;
+    }
+    // Packet type
+    m_uplink_data[2 * sizeof(FP_FRAME_TOKEN_TYPE) + 0] = (static_cast<U32>(m_uplink_com_type) >> 24) & 0xFF;
+    m_uplink_data[2 * sizeof(FP_FRAME_TOKEN_TYPE) + 1] = (static_cast<U32>(m_uplink_com_type) >> 16) & 0xFF;
+    m_uplink_data[2 * sizeof(FP_FRAME_TOKEN_TYPE) + 2] = (static_cast<U32>(m_uplink_com_type) >> 8) & 0xFF;
+    m_uplink_data[2 * sizeof(FP_FRAME_TOKEN_TYPE) + 3] = (static_cast<U32>(m_uplink_com_type) >> 0) & 0xFF;
+
+    Utils::Hash hash;
+    Utils::HashBuffer hashBuffer;
+    hash.update(m_uplink_data,  2 * sizeof(FP_FRAME_TOKEN_TYPE) + m_uplink_used);
+    hash.final(hashBuffer);
+
+    for (U32 i = 0; i < sizeof(U32); i++) {
+        m_uplink_data[i + 2 * sizeof(FP_FRAME_TOKEN_TYPE) + m_uplink_used] = hashBuffer.getBuffAddr()[i] & 0xFF;
+    }
+    if (m_garbage) {
+        m_uplink_data[garbage_index] += garbage_byte;
+    }
+}
+
+// ----------------------------------------------------------------------
+// Handlers for typed from ports
+// ----------------------------------------------------------------------
+
+void Tester ::from_comOut_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer& data, U32 context) {
+    this->pushFromPortEntry_comOut(data, context);
+    for (U32 i = 0; i < data.getBuffLength(); i++) {
+        ASSERT_EQ(data.getBuffAddr()[i], m_uplink_data[i + FP_FRAME_HEADER_SIZE]);
+    }
+}
+
+void Tester ::from_bufferOut_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+    // this->m_has_port_out = true;
+    this->pushFromPortEntry_bufferOut(fwBuffer);
+    for (U32 i = 0; i < fwBuffer.getSize(); i++) {
+        // File uplink strips type before outputting to FileUplink
+        ASSERT_EQ(fwBuffer.getData()[i], m_uplink_data[i + FP_FRAME_HEADER_SIZE + sizeof(FP_FRAME_TOKEN_TYPE)]);
+    }
+    // Have to clean up memory as in a normal mode, file downlink doesn't require deallocation
+    delete[](fwBuffer.getData() - sizeof(I32));
+}
+
+Fw::Buffer Tester ::from_bufferAllocate_handler(const NATIVE_INT_TYPE portNum, U32 size) {
+    this->pushFromPortEntry_bufferAllocate(size);
+    Fw::Buffer buffer(new U8[size], size);
+    m_buffer = buffer.getData();
+    return buffer;
+}
+
+void Tester ::from_bufferDeallocate_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+    // this->m_has_port_out = true;
+    delete[] fwBuffer.getData();
+    this->pushFromPortEntry_bufferDeallocate(fwBuffer);
+}
+
+void Tester ::from_framedDeallocate_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+    this->pushFromPortEntry_framedDeallocate(fwBuffer);
+}
+
+Drv::PollStatus Tester ::from_framedPoll_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& pollBuffer) {
+    this->pushFromPortEntry_framedPoll(pollBuffer);
+    U8* incoming = m_incoming_buffer.getData();
+    U8* outgoing = pollBuffer.getData();
+    for (U32 i = 0; i < m_incoming_buffer.getSize(); i++) {
+        outgoing[i] = incoming[i];
+    }
+    pollBuffer.setSize(m_incoming_buffer.getSize());
+    return Drv::POLL_OK;
+}
+
+// ----------------------------------------------------------------------
+// Helper methods
+// ----------------------------------------------------------------------
+
+void Tester ::connectPorts(void) {
+    // framedIn
+    this->connect_to_framedIn(0, this->component.get_framedIn_InputPort(0));
+
+    // schedIn
+    this->connect_to_schedIn(0, this->component.get_schedIn_InputPort(0));
+
+    // comOut
+    this->component.set_comOut_OutputPort(0, this->get_from_comOut(0));
+
+    // bufferOut
+    this->component.set_bufferOut_OutputPort(0, this->get_from_bufferOut(0));
+
+    // bufferAllocate
+    this->component.set_bufferAllocate_OutputPort(0, this->get_from_bufferAllocate(0));
+
+    // bufferDeallocate
+    this->component.set_bufferDeallocate_OutputPort(0, this->get_from_bufferDeallocate(0));
+
+    // framedDeallocate
+    this->component.set_framedDeallocate_OutputPort(0, this->get_from_framedDeallocate(0));
+
+    // framedPoll
+    this->component.set_framedPoll_OutputPort(0, this->get_from_framedPoll(0));
+}
+
+void Tester ::initComponents(void) {
+    this->init();
+    this->component.init(INSTANCE);
+}
+
+}  // end namespace Svc

--- a/Svc/Deframer/test/ut-unified/Tester.hpp
+++ b/Svc/Deframer/test/ut-unified/Tester.hpp
@@ -1,0 +1,131 @@
+// ======================================================================
+// \title  GroundInterface/test/ut/Tester.hpp
+// \author mstarch
+// \brief  hpp file for GroundInterface test harness implementation class
+//
+// \copyright
+// Copyright 2009-2015, by the California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+//
+// ======================================================================
+
+#ifndef TESTER_HPP
+#define TESTER_HPP
+
+#include <ComPacket.hpp>
+#include "GTestBase.hpp"
+#include "Svc/Deframer/DeframerComponentImpl.hpp"
+#include "Svc/FramingProtocol/FprimeProtocol.hpp"
+
+namespace Svc {
+
+class Tester : public DeframerGTestBase {
+  private:
+    friend struct RandomizeRule;
+    friend struct DownlinkRule;
+    friend struct FileDownlinkRule;
+    friend struct SendAvailableRule;
+    // ----------------------------------------------------------------------
+    // Construction and destruction
+    // ----------------------------------------------------------------------
+
+  public:
+    //! Construct object Tester
+    //!
+    Tester(void);
+
+    //! Destroy object Tester
+    //!
+    ~Tester(void);
+
+  public:
+    // ----------------------------------------------------------------------
+    // Tests
+    // ----------------------------------------------------------------------
+
+    void update_header_info(U32 garbage_index, U8 garbage_byte);
+
+    void setInputParams(FP_FRAME_TOKEN_TYPE size,
+                        U8* buffer,
+                        FP_FRAME_TOKEN_TYPE packet_type = Fw::ComPacket::FW_PACKET_UNKNOWN);
+
+  private:
+    // ----------------------------------------------------------------------
+    // Handlers for typed from ports
+    // ----------------------------------------------------------------------
+
+    //! Handler for from_comOut
+    //!
+    void from_comOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                             Fw::ComBuffer& data,           /*!< Buffer containing packet data*/
+                             U32 context                    /*!< Call context value; meaning chosen by user*/
+    );
+
+    //! Handler for from_bufferOut
+    //!
+    void from_bufferOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                                Fw::Buffer& fwBuffer);
+
+    //! Handler for from_bufferAllocate
+    //!
+    Fw::Buffer from_bufferAllocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                                           U32 size);
+
+    //! Handler for from_bufferDeallocate
+    //!
+    void from_bufferDeallocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                                       Fw::Buffer& fwBuffer);
+
+    //! Handler for from_framedDeallocate
+    //!
+    void from_framedDeallocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                                       Fw::Buffer& fwBuffer);
+
+    //! Handler for from_framedPoll
+    //!
+    Drv::PollStatus from_framedPoll_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                                            Fw::Buffer& pollBuffer);
+
+  private:
+    // ----------------------------------------------------------------------
+    // Helper methods
+    // ----------------------------------------------------------------------
+
+    //! Connect ports
+    //!
+    void connectPorts(void);
+
+    //! Initialize components
+    //!
+    void initComponents(void);
+
+  private:
+    // ----------------------------------------------------------------------
+    // Variables
+    // ----------------------------------------------------------------------
+
+    //! The component under test
+    //!
+    DeframerComponentImpl component;
+    Svc::FprimeDeframing protocol;
+
+    //! Expected buffer, for checking of the interface
+    FP_FRAME_TOKEN_TYPE m_size;
+    FP_FRAME_TOKEN_TYPE m_packet;
+    Fw::Buffer m_incoming_buffer;
+    Fw::Buffer m_incoming_file_buffer;
+    U8* m_buffer;
+    U32 m_uplink_type;
+    U32 m_uplink_used;
+    U32 m_uplink_size;
+    U32 m_uplink_point;
+    bool m_garbage;
+    Fw::ComPacket::ComPacketType m_uplink_com_type;
+    // Initialize to empty list to appease valgrind
+    U8 m_uplink_data[(sizeof(FP_FRAME_TOKEN_TYPE) * 2) + sizeof(U32) + FW_COM_BUFFER_MAX_SIZE] = {};
+};
+
+}  // end namespace Svc
+
+#endif

--- a/Svc/Deframer/test/ut-unified/Tester.hpp
+++ b/Svc/Deframer/test/ut-unified/Tester.hpp
@@ -13,6 +13,7 @@
 #ifndef TESTER_HPP
 #define TESTER_HPP
 
+#include <deque>
 #include <ComPacket.hpp>
 #include "GTestBase.hpp"
 #include "Svc/Deframer/DeframerComponentImpl.hpp"
@@ -31,9 +32,18 @@ class Tester : public DeframerGTestBase {
     // ----------------------------------------------------------------------
 
   public:
+    struct UplinkData {
+        Fw::ComPacket::ComPacketType type;
+        U32 size;
+        U32 partial;
+        U32 full_size;
+        bool corrupted;
+        U8 data[FW_COM_BUFFER_MAX_SIZE];
+    };
+
     //! Construct object Tester
     //!
-    Tester(void);
+    Tester(bool polling=false);
 
     //! Destroy object Tester
     //!
@@ -110,12 +120,19 @@ class Tester : public DeframerGTestBase {
     DeframerComponentImpl component;
     Svc::FprimeDeframing protocol;
 
-    //! Expected buffer, for checking of the interface
-    FP_FRAME_TOKEN_TYPE m_size;
-    FP_FRAME_TOKEN_TYPE m_packet;
+    std::deque<UplinkData> m_sending;
+    std::deque<UplinkData> m_receiving;
     Fw::Buffer m_incoming_buffer;
-    Fw::Buffer m_incoming_file_buffer;
-    U8* m_buffer;
+    bool m_polling;
+
+    //! Expected buffer, for checking of the interface
+    //FP_FRAME_TOKEN_TYPE m_size;
+    //FP_FRAME_TOKEN_TYPE m_packet;
+    //
+    //Fw::Buffer m_incoming_file_buffer;
+
+
+    /*U8* m_buffer;
     U32 m_uplink_type;
     U32 m_uplink_used;
     U32 m_uplink_size;
@@ -123,7 +140,7 @@ class Tester : public DeframerGTestBase {
     bool m_garbage;
     Fw::ComPacket::ComPacketType m_uplink_com_type;
     // Initialize to empty list to appease valgrind
-    U8 m_uplink_data[(sizeof(FP_FRAME_TOKEN_TYPE) * 2) + sizeof(U32) + FW_COM_BUFFER_MAX_SIZE] = {};
+    U8 m_uplink_data[(sizeof(FP_FRAME_TOKEN_TYPE) * 2) + sizeof(U32) + FW_COM_BUFFER_MAX_SIZE] = {};*/
 };
 
 }  // end namespace Svc

--- a/Svc/Deframer/test/ut/TestMain.cpp
+++ b/Svc/Deframer/test/ut/TestMain.cpp
@@ -3,25 +3,35 @@
 // ----------------------------------------------------------------------
 
 #include "Tester.hpp"
+#include <Svc/FramingProtocol/DeframingProtocol.hpp>
 
-TEST(Deframer, test_incoming_frame_with_valid_size) {
+TEST(Deframer, TestMoreNeeded) {
     Svc::Tester tester;
-    tester.test_incoming_frame(4, 4);
+    tester.test_incoming_frame(Svc::DeframingProtocol::DEFRAMING_MORE_NEEDED);
 }
-
-TEST(Deframer, test_incoming_frame_with_invalid_size) {
+TEST(Deframer, TestSuccess) {
     Svc::Tester tester;
-    tester.test_incoming_frame(1024, 1023);
+    tester.test_incoming_frame(Svc::DeframingProtocol::DEFRAMING_STATUS_SUCCESS);
 }
-
-TEST(Deframer, test_route_packet_command) {
+TEST(Deframer, TestBadChecksum) {
     Svc::Tester tester;
-    tester.test_route(Fw::ComPacket::FW_PACKET_COMMAND);
+    tester.test_incoming_frame(Svc::DeframingProtocol::DEFRAMING_INVALID_CHECKSUM);
 }
-
-TEST(Deframer, test_route_packet_file) {
+TEST(Deframer, TestBadSize) {
     Svc::Tester tester;
-    tester.test_route(Fw::ComPacket::FW_PACKET_FILE);
+    tester.test_incoming_frame(Svc::DeframingProtocol::DEFRAMING_INVALID_CHECKSUM);
+}
+TEST(Deframer, TestComInterface) {
+    Svc::Tester tester;
+    tester.test_com_interface();
+}
+TEST(Deframer, TestBufferInterface) {
+    Svc::Tester tester;
+    tester.test_buffer_interface();
+}
+TEST(Deframer, TestUnknownInterface) {
+    Svc::Tester tester;
+    tester.test_unnknown_interface();
 }
 
 int main(int argc, char **argv) {

--- a/Svc/Deframer/test/ut/TestMain.cpp
+++ b/Svc/Deframer/test/ut/TestMain.cpp
@@ -31,7 +31,7 @@ TEST(Deframer, TestBufferInterface) {
 }
 TEST(Deframer, TestUnknownInterface) {
     Svc::Tester tester;
-    tester.test_unnknown_interface();
+    tester.test_unknown_interface();
 }
 
 int main(int argc, char **argv) {

--- a/Svc/Deframer/test/ut/Tester.cpp
+++ b/Svc/Deframer/test/ut/Tester.cpp
@@ -20,7 +20,7 @@ namespace Svc {
 // ----------------------------------------------------------------------
 // Construction and destruction
 // ----------------------------------------------------------------------
-Tester::MockDeframer::MockDeframer(Tester& parent) : m_parent(parent), m_status(DeframingProtocol::DEFRAMING_STATUS_SUCCESS) {}
+Tester::MockDeframer::MockDeframer(Tester& parent) : m_status(DeframingProtocol::DEFRAMING_STATUS_SUCCESS) {}
 
 Tester::MockDeframer::DeframingStatus Tester::MockDeframer::deframe(Types::CircularBuffer& ring_buffer, U32& needed) {
     needed = ring_buffer.get_remaining_size();

--- a/Svc/Deframer/test/ut/Tester.cpp
+++ b/Svc/Deframer/test/ut/Tester.cpp
@@ -30,7 +30,7 @@ Tester::MockDeframer::DeframingStatus Tester::MockDeframer::deframe(Types::Circu
     return m_status;
 }
 
-void Tester::MockDeframer::test_iterface(Fw::ComPacket::ComPacketType com_packet_type) {
+void Tester::MockDeframer::test_interface(Fw::ComPacket::ComPacketType com_packet_type) {
     U8 chars[4];
     m_interface->allocate(3042);
     Fw::Buffer buffer(chars, sizeof(chars));
@@ -73,7 +73,7 @@ void Tester ::test_incoming_frame(Tester::MockDeframer::DeframingStatus status) 
 }
 
 void Tester ::test_com_interface() {
-    m_mock.test_iterface(Fw::ComPacket::FW_PACKET_COMMAND);
+    m_mock.test_interface(Fw::ComPacket::FW_PACKET_COMMAND);
     ASSERT_from_comOut_SIZE(1);
     ASSERT_from_bufferAllocate(0, 3042);
     ASSERT_from_bufferOut_SIZE(0);
@@ -81,15 +81,15 @@ void Tester ::test_com_interface() {
 }
 
 void Tester ::test_buffer_interface() {
-    m_mock.test_iterface(Fw::ComPacket::FW_PACKET_FILE);
+    m_mock.test_interface(Fw::ComPacket::FW_PACKET_FILE);
     ASSERT_from_comOut_SIZE(0);
     ASSERT_from_bufferAllocate(0, 3042);
     ASSERT_from_bufferOut_SIZE(1);
     ASSERT_from_bufferDeallocate_SIZE(0);
 }
 
-void Tester ::test_unnknown_interface() {
-    m_mock.test_iterface(Fw::ComPacket::FW_PACKET_UNKNOWN);
+void Tester ::test_unknown_interface() {
+    m_mock.test_interface(Fw::ComPacket::FW_PACKET_UNKNOWN);
     ASSERT_from_comOut_SIZE(0);
     ASSERT_from_bufferAllocate(0, 3042);
     ASSERT_from_bufferOut_SIZE(0);

--- a/Svc/Deframer/test/ut/Tester.hpp
+++ b/Svc/Deframer/test/ut/Tester.hpp
@@ -26,7 +26,7 @@ class Tester : public DeframerGTestBase {
       public:
         MockDeframer(Tester& parent);
         DeframingStatus deframe(Types::CircularBuffer& ring_buffer, U32& needed);
-        void test_iterface(Fw::ComPacket::ComPacketType  com_type);
+        void test_interface(Fw::ComPacket::ComPacketType  com_type);
 
         DeframingStatus m_status;
         Tester& m_parent;
@@ -49,7 +49,7 @@ class Tester : public DeframerGTestBase {
     void test_incoming_frame(DeframingProtocol::DeframingStatus status);
     void test_com_interface();
     void test_buffer_interface();
-    void test_unnknown_interface();
+    void test_unknown_interface();
 
   private:
     // ----------------------------------------------------------------------

--- a/Svc/Deframer/test/ut/Tester.hpp
+++ b/Svc/Deframer/test/ut/Tester.hpp
@@ -18,117 +18,102 @@
 
 namespace Svc {
 
-  class Tester :
-    public DeframerGTestBase
-  {
-      // ----------------------------------------------------------------------
-      // Construction and destruction
-      // ----------------------------------------------------------------------
-      class MockDeframer : public DeframingProtocol {
-        public:
-          MockDeframer(Tester& parent);
-          DeframingStatus deframe(Types::CircularBuffer& ring_buffer, U32& needed);
-          Tester& m_parent;
-      };
+class Tester : public DeframerGTestBase {
+    // ----------------------------------------------------------------------
+    // Construction and destruction
+    // ----------------------------------------------------------------------
+    class MockDeframer : public DeframingProtocol {
+      public:
+        MockDeframer(Tester& parent);
+        DeframingStatus deframe(Types::CircularBuffer& ring_buffer, U32& needed);
+        void test_iterface(Fw::ComPacket::ComPacketType  com_type);
 
-    public:
+        DeframingStatus m_status;
+        Tester& m_parent;
+    };
 
-      //! Construct object Tester
-      //!
-      Tester(void);
+  public:
+    //! Construct object Tester
+    //!
+    Tester(void);
 
-      //! Destroy object Tester
-      //!
-      ~Tester(void);
+    //! Destroy object Tester
+    //!
+    ~Tester(void);
 
-    public:
+  public:
+    // ----------------------------------------------------------------------
+    // Tests
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Tests
-      // ----------------------------------------------------------------------
+    void test_incoming_frame(DeframingProtocol::DeframingStatus status);
+    void test_com_interface();
+    void test_buffer_interface();
+    void test_unnknown_interface();
 
-      void test_incoming_frame(U32 buffer_size, U32 expected_size);
-      void test_route(Fw::ComPacket::ComPacketType packet_type);
-    private:
+  private:
+    // ----------------------------------------------------------------------
+    // Handlers for typed from ports
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Handlers for typed from ports
-      // ----------------------------------------------------------------------
+    //! Handler for from_comOut
+    //!
+    void from_comOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                             Fw::ComBuffer& data,           /*!< Buffer containing packet data*/
+                             U32 context                    /*!< Call context value; meaning chosen by user*/
+    );
 
-      //! Handler for from_comOut
-      //!
-      void from_comOut_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          Fw::ComBuffer &data, /*!< Buffer containing packet data*/
-          U32 context /*!< Call context value; meaning chosen by user*/
-      );
+    //! Handler for from_bufferOut
+    //!
+    void from_bufferOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                                Fw::Buffer& fwBuffer);
 
-      //! Handler for from_bufferOut
-      //!
-      void from_bufferOut_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          Fw::Buffer &fwBuffer 
-      );
+    //! Handler for from_bufferAllocate
+    //!
+    Fw::Buffer from_bufferAllocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                                           U32 size);
 
-      //! Handler for from_bufferAllocate
-      //!
-      Fw::Buffer from_bufferAllocate_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          U32 size 
-      );
+    //! Handler for from_bufferDeallocate
+    //!
+    void from_bufferDeallocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                                       Fw::Buffer& fwBuffer);
 
-      //! Handler for from_bufferDeallocate
-      //!
-      void from_bufferDeallocate_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          Fw::Buffer &fwBuffer 
-      );
+    //! Handler for from_framedDeallocate
+    //!
+    void from_framedDeallocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                                       Fw::Buffer& fwBuffer);
 
-      //! Handler for from_framedDeallocate
-      //!
-      void from_framedDeallocate_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          Fw::Buffer &fwBuffer 
-      );
+    //! Handler for from_framedPoll
+    //!
+    Drv::PollStatus from_framedPoll_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                                            Fw::Buffer& pollBuffer);
 
-      //! Handler for from_framedPoll
-      //!
-      Drv::PollStatus from_framedPoll_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          Fw::Buffer &pollBuffer 
-      );
+  private:
+    // ----------------------------------------------------------------------
+    // Helper methods
+    // ----------------------------------------------------------------------
 
-    private:
+    //! Connect ports
+    //!
+    void connectPorts(void);
 
-      // ----------------------------------------------------------------------
-      // Helper methods
-      // ----------------------------------------------------------------------
+    //! Initialize components
+    //!
+    void initComponents(void);
 
-      //! Connect ports
-      //!
-      void connectPorts(void);
+  private:
+    // ----------------------------------------------------------------------
+    // Variables
+    // ----------------------------------------------------------------------
 
-      //! Initialize components
-      //!
-      void initComponents(void);
+    //! The component under test
+    //!
+    DeframerComponentImpl component;
 
-    private:
+    Fw::Buffer m_buffer;
+    MockDeframer m_mock;
+};
 
-      // ----------------------------------------------------------------------
-      // Variables
-      // ----------------------------------------------------------------------
-
-      //! The component under test
-      //!
-      DeframerComponentImpl component;
-
-      Fw::Buffer m_buffer;
-      MockDeframer m_mock;
-      DeframingProtocol::DeframingStatus m_status;
-      U32 m_remaining_size;
-      bool m_has_port_out;
-  };
-
-} // end namespace Svc
+}  // end namespace Svc
 
 #endif

--- a/Svc/Deframer/test/ut/Tester.hpp
+++ b/Svc/Deframer/test/ut/Tester.hpp
@@ -27,9 +27,7 @@ class Tester : public DeframerGTestBase {
         MockDeframer(Tester& parent);
         DeframingStatus deframe(Types::CircularBuffer& ring_buffer, U32& needed);
         void test_interface(Fw::ComPacket::ComPacketType  com_type);
-
         DeframingStatus m_status;
-        Tester& m_parent;
     };
 
   public:

--- a/Svc/GroundInterface/test/ut/DeframerRules.hpp
+++ b/Svc/GroundInterface/test/ut/DeframerRules.hpp
@@ -1,0 +1,77 @@
+/**
+ * GroundInterfaceRules.hpp:
+ *
+ * This file specifies Rule classes for testing of the Svc::GroundInterface. These rules can then be used by the main
+ * testing program to test the code. These rules support rule-based random testing.
+ *
+ * GroundInterface rules:
+ *
+ * 1. On read-callback of sufficient parts, an uplink-out is produced
+ * 2. On schedIn a sufficient number of times, an uplink-out is produced
+ * 3. On a call to Log, TextLog, downlink, a framed call to write is produced.
+ *
+ * @author mstarch
+ */
+#ifndef FPRIME_SVC_GROUND_INTERFACE_HPP
+#define FPRIME_SVC_GROUND_INTERFACE_HPP
+
+#include <Fw/Types/BasicTypes.hpp>
+#include <Fw/Types/EightyCharString.hpp>
+#include <Svc/GroundInterface/test/ut/Tester.hpp>
+#include <STest/STest/Rule/Rule.hpp>
+#include <STest/STest/Pick/Pick.hpp>
+
+
+namespace Svc {
+
+    /**
+     * RandomizeRule:
+     *
+     * This rule sets up random state
+     */
+    struct RandomizeRule : public STest::Rule<Tester> {
+        // Constructor
+        RandomizeRule(const Fw::EightyCharString& name);
+
+        // Always valid
+        bool precondition(const Tester& state);
+
+        // Will randomize the test state
+        void action(Tester& truth);
+    };
+
+    struct DownlinkRule : public STest::Rule<Tester> {
+        // Constructor
+        DownlinkRule(const Fw::EightyCharString& name);
+
+        // Always valid
+        bool precondition(const Tester& state);
+
+        // Will randomize the test state
+        void action(Tester& truth);
+    };
+
+    struct FileDownlinkRule : public STest::Rule<Tester> {
+        // Constructor
+        FileDownlinkRule(const Fw::EightyCharString& name);
+
+        // Always valid
+        bool precondition(const Tester& state);
+
+        // Will randomize the test state
+        void action(Tester& truth);
+    };
+
+    struct SendAvailableRule : public STest::Rule<Tester> {
+        // Constructor
+        SendAvailableRule(const Fw::EightyCharString& name);
+
+        // Always valid
+        bool precondition(const Tester& state);
+
+        // Will randomize the test state
+        void action(Tester& truth);
+    };
+
+};
+#endif //FPRIME_SVC_GROUND_INTERFACE_HPP


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Fixes a known bug in the deframer where packets aggregated into a single receive call will not all unpack when the size of each packet decreases from the previous.

Fixed UTs to work with this fix, and put in a randomized test for framer + fprime protocol.