### PR TITLE
More VxWorks fixes

### DIFF
--- a/Fw/Types/VxWorks/StandardTypes.hpp
+++ b/Fw/Types/VxWorks/StandardTypes.hpp
@@ -1,6 +1,18 @@
+#ifndef VXWORKS_STD_TYPES_H
+#define VXWORKS_STD_TYPES_H
+
 #include <vxWorks.h>
 
-#define VXWORKS_OK OK
+#if OK != 0
+#error "Expected OK = 0 in VxWorks build"
+#endif
+#define VXWORKS_OK 0
 #undef OK
-#define VXWORKS_ERROR ERROR
+
+#if ERROR != -1
+#error "Expected ERROR = -1 in VxWorks build"
+#endif
+#define VXWORKS_ERROR -1
 #undef ERROR
+
+#endif

--- a/Fw/Types/VxWorks/StandardTypes.hpp
+++ b/Fw/Types/VxWorks/StandardTypes.hpp
@@ -3,14 +3,16 @@
 
 #include <vxWorks.h>
 
-// Covert OK macro to constexpr
-constexpr I32 VXWORKS_OK = OK;
+// Covert VxWorks OK and ERROR macros to enums
+enum {
+  VXWORKS_OK = OK,
+  VXWORKS_ERROR = ERROR
+};
 #undef OK
-constexpr I32 OK = VXWORKS_OK;
-
-// Convert ERROR macro to constexpr
-constexpr I32 VXWORKS_ERROR = ERROR;
 #undef ERROR
-constexpr I32 ERROR = VXWORKS_ERROR;
+enum {
+  OK = VXWORKS_OK,
+  ERROR = VXWORKS_ERROR
+};
 
 #endif

--- a/Fw/Types/VxWorks/StandardTypes.hpp
+++ b/Fw/Types/VxWorks/StandardTypes.hpp
@@ -3,16 +3,14 @@
 
 #include <vxWorks.h>
 
-#if OK != 0
-#error "Expected OK = 0 in VxWorks build"
-#endif
-#define VXWORKS_OK 0
+// Covert OK macro to constexpr
+constexpr I32 VXWORKS_OK = OK;
 #undef OK
+constexpr I32 OK = VXWORKS_OK;
 
-#if ERROR != -1
-#error "Expected ERROR = -1 in VxWorks build"
-#endif
-#define VXWORKS_ERROR -1
+// Convert ERROR macro to constexpr
+constexpr I32 VXWORKS_ERROR = ERROR;
 #undef ERROR
+constexpr I32 ERROR = VXWORKS_ERROR;
 
 #endif

--- a/Svc/SystemResources/SystemResources.cpp
+++ b/Svc/SystemResources/SystemResources.cpp
@@ -128,7 +128,7 @@ void SystemResources::Cpu() {
         }
     }
 
-    cpuAvg = (count == 0) ? 0.0f : (cpuAvg / count);
+    cpuAvg = (count == 0) ? 0.0f : (cpuAvg / static_cast<F32>(count));
     this->tlmWrite_CPU(cpuAvg);
 }
 


### PR DESCRIPTION
* Use enums instead of macros to capture the VxWorks macro definitions
* Put OK and ERROR symbols back in (as enums) so VxWorks inline functions can use them
* Silence another compiler warning involving type conversion