### PR TITLE
updated fprime types for correct compilation with vxworks and baremetal

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
@@ -52,6 +52,34 @@ namespace ${namespace} {
     return *this;
   }
 
+  ${name}& ${name} :: operator=(const t a)
+  {
+#for $item_name,$item_value,$item_comment in $items_list:
+#if not $item_value == ""
+#set $manual_values = True
+#else
+#set $manual_values = False
+#end if
+#end for
+#if $manual_values == True
+    FW_ASSERT(#slurp
+#set $value_iter = 0
+#for $item_name,$item_value,$item_comment in $items_list:
+#if $value_iter == 0
+a == $item_value#slurp
+#else
+ || a == $item_value#slurp
+#end if
+#set $value_iter = $value_iter + 1
+#end for
+, a);
+#else
+    FW_ASSERT(a >= 0 && a <= $max_value, a);
+#end if
+    this->e = a;
+    return *this;
+  }
+
   ${name}& ${name} :: operator=(const NATIVE_INT_TYPE a)
   {
 #for $item_name,$item_value,$item_comment in $items_list:

--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
@@ -98,6 +98,11 @@ namespace ${namespace} {
 
     //! Assignment operator
     ${name}& operator=(
+        const t a //!< The integer to copy
+        );
+
+    //! Assignment operator
+    ${name}& operator=(
         const NATIVE_INT_TYPE a //!< The integer to copy
         );
 

--- a/Autocoders/Python/src/fprime_ac/generators/templates/port/finishPortCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/port/finishPortCpp.tmpl
@@ -37,24 +37,24 @@ ${return_type}Output${name}Port::invoke(${args_proto_string}) {
 \#if FW_PORT_SERIALIZATION
     } else if (this->m_serPort) {
 
-        Fw::SerializeStatus status;
+        Fw::SerializeStatus _status;
 
         ${name}PortBuffer _buffer;
  #set $num = 0
  #for $arg in $args:
   #if $enum_marker[$num] == 'ENUM':
-        status = _buffer.serialize(static_cast<NATIVE_INT_TYPE>($arg[0]));
+        _status = _buffer.serialize(static_cast<NATIVE_INT_TYPE>($arg[0]));
   #elif $pointer_marker[$num] == True:
-        status = _buffer.serialize(static_cast<void*>($arg[0]));
+        _status = _buffer.serialize(static_cast<void*>($arg[0]));
   #else:
-        status = _buffer.serialize($arg[0]);
+        _status = _buffer.serialize($arg[0]);
   #end if
   #set $num = $num + 1
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<AssertArg>(status));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == _status,static_cast<AssertArg>(_status));
 
  #end for
-        status = this->m_serPort->invokeSerial(_buffer);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<AssertArg>(status));
+        _status = this->m_serPort->invokeSerial(_buffer);
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == _status,static_cast<AssertArg>(_status));
     }
 \#else
     }

--- a/Fw/Test/UnitTestAssert.cpp
+++ b/Fw/Test/UnitTestAssert.cpp
@@ -43,9 +43,9 @@ namespace Test {
     void UnitTestAssert::doAssert() {
         this->m_assertFailed = true;
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
-        (void)fprintf(stderr,"Assert File: 0x%x, Line: %u\n", this->m_file, this->m_lineNo);
+        (void)fprintf(stderr,"Assert File: 0x%x, Line: %" PRIfwit "\n", this->m_file, this->m_lineNo);
 #else
-        (void)fprintf(stderr,"Assert File: %s, Line: %u\n", this->m_file.toChar(), this->m_lineNo);
+        (void)fprintf(stderr,"Assert File: %s, Line: %" PRIfwit "\n", this->m_file.toChar(), this->m_lineNo);
 #endif
     }
 

--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -10,9 +10,9 @@
 #else
 
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
-#define fileIdFs "Assert file ID 0x%08X: Line: %d "
+#define fileIdFs "Assert file ID 0x%08X: Line: %" PRIfwit
 #else
-#define fileIdFs "Assert file \"%s\": Line: %d "
+#define fileIdFs "Assert file \"%s\": Line: %" PRIfwit
 #endif
 
 namespace Fw {

--- a/Fw/Types/BasicTypes.hpp
+++ b/Fw/Types/BasicTypes.hpp
@@ -14,22 +14,9 @@
 #define FW_BASIC_TYPES_HPP
 
 #include <FpConfig.hpp>
-#include <StandardTypes.hpp> // This header will be found be include paths by target. This hides different header files for each target.
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
-
-// Define native integer/unsigned integer types
-#ifdef _WRS_KERNEL
-typedef int32_t NATIVE_INT_TYPE;
-typedef uint32_t NATIVE_UINT_TYPE;
-#else
-// Allow overriding of native types for systems whose stdint.h is malformed
-#ifndef FPRIME_OVERRIDE_NATIVE_TYPES
-typedef int NATIVE_INT_TYPE; //!< native integer type declaration
-typedef unsigned int NATIVE_UINT_TYPE; //!< native unsigned integer type declaration
-#endif
-#endif
 
 #if defined __GNUC__ || __llvm__
 

--- a/Fw/Types/DefaultTypes.hpp
+++ b/Fw/Types/DefaultTypes.hpp
@@ -1,0 +1,15 @@
+
+#ifndef PLATFORM_INT_TYPE_DEFINED
+typedef int PLATFORM_INT_TYPE;
+#define PRIfwpit "d"
+#endif
+#ifndef PLATFORM_UINT_TYPE_DEFINED
+typedef unsigned int PLATFORM_UINT_TYPE;
+#define PRIfwpuit "u"
+#endif
+#ifndef PLATFORM_INDEX_TYPE_DEFINED
+typedef PLATFORM_INT_TYPE PLATFORM_INDEX_TYPE;
+#endif
+#ifndef PLATFORM_SIZE_TYPE_DEFINED
+typedef PLATFORM_INT_TYPE PLATFORM_SIZE_TYPE;
+#endif

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -411,7 +411,7 @@ namespace Fw {
                     valIsEqual = false;
                     break;
                 default:
-                    FW_ASSERT(0,static_cast<NATIVE_INT_TYPE>(this->m_dataType));
+                    FW_ASSERT(0,static_cast<AssertArg>(this->m_dataType));
                     return false; // for compiler
                 }
             return valIsEqual;
@@ -474,7 +474,7 @@ namespace Fw {
                     result = false;
                     break;
                 default:
-                    FW_ASSERT(0,static_cast<NATIVE_INT_TYPE>(this->m_dataType));
+                    FW_ASSERT(0,static_cast<AssertArg>(this->m_dataType));
                     return false; // for compiler
             }
             return result;

--- a/Fw/Types/VxWorks/StandardTypes.hpp
+++ b/Fw/Types/VxWorks/StandardTypes.hpp
@@ -16,4 +16,11 @@ enum {
   ERROR = VXWORKS_ERROR
 };
 
+#define PLATFORM_INT_TYPE_DEFINED
+typedef int32_t PLATFORM_INT_TYPE;
+#define PRIfwpit "d"
+#define PLATFORM_UINT_TYPE_DEFINED
+typedef uint32_t PLATFORM_UINT_TYPE;
+#define PRIfwpuit "u"
+
 #endif

--- a/RPI/Top/instances.fpp
+++ b/RPI/Top/instances.fpp
@@ -314,12 +314,17 @@ module RPI {
   {
 
     phase Fpp.ToCpp.Phases.configObjects """
-    NATIVE_INT_TYPE rgDivs[Svc::RateGroupDriver::DIVIDER_SIZE] = { 1, 10, 0 };
+    FW_INDEX_TYPE rgDivs[Svc::RateGroupDriver::DIVIDER_SIZE] = { 1, 10, 0 };
     """
 
     phase Fpp.ToCpp.Phases.instances """
     Svc::RateGroupDriver rateGroupDriverComp(
-        FW_OPTIONAL_NAME("rateGroupDriverComp"),
+        FW_OPTIONAL_NAME("rateGroupDriverComp")
+    );
+    """
+
+    phase Fpp.ToCpp.Phases.configComponents """
+    rateGroupDriverComp.configure(
         ConfigObjects::rateGroupDriverComp::rgDivs,
         FW_NUM_ARRAY_ELEMENTS(ConfigObjects::rateGroupDriverComp::rgDivs)
     );

--- a/Ref/Top/instances.fpp
+++ b/Ref/Top/instances.fpp
@@ -332,12 +332,17 @@ module Ref {
   instance rateGroupDriverComp: Svc.RateGroupDriver base id 0x4600 {
 
     phase Fpp.ToCpp.Phases.configObjects """
-    NATIVE_INT_TYPE rgDivs[Svc::RateGroupDriver::DIVIDER_SIZE] = { 1, 2, 4 };
+    FW_INDEX_TYPE rgDivs[Svc::RateGroupDriver::DIVIDER_SIZE] = { 1, 2, 4 };
     """
 
     phase Fpp.ToCpp.Phases.instances """
     Svc::RateGroupDriver rateGroupDriverComp(
-        FW_OPTIONAL_NAME("rateGroupDriverComp"),
+        FW_OPTIONAL_NAME("rateGroupDriverComp")
+    );
+    """
+
+    phase Fpp.ToCpp.Phases.configComponents """
+    rateGroupDriverComp.configure(
         ConfigObjects::rateGroupDriverComp::rgDivs,
         FW_NUM_ARRAY_ELEMENTS(ConfigObjects::rateGroupDriverComp::rgDivs)
     );

--- a/Svc/ActiveTextLogger/ActiveTextLoggerImpl.cpp
+++ b/Svc/ActiveTextLogger/ActiveTextLoggerImpl.cpp
@@ -94,7 +94,7 @@ namespace Svc {
 
             (void) snprintf(textStr,
                             FW_INTERNAL_INTERFACE_STRING_MAX_SIZE,
-                            "EVENT: (%d) (%04d-%02d-%02dT%02d:%02d:%02d.%03u) %s: %s\n",
+                            "EVENT: (%" PRId32 ") (%04d-%02d-%02dT%02d:%02d:%02d.%03" PRIu32 ") %s: %s\n",
                             id, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour,
                             tm.tm_min,tm.tm_sec,timeTag.getUSeconds(),
                             severityString,text.toChar());
@@ -103,8 +103,8 @@ namespace Svc {
 
             (void) snprintf(textStr,
                             FW_INTERNAL_INTERFACE_STRING_MAX_SIZE,
-                            "EVENT: (%d) (%d:%d,%d) %s: %s\n",
-                            id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severityString,text.toChar());
+                            "EVENT: (%" PRId32 ") (%" PRId16 ":%" PRId32 ",%" PRId32 ") %s: %s\n",
+                            id, static_cast<U16>(timeTag.getTimeBase()),timeTag.getSeconds(),timeTag.getUSeconds(),severityString,text.toChar());
         }
 
         // Call internal interface so that everything else is done on component thread,

--- a/Svc/ActiveTextLogger/LogFile.cpp
+++ b/Svc/ActiveTextLogger/LogFile.cpp
@@ -119,7 +119,7 @@ namespace Svc {
             }
 
             NATIVE_INT_TYPE stat = snprintf(fileNameFinal,Fw::String::STRING_SIZE,
-                                            "%s%d",fileName,suffix);
+                                            "%s%" PRIu32,fileName,suffix);
 
             // If there was error, then just fail:
             if (stat <= 0) {

--- a/Svc/BufferLogger/BufferLoggerFile.cpp
+++ b/Svc/BufferLogger/BufferLoggerFile.cpp
@@ -198,7 +198,7 @@ namespace Svc {
   bool BufferLogger::File ::
     writeBytes(
         const void *const data,
-        const NATIVE_UINT_TYPE length
+        const U32 length
     )
   {
     FW_ASSERT(length > 0, length);

--- a/Svc/ComLogger/ComLogger.cpp
+++ b/Svc/ComLogger/ComLogger.cpp
@@ -147,7 +147,7 @@ namespace Svc {
     // Create filename:
     Fw::Time timestamp = getTime();
     memset(this->fileName, 0, sizeof(this->fileName));
-    bytesCopied = snprintf(this->fileName, sizeof(this->fileName), "%s_%d_%d_%06d.com",
+    bytesCopied = snprintf(this->fileName, sizeof(this->fileName), "%s_%" PRIu32 "_%" PRIu32 "_%06" PRIu32 ".com",
       this->filePrefix, static_cast<U32>(timestamp.getTimeBase()), timestamp.getSeconds(), timestamp.getUSeconds());
 
     // "A return value of size or more means that the output was truncated"
@@ -155,7 +155,7 @@ namespace Svc {
     FW_ASSERT( bytesCopied < sizeof(this->fileName) );
 
     // Create sha filename:
-    bytesCopied = snprintf(this->hashFileName, sizeof(this->hashFileName), "%s_%d_%d_%06d.com%s",
+    bytesCopied = snprintf(this->hashFileName, sizeof(this->hashFileName), "%s_%" PRIu32 "_%" PRIu32 "_%06" PRIu32 ".com%s",
       this->filePrefix, static_cast<U32>(timestamp.getTimeBase()), timestamp.getSeconds(), timestamp.getUSeconds(), Utils::Hash::getFileExtensionString());
     FW_ASSERT( bytesCopied < sizeof(this->hashFileName) );
 

--- a/Svc/ComLogger/ComLogger.hpp
+++ b/Svc/ComLogger/ComLogger.hpp
@@ -24,6 +24,13 @@
 #define COMLOGGER_PATH_MAX 255
 #endif
 
+// some limits.h don't have NAME_MAX
+#ifdef NAME_MAX
+#define COMLOGGER_NAME_MAX NAME_MAX
+#else
+#define COMLOGGER_NAME_MAX 255
+#endif
+
 namespace Svc {
 
   class ComLogger :
@@ -81,7 +88,7 @@ namespace Svc {
       // ----------------------------------------------------------------------
       // The maximum size of a filename
       enum {
-        MAX_FILENAME_SIZE = NAME_MAX, // as defined in limits.h
+        MAX_FILENAME_SIZE = COMLOGGER_NAME_MAX,
         MAX_PATH_SIZE = COMLOGGER_PATH_MAX
       };
 

--- a/Svc/RateGroupDriver/RateGroupDriverImpl.cpp
+++ b/Svc/RateGroupDriver/RateGroupDriverImpl.cpp
@@ -6,23 +6,34 @@
 
 namespace Svc {
 
-    RateGroupDriverImpl::RateGroupDriverImpl(const char* compName, I32 dividers[], I32 numDividers) :
+    RateGroupDriverImpl::RateGroupDriverImpl(const char* compName) :
         RateGroupDriverComponentBase(compName),
     m_ticks(0),m_rollover(1)
     {
+        (void) ::memset(this->m_dividers,0,sizeof(this->m_dividers));
+    }
 
+    RateGroupDriverImpl::~RateGroupDriverImpl() {
+
+    }
+
+    void RateGroupDriverImpl::init(FW_INDEX_TYPE instanceId) {
+        RateGroupDriverComponentBase::init(instanceId);
+    }
+
+    void RateGroupDriverImpl:: configure(const FW_INDEX_TYPE dividers[], const FW_SIZE_TYPE numDividers) {
         // double check arguments
         FW_ASSERT(dividers);
-        FW_ASSERT(numDividers <= static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)),
+        FW_ASSERT(numDividers <= static_cast<FW_SIZE_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)),
                 numDividers,
-                static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)));
+                static_cast<FW_SIZE_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)));
         // verify port/table size matches
         FW_ASSERT(FW_NUM_ARRAY_ELEMENTS(this->m_dividers) == this->getNum_CycleOut_OutputPorts(),
-                static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)),
+                static_cast<FW_SIZE_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)),
                 this->getNum_CycleOut_OutputPorts());
         // clear table
-        ::memset(this->m_dividers,0,sizeof(this->m_dividers));
-        for (NATIVE_INT_TYPE entry = 0; entry < numDividers; entry++) {
+        (void) ::memset(this->m_dividers,0,sizeof(this->m_dividers));
+        for (FW_SIZE_TYPE entry = 0; entry < numDividers; entry++) {
             this->m_dividers[entry] = dividers[entry];
             // rollover value should be product of all dividers to make sure integer rollover doesn't jump cycles
             // only use non-zero dividers
@@ -30,23 +41,15 @@ namespace Svc {
                 this->m_rollover *= dividers[entry];
             }
         }
-
     }
 
-    RateGroupDriverImpl::~RateGroupDriverImpl() {
 
-    }
-
-    void RateGroupDriverImpl::init(NATIVE_INT_TYPE instanceId) {
-        RateGroupDriverComponentBase::init(instanceId);
-    }
-
-    void RateGroupDriverImpl::CycleIn_handler(NATIVE_INT_TYPE portNum, Svc::TimerVal& cycleStart) {
+    void RateGroupDriverImpl::CycleIn_handler(FW_INDEX_TYPE portNum, Svc::TimerVal& cycleStart) {
 
         // Loop through each divider. For a given port, the port will be called when the divider value
         // divides evenly into the number of ticks. For example, if the divider value for a port is 4,
         // it would be called every fourth invocation of the CycleIn port.
-        for (NATIVE_INT_TYPE entry = 0; entry < static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)); entry++) {
+        for (FW_SIZE_TYPE entry = 0; entry < static_cast<FW_SIZE_TYPE>(FW_NUM_ARRAY_ELEMENTS(this->m_dividers)); entry++) {
             if (this->m_dividers[entry] != 0) {
                 if (this->isConnected_CycleOut_OutputPort(entry)) {
                     if ((this->m_ticks % this->m_dividers[entry]) == 0) {

--- a/Svc/RateGroupDriver/RateGroupDriverImpl.hpp
+++ b/Svc/RateGroupDriver/RateGroupDriverImpl.hpp
@@ -40,17 +40,21 @@ namespace Svc {
             //!  for use when the CycleIn port is called.
             //!
             //!  \param compName component name
-            //!  \param dividers array of integers used to divide down input tick
-            //!  \param numDividers size of dividers array
             //!
             //!  \return return value description
-            RateGroupDriverImpl(const char* compName, NATIVE_INT_TYPE dividers[], NATIVE_INT_TYPE numDividers);
+            RateGroupDriverImpl(const char* compName);
 
             //!  \brief RateGroupDriverImpl initialization function
             //!
             //!  The init() function initializes the autocoded base class
 
-            void init(NATIVE_INT_TYPE instanceId = 0);
+            void init(FW_INDEX_TYPE instanceId = 0);
+
+            //!  \brief configure the rate group driver
+            //!
+            //!  \param dividers array of integers used to divide down input tick
+            //!  \param numDividers size of dividers array
+            void configure(const FW_INDEX_TYPE dividers[], const FW_SIZE_TYPE numDividers);
 
             //!  \brief RateGroupDriverImpl destructor
 
@@ -60,18 +64,18 @@ namespace Svc {
 
             //! downcall for input port
             //! NOTE: This port can execute in ISR context.
-            void CycleIn_handler(NATIVE_INT_TYPE portNum, Svc::TimerVal& cycleStart);
+            void CycleIn_handler(FW_INDEX_TYPE portNum, Svc::TimerVal& cycleStart);
 
             //! divider array
-            NATIVE_INT_TYPE m_dividers[NUM_CYCLEOUT_OUTPUT_PORTS];
+            FW_INDEX_TYPE m_dividers[NUM_CYCLEOUT_OUTPUT_PORTS];
 
             //! tick counter
-            NATIVE_INT_TYPE m_ticks;
+            FW_INDEX_TYPE m_ticks;
             //! rollover counter
-            NATIVE_INT_TYPE m_rollover;
+            FW_INDEX_TYPE m_rollover;
         public:
             //! Size of the divider table, provided as a constants to users passing the table in
-            static const NATIVE_UINT_TYPE DIVIDER_SIZE = NUM_CYCLEOUT_OUTPUT_PORTS;
+            static const FW_SIZE_TYPE DIVIDER_SIZE = NUM_CYCLEOUT_OUTPUT_PORTS;
     };
 
 }

--- a/Svc/RateGroupDriver/docs/sdd.md
+++ b/Svc/RateGroupDriver/docs/sdd.md
@@ -4,7 +4,7 @@
 ## 1. Introduction
 
 The RateGroupDriver Component is used to take a single system tick and distribute it to multiple rate groups in a system. 
-It takes the input `Svc::Sched` port, then divides down the tick rate based on arguments to the constructor. 
+It takes the input `Svc::Sched` port, then divides down the tick rate based on arguments to `configure`. 
 Typically, the output ports would be connected to the asynchronous inputs of an `ActiveRateGroup`.
 
 ## 2. Requirements
@@ -38,9 +38,9 @@ Port Data Type | Name | Direction | Kind | Usage
 #### 3.2 Functional Description
 
 The Svc::RateGroupDriver component has one input port that receives a system tick. 
-The constructor has an array of integer arguments that specifies the divisors for each output port.
+The configure function has an array of integer arguments that specifies the divisors for each output port.
 
-    RateGroupDriverImpl(const char* compName, NATIVE_INT_TYPE dividers[], NATIVE_INT_TYPE numDividers);
+    RateGroupDriverImpl::configure(const FW_INDEX_TYPE dividers[], const FW_SIZE_TYPE numDividers);
 
 The input rate for each output port will be divided down by the value in the `dividers[]` array corresponding to the output port number.
 

--- a/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
+++ b/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
@@ -31,9 +31,11 @@ void connectPorts(Svc::RateGroupDriverImpl& impl, Svc::RateGroupDriverImplTester
 
 TEST(RateGroupDriverTest,NominalSchedule) {
 
-    NATIVE_INT_TYPE dividers[] = {1,2,3};
+    FW_INDEX_TYPE dividers[] = {1,2,3};
 
-    Svc::RateGroupDriverImpl impl("RateGroupDriverImpl",dividers,FW_NUM_ARRAY_ELEMENTS(dividers));
+    Svc::RateGroupDriverImpl impl("RateGroupDriverImpl");
+
+    impl.configure(dividers,FW_NUM_ARRAY_ELEMENTS(dividers));
 
     Svc::RateGroupDriverImplTester tester(impl);
 

--- a/config/FpConfig.hpp
+++ b/config/FpConfig.hpp
@@ -9,6 +9,9 @@
  * acknowledged.
  * <br /><br />
  */
+#include <StandardTypes.hpp> // Platform (toolchain) defined types come first
+#include <Fw/Types/DefaultTypes.hpp> // Default types fill in missing platform types
+
 #ifndef _FW_CONFIG_HPP_
 #define _FW_CONFIG_HPP_
 
@@ -31,6 +34,23 @@
 
 #ifndef FW_HAS_F64
 #define FW_HAS_F64                          1  //!< Architecture supports 64 bit floating point numbers
+#endif
+
+// Project configured types
+#ifndef NATIVE_INT_TYPE_DEFINED
+typedef PLATFORM_INT_TYPE NATIVE_INT_TYPE;
+#define PRIfwit PRIfwpit
+#endif
+#ifndef NATIVE_UINT_TYPE_DEFINED
+typedef PLATFORM_UINT_TYPE NATIVE_UINT_TYPE;
+#define PRIfwuit PRIfwpuit
+#endif
+
+#ifndef FW_SIZE_TYPE_DEFINED
+typedef PLATFORM_SIZE_TYPE FW_SIZE_TYPE;
+#endif
+#ifndef FW_INDEX_TYPE_DEFINED
+typedef PLATFORM_INDEX_TYPE FW_INDEX_TYPE;
 #endif
 
 // Boolean values for serialization


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|@kevin-f-ortega |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  y|
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixed bugs founds when compiling for baremetal,  added the PLATFORM_*_TYPE macros, updated RateGroupDriver to use the configure pattern.

## Rationale

Bug fixes.
To be more consistent.

## Testing/Review Recommendations

PLATFORM_*_TYPES should be reviewed

## Future Work
