### PR TITLE
lestarch: command response errors to use COMMAND severity, #1095

### DIFF
--- a/Svc/CmdDispatcher/CommandDispatcherComponentAi.xml
+++ b/Svc/CmdDispatcher/CommandDispatcherComponentAi.xml
@@ -125,7 +125,7 @@
                 </arg>          
             </args>
         </event>
-        <event id="3" name="OpCodeError" severity="WARNING_HI" format_string = "Opcode 0x%04X completed with error %d " >
+        <event id="3" name="OpCodeError" severity="COMMAND" format_string = "Opcode 0x%04X completed with error %d " >
             <comment>
             Op code completed with error event
             </comment>

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
@@ -85,7 +85,7 @@ namespace Svc {
                     evrResp = ERR_UNEXP;
                     break;
             }
-            this->log_WARNING_HI_OpCodeError(opCode,evrResp);
+            this->log_COMMAND_OpCodeError(opCode,evrResp);
         }
         // look for command source
         NATIVE_INT_TYPE portToCall = -1;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description
See #1095 