### PR TITLE
Revise FPP code generation for F32 literals

### DIFF
--- a/Autocoders/Python/schema/default/common_types.rng
+++ b/Autocoders/Python/schema/default/common_types.rng
@@ -173,8 +173,8 @@
     <define name="F32_define">
         <a:documentation>32 bit float</a:documentation>
         <!--
-        Use text instead of float here
-        Float does not accept the full range of C++ floating literal syntax
+        Use text instead of "float" here
+        "Float" does not accept the C++ syntax for F32 literal values, e.g., 1.0f
         <data type="float">
         </data>
         -->

--- a/Autocoders/Python/schema/default/common_types.rng
+++ b/Autocoders/Python/schema/default/common_types.rng
@@ -172,8 +172,13 @@
 
     <define name="F32_define">
         <a:documentation>32 bit float</a:documentation>
+        <!--
+        Use text instead of float here
+        Float does not accept the full range of C++ floating literal syntax
         <data type="float">
         </data>
+        -->
+        <text/>
     </define>
 
     <define name="F64_define">

--- a/cmake/fpp-download/fpp.cmake
+++ b/cmake/fpp-download/fpp.cmake
@@ -5,7 +5,7 @@
 # should install FPP on the system path and that will be used.
 ####
 
-set(FPP_VERSION 4b338768dc9318f377c8e9bca1fecc1c687d8eb6)
+set(FPP_VERSION e437e82f308e02e8d91930b0b245ff3a585dc5c9)
 set(FPP_TOOLS_PATH "${CMAKE_BINARY_DIR}/fpp-tools-install" CACHE PATH "Installation path for fpp tools")
 
 ####


### PR DESCRIPTION
This PR does the following:

1. Update the embedded FPP version. In the new version, C++ F32 literals are written with an f suffix, e.g., 1.0f instead of 1.0. This change is necessary for compliance with strict checking of type conversions in C++.
2. Update the XML schema for default values to use "text" instead of "float" for F32 values. The "float" type in the existing schema does not accept the syntax with the f suffix (so the "float" schema is not consistent with C++ floating literal syntax).

Notes on the schema change:

1. The "float" check was not used consistently anyway. It was used only for parameter default values. For array and serializable default values, the schema accepted (and still accepts) general text.
2. After this PR
   1. Users who write FPP models will get the benefit of the correct code gen and won't need the schema check that is being phased out.
   1. Users who hand-write XML will have to rely on the C++ compiler to catch any parsing errors in their F32 literals for parameter default values (as they already do for array and serializable default values).
3. In general, we are phasing out reliance on these XML schema checks and moving the semantic checking into FPP.