### PR TITLE
lestarch: fixing apt install failures in CI

### DIFF
--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -15,6 +15,8 @@ jobs:
     - name: Install fprime tools
       run: pip3 install fprime-tools fprime-gds
     - name: Setup Dependencies
-      run: sudo apt-get install doxygen
+      run: |
+           sudo apt-get update
+           sudo apt-get install doxygen
     - name: Autodocs
       run: .github/actions/autodoc.bash

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -82,7 +82,9 @@ jobs:
     - name: Install fprime tools
       run: pip3 install fprime-tools fprime-gds
     - name: Setup Dependencies
-      run: sudo apt-get install valgrind
+      run: |
+           sudo apt-get update
+           sudo apt-get install valgrind
     - name: F prime CI step
       run: ./ci/tests/30-ints.bash
     # Archive the outputs


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The failures in CI are likely caused by un-updated APT packages on the base image.  Apt update before installing packages will fix.