### PR TITLE
Add A Note For User-Installed Pip Packages

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -51,6 +51,10 @@ tools package. This is to enable users to choose which tools they'd like to use.
 pip install --upgrade fprime-tools fprime-gds
 ```
 
+> Note: On some systems pip places user-installed tools in the `.local` folder.
+This results in a `fprime-util: command not found` error when trying to run 
+fprime-util. You will need to add `.local` to your `$PATH` or run as an admin.
+
 ## Checking Your F´ Installation
 
 The user may easily checkout that their F´ installation has succeeded by testing the following


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @astroesteban |
|**_Affected Component_**| INSTALL.md |
|**_Affected Architectures(s)_**| Docs |
|**_Related Issue(s)_**| #1193  |
|**_Has Unit Tests (y/n)_**| N |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| Y  |
|**_Documentation Included (y/n)_**| Y  |

---
## Change Description

Add a note to users that sometimes pip will install packages in a folder that needs to be added to the user's `$PATH` environment variable.

## Rationale

Per issue #1193 it can be unclear to users why the `fprime-util` command fails. This adds some clarification to the Python package installation step. 

## Testing/Review Recommendations

None

## Future Work

None.
