### PR TITLE
Avoid assert on BufferManager destruction

### DIFF
--- a/Svc/BufferManager/BufferManagerComponentImpl.cpp
+++ b/Svc/BufferManager/BufferManagerComponentImpl.cpp
@@ -53,7 +53,9 @@ namespace Svc {
   BufferManagerComponentImpl ::
     ~BufferManagerComponentImpl()
   {
-      this->cleanup();
+      if (m_setup) {
+          this->cleanup();
+      }
   }
 
   void BufferManagerComponentImpl ::


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Svc/BufferManager |
|**_Affected Architectures(s)_**| All |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Avoid calling `BufferManager::cleanup()` if `BufferManager::setup()` was never called.

## Rationale

Relevant when FSW exits early (before initialization). The BufferManager destructor will be called and either an assertion will trip saying `m_allocator`  is NULL or segfault if there is no assertion hook set up.

https://github.com/nasa/fprime/blob/582f180602afacddbbb6157ddeb68ecdb485183d/Svc/BufferManager/BufferManagerComponentImpl.cpp#L65-L74