### PR TITLE
Fix broken Doxygen image references

### DIFF
--- a/docs/doxygen/generate_docs.bash
+++ b/docs/doxygen/generate_docs.bash
@@ -96,4 +96,7 @@ function make_version
 github_page_adjustment "${DOXY_OUTPUT}/html"
 make_version "${VERSIONED_OUTPUT}"
 
-
+# Copy images so they're properly referenced
+IMG_DIR="${FPRIME}/docs/UsersGuide/api/c++/html/img"
+mkdir -p "${IMG_DIR}"
+find "${FPRIME}/Fw" "${FPRIME}/Svc" "${FPRIME}/Drv" \( -name '*.jpg' -o -name '*.png' -o -name '*.svg' \) -print0 | xargs -0 cp -t "${IMG_DIR}"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @cadomani - ABEX (Alabama Burst Energetics eXplorer) |
|**_Affected Component_**| Doxygen Documentation |
|**_Affected Architectures(s)_**| N/A |
|**_Related Issue(s)_**| #1424 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

While generating Doxygen documentation, the relative path references are not updated, and the site expects images to reside locally in an img/ path, but breaks when they cannot be found. This adds in a section at the bottom of the generation script to find all image files in Fw, Svc, and Drv, and copy them into the appropriate Doxygen folder so references are found.

## Rationale

Viewing markdown documentation retains images and diagrams that are helpful in understanding the framework, but the online documentation loses some usability when it does not show images alongside the components and ports it documents.

## Testing/Review Recommendations

Additional logic could be added to ensure that the find command was able to locate images in the provided directories, and check if the output path has received images to ensure copy was successful. 

## Future Work

None
