### PR TITLE
Autocoders: Convert C style casts to C++ style casts

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
@@ -244,7 +244,7 @@ void ${name}::toString(Fw::StringBase& text) const {
 #if $type == "bool":
       ,this->elements[$index]?"T":"F"
 #else if $type == "ENUM":
-      ,(NATIVE_INT_TYPE)this->elements[$index]
+      ,static_cast<NATIVE_INT_TYPE>(this->elements[$index])
 #else if $typeinfo == "extern":
       ,str${index}.toChar()
 #else if $type == "string":

--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
@@ -306,7 +306,7 @@ namespace ${namespace} {
        #end for
           default:
              // Silence compiler warning
-             _id = (FwPrmIdType) 0;
+             _id = static_cast<FwPrmIdType>(0);
              FW_ASSERT(0,this->getInstance());
              break;
        }
@@ -577,9 +577,7 @@ namespace ${namespace} {
   NATIVE_INT_TYPE ${class_name} ::
     getNum_${instance}_${direction}Ports()
   {
-    return (NATIVE_INT_TYPE) FW_NUM_ARRAY_ELEMENTS(
-        this->m_${instance}_${direction}Port
-    );
+    return static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_${instance}_${direction}Port));
   }
     #if $role == "LogTextEvent":
 \#endif
@@ -628,8 +626,7 @@ namespace ${namespace} {
 
     // Select base class function based on opcode
     FW_ASSERT(callComp);
-    ${class_name}* compPtr =
-      (${class_name}*) callComp;
+    ${class_name}* compPtr = static_cast<${class_name}*>(callComp);
 
     const U32 idBase = callComp->getIdBase();
     FW_ASSERT(opCode >= idBase, opCode, idBase);
@@ -743,7 +740,7 @@ namespace ${namespace} {
           #if $is_enum == "enum":
     FwEnumStoreType ${arg_name}Int = 0;
     _status = args.deserialize(${arg_name}Int);
-    $arg_name = (${arg_type})${arg_name}Int;
+    $arg_name = static_cast<${arg_type}>(${arg_name}Int);
           #else
     _status = args.deserialize($arg_name);
           #end if
@@ -800,19 +797,19 @@ namespace ${namespace} {
 
     // Serialize for IPC
     #if len($opcodes) == 1
-    _status = msg.serialize((NATIVE_INT_TYPE)CMD_${mnemonic.upper()});
+    _status = msg.serialize(static_cast<NATIVE_INT_TYPE>(CMD_${mnemonic.upper()}));
     #else
     switch (this->getInstance()) {
        #set $inst = 0
        #for $opcode in $opcodes
         case $inst:
-            _status = msg.serialize((NATIVE_INT_TYPE)CMD_${mnemonic.upper()}_${inst});
+            _status = msg.serialize(static_cast<NATIVE_INT_TYPE>(CMD_${mnemonic.upper()}_${inst}));
             break;
          #set $inst = $inst + 1
        #end for
         default:
            // Silence compiler warning
-           _status = (Fw::SerializeStatus) 0;
+           _status = static_cast<Fw::SerializeStatus>(0);
            FW_ASSERT(0,this->getInstance());
            break;
     };
@@ -926,7 +923,7 @@ namespace ${namespace} {
       arg.setMaxSerialize($size);
     #end if
     #if $typeinfo == "enum":
-      Fw::SerializeStatus _stat = _tlmBuff.serialize((FwEnumStoreType)arg);
+      Fw::SerializeStatus _stat = _tlmBuff.serialize(static_cast<FwEnumStoreType>(arg));
     #else
       Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
     #end if
@@ -950,7 +947,7 @@ namespace ${namespace} {
       #end for
           default:
             // Silence compiler warning
-            _id = (FwChanIdType) 0;
+            _id = static_cast<FwChanIdType>(0);
             FW_ASSERT(0,this->getInstance());
             break;
       }
@@ -1456,7 +1453,7 @@ namespace ${namespace} {
         Fw::SerializeBufferBase& buffer) {
 
     FW_ASSERT(callComp);
-    ${class_name}* compPtr = (${class_name}*) callComp;
+    ${class_name}* compPtr = static_cast<${class_name}*>(callComp);
     compPtr->${instance}_handlerBase(portNum,buffer);
   }
     #end if
@@ -1558,8 +1555,7 @@ namespace ${namespace} {
     )
   {
     FW_ASSERT(callComp);
-    ${class_name}* compPtr =
-      (${class_name}*) callComp;
+    ${class_name}* compPtr = static_cast<${class_name}*>(callComp);
     #if $void_params and $void_return_type:
     compPtr->${instance}_handlerBase(portNum);
     #else if $void_params
@@ -1799,7 +1795,7 @@ namespace ${namespace} {
         $arg_type $arg_name;
         FwEnumStoreType ${arg_name}Int = 0;
         deserStatus = msg.deserialize(${arg_name}Int);
-        $arg_name = ($arg_type) ${arg_name}Int;
+        $arg_name = static_cast<$arg_type>(${arg_name}Int);
         #else
         $arg_type $arg_name;
         deserStatus = msg.deserialize($arg_name);
@@ -1886,7 +1882,7 @@ namespace ${namespace} {
         #if $arg_enum == "enum"
         FwEnumStoreType ${arg_name}Int = 0;
         deserStatus = args.deserialize(${arg_name}Int);
-        $arg_name = (${arg_type})${arg_name}Int;
+        $arg_name = static_cast<${arg_type}>(${arg_name}Int);
         #else
         deserStatus = args.deserialize($arg_name);
         #end if

--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
@@ -36,9 +36,9 @@ namespace ${namespace} {
   ${name} :: ${name}():Serializable()
   {
 #if $default
-    this->e = (t) ${default};
+    this->e = static_cast<t>(${default});
 #else
-    this->e = (t) 0;
+    this->e = static_cast<t>(0);
 #end if
   }
 

--- a/Autocoders/Python/src/fprime_ac/generators/templates/gtest/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/gtest/cpp.tmpl
@@ -56,7 +56,7 @@ $emit_cpp_params([ $param_maxHistorySize ])
 $emit_cpp_params($params_assert_size)
     ) const
   {
-    ASSERT_EQ((unsigned long) size, this->cmdResponseHistory->size())
+    ASSERT_EQ(size, this->cmdResponseHistory->size())
       $failure_message
       $LTLT "  Value:    Size of command response history\n"
       $LTLT "  Expected: " $LTLT size $LTLT "\n"

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialCpp.tmpl
@@ -102,13 +102,13 @@ Fw::SerializeStatus ${name}::serialize(Fw::SerializeBufferBase& buffer) const {
 
 \#if FW_SERIALIZATION_TYPE_ID
     // serialize type ID
-    stat = buffer.serialize((U32)${name}::TYPE_ID);
+    stat = buffer.serialize(static_cast<U32>(${name}::TYPE_ID));
 \#endif
 
 #for ($member,$type,$size,$format,$comment,$default,$typeinfo) in $members:
 #if $size == None or $typeinfo == "string":
 #if $typeinfo == "enum":
-    stat = buffer.serialize((FwEnumStoreType)this->m_${member});
+    stat = buffer.serialize(static_cast<FwEnumStoreType>(this->m_${member}));
 #else
     stat = buffer.serialize(this->m_${member});
 #end if
@@ -213,7 +213,7 @@ void ${name}::toString(Fw::StringBase& text) const {
 #if $type == "bool":
        ,this->m_${member}[$elem]?"T":"F"
 #else if $type == "enum":
-       ,(NATIVE_INT_TYPE)this->m_${member}[$elem]
+       ,static_cast<NATIVE_INT_TYPE>(this->m_${member}[$elem])
 #else:
        ,this->m_${member}[$elem]
 #end if
@@ -222,7 +222,7 @@ void ${name}::toString(Fw::StringBase& text) const {
 #if $type == "bool":
        ,this->m_${member}?"T":"F"
 #else if $type == "enum":
-       ,(NATIVE_INT_TYPE)this->m_${member}
+       ,static_cast<NATIVE_INT_TYPE>(this->m_${member})
 #else if $typeinfo == "string":
        ,this->m_${member}.toChar()
 #else if $typeinfo == "extern":

--- a/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
@@ -202,7 +202,7 @@ $emit_cpp_params([ $param_instance ])
   NATIVE_INT_TYPE ${tester_base} ::
     getNum_to_${instance}() const
   {
-    return (NATIVE_INT_TYPE) FW_NUM_ARRAY_ELEMENTS(this->m_to_${instance});
+    return static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_to_${instance}));
   }
 
     #else if $direction == "Output":
@@ -212,7 +212,7 @@ $emit_cpp_params([ $param_instance ])
   NATIVE_INT_TYPE ${tester_base} ::
     getNum_from_${instance}() const
   {
-    return (NATIVE_INT_TYPE) FW_NUM_ARRAY_ELEMENTS(this->m_from_${instance});
+    return static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_from_${instance}));
   }
       #if $role == "LogTextEvent":
 \#endif
@@ -732,7 +732,7 @@ $emit_cpp_params([ $param_instance, $param_cmdSeq ] + $get_command_params($mnemo
     #end if
     #for $arg_name, $arg_type, $comment, $is_enum in $args:
       #if $is_enum == "enum":
-    _status = buff.serialize((FwEnumStoreType) ${arg_name});
+    _status = buff.serialize(static_cast<FwEnumStoreType>(${arg_name}));
       #else
     _status = buff.serialize($arg_name);
       #end if

--- a/Autocoders/Python/src/fprime_ac/utils/TlmPacketDefBase.tmpl
+++ b/Autocoders/Python/src/fprime_ac/utils/TlmPacketDefBase.tmpl
@@ -240,7 +240,7 @@ tlmPacketDefBase *tlmPacketDefBase::getPacketById(I32 packet_id)
     int i;
     for (i = 0; i < NUM_PACKETS; i++)
     {
-        if (packet_id == (I32)TlmPacker::packet_list[i]->getPacketId())
+        if (packet_id == static_cast<I32>(TlmPacker::packet_list[i]->getPacketId()))
         {
             return TlmPacker::packet_list[i];
         }
@@ -253,7 +253,7 @@ tlmPacketDefBase *tlmPacketDefBase::ingestPacket(I32 packet_id, const void *pack
 {
     for (int i = 0; i < NUM_PACKETS; i++)
     {
-    if (packet_id == (I32)TlmPacker::packet_list[i]->getPacketId())
+    if (packet_id == static_cast<I32>(TlmPacker::packet_list[i]->getPacketId()))
     {
         TlmPacker::packet_list[i]->ingestPacket(packet);
         return TlmPacker::packet_list[i];

--- a/Autocoders/Python/templates/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/templates/ExampleComponentImpl.cpp
@@ -47,7 +47,7 @@ namespace ExampleComponents {
     void ExampleComponentImpl::TEST_CMD_1_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, ExampleComponentBase::CmdEnum arg2, const Fw::CmdStringArg& arg3) {
         // issue the test event with the opcode
         Fw::LogStringArg str = "TEST_CMD_1";
-        this->log_ACTIVITY_HI_SomeEvent(opCode,(F32)arg1, Example4::Example2(2.0,3.0,4,5), str,ExampleComponentBase::EVENT_MEMB2);
+        this->log_ACTIVITY_HI_SomeEvent(opCode, static_cast<F32>(arg1), Example4::Example2(2.0,3.0,4,5), str,ExampleComponentBase::EVENT_MEMB2);
         // write a value to a telemetry channel
         U32 chan = 12;
         this->tlmWrite_somechan(chan);

--- a/Autocoders/Python/templates/ExampleType.cpp
+++ b/Autocoders/Python/templates/ExampleType.cpp
@@ -42,7 +42,7 @@ Fw::SerializeStatus mytype::serialize(Fw::SerializeBufferBase& buffer) const {
     if (Fw::FW_SERIALIZE_OK != stat) {
         return stat;
     }
-    return buffer.serialize((NATIVE_INT_TYPE)mytype::TYPE_ID);
+    return buffer.serialize(static_cast<NATIVE_INT_TYPE>(mytype::TYPE_ID));
 }
 
 Fw::SerializeStatus mytype::deserialize(Fw::SerializeBufferBase& buffer) {
@@ -53,7 +53,7 @@ Fw::SerializeStatus mytype::deserialize(Fw::SerializeBufferBase& buffer) {
         return stat;
     }
 
-    if (id != (NATIVE_INT_TYPE)mytype::TYPE_ID) {
+    if (id != static_cast<NATIVE_INT_TYPE>(mytype::TYPE_ID)) {
         return Fw::FW_DESERIALIZE_TYPE_MISMATCH;
     }
 

--- a/Autocoders/Python/test/enum1port/DrvTimingSignalPort.cpp
+++ b/Autocoders/Python/test/enum1port/DrvTimingSignalPort.cpp
@@ -107,7 +107,7 @@ namespace Drv {
 #if FW_PORT_SERIALIZATION
         } else if (this->m_serPort) {
             TimingSignalPortBuffer buffer;
-            Fw::SerializeStatus status = buffer.serialize((I32)signal);
+            Fw::SerializeStatus status = buffer.serialize(static_cast<I32>(signal));
             FW_ASSERT(Fw::FW_SERIALIZE_OK == status);
             this->m_serPort->invokeSerial(buffer);
 #endif

--- a/Autocoders/Python/test/event_enum/TestLogImpl.cpp
+++ b/Autocoders/Python/test/event_enum/TestLogImpl.cpp
@@ -30,5 +30,5 @@ void TestLogImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 
 
 void TestLogImpl::sendEvent(I32 arg1, I32 arg2, U8 arg3) {
     printf("Sending event args %d, %d, %d\n",arg1, arg2, arg3);
-    this->log_ACTIVITY_LO_SomeEvent(arg1,(SomeEnum)arg2,arg3);
+    this->log_ACTIVITY_LO_SomeEvent(arg1,static_cast<SomeEnum>(arg2),arg3);
 }

--- a/Autocoders/Python/test/ext_dict/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/test/ext_dict/ExampleComponentImpl.cpp
@@ -42,7 +42,7 @@ namespace ExampleComponents {
     void ExampleComponentImpl::TEST_CMD_1_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, ExampleComponentBase::CmdEnum arg2, const Fw::CmdStringArg& arg3) {
         // issue the test event with the opcode
         Fw::LogStringArg str = "TEST_CMD_1";
-        this->log_ACTIVITY_HI_SomeEvent(opCode,(F32)arg1, 0, str,ExampleComponentBase::EVENT_MEMB2);
+        this->log_ACTIVITY_HI_SomeEvent(opCode,static_cast<F32>(arg1), 0, str,ExampleComponentBase::EVENT_MEMB2);
         // write a value to a telemetry channel
         U32 chan = 12;
         this->tlmWrite_somechan(chan);

--- a/Autocoders/Python/test/ext_dict/ExampleType.cpp
+++ b/Autocoders/Python/test/ext_dict/ExampleType.cpp
@@ -42,7 +42,7 @@ Fw::SerializeStatus mytype::serialize(Fw::SerializeBufferBase& buffer) const {
     if (Fw::FW_SERIALIZE_OK != stat) {
         return stat;
     }
-    return buffer.serialize((NATIVE_INT_TYPE)mytype::TYPE_ID);
+    return buffer.serialize(static_cast<NATIVE_INT_TYPE>(mytype::TYPE_ID));
 }
 
 Fw::SerializeStatus mytype::deserialize(Fw::SerializeBufferBase& buffer) {
@@ -53,7 +53,7 @@ Fw::SerializeStatus mytype::deserialize(Fw::SerializeBufferBase& buffer) {
         return stat;
     }
 
-    if (id != (NATIVE_INT_TYPE)mytype::TYPE_ID) {
+    if (id != static_cast<NATIVE_INT_TYPE>(mytype::TYPE_ID)) {
         return Fw::FW_DESERIALIZE_TYPE_MISMATCH;
     }
 

--- a/Autocoders/Python/test/interface1/UserSerializer.cpp
+++ b/Autocoders/Python/test/interface1/UserSerializer.cpp
@@ -35,12 +35,12 @@ void UserSerializer::setVal(const SomeUserStruct& val) {
 }
 
 Fw::SerializeStatus UserSerializer::serialize(Fw::SerializeBufferBase& buffer) const {
-    return buffer.serialize((U8*)&m_struct,sizeof(m_struct));
+    return buffer.serialize(reinterpret_cast<const U8*>(&m_struct),sizeof(m_struct));
 }
 
 Fw::SerializeStatus UserSerializer::deserialize(Fw::SerializeBufferBase& buffer) {
     NATIVE_UINT_TYPE serSize = sizeof(m_struct);
-    Fw::SerializeStatus stat =  buffer.deserialize((U8*)&m_struct,serSize);
+    Fw::SerializeStatus stat =  buffer.deserialize(reinterpret_cast<U8*>(&m_struct),serSize);
     FW_ASSERT(serSize == sizeof(m_struct));
     return stat;
 }

--- a/Autocoders/Python/test/port_loopback/ExampleType.cpp
+++ b/Autocoders/Python/test/port_loopback/ExampleType.cpp
@@ -42,7 +42,7 @@ Fw::SerializeStatus mytype::serialize(Fw::SerializeBufferBase& buffer) const {
     if (Fw::FW_SERIALIZE_OK != stat) {
         return stat;
     }
-    return buffer.serialize((NATIVE_INT_TYPE)mytype::TYPE_ID);
+    return buffer.serialize(static_cast<NATIVE_INT_TYPE>(mytype::TYPE_ID));
 }
 
 Fw::SerializeStatus mytype::deserialize(Fw::SerializeBufferBase& buffer) {
@@ -53,7 +53,7 @@ Fw::SerializeStatus mytype::deserialize(Fw::SerializeBufferBase& buffer) {
         return stat;
     }
 
-    if (id != (NATIVE_INT_TYPE)mytype::TYPE_ID) {
+    if (id != static_cast<NATIVE_INT_TYPE>(mytype::TYPE_ID)) {
         return Fw::FW_DESERIALIZE_TYPE_MISMATCH;
     }
 

--- a/Autocoders/Python/test/port_nogen/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/test/port_nogen/ExampleComponentImpl.cpp
@@ -41,7 +41,7 @@ namespace ExampleComponents {
     void ExampleComponentImpl::TEST_CMD_1_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, ExampleComponentBase::CmdEnum arg2, const Fw::CmdStringArg& arg3) {
         // issue the test event with the opcode
         Fw::LogStringArg str = "TEST_CMD_1";
-        this->log_FATAL_SomeEvent(opCode,(F32)arg1, 0, str,ExampleComponentBase::EVENT_MEMB2);
+        this->log_FATAL_SomeEvent(opCode, static_cast<F32>(arg1), 0, str,ExampleComponentBase::EVENT_MEMB2);
         // write a value to a telemetry channel
         U32 chan = 12;
         this->tlmWrite_somechan(chan);

--- a/Autocoders/Python/test/port_nogen/ExampleType.cpp
+++ b/Autocoders/Python/test/port_nogen/ExampleType.cpp
@@ -42,7 +42,7 @@ Fw::SerializeStatus mytype::serialize(Fw::SerializeBufferBase& buffer) const {
     if (Fw::FW_SERIALIZE_OK != stat) {
         return stat;
     }
-    return buffer.serialize((NATIVE_INT_TYPE)mytype::TYPE_ID);
+    return buffer.serialize(static_cast<NATIVE_INT_TYPE>(mytype::TYPE_ID));
 }
 
 Fw::SerializeStatus mytype::deserialize(Fw::SerializeBufferBase& buffer) {
@@ -53,7 +53,7 @@ Fw::SerializeStatus mytype::deserialize(Fw::SerializeBufferBase& buffer) {
         return stat;
     }
 
-    if (id != (NATIVE_INT_TYPE)mytype::TYPE_ID) {
+    if (id != static_cast<NATIVE_INT_TYPE>(mytype::TYPE_ID)) {
         return Fw::FW_DESERIALIZE_TYPE_MISMATCH;
     }
 

--- a/Autocoders/Python/test/serialize_user/UserSerializer.cpp
+++ b/Autocoders/Python/test/serialize_user/UserSerializer.cpp
@@ -35,12 +35,12 @@ void UserSerializer::setVal(const SomeUserStruct& val) {
 }
 
 Fw::SerializeStatus UserSerializer::serialize(Fw::SerializeBufferBase& buffer) const {
-    return buffer.serialize((U8*)&m_struct,sizeof(m_struct));
+    return buffer.serialize(reinterpret_cast<const U8*>(&m_struct),sizeof(m_struct));
 }
 
 Fw::SerializeStatus UserSerializer::deserialize(Fw::SerializeBufferBase& buffer) {
     NATIVE_UINT_TYPE serSize = sizeof(m_struct);
-    Fw::SerializeStatus stat =  buffer.deserialize((U8*)&m_struct,serSize);
+    Fw::SerializeStatus stat =  buffer.deserialize(reinterpret_cast<U8*>(&m_struct),serSize);
     FW_ASSERT(serSize == sizeof(m_struct));
     return stat;
 }

--- a/Autocoders/Python/test/tlm_enum/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm_enum/TestTelemImpl.cpp
@@ -25,7 +25,7 @@ void TestTlmImpl::init() {
 
 void TestTlmImpl::genTlm(I32 val) {
     printf("Writing value %d to telemetry.\n",val);
-    SomeEnum argVal = (SomeEnum) val;
+    SomeEnum argVal = static_cast<SomeEnum>(val);
     this->tlmWrite_somechan(argVal);
 }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Autocoders |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---

## Change Description

Breaking changes in #955 into smaller chunks. This PR is just the modifications to the Autocoders directory.

Switch fprime from using a mix of C/C++ style casts to C++ style casts only. Add compiler warning to core framework project to error on use of C style casts. Note, using a c-style cast to cast return value to void and signal that the return value is ignored is still permitted.

## Rationale

C++ style static, const, and reinterpret casts are safer than C style casts by forcing developers to be explicit about how they intend to typecast a value. This brings fprime inline with the C++ best practice of avoiding C style casts.