### PR TITLE
lestarch: adding deployment targets to fpp-locs faux target list

### DIFF
--- a/Ref/CMakeLists.txt
+++ b/Ref/CMakeLists.txt
@@ -51,7 +51,6 @@ set(SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/Top/Main.cpp")
 set(MOD_DEPS ${PROJECT_NAME}/Top)
 
 register_fprime_deployment()
-if (NOT FPRIME_FPP_LOCS_BUILD)
 # The following compile options will only apply to the deployment executable.
 # The extra warnings trigger in core F Prime so we don't apply them there.
 target_compile_options("${PROJECT_NAME}" PUBLIC -Wall)
@@ -67,4 +66,3 @@ target_compile_options("${PROJECT_NAME}" PUBLIC -Woverloaded-virtual)
 target_compile_options("${PROJECT_NAME}" PUBLIC -Wno-unused-parameter)
 target_compile_options("${PROJECT_NAME}" PUBLIC -Wundef)
 set_property(TARGET "${PROJECT_NAME}" PROPERTY CXX_STANDARD 11)
-endif()

--- a/cmake/module.cmake
+++ b/cmake/module.cmake
@@ -23,7 +23,7 @@ function(generate_deployment EXECUTABLE_NAME SOURCE_FILES DEPENDENCIES)
         set(FPRIME_OBJECT_TYPE "Deployment")
     endif()
     setup_all_deployment_targets(FPRIME_TARGET_LIST "${EXECUTABLE_NAME}" "${SOURCE_FILES}" "${DEPENDENCIES}")
-    if (TARGET "${EXECUTABLE_NAME}")
+    if (TARGET "${EXECUTABLE_NAME}" AND NOT FPRIME_FPP_LOCS_BUILD)
         add_dependencies("${EXECUTABLE_NAME}" "${EXECUTABLE_NAME}_dict")
     endif()
     # Add unit test targets to deployment

--- a/cmake/target/fpp-locs.cmake
+++ b/cmake/target/fpp-locs.cmake
@@ -70,6 +70,11 @@ endfunction()
 # Does nothing.  Fpp locations are truly global.
 ####
 function(add_deployment_target MODULE TARGET SOURCES DEPENDENCIES FULL_DEPENDENCIES)
+    if (NOT TARGET MODULE)
+        set(EMPTY_C_SRC "${CMAKE_CURRENT_BINARY_DIR}/empty.c")
+        file(WRITE "${EMPTY_C_SRC}" "#define CMAKE_EMPTY_SOURCE\n")
+        add_library(${MODULE} "${EMPTY_C_SRC}") # Fake target to appease those who hand-edit targets outside of fprime
+    endif()
 endfunction()
 
 ####


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Bug fix for fpp-locs targets.