### PR TITLE
Use f-strings for concatenating strings instead of '+'

### DIFF
--- a/Autocoders/Python/bin/JSONDictionaryGen.py
+++ b/Autocoders/Python/bin/JSONDictionaryGen.py
@@ -55,7 +55,7 @@ def pinit():
     current_dir = os.getcwd()
 
     usage = "usage: %prog [options] [xml_filename]"
-    vers = "%prog " + VERSION.id + " " + VERSION.comment
+    vers = f"%prog {VERSION.id} {VERSION.comment}"
     program_longdesc = """
         This script reads F' topology XML and produces dictionaries represented as
         JSON. These documents contain all command, evr, and channel telemetry

--- a/Autocoders/Python/bin/codegen.py
+++ b/Autocoders/Python/bin/codegen.py
@@ -315,12 +315,12 @@ def generate_topology(the_parsed_topology_xml, xml_filename, opt):
 
     if "Ai" in xml_filename:
         base = xml_filename.split("Ai")[0]
-        h_instance_name = base + "_H"
-        cpp_instance_name = base + "_Cpp"
-        csv_instance_name = base + "_ID"
-        cmd_html_instance_name = base + "_Cmd_HTML"
-        channel_html_instance_name = base + "_Channel_HTML"
-        event_html_instance_name = base + "_Event_HTML"
+        h_instance_name = f"{base}_H"
+        cpp_instance_name = f"{base}_Cpp"
+        csv_instance_name = f"{base}_ID"
+        cmd_html_instance_name = f"{base}_Cmd_HTML"
+        channel_html_instance_name = f"{base}_Channel_HTML"
+        event_html_instance_name = f"{base}_Event_HTML"
     else:
         PRINT.info("Missing Ai at end of file name...")
         raise OSError

--- a/Autocoders/Python/bin/gds_dictgen.py
+++ b/Autocoders/Python/bin/gds_dictgen.py
@@ -61,7 +61,7 @@ def pinit():
     Initialize the option parser and return it.
     """
     usage = "usage: %prog [options] [xml_topology_filename]"
-    vers = "%prog " + VERSION.id + " " + VERSION.comment
+    vers = f"%prog {VERSION.id} {VERSION.comment}"
     program_longdesc = (
         """This script reads F' topology XML and produces GDS XML Dictionaries."""
     )

--- a/Autocoders/Python/bin/implgen.py
+++ b/Autocoders/Python/bin/implgen.py
@@ -81,7 +81,7 @@ def pinit():
     Initialize the option parser and return it.
     """
     usage = "usage: %prog [options] [xml_filename]"
-    vers = "%prog " + VERSION.id + " " + VERSION.comment
+    vers = f"%prog {VERSION.id} {VERSION.comment}"
     program_longdesc = "Testgen creates the Tester.cpp, Tester.hpp, GTestBase.cpp, GTestBase.hpp, TesterBase.cpp, and TesterBase.hpp test component."
 
     parser = OptionParser(usage, version=vers, epilog=program_longdesc)
@@ -167,7 +167,7 @@ def generate_impl_files(opt, component_model):
     implFiles = []
 
     if VERBOSE:
-        print("Generating impl files for " + component_model.get_xml_filename())
+        print(f"Generating impl files for {component_model.get_xml_filename()}")
 
     # ComponentImpl.cpp
     implFiles.append(ImplCppWriter.ImplCppWriter())

--- a/Autocoders/Python/bin/pymod_dictgen.py
+++ b/Autocoders/Python/bin/pymod_dictgen.py
@@ -75,7 +75,7 @@ def pinit():
     Initialize the option parser and return it.
     """
     usage = "usage: %prog [options] [xml_topology_filename]"
-    vers = "%prog " + VERSION.id + " " + VERSION.comment
+    vers = f"%prog {VERSION.id} {VERSION.comment}"
     program_longdesc = """This script reads F' topology XML and produces GDS Python Dictionaries. They are generated into your build dir under a py_dict directory"""
 
     parser = OptionParser(usage, version=vers, epilog=program_longdesc)

--- a/Autocoders/Python/bin/testgen.py
+++ b/Autocoders/Python/bin/testgen.py
@@ -87,7 +87,7 @@ def pinit():
     Initialize the option parser and return it.
     """
     usage = "usage: %prog [options] [xml_filename]"
-    vers = "%prog " + VERSION.id + " " + VERSION.comment
+    vers = f"%prog {VERSION.id} {VERSION.comment}"
     program_longdesc = "Testgen creates the Tester.cpp, Tester.hpp, GTestBase.cpp, GTestBase.hpp, TesterBase.cpp, and TesterBase.hpp test component."
 
     parser = OptionParser(usage, version=vers, epilog=program_longdesc)
@@ -191,7 +191,7 @@ def generate_tests(opt, component_model):
     unitTestFiles = []
 
     if VERBOSE:
-        print("Generating test files for " + component_model.get_xml_filename())
+        print(f"Generating test files for {component_model.get_xml_filename()}")
 
     # TesterBase.hpp
     unitTestFiles.append(ComponentTestHWriter.ComponentTestHWriter())
@@ -273,7 +273,7 @@ def generate_tests(opt, component_model):
                 print("Generated TestMain.cpp")
 
     if VERBOSE:
-        print("Generated test files for " + component_model.get_xml_filename())
+        print(f"Generated test files for {component_model.get_xml_filename()}")
 
 
 def main():

--- a/Autocoders/Python/bin/tlmLayout.py
+++ b/Autocoders/Python/bin/tlmLayout.py
@@ -565,7 +565,7 @@ class CsvFile:
         try:
             m_fp = open(name)
         except OSError:
-            print("Error opening " + name)
+            print(f"Error opening {name}")
             exit()
         m_reader = csv.reader(m_fp, dialect="excel")
 

--- a/Autocoders/Python/bin/tlm_packet_gen.py
+++ b/Autocoders/Python/bin/tlm_packet_gen.py
@@ -239,7 +239,7 @@ class TlmPacketParser(object):
             # check for channels
             if parsed_xml_dict[comp_type].get_channels() is not None:
                 for chan in parsed_xml_dict[comp_type].get_channels():
-                    channel_name = comp_name + "." + chan.get_name()
+                    channel_name = f"{comp_name}.{chan.get_name()}"
                     if self.verbose:
                         print("Processing Channel %s" % channel_name)
                     chan_type = chan.get_type()

--- a/Autocoders/Python/schema/testSchemas.py
+++ b/Autocoders/Python/schema/testSchemas.py
@@ -49,7 +49,7 @@ class schema_test:
         if not os.path.exists(file_name):
             raise Exception("File does not exist - {}.".format(file_name))
 
-        if not file_name.upper().endswith("." + extension.upper()):
+        if not file_name.upper().endswith(f".{extension.upper()}"):
             raise Exception(
                 "File does not end with proper extension {} - {}".format(
                     extension, file_name
@@ -115,9 +115,7 @@ class schema_test:
                         parsed = self.__get_parsed_relaxng(new_path)
                         root_tag = parsed.getroot().tag
                         if root_tag in list_of_root_tags:
-                            self.add_test(
-                                "Path Added: " + file, new_path, None, parsed_xml=parsed
-                            )
+                            self.add_test(f"Path Added: {file}", new_path, None, parsed_xml=parsed)
                     except:
                         pass
 
@@ -167,7 +165,7 @@ class schema_test:
                         + str(test_set[2])
                         + "."
                     )
-                    print("File path - " + test_set[1])
+                    print(f"File path - {test_set[1]}")
                     print(excinfo)
                     print("\n")
                     sys.exit(1)
@@ -182,8 +180,8 @@ class schema_test:
                     + " failed validating the current file."
                 )
                 print("\n")
-                print(test_set[0] + " raised an exception but was supposed to pass.")
-                print("File path - " + test_set[1])
+                print(f"{test_set[0]} raised an exception but was supposed to pass.")
+                print(f"File path - {test_set[1]}")
 
                 print("\n")
                 raise

--- a/Autocoders/Python/schema/testSchemas.py
+++ b/Autocoders/Python/schema/testSchemas.py
@@ -115,7 +115,9 @@ class schema_test:
                         parsed = self.__get_parsed_relaxng(new_path)
                         root_tag = parsed.getroot().tag
                         if root_tag in list_of_root_tags:
-                            self.add_test(f"Path Added: {file}", new_path, None, parsed_xml=parsed)
+                            self.add_test(
+                                f"Path Added: {file}", new_path, None, parsed_xml=parsed
+                            )
                     except:
                         pass
 

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -381,7 +381,7 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
             (mnemonic, opcodes, sync, priority, full, comment) = xxx_todo_changeme3
             if self.isAsync(sync):
                 if len(opcodes) == 1:
-                    return "CMD_" + mnemonic.upper()
+                    return f"CMD_{mnemonic.upper()}"
                 else:
                     mlist = list()
                     inst = 0
@@ -396,7 +396,7 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
 
         def h(xxx_todo_changeme4):
             (name, priority, full) = xxx_todo_changeme4
-            return "INT_IF_" + name.upper()
+            return f"INT_IF_{name.upper()}"
 
         self.__model_parser.getInternalInterfacesList(obj)
         interface_types = self.mapPartial(h, c.internal_interfaces)

--- a/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
@@ -391,7 +391,7 @@ class ComponentWriterBase(AbstractWriter.AbstractWriter):
             (mnemonic, opcodes, sync, priority, full, comment) = xxx_todo_changeme3
             if self.isAsync(sync):
                 if len(opcodes) == 1:
-                    return "CMD_" + mnemonic.upper()
+                    return f"CMD_{mnemonic.upper()}"
                 else:
                     mlist = list()
                     inst = 0


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| Autocoders/Python |
|**_Affected Architectures(s)_**| autocoders |
|**_Related Issue(s)_**|  (void) |
|**_Has Unit Tests (y/n)_**|  n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| (void)   |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR replaces string concatenations using '+' with F-strings.

## Rationale

Python added F-strings in version 3.6, with [PEP 498](https://peps.python.org/pep-0498/).
F-strings are a flexible and powerful way to concatenate strings. They make the code shorter and more readable, since the code now looks more like the output.

## Testing/Review Recommendations

(none)

## Future Work

I'm not sure I caught them all.
