### PR TITLE
Only support set_cpu_affinity with glibc for musl compat

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -631,6 +631,7 @@ gh
 ghprb
 github
 gjslint
+glibc
 globals
 gmail
 gmtime

--- a/Os/Posix/Task.cpp
+++ b/Os/Posix/Task.cpp
@@ -11,6 +11,9 @@
 #include <climits>
 #include <Fw/Logger/Logger.hpp>
 
+#ifdef TGT_OS_TYPE_LINUX 
+#include <features.h>
+#endif
 
 static const NATIVE_INT_TYPE SCHED_POLICY = SCHED_RR;
 
@@ -100,7 +103,7 @@ namespace Os {
 
     Task::TaskStatus set_cpu_affinity(pthread_attr_t& att, NATIVE_UINT_TYPE cpuAffinity) {
         if (cpuAffinity != Task::TASK_DEFAULT) {
-#ifdef TGT_OS_TYPE_LINUX
+#if TGT_OS_TYPE_LINUX && __GLIBC__
             cpu_set_t cpuset;
             CPU_ZERO(&cpuset);
             CPU_SET(cpuAffinity, &cpuset);
@@ -111,6 +114,8 @@ namespace Os {
                                    reinterpret_cast<POINTER_CAST>(strerror(stat)));
                 return Task::TASK_INVALID_PARAMS;
             }
+#elif TGT_OS_TYPE_LINUX
+            Fw::Logger::logMsg("[WARNING] Setting CPU affinity is only available on Linux with glibc\n");
 #else
             Fw::Logger::logMsg("[WARNING] Setting CPU affinity is only available on Linux\n");
 #endif


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @aditsachde |
|**_Affected Component_**| `Os/Task` |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| #1507 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Only support set_cpu_affinity when using glibc. Detects glibc in a way that will not break due to glibc updates.

## Rationale

This PR is meant as a discussion and not necessarily merged in as is. We are aiming to deploy fprime on the Onion Omega2, whose toolchain uses musl instead of glibc. This is one of the two changes (#1508) required to support building fprime with musl. 

As mentioned in this discussion (#1507), it would be preferred to be able to set cpu affinity when musl. However, musl only supports setting cpu affinity after starting the thread using the `pthread_setaffinity_np` function, and not before, using `pthread_attr_setaffinity_np`.

It is possible to change the ordering, so that fprime sets CPU affinity after starting the thread. This then raises the question of what to do if starting the thread succeeds, but setting CPU affinity fails. If there is a way to acceptably handle this case, then it would make sense to switch this ordering and use `pthread_setaffinity_np` instead.

I would appreciate any thoughts on the best way this, and on musl compatibility in general.

## Testing/Review Recommendations

This PR was opened to as a discussion, as mentioned in rational. For testing, CI should validate the change.

## Future Work

Add a CI pipeline to run build and integration tests on a musl based system.
