### PR TITLE
lestarch: noop cmake target and cleaner memo for fprime-util integration

### DIFF
--- a/cmake/FPrime.cmake
+++ b/cmake/FPrime.cmake
@@ -63,6 +63,7 @@ else()
     generate_fpp_locs()
     message(STATUS "[autocode/fpp] Generating fpp locator file -- DONE")
 
+    register_fprime_target(target/noop)
     register_fprime_target(target/build)
     register_fprime_target(target/dict)
     register_fprime_target(target/install)

--- a/cmake/autocoder/autocoder.cmake
+++ b/cmake/autocoder/autocoder.cmake
@@ -42,8 +42,12 @@ endfunction()
 # SOURCES: source file that is being parsed and must have changed for a recalculation
 ####
 function (__memoize SOURCES)
-    string(MD5 SOURCES_HASH "${SOURCES}")
+    set(SOURCES_HASH "multiple")
+    if (HANDLES_INDIVIDUAL_SOURCES)
+        string(MD5 SOURCES_HASH "${SOURCES}")
+    endif()
     set(MEMO_FILE "${CMAKE_CURRENT_BINARY_DIR}/${AUTOCODER_NAME}.${SOURCES_HASH}.dep")
+
     regenerate_memo(FORCE_REGENERATE "${MEMO_FILE}" "${SOURCES}")
     if (FORCE_REGENERATE)
         get_generated_files("${SOURCES}")

--- a/cmake/target/noop.cmake
+++ b/cmake/target/noop.cmake
@@ -1,0 +1,15 @@
+####
+# cmake/target/noop.cmake:
+#
+# A target that does nothing, or a quick way to refresh cache only when necessary.
+####
+
+function(add_global_target)
+    add_custom_target("noop")
+endfunction()
+
+function(add_deployment_target MODULE TARGET SOURCES DEPENDENCIES FULL_DEPENDENCIES)
+endfunction()
+
+function(add_module_target MODULE_NAME TARGET_NAME SOURCE_FILES DEPENDENCIES)
+endfunction(add_module_target)


### PR DESCRIPTION
@bocchino this fixes two minor issues to make `fprime-util` to `fpp-check` integration cleaner.

1. It renames memo files for `fpp` invocations to make them deterministic to find. This is needed use this file as an "export" of data.
2. Adds a "noop" target to CMake.  This changes the "regenerate cache", which always regenerates, to a "noop" build which will regenerate only if necessary. In the small cases where `fprime-util` needs to regenerate (e.g. adding directory) will now be much more efficient in the "nothing changed" case.  Thus errors come out quickly.

Both are leveraged in the fprime-util updates.
