### PR TITLE
Handle 0 and negative numbers on string_copy

### DIFF
--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -3,8 +3,8 @@
 #include <cstring>
 
 char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 num) {
-    // Handle self-copy
-    if(destination == source) {
+    // Handle self-copy and negative numbers
+    if(destination == source || num <= 0) {
         return destination;
     }
 

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -3,8 +3,8 @@
 #include <cstring>
 
 char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 num) {
-    // Handle self-copy and negative numbers
-    if(destination == source || num <= 0) {
+    // Handle self-copy and 0 bytes copy
+    if(destination == source || num == 0) {
         return destination;
     }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Avoids  to write '\0' before  the destination pointer if num is 0
which is set by the following line:
> destination[ num - 1] = '\0'
