### PR TITLE
Use if-expression rather than Python 2.5 ternary syntax

### DIFF
--- a/Autocoders/Python/src/fprime_ac/utils/pyparsing.py
+++ b/Autocoders/Python/src/fprime_ac/utils/pyparsing.py
@@ -535,9 +535,7 @@ def col(loc, strg):
     """Returns current column within a string, counting newlines as line separators.
     The first column is number 1.
     """
-    return (
-        (loc < len(strg) and strg[loc] == "\n") and 1 or loc - strg.rfind("\n", 0, loc)
-    )
+    return 1 if (loc < len(strg) and strg[loc] == "\n") else loc - strg.rfind("\n", 0, loc)
 
 
 def lineno(loc, strg):
@@ -1663,11 +1661,7 @@ class QuotedString(Token):
         self.mayReturnEmpty = True
 
     def parseImpl(self, instring, loc, doActions=True):
-        result = (
-            instring[loc] == self.firstQuoteChar
-            and self.re.match(instring, loc)
-            or None
-        )
+        result = self.re.match(instring, loc) if instring[loc] == self.firstQuoteChar else None
         if not result:
             exc = self.myException
             exc.loc = loc


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| fprime_ac |
|**_Affected Architectures(s)_**| (void) |
|**_Related Issue(s)_**| (void) |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Change Pthon 2.5 ternary syntax with if-expr for readibility and bug-prone.

## Rationale

It is recommended to use an if expression like: ``foo if condition else bar`` rather than using the ternary syntax of Python 2.5 like ``[condition] and [on_true] or [on_false]`` because it can give wrong results when on_true has a false boolean value.

Consider this example from [DeepSource](https://deepsource.io/gh/rayandas/pip/issue/PYL-R1706/occurrences):

```py
def get_val(condition, fallback, on_truth=None):
    if on_truth is None:
        on_truth = []

    return condition and on_truth or fallback
```

Here, if condition is ``True``, the function is supposed to return the value ``on_truth`` otherwise it will return the value fallback.
This would work fine for calls where the ``on_truth`` is not a falsey value.
So, for a call: ``get_val(2>1, [1, 2, 3], [10, 20, 30])``, the output is as expected -> ``[10, 20, 30]``.

But, it would give the wrong result when ``on_truth`` is falsey value.
For the call: ``get_val(2>1, [1, 2, 3])`` expected result is [], but the function will return the fallback value ``[1, 2, 3]``.

This can be avoided by using if expression like:

```py
def get_val(condition, fallback, on_truth=None):
    if on_truth is None:
        on_truth = []

    return on_truth if condition else fallback
```

The if expression is also more readable and straight forward.


## Testing/Review Recommendations

(void)

## Future Work

(void)
