### PR TITLE
Fixed bugs found while compiling for baremetal.

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
@@ -52,6 +52,34 @@ namespace ${namespace} {
     return *this;
   }
 
+  ${name}& ${name} :: operator=(const t a)
+  {
+#for $item_name,$item_value,$item_comment in $items_list:
+#if not $item_value == ""
+#set $manual_values = True
+#else
+#set $manual_values = False
+#end if
+#end for
+#if $manual_values == True
+    FW_ASSERT(#slurp
+#set $value_iter = 0
+#for $item_name,$item_value,$item_comment in $items_list:
+#if $value_iter == 0
+a == $item_value#slurp
+#else
+ || a == $item_value#slurp
+#end if
+#set $value_iter = $value_iter + 1
+#end for
+, a);
+#else
+    FW_ASSERT(a >= 0 && a <= $max_value, a);
+#end if
+    this->e = a;
+    return *this;
+  }
+
   ${name}& ${name} :: operator=(const NATIVE_INT_TYPE a)
   {
 #for $item_name,$item_value,$item_comment in $items_list:

--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_cpp.tmpl
@@ -54,39 +54,17 @@ namespace ${namespace} {
 
   ${name}& ${name} :: operator=(const t a)
   {
-#for $item_name,$item_value,$item_comment in $items_list:
-#if not $item_value == ""
-#set $manual_values = True
-#else
-#set $manual_values = False
-#end if
-#end for
-#if $manual_values == True
-    FW_ASSERT(#slurp
-#set $value_iter = 0
-#for $item_name,$item_value,$item_comment in $items_list:
-#if $value_iter == 0
-a == $item_value#slurp
-#else
- || a == $item_value#slurp
-#end if
-#set $value_iter = $value_iter + 1
-#end for
-, a);
-#else
-    FW_ASSERT(a >= 0 && a <= $max_value, a);
-#end if
     this->e = a;
     return *this;
   }
 
   ${name}& ${name} :: operator=(const NATIVE_INT_TYPE a)
   {
+#set $manual_values = False
 #for $item_name,$item_value,$item_comment in $items_list:
 #if not $item_value == ""
 #set $manual_values = True
-#else
-#set $manual_values = False
+#break
 #end if
 #end for
 #if $manual_values == True
@@ -110,11 +88,11 @@ a == $item_value#slurp
 
   ${name}& ${name} :: operator=(const NATIVE_UINT_TYPE a)
   {
+#set $manual_values = False
 #for $item_name,$item_value,$item_comment in $items_list:
 #if not $item_value == ""
 #set $manual_values = True
-#else
-#set $manual_values = False
+#break
 #end if
 #end for
 #if $manual_values == True

--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
@@ -98,6 +98,11 @@ namespace ${namespace} {
 
     //! Assignment operator
     ${name}& operator=(
+        const t a //!< The integer to copy
+        );
+
+    //! Assignment operator
+    ${name}& operator=(
         const NATIVE_INT_TYPE a //!< The integer to copy
         );
 

--- a/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/enums/enum_hpp.tmpl
@@ -98,7 +98,7 @@ namespace ${namespace} {
 
     //! Assignment operator
     ${name}& operator=(
-        const t a //!< The integer to copy
+        const t a //!< The enumerated constant to copy
         );
 
     //! Assignment operator

--- a/Autocoders/Python/src/fprime_ac/generators/templates/port/finishPortCpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/port/finishPortCpp.tmpl
@@ -37,24 +37,24 @@ ${return_type}Output${name}Port::invoke(${args_proto_string}) {
 \#if FW_PORT_SERIALIZATION
     } else if (this->m_serPort) {
 
-        Fw::SerializeStatus status;
+        Fw::SerializeStatus _status;
 
         ${name}PortBuffer _buffer;
  #set $num = 0
  #for $arg in $args:
   #if $enum_marker[$num] == 'ENUM':
-        status = _buffer.serialize(static_cast<NATIVE_INT_TYPE>($arg[0]));
+        _status = _buffer.serialize(static_cast<NATIVE_INT_TYPE>($arg[0]));
   #elif $pointer_marker[$num] == True:
-        status = _buffer.serialize(static_cast<void*>($arg[0]));
+        _status = _buffer.serialize(static_cast<void*>($arg[0]));
   #else:
-        status = _buffer.serialize($arg[0]);
+        _status = _buffer.serialize($arg[0]);
   #end if
   #set $num = $num + 1
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<AssertArg>(status));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == _status,static_cast<AssertArg>(_status));
 
  #end for
-        status = this->m_serPort->invokeSerial(_buffer);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<AssertArg>(status));
+        _status = this->m_serPort->invokeSerial(_buffer);
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == _status,static_cast<AssertArg>(_status));
     }
 \#else
     }

--- a/Autocoders/Python/test/enum_xml/main.cpp
+++ b/Autocoders/Python/test/enum_xml/main.cpp
@@ -147,7 +147,7 @@ TEST(EnumXML, InvalidNegativeConstant) {
   Example::Enum1 enum1 = getEnum();
   // Get a valid negative constant
   const I32 negativeConstant = getNegativeConstant();
-  const U32 expectedLineNumber = 62;
+  const U32 expectedLineNumber = 61;
   // Turn it into a U32
   const U32 expectedArg1 = negativeConstant;
   // As a U32, the constant is not valid
@@ -163,7 +163,7 @@ TEST(EnumXML, InvalidConstant) {
   const I32 invalidConstant = 42;
   // This should cause an assertion failure
   enum1 = invalidConstant;
-  const U32 expectedLineNumber = 55;
+  const U32 expectedLineNumber = 54;
   const U32 expectedArg1 = invalidConstant;
   checkAssertionFailure(uta, expectedLineNumber, expectedArg1);
 }

--- a/Autocoders/Python/test/enum_xml/main.cpp
+++ b/Autocoders/Python/test/enum_xml/main.cpp
@@ -147,7 +147,7 @@ TEST(EnumXML, InvalidNegativeConstant) {
   Example::Enum1 enum1 = getEnum();
   // Get a valid negative constant
   const I32 negativeConstant = getNegativeConstant();
-  const U32 expectedLineNumber = 55;
+  const U32 expectedLineNumber = 62;
   // Turn it into a U32
   const U32 expectedArg1 = negativeConstant;
   // As a U32, the constant is not valid
@@ -163,7 +163,7 @@ TEST(EnumXML, InvalidConstant) {
   const I32 invalidConstant = 42;
   // This should cause an assertion failure
   enum1 = invalidConstant;
-  const U32 expectedLineNumber = 48;
+  const U32 expectedLineNumber = 55;
   const U32 expectedArg1 = invalidConstant;
   checkAssertionFailure(uta, expectedLineNumber, expectedArg1);
 }

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -411,7 +411,7 @@ namespace Fw {
                     valIsEqual = false;
                     break;
                 default:
-                    FW_ASSERT(0,static_cast<NATIVE_INT_TYPE>(this->m_dataType));
+                    FW_ASSERT(0,static_cast<AssertArg>(this->m_dataType));
                     return false; // for compiler
                 }
             return valIsEqual;
@@ -474,7 +474,7 @@ namespace Fw {
                     result = false;
                     break;
                 default:
-                    FW_ASSERT(0,static_cast<NATIVE_INT_TYPE>(this->m_dataType));
+                    FW_ASSERT(0,static_cast<AssertArg>(this->m_dataType));
                     return false; // for compiler
             }
             return result;

--- a/Svc/BufferLogger/BufferLoggerFile.cpp
+++ b/Svc/BufferLogger/BufferLoggerFile.cpp
@@ -198,7 +198,7 @@ namespace Svc {
   bool BufferLogger::File ::
     writeBytes(
         const void *const data,
-        const NATIVE_UINT_TYPE length
+        const U32 length
     )
   {
     FW_ASSERT(length > 0, length);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @kevin-f-ortega |
|**_Affected Component_**|  Autocoder, PolyType, and BufferLogger|
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Discovered a lack of `operator=` for enum in Autocoder's template files. 
A mismatch in function definition with its prototype in BufferLogger. 
An invalid casting in PolyType

## Rationale

Fixes bugs found while compiling for baremetal

## Testing/Review Recommendations

Re-run the UTs on your side.

## Future Work

