### PR TITLE
astroesteban: missing setuptools_scm install

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -49,7 +49,7 @@ tool installations are described in [Advanced](#Advanced).
 **Installing F´ Python Packages**
 
 ```
-pip install -U setuptools wheel pip
+pip install -U setuptools setuptools_scm wheel pip
 pip install -U -r fprime/requirements.txt
 ```
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|@astroesteban |
|**_Affected Component_**|Install instructions  |
|**_Affected Architectures(s)_**|None  |
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| N |
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**|Y  |
|**_Documentation Included (y/n)_**| Y |

---
## Change Description

Adds the `setuptools_scm` to the list of packages the user must install prior to installing the packages in the requirements.txt

## Rationale

In upgrading to the latest `devel` branch I came across the following error when installing `fprime-fpp` from the requirements.txt:
```
  WARNING: Requested fprime-fpp==1.0.2b13 from https://files.pythonhosted.org/packages/39/fc/e92b3957dba9434a159cc77d01e08206cb4a8f58d08d1ad310933eb4d19f/fprime-fpp-1.0.2b13.tar.gz#sha256=bbf1a60a82abface38f16486fba1226eb3845467c24204fd50e82ce1946ccf82, but installing version 0.0.0
Discarding https://files.pythonhosted.org/packages/39/fc/e92b3957dba9434a159cc77d01e08206cb4a8f58d08d1ad310933eb4d19f/fprime-fpp-1.0.2b13.tar.gz#sha256=bbf1a60a82abface38f16486fba1226eb3845467c24204fd50e82ce1946ccf82 (from https://pypi.org/simple/fprime-fpp/) (requires-python:>=3.6): Requested fprime-fpp==1.0.2b13 from https://files.pythonhosted.org/packages/39/fc/e92b3957dba9434a159cc77d01e08206cb4a8f58d08d1ad310933eb4d19f/fprime-fpp-1.0.2b13.tar.gz#sha256=bbf1a60a82abface38f16486fba1226eb3845467c24204fd50e82ce1946ccf82 has inconsistent version: filename has '1.0.2b13', but metadata has '0.0.0'
ERROR: Could not find a version that satisfies the requirement fprime-fpp==1.0.2b13 (from versions: 1.0.1, 1.0.2a8, 1.0.2a10, 1.0.2b1, 1.0.2b6, 1.0.2b10, 1.0.2b11, 1.0.2b12, 1.0.2b13, 1.0.2b15)
ERROR: No matching distribution found for fprime-fpp==1.0.2b13
```

The error is not obvious to debug for users as a quick visit to the package's PyPi entry clearly shows that package as existing. The solution is to install `setuptools_scm` to allow installing these dev tools.

## Testing/Review Recommendations

I successfully ran:
```
python3 -m pip install -U --upgrade pip setuptools setuptools_scm wheel
python3 -m pip install -U -r requirements.txt
```

## Future Work

None.
