### PR TITLE
Remove use of `len(seq) - 1` to get last item of an iterable

### DIFF
--- a/Autocoders/Python/test/dictgen/test_dictgen.py
+++ b/Autocoders/Python/test/dictgen/test_dictgen.py
@@ -619,7 +619,7 @@ def compare_serials_ai_gds(topology_serials, gds_serials):
     for gds_serial in gds_serials:
         # For scope of test, only verify serial type and member names/types
         type = gds_serial.attrib["type"].split("::")
-        type = type[len(type) - 1]
+        type = type[-1]
         types.append(type)
         if not type in member_names.keys():
             member_names[type] = []
@@ -675,7 +675,7 @@ def compare_enums_ai_gds(topology_enums, gds_enums):
     for gds_enum in gds_enums:
         # For scope of test, only verify enum name and item names
         name = gds_enum.attrib["type"].split("::")
-        name = name[len(name) - 1]
+        name = name[-1]
         names.append(name)
         if not name in items.keys():
             items[name] = []


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| python autocoder |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR removes the use of `len(seq) - 1` to get last item of an iterable.

## Rationale

It is not necessary to calculate the length of an iterable in order to get the last element of the iterable.
We can directly give it a negative index `-1` to get the last element. We won't have to iterate over the sequence using `len` to get the last index if the goal is simply to get the last element.


## Testing/Review Recommendations

void

## Future Work

 void