### PR TITLE
Merge multiple consecutive `isinstance` calls into one

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceCommandVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceCommandVisitor.py
@@ -104,7 +104,7 @@ class InstanceCommandVisitor(AbstractVisitor.AbstractVisitor):
                 obj.get_component_base_name()
             ]
         except Exception:
-            if isinstance(obj, Parameter.Parameter) or isinstance(obj, Command.Command):
+            if isinstance(obj, (Parameter.Parameter, Command.Command)):
                 PRINT.info(
                     "ERROR: Could not find instance object for component "
                     + obj.get_component_base_name()

--- a/Autocoders/Python/src/fprime_ac/generators/writers/InstCommandWriter.py
+++ b/Autocoders/Python/src/fprime_ac/generators/writers/InstCommandWriter.py
@@ -104,7 +104,7 @@ class InstCommandWriter(AbstractDictWriter.AbstractDictWriter):
                 obj.get_component_base_name()
             ]
         except Exception:
-            if isinstance(obj, Parameter.Parameter) or isinstance(obj, Command.Command):
+            if isinstance(obj, (Parameter.Parameter, Command.Command)):
                 PRINT.info(
                     "ERROR: Could not find instance object for component "
                     + obj.get_component_base_name()

--- a/Autocoders/Python/src/fprime_ac/utils/DumpObj.py
+++ b/Autocoders/Python/src/fprime_ac/utils/DumpObj.py
@@ -112,11 +112,9 @@ def dumpObj(
             objdoc = attr
         elif slot == "__module__":
             objmodule = attr
-        elif isinstance(attr, types.BuiltinMethodType) or isinstance(
-            attr, MethodWrapperType
-        ):
+        elif isinstance(attr, (types.BuiltinMethodType, MethodWrapperType)):
             builtins.append(slot)
-        elif isinstance(attr, types.MethodType) or isinstance(attr, types.FunctionType):
+        elif isinstance(attr, (types.MethodType, types.FunctionType)):
             methods.append((slot, attr))
         elif isinstance(attr, type):
             classes.append((slot, attr))


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| python autocoder |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to merge several consecutive `isinstance` calls into one.

## Rationale

We can pass a tuple of types we want to check as a second argument to isinstance. If the object matches one of the types, it returns `True`, otherwise `False`.

This is clearer and improves readability.

## Testing/Review Recommendations

void

## Future Work

 void