### PR TITLE
Fix MathComponent Tutorial.md typos

### DIFF
--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -188,7 +188,7 @@ The `<args>` tag begins the section of the XML defining the arguments, while the
 The enumerations are a special type of argument. When `type="ENUM"` is an attribute of the arguments, a further listing of the elements of the enumeration are needed. For each element of the array, a name is specified. These end up being C++ enumerated types.
 
 ```xml
-           <enum name="MathOperation">
+            <enum name="MathOperation">
                 <item name="MATH_ADD"/>
                 <item name="MATH_SUB"/>
                 <item name="MATH_MULTIPLY"/>
@@ -642,7 +642,7 @@ The XML for the defined events is as follows:
 
 ```xml
     <events>
-        <event id="0" name="MS_COMMAND_RECV" severity="ACTIVITY_LO" format_string = "Math Cmd Recvd: %f %f %d"  >
+        <event id="0" name="MS_COMMAND_RECV" severity="ACTIVITY_LO" format_string="Math Cmd Recvd: %f %f %d"  >
             <comment>
             Math command received
             </comment>
@@ -651,7 +651,7 @@ The XML for the defined events is as follows:
                     <comment>The val1 argument</comment>
                 </arg>
                 <arg name="val2" type="F32">
-                    <comment>The val1 argument</comment>
+                    <comment>The val2 argument</comment>
                 </arg>
                 <arg name="op" type="ENUM">
                     <comment>The requested operation</comment>
@@ -1807,7 +1807,7 @@ This C++ file is where the instances of all the components are declared and init
 
 Put these declarations after the declarations for the other `Ref` components:
 
-`Ref/Top/Topology.cpp`, line 187:
+`Ref/Top/Topology.cpp`, line 106:
 
 ```c++
 Ref::MathSenderComponentImpl mathSender(FW_OPTIONAL_NAME("mathSender"));
@@ -1819,7 +1819,7 @@ Where the other components are initialized, add `MathSender` and `MathReceiver`:
 `Ref/Top/Topology.cpp`, line 172:
 
 ```c++
-	pingRcvr.init(10);
+    pingRcvr.init(10);
 
     mathSender.init(10,0);
     mathReceiver.init(10,0);
@@ -1925,8 +1925,8 @@ The Component instances must be declared.
 ```xml
     <instance namespace="Svc" name="uplink" type="Deframer" base_id="701"  base_id_window="20" />
 
-   <instance namespace="Ref" name="mathSender" type="MathSender" base_id="1000"  base_id_window="20" />
-   <instance namespace="Ref" name="mathReceiver" type="MathReceiver" base_id="1100"  base_id_window="20" />
+    <instance namespace="Ref" name="mathSender" type="MathSender" base_id="1000"  base_id_window="20" />
+    <instance namespace="Ref" name="mathReceiver" type="MathReceiver" base_id="1100"  base_id_window="20" />
 ```
 
 The name in the `name=` attribute must match the one declared previously in `Ref/Top/Components.hpp`. For example:
@@ -2093,7 +2093,7 @@ Components that have telemetry or events need to be able to time stamp the event
 
 The `MathReceiver` component does not have a thread of its own, but relies on the thread of another component to drive it via the `SchedIn` port. The `SchedIn` port is connected to the 1Hz rate group component that is part of the `Ref` example. This means that every second the component gets a call and can unload messages from its message queue and dispatch them to handlers.
 
-`Ref/Top/RefTopologyAppAi.xml`, line 894:
+`Ref/Top/RefTopologyAppAi.xml`, can be added near the end of the file after the previous connection's closing brace (`</connection>`):
 
 ```xml
    <!-- Scheduler Connection -->
@@ -2107,7 +2107,7 @@ The `MathReceiver` component does not have a thread of its own, but relies on th
 
 The final connection is the connection that performs the math operation. It goes from `MathSender` to `MathReceiver`.
 
-`Ref/Top/RefTopologyAppAi.xml`, line 911:
+`Ref/Top/RefTopologyAppAi.xml`, can be added after the Scheduler Connection added above:
 
 ```xml
 

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -97,7 +97,7 @@ result = (value1 operation value2)*factor1/factor2
 This section will cover the implementation of the components for this tutorial. The implementation of these components
 will have the following steps:
 
-1) Define the `MathOpPort` and 'MathResultPort' ports that are used between the components.
+1) Define the `MathOpPort` and `MathResultPort` ports that are used between the components.
 2) Define the `MathSender` component in XML and compile it.
 3) Implement the `MathSender` derived implementation class.
 4) Unit test the `MathSender` implementation component.
@@ -154,7 +154,7 @@ The `interface` tag specifies that a port is being defined. The attributes are a
 |Attribute|Description|
 |---|---|
 |name|The name of the component type. Becomes the C++ class name|
-|namespace|The namespace of the component. The C++ namespace the where the component class will appear|
+|namespace|The namespace of the component. The C++ namespace where the component class will appear|
 
 #### 2.1.1.2 Port Argument Specification
 
@@ -1717,7 +1717,7 @@ It is a way to test default settings for parameters.
 
 ```
 
-In this test case, the parameter value was set prior to the `loadParameters()` call. A `Fw::PARAM_VALID` status is also set, which allows the component consider the value valid and use it.
+In this test case, the parameter value was set prior to the `loadParameters()` call. A `Fw::PARAM_VALID` status is also set, which allows the component to consider the value valid and use it.
 
 ##### 2.4.2.2.3 Serializable Usage
 
@@ -1879,7 +1879,7 @@ The thread for the active `MathSender` component needs to be started:
     mathSender.start();
 ```
 
-The start call without arguments uses the Os defaults for priority, stack size, etc.
+The start call without arguments uses the OS defaults for priority, stack size, etc.
 
 The `MathReceiver` queued component will execute on the thread of the 1Hz rate group, which will be shown later.
 It does not need to have a thread started, since queued components do not have threads.

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -1845,6 +1845,7 @@ Next, the components commands are registered.
 ```c++
     health.regCommands();
     pingRcvr.regCommands();
+    pktTlm.regCommands();
 
     mathSender.regCommands();
     mathReceiver.regCommands();
@@ -1861,7 +1862,7 @@ Component parameters are retrieved from disk by `prmDb` prior to the components 
 
 Once the parameters are read by `prmDb`, the components can request them:
 
-`Ref/Top/Topology.cpp`, line 208:
+`Ref/Top/Topology.cpp`, line 209:
 
 ```c++
     sendBuffComp.loadParameters();
@@ -1888,10 +1889,10 @@ The `exitTasks()` function is called when the process is shut down.
 It contains `exit()` calls to all the active components.
 These functions internally send a message to the component's thread to shut down.
 
-`Ref/Top/Topology.cpp`, line 288:
+`Ref/Top/Topology.cpp`, line 289:
 
 ```c++
-    cmdSeq.exit();
+    pingRcvr.exit();
 
     mathSender.exit();
 ```

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -2107,7 +2107,7 @@ The `MathReceiver` component does not have a thread of its own, but relies on th
 
 The final connection is the connection that performs the math operation. It goes from `MathSender` to `MathReceiver`.
 
-`Ref/Top/RefTopologyAppAi.xml`, can be added after the Scheduler Connection added above:
+`Ref/Top/RefTopologyAppAi.xml`, can be added after the Scheduler Connection which was inserted in the previous step:
 
 ```xml
 

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -1790,7 +1790,7 @@ There is a C++ header file that declares all the component instances as external
 
 `extern` declarations need to be made in this header file for use by the topology connection file that is discussed later as well as initialization code.
 
-`Ref/Top/Components.hpp`, line 61:
+`Ref/Top/Components.hpp`, line 62:
 
 ```c++
 extern Ref::PingReceiverComponentImpl pingRcvr;
@@ -1816,7 +1816,7 @@ Ref::MathReceiverComponentImpl mathReceiver(FW_OPTIONAL_NAME("mathReceiver"));
 
 Where the other components are initialized, add `MathSender` and `MathReceiver`:
 
-`Ref/Top/Topology.cpp`, line 286:
+`Ref/Top/Topology.cpp`, line 172:
 
 ```c++
 	pingRcvr.init(10);
@@ -1830,7 +1830,7 @@ This is the number of messages that can be pending while other messages are bein
 
 After all the components are initialized, the generated function `constructRefArchitecture()` (see `RefTopologyAppAc.cpp`) can be called to connect the components together. How this function is generated will be seen later in the tutorial.
 
-`Ref/Top/Topology.cpp`, line 291:
+`Ref/Top/Topology.cpp`, line 177:
 
 ```c++
     // Connect rate groups to rate group driver
@@ -1840,7 +1840,7 @@ After all the components are initialized, the generated function `constructRefAr
 
 Next, the components commands are registered.
 
-`Ref/Top/Topology.cpp`, line 308:
+`Ref/Top/Topology.cpp`, line 202:
 
 ```c++
     health.regCommands();
@@ -1852,7 +1852,7 @@ Next, the components commands are registered.
 
 Component parameters are retrieved from disk by `prmDb` prior to the components requesting them:
 
-`Ref/Top/Topology.cpp`, line 314:
+`Ref/Top/Topology.cpp`, line 206:
 
 ```c++
     // read parameters
@@ -1861,7 +1861,7 @@ Component parameters are retrieved from disk by `prmDb` prior to the components 
 
 Once the parameters are read by `prmDb`, the components can request them:
 
-`Ref/Top/Topology.cpp`, line 300:
+`Ref/Top/Topology.cpp`, line 208:
 
 ```c++
     sendBuffComp.loadParameters();
@@ -1871,7 +1871,7 @@ Once the parameters are read by `prmDb`, the components can request them:
 
 The thread for the active `MathSender` component needs to be started:
 
-`Ref/Top/Topology.cpp`, line 357:
+`Ref/Top/Topology.cpp`, line 261:
 
 ```c++
     pingRcvr.start();
@@ -1888,7 +1888,7 @@ The `exitTasks()` function is called when the process is shut down.
 It contains `exit()` calls to all the active components.
 These functions internally send a message to the component's thread to shut down.
 
-`Ref/Top/Topology.cpp`, line 396:
+`Ref/Top/Topology.cpp`, line 288:
 
 ```c++
     cmdSeq.exit();
@@ -1906,7 +1906,7 @@ The connections for the new components will be added to the existing connections
 
 The component XML definitions must be imported into the topology file:
 
-`Ref/Top/RefTopologyAppAi.xml`, line 32:
+`Ref/Top/RefTopologyAppAi.xml`, line 33:
 
 ```xml
     <import_component_type>Svc/Deframer/DeframerComponentAi.xml</import_component_type>
@@ -1919,7 +1919,7 @@ The component XML definitions must be imported into the topology file:
 
 The Component instances must be declared.
 
-`Ref/Top/RefTopologyAppAi.xml`, line 92:
+`Ref/Top/RefTopologyAppAi.xml`, line 55:
 
 ```xml
     <instance namespace="Svc" name="uplink" type="Deframer" base_id="701"  base_id_window="20" />
@@ -1961,7 +1961,7 @@ The following XML shows the command connection for the tutorial components.
 The port number used for the registration and dispatch ports is selected as 20,
 a unique number that hasn't been used yet in the `Ref` example.
 
-`Ref/Top/RefTopologyAppAi.xml`, line 817:
+`Ref/Top/RefTopologyAppAi.xml`, line 154:
 
 ```xml
    <!-- Command Registration Ports - Registration port number must match dispatch port for each component -->
@@ -2002,7 +2002,7 @@ a unique number that hasn't been used yet in the `Ref` example.
 
 The output connections for log ports are connected to the `eventLogger` component.
 
-`Ref/Top/RefTopologyAppAi.xml`, line 845:
+`Ref/Top/RefTopologyAppAi.xml`, line 376:
 
 ```xml
    <!-- Event Logger Binary Connections -->
@@ -2034,7 +2034,7 @@ There are two kinds of connections for logging: One for a binary form that will 
 
 The telemetry output ports are connected to the `chanTlm` component.
 
-`Ref/Top/RefTopologyAppAi.xml`, line 872:
+`Ref/Top/RefTopologyAppAi.xml`, line 546:
 
 ```xml
    <!-- Telemetry Connections -->
@@ -2054,7 +2054,7 @@ The telemetry output ports are connected to the `chanTlm` component.
 
 There are two parameter connections, a `PrmGet` connection for reading parameters during software initialization and a `PrmSet` for updating parameters in the component that manages parameter values. F' has a basic parameter storage component `prmDb` that stores parameters in files. Upon bootup, they are read from a file specified in the constructor and stored in memory. Subsequent to this, components request their parameters via the `PrmGet` connection. If they are updated by command, they can be saved to storage by issuing a command to call the `PrmSet` with the new value and issuing the `PRM_SAVE_FILE` command.
 
-`Ref/Top/RefTopologyAppAi.xml`, line 883:
+`Ref/Top/RefTopologyAppAi.xml`, line 629:
 
 ```xml
    <!-- Parameter Connections -->
@@ -2073,7 +2073,7 @@ There are two parameter connections, a `PrmGet` connection for reading parameter
 
 Components that have telemetry or events need to be able to time stamp the events. The time connections connect the components to a time source to provide the time stamps.
 
-`Ref/Top/RefTopologyAppAi.xml`, line 894:
+`Ref/Top/RefTopologyAppAi.xml`, line 648:
 
 ```xml
    <!-- Time Connections -->

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -1425,7 +1425,7 @@ Next, the test checks for the expected telemetry and events:
       ASSERT_EVENTS_SIZE(1);
       // verify the expected event was only sent once
       ASSERT_EVENTS_MS_RESULT_SIZE(1);
-      // verify the expected value of the event
+      // verify the expected value of the event arguments
       ASSERT_EVENTS_MS_RESULT(0,10.0);
 ```
 
@@ -1782,7 +1782,7 @@ There is a C++ header file that declares all the component instances as external
 `Ref/Top/Components.hpp`, line 30:
 
 ```c++
-#include <Drv/BlockDriver/BlockDriverImpl.hpp>
+#include <Svc/Deframer/DeframerComponentImpl.hpp>
 
 #include <Ref/MathSender/MathSenderComponentImpl.hpp>
 #include <Ref/MathReceiver/MathReceiverComponentImpl.hpp>
@@ -1833,7 +1833,7 @@ After all the components are initialized, the generated function `constructRefAr
 `Ref/Top/Topology.cpp`, line 291:
 
 ```c++
-    // call generated function to connect components
+    // Connect rate groups to rate group driver
     constructRefArchitecture();
 
 ```
@@ -1909,8 +1909,7 @@ The component XML definitions must be imported into the topology file:
 `Ref/Top/RefTopologyAppAi.xml`, line 32:
 
 ```xml
-	<import_component_type>Svc/PassiveConsoleTextLogger/PassiveTextLoggerComponentAi.xml</import_component_type>
-
+    <import_component_type>Svc/Deframer/DeframerComponentAi.xml</import_component_type>
 
     <import_component_type>Ref/MathSender/MathSenderComponentAi.xml</import_component_type>
     <import_component_type>Ref/MathReceiver/MathReceiverComponentAi.xml</import_component_type>
@@ -1923,7 +1922,7 @@ The Component instances must be declared.
 `Ref/Top/RefTopologyAppAi.xml`, line 92:
 
 ```xml
-   <instance namespace="Svc" name="textLogger" type="PassiveTextLogger" base_id="521"  base_id_window="20" />
+    <instance namespace="Svc" name="uplink" type="Deframer" base_id="701"  base_id_window="20" />
 
    <instance namespace="Ref" name="mathSender" type="MathSender" base_id="1000"  base_id_window="20" />
    <instance namespace="Ref" name="mathReceiver" type="MathReceiver" base_id="1100"  base_id_window="20" />


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixed a few minor typos in MathComponent Tutorial as some of the line references and code snippets had become outdated since refactoring of the files referenced.

## Rationale

To improve code clarity.

## Testing/Review Recommendations

None. Only changing docs - no code changes.

## Future Work

n/a
