### PR TITLE
Use `any()` built-in function when possible

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/formatters.py
+++ b/Autocoders/Python/src/fprime_ac/generators/formatters.py
@@ -751,10 +751,7 @@ class Formatters:
         return True if an array arg is
         found, else return False.
         """
-        for arg in args:
-            if arg[3] != "":
-                return True
-        return False
+        return any(arg[3] != "" for arg in args)
 
     def commentInArgsPresent(self, args):
         """
@@ -762,10 +759,7 @@ class Formatters:
         return True if a comment for
         an arg is found, else return False.
         """
-        for arg in args:
-            if arg[2] != "":
-                return True
-        return False
+        return any(arg[2] != "" for arg in args)
 
     ##########################################
     # Methods for argument handling.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| python autocoder |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to replace the specific loops looking if at least one element of an iterable is true by the built-in `any()` function.

## Rationale

When possible, it is recommended to use the built-in `any()` function, as this will make the code smaller and more readable.

## Testing/Review Recommendations

void

## Future Work

 void