### PR TITLE
Fix for baremetal compilation

### DIFF
--- a/Os/TaskIdRepr.hpp
+++ b/Os/TaskIdRepr.hpp
@@ -15,7 +15,7 @@ extern "C" {
 #endif
 
 namespace Os {
-#if defined(TGT_OS_TYPE_VXWORKS)
+#if defined(TGT_OS_TYPE_VXWORKS) || (FW_BAREMETAL_SCHEDULER == 1)
     typedef int TaskIdRepr;
 #elif defined(TGT_OS_TYPE_LINUX) || defined(TGT_OS_TYPE_DARWIN)
     typedef pthread_t TaskIdRepr;


### PR DESCRIPTION
When compiling for baremetal, the TaskIdRepr definition was missing. This fixes that.

| | |
|:---|:---|
|**_Originating Project/Creator_**| @kevin-f-ortega |
|**_Affected Component_**| Os/TaskIdRepr.hpp |
|**_Affected Architectures(s)_**|  Baremetal |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adding if condition arond TaskIdRepr definition for when FW_BAREMETAL_SCHEDULER is 1.

## Rationale

Fixes compilation for when compiling for baremetal

## Testing/Review Recommendations


## Future Work
