### PR TITLE
Replace interpolations with Fstring [2/n]

### DIFF
--- a/Autocoders/Python/bin/JSONDictionaryGen.py
+++ b/Autocoders/Python/bin/JSONDictionaryGen.py
@@ -73,7 +73,7 @@ def pinit():
         "--path",
         dest="work_path",
         type="string",
-        help="Switch to new working directory (def: %s)." % current_dir,
+        help=f"Switch to new working directory (def: {current_dir}).",
         action="store",
         default=current_dir,
     )

--- a/Autocoders/Python/bin/gds_dictgen.py
+++ b/Autocoders/Python/bin/gds_dictgen.py
@@ -94,7 +94,7 @@ def generate_xml_dict(the_parsed_topology_xml, xml_filename, opt):
     Generates GDS XML dictionary from parsed topology XML
     """
     if VERBOSE:
-        print("Topology xml type description file: %s" % xml_filename)
+        print(f"Topology xml type description file: {xml_filename}")
     model = TopoFactory.TopoFactory.getInstance()
     topology_model = model.create(the_parsed_topology_xml)
 
@@ -191,7 +191,7 @@ def main():
     #  Parse the input Topology XML filename
     #
     if len(args) == 0:
-        print("Usage: %s [options] xml_filename" % sys.argv[0])
+        print(f"Usage: {sys.argv[0]} [options] xml_filename")
         return
     elif len(args) == 1:
         xml_filename = args[0]
@@ -205,14 +205,14 @@ def main():
     if not opt.build_root_overwrite is None:
         set_build_roots(opt.build_root_overwrite)
         if VERBOSE:
-            print("BUILD_ROOT set to %s" % ",".join(get_build_roots()))
+            print(f'BUILD_ROOT set to {",".join(get_build_roots())}')
     else:
         if ("BUILD_ROOT" in os.environ.keys()) == False:
             print("ERROR: Build root not set to root build path...")
             sys.exit(-1)
         set_build_roots(os.environ["BUILD_ROOT"])
         if VERBOSE:
-            print("BUILD_ROOT set to %s" % ",".join(get_build_roots()))
+            print(f'BUILD_ROOT set to {",".join(get_build_roots())}')
 
     if not "Ai" in xml_filename:
         print("ERROR: Missing Ai at end of file name...")

--- a/Autocoders/Python/bin/implgen.py
+++ b/Autocoders/Python/bin/implgen.py
@@ -187,7 +187,7 @@ def generate_impl_files(opt, component_model):
 
         file.write(component_model)
         if VERBOSE:
-            print("Generated %s" % file.toString())
+            print(f"Generated {file.toString()}")
 
     if VERBOSE:
         print("Generated impl files for " + component_model.get_xml_filename())
@@ -217,7 +217,7 @@ def main():
     #  Parse the input Topology XML filename
     #
     if len(args) == 0:
-        print("ERROR: Usage: %s [options] xml_filename" % sys.argv[0])
+        print(f"ERROR: Usage: {sys.argv[0]} [options] xml_filename")
         return
     elif len(args) == 1:
         xml_filename = args[0]
@@ -231,14 +231,14 @@ def main():
     if not opt.build_root_overwrite is None:
         set_build_roots(opt.build_root_overwrite)
         if VERBOSE:
-            print("BUILD_ROOT set to %s" % ",".join(get_build_roots()))
+            print(f'BUILD_ROOT set to {",".join(get_build_roots())}')
     else:
         if ("BUILD_ROOT" in os.environ.keys()) == False:
             print("ERROR: Build root not set to root build path...")
             sys.exit(-1)
         set_build_roots(os.environ["BUILD_ROOT"])
         if VERBOSE:
-            print("BUILD_ROOT set to %s" % ",".join(get_build_roots()))
+            print(f'BUILD_ROOT set to {",".join(get_build_roots())}')
 
     #
     # Write test component

--- a/Autocoders/Python/bin/pymod_dictgen.py
+++ b/Autocoders/Python/bin/pymod_dictgen.py
@@ -116,18 +116,10 @@ def generate_pymods(the_parsed_topology_xml, xml_filename, opt):
     if the_parsed_topology_xml.get_namespace():
         if VERBOSE:
             print(
-                "Generating pymods for topology %s::%s"
-                % (
-                    the_parsed_topology_xml.get_namespace(),
-                    the_parsed_topology_xml.get_name(),
-                )
-            )
+                f"Generating pymods for topology {the_parsed_topology_xml.get_namespace()}::{the_parsed_topology_xml.get_name()}"
     else:
         if VERBOSE:
-            print(
-                "Generating pymods for topology %s"
-                % (the_parsed_topology_xml.get_name())
-            )
+            print(f"Generating pymods for topology {the_parsed_topology_xml.get_name()}")
     model = TopoFactory.TopoFactory.getInstance()
     topology_model = model.create(the_parsed_topology_xml)
 
@@ -266,7 +258,7 @@ def write_pymods_from_comp(the_parsed_component_xml, opt, topology_model):
 
     for parameter_model in component_model.get_parameters():
         if VERBOSE:
-            print("Generating parameter dict %s" % parameter_model.get_name())
+            print(f"Generating parameter dict {parameter_model.get_name()}")
         instCommandWriter.DictStartWrite(parameter_model, topology_model)
         instCommandWriter.DictHeaderWrite(parameter_model, topology_model)
         instCommandWriter.DictBodyWrite(parameter_model, topology_model)
@@ -274,7 +266,7 @@ def write_pymods_from_comp(the_parsed_component_xml, opt, topology_model):
     # iterate through command instances
     for event_model in component_model.get_events():
         if VERBOSE:
-            print("Generating event dict %s" % event_model.get_name())
+            print(f"Generating event dict {event_model.get_name()}")
         instEventWriter.DictStartWrite(event_model, topology_model)
         instEventWriter.DictHeaderWrite(event_model, topology_model)
         instEventWriter.DictBodyWrite(event_model, topology_model)
@@ -282,7 +274,7 @@ def write_pymods_from_comp(the_parsed_component_xml, opt, topology_model):
     # iterate through command instances
     for channel_model in component_model.get_channels():
         if VERBOSE:
-            print("Generating channel dict %s" % channel_model.get_name())
+            print(f"Generating channel dict {channel_model.get_name()}")
         instChannelWriter.DictStartWrite(channel_model, topology_model)
         instChannelWriter.DictHeaderWrite(channel_model, topology_model)
         instChannelWriter.DictBodyWrite(channel_model, topology_model)
@@ -309,13 +301,13 @@ def main():
         BUILD_ROOT = os.environ["BUILD_ROOT"]
         ModelParser.BUILD_ROOT = BUILD_ROOT
         if VERBOSE:
-            print("BUILD_ROOT set to %s in environment" % BUILD_ROOT)
+            print(f"BUILD_ROOT set to {BUILD_ROOT} in environment")
 
     #
     #  Parse the input Topology XML filename
     #
     if len(args) == 0:
-        print("ERROR: Usage: %s [options] xml_filename" % sys.argv[0])
+        print(f"ERROR: Usage: {sys.argv[0]} [options] xml_filename")
         return
     elif len(args) == 1:
         xml_filename = args[0]
@@ -329,14 +321,14 @@ def main():
     if not opt.build_root_overwrite is None:
         set_build_roots(opt.build_root_overwrite)
         if VERBOSE:
-            print("BUILD_ROOT set to %s" % ",".join(get_build_roots()))
+            print(f'BUILD_ROOT set to {",".join(get_build_roots())}')
     else:
         if ("BUILD_ROOT" in os.environ.keys()) == False:
             print("ERROR: Build root not set to root build path...")
             sys.exit(-1)
         set_build_roots(os.environ["BUILD_ROOT"])
         if VERBOSE:
-            print("BUILD_ROOT set to %s" % ",".join(get_build_roots()))
+            print(f'BUILD_ROOT set to {",".join(get_build_roots())}')
 
     if not "Ai" in xml_filename:
         print("ERROR: Missing Ai at end of file name...")

--- a/Autocoders/Python/bin/testgen.py
+++ b/Autocoders/Python/bin/testgen.py
@@ -223,7 +223,7 @@ def generate_tests(opt, component_model):
     for file in unitTestFiles:
         file.write(component_model)
         if VERBOSE:
-            print("Generated %s" % file.toString())
+            print(f"Generated {file.toString()}")
 
     time.sleep(3)
 
@@ -297,7 +297,7 @@ def main():
     #  Parse the input Topology XML filename
     #
     if len(args) == 0:
-        print("ERROR: Usage: %s [options] xml_filename" % sys.argv[0])
+        print(f"ERROR: Usage: {sys.argv[0]} [options] xml_filename")
         return
     elif len(args) == 1:
         xml_filename = args[0]
@@ -311,14 +311,14 @@ def main():
     if not opt.build_root_overwrite is None:
         set_build_roots(opt.build_root_overwrite)
         if VERBOSE:
-            print("BUILD_ROOT set to %s" % ",".join(get_build_roots()))
+            print(f'BUILD_ROOT set to {",".join(get_build_roots())}')
     else:
         if ("BUILD_ROOT" in os.environ.keys()) == False:
             print("ERROR: Build root not set to root build path...")
             sys.exit(-1)
         set_build_roots(os.environ["BUILD_ROOT"])
         if VERBOSE:
-            print("BUILD_ROOT set to %s" % ",".join(get_build_roots()))
+            print(f'BUILD_ROOT set to {",".join(get_build_roots())}')
 
     #
     # Write test component

--- a/Autocoders/Python/bin/tlm_packet_gen.py
+++ b/Autocoders/Python/bin/tlm_packet_gen.py
@@ -190,7 +190,7 @@ class TlmPacketParser(object):
         Generates GDS XML dictionary from parsed topology XML
         """
         if self.verbose:
-            print("Topology xml type description file: %s" % xml_filename)
+            print(f"Topology xml type description file: {xml_filename}")
         model = TopoFactory.TopoFactory.getInstance()
         topology_model = model.create(the_parsed_topology_xml, generate_list_file=False)
 
@@ -613,7 +613,7 @@ def main():
     #  Parse the input Topology XML filename
     #
     if len(args) == 0:
-        print("Usage: %s [options] xml_filename" % sys.argv[0])
+        print(f"Usage: {sys.argv[0]} [options] xml_filename")
         return
     elif len(args) == 1:
         xml_filename = args[0]

--- a/Autocoders/Python/src/fprime_ac/generators/GenFactory.py
+++ b/Autocoders/Python/src/fprime_ac/generators/GenFactory.py
@@ -205,9 +205,7 @@ class GenFactory:
             elif self.__type == "TopologyIDVisitor":
                 inst = TopologyIDVisitor.TopologyIDVisitor()
             else:
-                s = "VisitorConfig.getInstance: unsupported visitor type (%s)" % (
-                    self.__type
-                )
+                s = f"VisitorConfig.getInstance: unsupported visitor type ({self.__type})"
                 PRINT.info(s)
                 raise ValueError(s)
             return inst
@@ -309,7 +307,7 @@ class GenFactory:
             code_section_generator = MdDocPage.MdDocPage()
 
         else:
-            print("GenFactory: unsupported code section (%s)." % (the_type))
+            print(f"GenFactory: unsupported code section ({the_type}).")
             return None
 
         self._addVisitor(code_section_generator, project_visitor_list)

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/AbstractVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/AbstractVisitor.py
@@ -189,8 +189,7 @@ class AbstractVisitor:
             relative_path = build_root_relative_path(path)
         except BuildRootMissingException as bre:
             PRINT.info(
-                "ERROR: BUILD_ROOT and current execution path (%s) not consistent! %s"
-                % (path, str(bre))
+                f"ERROR: BUILD_ROOT and current execution path ({path}) not consistent! {str(bre)}"
             )
             sys.exit(-1)
         DEBUG.debug("Relative path: %s", relative_path)

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ChannelVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ChannelVisitor.py
@@ -76,7 +76,7 @@ class ChannelVisitor(AbstractVisitor.AbstractVisitor):
         """
         Wrapper to write tmpl to files desc.
         """
-        DEBUG.debug("ChannelVisitor:%s" % visit_str)
+        DEBUG.debug(f"ChannelVisitor:{visit_str}")
         DEBUG.debug("===================================")
         DEBUG.debug(c)
         fp.writelines(c.__str__())
@@ -100,18 +100,18 @@ class ChannelVisitor(AbstractVisitor.AbstractVisitor):
             pyfile = "{}/{}.py".format(output_dir, obj.get_name())
             fd = open(pyfile, "w")
             if fd is None:
-                raise Exception("Could not open %s file." % pyfile)
+                raise Exception(f"Could not open {pyfile} file.")
             self.__fp.append(fd)
         else:
             inst = 0
             for id in obj.get_ids():
                 pyfile = "%s/%s_%d.py" % (output_dir, obj.get_name(), inst)
                 inst += 1
-                DEBUG.info("Open file: %s" % pyfile)
+                DEBUG.info(f"Open file: {pyfile}")
                 fd = open(pyfile, "w")
                 if fd is None:
-                    raise Exception("Could not open %s file." % pyfile)
-                DEBUG.info("Completed %s open" % pyfile)
+                    raise Exception(f"Could not open {pyfile} file.")
+                DEBUG.info(f"Completed {pyfile} open")
                 self.__fp.append(fd)
 
     def DictHeaderVisit(self, obj):

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/CommandVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/CommandVisitor.py
@@ -79,7 +79,7 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
         """
         Wrapper to write tmpl to files desc.
         """
-        DEBUG.debug("CommandVisitor:%s" % visit_str)
+        DEBUG.debug(f"CommandVisitor:{visit_str}")
         DEBUG.debug("===================================")
         DEBUG.debug(c)
         fp.writelines(c.__str__())
@@ -109,18 +109,18 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                 pyfile = "{}/{}.py".format(output_dir, obj.get_mnemonic())
                 fd = open(pyfile, "w")
                 if fd is None:
-                    raise Exception("Could not open %s file." % pyfile)
+                    raise Exception(f"Could not open {pyfile} file.")
                 self.__fp1.append(fd)
             else:
                 inst = 0
                 for opcode in obj.get_opcodes():
                     pyfile = "%s/%s_%d.py" % (output_dir, obj.get_mnemonic(), inst)
                     inst += 1
-                    DEBUG.info("Open file: %s" % pyfile)
+                    DEBUG.info(f"Open file: {pyfile}")
                     fd = open(pyfile, "w")
                     if fd is None:
-                        raise Exception("Could not open %s file." % pyfile)
-                    DEBUG.info("Completed %s open" % pyfile)
+                        raise Exception(f"Could not open {pyfile} file.")
+                    DEBUG.info(f"Completed {pyfile} open")
                     self.__fp1.append(fd)
         elif type(obj) is Parameter.Parameter:
             self.__fp1 = []
@@ -135,33 +135,33 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                 pyfile = "{}/{}_PRM_SET.py".format(output_dir, self.__stem)
                 fd = open(pyfile, "w")
                 if fd is None:
-                    raise Exception("Could not open %s file." % pyfile)
+                    raise Exception(f"Could not open {pyfile} file.")
                 self.__fp1.append(fd)
 
                 pyfile = "{}/{}_PRM_SAVE.py".format(output_dir, self.__stem)
                 fd = open(pyfile, "w")
                 if fd is None:
-                    raise Exception("Could not open %s file." % pyfile)
+                    raise Exception(f"Could not open {pyfile} file.")
                 self.__fp2.append(fd)
             else:
                 inst = 0
                 for opcode in obj.get_set_opcodes():
                     pyfile = "%s/%s_%d_PRM_SET.py" % (output_dir, self.__stem, inst)
-                    DEBUG.info("Open file: %s" % pyfile)
+                    DEBUG.info(f"Open file: {pyfile}")
                     fd = open(pyfile, "w")
                     if fd is None:
-                        raise Exception("Could not open %s file." % pyfile)
+                        raise Exception(f"Could not open {pyfile} file.")
                     self.__fp1.append(fd)
-                    DEBUG.info("Completed %s open" % pyfile)
+                    DEBUG.info(f"Completed {pyfile} open")
 
                     pyfile = "%s/%s_%d_PRM_SAVE.py" % (output_dir, self.__stem, inst)
-                    DEBUG.info("Open file: %s" % pyfile)
+                    DEBUG.info(f"Open file: {pyfile}")
                     fd = open(pyfile, "w")
                     if fd is None:
-                        raise Exception("Could not open %s file." % pyfile)
+                        raise Exception(f"Could not open {pyfile} file.")
                     self.__fp2.append(fd)
                     inst += 1
-                    DEBUG.info("Completed %s open" % pyfile)
+                    DEBUG.info(f"Completed {pyfile} open")
 
         else:
             print("Invalid type %s" % type(obj))
@@ -256,7 +256,7 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                 if len(obj.get_set_opcodes()) > 1:
                     c.mnemonic = "%s_%d_PRM_SET" % (self.__stem, inst)
                 else:
-                    c.mnemonic = "%s_PRM_SET" % (self.__stem)
+                    c.mnemonic = f"{self.__stem}_PRM_SET"
 
                 c.opcode = opcode
                 c.description = obj.get_comment()
@@ -288,7 +288,7 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                 if len(obj.get_save_opcodes()) > 1:
                     c.mnemonic = "%s_%d_PRM_SAVE" % (self.__stem, inst)
                 else:
-                    c.mnemonic = "%s_PRM_SAVE" % (self.__stem)
+                    c.mnemonic = f"{self.__stem}_PRM_SAVE"
                 c.opcode = opcode
                 c.description = obj.get_comment()
                 c.component = obj.get_component_name()

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -863,7 +863,7 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
         """
         Open the file for writing
         """
-        DEBUG.info("Open file: %s" % filename)
+        DEBUG.info(f"Open file: {filename}")
         self.__fp = open(filename, "w")
         if self.__fp is None:
             raise Exception("Could not open file %s") % filename

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -58,7 +58,7 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
         """
         Wrapper to write tmpl to files desc.
         """
-        DEBUG.debug("ComponentVisitorBase:%s" % visit_str)
+        DEBUG.debug(f"ComponentVisitorBase:{visit_str}")
         DEBUG.debug("===================================")
         DEBUG.debug(c)
         self.__fp.writelines(c.__str__())
@@ -81,8 +81,7 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
                 + self.config("component", self.__visitor)
             )
             DEBUG.info(
-                "Generating code filename: %s, using XML namespace and name attributes..."
-                % filename
+                f"Generating code filename: {filename}, using XML namespace and name attributes..."
             )
         else:
             xml_file = obj.get_xml_filename()
@@ -93,12 +92,9 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
                 filename = x[0].split(s[0])[0] + self.config(
                     "component", self.__visitor
                 )
-                DEBUG.info("Generating code filename: %s..." % filename)
+                DEBUG.info(f"Generating code filename: {filename}...")
             else:
-                msg = (
-                    "XML file naming format not allowed (must be XXXComponentAi.xml), Filename: %s"
-                    % xml_file
-                )
+                msg = f"XML file naming format not allowed (must be XXXComponentAi.xml), Filename: {xml_file}"
                 PRINT.info(msg)
                 raise ValueError(msg)
         return filename

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/EventVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/EventVisitor.py
@@ -177,8 +177,7 @@ class EventVisitor(AbstractVisitor.AbstractVisitor):
                     # check for an error
                     if format_string is None:
                         PRINT.info(
-                            "Event %s in component %s had error processing format specifier"
-                            % (c.name, c.component)
+                            f"Event {c.name} in component {c.component} had error processing format specifier"
                         )
                         sys.exit(-1)
                     else:

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/EventVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/EventVisitor.py
@@ -102,18 +102,18 @@ class EventVisitor(AbstractVisitor.AbstractVisitor):
             pyfile = "{}/{}.py".format(output_dir, obj.get_name())
             fd = open(pyfile, "w")
             if fd is None:
-                raise Exception("Could not open %s file." % pyfile)
+                raise Exception(f"Could not open {pyfile} file.")
             self.__fp.append(fd)
         else:
             inst = 0
             for id in obj.get_ids():
                 pyfile = "%s/%s_%d.py" % (output_dir, obj.get_name(), inst)
                 inst += 1
-                DEBUG.info("Open file: %s" % pyfile)
+                DEBUG.info(f"Open file: {pyfile}")
                 fd = open(pyfile, "w")
                 if fd is None:
-                    raise Exception("Could not open %s file." % pyfile)
-                DEBUG.info("Completed %s open" % pyfile)
+                    raise Exception(f"Could not open {pyfile} file.")
+                DEBUG.info(f"Completed {pyfile} open")
                 self.__fp.append(fd)
 
     def DictHeaderVisit(self, obj):

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceChannelVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceChannelVisitor.py
@@ -76,7 +76,7 @@ class InstanceChannelVisitor(AbstractVisitor.AbstractVisitor):
         """
         Wrapper to write tmpl to files desc.
         """
-        DEBUG.debug("ChannelVisitor:%s" % visit_str)
+        DEBUG.debug(f"ChannelVisitor:{visit_str}")
         DEBUG.debug("===================================")
         DEBUG.debug(c)
         fp.writelines(c.__str__())

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceCommandVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceCommandVisitor.py
@@ -79,7 +79,7 @@ class InstanceCommandVisitor(AbstractVisitor.AbstractVisitor):
         """
         Wrapper to write tmpl to files desc.
         """
-        DEBUG.debug("InstanceCommandVisitor:%s" % visit_str)
+        DEBUG.debug(f"InstanceCommandVisitor:{visit_str}")
         DEBUG.debug("===================================")
         DEBUG.debug(c)
         fp.writelines(c.__str__())

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceEventVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceEventVisitor.py
@@ -77,7 +77,7 @@ class InstanceEventVisitor(AbstractVisitor.AbstractVisitor):
         """
         Wrapper to write tmpl to files desc.
         """
-        DEBUG.debug("InstanceEventVisitor:%s" % visit_str)
+        DEBUG.debug(f"InstanceEventVisitor:{visit_str}")
         DEBUG.debug("===================================")
         DEBUG.debug(c)
         fp.writelines(c.__str__())
@@ -222,8 +222,7 @@ class InstanceEventVisitor(AbstractVisitor.AbstractVisitor):
                     # check for an error
                     if format_string is None:
                         PRINT.info(
-                            "Event %s in component %s had error processing format specifier"
-                            % (c.name, c.component)
+                            f"Event {c.name} in component {c.component} had error processing format specifier"
                         )
                         sys.exit(-1)
                     else:

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceSerializableVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceSerializableVisitor.py
@@ -187,7 +187,7 @@ class InstanceSerializableVisitor(AbstractVisitor.AbstractVisitor):
         open("{}/{}".format(output_dir, "__init__.py"), "w").close()
 
         # Open file for writing here...
-        DEBUG.info("Open file: %s" % pyfile)
+        DEBUG.info(f"Open file: {pyfile}")
         self.__fp = open(pyfile, "w")
         if self.__fp is None:
             raise Exception("Could not open %s file.") % pyfile

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceSerializableVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceSerializableVisitor.py
@@ -95,7 +95,7 @@ class InstanceSerializableVisitor(AbstractVisitor.AbstractVisitor):
                 arg_str += "const {}& {}, ".format(mtype, name)
             elif size is not None:
                 arg_str += "const {}* {}, ".format(mtype, name)
-                arg_str += "NATIVE_INT_TYPE %sSize, " % (name)
+                arg_str += f"NATIVE_INT_TYPE {name}Size, "
             else:
                 arg_str += "{} {}".format(mtype, name)
                 arg_str += ", "
@@ -132,7 +132,7 @@ class InstanceSerializableVisitor(AbstractVisitor.AbstractVisitor):
         for e in enum_list:
             # No value, No comment
             if (e[1] is None) and (e[2] is None):
-                s = "%s," % (e[0])
+                s = f"{e[0]},"
             # No value, With comment
             elif (e[1] is None) and (e[2] is not None):
                 s = "{},  // {}".format(e[0], e[2])
@@ -153,7 +153,7 @@ class InstanceSerializableVisitor(AbstractVisitor.AbstractVisitor):
         """
         Wrapper to write tmpl to files desc.
         """
-        DEBUG.debug("InstanceSerializableVisitor:%s" % visit_str)
+        DEBUG.debug(f"InstanceSerializableVisitor:{visit_str}")
         DEBUG.debug("===================================")
         DEBUG.debug(c)
         self.__fp.writelines(c.__str__())
@@ -172,7 +172,7 @@ class InstanceSerializableVisitor(AbstractVisitor.AbstractVisitor):
         dict_dir = os.environ["DICT_DIR"]
 
         if namespace is None:
-            output_dir = "%s/serializable/" % (dict_dir)
+            output_dir = f"{dict_dir}/serializable/"
         else:
             output_dir = "{}/serializable/{}".format(
                 dict_dir, namespace.replace("::", "/")

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyChannelsHTMLVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyChannelsHTMLVisitor.py
@@ -82,7 +82,7 @@ class InstanceTopologyChannelsHTMLVisitor(AbstractVisitor.AbstractVisitor):
         """
         Wrapper to write tmpl to files desc.
         """
-        DEBUG.debug("InstanceTopologyChannelHTMLVisitor:%s" % visit_str)
+        DEBUG.debug(f"InstanceTopologyChannelHTMLVisitor:{visit_str}")
         DEBUG.debug("===================================")
         DEBUG.debug(c)
         self.__fp_dict[instance].writelines(c.__str__())
@@ -108,18 +108,17 @@ class InstanceTopologyChannelsHTMLVisitor(AbstractVisitor.AbstractVisitor):
                 name = t[0]
                 ch_list = t[3].get_comp_xml().get_channels()
                 if len(ch_list) > 0:
-                    filename = "%s_channels.html" % t[0]
+                    filename = f"{t[0]}_channels.html"
                     # Open file for writing here...
-                    DEBUG.info("Open file: %s" % filename)
+                    DEBUG.info(f"Open file: {filename}")
                     try:
                         self.__fp_dict[name] = open(filename, "w")
                         DEBUG.info("Completed")
                     except OSError:
-                        PRINT.info("Could not open %s file." % filename)
+                        PRINT.info(f"Could not open {filename} file.")
                         sys.exit(-1)
                     DEBUG.info(
-                        "Generating HTML Channels Table for %s:%s component instance..."
-                        % (t[0], k)
+                        f"Generating HTML Channels Table for {t[0]}:{k} component instance..."
                     )
         os.chdir("..")
 

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyCmdHTMLVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyCmdHTMLVisitor.py
@@ -84,7 +84,7 @@ class InstanceTopologyCmdHTMLVisitor(AbstractVisitor.AbstractVisitor):
         """
         Wrapper to write tmpl to files desc.
         """
-        DEBUG.debug("InstanceTopologyCmdHTMLVisitor:%s" % visit_str)
+        DEBUG.debug(f"InstanceTopologyCmdHTMLVisitor:{visit_str}")
         DEBUG.debug("===================================")
         DEBUG.debug(c)
         self.__fp_dict[instance].writelines(c.__str__())
@@ -110,18 +110,17 @@ class InstanceTopologyCmdHTMLVisitor(AbstractVisitor.AbstractVisitor):
                 name = t[0]
                 cmd_list = t[3].get_comp_xml().get_commands()
                 if len(cmd_list) > 0:
-                    filename = "%s_commands.html" % t[0]
+                    filename = f"{t[0]}_commands.html"
                     # Open file for writing here...
-                    DEBUG.info("Open file: %s" % filename)
+                    DEBUG.info(f"Open file: {filename}")
                     try:
                         self.__fp_dict[name] = open(filename, "w")
                         DEBUG.info("Completed")
                     except OSError:
-                        PRINT.info("Could not open %s file." % filename)
+                        PRINT.info(f"Could not open {filename} file.")
                         sys.exit(-1)
                     DEBUG.info(
-                        "Generating HTML Command Table for %s:%s component instance..."
-                        % (t[0], k)
+                        f"Generating HTML Command Table for {t[0]}:{k} component instance..."
                     )
         os.chdir("..")
 

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyCppVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyCppVisitor.py
@@ -82,7 +82,7 @@ class InstanceTopologyCppVisitor(AbstractVisitor.AbstractVisitor):
         """
         Wrapper to write tmpl to files desc.
         """
-        DEBUG.debug("InstanceTopologyCppVisitor:%s" % visit_str)
+        DEBUG.debug(f"InstanceTopologyCppVisitor:{visit_str}")
         DEBUG.debug("===================================")
         DEBUG.debug(c)
         self.__fp.writelines(c.__str__())
@@ -105,14 +105,10 @@ class InstanceTopologyCppVisitor(AbstractVisitor.AbstractVisitor):
                     "assembly", "TopologyCpp"
                 )
                 DEBUG.info(
-                    "Generating code filename: %s topology, using default XML filename prefix..."
-                    % filename
+                    f"Generating code filename: {filename} topology, using default XML filename prefix..."
                 )
             else:
-                msg = (
-                    "XML file naming format not allowed (must be XXXAppAi.xml), Filename: %s"
-                    % xml_file
-                )
+                msg = f"XML file naming format not allowed (must be XXXAppAi.xml), Filename: {xml_file}"
                 PRINT.info(msg)
                 raise ValueError(msg)
             #
@@ -126,7 +122,7 @@ class InstanceTopologyCppVisitor(AbstractVisitor.AbstractVisitor):
                 self.partition = None
             #
             # Open file for writing here...
-            DEBUG.info("Open file: %s" % filename)
+            DEBUG.info(f"Open file: {filename}")
             self.__fp = open(filename, "w")
             if self.__fp is None:
                 raise Exception("Could not open %s file.") % filename

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyEventsHTMLVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyEventsHTMLVisitor.py
@@ -111,7 +111,7 @@ class InstanceTopologyEventsHTMLVisitor(AbstractVisitor.AbstractVisitor):
                 if len(events_list) > 0:
                     filename = "%s_events.html" % t[0]
                     # Open file for writing here...
-                    DEBUG.info("Open file: %s" % filename)
+                    DEBUG.info(f"Open file: {filename}")
                     try:
                         self.__fp_dict[name] = open(filename, "w")
                         DEBUG.info("Completed")

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyHVisitor.py
@@ -105,14 +105,10 @@ class InstanceTopologyHVisitor(AbstractVisitor.AbstractVisitor):
                     "assembly", "TopologyH"
                 )
                 PRINT.info(
-                    "Generating code filename: %s topology, using default XML filename prefix..."
-                    % filename
+                    f"Generating code filename: {filename} topology, using default XML filename prefix..."
                 )
             else:
-                msg = (
-                    "XML file naming format not allowed (must be XXXAppAi.xml), Filename: %s"
-                    % xml_file
-                )
+                msg = f"XML file naming format not allowed (must be XXXAppAi.xml), Filename: {xml_file}"
                 PRINT.info(msg)
                 raise ValueError(msg)
             #
@@ -126,7 +122,7 @@ class InstanceTopologyHVisitor(AbstractVisitor.AbstractVisitor):
                 self.partition = None
             #
             # Open file for writing here...
-            DEBUG.info("Open file: %s" % filename)
+            DEBUG.info(f"Open file: {filename}")
             self.__fp = open(filename, "w")
             if self.__fp is None:
                 raise Exception("Could not open %s file.") % filename

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/PortCppVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/PortCppVisitor.py
@@ -193,7 +193,7 @@ class PortCppVisitor(AbstractVisitor.AbstractVisitor):
                 raise ValueError(msg)
 
         # Open file for writing here...
-        DEBUG.info("Open file: %s" % filename)
+        DEBUG.info(f"Open file: {filename}")
         self.__fp = open(filename, "w")
         if self.__fp is None:
             raise Exception("Could not open %s file.") % filename

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/PortCppVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/PortCppVisitor.py
@@ -170,8 +170,7 @@ class PortCppVisitor(AbstractVisitor.AbstractVisitor):
         if self.__config.get("port", "XMLDefaultFileName") == "True":
             filename = obj.get_type() + self.__config.get("port", "PortCpp")
             PRINT.info(
-                "Generating code filename: %s, using XML namespace and name attributes..."
-                % filename
+                f"Generating code filename: {filename}, using XML namespace and name attributes..."
             )
         else:
             xml_file = obj.get_xml_filename()

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
@@ -230,8 +230,7 @@ class PortHVisitor(AbstractVisitor.AbstractVisitor):
         if self.__config.get("port", "XMLDefaultFileName") == "True":
             filename = obj.get_type() + self.__config.get("port", "PortH")
             PRINT.info(
-                "Generating code filename: %s, using XML namespace and name attributes..."
-                % filename
+                f"Generating code filename: {filename}, using XML namespace and name attributes..."
             )
         else:
             xml_file = obj.get_xml_filename()

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
@@ -253,7 +253,7 @@ class PortHVisitor(AbstractVisitor.AbstractVisitor):
                 raise ValueError(msg)
 
         # Open file for writing here...
-        DEBUG.info("Open file: %s" % filename)
+        DEBUG.info(f"Open file: {filename}")
         self.__fp = open(filename, "w")
         if self.__fp is None:
             raise Exception("Could not open %s file.") % filename
@@ -312,7 +312,7 @@ class PortHVisitor(AbstractVisitor.AbstractVisitor):
         for e in enum_list:
             # No value, No comment
             if (e[1] is None) and (e[2] is None):
-                s = "%s," % (e[0])
+                s = f"{e[0]},"
             # No value, With comment
             elif (e[1] is None) and (e[2] is not None):
                 s = "{},  // {}".format(e[0], e[2])

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/SerialCppVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/SerialCppVisitor.py
@@ -223,8 +223,7 @@ class SerialCppVisitor(AbstractVisitor.AbstractVisitor):
                 + self.__config.get("serialize", "SerializableCpp")
             )
             PRINT.info(
-                "Generating code filename: %s, using XML namespace and name attributes..."
-                % filename
+                f"Generating code filename: {filename}, using XML namespace and name attributes..."
             )
         else:
             xml_file = obj.get_xml_filename()

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/SerialCppVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/SerialCppVisitor.py
@@ -101,12 +101,12 @@ class SerialCppVisitor(AbstractVisitor.AbstractVisitor):
                 arg_str += "const {}::{}String& {}, ".format(obj.get_name(), name, name)
             elif mtype == "string" and array_size is not None:
                 arg_str += "const {}::{}String* {}, ".format(obj.get_name(), name, name)
-                arg_str += "NATIVE_INT_TYPE %sSize, " % (name)
+                arg_str += f"NATIVE_INT_TYPE {name}Size, "
             elif mtype not in typelist:
                 arg_str += "const {}& {}, ".format(mtype, name)
             elif array_size is not None:
                 arg_str += "const {}* {}, ".format(mtype, name)
-                arg_str += "NATIVE_INT_TYPE %sSize, " % (name)
+                arg_str += f"NATIVE_INT_TYPE {name}Size, "
             else:
                 arg_str += "{} {}".format(mtype, name)
                 arg_str += ", "
@@ -248,7 +248,7 @@ class SerialCppVisitor(AbstractVisitor.AbstractVisitor):
                 sys.exit(-1)
 
         # Open file for writing here...
-        DEBUG.info("Open file: %s" % filename)
+        DEBUG.info(f"Open file: {filename}")
         self.__fp = open(filename, "w")
         if self.__fp is None:
             raise Exception("Could not open %s file.") % filename

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/SerialHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/SerialHVisitor.py
@@ -105,12 +105,12 @@ class SerialHVisitor(AbstractVisitor.AbstractVisitor):
                 arg_str += "const {}::{}String& {}, ".format(obj.get_name(), name, name)
             elif mtype == "string" and array_size is not None:
                 arg_str += "const {}::{}String* {}, ".format(obj.get_name(), name, name)
-                arg_str += "NATIVE_INT_TYPE %sSize, " % (name)
+                arg_str += f"NATIVE_INT_TYPE {name}Size, "
             elif mtype not in typelist:
                 arg_str += "const {}& {}, ".format(mtype, name)
             elif array_size is not None:
                 arg_str += "const {}* {}, ".format(mtype, name)
-                arg_str += "NATIVE_INT_TYPE %sSize, " % (name)
+                arg_str += f"NATIVE_INT_TYPE {name}Size, "
             else:
                 arg_str += "{} {}".format(mtype, name)
                 arg_str += ", "
@@ -189,7 +189,7 @@ class SerialHVisitor(AbstractVisitor.AbstractVisitor):
         for e in enum_list:
             # No value, No comment
             if (e[1] is None) and (e[2] is None):
-                s = "%s," % (e[0])
+                s = f"{e[0]},"
             # No value, With comment
             elif (e[1] is None) and (e[2] is not None):
                 s = "{},  // {}".format(e[0], e[2])
@@ -254,7 +254,7 @@ class SerialHVisitor(AbstractVisitor.AbstractVisitor):
                 sys.exit(-1)
 
         # Open file for writing here...
-        DEBUG.info("Open file: %s" % filename)
+        DEBUG.info(f"Open file: {filename}")
         self.__fp = open(filename, "w")
         if self.__fp is None:
             raise Exception("Could not open %s file.") % filename

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/SerialHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/SerialHVisitor.py
@@ -229,8 +229,7 @@ class SerialHVisitor(AbstractVisitor.AbstractVisitor):
                 + self.__config.get("serialize", "SerializableH")
             )
             PRINT.info(
-                "Generating code filename: %s, using XML namespace and name attributes..."
-                % filename
+                f"Generating code filename: {filename}, using XML namespace and name attributes..."
             )
         else:
             xml_file = obj.get_xml_filename()

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/SerializableVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/SerializableVisitor.py
@@ -95,7 +95,7 @@ class SerializableVisitor(AbstractVisitor.AbstractVisitor):
                 arg_str += "const {}& {}, ".format(mtype, name)
             elif size is not None:
                 arg_str += "const {}* {}, ".format(mtype, name)
-                arg_str += "NATIVE_INT_TYPE %sSize, " % (name)
+                arg_str += f"NATIVE_INT_TYPE {name}Size, "
             else:
                 arg_str += "{} {}".format(mtype, name)
                 arg_str += ", "
@@ -132,7 +132,7 @@ class SerializableVisitor(AbstractVisitor.AbstractVisitor):
         for e in enum_list:
             # No value, No comment
             if (e[1] is None) and (e[2] is None):
-                s = "%s," % (e[0])
+                s = f"{e[0]},"
             # No value, With comment
             elif (e[1] is None) and (e[2] is not None):
                 s = "{},  // {}".format(e[0], e[2])
@@ -172,7 +172,7 @@ class SerializableVisitor(AbstractVisitor.AbstractVisitor):
         dict_dir = os.environ["DICT_DIR"]
 
         if namespace is None:
-            output_dir = "%s/serializable/" % (dict_dir)
+            output_dir = f"{dict_dir}/serializable/"
         else:
             output_dir = "{}/serializable/{}".format(
                 dict_dir, namespace.replace("::", "/")

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/SerializableVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/SerializableVisitor.py
@@ -187,7 +187,7 @@ class SerializableVisitor(AbstractVisitor.AbstractVisitor):
         open("{}/{}".format(output_dir, "__init__.py"), "w").close()
 
         # Open file for writing here...
-        DEBUG.info("Open file: %s" % pyfile)
+        DEBUG.info(f"Open file: {pyfile}")
         self.__fp = open(pyfile, "w")
         if self.__fp is None:
             raise Exception("Could not open %s file.") % pyfile

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyCppVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyCppVisitor.py
@@ -105,14 +105,10 @@ class TopologyCppVisitor(AbstractVisitor.AbstractVisitor):
                     "assembly", "TopologyCpp"
                 )
                 PRINT.info(
-                    "Generating code filename: %s topology, using default XML filename prefix..."
-                    % filename
+                    f"Generating code filename: {filename} topology, using default XML filename prefix..."
                 )
             else:
-                msg = (
-                    "XML file naming format not allowed (must be XXXAppAi.xml), Filename: %s"
-                    % xml_file
-                )
+                msg = f"XML file naming format not allowed (must be XXXAppAi.xml), Filename: {xml_file}"
                 PRINT.info(msg)
                 raise ValueError(msg)
             #
@@ -126,7 +122,7 @@ class TopologyCppVisitor(AbstractVisitor.AbstractVisitor):
                 self.partition = None
             #
             # Open file for writing here...
-            DEBUG.info("Open file: %s" % filename)
+            DEBUG.info(f"Open file: {filename}")
             self.__fp = open(filename, "w")
             if self.__fp is None:
                 raise Exception("Could not open %s file.") % filename

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyHVisitor.py
@@ -105,14 +105,10 @@ class TopologyHVisitor(AbstractVisitor.AbstractVisitor):
                     "assembly", "TopologyH"
                 )
                 PRINT.info(
-                    "Generating code filename: %s topology, using default XML filename prefix..."
-                    % filename
+                    f"Generating code filename: {filename} topology, using default XML filename prefix..."
                 )
             else:
-                msg = (
-                    "XML file naming format not allowed (must be XXXAppAi.xml), Filename: %s"
-                    % xml_file
-                )
+                msg = f"XML file naming format not allowed (must be XXXAppAi.xml), Filename: {xml_file}"
                 PRINT.info(msg)
                 raise ValueError(msg)
             #
@@ -126,7 +122,7 @@ class TopologyHVisitor(AbstractVisitor.AbstractVisitor):
                 self.partition = None
             #
             # Open file for writing here...
-            DEBUG.info("Open file: %s" % filename)
+            DEBUG.info(f"Open file: {filename}")
             self.__fp = open(filename, "w")
             if self.__fp is None:
                 raise Exception("Could not open %s file.") % filename

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyIDVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyIDVisitor.py
@@ -101,19 +101,15 @@ class TopologyIDVisitor(AbstractVisitor.AbstractVisitor):
                     "assembly", "TopologyID"
                 )
                 PRINT.info(
-                    "Generating code filename: %s topology, using default XML filename prefix..."
-                    % filename
+                    f"Generating code filename: {filename} topology, using default XML filename prefix..."
                 )
             else:
-                msg = (
-                    "XML file naming format not allowed (must be XXXAppAi.xml), Filename: %s"
-                    % xml_file
-                )
+                msg = f"XML file naming format not allowed (must be XXXAppAi.xml), Filename: {xml_file}"
                 PRINT.info(msg)
                 raise ValueError(msg)
 
             # Open file for writing here...
-            DEBUG.info("Open file: %s" % filename)
+            DEBUG.info(f"Open file: {filename}")
             self.__fp = open(filename, "w")
             if self.__fp is None:
                 raise Exception("Could not open %s file.") % filename

--- a/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
@@ -867,7 +867,7 @@ class ComponentWriterBase(AbstractWriter.AbstractWriter):
         """
         Open the file for writing
         """
-        DEBUG.info("Open file: %s" % filename)
+        DEBUG.info(f"Open file: {filename}")
         self.__fp = open(filename, "w")
         if self.__fp is None:
             raise Exception("Could not open file %s") % filename

--- a/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/writers/ComponentWriterBase.py
@@ -92,8 +92,7 @@ class ComponentWriterBase(AbstractWriter.AbstractWriter):
                 + self.config("component", self.__writer)
             )
             DEBUG.info(
-                "Generating code filename: %s, using XML namespace and name attributes..."
-                % filename
+                f"Generating code filename: {filename}, using XML namespace and name attributes..."
             )
         else:
             xml_file = obj.get_xml_filename()
@@ -102,12 +101,9 @@ class ComponentWriterBase(AbstractWriter.AbstractWriter):
             l = len(s[0])
             if (x[0][-l:] == s[0]) & (x[1] == s[1]):
                 filename = x[0].split(s[0])[0] + self.config("component", self.__writer)
-                DEBUG.info("Generating code filename: %s..." % filename)
+                DEBUG.info(f"Generating code filename: {filename}...")
             else:
-                msg = (
-                    "XML file naming format not allowed (must be XXXComponentAi.xml), Filename: %s"
-                    % xml_file
-                )
+                msg = f"XML file naming format not allowed (must be XXXComponentAi.xml), Filename: {xml_file}"
                 PRINT.info(msg)
                 raise ValueError(msg)
         return filename
@@ -933,8 +929,7 @@ class ComponentWriterBase(AbstractWriter.AbstractWriter):
             relative_path = build_root_relative_path(path)
         except BuildRootMissingException as bre:
             PRINT.info(
-                "ERROR: BUILD_ROOT and current execution path (%s) not consistent! %s"
-                % (path, str(bre))
+                f"ERROR: BUILD_ROOT and current execution path ({path}) not consistent! {str(bre)}"
             )
             sys.exit(-1)
         DEBUG.debug("Relative path: %s", relative_path)

--- a/Autocoders/Python/src/fprime_ac/generators/writers/InstEventWriter.py
+++ b/Autocoders/Python/src/fprime_ac/generators/writers/InstEventWriter.py
@@ -222,8 +222,7 @@ class InstEventWriter(AbstractDictWriter.AbstractDictWriter):
                     # check for an error
                     if format_string is None:
                         PRINT.info(
-                            "Event %s in component %s had error processing format specifier"
-                            % (c.name, c.component)
+                            f"Event {c.name} in component {c.component} had error processing format specifier"
                         )
                         sys.exit(-1)
                     else:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| python autocoder |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims at replacing the use of the ``%`` string interpolation operator with f-strings

## Rationale

According to the [Python documentation](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting), using the ``%`` operator to format strings can lead to "a variety of quirks that lead to a number of common errors."

[PEP 498](https://peps.python.org/pep-0498/) added F-strings to Python in version 3.6. F-strings are a versatile and powerful method of string formatting. Because the code looks more like the output, they make it shorter and more readable.

## Testing/Review Recommendations

void

## Future Work

This PR is the second in a series of PRs on the same theme.
