### PR TITLE
Fix Baremetal System Resources Bugs

### DIFF
--- a/Os/Baremetal/SystemResources.cpp
+++ b/Os/Baremetal/SystemResources.cpp
@@ -10,6 +10,8 @@
 //
 // ======================================================================
 
+#include <Os/SystemResources.hpp>
+
 namespace Os {
 
 SystemResources::SystemResourcesStatus SystemResources::getCpuCount(U32& cpuCount) {
@@ -29,7 +31,7 @@ SystemResources::SystemResourcesStatus SystemResources::getCpuTicks(CpuTicks& cp
 SystemResources::SystemResourcesStatus SystemResources::getMemUtil(MemUtil& memory_util) {
     // Always 100 percent
     memory_util.total = 1;
-    memory_util.util = 1;
+    memory_util.used = 1;
     return SYSTEM_RESOURCES_OK;
 }
 }  // namespace Os


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|@astroesteban |
|**_Affected Component_**|  Os/Baremetal/SystemResources|
|**_Affected Architectures(s)_**| Baremetal |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| N/A |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**|N/A  |

---
## Change Description

When cross-compiling F Prime to a bare metal platform I came across the following build errors:

1. `SystemResources does not name a type`: This was fixed by including the `Os/SystemResources.hpp` header
2. A build failure caused by referencing a misnamed `MemUtil` variable `used` as `util`.

## Rationale

Fixes a bug in the Os/Baremetal/SystemResources source file.

## Testing/Review Recommendations

Got that part of the software to successfully compile.

## Future Work

Keep working towards porting F Prime `v3.0.0` to a bare metal platform and fixing bugs we come across.
