### PR TITLE
Fixed BasicTypes preproc checks for pointer type

### DIFF
--- a/Fw/Types/BasicTypes.hpp
+++ b/Fw/Types/BasicTypes.hpp
@@ -49,13 +49,13 @@ typedef unsigned int NATIVE_UINT_TYPE; //!< native unsigned integer type declara
  #else
   #define POINTER_CAST U8
  #endif
-#elif __i386 == 1 // GCC 4.1.2
+#elif defined (__i386) && __i386 == 1 // GCC 4.1.2
   #define POINTER_CAST U32
-#elif __x86_64 == 1 // GCC 4.1.2
+#elif defined (__x86_64) && __x86_64 == 1 // GCC 4.1.2
   #define POINTER_CAST U64
-#elif CPU == PPC604 // VxWorks 6.7 RAD750
+#elif defined (CPU) && defined (PPC604) && CPU == PPC604 // VxWorks 6.7 RAD750
   #define POINTER_CAST U32
-#elif CPU == SPARC
+#elif defined (CPU) && defined(SPARC) && CPU == SPARC
   #define POINTER_CAST U32
 #else
  #error Cannot get size of pointer cast!


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|CADRE|
|**_Affected Component_**|n/a|
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|n/a|
|**_Builds Without Errors (y/n)_**|y|
|**_Unit Tests Pass (y/n)_**|n/a|
|**_Documentation Included (y/n)_**|n/a|

---
## Change Description
Changes the preprocessor checks for defining the `POINTER_CAST` type so that they're acceptable by the compiler even if the expected architecture-dependent definitions are not present.

## Rationale
When built in the CADRE cross compilation environment with `-Werror` enabled this produces compilation errors pertaining to checking against undefined preprocessor variables (the originating warning was `-Wundef` if I remember correctly).

## Testing/Review Recommendations
Test against software built against architectures covered by these different preprocessor definitions that are checked.

## Future Work
n/a
