### PR TITLE
Remove redundant null terminate

### DIFF
--- a/Fw/Comp/ActiveComponentBase.cpp
+++ b/Fw/Comp/ActiveComponentBase.cpp
@@ -44,7 +44,10 @@ namespace Fw {
 
 #if FW_OBJECT_TO_STRING == 1 && FW_OBJECT_NAMES == 1
     void ActiveComponentBase::toString(char* buffer, NATIVE_INT_TYPE size) {
-        (void)snprintf(buffer, size, "ActComp: %s", this->m_objName);
+        FW_ASSERT(size > 0);
+        if (snprintf(buffer, size, "ActComp: %s", this->m_objName) < 0) {
+            buffer[0] = 0;
+        }
     }
 #endif
 

--- a/Fw/Comp/ActiveComponentBase.cpp
+++ b/Fw/Comp/ActiveComponentBase.cpp
@@ -45,7 +45,6 @@ namespace Fw {
 #if FW_OBJECT_TO_STRING == 1 && FW_OBJECT_NAMES == 1
     void ActiveComponentBase::toString(char* buffer, NATIVE_INT_TYPE size) {
         (void)snprintf(buffer, size, "ActComp: %s", this->m_objName);
-        buffer[size-1] = 0;
     }
 #endif
 

--- a/Fw/Comp/PassiveComponentBase.cpp
+++ b/Fw/Comp/PassiveComponentBase.cpp
@@ -12,7 +12,10 @@ namespace Fw {
 #if FW_OBJECT_TO_STRING == 1 && FW_OBJECT_NAMES == 1
     void PassiveComponentBase::toString(char* buffer, NATIVE_INT_TYPE size) {
         FW_ASSERT(buffer);
-        (void)snprintf(buffer, size, "Comp: %s", this->m_objName);
+        FW_ASSERT(size > 0);
+        if (snprintf(buffer, size, "Comp: %s", this->m_objName) < 0) {
+            buffer[0] = 0;
+        }
     }
 #endif
     

--- a/Fw/Comp/PassiveComponentBase.cpp
+++ b/Fw/Comp/PassiveComponentBase.cpp
@@ -13,8 +13,6 @@ namespace Fw {
     void PassiveComponentBase::toString(char* buffer, NATIVE_INT_TYPE size) {
         FW_ASSERT(buffer);
         (void)snprintf(buffer, size, "Comp: %s", this->m_objName);
-        // null terminate
-        buffer[size-1] = 0;
     }
 #endif
     

--- a/Fw/Comp/QueuedComponentBase.cpp
+++ b/Fw/Comp/QueuedComponentBase.cpp
@@ -21,7 +21,10 @@ namespace Fw {
 
 #if FW_OBJECT_TO_STRING == 1 && FW_OBJECT_NAMES == 1
     void QueuedComponentBase::toString(char* buffer, NATIVE_INT_TYPE size) {
-        (void)snprintf(buffer, size,"QueueComp: %s", this->m_objName);
+        FW_ASSERT(size > 0);
+        if (snprintf(buffer, size,"QueueComp: %s", this->m_objName) < 0) {
+            buffer[0] = 0;
+        }
     }
 #endif
 

--- a/Fw/Comp/QueuedComponentBase.cpp
+++ b/Fw/Comp/QueuedComponentBase.cpp
@@ -22,7 +22,6 @@ namespace Fw {
 #if FW_OBJECT_TO_STRING == 1 && FW_OBJECT_NAMES == 1
     void QueuedComponentBase::toString(char* buffer, NATIVE_INT_TYPE size) {
         (void)snprintf(buffer, size,"QueueComp: %s", this->m_objName);
-        buffer[size-1] = 0;
     }
 #endif
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

From the `snprintf` function documentation :

> The functions snprintf() and vsnprintf() write at most size bytes (in‐cluding the terminating null byte ('\0')) to str.

So there's no need to null terminate the buffer.

## Rationale

To avoid redundancy and improve overall readability of the code.

## Testing/Review Recommendations

I made some changes in the component base classes. Specifically, I removed some redundant code that is already implemented in the `snprintf` function.

