### PR TITLE
Fix snprintf

### DIFF
--- a/Fw/Obj/ObjBase.cpp
+++ b/Fw/Obj/ObjBase.cpp
@@ -1,5 +1,6 @@
 #include <FpConfig.hpp>
 #include <Fw/Obj/ObjBase.hpp>
+#include <Fw/Types/Assert.hpp>
 #include <string.h>
 #include <stdio.h>
 
@@ -46,8 +47,10 @@ namespace Fw {
     }
 #if FW_OBJECT_TO_STRING == 1
     void ObjBase::toString(char* str, NATIVE_INT_TYPE size) {
-        (void)snprintf(str, size, "Obj: %s",this->m_objName);
-        str[size-1] = 0;
+        FW_ASSERT(size > 0);
+        if (snprintf(str, size, "Obj: %s",this->m_objName) < 0) {
+            str[0] = 0;
+        }
     }
 #endif    
 #endif

--- a/Fw/Port/InputPortBase.cpp
+++ b/Fw/Port/InputPortBase.cpp
@@ -29,10 +29,12 @@ namespace Fw {
     
 #if FW_OBJECT_TO_STRING == 1
     void InputPortBase::toString(char* buffer, NATIVE_INT_TYPE size) {
-#if FW_OBJECT_NAMES == 1        
-        (void)snprintf(buffer, size, "InputPort: %s->%s", this->m_objName,
-                        this->isConnected() ? this->m_connObj->getObjName() : "None");
-        buffer[size-1] = 0;
+#if FW_OBJECT_NAMES == 1 
+        FW_ASSERT(size > 0);
+        if (snprintf(buffer, size, "InputPort: %s->%s", this->m_objName,
+                     this->isConnected() ? this->m_connObj->getObjName() : "None") < 0) {
+            buffer[0] = 0;
+        }
 #else
         (void)snprintf(buffer,size,"%s","Unnamed Input port");
 #endif

--- a/Fw/Port/InputSerializePort.cpp
+++ b/Fw/Port/InputSerializePort.cpp
@@ -38,10 +38,12 @@ namespace Fw {
 
 #if FW_OBJECT_TO_STRING == 1
     void InputSerializePort::toString(char* buffer, NATIVE_INT_TYPE size) {
-#if FW_OBJECT_NAMES == 1        
-        (void)snprintf(buffer, size, "Input Serial Port: %s %s->(%s)", this->m_objName, this->isConnected() ? "C" : "NC",
-                        this->isConnected() ? this->m_connObj->getObjName() : "None");
-        buffer[size-1] = 0;
+#if FW_OBJECT_NAMES == 1
+        FW_ASSERT(size > 0);
+        if (snprintf(buffer, size, "Input Serial Port: %s %s->(%s)", this->m_objName, this->isConnected() ? "C" : "NC",
+                     this->isConnected() ? this->m_connObj->getObjName() : "None") < 0) {
+            buffer[0] = 0;
+        }
 #else
         (void)snprintf(buffer,size,"%s","InputSerializePort");
 #endif

--- a/Fw/Port/OutputPortBase.cpp
+++ b/Fw/Port/OutputPortBase.cpp
@@ -38,10 +38,12 @@ namespace Fw {
     
 #if FW_OBJECT_TO_STRING == 1
     void OutputPortBase::toString(char* buffer, NATIVE_INT_TYPE size) {
-#if FW_OBJECT_NAMES == 1        
-        (void)snprintf(buffer, size, "OutputPort: %s %s->(%s)", this->m_objName, this->isConnected() ? "C" : "NC",
-                        this->isConnected() ? this->m_connObj->getObjName() : "None");
-        buffer[size-1] = 0;
+#if FW_OBJECT_NAMES == 1
+        FW_ASSERT(size > 0);
+        if (snprintf(buffer, size, "OutputPort: %s %s->(%s)", this->m_objName, this->isConnected() ? "C" : "NC",
+                     this->isConnected() ? this->m_connObj->getObjName() : "None") < 0) {
+            buffer[0] = 0;
+        }
 #else
         (void)snprintf(buffer,size,"%s","OutputPort");
 #endif

--- a/Fw/Port/OutputSerializePort.cpp
+++ b/Fw/Port/OutputSerializePort.cpp
@@ -20,10 +20,12 @@ namespace Fw {
     
 #if FW_OBJECT_TO_STRING == 1
     void OutputSerializePort::toString(char* buffer, NATIVE_INT_TYPE size) {
-#if FW_OBJECT_NAMES == 1        
-        (void)snprintf(buffer, size, "Output Serial Port: %s %s->(%s)", this->m_objName, this->isConnected() ? "C" : "NC",
-                        this->isConnected() ? this->m_connObj->getObjName() : "None");
-        buffer[size-1] = 0;
+#if FW_OBJECT_NAMES == 1
+        FW_ASSERT(size > 0);
+        if (snprintf(buffer, size, "Output Serial Port: %s %s->(%s)", this->m_objName, this->isConnected() ? "C" : "NC",
+                     this->isConnected() ? this->m_connObj->getObjName() : "None") < 0) {
+            buffer[0] = 0;
+        }
 #else
         (void)snprintf(buffer,size,"%s","OutputSerializePort");
 #endif

--- a/Fw/Port/PortBase.cpp
+++ b/Fw/Port/PortBase.cpp
@@ -1,6 +1,7 @@
 #include <Fw/Port/PortBase.hpp>
 #include <Fw/Types/BasicTypes.hpp>
 #include <Fw/Logger/Logger.hpp>
+#include "Fw/Types/Assert.hpp"
 #include <stdio.h>
 
 #if FW_PORT_TRACING
@@ -77,10 +78,11 @@ namespace Fw {
 #if FW_OBJECT_NAMES == 1
 #if FW_OBJECT_TO_STRING == 1
     void PortBase::toString(char* buffer, NATIVE_INT_TYPE size) {
-        (void)snprintf(buffer, size, "Port: %s %s->(%s)", this->m_objName, this->m_connObj ? "C" : "NC",
-                        this->m_connObj ? this->m_connObj->getObjName() : "None");
-        // NULL terminate
-        buffer[size-1] = 0;
+        FW_ASSERT(size > 0);
+        if (snprintf(buffer, size, "Port: %s %s->(%s)", this->m_objName, this->m_connObj ? "C" : "NC",
+                     this->m_connObj ? this->m_connObj->getObjName() : "None") < 0) {
+            buffer[0] = 0;
+        }
     }
 #endif // FW_OBJECT_TO_STRING
 #endif // FW_OBJECT_NAMES


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

`snprintf` changes in some Fw classes as already discussed in [pull request #1151](https://github.com/nasa/fprime/pull/1151) .

## Rationale

To avoid redundancy and improve overall readability of the code.

## Testing/Review Recommendations
I made some changes in some Fw classes. Specifically, I removed some redundant code that is already implemented in the `snprintf` function as already discussed with @LeStarch in [pull request #1151](https://github.com/nasa/fprime/pull/1151) .
