### PR TITLE
Avoid violating `-Wpedantic`

### DIFF
--- a/Fw/Types/StringUtils.hpp
+++ b/Fw/Types/StringUtils.hpp
@@ -32,6 +32,6 @@ char* string_copy(char* destination, const char* source, U32 num);
  */
 U32 string_length(const CHAR* source, U32 max_len);
 
-};      // namespace StringUtils
-};      // namespace Fw
+}       // namespace StringUtils
+}       // namespace Fw
 #endif  // FW_STRINGUTILS_HPP

--- a/Os/Posix/TaskId.cpp
+++ b/Os/Posix/TaskId.cpp
@@ -7,7 +7,7 @@
 
 extern "C" {
 #include <pthread.h>
-};
+}
 
 #include <Os/TaskId.hpp>
 

--- a/Os/TaskIdRepr.hpp
+++ b/Os/TaskIdRepr.hpp
@@ -11,7 +11,7 @@
 #if defined(TGT_OS_TYPE_LINUX) || defined(TGT_OS_TYPE_DARWIN)
 extern "C" {
 #include <pthread.h>
-};
+}
 #endif
 
 namespace Os {

--- a/Svc/CmdSequencer/CmdSequencerImpl.hpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.hpp
@@ -776,6 +776,6 @@ namespace Svc {
       bool m_join_waiting;
   };
 
-};
+}
 
 #endif


### PR DESCRIPTION
This cleans up the GCC/Clang compiler warnings like:

    extra ‘;’ [-Wpedantic] }; // namespace StringUtils

| | |
|:---|:---|
|**_Originating Project/Creator_**| JPL COLDArm / Steven Myint |
|**_Affected Component_**| Multiple |
|**_Affected Architectures(s)_**| All |
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| n/a |
|**_Documentation Included (y/n)_**| no |

---
## Change Description

Remove unnecessary semicolons from `Fw/Types/StringUtils.hpp`, `Os/Posix/TaskId.cpp`, `Os/TaskIdRepr.hpp`, and `Svc/CmdSequencer/CmdSequencerImpl.hpp`.

## Rationale

Without this, we get warnings from GCC and Clang.

## Testing/Review Recommendations

None

## Future Work

None