### PR TITLE
lestarch: fixing issues with small stack sizes

### DIFF
--- a/RPI/Top/instances.fpp
+++ b/RPI/Top/instances.fpp
@@ -8,7 +8,7 @@ module RPI {
 
     constant queueSize = 10
 
-    constant stackSize = 16 * 1024
+    constant stackSize = 64 * 1024
 
   }
 

--- a/Ref/Top/instances.fpp
+++ b/Ref/Top/instances.fpp
@@ -8,7 +8,7 @@ module Ref {
 
     constant queueSize = 10
 
-    constant stackSize = 16 * 1024
+    constant stackSize = 64 * 1024
 
   }
 

--- a/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
+++ b/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
@@ -126,7 +126,9 @@ namespace Svc {
 
       CHAR msg[FW_ASSERT_TEXT_SIZE] = {0};
       Fw::defaultReportAssert(file,lineNo,numArgs,arg1,arg2,arg3,arg4,arg5,arg6,msg,sizeof(msg));
-      fprintf(stderr, "%s\n", msg);
+      // fprintf(stderr... allocates large buffers on stack as stderr is unbuffered by the OS
+      // and this can conflict with the traditionally smaller stack sizes.
+      printf("%s\n", msg);
 
       switch (numArgs) {
           case 0:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Bump the default stack size for RPI and Ref to 64K as 16K as a default was a bit small.  Removing the fprintf(stderr... to fix #1418 