### PR TITLE
fix typo in CMake Intro Getting Started guide

### DIFF
--- a/docs/UsersGuide/cmake/cmake-intro.md
+++ b/docs/UsersGuide/cmake/cmake-intro.md
@@ -19,7 +19,7 @@ Installation guides for CMake can be found here: [https://cmake.org/install/](ht
 A Basic CMake tutorial can be found here: [https://cmake.org/cmake/help/latest/guide/tutorial/index.html](https://cmake.org/cmake/help/latest/guide/tutorial/index.html).
 Although fprime tries to simplify CMake usage for fprime specific tasks, an understanding of basic CMake is useful.
 
-## Getting Started Using with and F`
+## Getting Started with CMake and F´
 
 CMake as a system auto-generates OS-specific make files for building F´. Once these file are
 generated, standard make tools can be run to perform the compiling, assembling, linking etc. In other words, CMake is a


### PR DESCRIPTION
- updated header to say `Getting Started with CMake and F´` in [cmake-intro](https://github.com/nasa/fprime/blob/devel/docs/UsersGuide/cmake/cmake-intro.md#getting-started-using-with-and-f)

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

A description of the changes contained in the PR.

## Rationale

A rationale for this change. e.g. fixes bug, or most projects need XYZ feature.

## Testing/Review Recommendations

Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality.

## Future Work

Note any additional work that will be done relating to this issue.
