### PR TITLE
Use clang-tidy to warn on uses of recursion

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,6 @@
-Checks: "modernize-use-bool-literals,modernize-redundant-void-arg,modernize-deprecated-headers,-clang-analyzer-security.insecureAPI.rand"
+Checks: >
+    modernize-use-bool-literals,
+    modernize-redundant-void-arg,
+    modernize-deprecated-headers,
+    -clang-analyzer-security.insecureAPI.rand
 WarningsAsErrors: '*'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -100,10 +100,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install clang-tidy-12
     # TODO: Switch to using fprime-util build --all --ut after next fprime-tools release
-    - name: F prime CI step
+    - name: General Static Analysis
       run: |
         fprime-util generate --ut -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CXX_CLANG_TIDY=clang-tidy-12
         cd build-fprime-automatic-native-ut && make -j4
+    - name: Flight Code Static Analysis
+      run: |
+        fprime-util generate -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CXX_CLANG_TIDY="clang-tidy-12;--config-file=$PWD/release.clang-tidy"
+        fprime-util build --all -j4
 
 
 #  CMake:

--- a/release.clang-tidy
+++ b/release.clang-tidy
@@ -1,0 +1,4 @@
+Checks: >
+    -*,
+    misc-no-recursion
+WarningsAsErrors: '*'


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n/a  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Use clang-tidy to check for uses of recursion within flight code.
Because we allow recursion within unit test, this check only runs on the flight code. I added a separate clang-tidy scan to the quality CI job that only scans the flight code.