### PR TITLE
Os: Convert C style casts to C++ style casts

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -542,8 +542,8 @@ formatline
 foundin
 fpconfighpp
 FPGA
-FPL
 fpl
+FPL
 FPL
 fpp
 fppi
@@ -1010,8 +1010,8 @@ ncsl
 NDELAY
 ndiffs
 netdb
-Netscape's
 Netscape
+Netscape's
 newloc
 newroot
 newself
@@ -1069,8 +1069,8 @@ odo
 oflag
 okidocki
 oldeol
-OMG's
 OMG
+OMG's
 onchange
 onlinepubs
 OParg
@@ -1329,8 +1329,8 @@ saveop
 saxutils
 sbb
 SBF
-sbt
 sbin
+sbt
 sched
 schem
 schematron
@@ -1649,8 +1649,8 @@ tt
 ttype
 Tuszynski
 TXD
-typedef'ed
 typedef
+typedef'ed
 typeid
 typeinfo
 typelist
@@ -1798,3 +1798,4 @@ yacgen
 yml
 yyyymmdd
 zsh
+zu

--- a/Os/Baremetal/Queue.cpp
+++ b/Os/Baremetal/Queue.cpp
@@ -114,7 +114,7 @@ Queue::QueueStatus Queue::send(const U8* buffer, NATIVE_INT_TYPE size, NATIVE_IN
         return QUEUE_EMPTY_BUFFER;
     }
     //Fail if there is a size miss-match
-    if (size < 0 || (NATIVE_UINT_TYPE) size > queue.getMsgSize()) {
+    if (size < 0 || static_cast<NATIVE_UINT_TYPE>(size) > queue.getMsgSize()) {
         return QUEUE_SIZE_MISMATCH;
     }
     //Send to the queue
@@ -128,19 +128,19 @@ Queue::QueueStatus Queue::send(const U8* buffer, NATIVE_INT_TYPE size, NATIVE_IN
 Queue::QueueStatus bareReceiveNonBlock(BareQueueHandle& handle, U8* buffer, NATIVE_INT_TYPE capacity, NATIVE_INT_TYPE &actualSize, NATIVE_INT_TYPE &priority) {
     FW_ASSERT(handle.m_init);
     BufferQueue& queue = handle.m_queue;
-    NATIVE_UINT_TYPE size = capacity;
+    NATIVE_UINT_TYPE size = static_cast<NATIVE_UINT_TYPE>(capacity);
     NATIVE_INT_TYPE pri = 0;
     Queue::QueueStatus status = Queue::QUEUE_OK;
     // Get an item off of the queue:
     bool success = queue.pop(buffer, size, pri);
     if(success) {
         // Pop worked - set the return size and priority:
-        actualSize = (NATIVE_INT_TYPE) size;
+        actualSize = static_cast<NATIVE_INT_TYPE>(size);
         priority = pri;
     }
     else {
         actualSize = 0;
-        if( size > (NATIVE_UINT_TYPE) capacity ) {
+        if( size > static_cast<NATIVE_UINT_TYPE>(capacity) ) {
             // The buffer capacity was too small!
             status = Queue::QUEUE_SIZE_MISMATCH;
         }
@@ -159,7 +159,7 @@ Queue::QueueStatus bareReceiveNonBlock(BareQueueHandle& handle, U8* buffer, NATI
 Queue::QueueStatus bareReceiveBlock(BareQueueHandle& handle, U8* buffer, NATIVE_INT_TYPE capacity, NATIVE_INT_TYPE &actualSize, NATIVE_INT_TYPE &priority) {
     FW_ASSERT(handle.m_init);
     BufferQueue& queue = handle.m_queue;
-    NATIVE_UINT_TYPE size = capacity;
+    NATIVE_UINT_TYPE size = static_cast<NATIVE_UINT_TYPE>(capacity);
     NATIVE_INT_TYPE pri = 0;
     Queue::QueueStatus status = Queue::QUEUE_OK;
     // If the queue is full, wait until a message is taken off the queue.
@@ -171,12 +171,12 @@ Queue::QueueStatus bareReceiveBlock(BareQueueHandle& handle, U8* buffer, NATIVE_
     bool success = queue.pop(buffer, size, pri);
     if(success) {
         // Pop worked - set the return size and priority:
-        actualSize = (NATIVE_INT_TYPE) size;
+        actualSize = static_cast<NATIVE_INT_TYPE>(size);
         priority = pri;
     }
     else {
         actualSize = 0;
-        if( size > (NATIVE_UINT_TYPE) capacity ) {
+        if( size > (static_cast<NATIVE_UINT_TYPE>(capacity) ) {
             // The buffer capacity was too small!
             status = Queue::QUEUE_SIZE_MISMATCH;
         }

--- a/Os/FileSystem.hpp
+++ b/Os/FileSystem.hpp
@@ -5,7 +5,7 @@
 #include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Types/String.hpp>
 
-#define FILE_SYSTEM_CHUNK_SIZE (256)
+#define FILE_SYSTEM_CHUNK_SIZE (256u)
 
 namespace Os {
 

--- a/Os/Linux/File.cpp
+++ b/Os/Linux/File.cpp
@@ -74,7 +74,7 @@ namespace Os {
                 flags = O_WRONLY | O_CREAT | O_APPEND;
                 break;
             default:
-                FW_ASSERT(0,(NATIVE_INT_TYPE)mode);
+                FW_ASSERT(0, mode);
                 break;
         }
 
@@ -226,9 +226,9 @@ namespace Os {
                         break; // break out of while loop
                     } else {
                         // in order to move the pointer ahead, we need to cast it
-                        U8* charPtr = (U8*)buffer;
+                        U8* charPtr = static_cast<U8*>(buffer);
                         charPtr = &charPtr[readSize];
-                        buffer = (void*)charPtr;
+                        buffer = static_cast<void*>(charPtr);
                     }
                     maxIters--; // decrement loop count
                 }
@@ -285,8 +285,8 @@ namespace Os {
                         stat = NO_SPACE;
                         break;
                     default:
-                        DEBUG_PRINT("Error %d during write of 0x0%llx, addrMod %d, size %d, sizeMod %d\n",
-                                    errno, (U64) buffer, ((U64) buffer) % 512, size, size % 512);
+                        DEBUG_PRINT("Error %d during write of 0x%p, addrMod %d, size %d, sizeMod %d\n",
+                                    errno, buffer, static_cast<POINTER_CAST>(buffer) % 512, size, size % 512);
                         stat = OTHER_ERROR;
                         break;
                 }
@@ -346,7 +346,7 @@ namespace Os {
             }
             const NATIVE_INT_TYPE toWrite = size;
             FW_ASSERT(idx + size <= totalSize, idx + size);
-            const Os::File::Status fileStatus = this->write((U8*) buffer + idx, size, false);
+            const Os::File::Status fileStatus = this->write(static_cast<const U8*>(buffer) + idx, size, false);
             if (!(fileStatus == Os::File::OP_OK
                   && size == static_cast<NATIVE_INT_TYPE>(toWrite))) {
                 totalSize = newBytesWritten;

--- a/Os/Linux/FileSystem.cpp
+++ b/Os/Linux/FileSystem.cpp
@@ -336,7 +336,7 @@ namespace Os {
 			File::Status file_status;
 
 			// Set loop limit
-			const U64 copyLoopLimit = (((U64)size/FILE_SYSTEM_CHUNK_SIZE)) + 2;
+			const U64 copyLoopLimit = (size/FILE_SYSTEM_CHUNK_SIZE) + 2;
 
 			U64 loopCounter = 0;
 			NATIVE_INT_TYPE chunkSize;
@@ -515,8 +515,8 @@ namespace Os {
 				return stat;
 			}
 
-			totalBytes = (U64) fsStat.f_blocks * (U64) fsStat.f_frsize;
-			freeBytes = (U64) fsStat.f_bfree * (U64) fsStat.f_frsize;
+			totalBytes = static_cast<U64>(fsStat.f_blocks) * static_cast<U64>(fsStat.f_frsize);
+			freeBytes = static_cast<U64>(fsStat.f_bfree) * static_cast<U64>(fsStat.f_frsize);
 			return stat;
 		}
 
@@ -526,7 +526,7 @@ namespace Os {
 			DIR * dirPtr = NULL;
 			struct dirent *direntData = NULL;
 			U32 limitCount;
-			const U64 loopLimit = ((((U64) 1) << 32)-1); // Max value of U32
+			const U64 loopLimit = std::numeric_limits<U32>::max();
 
 			fileCount = 0;
 			if((dirPtr = ::opendir(directory)) == NULL) {

--- a/Os/MacOs/IPCQueueStub.cpp
+++ b/Os/MacOs/IPCQueueStub.cpp
@@ -55,7 +55,7 @@ namespace Os {
   }
 
   Queue::QueueStatus IPCQueue::create(const Fw::StringBase &name, NATIVE_INT_TYPE depth, NATIVE_INT_TYPE msgSize) {
-    QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+    QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
 
     // Queue has already been created... remove it and try again:
     if (NULL != queueHandle) {
@@ -71,7 +71,7 @@ namespace Os {
     if( !queueHandle->create(depth, msgSize) ) {
       return QUEUE_UNINITIALIZED;
     }
-    this->m_handle = (POINTER_CAST) queueHandle;
+    this->m_handle = reinterpret_cast<POINTER_CAST>(queueHandle);
 
 #if FW_QUEUE_REGISTRATION
     if (this->s_queueRegistry) {
@@ -84,11 +84,11 @@ namespace Os {
 
   IPCQueue::~IPCQueue() {
     // Clean up the queue handle:
-    QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+    QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
     if (NULL != queueHandle) {
       delete queueHandle;
     }
-    this->m_handle = (POINTER_CAST) NULL;
+    this->m_handle = static_cast<POINTER_CAST>(NULL);
   }
 
   Queue::QueueStatus sendNonBlockIPCStub(QueueHandle* queueHandle, const U8* buffer, NATIVE_INT_TYPE size, NATIVE_INT_TYPE priority) {
@@ -176,7 +176,7 @@ namespace Os {
 
   Queue::QueueStatus IPCQueue::send(const U8* buffer, NATIVE_INT_TYPE size, NATIVE_INT_TYPE priority, QueueBlocking block) {
     (void) block; // Always non-blocking for now
-    QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+    QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
     BufferQueue* queue = &queueHandle->queue;
 
     if (NULL == queueHandle) {
@@ -187,7 +187,7 @@ namespace Os {
         return QUEUE_EMPTY_BUFFER;
     }
 
-    if (size < 0 || (NATIVE_UINT_TYPE) size > queue->getMsgSize()) {
+    if (size < 0 || static_cast<NATIVE_UINT_TYPE>(size) > queue->getMsgSize()) {
         return QUEUE_SIZE_MISMATCH;
     }
 
@@ -205,7 +205,7 @@ namespace Os {
       pthread_cond_t* queueNotFull = &queueHandle->queueNotFull;
       NATIVE_INT_TYPE ret;
 
-      NATIVE_UINT_TYPE size = capacity;
+      NATIVE_UINT_TYPE size = static_cast<NATIVE_UINT_TYPE>(capacity);
       NATIVE_INT_TYPE pri = 0;
       Queue::QueueStatus status = Queue::QUEUE_OK;
 
@@ -221,7 +221,7 @@ namespace Os {
 
       if(popSucceeded) {
         // Pop worked - set the return size and priority:
-        actualSize = (NATIVE_INT_TYPE) size;
+        actualSize = static_cast<NATIVE_INT_TYPE>(size);
         priority = pri;
 
         // Pop worked - wake up a thread that might be waiting on
@@ -231,7 +231,7 @@ namespace Os {
       }
       else {
         actualSize = 0;
-        if( size > (NATIVE_UINT_TYPE) capacity ) {
+        if( size > static_cast<NATIVE_UINT_TYPE>(capacity) ) {
           // The buffer capacity was too small!
           status = Queue::QUEUE_SIZE_MISMATCH;
         }
@@ -284,7 +284,7 @@ namespace Os {
 
       if(popSucceeded) {
         // Pop worked - set the return size and priority:
-        actualSize = (NATIVE_INT_TYPE) size;
+        actualSize = static_cast<NATIVE_INT_TYPE>(size);
         priority = pri;
 
         // Pop worked - wake up a thread that might be waiting on
@@ -294,7 +294,7 @@ namespace Os {
       }
       else {
         actualSize = 0;
-        if( size > (NATIVE_UINT_TYPE) capacity ) {
+        if( size > static_cast<NATIVE_UINT_TYPE>(capacity) ) {
           // The buffer capacity was too small!
           status = Queue::QUEUE_SIZE_MISMATCH;
         }
@@ -317,11 +317,11 @@ namespace Os {
 
   Queue::QueueStatus IPCQueue::receive(U8* buffer, NATIVE_INT_TYPE capacity, NATIVE_INT_TYPE &actualSize, NATIVE_INT_TYPE &priority, QueueBlocking block) {
 
-      if( (POINTER_CAST) NULL == this->m_handle ) {
+      if( static_cast<POINTER_CAST>(NULL) == this->m_handle ) {
         return QUEUE_UNINITIALIZED;
       }
 
-      QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+      QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
 
       if (NULL == queueHandle) {
         return QUEUE_UNINITIALIZED;
@@ -341,7 +341,7 @@ namespace Os {
   }
 
   NATIVE_INT_TYPE IPCQueue::getNumMsgs() const {
-      QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+      QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
       if (NULL == queueHandle) {
           return 0;
       }
@@ -350,7 +350,7 @@ namespace Os {
   }
 
   NATIVE_INT_TYPE IPCQueue::getMaxMsgs() const {
-      QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+      QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
       if (NULL == queueHandle) {
           return 0;
       }
@@ -359,7 +359,7 @@ namespace Os {
   }
 
   NATIVE_INT_TYPE IPCQueue::getQueueSize() const {
-      QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+      QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
       if (NULL == queueHandle) {
           return 0;
       }
@@ -368,7 +368,7 @@ namespace Os {
   }
 
   NATIVE_INT_TYPE IPCQueue::getMsgSize() const {
-      QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+      QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
       if (NULL == queueHandle) {
           return 0;
       }

--- a/Os/Posix/IPCQueue.cpp
+++ b/Os/Posix/IPCQueue.cpp
@@ -68,7 +68,7 @@ namespace Os {
         handle = mq_open(this->m_name.toChar(), O_RDWR | O_CREAT | O_EXCL, 0666, &att);
 
         // If queue already exists, then unlink it and try again.
-        if (-1 == (NATIVE_INT_TYPE) handle) {
+        if (-1 ==  handle) {
             switch (errno) {
                 case EEXIST:
                     (void)mq_unlink(this->m_name.toChar());
@@ -79,7 +79,7 @@ namespace Os {
 
             handle = mq_open(this->m_name.toChar(), O_RDWR | O_CREAT | O_EXCL, 0666, &att);
 
-            if (-1 == (NATIVE_INT_TYPE) handle) {
+            if (-1 == handle) {
                 return QUEUE_UNINITIALIZED;
             }
         }
@@ -89,7 +89,7 @@ namespace Os {
         if (NULL == queueHandle) {
           return QUEUE_UNINITIALIZED;
         }
-        this->m_handle = (POINTER_CAST) queueHandle;
+        this->m_handle = reinterpret_cast<POINTER_CAST>(queueHandle);
 
         Queue::s_numQueues++;
 
@@ -98,17 +98,17 @@ namespace Os {
 
     IPCQueue::~IPCQueue() {
         // Clean up the queue handle:
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         if (NULL != queueHandle) {
           delete queueHandle;
         }
-        this->m_handle = (POINTER_CAST) NULL; // important so base Queue class doesn't free it
+        this->m_handle = static_cast<POINTER_CAST>(NULL); // important so base Queue class doesn't free it
         (void) mq_unlink(this->m_name.toChar());
     }
 
     Queue::QueueStatus IPCQueue::send(const U8* buffer, NATIVE_INT_TYPE size, NATIVE_INT_TYPE priority, QueueBlocking block) {
 
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         mqd_t handle = queueHandle->handle;
 
         if (-1 == handle) {
@@ -130,7 +130,7 @@ namespace Os {
             if (block == QUEUE_BLOCKING) {
                 wait.tv_sec += IPC_QUEUE_TIMEOUT_SEC;
             }
-            NATIVE_INT_TYPE stat = mq_timedsend(handle, (const char*) buffer, size, priority, &wait);
+            NATIVE_INT_TYPE stat = mq_timedsend(handle, reinterpret_cast<const char*>(buffer), size, priority, &wait);
             if (-1 == stat) {
                 switch (errno) {
                     case EINTR:
@@ -164,7 +164,7 @@ namespace Os {
 
     Queue::QueueStatus IPCQueue::receive(U8* buffer, NATIVE_INT_TYPE capacity, NATIVE_INT_TYPE &actualSize, NATIVE_INT_TYPE &priority, QueueBlocking block) {
 
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         mqd_t handle = queueHandle->handle;
 
         if (-1 == handle) {
@@ -183,11 +183,11 @@ namespace Os {
             if (block == QUEUE_BLOCKING) {
                 wait.tv_sec += IPC_QUEUE_TIMEOUT_SEC;
             }
-            size = mq_timedreceive(handle, (char*) buffer, (size_t) capacity,
+            size = mq_timedreceive(handle, reinterpret_cast<char*>(buffer), static_cast<size_t>(capacity),
 #ifdef TGT_OS_TYPE_VXWORKS
-                        (int*)&priority, &wait);
+                        reinterpret_cast<int*>(&priority), &wait);
 #else
-                        (unsigned int*) &priority, &wait);
+                        reinterpret_cast<unsigned int*>(&priority), &wait);
 #endif
 
             if (-1 == size) { // error
@@ -218,18 +218,18 @@ namespace Os {
             }
         }
 
-        actualSize = (NATIVE_INT_TYPE) size;
+        actualSize = static_cast<NATIVE_INT_TYPE>(size);
         return QUEUE_OK;
     }
 
     NATIVE_INT_TYPE IPCQueue::getNumMsgs() const {
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         mqd_t handle = queueHandle->handle;
 
         struct mq_attr attr;
         int status = mq_getattr(handle, &attr);
         FW_ASSERT(status == 0);
-        return (U32) attr.mq_curmsgs;
+        return static_cast<U32>(attr.mq_curmsgs);
     }
 
     NATIVE_INT_TYPE IPCQueue::getMaxMsgs() const {
@@ -238,23 +238,23 @@ namespace Os {
     }
 
     NATIVE_INT_TYPE IPCQueue::getQueueSize() const {
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         mqd_t handle = queueHandle->handle;
 
         struct mq_attr attr;
         int status = mq_getattr(handle, &attr);
         FW_ASSERT(status == 0);
-        return (U32) attr.mq_maxmsg;
+        return static_cast<U32>(attr.mq_maxmsg);
     }
 
     NATIVE_INT_TYPE IPCQueue::getMsgSize() const {
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         mqd_t handle = queueHandle->handle;
 
         struct mq_attr attr;
         int status = mq_getattr(handle, &attr);
         FW_ASSERT(status == 0);
-        return (U32) attr.mq_msgsize;
+        return static_cast<U32>(attr.mq_msgsize);
     }
 
 }

--- a/Os/Posix/Mutex.cpp
+++ b/Os/Posix/Mutex.cpp
@@ -29,22 +29,22 @@ namespace Os {
         stat = pthread_mutex_init(handle,&attr);
         FW_ASSERT(stat == 0,stat);
 
-        this->m_handle = (POINTER_CAST) handle;
+        this->m_handle = reinterpret_cast<POINTER_CAST>(handle);
     }
 
     Mutex::~Mutex() {
-        NATIVE_INT_TYPE stat = pthread_mutex_destroy((pthread_mutex_t*)this->m_handle);
+        NATIVE_INT_TYPE stat = pthread_mutex_destroy(reinterpret_cast<pthread_mutex_t*>(this->m_handle));
         FW_ASSERT(stat == 0,stat);
-        delete (pthread_mutex_t*)this->m_handle;
+        delete reinterpret_cast<pthread_mutex_t*>(this->m_handle);
     }
 
     void Mutex::lock() {
-        NATIVE_INT_TYPE stat = pthread_mutex_lock((pthread_mutex_t*)this->m_handle);
+        NATIVE_INT_TYPE stat = pthread_mutex_lock(reinterpret_cast<pthread_mutex_t*>(this->m_handle));
         FW_ASSERT(stat == 0,stat);
     }
 
     void Mutex::unLock() {
-        NATIVE_INT_TYPE stat = pthread_mutex_unlock((pthread_mutex_t*)this->m_handle);
+        NATIVE_INT_TYPE stat = pthread_mutex_unlock(reinterpret_cast<pthread_mutex_t*>(this->m_handle));
         FW_ASSERT(stat == 0,stat);
     }
 

--- a/Os/Posix/Queue.cpp
+++ b/Os/Posix/Queue.cpp
@@ -74,7 +74,7 @@ namespace Os {
         handle = mq_open(this->m_name.toChar(), O_RDWR | O_CREAT | O_EXCL | O_NONBLOCK, 0666, &att);
 
         // If queue already exists, then unlink it and try again.
-        if (-1 == (NATIVE_INT_TYPE) handle) {
+        if (-1 == handle) {
         	switch (errno) {
         	case EEXIST:
         		(void)mq_unlink(this->m_name.toChar());
@@ -85,7 +85,7 @@ namespace Os {
 
         	handle = mq_open(this->m_name.toChar(), O_RDWR | O_CREAT | O_EXCL, 0666, &att);
 
-            if (-1 == (NATIVE_INT_TYPE) handle) {
+            if (-1 == handle) {
                 return QUEUE_UNINITIALIZED;
             }
         }
@@ -95,7 +95,7 @@ namespace Os {
         if (NULL == queueHandle) {
           return QUEUE_UNINITIALIZED;
         }
-        this->m_handle = (POINTER_CAST) queueHandle;
+        this->m_handle = reinterpret_cast<POINTER_CAST>(queueHandle);
 
         Queue::s_numQueues++;
 
@@ -103,14 +103,14 @@ namespace Os {
     }
 
     Queue::~Queue() {
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         delete queueHandle;
         (void) mq_unlink(this->m_name.toChar());
     }
 
     Queue::QueueStatus Queue::send(const U8* buffer, NATIVE_INT_TYPE size, NATIVE_INT_TYPE priority, QueueBlocking block) {
 
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         mqd_t handle = queueHandle->handle;
         pthread_cond_t* queueNotEmpty = &queueHandle->queueNotEmpty;
         pthread_cond_t* queueNotFull = &queueHandle->queueNotFull;
@@ -127,7 +127,7 @@ namespace Os {
         bool keepTrying = true;
         int ret;
         while (keepTrying) {
-            NATIVE_INT_TYPE stat = mq_send(handle, (const char*) buffer, size, priority);
+            NATIVE_INT_TYPE stat = mq_send(handle, reinterpret_cast<const char*>(buffer), size, priority);
             if (-1 == stat) {
                 switch (errno) {
                     case EINTR:
@@ -169,7 +169,7 @@ namespace Os {
 
     Queue::QueueStatus Queue::receive(U8* buffer, NATIVE_INT_TYPE capacity, NATIVE_INT_TYPE &actualSize, NATIVE_INT_TYPE &priority, QueueBlocking block) {
 
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         mqd_t handle = queueHandle->handle;
         pthread_cond_t* queueNotEmpty = &queueHandle->queueNotEmpty;
         pthread_cond_t* queueNotFull = &queueHandle->queueNotFull;
@@ -183,11 +183,11 @@ namespace Os {
         int ret;
         bool notFinished = true;
         while (notFinished) {
-            size = mq_receive(handle, (char*) buffer, (size_t) capacity,
+            size = mq_receive(handle, static_cast<char*>(buffer), static_cast<size_t>(capacity),
 #ifdef TGT_OS_TYPE_VXWORKS
-                        (int*)&priority);
+                        reinterpret_cast<int*>(&priority));
 #else
-                        (unsigned int*) &priority);
+                        reinterpret_cast<unsigned int*>(&priority));
 #endif
 
             if (-1 == size) { // error
@@ -226,18 +226,18 @@ namespace Os {
             }
         }
 
-        actualSize = (NATIVE_INT_TYPE) size;
+        actualSize = static_cast<NATIVE_INT_TYPE>(size);
         return QUEUE_OK;
     }
 
     NATIVE_INT_TYPE Queue::getNumMsgs() const {
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         mqd_t handle = queueHandle->handle;
 
         struct mq_attr attr;
         int status = mq_getattr(handle, &attr);
         FW_ASSERT(status == 0);
-        return (U32) attr.mq_curmsgs;
+        return static_cast<U32>(attr.mq_curmsgs);
     }
 
     NATIVE_INT_TYPE Queue::getMaxMsgs() const {
@@ -246,23 +246,23 @@ namespace Os {
     }
 
     NATIVE_INT_TYPE Queue::getQueueSize() const {
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         mqd_t handle = queueHandle->handle;
 
         struct mq_attr attr;
         int status = mq_getattr(handle, &attr);
         FW_ASSERT(status == 0);
-        return (U32) attr.mq_maxmsg;
+        return static_cast<U32>(attr.mq_maxmsg);
     }
 
     NATIVE_INT_TYPE Queue::getMsgSize() const {
-        QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+        QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
         mqd_t handle = queueHandle->handle;
 
         struct mq_attr attr;
         int status = mq_getattr(handle, &attr);
         FW_ASSERT(status == 0);
-        return (U32) attr.mq_msgsize;
+        return static_cast<U32>(attr.mq_msgsize);
     }
 
 }

--- a/Os/Posix/Task.cpp
+++ b/Os/Posix/Task.cpp
@@ -64,7 +64,7 @@ namespace Os {
         if (stat != 0) {
         	return TASK_INVALID_PARAMS;
         }
-        stat = pthread_attr_setname(&att,(char*)this->m_name.toChar());
+        stat = pthread_attr_setname(&att,this->m_name.toChar());
         if (stat != 0) {
         	return TASK_INVALID_PARAMS;
         }
@@ -134,7 +134,7 @@ namespace Os {
 
         switch (stat) {
             case 0:
-                this->m_handle = (POINTER_CAST)tid;
+                this->m_handle = reinterpret_cast<POINTER_CAST>(tid);
                 Task::s_numTasks++;
                 break;
             case EINVAL:
@@ -190,7 +190,7 @@ namespace Os {
 
     Task::~Task() {
     	if (this->m_handle) {
-    		delete (pthread_t*)this->m_handle;
+    		delete reinterpret_cast<pthread_t*>(this->m_handle);
     	}
         // If a registry has been registered, remove task
         if (Task::s_taskRegistry) {
@@ -225,7 +225,7 @@ namespace Os {
         if (!(this->m_handle)) {
             return TASK_JOIN_ERROR;
         }
-        stat = pthread_join(*((pthread_t*) this->m_handle), value_ptr);
+        stat = pthread_join(*reinterpret_cast<pthread_t*>(this->m_handle), value_ptr);
 
         if (stat != 0) {
             return TASK_JOIN_ERROR;

--- a/Os/Posix/TaskRoot.cpp
+++ b/Os/Posix/TaskRoot.cpp
@@ -100,7 +100,7 @@ namespace Os {
 
         switch (stat) {
             case 0:
-                this->m_handle = (POINTER_CAST)tid;
+                this->m_handle = reinterpret_cast<POINTER_CAST>(tid);
                 Task::s_numTasks++;
                 break;
             case EINVAL:
@@ -116,7 +116,7 @@ namespace Os {
 
         if (tStat == TASK_OK) {
 
-            stat = pthread_setname_np(*tid,(char*)this->m_name.toChar());
+            stat = pthread_setname_np(*tid,this->m_name.toChar());
             if (stat != 0) {
                 Fw::Logger::logMsg("pthread_setname_np: %s %s\n",this->m_name.toChar(),strerror(stat));
                 delete tid;

--- a/Os/Pthreads/BufferQueueCommon.cpp
+++ b/Os/Pthreads/BufferQueueCommon.cpp
@@ -1,7 +1,7 @@
 // ======================================================================
 // \title  BufferQueueCommon.hpp
 // \author dinkel
-// \brief  This file implements some of the methods for the generic 
+// \brief  This file implements some of the methods for the generic
 //         buffer queue data structure declared in BufferQueue.hpp that
 //         are common amongst different queue implementations.
 //
@@ -40,7 +40,7 @@ namespace Os {
     if (NULL != this->queue) {
       this->finalize();
     }
-    FW_ASSERT(NULL == this->queue, (POINTER_CAST) this->queue);
+    FW_ASSERT(NULL == this->queue, reinterpret_cast<POINTER_CAST>(this->queue));
 
     // Set member variables:
     this->msgSize = msgSize;
@@ -50,7 +50,7 @@ namespace Os {
 
   bool BufferQueue::push(const U8* buffer, NATIVE_UINT_TYPE size, NATIVE_INT_TYPE priority) {
 
-    FW_ASSERT(size <= this->msgSize);   
+    FW_ASSERT(size <= this->msgSize);
     if( this->isFull() ) {
       return false;
     }
@@ -68,7 +68,7 @@ namespace Os {
     }
     return true;
   }
- 
+
   bool BufferQueue::pop(U8* buffer, NATIVE_UINT_TYPE& size, NATIVE_INT_TYPE &priority) {
 
     if( this->isEmpty() ) {
@@ -81,17 +81,17 @@ namespace Os {
     if( !ret ) {
       return false;
     }
-    
+
     // Decrement count:
     --this->count;
 
     return true;
   }
- 
+
   bool BufferQueue::isFull() {
     return (this->count == this->depth);
   }
-  
+
   bool BufferQueue::isEmpty() {
     return (this->count == 0);
   }
@@ -105,12 +105,12 @@ namespace Os {
   }
 
 
-  NATIVE_UINT_TYPE BufferQueue::getMsgSize() { 
-    return this->msgSize; 
+  NATIVE_UINT_TYPE BufferQueue::getMsgSize() {
+    return this->msgSize;
   }
 
-  NATIVE_UINT_TYPE BufferQueue::getDepth() { 
-    return this->depth; 
+  NATIVE_UINT_TYPE BufferQueue::getDepth() {
+    return this->depth;
   }
 
   NATIVE_UINT_TYPE BufferQueue::getBufferIndex(NATIVE_INT_TYPE index) {

--- a/Os/Pthreads/MaxHeap/test/ut/MaxHeapTest.cpp
+++ b/Os/Pthreads/MaxHeap/test/ut/MaxHeapTest.cpp
@@ -58,9 +58,9 @@ int main() {
   for(NATIVE_INT_TYPE ii = DEPTH-1; ii >= 0; --ii) {
     ret = heap.pop(value, id);
     FW_ASSERT(ret, ret);
-    FW_ASSERT(id == (NATIVE_UINT_TYPE) ii, id, ii);
+    FW_ASSERT(id == static_cast<NATIVE_UINT_TYPE>(ii), id, ii);
     size = heap.getSize();
-    FW_ASSERT((NATIVE_INT_TYPE) size == ii, size, ii);
+    FW_ASSERT(size == static_cast<NATIVE_UINT_TYPE>(ii), size, ii);
     //printf("Heap state after pop:\n");
     //heap.print();
     //printf("Got value %d\n", value);
@@ -97,7 +97,7 @@ int main() {
   }
   ret = heap.push(values[0], id);
   FW_ASSERT(!ret, ret);
-  
+
   // Get values out from largest to smallest:
   for(NATIVE_UINT_TYPE ii = 0; ii < DEPTH; ++ii) {
     // Pop the top value:
@@ -137,7 +137,7 @@ int main() {
     size = heap.getSize();
     FW_ASSERT(size == ii+1, size, ii+1);
   }
-  
+
   // Get values out in FIFO order:
   for(NATIVE_UINT_TYPE ii = 0; ii < DEPTH; ++ii) {
     // Pop the top value:

--- a/Os/Pthreads/Queue.cpp
+++ b/Os/Pthreads/Queue.cpp
@@ -52,11 +52,11 @@ namespace Os {
   };
 
   Queue::Queue() :
-    m_handle((POINTER_CAST) NULL) {
+    m_handle(static_cast<POINTER_CAST>(NULL)) {
   }
 
   Queue::QueueStatus Queue::createInternal(const Fw::StringBase &name, NATIVE_INT_TYPE depth, NATIVE_INT_TYPE msgSize) {
-    QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+    QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
 
     // Queue has already been created... remove it and try again:
     if (NULL != queueHandle) {
@@ -72,7 +72,7 @@ namespace Os {
     if( !queueHandle->create(depth, msgSize) ) {
       return QUEUE_UNINITIALIZED;
     }
-    this->m_handle = (POINTER_CAST) queueHandle;
+    this->m_handle = reinterpret_cast<POINTER_CAST>(queueHandle);
 
 #if FW_QUEUE_REGISTRATION
     if (this->s_queueRegistry) {
@@ -85,11 +85,11 @@ namespace Os {
 
   Queue::~Queue() {
     // Clean up the queue handle:
-    QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+    QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
     if (NULL != queueHandle) {
       delete queueHandle;
     }
-    this->m_handle = (POINTER_CAST) NULL;
+    this->m_handle = static_cast<POINTER_CAST>(NULL);
   }
 
   Queue::QueueStatus sendNonBlock(QueueHandle* queueHandle, const U8* buffer, NATIVE_INT_TYPE size, NATIVE_INT_TYPE priority) {
@@ -177,7 +177,7 @@ namespace Os {
 
   Queue::QueueStatus Queue::send(const U8* buffer, NATIVE_INT_TYPE size, NATIVE_INT_TYPE priority, QueueBlocking block) {
     (void) block; // Always non-blocking for now
-    QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+    QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
     BufferQueue* queue = &queueHandle->queue;
 
     if (NULL == queueHandle) {
@@ -188,7 +188,7 @@ namespace Os {
         return QUEUE_EMPTY_BUFFER;
     }
 
-    if (size < 0 || (NATIVE_UINT_TYPE) size > queue->getMsgSize()) {
+    if (size < 0 || static_cast<NATIVE_UINT_TYPE>(size) > queue->getMsgSize()) {
         return QUEUE_SIZE_MISMATCH;
     }
 
@@ -206,7 +206,7 @@ namespace Os {
       pthread_cond_t* queueNotFull = &queueHandle->queueNotFull;
       NATIVE_INT_TYPE ret;
 
-      NATIVE_UINT_TYPE size = capacity;
+      NATIVE_UINT_TYPE size = static_cast<NATIVE_UINT_TYPE>(capacity);
       NATIVE_INT_TYPE pri = 0;
       Queue::QueueStatus status = Queue::QUEUE_OK;
 
@@ -222,7 +222,7 @@ namespace Os {
 
       if(popSucceeded) {
         // Pop worked - set the return size and priority:
-        actualSize = (NATIVE_INT_TYPE) size;
+        actualSize = static_cast<NATIVE_INT_TYPE>(size);
         priority = pri;
 
         // Pop worked - wake up a thread that might be waiting on
@@ -232,7 +232,7 @@ namespace Os {
       }
       else {
         actualSize = 0;
-        if( size > (NATIVE_UINT_TYPE) capacity ) {
+        if( size > static_cast<NATIVE_UINT_TYPE>(capacity) ) {
           // The buffer capacity was too small!
           status = Queue::QUEUE_SIZE_MISMATCH;
         }
@@ -263,7 +263,7 @@ namespace Os {
       pthread_mutex_t* queueLock = &queueHandle->queueLock;
       NATIVE_INT_TYPE ret;
 
-      NATIVE_UINT_TYPE size = capacity;
+      NATIVE_UINT_TYPE size = static_cast<NATIVE_UINT_TYPE>(capacity);
       NATIVE_INT_TYPE pri = 0;
       Queue::QueueStatus status = Queue::QUEUE_OK;
 
@@ -285,7 +285,7 @@ namespace Os {
 
       if(popSucceeded) {
         // Pop worked - set the return size and priority:
-        actualSize = (NATIVE_INT_TYPE) size;
+        actualSize = static_cast<NATIVE_INT_TYPE>(size);
         priority = pri;
 
         // Pop worked - wake up a thread that might be waiting on
@@ -295,7 +295,7 @@ namespace Os {
       }
       else {
         actualSize = 0;
-        if( size > (NATIVE_UINT_TYPE) capacity ) {
+        if( size > static_cast<NATIVE_UINT_TYPE>(capacity) ) {
           // The buffer capacity was too small!
           status = Queue::QUEUE_SIZE_MISMATCH;
         }
@@ -318,11 +318,11 @@ namespace Os {
 
   Queue::QueueStatus Queue::receive(U8* buffer, NATIVE_INT_TYPE capacity, NATIVE_INT_TYPE &actualSize, NATIVE_INT_TYPE &priority, QueueBlocking block) {
 
-      if( (POINTER_CAST) NULL == this->m_handle ) {
+      if( static_cast<POINTER_CAST>(NULL) == this->m_handle ) {
         return QUEUE_UNINITIALIZED;
       }
 
-      QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+      QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
 
       if (NULL == queueHandle) {
         return QUEUE_UNINITIALIZED;
@@ -342,7 +342,7 @@ namespace Os {
   }
 
   NATIVE_INT_TYPE Queue::getNumMsgs() const {
-      QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+      QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
       if (NULL == queueHandle) {
           return 0;
       }
@@ -351,7 +351,7 @@ namespace Os {
   }
 
   NATIVE_INT_TYPE Queue::getMaxMsgs() const {
-      QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+      QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
       if (NULL == queueHandle) {
           return 0;
       }
@@ -360,7 +360,7 @@ namespace Os {
   }
 
   NATIVE_INT_TYPE Queue::getQueueSize() const {
-      QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+      QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
       if (NULL == queueHandle) {
           return 0;
       }
@@ -369,7 +369,7 @@ namespace Os {
   }
 
   NATIVE_INT_TYPE Queue::getMsgSize() const {
-      QueueHandle* queueHandle = (QueueHandle*) this->m_handle;
+      QueueHandle* queueHandle = reinterpret_cast<QueueHandle*>(this->m_handle);
       if (NULL == queueHandle) {
           return 0;
       }

--- a/Os/Pthreads/test/ut/BufferQueueTest.cpp
+++ b/Os/Pthreads/test/ut/BufferQueueTest.cpp
@@ -98,8 +98,8 @@ int main() {
   const char* messages[DEPTH] = {"hello", "how are you", "pretty good", "cosmic bro", "kthxbye"};
   // Fill queue:
   for(NATIVE_UINT_TYPE ii = 0; ii < DEPTH; ++ii) {
-    printf("Pushing '%s' at priority %d with size %d\n", messages[ii], priorities[ii], (int)strlen(messages[ii]));
-    ret = queue2.push((U8*) messages[ii], (int)strlen(messages[ii]), priorities[ii]);
+    printf("Pushing '%s' at priority %d with size %zu\n", messages[ii], priorities[ii], strlen(messages[ii]));
+    ret = queue2.push(reinterpret_cast<const U8*>(messages[ii]), strlen(messages[ii]), priorities[ii]);
     FW_ASSERT(ret, ret);
     count = queue2.getCount();
     maxCount = queue2.getMaxCount();
@@ -118,7 +118,7 @@ int main() {
   char temp[101];
   size = sizeof(temp) - 1; // Leave room for extra \0 because of the message print
   for(NATIVE_UINT_TYPE ii = 0; ii < DEPTH; ++ii) {
-    ret = queue2.pop((U8*) temp, size, priority);
+    ret = queue2.pop(reinterpret_cast<U8*>(temp), size, priority);
     temp[size] = '\0';
     FW_ASSERT(ret, ret);
     FW_ASSERT(priority == orderedPriorities[ii], priority);

--- a/Os/Stubs/Linux/FileStub.cpp
+++ b/Os/Stubs/Linux/FileStub.cpp
@@ -120,7 +120,7 @@ namespace Os {
                 }
                 break;
             default:
-                FW_ASSERT(0,(NATIVE_INT_TYPE)mode);
+                FW_ASSERT(0,mode);
                 break;
         }
 
@@ -274,9 +274,9 @@ namespace Os {
                         break; // break out of while loop
                     } else {
                         // in order to move the pointer ahead, we need to cast it
-                        U8* charPtr = (U8*)buffer;
+                        U8* charPtr = static_cast<U8*>(buffer);
                         charPtr = &charPtr[readSize];
-                        buffer = (void*)charPtr;
+                        buffer = static_cast<void*>(charPtr);
                     }
                     maxIters--; // decrement loop count
                 }

--- a/Os/ValidateFileCommon.cpp
+++ b/Os/ValidateFileCommon.cpp
@@ -24,7 +24,7 @@ namespace Os {
             return File::BAD_SIZE;
         }
         const NATIVE_INT_TYPE max_itr = static_cast<NATIVE_INT_TYPE>(fileSize/VFILE_HASH_CHUNK_SIZE + 1);
-        
+
         // Read all data from file and update hash:
         Utils::Hash hash;
         hash.init();
@@ -51,7 +51,7 @@ namespace Os {
         // We should not have left the loop because of cnt > max_itr:
         FW_ASSERT(size == 0);
         FW_ASSERT(cnt <= max_itr);
-        
+
         // Calculate hash:
         Utils::HashBuffer computedHashBuffer;
         hash.final(computedHashBuffer);
@@ -64,7 +64,7 @@ namespace Os {
 
         File::Status status;
 
-        // Open hash file: 
+        // Open hash file:
         File hashFile;
         status = hashFile.open(hashFileName, File::OPEN_READ);
         if( File::OP_OK != status ) {
@@ -73,16 +73,16 @@ namespace Os {
 
         // Read hash from checksum file:
         unsigned char savedHash[HASH_DIGEST_LENGTH];
-        NATIVE_INT_TYPE size = hashBuffer.getBuffCapacity(); 
+        NATIVE_INT_TYPE size = hashBuffer.getBuffCapacity();
         status = hashFile.read(&savedHash[0], size);
         if( File::OP_OK != status ) {
             return status;
         }
-        if( size != (NATIVE_INT_TYPE) hashBuffer.getBuffCapacity() ) {
+        if( size != static_cast<NATIVE_INT_TYPE>(hashBuffer.getBuffCapacity()) ) {
             return File::BAD_SIZE;
         }
         hashFile.close();
-        
+
         // Return the hash buffer:
         Utils::HashBuffer savedHashBuffer(savedHash, size);
         hashBuffer = savedHashBuffer;
@@ -91,7 +91,7 @@ namespace Os {
     }
 
     File::Status writeHash(const char* hashFileName, Utils::HashBuffer hashBuffer) {
-        // Open hash file: 
+        // Open hash file:
         File hashFile;
         File::Status status;
         status = hashFile.open(hashFileName, File::OPEN_WRITE);
@@ -105,7 +105,7 @@ namespace Os {
         if( File::OP_OK != status ) {
             return status;
         }
-        if( size != (NATIVE_INT_TYPE) hashBuffer.getBuffLength() ) {
+        if( size != static_cast<NATIVE_INT_TYPE>(hashBuffer.getBuffLength()) ) {
             return File::BAD_SIZE;
         }
         hashFile.close();
@@ -113,7 +113,7 @@ namespace Os {
         return status;
     }
 
-    // Enum and function for translating from a status to a validation status: 
+    // Enum and function for translating from a status to a validation status:
     typedef enum {
         FileType,
         HashFileType
@@ -168,7 +168,7 @@ namespace Os {
 
         return ValidateFile::OTHER_ERROR;
     }
-  
+
     ValidateFile::Status ValidateFile::validate(const char* fileName, const char* hashFileName) {
         Utils::HashBuffer hashBuffer; // pass by reference - final value is unused
         return validate(fileName, hashFileName, hashBuffer);
@@ -178,13 +178,13 @@ namespace Os {
 
         File::Status status;
 
-        // Read the hash file: 
+        // Read the hash file:
         Utils::HashBuffer savedHash;
         status = readHash(hashFileName, savedHash);
         if( File::OP_OK != status ) {
             return translateStatus(status, HashFileType);
         }
-        
+
         // Compute the file's hash:
         Utils::HashBuffer computedHash;
         status = computeHash(fileName, computedHash);

--- a/Os/test/ut/OsQueueTest.cpp
+++ b/Os/test/ut/OsQueueTest.cpp
@@ -34,7 +34,7 @@ class MyTestSerializedBuffer : public Fw::SerializeBufferBase {
         U8 m_someBuffer[SER_BUFFER_SIZE];
 };
 
-Os::Queue* createTestQueue(char *name, U32 size, I32 depth) {
+Os::Queue* createTestQueue(const char *name, U32 size, I32 depth) {
     Os::Queue* testQueue = new Os::Queue();
     Os::Queue::QueueStatus stat = testQueue->create(Os::QueueString(name), depth, size);
     EXPECT_EQ(stat,Os::Queue::QUEUE_OK);
@@ -48,7 +48,7 @@ Os::Queue* createTestQueue(char *name, U32 size, I32 depth) {
     num = testQueue->getQueueSize(); //!< get the queue depth (maximum number of messages queue can hold)
     EXPECT_EQ(num, depth);
     num = testQueue->getMsgSize(); //!< get the message size (maximum message size queue can hold)
-    EXPECT_EQ(num, (I32) size);
+    EXPECT_EQ(num, static_cast<I32>(size));
 
     return testQueue;
 }
@@ -61,7 +61,7 @@ MyTestSerializedBuffer getSendBuffer(I32 startByte) {
     // Fill serialized buffer with data:
     U8 sendDataBuff[SER_BUFFER_SIZE];
     I32 count = startByte;
-    for (I32 byte = 0; byte < (I32)size; byte++) {
+    for (U32 byte = 0; byte < size; byte++) {
         sendDataBuff[byte] = count;
         count++;
     }
@@ -80,9 +80,9 @@ void compareBuffers(MyTestSerializedBuffer& a, MyTestSerializedBuffer& b) {
     serStat = b.deserialize(bBuff, size);
     EXPECT_EQ(serStat,Fw::FW_SERIALIZE_OK);
 
-    for (I32 ii = 0; ii < (I32)size; ii++) {
+    for (U32 ii = 0; ii < size; ii++) {
         if (aBuff[ii] != bBuff[ii]) {
-            printf("Byte %d mismatch. A: %d B: %d\n", ii, aBuff[ii], bBuff[ii]);
+            printf("Byte %u mismatch. A: %d B: %d\n", ii, aBuff[ii], bBuff[ii]);
             EXPECT_TRUE(0);
         }
     }
@@ -175,7 +175,7 @@ void qtest_nonblock_send() {
     printf("-----------------------------\n");
     printf("-- nonblocking send test ----\n");
     printf("-----------------------------\n");
-    Os::Queue* testQueue = createTestQueue((char*)"TestQ",SER_BUFFER_SIZE,QUEUE_SIZE);
+    Os::Queue* testQueue = createTestQueue("TestQ",SER_BUFFER_SIZE,QUEUE_SIZE);
     Os::Queue::QueueStatus stat;
     MyTestSerializedBuffer sendBuff = getSendBuffer(0);
 
@@ -205,7 +205,7 @@ void qtest_block_send() {
     printf("-----------------------------\n");
     printf("---- blocking send test -----\n");
     printf("-----------------------------\n");
-    Os::Queue* testQueue = createTestQueue((char*)"TestQ",SER_BUFFER_SIZE,QUEUE_SIZE);
+    Os::Queue* testQueue = createTestQueue("TestQ",SER_BUFFER_SIZE,QUEUE_SIZE);
     Os::Queue::QueueStatus stat;
     MyTestSerializedBuffer sendBuff = getSendBuffer(0);
 
@@ -253,7 +253,7 @@ void qtest_block_receive() {
     printf("-----------------------------\n");
     printf("-- blocking receive test ----\n");
     printf("-----------------------------\n");
-    Os::Queue* testQueue = createTestQueue((char*)"TestQ",SER_BUFFER_SIZE,QUEUE_SIZE);
+    Os::Queue* testQueue = createTestQueue("TestQ",SER_BUFFER_SIZE,QUEUE_SIZE);
     Os::Queue::QueueStatus stat;
     MyTestSerializedBuffer recvBuff;
     MyTestSerializedBuffer sendBuff = getSendBuffer(0);
@@ -333,7 +333,7 @@ void qtest_nonblock_receive() {
     printf("-----------------------------\n");
     printf("- nonblocking receive test --\n");
     printf("-----------------------------\n");
-    Os::Queue* testQueue = createTestQueue((char*)"TestQ", SER_BUFFER_SIZE, QUEUE_SIZE);
+    Os::Queue* testQueue = createTestQueue("TestQ", SER_BUFFER_SIZE, QUEUE_SIZE);
     Os::Queue::QueueStatus stat;
     MyTestSerializedBuffer recvBuff;
     MyTestSerializedBuffer sendBuff = getSendBuffer(0);
@@ -396,7 +396,7 @@ void qtest_performance() {
     printf("-----------------------------\n");
     printf("---- performance test -------\n");
     printf("-----------------------------\n");
-    Os::Queue* testQueue = createTestQueue((char*)"TestQ", SER_BUFFER_SIZE, 10);
+    Os::Queue* testQueue = createTestQueue("TestQ", SER_BUFFER_SIZE, 10);
     Os::Queue::QueueStatus stat;
     MyTestSerializedBuffer recvBuff;
     MyTestSerializedBuffer sendBuff = getSendBuffer(0);
@@ -438,13 +438,13 @@ void qtest_performance() {
     }
 #if defined TGT_OS_TYPE_LINUX
     (void)clock_gettime(CLOCK_REALTIME,&etime);
-    elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_nsec - stime.tv_nsec))/1000000000;
-    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);
+    elapsedTime = static_cast<F64>(etime.tv_sec - stime.tv_sec) + static_cast<F64>(etime.tv_nsec - stime.tv_nsec)/1000000000;
+    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/static_cast<F64>(numIterations));
 #endif
 #if defined TGT_OS_TYPE_DARWIN
     (void)gettimeofday(&etime,0);
-    elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_usec - stime.tv_usec))/1000000;
-    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);
+    elapsedTime = static_cast<F64>(etime.tv_sec - stime.tv_sec) + static_cast<F64>(etime.tv_usec - stime.tv_usec)/1000000;
+    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/static_cast<F64>(numIterations));
 #endif
 
     // TEST 2
@@ -480,13 +480,13 @@ void qtest_performance() {
     }
 #if defined TGT_OS_TYPE_LINUX
     (void)clock_gettime(CLOCK_REALTIME,&etime);
-    elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_nsec - stime.tv_nsec))/1000000000;
-    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);
+    elapsedTime = static_cast<F64>(etime.tv_sec - stime.tv_sec) + static_cast<F64>(etime.tv_nsec - stime.tv_nsec)/1000000000;
+    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/static_cast<F64>(numIterations));
 #endif
 #if defined TGT_OS_TYPE_DARWIN
     (void)gettimeofday(&etime,0);
-    elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_usec - stime.tv_usec))/1000000;
-    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);
+    elapsedTime = static_cast<F64>(etime.tv_sec - stime.tv_sec) + static_cast<F64>(etime.tv_usec - stime.tv_usec)/1000000;
+    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/static_cast<F64>(numIterations));
 #endif
     while(1) {
       stat = testQueue->receive(recvBuff, prio, Os::Queue::QUEUE_NONBLOCKING);
@@ -504,7 +504,7 @@ void qtest_performance() {
 I32 numIterations = 50000;
 void *run_task(void *ptr)
 {
-  Os::Queue* testQueue = (Os::Queue*) ptr;
+  Os::Queue* testQueue = static_cast<Os::Queue*>(ptr);
   Os::Queue::QueueStatus stat;
   I32 prio; // not used
   MyTestSerializedBuffer recvBuff;
@@ -532,7 +532,7 @@ void qtest_concurrent() {
     printf("---------------------\n");
     printf("-- concurrent test --\n");
     printf("---------------------\n");
-    Os::Queue* testQueue = createTestQueue((char*)"TestQ", SER_BUFFER_SIZE, 10);
+    Os::Queue* testQueue = createTestQueue("TestQ", SER_BUFFER_SIZE, 10);
     Os::Queue::QueueStatus stat;
     MyTestSerializedBuffer recvBuff;
     MyTestSerializedBuffer sendBuff = getSendBuffer(0);
@@ -581,13 +581,13 @@ void qtest_concurrent() {
 
 #if defined TGT_OS_TYPE_LINUX
     (void)clock_gettime(CLOCK_REALTIME,&etime);
-    elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_nsec - stime.tv_nsec))/1000000000;
-    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);
+    elapsedTime = static_cast<F64>(etime.tv_sec - stime.tv_sec) + static_cast<F64>(etime.tv_nsec - stime.tv_nsec)/1000000000;
+    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/static_cast<F64>(numIterations));
 #endif
 #if defined TGT_OS_TYPE_DARWIN
     (void)gettimeofday(&etime,0);
-    elapsedTime = ((F64)(etime.tv_sec - stime.tv_sec)) + ((F64)(etime.tv_usec - stime.tv_usec))/1000000;
-    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/(F64) numIterations);
+    elapsedTime = static_cast<F64>(etime.tv_sec - stime.tv_sec) + static_cast<F64>(etime.tv_usec - stime.tv_usec)/1000000;
+    printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/static_cast<F64>(numIterations));
 #endif
 
     delete testQueue;

--- a/Os/test/ut/OsTaskTest.cpp
+++ b/Os/test/ut/OsTaskTest.cpp
@@ -7,7 +7,7 @@ extern "C" {
 }
 
 void someTask(void* ptr) {
-    bool* ran = (bool*) ptr;
+    bool* ran = static_cast<bool*>(ptr);
     *ran = true;
 }
 
@@ -15,7 +15,7 @@ void startTestTask() {
     volatile bool taskRan = false;
     Os::Task testTask;
     Os::TaskString name("ATestTask");
-    Os::Task::TaskStatus stat = testTask.start(name,12,100,10*1024,someTask,(void*) &taskRan);
+    Os::Task::TaskStatus stat = testTask.start(name,12,100,10*1024,someTask,const_cast<bool*>(&taskRan));
     ASSERT_EQ(stat, Os::Task::TASK_OK);
     testTask.join(NULL);
     ASSERT_EQ(taskRan, true);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  Os |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Breaking changes in #955 into smaller chunks. This PR is just the modifications to the Os directory.

Switch fprime from using a mix of C/C++ style casts to C++ style casts only. Add compiler warning to core framework project to error on use of C style casts. Note, using a c-style cast to cast return value to void and signal that the return value is ignored is still permitted.

## Rationale

C++ style static, const, and reinterpret casts are safer than C style casts by forcing developers to be explicit about how they intend to typecast a value. This brings fprime inline with the C++ best practice of avoiding C style casts.
