### PR TITLE
Check for object self-assignment in assignment constructor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 Checks: >
+    bugprone-unhandled-self-assignment,
     modernize-use-bool-literals,
     modernize-redundant-void-arg,
     modernize-deprecated-headers,

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -140,6 +140,7 @@ BUFFERMANAGERCOMPONENTIMPLCFG
 BUFFERMGR
 buffsize
 BUGLIST
+bugprone
 builddir
 buildroot
 builtins

--- a/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/arrays/array_cpp.tmpl
@@ -51,11 +51,19 @@ namespace ${namespace} {
     }
 
     ${name}::${name}String& ${name}::${name}String::operator=(const ${name}String& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     ${name}::${name}String& ${name}::${name}String::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
@@ -174,6 +182,10 @@ namespace ${namespace} {
   ${name}& ${name} ::
     operator=(const ${name}& other)
   {
+    if(this == &other) {
+      return *this;
+    }
+
     for(U32 index = 0; index < SIZE; index++) {
       this->elements[index] = other.elements[index];
     }

--- a/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/port/namespacePortCpp.tmpl
@@ -24,11 +24,19 @@ namespace ${n} {
     }
 
     ${argname}String& ${argname}String::operator=(const ${argname}String& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     ${argname}String& ${argname}String::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
@@ -67,6 +75,10 @@ namespace ${n} {
     }
 
     const ${argname}Buffer& ${argname}Buffer::operator=(const ${argname}Buffer& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::SerializeBufferBase::setBuff(other.m_data,other.getBuffLength());
         return other;
     }

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/namespaceSerialCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/namespaceSerialCpp.tmpl
@@ -23,11 +23,19 @@ namespace ${n} {
     }
 
     ${name}::${memname}String& ${name}::${memname}String::operator=(const ${memname}String& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     ${name}::${memname}String& ${name}::${memname}String::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/serialize/publicSerialCpp.tmpl
@@ -41,6 +41,10 @@ ${name}::${name}(${args_scalar_array_string}) : Serializable() {
 #end if
 
 ${name}& ${name}::operator=(const ${name}& src) {
+    if(this == &src) {
+            return *this;
+    }
+
     this->set(${args_mstring});
     return *this;
 }

--- a/Drv/DataTypes/DataBuffer.cpp
+++ b/Drv/DataTypes/DataBuffer.cpp
@@ -20,6 +20,10 @@ namespace Drv {
     }
 
     DataBuffer& DataBuffer::operator=(const DataBuffer& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::SerializeStatus stat = Fw::SerializeBufferBase::setBuff(other.m_data,other.getBuffLength());
         FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;

--- a/Fw/Cmd/CmdArgBuffer.cpp
+++ b/Fw/Cmd/CmdArgBuffer.cpp
@@ -20,6 +20,10 @@ namespace Fw {
     }
 
     CmdArgBuffer& CmdArgBuffer::operator=(const CmdArgBuffer& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         SerializeStatus stat = this->setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;

--- a/Fw/Cmd/CmdString.cpp
+++ b/Fw/Cmd/CmdString.cpp
@@ -20,11 +20,19 @@ namespace Fw {
     }
 
     CmdStringArg& CmdStringArg::operator=(const CmdStringArg& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     CmdStringArg& CmdStringArg::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Fw/Com/ComBuffer.cpp
+++ b/Fw/Com/ComBuffer.cpp
@@ -20,6 +20,10 @@ namespace Fw {
     }
 
     ComBuffer& ComBuffer::operator=(const ComBuffer& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;

--- a/Fw/Log/LogBuffer.cpp
+++ b/Fw/Log/LogBuffer.cpp
@@ -20,6 +20,10 @@ namespace Fw {
     }
 
     LogBuffer& LogBuffer::operator=(const LogBuffer& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;

--- a/Fw/Log/LogString.cpp
+++ b/Fw/Log/LogString.cpp
@@ -103,6 +103,10 @@ namespace Fw {
     }
 
     LogStringArg& LogStringArg::operator=(const LogStringArg& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Fw/Log/TextLogString.cpp
+++ b/Fw/Log/TextLogString.cpp
@@ -19,11 +19,19 @@ namespace Fw {
     }
 
     TextLogString& TextLogString::operator=(const TextLogString& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     TextLogString& TextLogString::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Fw/Prm/PrmBuffer.cpp
+++ b/Fw/Prm/PrmBuffer.cpp
@@ -20,6 +20,10 @@ namespace Fw {
 	}
 
     ParamBuffer& ParamBuffer::operator=(const ParamBuffer& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;

--- a/Fw/Prm/PrmString.cpp
+++ b/Fw/Prm/PrmString.cpp
@@ -20,11 +20,19 @@ namespace Fw {
     }
 
     ParamString& ParamString::operator=(const ParamString& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     ParamString& ParamString::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Fw/Test/String.cpp
+++ b/Fw/Test/String.cpp
@@ -20,11 +20,19 @@ namespace Test {
     }
 
     String& String::operator=(const String& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     String& String::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Fw/Tlm/TlmBuffer.cpp
+++ b/Fw/Tlm/TlmBuffer.cpp
@@ -20,6 +20,10 @@ namespace Fw {
     }
 
     TlmBuffer& TlmBuffer::operator=(const TlmBuffer& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;

--- a/Fw/Tlm/TlmString.cpp
+++ b/Fw/Tlm/TlmString.cpp
@@ -92,6 +92,10 @@ namespace Fw {
     }
 
     TlmString& TlmString::operator=(const TlmString& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Fw/Types/EightyCharString.cpp
+++ b/Fw/Types/EightyCharString.cpp
@@ -20,11 +20,19 @@ namespace Fw {
     }
 
     EightyCharString& EightyCharString::operator=(const EightyCharString& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     EightyCharString& EightyCharString::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Fw/Types/InternalInterfaceString.cpp
+++ b/Fw/Types/InternalInterfaceString.cpp
@@ -20,11 +20,19 @@ namespace Fw {
     }
 
     InternalInterfaceString& InternalInterfaceString::operator=(const InternalInterfaceString& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     InternalInterfaceString& InternalInterfaceString::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Fw/Types/String.cpp
+++ b/Fw/Types/String.cpp
@@ -20,11 +20,19 @@ namespace Fw {
     }
 
     String& String::operator=(const String& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     String& String::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Fw/Types/StringType.cpp
+++ b/Fw/Types/StringType.cpp
@@ -92,6 +92,10 @@ namespace Fw {
 #endif
 
     StringBase& StringBase::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(const_cast<char *>(this->toChar()), other.toChar(), this->getCapacity());
         return *this;
     }

--- a/Os/QueueString.cpp
+++ b/Os/QueueString.cpp
@@ -20,11 +20,19 @@ namespace Os {
     }
 
     QueueString& QueueString::operator=(const QueueString& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     QueueString& QueueString::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Os/TaskString.cpp
+++ b/Os/TaskString.cpp
@@ -20,11 +20,19 @@ namespace Os {
     }
 
     TaskString& TaskString::operator=(const TaskString& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }
 
     TaskString& TaskString::operator=(const StringBase& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
         return *this;
     }

--- a/Utils/Hash/HashBufferCommon.cpp
+++ b/Utils/Hash/HashBufferCommon.cpp
@@ -20,6 +20,10 @@ namespace Utils {
     }
 
     HashBuffer& HashBuffer::operator=(const HashBuffer& other) {
+        if(this == &other) {
+            return *this;
+        }
+
         Fw::SerializeStatus stat = Fw::SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
         FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
         return *this;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n/a  |
|**_Builds Without Errors (y/n)_**| y  |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Used clang-tidy to make sure F' classes properly check for and handle self-assignment.
