### PR TITLE
#1196: Replace LINK_DEPS With MOD_DEPS

### DIFF
--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -84,7 +84,7 @@ endfunction(add_fprime_subdirectory)
 #
 # **i.e.:**
 # ```
-# set(LINK_DEPS
+# set(MOD_DEPS
 #     Os
 #     Module1
 #     Module2
@@ -195,7 +195,7 @@ endfunction(register_fprime_module)
 #
 # **i.e.:**
 # ```
-# set(LINK_DEPS
+# set(MOD_DEPS
 #     Module1
 #     Module2
 #     -lpthread)
@@ -298,7 +298,7 @@ endfunction(register_fprime_executable)
 #
 # **i.e.:**
 # ```
-# set(LINK_DEPS
+# set(MOD_DEPS
 #     Module1
 #     Module2
 #     -lpthread)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @astroesteban|
|**_Affected Component_**| API.cmake Docs |
|**_Affected Architectures(s)_**|N/A |
|**_Related Issue(s)_**| #1196 |
|**_Has Unit Tests (y/n)_**| N/A |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**|Y |
|**_Documentation Included (y/n)_**| Y |

---
## Change Description

Change references of `LINK_DEPS` to `MOD_DEPS` in the CMake API.cmake comments.

## Rationale

The `LINK_DEPS` CMake variable was deprecated in favor of `MOD_DEPS` but some of the comments still had `LINK_DEPS`.

## Testing/Review Recommendations

None. Only documentation changes were made

## Future Work

None.
