### PR TITLE
Added missing GenericHub.hpp file

### DIFF
--- a/Svc/GenericHub/GenericHub.hpp
+++ b/Svc/GenericHub/GenericHub.hpp
@@ -1,0 +1,17 @@
+// ======================================================================
+// GenericHub.hpp
+// Standardization header for GenericHub
+// ======================================================================
+
+#ifndef Svc_GenericHub_HPP
+#define Svc_GenericHub_HPP
+
+#include "Svc/GenericHub/GenericHubComponentImpl.hpp"
+
+namespace Svc {
+
+  using GenericHub = GenericHubComponentImpl;
+
+}
+
+#endif


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F Prime |
|**_Affected Component_**|  GenericHub |
|**_Affected Architectures(s)_**| NA |
|**_Related Issue(s)_**|  NA |
|**_Has Unit Tests (y/n)_**|  No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| Yes |
|**_Documentation Included (y/n)_**| No |

---
## Change Description
Generalized GenericHub.hpp was missing in the Svc/GenericHub. This was causing the following error:

``` Bash
In file included from /home/work/Swift/build-fprime-automatic-microblaze-qcp/Swift/Top/SwiftTopologyAc.cpp:12:
Swift/Top/CMakeFiles/Swift_Top.dir/build.make:245: recipe for target 'Swift/Top/CMakeFiles/Swift_Top.dir/SwiftTopologyAc.cpp.o' failed
/home/work/Swift/build-fprime-automatic-microblaze-qcp/Swift/Top/SwiftTopologyAc.hpp:29:10: fatal error: Svc/GenericHub/GenericHub.hpp: No such file or directory
   29 | #include "Svc/GenericHub/GenericHub.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[3]: *** [Swift/Top/CMakeFiles/Swift_Top.dir/SwiftTopologyAc.cpp.o] Error 1
CMakeFiles/Makefile2:7945: recipe for target 'Swift/Top/CMakeFiles/Swift_Top.dir/all' failed
[ERROR] CMake erred with return code 2
```

## Rationale

Generalized header has been added.

## Testing/Review Recommendations
Ran GenericHub UT test after adding the generalized header with no test failure.

## Future Work

Need to check all components to make sure they are not missing any files after the upgrade to the F Prime 3.0
