### PR TITLE
lestarch: pinning click version per recommendation

### DIFF
--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -13,5 +13,5 @@ jobs:
           python-version: 3.7
       - name: Check formatting
         run: |
-          pip install black==21.6b0
+          pip install click==8.0.4 black==21.6b0
           black --check --diff ./

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
         "Programming Language :: Python :: 3.9",
     ],
     python_requires=">=3.6",
-    install_requires=["fprime-tools==3.0.1", "fprime-fpp==1.0.1", "fprime-gds==3.0.1"],
+    install_requires=["fprime-tools==3.0.2", "fprime-fpp==1.0.1", "fprime-gds==3.0.1"],
 )

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
         "Programming Language :: Python :: 3.9",
     ],
     python_requires=">=3.6",
-    install_requires=["fprime-tools==3.0.2", "fprime-fpp==1.0.1", "fprime-gds==3.0.1"],
+    install_requires=["fprime-tools==3.0.1", "fprime-fpp==1.0.1", "fprime-gds==3.0.2"],
 )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description
Upgrading black will likely cause a need to reformat. To continue using the set black version, we must pin click:

https://github.com/psf/black/issues/2964