### PR TITLE
Fix Section 4.5.1 of Math Component Tutorial

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1150,6 +1150,7 @@ PINGSEND
 pinit
 pkill
 pkts
+placeholders
 plainnat
 plantuml
 plugin

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -757,35 +757,13 @@ Do the following in directory `Ref/MathSender`:
 1. Run `mkdir -p test/ut` to create the directory where
 the unit tests will reside.
 
-1. Run the command `fprime-util impl --ut`.
-It should generate files `Tester.cpp` and `Tester.hpp`.
-
-1. Move these files to the `test/ut` directory:
-
-   ```bash
-   mv Tester.* test/ut
-   ```
-
-**Create a stub main.cpp file:**
-Now go to the directory `Ref/MathSender/test/ut`.
-In that directory, create a file `main.cpp` with the
-following contents:
-
-```c++
-#include "Tester.hpp"
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+1. Create two placeholder unit test files so that the CMake cache can be generated:
+```sh
+touch test/ut/Tester.cpp
+touch test/ut/main.cpp
 ```
 
-This file is a stub for running tests using the
-[Google Test framework](https://github.com/google/googletest).
-Right now there aren't any tests to run; we will add one
-in the next section.
-
-**Update Ref/MathSender/CMakeLists.txt:**
+1. Update Ref/MathSender/CMakeLists.txt:
 Go back to the directory `Ref/MathSender`.
 Add the following lines to `CMakeLists.txt`:
 
@@ -801,6 +779,35 @@ register_fprime_ut()
 
 This code tells the build system how to build
 and run the unit tests.
+
+1. Run `fprime-util generate --ut` to generate the unit test cache.
+
+1. Run the command `fprime-util impl --ut`.
+It should generate files `Tester.cpp` and `Tester.hpp`.
+
+1. Move these files to the `test/ut` directory and replace the old placeholders:
+
+   ```bash
+   mv Tester.* test/ut
+   ```
+
+**Create a stub main.cpp file:**
+Now go to the directory `Ref/MathSender/test/ut`.
+In that directory, open the file `main.cpp` and add the following contents:
+
+```c++
+#include "Tester.hpp"
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+```
+
+This file is a stub for running tests using the
+[Google Test framework](https://github.com/google/googletest).
+Right now there aren't any tests to run; we will add one
+in the next section.
 
 **Run the build:**
 Now we can check that the unit test build is working.

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -757,13 +757,7 @@ Do the following in directory `Ref/MathSender`:
 1. Run `mkdir -p test/ut` to create the directory where
 the unit tests will reside.
 
-2. Create two placeholder unit test files so that the CMake cache can be generated:
-```sh
-touch test/ut/Tester.cpp
-touch test/ut/main.cpp
-```
-
-3. Update Ref/MathSender/CMakeLists.txt:
+2. Update Ref/MathSender/CMakeLists.txt:
 Go back to the directory `Ref/MathSender`.
 Add the following lines to `CMakeLists.txt`:
 
@@ -771,8 +765,6 @@ Add the following lines to `CMakeLists.txt`:
 # Register the unit test build
 set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/MathSender.fpp"
-  "${CMAKE_CURRENT_LIST_DIR}/test/ut/Tester.cpp"
-  "${CMAKE_CURRENT_LIST_DIR}/test/ut/main.cpp"
 )
 register_fprime_ut()
 ```
@@ -785,15 +777,15 @@ and run the unit tests.
 5. Run the command `fprime-util impl --ut`.
 It should generate files `Tester.cpp` and `Tester.hpp`.
 
-6. Move these files to the `test/ut` directory and replace the old placeholders:
+6. Move these files to the `test/ut` directory:
 
-   ```bash
-   mv Tester.* test/ut
-   ```
+```bash
+mv Tester.* test/ut
+```
 
 **Create a stub main.cpp file:**
 Now go to the directory `Ref/MathSender/test/ut`.
-In that directory, open the file `main.cpp` and add the following contents:
+In that directory, create the file `main.cpp` and add the following contents:
 
 ```c++
 #include "Tester.hpp"
@@ -808,6 +800,20 @@ This file is a stub for running tests using the
 [Google Test framework](https://github.com/google/googletest).
 Right now there aren't any tests to run; we will add one
 in the next section.
+
+7. Add the new files to the build.
+
+Open `MathSender/CMakeLists.txt` and modify the `UT_SOURCE_FILES` by adding
+your new test files:
+```cmake
+# Register the unit test build
+set(UT_SOURCE_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/MathSender.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/main.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/Tester.cpp"
+)
+register_fprime_ut()
+```
 
 **Run the build:**
 Now we can check that the unit test build is working.

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -757,13 +757,13 @@ Do the following in directory `Ref/MathSender`:
 1. Run `mkdir -p test/ut` to create the directory where
 the unit tests will reside.
 
-1. Create two placeholder unit test files so that the CMake cache can be generated:
+2. Create two placeholder unit test files so that the CMake cache can be generated:
 ```sh
 touch test/ut/Tester.cpp
 touch test/ut/main.cpp
 ```
 
-1. Update Ref/MathSender/CMakeLists.txt:
+3. Update Ref/MathSender/CMakeLists.txt:
 Go back to the directory `Ref/MathSender`.
 Add the following lines to `CMakeLists.txt`:
 
@@ -780,12 +780,12 @@ register_fprime_ut()
 This code tells the build system how to build
 and run the unit tests.
 
-1. Run `fprime-util generate --ut` to generate the unit test cache.
+4. Run `fprime-util generate --ut` to generate the unit test cache.
 
-1. Run the command `fprime-util impl --ut`.
+5. Run the command `fprime-util impl --ut`.
 It should generate files `Tester.cpp` and `Tester.hpp`.
 
-1. Move these files to the `test/ut` directory and replace the old placeholders:
+6. Move these files to the `test/ut` directory and replace the old placeholders:
 
    ```bash
    mv Tester.* test/ut


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|@astroesteban |
|**_Affected Component_**|Math Component Tutorial  |
|**_Affected Architectures(s)_**| Testing |
|**_Related Issue(s)_**| #1238  |
|**_Has Unit Tests (y/n)_**| N |
|**_Builds Without Errors (y/n)_**|Y  |
|**_Unit Tests Pass (y/n)_**| Y |
|**_Documentation Included (y/n)_**| Y |

---
## Change Description

Add missing steps and rearrange steps in order to get section **4.5.1** of the Math Component tutorial working. Specifically, users are experiencing a CMake error when running `fprime-util impl --ut`. 

The new procedure is:

1. Create the `test/ut` folders.
2. Create placeholder files.
3. Update the CMakeLists.txt files.
4. Generate the cache
5. Generate the implementation files.
6. Replace the placeholder files with the newly generated files.
7. Build the unit tests.

## Rationale

The tools requires some dummy placeholder files to get CMake to generate the cache correctly. The  user can then simply replace the placeholder files with the files generated by `fprime-util`. 

## Testing/Review Recommendations

Managed to successfully complete the **4.5** section of the Math Component tutorial and resolve the issue.

## Future Work

None.
