### PR TITLE
Add Missing Paren In Baremetal Queue

### DIFF
--- a/Os/Baremetal/Queue.cpp
+++ b/Os/Baremetal/Queue.cpp
@@ -176,7 +176,7 @@ Queue::QueueStatus bareReceiveBlock(BareQueueHandle& handle, U8* buffer, NATIVE_
     }
     else {
         actualSize = 0;
-        if( size > (static_cast<NATIVE_UINT_TYPE>(capacity) ) {
+        if( size > (static_cast<NATIVE_UINT_TYPE>(capacity)) ) {
             // The buffer capacity was too small!
             status = Queue::QUEUE_SIZE_MISMATCH;
         }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|@astroesteban |
|**_Affected Component_**|Os/Baremetal/Queue  |
|**_Affected Architectures(s)_**|Baremetal  |
|**_Related Issue(s)_**|N/A  |
|**_Has Unit Tests (y/n)_**| N/A |
|**_Builds Without Errors (y/n)_**|Y  |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

In my attempt to port F Prime to the Raspberry Pi Pico I came across a build error in the bare metal Queue. There is a missing parenthesis in an if statement.

## Rationale

The missing closing parenthesis causes a build failure.

## Testing/Review Recommendations

None.

## Future Work

None.
