### PR TITLE
type issue with Drv::LinuxSerialDriver

### DIFF
--- a/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.cpp
+++ b/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.cpp
@@ -414,7 +414,7 @@ namespace Drv {
   }
 
   void LinuxSerialDriverComponentImpl ::
-    startReadThread(NATIVE_INT_TYPE priority, NATIVE_INT_TYPE stackSize, NATIVE_INT_TYPE cpuAffinity) {
+    startReadThread(NATIVE_UINT_TYPE priority, NATIVE_UINT_TYPE stackSize, NATIVE_UINT_TYPE cpuAffinity) {
 
       Os::TaskString task("SerReader");
       Os::Task::TaskStatus stat = this->m_readTask.start(task, serialReadTaskEntry, this, priority, stackSize, cpuAffinity);

--- a/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.hpp
+++ b/Drv/LinuxSerialDriver/LinuxSerialDriverComponentImpl.hpp
@@ -71,7 +71,7 @@ namespace Drv {
       //! start the serial poll thread.
       //! buffSize is the max receive buffer size
       //!
-      void startReadThread(NATIVE_INT_TYPE priority = Os::Task::TASK_DEFAULT, NATIVE_INT_TYPE stackSize = Os::Task::TASK_DEFAULT, NATIVE_INT_TYPE cpuAffinity = Os::Task::TASK_DEFAULT);
+      void startReadThread(NATIVE_UINT_TYPE priority = Os::Task::TASK_DEFAULT, NATIVE_UINT_TYPE stackSize = Os::Task::TASK_DEFAULT, NATIVE_UINT_TYPE cpuAffinity = Os::Task::TASK_DEFAULT);
 
       //! Quit thread
       void quitReadThread();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|@danjwait |
|**_Affected Component_**|  Drv::LinuxSerialDriver |
|**_Affected Architectures(s)_**| Linux |
|**_Related Issue(s)_**|  None |
|**_Has Unit Tests (y/n)_**| No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

Modifying LinuxSerialDriver startReadThread() to agree on types

## Rationale

Type mismatch Os::Task::TASK_DEFAULT are NATIVE_UINT_TYPE , but call was for NATIVE_INT_TYPE . Ref ["type conversion error in LinuxSerialDriver/LinuxSerialDriver.hpp?"](https://github.com/nasa/fprime/discussions/1343) in Q&A

## Testing/Review Recommendations

make change in startReadThread() to match the  Os::Task::TASK_DEFAULT

## Future Work

Presently running GpsApp w/ this change on RPi w/ a GPS waiting for lock; but it build for native (linux) and RPi without errors.
