### PR TITLE
Compile test project with pedantic

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -525,8 +525,8 @@ findall
 fio
 Firefox
 Fixme
-FIXME
 Fixme
+FIXME
 flist
 FNDELAY
 fnmatch
@@ -1730,6 +1730,7 @@ virtualbox
 virtualenv
 virtualization
 virtualized
+vla
 vlist
 vm
 VMIN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,19 +9,48 @@ set(FPRIME_FRAMEWORK_PATH "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Location of F 
 set(FPRIME_PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Root path of F prime project" FORCE)
 
 # This cmake project is only intended to be used by CI and developers to test F-prime. We enable
-# -Wall and -Wextra on this particular project as a canary to warn about compilation errors without
-# impacting real projects, where a warning from an untested compiler could break the build.
+# -Wall and -Wextra on this particular project as a canary to warn about compilation
+# errors without impacting real projects, where a warning from an untested compiler could break the
+# build.
+
+add_compile_options(
+    -Wall
+    -Wextra
+    -Werror
+    $<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>
+    -Wno-unused-parameter
+)
+
+# Turn on pedantic checks for clang, but disable specific checks that F' doesn't comply with.
+# GCC doesn't support disabling specific pedantic checks, so skip pedantic on GCC for now.
 #
-# Disable the unused parameter warning for now. F' has a lot of interfaces, so unused method
-# parameters are common in the F prime code base. Eventually all intentionally unused parameters
-# should be annotated to avoid this error.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wno-unused-parameter")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wold-style-cast -Wno-unused-parameter")
+# -Wno-unused-parameter: Disable the unused parameter warning for now. F' has a lot of interfaces,
+# so unused method parameters are common in the F prime code base. Eventually all intentionally
+# unused parameters should be annotated to avoid this error.
+#
+# -Wno-gnu-zero-variadic-macro-arguments: gnu extension required to allow FW_ASSERT to support 0+
+# optional arguments
+#
+# -Wno-vla-extension: Variable length arrays are required to support sending to async serializable
+# ports. https://github.com/nasa/fprime/issues/945
+#
+# -Wno-zero-length-array: maximum port message size calculated by using sizeof on an array the size
+# of all the port's arguments. When port has no argument array is zero sized. Array is used at
+# compile time only.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(
+        -pedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        $<$<COMPILE_LANGUAGE:CXX>:-Wno-vla-extension>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wno-zero-length-array>
+    )
+endif()
 
 # For this testing cmake project, enable AddressSanitizer, a runtime memory sanitizer, on all unit tests
-set (CMAKE_C_FLAGS_TESTING "${CMAKE_C_FLAGS_TESTING} -fno-omit-frame-pointer -fsanitize=address")
-set (CMAKE_CXX_FLAGS_TESTING "${CMAKE_CXX_FLAGS_TESTING} -fno-omit-frame-pointer -fsanitize=address")
-set (CMAKE_LINKER_FLAGS_TESTING "${CMAKE_LINKER_FLAGS_TESTING} -fno-omit-frame-pointer -fsanitize=address")
+if (CMAKE_BUILD_TYPE STREQUAL "Testing" OR CMAKE_BUILD_TYPE STREQUAL "TESTING")
+    add_compile_options(-fno-omit-frame-pointer -fsanitize=address)
+    add_link_options(-fno-omit-frame-pointer -fsanitize=address)
+endif()
 
 # Include the build for F prime.
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/FPrime.cmake")


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|   |
|**_Related Issue(s)_**| #945 |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Compile the test project with pedantic to catch non-portable C++. A few of the pedantic warnings had to be disabled but hopefully we can slowly resolve these issues over time. Ideally we'd disable specific compilation warnings only on the affected  files, but it's tricky to do in a portable way.