### PR TITLE
Mutex BasicLockable

### DIFF
--- a/Os/CMakeLists.txt
+++ b/Os/CMakeLists.txt
@@ -101,6 +101,7 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/OsTaskTest.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/OsFileSystemTest.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/OsSystemResourcesTest.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/OsMutexBasicLockableTest.cpp"
 )
 register_fprime_ut()
 

--- a/Os/Mutex.hpp
+++ b/Os/Mutex.hpp
@@ -13,6 +13,7 @@ namespace Os {
 
             void lock(); //!<  lock the mutex
             void unLock(); //!<  unlock the mutex
+            void unlock() { this->unLock(); } //!<  alias for unLock to meet BasicLockable requirements
 
         private:
 

--- a/Os/test/ut/OsMutexBasicLockableTest.cpp
+++ b/Os/test/ut/OsMutexBasicLockableTest.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+
+#include <Os/Mutex.hpp>
+#include <Fw/Types/Assert.hpp>
+
+#include <mutex>
+
+
+// This is exclusively a compile-time check
+void testMutexBasicLockableTest() {
+  Os::Mutex mux;
+
+  {
+    std::lock_guard<Os::Mutex> lock(mux);
+  }
+
+  ASSERT_TRUE(true); // if runs will pass
+}
+
+extern "C" {
+  void mutexBasicLockableTest();
+}
+
+void mutexBasicLockableTest() {
+  testMutexBasicLockableTest();
+}

--- a/Os/test/ut/TestMain.cpp
+++ b/Os/test/ut/TestMain.cpp
@@ -14,7 +14,8 @@ extern "C" {
   void intervalTimerTest();
   void fileSystemTest();
   void validateFileTest(const char* filename);
-  void systemResourcesTest(void);
+  void systemResourcesTest();
+  void mutexBasicLockableTest();
 }
 const char* filename;
 TEST(Nominal, StartTestTask) {
@@ -55,6 +56,9 @@ TEST(Nominal, ValidateFileTest) {
 }
 TEST(Nominal, SystemResourcesTest) { 
    systemResourcesTest();
+}
+TEST(Nominal, MutexBasicLockableTest) {
+  mutexBasicLockableTest();
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Connor Fuhrman|
|**_Affected Component_**|  None |
|**_Affected Architectures(s)_**|  None |
|**_Related Issue(s)_**|  #1229 |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**|  y|
|**_Unit Tests Pass (y/n)_**|  y|
|**_Documentation Included (y/n)_**|y |

---
## Change Description

Added `unlock` alias for `Os::Mutex` type.

## Rationale

`Os::Mutex` is now [BasicLoackable](https://en.cppreference.com/w/cpp/named_req/BasicLockable).
## Testing/Review Recommendations

Added test in Os folder but is really only a compile-time check. Perhaps there is a better way to assert at compile-time that the BaiscLockable requirements are satisfied. For now a `std::lock_guard` is instantiated with an `Os::Mutex` parameter to show correctness. 

## Future Work

When/if F' C++ standard bumps to C++17 or above Mutex could be upgraded to satisfy the [Lockable](https://en.cppreference.com/w/cpp/named_req/Lockable) requirement. 