### PR TITLE
Added sequence join wait command

### DIFF
--- a/Svc/CmdSequencer/CMakeLists.txt
+++ b/Svc/CmdSequencer/CMakeLists.txt
@@ -55,6 +55,7 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/SizeFieldTooSmallFile.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/TooLargeFile.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/USecFieldTooShortFile.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/JoinWait.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/Main.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/Tester.cpp"
 )

--- a/Svc/CmdSequencer/CmdSequencerImpl.cpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.cpp
@@ -268,13 +268,14 @@ namespace Svc {
         this->m_cmdTimer.clear();
         this->m_cmdTimeoutTimer.clear();
         this->m_executedCount = 0;
-        this->m_join_waiting = false;
         // write sequence done port with error, if connected
         if (this->isConnected_seqDone_OutputPort(0)) {
             this->seqDone_out(0,0,0,Fw::COMMAND_EXECUTION_ERROR);
         }
 
         if (SEQ_BLOCK == this->m_blockState || m_join_waiting) {
+            // Do not wait if sequence was canceled or a cmd failed
+            this->m_join_waiting = false;
             this->cmdResponse_out(this->m_opCode, this->m_cmdSeq, Fw::COMMAND_EXECUTION_ERROR);
         }
 

--- a/Svc/CmdSequencer/CmdSequencerImpl.cpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.cpp
@@ -38,7 +38,8 @@ namespace Svc {
         m_timeout(0),
         m_blockState(SEQ_NO_BLOCK),
         m_opCode(0),
-        m_cmdSeq(0)
+        m_cmdSeq(0),
+        m_join_waiting(false)
     {
 
     }
@@ -98,6 +99,10 @@ namespace Svc {
             SeqBlkState block) {
 
         if (not this->requireRunMode(STOPPED)) {
+            if (m_join_waiting) {
+                // Inform user previous seq file is not complete
+                this->log_WARNING_HI_CS_JoinWaitingNotComplete();
+            }
             this->cmdResponse_out(opCode, cmdSeq, Fw::COMMAND_EXECUTION_ERROR);
             return;
         }
@@ -218,6 +223,23 @@ namespace Svc {
         this->cmdResponse_out(opCode, cmdSeq, Fw::COMMAND_OK);
     }
 
+    void CmdSequencerComponentImpl::CS_JOIN_WAIT_cmdHandler(
+        const FwOpcodeType opCode, const U32 cmdSeq) {
+
+        // If there is no running sequence do not wait
+        if (m_runMode != RUNNING) {
+            this->log_WARNING_LO_CS_NoSequenceActive();
+            this->cmdResponse_out(opCode,cmdSeq,Fw::COMMAND_OK);
+            return;
+        } else {
+            m_join_waiting = true;
+            Fw::LogStringArg& logFileName = this->m_sequence->getLogFileName();
+            this->log_ACTIVITY_HI_CS_JoinWaiting(logFileName, m_cmdSeq, m_opCode);
+            m_cmdSeq = cmdSeq;
+            m_opCode = opCode;
+        }
+    }
+
     // ----------------------------------------------------------------------
     // Private helper methods
     // ----------------------------------------------------------------------
@@ -246,12 +268,13 @@ namespace Svc {
         this->m_cmdTimer.clear();
         this->m_cmdTimeoutTimer.clear();
         this->m_executedCount = 0;
+        this->m_join_waiting = false;
         // write sequence done port with error, if connected
         if (this->isConnected_seqDone_OutputPort(0)) {
             this->seqDone_out(0,0,0,Fw::COMMAND_EXECUTION_ERROR);
         }
 
-        if (SEQ_BLOCK == this->m_blockState) {
+        if (SEQ_BLOCK == this->m_blockState || m_join_waiting) {
             this->cmdResponse_out(this->m_opCode, this->m_cmdSeq, Fw::COMMAND_EXECUTION_ERROR);
         }
 
@@ -446,10 +469,11 @@ namespace Svc {
             this->seqDone_out(0,0,0,Fw::COMMAND_OK);
         }
 
-        if (SEQ_BLOCK == this->m_blockState) {
+        if (SEQ_BLOCK == this->m_blockState || m_join_waiting) {
             this->cmdResponse_out(this->m_opCode, this->m_cmdSeq, Fw::COMMAND_OK);
         }
 
+        m_join_waiting = false;
         this->m_blockState = SEQ_NO_BLOCK;
 
     }

--- a/Svc/CmdSequencer/CmdSequencerImpl.hpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.hpp
@@ -679,6 +679,15 @@ namespace Svc {
           const Fw::CmdStringArg& fileName //!< The name of the sequence file
       );
 
+      //! Implementation for CS_JOIN command handler
+      //! Wait for sequences that are running to finish.
+			//! Allow user to run multiple seq files in SEQ_NO_BLOCK mode
+			//! then wait for them to finish before allowing more seq run request.
+      void CS_JOIN_WAIT_cmdHandler(
+          const FwOpcodeType opCode, /*!< The opcode*/
+          const U32 cmdSeq /*!< The command sequence number*/
+      );
+
     PRIVATE:
 
       // ----------------------------------------------------------------------
@@ -788,7 +797,7 @@ namespace Svc {
       SeqBlkState m_blockState;
       FwOpcodeType m_opCode;
       U32 m_cmdSeq;
-
+      bool m_join_waiting;
   };
 
 };

--- a/Svc/CmdSequencer/Commands.xml
+++ b/Svc/CmdSequencer/Commands.xml
@@ -48,4 +48,7 @@ acknowledged.
 	<command kind="async" opcode="6" mnemonic="CS_MANUAL">
 		<comment>Set the run mode to MANUAL.</comment>
 	</command>
+	<command kind="async" opcode="7" mnemonic="CS_JOIN_WAIT">
+		<comment> Wait for sequences that are running to finish. Allow user to run multiple seq files in SEQ_NO_BLOCK mode then wait for them to finish before allowing more seq run request.</comment>
+	</command>
 </commands>

--- a/Svc/CmdSequencer/Events.xml
+++ b/Svc/CmdSequencer/Events.xml
@@ -285,4 +285,26 @@ acknowledged.
             </arg>
         </args>
     </event>
+    <event id="23" name="CS_JoinWaiting" severity="ACTIVITY_HI"
+        format_string="Start waiting for sequence file %s: Command %d (opcode %d) to complete">
+        <comment>Wait for the current running sequence file complete
+        </comment>
+        <args>
+            <arg name="fileName" type="string" size="60">
+                <comment>The name of the sequence file</comment>
+            </arg>
+            <arg name="recordNumber" type="U32">
+                <comment>The record number</comment>
+            </arg>
+            <arg name="opCode" type="U32">
+                <comment>The opcode</comment>
+            </arg>
+        </args>
+    </event>
+    <event id="24" name="CS_JoinWaitingNotComplete" severity="WARNING_HI"
+        format_string="Still waiting for sequence file to complete">
+        <comment>
+            Cannot run new sequence when current sequence file is still running.
+        </comment>
+    </event>
 </events>

--- a/Svc/CmdSequencer/test/ut/JoinWait.cpp
+++ b/Svc/CmdSequencer/test/ut/JoinWait.cpp
@@ -1,5 +1,5 @@
 // ====================================================================== 
-// \title  CmdSequencer.hpp
+// \title  JoinWait.hpp
 // \author janamian
 // \brief  cpp file for CmdSequencer test harness implementation class
 //

--- a/Svc/CmdSequencer/test/ut/JoinWait.cpp
+++ b/Svc/CmdSequencer/test/ut/JoinWait.cpp
@@ -1,0 +1,97 @@
+// ====================================================================== 
+// \title  CmdSequencer.hpp
+// \author janamian
+// \brief  cpp file for CmdSequencer test harness implementation class
+//
+// \copyright
+// Copyright 2009-2021, by the California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+// 
+// ====================================================================== 
+
+#include "Svc/CmdSequencer/test/ut/JoinWait.hpp"
+#include "Svc/CmdSequencer/test/ut/Relative.hpp"
+
+namespace Svc {
+
+  namespace JoinWait {
+
+    // ----------------------------------------------------------------------
+    // Constructors 
+    // ----------------------------------------------------------------------
+
+    Tester ::
+      Tester(const SequenceFiles::File::Format::t format) :
+        Svc::Tester(format)
+    {
+
+    }
+    // ----------------------------------------------------------------------
+    // Tests 
+    // ----------------------------------------------------------------------
+
+    void Tester ::
+      test_join_wait_without_active_seq()
+    {
+      // Send join wait command when there is no active seq
+      this->sendCmd_CS_JOIN_WAIT(0, 0);
+      this->clearAndDispatch();
+      // Assert events
+      ASSERT_EVENTS_SIZE(1);
+      ASSERT_EVENTS_CS_NoSequenceActive_SIZE(1);
+    }
+
+    void Tester ::test_join_wait_with_active_seq() {
+      const U32 numRecords = 1;
+      SequenceFiles::RelativeFile file(numRecords, this->format);
+      // Set the time
+      Fw::Time testTime(TB_WORKSTATION_TIME, 0, 0);
+      this->setTestTime(testTime);
+      // Write the file
+      const char *const fileName = file.getName().toChar();
+      file.write();
+      // Validate the file
+      this->validateFile(0, fileName);
+      // Run the sequence
+      this->runSequence(0, fileName);
+      
+      // Assert that timer is set
+      ASSERT_EQ(
+          CmdSequencerComponentImpl::Timer::SET,
+          this->component.m_cmdTimer.m_state
+      );
+      
+      // Run one cycle to make sure nothing is dispatched yet
+      this->invoke_to_schedIn(0, 0);
+      this->clearAndDispatch();
+      ASSERT_from_comCmdOut_SIZE(0);
+      ASSERT_EVENTS_SIZE(0);
+      
+      // Assert that timer hasn't expired
+      ASSERT_EQ(
+          CmdSequencerComponentImpl::Timer::SET,
+          this->component.m_cmdTimer.m_state
+      );
+
+      // Request join wait
+      this->sendCmd_CS_JOIN_WAIT(0, 0);
+      this->clearAndDispatch();
+      // Make sure JOIN_WAIT is active
+      ASSERT_EVENTS_CS_NoSequenceActive_SIZE(0);
+      ASSERT_TRUE(this->component.m_join_waiting);
+      
+      // Send status back
+      this->invoke_to_cmdResponseIn(0, 0, 0, Fw::COMMAND_OK);
+      this->clearAndDispatch();
+
+      // Make sure we received completion for both command and join_wait
+      ASSERT_EVENTS_SIZE(2);
+      // Make sure join wait has been cleared
+      ASSERT_FALSE(this->component.m_join_waiting);
+
+      }
+
+  }
+
+}

--- a/Svc/CmdSequencer/test/ut/JoinWait.hpp
+++ b/Svc/CmdSequencer/test/ut/JoinWait.hpp
@@ -10,8 +10,8 @@
 //
 // ======================================================================
 
-#ifndef JOINWAIT_HPP
-#define JOINWAIT_HPP
+#ifndef JOIN_WAIT_HPP
+#define JOIN_WAIT_HPP
 
 #include "Svc/CmdSequencer/test/ut/Tester.hpp"
 

--- a/Svc/CmdSequencer/test/ut/JoinWait.hpp
+++ b/Svc/CmdSequencer/test/ut/JoinWait.hpp
@@ -1,0 +1,55 @@
+// ======================================================================
+// \title  JoinWait.hpp
+// \author janamian
+// \brief  hpp file for CmdSequencer test harness implementation class
+//
+// \copyright
+// Copyright 2009-2021, by the California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+//
+// ======================================================================
+
+#ifndef JOINWAIT_HPP
+#define JOINWAIT_HPP
+
+#include "Svc/CmdSequencer/test/ut/Tester.hpp"
+
+namespace Svc {
+
+  namespace JoinWait {
+
+    class Tester :
+      public Svc::Tester
+    {
+
+      public:
+
+        // ----------------------------------------------------------------------
+        // Constructors
+        // ----------------------------------------------------------------------
+
+        //! Construct object Tester
+        Tester(
+            const SequenceFiles::File::Format::t format = 
+            SequenceFiles::File::Format::F_PRIME //!< The file format to use
+        );
+
+      public:
+
+        // ---------------------------------------------------------------------- 
+        // Tests
+        // ---------------------------------------------------------------------- 
+
+        //! Test
+        void test_join_wait_without_active_seq();
+
+        void test_join_wait_with_active_seq();
+
+    };
+
+  }
+
+}
+
+#endif

--- a/Svc/CmdSequencer/test/ut/Main.cpp
+++ b/Svc/CmdSequencer/test/ut/Main.cpp
@@ -19,6 +19,7 @@
 #include "Svc/CmdSequencer/test/ut/Tester.hpp"
 #include "Svc/CmdSequencer/test/ut/Mixed.hpp"
 #include "Svc/CmdSequencer/test/ut/UnitTest.hpp"
+#include "Svc/CmdSequencer/test/ut/JoinWait.hpp"
 
 TEST(AMPCS, MissingCRC) {
   Svc::AMPCS::Tester tester;
@@ -378,6 +379,17 @@ TEST(Relative, ValidateAMPCS) {
   Svc::Relative::Tester tester(Svc::SequenceFiles::File::Format::AMPCS);
   tester.Validate();
 }
+
+TEST(JoinWait, JoinWaitNoActiveSeq) {
+    Svc::JoinWait::Tester tester;
+    tester.test_join_wait_without_active_seq();
+}
+
+TEST(JoinWait, JoinWaitWithActiveSeq) {
+    Svc::JoinWait::Tester tester;
+    tester.test_join_wait_with_active_seq();
+}
+
 
 int main(int argc, char **argv) {
   // Create ./bin directory for test files


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F Prime |
|**_Affected Component_**|  CmdSequencer |
|**_Affected Architectures(s)_**| Svc |
|**_Related Issue(s)_**| NA |
|**_Has Unit Tests (y/n)_**| Y |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| Y |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

Background:  
F Prime CmdSequncer allows nested sequence engine calls. (e.g. `seqEng_Primary` can execute a sequence file that contains `seqEng_Secondary` which executes a different sequence files)  

This PR allows user to run multiple sequence engines in parallel and wait for them to complete before continue executing the rest of the requests from the same sequence engines.  

## Rationale
Use case example:  

Assume we have the following sequence file, `seq_file_1.seq`, that contains two different sequence engine, `seqEng_Secondary_A` and `seqEng_Secondary_B`, that execute `seq_file_2.bin` and `seq_file_3.bin`:
 
seq_file_1.seq  
```
seqEng_Secondary_A.CS_RUN "seq_file_2.bin" SEQ_NO_BLOCK;
seqEng_Secondary_B.CS_RUN "seq_file_3.bin" SEQ_NO_BLOCK;
seqEng_Secondary_A.JOIN_WAIT; 
seqEng_Secondary_B.JOIN_WAIT; 
seqEng_Secondary_A.CS_RUN "seq_file_2.bin" SEQ_NO_BLOCK;
```

If the user run the above sequence file with the following command:

```
seqEng_Primary.CS_RUN "seq_file_1.bin" SEQ_NO_BLOCK;
```

`seqEng_Secondary_A` and `seqEng_Secondary_B` will run simultaneously, and the process will wait for them to complete before executing the next `seqEng_Secondary_A` request.

Without the join_wait command the last request will be dropped with a warning_hi `EXECUTION_ERR` if the first request is still in progress.

## Testing/Review Recommendations
Created UT and manually checked the behavior of running multiple seq engines with and without join_wait command: 

Running multiple seq engines without join_wait:
https://youtu.be/DBR2DKnVZbU

Running multiple seq engines with join_wait:
https://youtu.be/eaCFJH6IN-s

## Future Work

NA
