### PR TITLE
Remove built-in function `len` used as condition

### DIFF
--- a/Autocoders/Python/bin/tlmLayout.py
+++ b/Autocoders/Python/bin/tlmLayout.py
@@ -220,7 +220,7 @@ class Packet:
             self.err_msg("Missing parameter(s) for identifier")
 
         self.m_name = line[1].strip()
-        if not len(self.m_name):
+        if not self.m_name:
             self.err_msg("Name cannot be blank")
 
         if len(self.m_name.split()) > 1:
@@ -254,7 +254,7 @@ class Packet:
             self.err_msg("Missing parameter(s) for item")
 
         it.m_name = line[1].strip()
-        if not len(it.m_name):
+        if not it.m_name:
             self.err_msg("Name cannot be blank")
 
         if len(it.m_name.split()) > 1:
@@ -353,7 +353,7 @@ class Packet:
         it.m_is_constant = True
 
         it.m_name = line[1].strip()
-        if not len(it.m_name):
+        if not it.m_name:
             self.err_msg("Name cannot be blank")
 
         if len(it.m_name.split()) > 1:
@@ -412,7 +412,7 @@ class Packet:
         global tlm_period
         global verbose
 
-        if not len(self.m_header_list) and not len(self.m_item_list):
+        if not self.m_header_list and not self.m_item_list:
             return
 
         self.m_bytes = (self.m_bit_index + 7) / 8
@@ -529,7 +529,7 @@ class CsvLine:
 
         global tlm_input_line_num
 
-        if not len(line):
+        if not line:
             return
 
         nonblank = False


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| python autocoder |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR changes the way to determine if a sequence is empty with `len` by computing its boolean value.

## Rationale

Using the ``len`` function to determine whether a sequence is empty is not idiomatic and may be less efficient than determining the veracity of the object.

``len`` does not know the context in which it is called, so computing the length requires traversing the entire sequence. It does not know that the result is simply compared to ``0``.

Regardless of the length of the sequence, the boolean value calculation may stop after seeing the first element.


## Testing/Review Recommendations

void

## Future Work

 void