### PR TITLE
astroesteban: fix math component misleading instructions

### DIFF
--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -101,7 +101,7 @@ in the [F Prime git repository](https://github.com/nasa/fprime).
 You may also wish to work through the Getting Started tutorial at
 `docs/GettingStarted/Tutorial.md`.
 
-**Git branch:** This tutorial is designed to work on the branch `release/v3.0.0`.
+**F' Version:** This tutorial is designed to work with release `v3.0.0`.
 
 Working on this tutorial will modify some files under version control in the
 F Prime git repository.
@@ -109,7 +109,7 @@ Therefore it is a good idea to do this work on a new branch.
 For example:
 
 ```bash
-git checkout release/v3.0.0
+git checkout -b release/v3.0.0 v3.0.0
 git checkout -b math-tutorial
 ```
 
@@ -571,7 +571,7 @@ for <a href="#types_add">`Ref/MathTypes`</a>.
 ### 4.3. Build the Stub Implementation
 
 **Run the build:**
-Go into the directory `Ref/MathTypes`.
+Go into the directory `Ref/MathSender`.
 Run the following commands:
 
 ```bash
@@ -2017,7 +2017,7 @@ These lines add the `mathSender` and `mathReceiver`
 instances to the topology.
 
 **Check for unconnected ports:**
-Run the following commands:
+Run the following commands in the `Ref/Top` directory:
 
 ```bash
 fprime-util fpp-check -u unconnected.txt
@@ -2033,14 +2033,13 @@ Those ports will include the ports for the new instances
 Find the line that starts `connections RateGroups`.
 This is the beginning of the definition of the `RateGroups`
 connection graph.
-Inside the block of that definition,
-find the line
-`rateGroup1Comp.RateGroupMemberOut[3] -> fileDownlink.Run`.
-After that line, add the line
-
+After the last entry for the `rateGroup1Comp` (rate group 1) add the line:
 ```fpp
-rateGroup1Comp.RateGroupMemberOut[4] -> mathReceiver.schedIn
+rateGroup1Comp.RateGroupMemberOut[5] -> mathReceiver.schedIn
 ```
+
+> You might need to change the array index 5 to be one greater than the previous
+`rateGroup1Comp` index. Otherwise you'll get a duplicate connection error.
 
 This line adds the connection that drives the `schedIn`
 port of the `mathReceiver` component instance.

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -101,7 +101,7 @@ in the [F Prime git repository](https://github.com/nasa/fprime).
 You may also wish to work through the Getting Started tutorial at
 `docs/GettingStarted/Tutorial.md`.
 
-**F' Version:** This tutorial is designed to work with release `v3.0.0`.
+**F´ Version:** This tutorial is designed to work with release `v3.0.0`.
 
 Working on this tutorial will modify some files under version control in the
 F Prime git repository.
@@ -109,8 +109,7 @@ Therefore it is a good idea to do this work on a new branch.
 For example:
 
 ```bash
-git checkout -b release/v3.0.0 v3.0.0
-git checkout -b math-tutorial
+git checkout -b math-tutorial v3.0.0
 ```
 
 If you wish, you can save your work by committing to this branch.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|@astroesteban |
|**_Affected Component_**| Math Component Tutorial |
|**_Affected Architectures(s)_**| None |
|**_Related Issue(s)_**| #1255 |
|**_Has Unit Tests (y/n)_**| N/A |
|**_Builds Without Errors (y/n)_**| N/A |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| N/A  |

---
## Change Description

1. In section **1. Introduction** of the tutorial the **Git Branch** instruction has been changed to **F' Version**
2. In section **4.3. Build the Stub Implementation** the "Run the build" step has been changed to "Go into the directory Ref/MathSender"
3. In section **6.2. Updating the Topology** the "Check for unconnected ports" step has been changed to instruct the user to go to the `Ref/Top` directory.
4. In section **6.2 Updating the Topology** the "Connect mathReceiver to rate group 1" step has been modified to prevent array index conflict errors.

## Rationale

1. The existing documentation informs the reader that  "This tutorial is designed to work on the branch release/v3.0.0" and proceeds to instruct the user to switch to the branch `release/v3.0.0`. The problem is that this branch does not exist. Only the tag exists. Instead, the docs should tell the user to create a new branch off of the `v3.0.0` tag.
2. There is a typo where it instructs the user to go to `Ref/MathTypes` directory to create the `MathSender.cpp` file. This should be `Ref/MathSender`.
3. Running the command `fprime-util fpp-check -u unconnected.txt` in the Ref directory results in the error `[ERROR] No fpp dependency memo found. Perhaps directory is outside build?` as reported in issue #1255. I too encountered this error and the fix is to run `fprime-util fpp-check -u unconnected.txt` in the `Ref/Top` directory. We need to add an instruction that the user should run `fpp-check` from the `Ref/Top` directory.
4. The existing documentation instructs the user to copy and paste the `rateGroup1Comp.RateGroupMemberOut[4] -> mathReceiver.schedIn` into the `connections RateGroups` section of topology.fpp. The array index of `4` conflicts with the existing `rateGroup1Comp.RateGroupMemberOut[4] -> systemResources.run` resulting in the error `error: duplicate connection at output port 4`. We need to add a note that tells users they may need to modify the array index of the new rate group index.

## Testing/Review Recommendations

- Successfully completed the entire Math Component tutorial.

## Future Work

None.
