### PR TITLE
Switch to C++11 static assertions

### DIFF
--- a/Fw/Cfg/ConfigCheck.cpp
+++ b/Fw/Cfg/ConfigCheck.cpp
@@ -10,17 +10,18 @@
  *
  */
 
+#include <type_traits>
 #include <FpConfig.hpp>
 #include <Fw/Types/BasicTypes.hpp>
 
 // Check that command/telemetry strings are not larger than an argument buffer
 
-FW_CONFIG_ERROR(FW_CMD_STRING_MAX_SIZE <= FW_CMD_ARG_BUFFER_MAX_SIZE,CMD_STRING_TOO_BIG);
-FW_CONFIG_ERROR(FW_LOG_STRING_MAX_SIZE <= FW_LOG_BUFFER_MAX_SIZE,LOG_STRING_TOO_BIG);
-FW_CONFIG_ERROR(FW_TLM_STRING_MAX_SIZE <= FW_TLM_BUFFER_MAX_SIZE,TLM_STRING_TOO_BIG);
-FW_CONFIG_ERROR(FW_PARAM_STRING_MAX_SIZE <= FW_PARAM_BUFFER_MAX_SIZE,PRM_STRING_TOO_BIG);
+static_assert(FW_CMD_STRING_MAX_SIZE <= FW_CMD_ARG_BUFFER_MAX_SIZE, "FW_CMD_STRING_MAX_SIZE cannot be larger than FW_CMD_ARG_BUFFER_MAX_SIZE");
+static_assert(FW_LOG_STRING_MAX_SIZE <= FW_LOG_BUFFER_MAX_SIZE, "FW_LOG_STRING_MAX_SIZE cannot be larger than FW_LOG_BUFFER_MAX_SIZE");
+static_assert(FW_TLM_STRING_MAX_SIZE <= FW_TLM_BUFFER_MAX_SIZE, "FW_TLM_STRING_MAX_SIZE cannot be larger than FW_TLM_BUFFER_MAX_SIZE");
+static_assert(FW_PARAM_STRING_MAX_SIZE <= FW_PARAM_BUFFER_MAX_SIZE, "FW_PARAM_STRING_MAX_SIZE cannot be larger than FW_PARAM_BUFFER_MAX_SIZE");
 
 // Text logging needs the code generator for serializables to generate a stringified version of the
 // value.
-FW_CONFIG_ERROR((FW_ENABLE_TEXT_LOGGING == 0) || ( FW_SERIALIZABLE_TO_STRING == 1),FW_SERIALIZABLE_TO_STRING_not_enabled_for_FW_ENABLE_TEXT_LOGGING);
+static_assert((FW_ENABLE_TEXT_LOGGING == 0) || ( FW_SERIALIZABLE_TO_STRING == 1), "FW_SERIALIZABLE_TO_STRING must be enabled to enable FW_ENABLE_TEXT_LOGGING");
 

--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -5,15 +5,8 @@
 #include <Fw/Types/BasicTypes.hpp>
 
 #if FW_ASSERT_LEVEL == FW_NO_ASSERT
-
 #define FW_ASSERT(...)
-#define FW_STATIC_ASSERT(...)
-
 #else // ASSERT is defined
-
-#define FW_STATIC_CAT_(a, b) a ## b
-#define FW_STATIC_CAT(a, b) FW_STATIC_CAT_(a, b)
-#define FW_STATIC_ASSERT(cond) typedef int FW_STATIC_CAT(FW_STATIC_ASSERT,__LINE__)[(cond) ? 1 : -1]
 
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
 #define FILE_NAME_ARG NATIVE_UINT_TYPE

--- a/Svc/GenericHub/GenericHubComponentImpl.cpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.cpp
@@ -14,10 +14,10 @@
 #include "Fw/Logger/Logger.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/BasicTypes.hpp"
-#include <cstring>
+#include <type_traits>
 
 // Required port serialization or the hub cannot work
-FW_STATIC_ASSERT(FW_PORT_SERIALIZATION);
+static_assert(FW_PORT_SERIALIZATION, "FW_PORT_SERIALIZATION must be enabled to use GenericHub");
 
 namespace Svc {
 

--- a/Svc/Health/test/ut/Tester.cpp
+++ b/Svc/Health/test/ut/Tester.cpp
@@ -10,6 +10,8 @@
 //
 // ======================================================================
 
+#include <type_traits>
+
 #include "Tester.hpp"
 #include <Fw/Test/UnitTest.hpp>
 
@@ -18,7 +20,7 @@
 #define QUEUE_DEPTH (Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS*2)
 #define FLAG_KEY_VALUE 0xcafecafe
 
-FW_STATIC_ASSERT(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS < 0xcafecafe);
+static_assert(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS < 0xcafecafe, "");
 
 namespace Svc {
 

--- a/config/FpConfig.hpp
+++ b/config/FpConfig.hpp
@@ -12,10 +12,6 @@
 #ifndef _FW_CONFIG_HPP_
 #define _FW_CONFIG_HPP_
 
-// A helper macro to declare errors in definitions of the constants
-#define FW_CONFIG_ERROR( condition, name )\
-    typedef char assert_failed_ ## name [ (condition) ? 1 : -1 ];
-
 // To enable various facilities, set the below to 0 or 1. If it is set in compiler flags,
 // these defaults will be overridden
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Switch custom static assertions to use C++11 builtin static assertions.
