### PR TITLE
Add items to a dictionary directly during its definition

### DIFF
--- a/Autocoders/Python/bin/JSONDictionaryGen.py
+++ b/Autocoders/Python/bin/JSONDictionaryGen.py
@@ -126,13 +126,12 @@ def main():
     outFilepath = "/".join([opts.work_path, outFilename])
     descriptionFilename = "/".join([opts.work_path, "/dictPath.txt"])
 
-    dictionary = {}
-    dictionary[deployment] = {
+    dictionary = {deployment: {
         "events": {},
         "channels": {},
         "commands": {},
         "serializables": {},
-    }
+    }}
 
     events = dictionary[deployment]["events"]
     channels = dictionary[deployment]["channels"]

--- a/Autocoders/Python/bin/codegen.py
+++ b/Autocoders/Python/bin/codegen.py
@@ -1208,7 +1208,14 @@ def main():
 
     # Configure the logging.
     log_level = opt.logger.upper()
-    log_level_dict = {}
+    log_level_dict = {
+        "QUIET": None,
+        "DEBUG": logging.DEBUG,
+        "INFO": logging.INFO,
+        "WARNING": logging.WARN,
+        "ERROR": logging.ERROR,
+        "CRITICAL": logging.CRITICAL,
+    }
 
     log_level_dict["QUIET"] = None
     log_level_dict["DEBUG"] = logging.DEBUG

--- a/Autocoders/Python/test/dictgen/test_dictgen.py
+++ b/Autocoders/Python/test/dictgen/test_dictgen.py
@@ -311,15 +311,15 @@ def check_generated_files(testdir):
     # Enums
     inst1_enums = get_enums_from_comp_xml(inst1.get_comp_xml())
     inst2_enums = get_enums_from_comp_xml(inst2.get_comp_xml())
-    inst_enums = {}
-    inst_enums["compxml"] = inst1_enums["compxml"] + inst2_enums["compxml"]
-    inst_enums["imports"] = inst1_enums["imports"] + inst2_enums["imports"]
+    inst_enums = {
+        "compxml": inst1_enums["compxml"] + inst2_enums["compxml"],
+        "imports": inst1_enums["imports"] + inst2_enums["imports"],
+    }
 
     # Serializables
     inst1_serials = get_serializables_from_comp_xml(inst1.get_comp_xml())
     inst2_serials = get_serializables_from_comp_xml(inst2.get_comp_xml())
-    inst_serials = {}
-    inst_serials["imports"] = inst1_serials["imports"] + inst2_serials["imports"]
+    inst_serials = {"imports": inst1_serials["imports"] + inst2_serials["imports"]}
 
     # GDS XML Dictionary
     dict_parser = XmlLoader()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| python autocoder |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR changes the way of adding elements to a dictionary just after its creation, these elements should be added in the dictionary definition itself.

## Rationale

 This method is faster, less verbose and easier to read.

## Testing/Review Recommendations

void

## Future Work

 void