### PR TITLE
fix StringUtils overlapping assert

### DIFF
--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -8,7 +8,7 @@ char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 nu
         return destination;
     }
 
-    // Copying a right overlapping range is undefined
+    // Copying an overlapping range is undefined
     U32 source_len = string_length(source, num) + 1;
     FW_ASSERT(source + source_len <= destination || destination + num <= source);
 

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -17,6 +17,6 @@ char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 nu
     return returned;
 }
 
-U32 Fw::StringUtils::string_length(CHAR* source, U32 max_len) {
+U32 Fw::StringUtils::string_length(const CHAR* source, U32 max_len) {
     return strnlen(source, max_len);
 }

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -8,8 +8,8 @@ char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 nu
         return destination;
     }
 
-    // Copying an overlapping range is undefined
-    FW_ASSERT(source < destination || destination + num <= source);
+    // Copying a right overlapping range is undefined
+    FW_ASSERT(destination < source ||  source + num < destination);
 
     char* returned = strncpy(destination, source, num);
     destination[num - 1] = '\0';

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -9,9 +9,14 @@ char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 nu
     }
 
     // Copying a right overlapping range is undefined
-    FW_ASSERT(destination < source ||  source + num < destination);
+    U32 source_len = string_length(source, num) + 1;
+    FW_ASSERT(source + source_len <= destination || destination + num <= source);
 
     char* returned = strncpy(destination, source, num);
     destination[num - 1] = '\0';
     return returned;
+}
+
+U32 Fw::StringUtils::string_length(CHAR* source, U32 max_len) {
+    return strnlen(source, max_len);
 }

--- a/Fw/Types/StringUtils.hpp
+++ b/Fw/Types/StringUtils.hpp
@@ -30,7 +30,7 @@ char* string_copy(char* destination, const char* source, U32 num);
  * \param max_len: the maximum length of the source string
  * \return length of the source string or max_len
  */
-U32 string_length(CHAR* source, U32 max_len);
+U32 string_length(const CHAR* source, U32 max_len);
 
 };      // namespace StringUtils
 };      // namespace Fw

--- a/Fw/Types/StringUtils.hpp
+++ b/Fw/Types/StringUtils.hpp
@@ -24,7 +24,7 @@ char* string_copy(char* destination, const char* source, U32 num);
 
 /**
  * \brief get the length of the source string or max_len if the string is
- * longer then max_len.
+ * longer than max_len.
  *
  * \param source: string to calculate the length
  * \param max_len: the maximum length of the source string

--- a/Fw/Types/StringUtils.hpp
+++ b/Fw/Types/StringUtils.hpp
@@ -21,6 +21,17 @@ namespace StringUtils {
  * \return destination buffer
  */
 char* string_copy(char* destination, const char* source, U32 num);
+
+/**
+ * \brief get the length of the source string or max_len if the string is
+ * longer then max_len.
+ *
+ * \param source: string to calculate the length
+ * \param max_len: the maximum length of the source string
+ * \return length of the source string or max_len
+ */
+U32 string_length(CHAR* source, U32 max_len);
+
 };      // namespace StringUtils
 };      // namespace Fw
 #endif  // FW_STRINGUTILS_HPP


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

There's an error in the `Fw/Types/StringUtils::string_copy` method. 

The original assertion
`FW_ASSERT((source < destination) || destination + num <= source);`

should be changed to 
`FW_ASSERT(destination < source ||  source + num < destination);`

## Rationale
I explain this assertion change by analyzing the 3 possible cases in which the destination string and the source string overlaps:
- Case 0: the two string completely overlaps(source and destination point to the same memory address). This problem is resolved in the first if clause by not executing the copy and returning the destination pointer.
- Case 1: the destination string overlaps with the left part of the source string(_Left overlap_). This case should be allowed since every character of the source string will be copied to the destination string one by one from the left to the right. No information is lost (this was forbidden in the original assertion).
- Case 2: the destination string overlaps with the right part of the source string(_Right overlap_). This case should be forbidden, in fact `strncpy` starts replacing every character of the destination string which causes the change of some parts of the original one. The overlapping characters of the source string will be replaced by the first characters of the original string. In the end, the last part of the source string will be lost.


In conclusion we should allow only 3 cases:
- destination and source are pointing to the same string (resolved in the first if clause by returning the destination)
- any string with `destination < source`, allowing in the worst case a "Left overlap" (Case 1)
- any string with `source < destination` but asserting that it doesn't overlap (`source + num < destination`)

## Graphical explanation
Suppose we have 2 strings of length 5 (one for the case 1 and the other for the case 2) that overlaps with the source string. The source string starts at address `2`, the Case 1 string starts at `0` and the Case 2 string starts at `5`. The graphical representation of the left and right overlap looks like the one in the following schema:

![overlaps](https://user-images.githubusercontent.com/15068390/146259514-61009e6f-751d-4728-ac3e-c6643e48ebff.png)


As you can see, the Case 1 should be allowed, but the case 2 should be forbidden: by copying the content of the source string to the destination string for the case 2 you will end up changing some parts of the source string that have not yet been copied. 