### PR TITLE
lestarch: writing FPP file input listing to file

### DIFF
--- a/cmake/autocoder/fpp.cmake
+++ b/cmake/autocoder/fpp.cmake
@@ -178,7 +178,7 @@ function(fpp_setup_autocode AC_INPUT_FILES)
             list(APPEND GENERATED_CPP "${GENERATED}")
         endif()
     endforeach()
-
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/fpp-input-list" "${FILE_DEPENDENCIES}")
     # Add in steps for Ai.xml generation
     if (GENERATED_AI)
         add_custom_command(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Spitting out the FPP input list for extra utilities like `fpp-check`