### PR TITLE
Various: Convert C style casts to C++ style casts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(FPRIME_PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Root path of F p
 # parameters are common in the F prime code base. Eventually all intentionally unused parameters
 # should be annotated to avoid this error.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wno-unused-parameter")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-unused-parameter")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wold-style-cast -Wno-unused-parameter")
 
 # For this testing cmake project, enable AddressSanitizer, a runtime memory sanitizer, on all unit tests
 set (CMAKE_C_FLAGS_TESTING "${CMAKE_C_FLAGS_TESTING} -fno-omit-frame-pointer -fsanitize=address")

--- a/Drv/Ip/IpSocket.cpp
+++ b/Drv/Ip/IpSocket.cpp
@@ -69,7 +69,7 @@ SocketIpStatus IpSocket::setupTimeouts(NATIVE_INT_TYPE socketFd) {
     timeout.tv_sec = this->m_timeoutSeconds;
     timeout.tv_usec = this->m_timeoutMicroseconds;
     // set socket write to timeout after 1 sec
-    if (setsockopt(socketFd, SOL_SOCKET, SO_SNDTIMEO, (char*)&timeout, sizeof(timeout)) < 0) {
+    if (setsockopt(socketFd, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<char *>(&timeout), sizeof(timeout)) < 0) {
         return SOCK_FAILED_TO_SET_SOCKET_OPTIONS;
     }
 #endif

--- a/Drv/Ip/test/ut/PortSelector.cpp
+++ b/Drv/Ip/test/ut/PortSelector.cpp
@@ -34,7 +34,7 @@ U16 get_free_port(bool udp) {
         return 0;
     }
     socklen_t size = sizeof(address);
-    if (::getsockname(socketFd, ((struct sockaddr *) &address), &size) == -1) {
+    if (::getsockname(socketFd, reinterpret_cast<struct sockaddr *>(&address), &size) == -1) {
         ::close(socketFd);
         return 0;
     }

--- a/Drv/Ip/test/ut/SocketTestHelper.cpp
+++ b/Drv/Ip/test/ut/SocketTestHelper.cpp
@@ -21,7 +21,7 @@ void force_recv_timeout(Drv::IpSocket& socket) {
     struct timeval timeout;
     timeout.tv_sec = 0;
     timeout.tv_usec = 50; // 50ms max before test failure
-    setsockopt(socket.m_fd, SOL_SOCKET, SO_RCVTIMEO, (char *) &timeout, sizeof(timeout));
+    setsockopt(socket.m_fd, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<char *>(&timeout), sizeof(timeout));
 }
 
 void validate_random_data(U8 *data, U8 *truth, U32 size) {
@@ -33,7 +33,7 @@ void validate_random_data(U8 *data, U8 *truth, U32 size) {
 void fill_random_data(U8 *data, U32 size) {
     ASSERT_NE(size, 0u) << "Trying to fill random data of size 0";
     for (U32 i = 0; i < size; i++) {
-        data[i] = (U8) STest::Pick::any();
+        data[i] = static_cast<U8>(STest::Pick::any());
     }
 }
 

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
@@ -325,7 +325,7 @@ namespace Drv {
     intTaskEntry(void * ptr) {
 
     FW_ASSERT(ptr);
-    LinuxGpioDriverComponentImpl* compPtr = (LinuxGpioDriverComponentImpl*) ptr;
+    LinuxGpioDriverComponentImpl* compPtr = static_cast<LinuxGpioDriverComponentImpl*>(ptr);
     FW_ASSERT(compPtr->m_fd != -1);
 
     // start GPIO interrupt
@@ -342,7 +342,7 @@ namespace Drv {
         NATIVE_INT_TYPE nfds = 1;
         NATIVE_INT_TYPE timeout = 10000; // Timeout of 10 seconds
 
-        memset((void*)fdset, 0, sizeof(fdset));
+        memset(fdset, 0, sizeof(fdset));
 
         fdset[0].fd = compPtr->m_fd;
         fdset[0].events = POLLPRI;

--- a/Drv/LinuxI2cDriver/test/ut/Tester.cpp
+++ b/Drv/LinuxI2cDriver/test/ut/Tester.cpp
@@ -49,7 +49,7 @@ namespace Drv {
     sendData(U32 addr, U8* data, NATIVE_INT_TYPE size)
   {
       Fw::Buffer dataBuff;
-      dataBuff.setdata((U64)data);
+      dataBuff.setdata(static_cast<POINTER_CAST>(data));
       dataBuff.setsize(size);
       this->invoke_to_write(0,addr,dataBuff);
   }

--- a/Drv/LinuxSerialDriver/test/ut/Tester.cpp
+++ b/Drv/LinuxSerialDriver/test/ut/Tester.cpp
@@ -43,9 +43,9 @@ namespace Drv {
     // allocate and configure buffers
     for (NATIVE_INT_TYPE buffer = 0; buffer < m_numBuffers; buffer++) {
         // initialize buffers
-        this->m_readData[buffer] = (BYTE*)malloc(bufferSize);
+        this->m_readData[buffer] = new BYTE[bufferSize];
         FW_ASSERT(this->m_readData[buffer]);
-        this->m_readBuffer[buffer].setdata((U64)this->m_readData[buffer]);
+        this->m_readBuffer[buffer].setdata(reinterpret_cast<POINTER_CAST>(this->m_readData[buffer]));
         this->m_readBuffer[buffer].setsize(bufferSize);
         this->m_readBuffer[buffer].setbufferID(buffer);
 
@@ -69,7 +69,7 @@ namespace Drv {
       // free buffers
       for (NATIVE_INT_TYPE buffer = 0; buffer < m_numBuffers; buffer++) {
           // initialize buffers
-          free(this->m_readData[buffer]);
+          delete[] this->m_readData[buffer];
       }
 
   }
@@ -82,7 +82,7 @@ namespace Drv {
       sendSerial(BYTE* data, NATIVE_INT_TYPE size)
   {
     Fw::Buffer buff;
-    buff.setdata((U64)data);
+    buff.setdata(reinterpret_cast<POINTER_CAST>(data));
     buff.setsize(size);
 
     this->invoke_to_serialSend(0,buff);

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -46,8 +46,8 @@ namespace Drv {
         spi_ioc_transfer tr;
         // Zero for unused fields:
         memset(&tr, 0, sizeof(tr));
-        tr.tx_buf = (U64)writeBuffer.getData();
-        tr.rx_buf = (U64)readBuffer.getData();
+        tr.tx_buf = reinterpret_cast<U64>(writeBuffer.getData());
+        tr.rx_buf = reinterpret_cast<U64>(readBuffer.getData());
         tr.len = writeBuffer.getSize();
 /*
             .speed_hz = 0,

--- a/Drv/LinuxSpiDriver/test/ut/Tester.cpp
+++ b/Drv/LinuxSpiDriver/test/ut/Tester.cpp
@@ -104,7 +104,7 @@ namespace Drv {
 
   void Tester::sendBuffer(BYTE* buffer, NATIVE_INT_TYPE size) {
       Fw::Buffer w;
-      w.setdata((U64)buffer);
+      w.setdata(reinterpret_cast<POINTER_CAST>(buffer));
       w.setsize(size);
 
       printf("WRITE: ");
@@ -114,11 +114,11 @@ namespace Drv {
       printf("\n");
 
       BYTE* rb = 0;
-      rb = (BYTE*) malloc(size);
+      rb = new BYTE[size];
 
       FW_ASSERT(rb);
 
-      Fw::Buffer r(0,0,(U64)rb,size);
+      Fw::Buffer r(0,0, reinterpret_cast<POINTER_CAST>(rb),size);
 
       this->invoke_to_SpiReadWrite(0,w,r);
 
@@ -129,7 +129,7 @@ namespace Drv {
       }
       printf("\n");
 
-      free(rb);
+      delete[] rb;
   }
 
 } // end namespace Drv

--- a/Drv/SocketIpDriver/SocketHelper.cpp
+++ b/Drv/SocketIpDriver/SocketHelper.cpp
@@ -156,7 +156,7 @@ namespace Drv {
         timeout.tv_sec = this->m_timeoutSeconds;
         timeout.tv_usec = this->m_timeoutMicroseconds;
         // set socket write to timeout after 1 sec
-        if (setsockopt(socketFd, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout, sizeof(timeout)) < 0) {
+        if (setsockopt(socketFd, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<char *>(&timeout), sizeof(timeout)) < 0) {
             (void) ::close(socketFd);
             return SOCK_FAILED_TO_SET_SOCKET_OPTIONS;
         }

--- a/RPI/RpiDemo/RpiDemoComponentImpl.cpp
+++ b/RPI/RpiDemo/RpiDemoComponentImpl.cpp
@@ -129,7 +129,7 @@ namespace Rpi {
   {
       // convert incoming data to string. If it is not printable, set character to '*'
       char uMsg[serBuffer.getSize()+1];
-      char* bPtr = (char*)serBuffer.getData();
+      char* bPtr = reinterpret_cast<char*>(serBuffer.getData());
 
       for (NATIVE_UINT_TYPE byte = 0; byte < serBuffer.getSize(); byte++) {
           uMsg[byte] = isalpha(bPtr[byte])?bPtr[byte]:'*';
@@ -160,7 +160,7 @@ namespace Rpi {
   {
       Fw::Buffer txt;
       txt.setSize(text.length());
-      txt.setData((U8*)text.toChar());
+      txt.setData(reinterpret_cast<U8*>(const_cast<char*>(text.toChar())));
       this->UartWrite_out(0,txt);
       this->m_uartWriteBytes += text.length();
 
@@ -236,11 +236,11 @@ namespace Rpi {
       // copy data from string to output buffer
       char inBuf[data.length()+1];
       Fw::Buffer in;
-      in.setData((U8*)inBuf);
+      in.setData(reinterpret_cast<U8*>(inBuf));
       in.setSize(sizeof(inBuf));
 
       Fw::Buffer out;
-      out.setData((U8*)data.toChar());
+      out.setData(reinterpret_cast<U8*>(const_cast<char*>(data.toChar())));
       out.setSize(data.length());
       this->SpiReadWrite_out(0,out,in);
       for (NATIVE_UINT_TYPE byte = 0; byte < sizeof(inBuf); byte++) {

--- a/Svc/TlmPacketizer/test/ut/Tester.cpp
+++ b/Svc/TlmPacketizer/test/ut/Tester.cpp
@@ -93,31 +93,31 @@ namespace Svc {
       Fw::TlmBuffer buff;
 
       // first channel
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U32)20));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U32>(20)));
       this->invoke_to_TlmRecv(0,10,ts,buff);
 
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(15)));
       this->invoke_to_TlmRecv(0,100,ts,buff);
 
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(14)));
       this->invoke_to_TlmRecv(0,333,ts,buff);
 
       // second channel
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U32)50));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U32>(50)));
       this->invoke_to_TlmRecv(0,10,ts,buff);
 
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U64)1000000));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U64>(1000000)));
       this->invoke_to_TlmRecv(0,13,ts,buff);
 
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)1010));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(1010)));
       this->invoke_to_TlmRecv(0,250,ts,buff);
 
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(15)));
       this->invoke_to_TlmRecv(0,22,ts,buff);
 
   }
@@ -131,32 +131,32 @@ namespace Svc {
       Fw::TlmBuffer buff;
 
       // first channel
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U32)20));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U32>(20)));
       this->invoke_to_TlmRecv(0,10,ts,buff);
 
       // second channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(15)));
       this->invoke_to_TlmRecv(0,100,ts,buff);
 
       // third channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(14)));
       this->invoke_to_TlmRecv(0,333,ts,buff);
 
       // fifth channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U64)1000000));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U64>(1000000)));
       this->invoke_to_TlmRecv(0,13,ts,buff);
 
       // sixth channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)1010));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(1010)));
       this->invoke_to_TlmRecv(0,250,ts,buff);
 
       // seventh channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(15)));
       this->invoke_to_TlmRecv(0,22,ts,buff);
 
       this->setTestTime(this->m_testTime);
@@ -173,22 +173,22 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(this->m_testTime));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)15));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(15)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(14)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       comBuff.resetSer();
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(this->m_testTime));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)1000000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)1010));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(1000000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(1010)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(15)));
 
-      ASSERT_from_PktSend(1,comBuff,(U32)0);
+      ASSERT_from_PktSend(1,comBuff,static_cast<U32>(0));
 
   }
 
@@ -200,32 +200,32 @@ namespace Svc {
       Fw::TlmBuffer buff;
 
       // first channel
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U32)20));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U32>(20)));
       this->invoke_to_TlmRecv(0,10,ts,buff);
 
       // second channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(15)));
       this->invoke_to_TlmRecv(0,100,ts,buff);
 
       // third channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(14)));
       this->invoke_to_TlmRecv(0,333,ts,buff);
 
       // fifth channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U64)1000000));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U64>(1000000)));
       this->invoke_to_TlmRecv(0,13,ts,buff);
 
       // sixth channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)1010));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(1010)));
       this->invoke_to_TlmRecv(0,250,ts,buff);
 
       // seventh channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(15)));
       this->invoke_to_TlmRecv(0,22,ts,buff);
 
       this->setTestTime(this->m_testTime);
@@ -242,22 +242,22 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(this->m_testTime));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)15));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(15)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(14)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       comBuff.resetSer();
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(this->m_testTime));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)1000000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)1010));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(1000000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(1010)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(15)));
 
-      ASSERT_from_PktSend(1,comBuff,(U32)0);
+      ASSERT_from_PktSend(1,comBuff,static_cast<U32>(0));
 
   }
 
@@ -279,7 +279,7 @@ namespace Svc {
 
       // first channel
       ts.set(100,1000);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U32)20));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U32>(20)));
       this->invoke_to_TlmRecv(0,10,ts,buff);
 
       this->m_testTime.add(1,0);
@@ -293,28 +293,28 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)0));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)0));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(0)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(0)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       comBuff.resetSer();
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)0));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)0));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)0));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(0)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(0)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(0)));
 
-      ASSERT_from_PktSend(1,comBuff,(U32)0);
+      ASSERT_from_PktSend(1,comBuff,static_cast<U32>(0));
 
       // second channel
 
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(15)));
       this->invoke_to_TlmRecv(0,100,ts,buff);
 
       this->m_testTime.add(1,0);
@@ -330,15 +330,15 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)15));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)0));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(15)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(0)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(14)));
       this->invoke_to_TlmRecv(0,333,ts,buff);
 
       this->clearFromPortHistory();
@@ -351,15 +351,15 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)15));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(15)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(14)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U64)1000000));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U64>(1000000)));
       this->invoke_to_TlmRecv(0,13,ts,buff);
 
       this->clearFromPortHistory();
@@ -371,16 +371,16 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)1000000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)0));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)0));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(1000000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(0)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(0)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)1010));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(1010)));
       this->invoke_to_TlmRecv(0,250,ts,buff);
 
       this->clearFromPortHistory();
@@ -394,16 +394,16 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)1000000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)1010));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)0));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(1000000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(1010)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(0)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(15)));
       this->invoke_to_TlmRecv(0,22,ts,buff);
 
       this->clearFromPortHistory();
@@ -415,19 +415,19 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)1000000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)1010));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(1000000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(1010)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(15)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       //** Update all the packets again with new values
 
       // first channel
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U32)1000));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U32>(1000)));
       this->invoke_to_TlmRecv(0,10,ts,buff);
 
       this->clearFromPortHistory();
@@ -439,28 +439,28 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)1000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)15));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(1000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(15)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(14)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       comBuff.resetSer();
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)1000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)1000000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)1010));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(1000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(1000000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(1010)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(15)));
 
-      ASSERT_from_PktSend(1,comBuff,(U32)0);
+      ASSERT_from_PktSend(1,comBuff,static_cast<U32>(0));
 
       // second channel
 
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)550));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(550)));
       this->invoke_to_TlmRecv(0,100,ts,buff);
 
       this->clearFromPortHistory();
@@ -472,15 +472,15 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)1000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)550));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(1000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(550)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(14)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)211));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(211)));
       this->invoke_to_TlmRecv(0,333,ts,buff);
 
       this->clearFromPortHistory();
@@ -492,15 +492,15 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)1000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)550));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)211));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(1000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(550)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(211)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U64)34441));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U64>(34441)));
       this->invoke_to_TlmRecv(0,13,ts,buff);
 
       this->clearFromPortHistory();
@@ -512,16 +512,16 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)1000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)34441));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)1010));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(1000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(34441)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(1010)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(15)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)8649));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(8649)));
       this->invoke_to_TlmRecv(0,250,ts,buff);
 
       this->clearFromPortHistory();
@@ -533,16 +533,16 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)1000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)34441));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)8649));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(1000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(34441)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(8649)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(15)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)65));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(65)));
       this->invoke_to_TlmRecv(0,22,ts,buff);
 
       this->clearFromPortHistory();
@@ -554,12 +554,12 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)1000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)34441));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)8649));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)65));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(1000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(34441)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(8649)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(65)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
   }
 
@@ -581,7 +581,7 @@ namespace Svc {
 
       // first channel
       ts.set(100,1000);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U32)20));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U32>(20)));
       this->invoke_to_TlmRecv(0,10,ts,buff);
 
       this->m_testTime.add(1,0);
@@ -595,28 +595,28 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)0));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)0));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(0)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(0)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       comBuff.resetSer();
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(ts));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)0));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)0));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)0));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(0)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(0)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(0)));
 
-      ASSERT_from_PktSend(1,comBuff,(U32)0);
+      ASSERT_from_PktSend(1,comBuff,static_cast<U32>(0));
 
       // ignored channel
 
       buff.resetSer();
       ts.add(1,0);
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)20));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(20)));
       this->invoke_to_TlmRecv(0,25,ts,buff);
 
       this->m_testTime.add(1,0);
@@ -638,32 +638,32 @@ namespace Svc {
       Fw::TlmBuffer buff;
 
       // first channel
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U32)20));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U32>(20)));
       this->invoke_to_TlmRecv(0,10,ts,buff);
 
       // second channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(15)));
       this->invoke_to_TlmRecv(0,100,ts,buff);
 
       // third channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(14)));
       this->invoke_to_TlmRecv(0,333,ts,buff);
 
       // fifth channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U64)1000000));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U64>(1000000)));
       this->invoke_to_TlmRecv(0,13,ts,buff);
 
       // sixth channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)1010));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(1010)));
       this->invoke_to_TlmRecv(0,250,ts,buff);
 
       // seventh channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(15)));
       this->invoke_to_TlmRecv(0,22,ts,buff);
 
       this->setTestTime(this->m_testTime);
@@ -680,22 +680,22 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(this->m_testTime));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize((U16)15));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(static_cast<U16>(15)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(static_cast<U8>(14)));
 
-      ASSERT_from_PktSend(0,comBuff1,(U32)0);
+      ASSERT_from_PktSend(0,comBuff1,static_cast<U32>(0));
 
       Fw::ComBuffer comBuff2;
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff2.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff2.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff2.serialize(this->m_testTime));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff2.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff2.serialize((U64)1000000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff2.serialize((U16)1010));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff2.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff2.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff2.serialize(static_cast<U64>(1000000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff2.serialize(static_cast<U16>(1010)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff2.serialize(static_cast<U8>(15)));
 
-      ASSERT_from_PktSend(1,comBuff2,(U32)0);
+      ASSERT_from_PktSend(1,comBuff2,static_cast<U32>(0));
 
       // should not be any new packets
       this->clearHistory();
@@ -716,7 +716,7 @@ namespace Svc {
       this->invoke_to_Run(0,0);
       this->component.doDispatch();
       ASSERT_from_PktSend_SIZE(1);
-      ASSERT_from_PktSend(0,comBuff1,(U32)0);
+      ASSERT_from_PktSend(0,comBuff1,static_cast<U32>(0));
 
       // another packet
       this->clearHistory();
@@ -738,7 +738,7 @@ namespace Svc {
       this->invoke_to_Run(0,0);
       this->component.doDispatch();
       ASSERT_from_PktSend_SIZE(1);
-      ASSERT_from_PktSend(0,comBuff2,(U32)0);
+      ASSERT_from_PktSend(0,comBuff2,static_cast<U32>(0));
 
       // Try to send invalid packet
       // send command to manually send a packet
@@ -760,32 +760,32 @@ namespace Svc {
       Fw::TlmBuffer buff;
 
       // first channel
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U32)0x20));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U32>(0x20)));
       this->invoke_to_TlmRecv(0,10,ts,buff);
 
       // second channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)0x15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(0x15)));
       this->invoke_to_TlmRecv(0,100,ts,buff);
 
       // third channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)0x14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(0x14)));
       this->invoke_to_TlmRecv(0,333,ts,buff);
 
       // fifth channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U64)0x1000000));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U64>(0x1000000)));
       this->invoke_to_TlmRecv(0,13,ts,buff);
 
       // sixth channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)0x1010));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(0x1010)));
       this->invoke_to_TlmRecv(0,250,ts,buff);
 
       // seventh channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)0x15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(0x15)));
       this->invoke_to_TlmRecv(0,22,ts,buff);
 
       this->setTestTime(this->m_testTime);
@@ -810,32 +810,32 @@ namespace Svc {
 
       // send the packets
       // first channel
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U32)0x20));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U32>(0x20)));
       this->invoke_to_TlmRecv(0,10,ts,buff);
 
       // second channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)0x15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(0x15)));
       this->invoke_to_TlmRecv(0,100,ts,buff);
 
       // third channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)0x14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(0x14)));
       this->invoke_to_TlmRecv(0,333,ts,buff);
 
       // fifth channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U64)0x1000000));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U64>(0x1000000)));
       this->invoke_to_TlmRecv(0,13,ts,buff);
 
       // sixth channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U16)0x1010));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U16>(0x1010)));
       this->invoke_to_TlmRecv(0,250,ts,buff);
 
       // seventh channel
       buff.resetSer();
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize((U8)0x15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,buff.serialize(static_cast<U8>(0x15)));
       this->invoke_to_TlmRecv(0,22,ts,buff);
 
       this->setTestTime(this->m_testTime);
@@ -853,11 +853,11 @@ namespace Svc {
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(this->m_testTime));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize((U32)0x20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize((U16)0x15));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize((U8)0x14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(static_cast<U32>(0x20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(static_cast<U16>(0x15)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff1.serialize(static_cast<U8>(0x14)));
 
-      ASSERT_from_PktSend(0,comBuff1,(U32)0);
+      ASSERT_from_PktSend(0,comBuff1,static_cast<U32>(0));
 
 return;
 
@@ -870,22 +870,22 @@ return;
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(this->m_testTime));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)15));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)14));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(15)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(14)));
 
-      ASSERT_from_PktSend(0,comBuff,(U32)0);
+      ASSERT_from_PktSend(0,comBuff,static_cast<U32>(0));
 
       comBuff.resetSer();
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_PACKETIZED_TLM)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
       ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(this->m_testTime));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U32)20));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U64)1000000));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U16)1010));
-      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize((U8)15));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U32>(20)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U64>(1000000)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U16>(1010)));
+      ASSERT_EQ(Fw::FW_SERIALIZE_OK,comBuff.serialize(static_cast<U8>(15)));
 
-      ASSERT_from_PktSend(1,comBuff,(U32)0);
+      ASSERT_from_PktSend(1,comBuff,static_cast<U32>(0));
 
   }
 
@@ -928,10 +928,10 @@ return;
       this->component.setPacketList(packetList,ignore,2);
       // ping component
       this->clearFromPortHistory();
-      this->invoke_to_pingIn(0,(U32)0x1234);
+      this->invoke_to_pingIn(0,static_cast<U32>(0x1234));
       this->component.doDispatch();
       ASSERT_from_pingOut_SIZE(1);
-      ASSERT_from_pingOut(0,(U32)0x1234);
+      ASSERT_from_pingOut(0,static_cast<U32>(0x1234));
 
   }
 

--- a/Utils/CRCChecker.cpp
+++ b/Utils/CRCChecker.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  CRCChecker.cpp
 // \author ortega
 // \brief  cpp file for a crc32 checker
@@ -7,7 +7,7 @@
 // Copyright 2009-2020, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// ====================================================================== 
+// ======================================================================
 
 #include <FpConfig.hpp>
 #include <cstdio> // For snprintf
@@ -105,7 +105,7 @@ namespace Utils {
 
     // Write  checksum  file
     bytes_to_write = sizeof(checksum);
-    stat = f.write((U8*)(&checksum), bytes_to_write);
+    stat = f.write(reinterpret_cast<U8*>(&checksum), bytes_to_write);
     if(stat != Os::File::OP_OK || sizeof(checksum) != bytes_to_write)
     {
       f.close();
@@ -135,7 +135,7 @@ namespace Utils {
 
       // Read  checksum  file
       NATIVE_INT_TYPE checksum_from_file_size = sizeof(checksum_from_file);
-      stat = f.read((U8*)(&checksum_from_file), checksum_from_file_size);
+      stat = f.read(reinterpret_cast<U8*>(&checksum_from_file), checksum_from_file_size);
       if(stat != Os::File::OP_OK || checksum_from_file_size != sizeof(checksum_from_file))
       {
         f.close();

--- a/Utils/Hash/libcrc/CRC32.cpp
+++ b/Utils/Hash/libcrc/CRC32.cpp
@@ -33,7 +33,7 @@ namespace Utils {
         FW_ASSERT(data);
         char c;
         for(int index = 0; index < len; index++) {
-            c = ((char*)data)[index];
+            c = static_cast<const char*>(data)[index];
             local_hash_handle = update_crc_32(local_hash_handle, c);
         }
         HashBuffer bufferOut;
@@ -55,7 +55,7 @@ namespace Utils {
         FW_ASSERT(data);
         char c;
         for(int index = 0; index < len; index++) {
-            c = ((char*)data)[index];
+            c = static_cast<const char*>(data)[index];
             this->hash_handle = update_crc_32(this->hash_handle, c);
         }
     }

--- a/Utils/Hash/openssl/SHA256.cpp
+++ b/Utils/Hash/openssl/SHA256.cpp
@@ -29,7 +29,7 @@ namespace Utils {
         hash(const void *const data, const NATIVE_INT_TYPE len, HashBuffer& buffer)
     {
         U8 out[SHA256_DIGEST_LENGTH];
-        U8* ret = SHA256((U8*) data, len, out);
+        U8* ret = SHA256(static_cast<const U8*>(data), len, out);
         FW_ASSERT(ret != NULL);
         HashBuffer bufferOut(out, sizeof(out));
         buffer = bufferOut;
@@ -45,7 +45,7 @@ namespace Utils {
     void Hash ::
         update(const void *const data, NATIVE_INT_TYPE len)
     {
-        int ret = SHA256_Update(&this->hash_handle, (U8*) data, len);
+        int ret = SHA256_Update(&this->hash_handle, static_cast<const U8*>(data), len);
         FW_ASSERT(ret == 1);
     }
 

--- a/Utils/test/ut/LockGuardTester.cpp
+++ b/Utils/test/ut/LockGuardTester.cpp
@@ -42,7 +42,7 @@ namespace Utils {
   };
   void taskMethod(void* ptr)
   {
-    TaskData* data = (TaskData*)ptr;
+    TaskData* data = static_cast<TaskData*>(ptr);
     LockGuard guard(data->mutex);
     data->i++;
   }
@@ -58,7 +58,7 @@ namespace Utils {
 
     {
       LockGuard guard(data.mutex);
-      stat = testTask.start(name,12,100,10*1024,taskMethod,(void*) &data);
+      stat = testTask.start(name,12,100,10*1024,taskMethod,&data);
       ASSERT_EQ(stat, Os::Task::TASK_OK);
       Os::Task::delay(100);
       ASSERT_EQ(data.i, 0);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| various |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Breaking changes in #955 into smaller chunks. This PR contains the remaining changes that didn't fit into previous pull requests.

Switch fprime from using a mix of C/C++ style casts to C++ style casts only. Add compiler warning to core framework project to error on use of C style casts. Note, using a c-style cast to cast return value to void and signal that the return value is ignored is still permitted.

## Rationale

C++ style static, const, and reinterpret casts are safer than C style casts by forcing developers to be explicit about how they intend to typecast a value. This brings fprime inline with the C++ best practice of avoiding C style casts.