### PR TITLE
Cleanup telemetry and event string classes

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -34,7 +34,7 @@ ALLEXTERNALS
 alloc
 Alltypes
 alphanums
-ampc
+ampcs
 amsmath
 aname
 ANamespace

--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
@@ -889,7 +889,7 @@ namespace ${namespace} {
   #for $ids, $tlmname, $type, $size, $update, $comment, $typeinfo in $channels:
     #set $tlm_type = $type
     #if $type == "string":
-      #set $tlm_type = "Fw::TlmString&"
+      #set $tlm_type = "const Fw::TlmString&"
     #else if $typeinfo == "user"
       #set $tlm_type = "const " + $type + "&"
     #else
@@ -920,9 +920,8 @@ namespace ${namespace} {
       }
       Fw::TlmBuffer _tlmBuff;
     #if $type == "string":
-      arg.setMaxSerialize($size);
-    #end if
-    #if $typeinfo == "enum":
+      Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, $size);
+    #else if $typeinfo == "enum":
       Fw::SerializeStatus _stat = _tlmBuff.serialize(static_cast<FwEnumStoreType>(arg));
     #else
       Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
@@ -1258,22 +1257,19 @@ namespace ${namespace} {
       _status = _logBuff.serialize(
           static_cast<FwEnumStoreType>(${arg_name})
       );
+      #else if $typeinfo == "string":
+      _status = ${arg_name}.serialize(_logBuff, ${size});
       #else
-        #if $typeinfo == "string":
-      ${arg_name}.setMaxSerialize(${size});
-        #else
 \#if FW_AMPCS_COMPATIBLE
       // Serialize the argument size
       _status = _logBuff.serialize(
-          static_cast<U8>(sizeof($arg_name))
+          static_cast<U8>(sizeof($size))
       );
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<AssertArg>(_status)
       );
 \#endif
-
-        #end if
       _status = _logBuff.serialize($arg_name);
       #end if
       FW_ASSERT(

--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
@@ -815,7 +815,7 @@ $emit_non_port_params(8, $params)
   #for $ids, $name, $type, $size, $update, $comment, $typeinfo in $channels:
     #set $tlm_type = $type
     #if $type == "string":
-      #set $tlm_type = "Fw::TlmString&"
+      #set $tlm_type = "const Fw::TlmString&"
     #else if $typeinfo == "user"
       #set $tlm_type = "const " + $type + "&"
     #else

--- a/Autocoders/Python/src/fprime_ac/models/ModelParser.py
+++ b/Autocoders/Python/src/fprime_ac/models/ModelParser.py
@@ -586,7 +586,7 @@ class ModelParser:
                         sys.exit(-1)
                     typeinfo = "enum"
                 elif t == "string":
-                    t = "Fw::LogStringArg&"
+                    t = "const Fw::LogStringArg&"
                     typeinfo = "string"
                 elif t not in TypesList.types_list:
                     typeinfo = "user"

--- a/Fw/Log/LogString.cpp
+++ b/Fw/Log/LogString.cpp
@@ -1,105 +1,23 @@
 #include <Fw/Log/LogString.hpp>
 #include <Fw/Types/StringUtils.hpp>
-#include <cstring>
 
 namespace Fw {
 
-    LogStringArg::LogStringArg(const char* src)
-            :  StringBase(), m_maxSer(FW_LOG_STRING_MAX_SIZE) {
+    LogStringArg::LogStringArg(const char* src) : StringBase() {
         Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
-    LogStringArg::LogStringArg(const StringBase& src)
-            : StringBase(), m_maxSer(FW_LOG_STRING_MAX_SIZE) {
+    LogStringArg::LogStringArg(const StringBase& src) : StringBase() {
         Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
-    LogStringArg::LogStringArg(const LogStringArg& src)
-            : StringBase(), m_maxSer(FW_LOG_STRING_MAX_SIZE) {
+    LogStringArg::LogStringArg(const LogStringArg& src) : StringBase() {
         Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
     LogStringArg::LogStringArg()
-            : StringBase(), m_maxSer(FW_LOG_STRING_MAX_SIZE) {
+            : StringBase() {
         this->m_buf[0] = 0;
-    }
-
-    LogStringArg::~LogStringArg() {
-    }
-
-    NATIVE_UINT_TYPE LogStringArg::length() const {
-        return static_cast<NATIVE_UINT_TYPE>(strnlen(this->m_buf,sizeof(m_buf)));
-    }
-
-    const char* LogStringArg::toChar() const {
-        return this->m_buf;
-    }
-
-    SerializeStatus LogStringArg::serialize(SerializeBufferBase& buffer) const {
-        // serialize string
-        NATIVE_UINT_TYPE strSize = FW_MIN(this->m_maxSer,static_cast<NATIVE_UINT_TYPE>(strnlen(this->m_buf,sizeof(this->m_buf))));
-#if FW_AMPCS_COMPATIBLE
-        // serialize string in AMPC compatible way
-        // AMPC requires an 8-bit argument size value before the string
-
-        // Omit the null terminator character because AMPCS does not like
-        // \0 in its strings. So subtract 1 from strSize
-        strSize--;
-
-        // serialize 8-bit size
-        // cap at 8 bit size value if higher
-        if (strSize > 256) {
-            strSize = 256;
-        }
-        SerializeStatus stat = buffer.serialize(static_cast<U8>(strSize));
-        if (stat != FW_SERIALIZE_OK) {
-            return stat;
-        }
-        return buffer.serialize(reinterpret_cast<const U8*>(this->m_buf),strSize,true);
-#else
-        return buffer.serialize(reinterpret_cast<const U8*>(this->m_buf),strSize);
-#endif
-    }
-
-    SerializeStatus LogStringArg::deserialize(SerializeBufferBase& buffer) {
-        SerializeStatus stat;
-#if FW_AMPCS_COMPATIBLE
-        // serialize string in AMPC compatible way
-        // AMPCS requires an 8-bit argument size value before the string
-
-        // deserialize 8-bit size
-        U8 deserSize;
-        stat = buffer.deserialize(deserSize);
-        if (stat != FW_SERIALIZE_OK) {
-            return stat;
-        }
-
-        NATIVE_UINT_TYPE deserSize_native = static_cast<NATIVE_UINT_TYPE>(deserSize);
-        buffer.deserialize(reinterpret_cast<U8*>(this->m_buf),deserSize_native,true);
-        this->m_buf[deserSize_native] = 0;
-        return stat;
-#else
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-        stat = buffer.deserialize(reinterpret_cast<U8*>(this->m_buf),maxSize);
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-#endif
-        return stat;
-    }
-
-    void LogStringArg::setMaxSerialize(NATIVE_UINT_TYPE size) {
-        this->m_maxSer = FW_MIN(size,FW_LOG_STRING_MAX_SIZE);
-    }
-
-    NATIVE_UINT_TYPE LogStringArg::getCapacity() const {
-        return FW_LOG_STRING_MAX_SIZE;
-    }
-
-    void LogStringArg::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
     }
 
     LogStringArg& LogStringArg::operator=(const LogStringArg& other) {
@@ -111,10 +29,73 @@ namespace Fw {
         return *this;
     }
 
-#if FW_SERIALIZABLE_TO_STRING
-    void LogStringArg::toString(StringBase& text) const {
-        text = this->m_buf;
+    LogStringArg& LogStringArg::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
     }
+
+    LogStringArg& LogStringArg::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    LogStringArg::~LogStringArg() {
+    }
+
+    const char* LogStringArg::toChar() const {
+        return this->m_buf;
+    }
+
+    NATIVE_UINT_TYPE LogStringArg::getCapacity() const {
+        return FW_LOG_STRING_MAX_SIZE;
+    }
+
+    SerializeStatus LogStringArg::serialize(SerializeBufferBase& buffer) const {
+        return this->serialize(buffer, this->length());
+    }
+
+    SerializeStatus LogStringArg::serialize(SerializeBufferBase& buffer, NATIVE_UINT_TYPE maxLength) const {
+        NATIVE_INT_TYPE len = FW_MIN(maxLength,this->length());
+#if FW_AMPCS_COMPATIBLE
+        // serialize 8-bit size with null terminator removed
+        U8 strSize = len - 1;
+        SerializeStatus stat = buffer.serialize(strSize);
+        if (stat != FW_SERIALIZE_OK) {
+            return stat;
+        }
+        return buffer.serialize(reinterpret_cast<const U8*>(this->toChar()),strSize, true);
+#else
+        return buffer.serialize(reinterpret_cast<const U8*>(this->toChar()),len);
+#endif
+    }
+
+    SerializeStatus LogStringArg::deserialize(SerializeBufferBase& buffer) {
+        NATIVE_UINT_TYPE maxSize = this->getCapacity() - 1;
+        CHAR* raw = const_cast<CHAR*>(this->toChar());
+
+#if FW_AMPCS_COMPATIBLE
+        // AMPCS encodes 8-bit string size
+        U8 strSize;
+        SerializeStatus stat = buffer.deserialize(strSize);
+        if (stat != FW_SERIALIZE_OK) {
+            return stat;
+        }
+        strSize = FW_MIN(maxSize,strSize);
+        stat = buffer.deserialize(reinterpret_cast<U8*>(raw),strSize,true);
+        // AMPCS Strings not null terminated
+        if(strSize < maxSize) {
+            raw[strSize] = 0;
+        }
+#else
+        SerializeStatus stat = buffer.deserialize(reinterpret_cast<U8*>(raw),maxSize);
 #endif
 
+        // Null terminate deserialized string
+        raw[maxSize] = 0;
+        return stat;
+    }
 }

--- a/Fw/Log/LogString.hpp
+++ b/Fw/Log/LogString.hpp
@@ -16,31 +16,25 @@ namespace Fw {
                 SERIALIZED_SIZE = FW_LOG_STRING_MAX_SIZE + sizeof(FwBuffSizeType) // size of buffer + storage of two size words
             };
 
-            LogStringArg(const char* src);
-            LogStringArg(const StringBase& src);
-            LogStringArg(const LogStringArg& src);
             LogStringArg();
+            LogStringArg(const LogStringArg& src); //!< LogStringArg string constructor
+            LogStringArg(const StringBase& src); //!< other string constructor
+            LogStringArg(const char* src); //!< char* source constructor
+            LogStringArg& operator=(const LogStringArg& other); //!< assignment operator
+            LogStringArg& operator=(const StringBase& other); //!< other string assignment operator
+            LogStringArg& operator=(const char* other); //!< char* assignment operator
             ~LogStringArg();
-            const char* toChar() const;
-            NATIVE_UINT_TYPE length() const;
-            // This method is set by the autocode to the max length specified in the XML declaration for a particular event.
-            void setMaxSerialize(NATIVE_UINT_TYPE size); // limit amount serialized
 
-            LogStringArg& operator=(const LogStringArg& other); //!< equal operator for other strings
+            const char* toChar() const override;
+            NATIVE_UINT_TYPE getCapacity() const override;
 
-            SerializeStatus serialize(SerializeBufferBase& buffer) const;
-            SerializeStatus deserialize(SerializeBufferBase& buffer);
-#if FW_SERIALIZABLE_TO_STRING
-            void toString(StringBase& text) const;
-#endif
+            SerializeStatus serialize(SerializeBufferBase& buffer) const override; //!< serialization function
+            SerializeStatus serialize(SerializeBufferBase& buffer, NATIVE_UINT_TYPE maxLen) const override; //!< serialization function
+            SerializeStatus deserialize(SerializeBufferBase& buffer) override; //!< deserialization function
 
         private:
 
-            NATIVE_UINT_TYPE getCapacity() const ; //!< return buffer size
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
-
             char m_buf[FW_LOG_STRING_MAX_SIZE];
-            NATIVE_UINT_TYPE m_maxSer;
     };
 
 }

--- a/Fw/Tlm/TlmString.cpp
+++ b/Fw/Tlm/TlmString.cpp
@@ -1,94 +1,22 @@
 #include <Fw/Tlm/TlmString.hpp>
 #include <Fw/Types/StringUtils.hpp>
-#include <cstring>
 
 namespace Fw {
 
-    TlmString::TlmString(const char* src) :  StringBase(), m_maxSer(FW_TLM_STRING_MAX_SIZE) {
+    TlmString::TlmString(const char* src) :  StringBase() {
         Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
     }
 
-    TlmString::TlmString(const StringBase& src) : StringBase(), m_maxSer(FW_TLM_STRING_MAX_SIZE) {
+    TlmString::TlmString(const StringBase& src) : StringBase() {
         Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
-    TlmString::TlmString(const TlmString& src) : StringBase(), m_maxSer(FW_TLM_STRING_MAX_SIZE) {
+    TlmString::TlmString(const TlmString& src) : StringBase() {
         Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
     }
 
-    TlmString::TlmString() : StringBase(), m_maxSer(FW_TLM_STRING_MAX_SIZE) {
+    TlmString::TlmString() : StringBase() {
         this->m_buf[0] = 0;
-    }
-
-    TlmString::~TlmString() {
-    }
-
-    NATIVE_UINT_TYPE TlmString::length() const {
-        return static_cast<NATIVE_UINT_TYPE>(strnlen(this->m_buf,sizeof(this->m_buf)));
-    }
-
-    const char* TlmString::toChar() const {
-        return this->m_buf;
-    }
-
-    SerializeStatus TlmString::serialize(SerializeBufferBase& buffer) const {
-        NATIVE_UINT_TYPE strSize = strnlen(this->m_buf,sizeof(this->m_buf));
-#if FW_AMPCS_COMPATIBLE
-        // serialize string in AMPC compatible way
-        // AMPC requires an 8-bit argument size value before the string
-
-        // Omit the null terminator character because AMPCS does not like
-        // \0 in its strings. So subtract 1 from strSize
-        strSize--;
-
-        // serialize 8-bit size
-        SerializeStatus stat = buffer.serialize(static_cast<U8>(strSize));
-        if (stat != FW_SERIALIZE_OK) {
-            return stat;
-        }
-        return buffer.serialize(reinterpret_cast<const U8*>(this->m_buf),strSize,true);
-#else
-        return buffer.serialize(reinterpret_cast<const U8*>(this->m_buf),strSize);
-#endif
-    }
-
-    SerializeStatus TlmString::deserialize(SerializeBufferBase& buffer) {
-        NATIVE_UINT_TYPE maxSize = sizeof(this->m_buf);
-        // deserialize string
-#if FW_AMPCS_COMPATIBLE
-        // AMPCS encodes 8-bit string size
-        U8 strSize;
-        SerializeStatus stat = buffer.deserialize(strSize);
-        if (stat != FW_SERIALIZE_OK) {
-            return stat;
-        }
-        NATIVE_UINT_TYPE buffSize = strSize;
-        // To make sure there is space when we add the null terminator
-        // which was omitted in the serialization of this buffer
-        strSize++;
-        stat = buffer.deserialize(reinterpret_cast<U8*>(this->m_buf),buffSize,true);
-        this->m_buf[strSize-1] = 0;
-#else
-        // deserialize string
-        SerializeStatus stat = buffer.deserialize(reinterpret_cast<U8*>(this->m_buf),maxSize);
-#endif
-        // make sure it is null-terminated
-        this->terminate(maxSize);
-
-        return stat;
-    }
-
-    void TlmString::setMaxSerialize(NATIVE_UINT_TYPE size) {
-        this->m_maxSer = FW_MIN(size,FW_TLM_STRING_MAX_SIZE);
-    }
-
-    NATIVE_UINT_TYPE TlmString::getCapacity() const {
-        return FW_TLM_STRING_MAX_SIZE;
-    }
-
-    void TlmString::terminate(NATIVE_UINT_TYPE size) {
-        // null terminate the string
-        this->m_buf[size < sizeof(this->m_buf)?size:sizeof(this->m_buf)-1] = 0;
     }
 
     TlmString& TlmString::operator=(const TlmString& other) {
@@ -100,10 +28,73 @@ namespace Fw {
         return *this;
     }
 
+    TlmString& TlmString::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
 
-#if FW_SERIALIZABLE_TO_STRING
-    void TlmString::toString(StringBase& text) const {
-        text = this->m_buf;
+        Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+        return *this;
     }
+
+    TlmString& TlmString::operator=(const char* other) {
+        Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+        return *this;
+    }
+
+    TlmString::~TlmString() {
+    }
+
+    const char* TlmString::toChar() const {
+        return this->m_buf;
+    }
+
+    NATIVE_UINT_TYPE TlmString::getCapacity() const {
+        return FW_TLM_STRING_MAX_SIZE;
+    }
+
+    SerializeStatus TlmString::serialize(SerializeBufferBase& buffer) const {
+        return this->serialize(buffer, this->length());
+    }
+
+    SerializeStatus TlmString::serialize(SerializeBufferBase& buffer, NATIVE_UINT_TYPE maxLength) const {
+        NATIVE_INT_TYPE len = FW_MIN(maxLength,this->length());
+#if FW_AMPCS_COMPATIBLE
+        // serialize 8-bit size with null terminator removed
+        U8 strSize = len - 1;
+        SerializeStatus stat = buffer.serialize(strSize);
+        if (stat != FW_SERIALIZE_OK) {
+            return stat;
+        }
+        return buffer.serialize(reinterpret_cast<const U8*>(this->toChar()),strSize, true);
+#else
+        return buffer.serialize(reinterpret_cast<const U8*>(this->toChar()),len);
 #endif
+    }
+
+    SerializeStatus TlmString::deserialize(SerializeBufferBase& buffer) {
+        NATIVE_UINT_TYPE maxSize = this->getCapacity() - 1;
+        CHAR* raw = const_cast<CHAR*>(this->toChar());
+
+#if FW_AMPCS_COMPATIBLE
+        // AMPCS encodes 8-bit string size
+        U8 strSize;
+        SerializeStatus stat = buffer.deserialize(strSize);
+        if (stat != FW_SERIALIZE_OK) {
+            return stat;
+        }
+        strSize = FW_MIN(maxSize,strSize);
+        stat = buffer.deserialize(reinterpret_cast<U8*>(raw),strSize,true);
+        // AMPCS Strings not null terminated
+        if(strSize < maxSize) {
+            raw[strSize] = 0;
+        }
+#else
+        SerializeStatus stat = buffer.deserialize(reinterpret_cast<U8*>(raw),maxSize);
+#endif
+
+        // Null terminate deserialized string
+        raw[maxSize] = 0;
+        return stat;
+    }
 }

--- a/Fw/Tlm/TlmString.hpp
+++ b/Fw/Tlm/TlmString.hpp
@@ -16,31 +16,25 @@ namespace Fw {
                 SERIALIZED_SIZE = FW_TLM_STRING_MAX_SIZE + sizeof(FwBuffSizeType) // size of buffer + storage of size word
             };
 
-            TlmString(const char* src);
-            TlmString(const StringBase& src);
-            TlmString(const TlmString& src);
             TlmString();
+            TlmString(const TlmString& src); //!< TlmString string constructor
+            TlmString(const StringBase& src); //!< other string constructor
+            TlmString(const char* src); //!< char* source constructor
+            TlmString& operator=(const TlmString& other); //!< assignment operator
+            TlmString& operator=(const StringBase& other); //!< other string assignment operator
+            TlmString& operator=(const char* other); //!< char* assignment operator
             ~TlmString();
-            const char* toChar() const;
-            NATIVE_UINT_TYPE length() const;
-            void setMaxSerialize(NATIVE_UINT_TYPE size); // limit amount serialized
 
-            TlmString& operator=(const TlmString& other); //!< equal operator for other strings
+            const char* toChar() const override;
+            NATIVE_UINT_TYPE getCapacity() const override;
 
-            SerializeStatus serialize(SerializeBufferBase& buffer) const;
-            SerializeStatus deserialize(SerializeBufferBase& buffer);
+            SerializeStatus serialize(SerializeBufferBase& buffer) const override; //!< serialization function
+            SerializeStatus serialize(SerializeBufferBase& buffer, NATIVE_UINT_TYPE maxLen) const override; //!< serialization function
+            SerializeStatus deserialize(SerializeBufferBase& buffer) override; //!< deserialization function
 
-#if FW_SERIALIZABLE_TO_STRING
-            void toString(StringBase& text) const;
-#endif
-        PRIVATE:
-            NATIVE_UINT_TYPE getCapacity() const ;
-            void terminate(NATIVE_UINT_TYPE size); //!< terminate the string
-
+        private:
             char m_buf[FW_TLM_STRING_MAX_SIZE];
-            NATIVE_UINT_TYPE m_maxSer;
     };
-
 }
 
 #endif

--- a/Fw/Types/StringType.cpp
+++ b/Fw/Types/StringType.cpp
@@ -128,6 +128,11 @@ namespace Fw {
         return buffer.serialize(reinterpret_cast<const U8*>(this->toChar()),this->length());
     }
 
+    SerializeStatus StringBase::serialize(SerializeBufferBase& buffer, NATIVE_UINT_TYPE maxLength) const {
+        NATIVE_INT_TYPE len = FW_MIN(maxLength,this->length());
+        return buffer.serialize(reinterpret_cast<const U8*>(this->toChar()), len);
+    }
+
     SerializeStatus StringBase::deserialize(SerializeBufferBase& buffer) {
         NATIVE_UINT_TYPE maxSize = this->getCapacity() - 1;
         CHAR* raw = const_cast<CHAR*>(this->toChar());

--- a/Fw/Types/StringType.hpp
+++ b/Fw/Types/StringType.hpp
@@ -37,8 +37,9 @@ namespace Fw {
 
             void format(const CHAR* formatString, ...); //!< write formatted string to buffer
 
-            SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
-            SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
+            virtual SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
+            virtual SerializeStatus serialize(SerializeBufferBase& buffer, NATIVE_UINT_TYPE maxLen) const; //!< serialization function
+            virtual SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
 
 #ifdef BUILD_UT
             // to support GoogleTest framework in unit tests


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Events/Telemetry  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

- Fixed broken string truncation for telemetry strings.
- Updated the way event and telemetry strings are truncated so that they don't modify the string class itself, allowing users to pass const strings into events and telemetry.
- Cleanup up telemetry and string classes in general to match other string classes