### PR TITLE
clang-tidy: enable modernize-use-bool-literals

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,2 @@
-Checks: "modernize-redundant-void-arg,modernize-deprecated-headers,-clang-analyzer-security.insecureAPI.rand"
+Checks: "modernize-use-bool-literals,modernize-redundant-void-arg,modernize-deprecated-headers,-clang-analyzer-security.insecureAPI.rand"
 WarningsAsErrors: '*'

--- a/Drv/LinuxGpioDriver/test/ut/Tester.cpp
+++ b/Drv/LinuxGpioDriver/test/ut/Tester.cpp
@@ -69,7 +69,7 @@ namespace Drv {
 
       // delay waiting for cycles to complete
       NATIVE_INT_TYPE maxCycles = 10;
-      while (1) {
+      while (true) {
           Os::Task::delay(500);
           bool state;
           //this->invoke_to_gpioRead(0,state);

--- a/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.cpp
+++ b/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.cpp
@@ -326,7 +326,7 @@ namespace Drv {
 
       Fw::Buffer buff;
 
-      while (1) {
+      while (true) {
           // wait for data
           int sizeRead = 0;
 

--- a/Os/test/ut/OsQueueTest.cpp
+++ b/Os/test/ut/OsQueueTest.cpp
@@ -451,7 +451,7 @@ void qtest_performance() {
     printf("Testing deep queue...\n");
     // Fill the queue up first:
     U32 count = 0;
-    while(1) {
+    while(true) {
       stat = testQueue->send(sendBuff, count%4, Os::Queue::QUEUE_NONBLOCKING);
       count++;
       if(stat == Os::Queue::QUEUE_FULL)
@@ -488,7 +488,7 @@ void qtest_performance() {
     elapsedTime = static_cast<F64>(etime.tv_sec - stime.tv_sec) + static_cast<F64>(etime.tv_usec - stime.tv_usec)/1000000;
     printf("Time: %0.3fs (%0.3fus per)\n", elapsedTime, 1000000*elapsedTime/static_cast<F64>(numIterations));
 #endif
-    while(1) {
+    while(true) {
       stat = testQueue->receive(recvBuff, prio, Os::Queue::QUEUE_NONBLOCKING);
       if(stat == Os::Queue::QUEUE_NO_MORE_MSGS)
         break;
@@ -550,7 +550,7 @@ void qtest_concurrent() {
     printf("Testing deep queue...\n");
     // Fill the queue up first:
     U32 count = 0;
-    while(1) {
+    while(true) {
       stat = testQueue->send(sendBuff,count%4, Os::Queue::QUEUE_NONBLOCKING);
       count++;
       if(stat == Os::Queue::QUEUE_FULL)

--- a/Svc/BufferManager/test/ut/Tester.cpp
+++ b/Svc/BufferManager/test/ut/Tester.cpp
@@ -247,7 +247,7 @@ namespace Svc {
 
       for (NATIVE_UINT_TYPE b=0; b<BIN1_NUM_BUFFERS; b++) {
           NATIVE_UINT_TYPE entry;
-          while (1) {
+          while (true) {
               entry = rand() % BIN1_NUM_BUFFERS;
               if (not returned[entry]) {
                   returned[entry] = true;

--- a/Svc/FatalHandler/FatalHandlerComponentBaremetalImpl.cpp
+++ b/Svc/FatalHandler/FatalHandlerComponentBaremetalImpl.cpp
@@ -20,7 +20,7 @@ namespace Svc {
             FwEventIdType Id) {
         // for **nix, delay then exit with error code
         Os::Log::logMsg("FATAL %d handled.\n",Id,0,0,0,0,0);
-        while (1) {} // Returning might be bad
+        while (true) {} // Returning might be bad
     }
 
 } // end namespace Svc

--- a/Svc/LinuxTimer/LinuxTimerComponentImplTaskDelay.cpp
+++ b/Svc/LinuxTimer/LinuxTimerComponentImplTaskDelay.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  LinuxTimerImpl.cpp
 // \author tim
 // \brief  cpp file for LinuxTimer component implementation class
@@ -7,8 +7,8 @@
 // Copyright 2009-2015, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 
 #include <Svc/LinuxTimer/LinuxTimerComponentImpl.hpp>
@@ -18,7 +18,7 @@
 namespace Svc {
 
   void LinuxTimerComponentImpl::startTimer(NATIVE_INT_TYPE interval) {
-      while (1) {
+      while (true) {
           Os::Task::delay(interval);
           if (this->m_quit) {
               return;

--- a/Svc/LinuxTimer/LinuxTimerComponentImplTimerFd.cpp
+++ b/Svc/LinuxTimer/LinuxTimerComponentImplTimerFd.cpp
@@ -34,7 +34,7 @@ namespace Svc {
 
       timerfd_settime (fd, 0, &itval, NULL);
 
-      while (1) {
+      while (true) {
           unsigned long long missed;
           int ret = read (fd, &missed, sizeof (missed));
           if (-1 == ret) {

--- a/Svc/UdpReceiver/UdpReceiverComponentImpl.cpp
+++ b/Svc/UdpReceiver/UdpReceiverComponentImpl.cpp
@@ -128,7 +128,7 @@ namespace Svc {
 
   void UdpReceiverComponentImpl::workerTask(void* ptr) {
       UdpReceiverComponentImpl *compPtr = static_cast<UdpReceiverComponentImpl*>(ptr);
-      while (1) {
+      while (true) {
           compPtr->doRecv();
       }
   }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Prefer true/false over 1/0 for boolean literals - uses clang-tidy to enforce and fix usages
