### PR TITLE
Allow removal of text loggers from build with CMake variable.

### DIFF
--- a/Svc/CMakeLists.txt
+++ b/Svc/CMakeLists.txt
@@ -11,7 +11,6 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/WatchDog/")
 
 # Components
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/ActiveLogger/")
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/ActiveTextLogger/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/ActiveRateGroup/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/AssertFatalAdapter/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/BufferManager/")
@@ -31,7 +30,6 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/GroundInterface/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Framer/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/FramingProtocol/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Health/")
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PassiveConsoleTextLogger/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PolyDb/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PrmDb/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/RateGroupDriver/")
@@ -39,6 +37,13 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/StaticMemory/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Time/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/TlmChan/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/TlmPacketizer/")
+
+# Allow and check for disabling of text loggers
+# Building these fails if FW_ENABLE_TEXT_LOGGING == 0
+if (NOT FPRIME_DISABLE_TEXT_LOGGERS)
+	add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PassiveConsoleTextLogger/")
+	add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/ActiveTextLogger/")
+endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 	add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/LinuxTime/")

--- a/Svc/CMakeLists.txt
+++ b/Svc/CMakeLists.txt
@@ -38,9 +38,9 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Time/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/TlmChan/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/TlmPacketizer/")
 
-# Allow and check for disabling of text loggers
-# Building these fails if FW_ENABLE_TEXT_LOGGING == 0
-if (NOT FPRIME_DISABLE_TEXT_LOGGERS)
+# Text logger components included by default, 
+# but can be disabled if FW_ENABLE_TEXT_LOGGING=0 is desired.
+if (FPRIME_ENABLE_TEXT_LOGGERS)
 	add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PassiveConsoleTextLogger/")
 	add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/ActiveTextLogger/")
 endif()

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -115,6 +115,22 @@ else()
 endif()
 
 ####
+# `FPRIME_ENABLE_TEXT_LOGGERS:`
+#
+# When FPRIME_ENABLE_TEXT_LOGGERS is set, the ActiveTextLogger and PassiveConsoleTextLogger 
+# svc components are included in the build. When unset, those components are excluded, 
+# allowing FpConfig.hpp:FW_ENABLE_TEXT_LOGGING to be unset as well, to save space.
+# TextLoggers will fail to build if FW_ENABLE_TEXT_LOGGING=0.
+#
+# **Values:**
+# - ON: (default) retains the text logger components in the target list
+# - OFF: removes text logger components from the target list
+#
+# e.g. `-DFPRIME_ENABLE_TEXT_LOGGERS=OFF`
+####
+option(FPRIME_ENABLE_TEXT_LOGGERS "Enable text loggers in build" ON)
+
+####
 # `CMAKE_BUILD_TYPE:`
 #
 # Allows for setting the CMake build type. Release is a normal build, Testing is used for unit testing and debug


### PR DESCRIPTION
Allow removal of text loggers from build with CMake variable. Otherwise build fails if FW_ENABLE_TEXT_LOGGING == 0.

| | |
|:---|:---|
|**_Originating Project/Creator_**| JPL COLDArm / Neil Abcouwer  |
|**_Affected Component_**| Build Process |
|**_Affected Architectures(s)_**| Any |
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| n/a |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

In https://github.com/nasa/fprime/blob/devel/Svc/CMakeLists.txt , move adding of Text Logger components into a `if (NOT FPRIME_DISABLE_TEXT_LOGGERS)` conditional. 

## Rationale

If FW_ENABLE_TEXT_LOGGING is set to 0 (https://github.com/nasa/fprime/blob/401c142c7bfd2f8d48dc40a8db25830985b97043/config/FpConfig.hpp#L290) , the text logger components, ActiveTextLogger and PassiveConsoleTextLogger, will fail to build, as will the entire build. 

Now, deployments that wish to set FW_ENABLE_TEXT_LOGGING to 0 can add `FPRIME_DISABLE_TEXT_LOGGERS = 1` to their CMakeLists to prevent the adding of these components.


## Testing/Review Recommendations

None

## Future Work

There may be a more desirable way to do this.
