### PR TITLE
Revised specification of implementation types in Ref and RPI topologies

### DIFF
--- a/RPI/Top/RPITopologyDefs.cpp
+++ b/RPI/Top/RPITopologyDefs.cpp
@@ -14,6 +14,4 @@ namespace RPI {
 
   }
 
-  Svc::LinuxTimer linuxTimer(FW_OPTIONAL_NAME("linuxTimer"));
-
 }

--- a/RPI/Top/RPITopologyDefs.hpp
+++ b/RPI/Top/RPITopologyDefs.hpp
@@ -9,9 +9,6 @@
 
 namespace RPI {
 
-  // Declare the Linux timer here so it is visible in main
-  extern Svc::LinuxTimer linuxTimer;
-
   namespace Allocation {
 
     // Malloc allocator for topology construction

--- a/RPI/Top/instances.fpp
+++ b/RPI/Top/instances.fpp
@@ -285,14 +285,8 @@ module RPI {
   }
 
   instance linuxTime: Svc.Time base id 1500 \
-    at "../../Svc/LinuxTime/LinuxTime.hpp" \
-  {
-
-    phase Fpp.ToCpp.Phases.instances """
-    Svc::LinuxTime linuxTime(FW_OPTIONAL_NAME("linuxTime"));
-    """
-
-  }
+    type "Svc::LinuxTime" \
+    at "../../Svc/LinuxTime/LinuxTime.hpp"
 
   instance linuxTimer: Svc.LinuxTimer base id 1600 \
   {

--- a/RPI/Top/instances.fpp
+++ b/RPI/Top/instances.fpp
@@ -249,12 +249,9 @@ module RPI {
   }
 
   instance comm: Drv.ByteStreamDriverModel base id 1260 \
+    type "Drv::TcpClient" \
     at "../../Drv/TcpClient/TcpClient.hpp" \
   {
-
-    phase Fpp.ToCpp.Phases.instances """
-    Drv::TcpClient comm(FW_OPTIONAL_NAME("comm"));
-    """
 
     phase Fpp.ToCpp.Phases.configConstants """
     enum {

--- a/RPI/Top/instances.fpp
+++ b/RPI/Top/instances.fpp
@@ -291,10 +291,6 @@ module RPI {
   instance linuxTimer: Svc.LinuxTimer base id 1600 \
   {
 
-    phase Fpp.ToCpp.Phases.instances """
-    // Declared in RPITopologyDefs.cpp
-    """
-
     phase Fpp.ToCpp.Phases.stopTasks """
     linuxTimer.quit();
     """

--- a/Ref/Top/RefTopologyDefs.cpp
+++ b/Ref/Top/RefTopologyDefs.cpp
@@ -8,6 +8,4 @@ namespace Ref {
 
   }
 
-  Drv::BlockDriver blockDrv(FW_OPTIONAL_NAME("blockDrv"));
-
 }

--- a/Ref/Top/RefTopologyDefs.hpp
+++ b/Ref/Top/RefTopologyDefs.hpp
@@ -8,9 +8,6 @@
 
 namespace Ref {
 
-  // Declare the block driver here so it is visible in main
-  extern Drv::BlockDriver blockDrv;
-
   namespace Allocation {
 
     // Malloc allocator for topology construction

--- a/Ref/Top/instances.fpp
+++ b/Ref/Top/instances.fpp
@@ -19,14 +19,7 @@ module Ref {
   instance blockDrv: Drv.BlockDriver base id 0x0100 \
     queue size Default.queueSize \
     stack size Default.stackSize \
-    priority 140 \
-  {
-
-    phase Fpp.ToCpp.Phases.instances """
-    // Declared in RefTopologyDefs.cpp
-    """
-
-  }
+    priority 140
 
   instance rateGroup1Comp: Svc.ActiveRateGroup base id 0x0200 \
     queue size Default.queueSize \

--- a/Ref/Top/instances.fpp
+++ b/Ref/Top/instances.fpp
@@ -235,12 +235,9 @@ module Ref {
   @ Communications driver. May be swapped with other comm drivers like UART
   @ Note: Here we have TCP reliable uplink and UDP (low latency) downlink
   instance comm: Drv.ByteStreamDriverModel base id 0x4000 \
+    type "Drv::TcpClient" \
     at "../../Drv/TcpClient/TcpClient.hpp" \
   {
-
-    phase Fpp.ToCpp.Phases.instances """
-    Drv::TcpClient comm(FW_OPTIONAL_NAME("comm"));
-    """
 
     phase Fpp.ToCpp.Phases.configConstants """
     enum {

--- a/Ref/Top/instances.fpp
+++ b/Ref/Top/instances.fpp
@@ -317,14 +317,8 @@ module Ref {
   }
 
   instance linuxTime: Svc.Time base id 0x4500 \
-    at "../../Svc/LinuxTime/LinuxTime.hpp" \
-  {
-
-    phase Fpp.ToCpp.Phases.instances """
-    Svc::LinuxTime linuxTime(FW_OPTIONAL_NAME("linuxTime"));
-    """
-
-  }
+    type "Svc::LinuxTime" \
+    at "../../Svc/LinuxTime/LinuxTime.hpp"
 
   instance rateGroupDriverComp: Svc.RateGroupDriver base id 0x4600 {
 

--- a/cmake/autocoder/fpp.cmake
+++ b/cmake/autocoder/fpp.cmake
@@ -6,7 +6,7 @@
 ####
 include(utilities)
 include(autocoder/helpers)
-set(FPP_VERSION v1.0.1)
+set(FPP_VERSION v1.0.1-22-g15c06e30)
 
 autocoder_setup_for_multiple_sources()
 ####

--- a/cmake/autocoder/fpp.cmake
+++ b/cmake/autocoder/fpp.cmake
@@ -6,7 +6,7 @@
 ####
 include(utilities)
 include(autocoder/helpers)
-set(FPP_VERSION v1.0.1-25-gb59041c4)
+set(FPP_VERSION v1.0.1-49-g324897b5)
 
 autocoder_setup_for_multiple_sources()
 ####

--- a/cmake/autocoder/fpp.cmake
+++ b/cmake/autocoder/fpp.cmake
@@ -6,7 +6,7 @@
 ####
 include(utilities)
 include(autocoder/helpers)
-set(FPP_VERSION v1.0.1-22-g15c06e30)
+set(FPP_VERSION v1.0.1-24-g009bb2f3)
 
 autocoder_setup_for_multiple_sources()
 ####

--- a/cmake/autocoder/fpp.cmake
+++ b/cmake/autocoder/fpp.cmake
@@ -6,7 +6,7 @@
 ####
 include(utilities)
 include(autocoder/helpers)
-set(FPP_VERSION v1.0.1-24-g009bb2f3)
+set(FPP_VERSION v1.0.1-25-gb59041c4)
 
 autocoder_setup_for_multiple_sources()
 ####


### PR DESCRIPTION
This PR simplifies the specification of the implementation types for the `comm` and `linuxTime` components in the Ref and RPI topologies. It moves the specification from handwritten C++ code into the model.

This PR is one in a series of two. The next PR will make more declarations `extern` in the generated C++ topology code, to enable #1460.

Note: This PR updates the version of FPP used by F Prime. CI is currently not able to pick up the new FPP version. CI failures are expected until this issue is fixed.