### PR TITLE
Fixed the override of timebase and context in Time::set()

### DIFF
--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -22,11 +22,11 @@ namespace Fw {
     }
 
     void Time::set(U32 seconds, U32 useconds) {
-        this->set(TB_NONE,0,seconds,useconds);
+        this->set(this->m_timeBase,this->m_timeContext,seconds,useconds);
     }
 
     void Time::set(TimeBase timeBase, U32 seconds, U32 useconds) {
-        this->set(timeBase,0,seconds,useconds);
+        this->set(timeBase,this->m_timeContext,seconds,useconds);
     }
 
     Time::Time(TimeBase timeBase, FwTimeContextStoreType context, U32 seconds, U32 useconds) {


### PR DESCRIPTION

| | |
|:---|:---|
|**_Originating Project/Creator_**| OWLS / Brandon Metz|
|**_Affected Component_**|  Fw::Time |
|**_Affected Architectures(s)_**| n/a |
|**_Related Issue(s)_**| none |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| n/a |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This is in response to this issue:
https://github.com/nasa/fprime/issues/1090

