### PR TITLE
Replace manual loop counters by `enumerate()` call

### DIFF
--- a/Autocoders/Python/bin/tlmLayout.py
+++ b/Autocoders/Python/bin/tlmLayout.py
@@ -472,9 +472,7 @@ class Packet:
             print("")
 
             print("Number of items in packet item list: ", len(self.m_item_list))
-            i = 0
-            for item in self.m_item_list:
-                i += 1
+            for i, item in enumerate(self.m_item_list, start=1):
                 print("Item # ", i)
                 print("\tis_reserve:     ", item.m_is_reserve)
                 print("\tis_constant:    ", item.m_is_constant)

--- a/Autocoders/Python/src/fprime_ac/generators/formatters.py
+++ b/Autocoders/Python/src/fprime_ac/generators/formatters.py
@@ -103,14 +103,10 @@ class CommentFormatters:
         Returns -1 if everything is a newline
         """
 
-        count = 0
-
-        for item in line_list:
+        for count, item in enumerate(line_list):
             item = item.strip()
             if item != "":
                 return count
-            count += 1
-
         return -1
 
     def _getEndsExcludingNewlines(self, line_list):
@@ -1078,15 +1074,13 @@ class Formatters:
                 cpos = apos + type_max + 1
 
             # place args and comments and put together the string.
-            i = 0
             func_arg_list = []
-            for a in format_func_list[1:]:
+            for i, a in enumerate(format_func_list[1:]):
                 pad = (cpos - (apos + len(a.strip()))) * " "
                 str = (
                     apad + a.strip() + pad + comment_list[i] + "\n"
                 )  #  + pad + comment_list[i]
                 func_arg_list.append(str)
-                i += 1
             #
             # print 'Last arg: ',func_arg_list[-1].replace(') ',');')
             # TODO: add switch so a ; is inserted - end of last arg after ).
@@ -1216,11 +1210,9 @@ class Formatters:
 
             max_type_length = max(list(map(len, type_list)))
 
-            i = 0
-            for type in type_list:
+            for i, type in enumerate(type_list):
                 pad = (max_type_length + pad_spaces) - len(type)
                 str = type + pad * " " + arg_list[i]
-                i += 1
                 str_list.append(str)
 
         return str_list

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ChannelVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ChannelVisitor.py
@@ -103,10 +103,8 @@ class ChannelVisitor(AbstractVisitor.AbstractVisitor):
                 raise Exception(f"Could not open {pyfile} file.")
             self.__fp.append(fd)
         else:
-            inst = 0
-            for id in obj.get_ids():
+            for inst, id in enumerate(obj.get_ids()):
                 pyfile = "%s/%s_%d.py" % (output_dir, obj.get_name(), inst)
-                inst += 1
                 DEBUG.info(f"Open file: {pyfile}")
                 fd = open(pyfile, "w")
                 if fd is None:
@@ -118,23 +116,20 @@ class ChannelVisitor(AbstractVisitor.AbstractVisitor):
         """
         Defined to generate header for channel python class.
         """
-        inst = 0
-        for id in obj.get_ids():
+        for inst, id in enumerate(obj.get_ids()):
             c = ChannelHeader.ChannelHeader()
             d = datetime.datetime.now()
             c.date = d.strftime("%A, %d %B %Y")
             c.user = getuser()
             c.source = obj.get_xml_filename()
             self._writeTmpl(c, self.__fp[inst], "channelHeaderVisit")
-            inst += 1
 
     def DictBodyVisit(self, obj):
         """
         Defined to generate the body of the Python channel class
         @param obj: the instance of the channel model to operation on.
         """
-        inst = 0
-        for id in obj.get_ids():
+        for inst, id in enumerate(obj.get_ids()):
             c = ChannelBody.ChannelBody()
             if len(obj.get_ids()) > 1:
                 c.name = obj.get_name() + "_%d" % inst
@@ -169,4 +164,3 @@ class ChannelVisitor(AbstractVisitor.AbstractVisitor):
 
             self._writeTmpl(c, self.__fp[inst], "channelBodyVisit")
             self.__fp[inst].close()
-            inst += 1

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/CommandVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/CommandVisitor.py
@@ -112,10 +112,8 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                     raise Exception(f"Could not open {pyfile} file.")
                 self.__fp1.append(fd)
             else:
-                inst = 0
-                for opcode in obj.get_opcodes():
+                for inst, opcode in enumerate(obj.get_opcodes()):
                     pyfile = "%s/%s_%d.py" % (output_dir, obj.get_mnemonic(), inst)
-                    inst += 1
                     DEBUG.info(f"Open file: {pyfile}")
                     fd = open(pyfile, "w")
                     if fd is None:
@@ -144,8 +142,7 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                     raise Exception(f"Could not open {pyfile} file.")
                 self.__fp2.append(fd)
             else:
-                inst = 0
-                for opcode in obj.get_set_opcodes():
+                for inst, opcode in enumerate(obj.get_set_opcodes()):
                     pyfile = "%s/%s_%d_PRM_SET.py" % (output_dir, self.__stem, inst)
                     DEBUG.info(f"Open file: {pyfile}")
                     fd = open(pyfile, "w")
@@ -160,7 +157,6 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                     if fd is None:
                         raise Exception(f"Could not open {pyfile} file.")
                     self.__fp2.append(fd)
-                    inst += 1
                     DEBUG.info(f"Completed {pyfile} open")
 
         else:
@@ -175,38 +171,32 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
         @param obj: the instance of the command model to visit.
         """
         if type(obj) is Command.Command:
-            inst = 0
-            for opcode in obj.get_opcodes():
+            for inst, opcode in enumerate(obj.get_opcodes()):
                 c = CommandHeader.CommandHeader()
                 d = datetime.datetime.now()
                 c.date = d.strftime("%A, %d %B %Y")
                 c.user = getuser()
                 c.source = obj.get_xml_filename()
                 self._writeTmpl(c, self.__fp1[inst], "commandHeaderVisit")
-                inst += 1
 
         elif type(obj) is Parameter.Parameter:
             # SET Command header
-            inst = 0
-            for opcode in obj.get_set_opcodes():
+            for inst, opcode in enumerate(obj.get_set_opcodes()):
                 c = CommandHeader.CommandHeader()
                 d = datetime.datetime.now()
                 c.date = d.strftime("%A, %d %B %Y")
                 c.user = getuser()
                 c.source = obj.get_xml_filename()
                 self._writeTmpl(c, self.__fp1[inst], "commandHeaderVisit")
-                inst += 1
 
             # SAVE Command header
-            inst = 0
-            for opcode in obj.get_save_opcodes():
+            for inst, opcode in enumerate(obj.get_save_opcodes()):
                 c = CommandHeader.CommandHeader()
                 d = datetime.datetime.now()
                 c.date = d.strftime("%A, %d %B %Y")
                 c.user = getuser()
                 c.source = obj.get_xml_filename()
                 self._writeTmpl(c, self.__fp2[inst], "commandHeaderVisit")
-                inst += 1
 
     def DictBodyVisit(self, obj):
         """
@@ -214,8 +204,7 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
         @param obj: the instance of the command model to operation on.
         """
         if type(obj) is Command.Command:
-            inst = 0
-            for opcode in obj.get_opcodes():
+            for inst, opcode in enumerate(obj.get_opcodes()):
                 c = CommandBody.CommandBody()
                 # only add the suffix if there is more than one opcode per command
                 if len(obj.get_opcodes()) > 1:
@@ -247,10 +236,8 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                     )
                 self._writeTmpl(c, self.__fp1[inst], "commandBodyVisit")
                 self.__fp1[inst].close()
-                inst += 1
         if type(obj) is Parameter.Parameter:
-            inst = 0
-            for opcode in obj.get_set_opcodes():
+            for inst, opcode in enumerate(obj.get_set_opcodes()):
                 # Set Command
                 c = CommandBody.CommandBody()
                 if len(obj.get_set_opcodes()) > 1:
@@ -279,10 +266,8 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                 c.arglist.append((obj.get_name(), obj.get_comment(), type_string))
                 self._writeTmpl(c, self.__fp1[inst], "commandBodyVisit")
                 self.__fp1[inst].close()
-                inst += 1
 
-            inst = 0
-            for opcode in obj.get_save_opcodes():
+            for inst, opcode in enumerate(obj.get_save_opcodes()):
                 # Save Command
                 c = CommandBody.CommandBody()
                 if len(obj.get_save_opcodes()) > 1:
@@ -298,4 +283,3 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
 
                 self._writeTmpl(c, self.__fp2[inst], "commandBodyVisit")
                 self.__fp2[inst].close()
-                inst += 1

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -379,12 +379,10 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
                 if len(opcodes) == 1:
                     return f"CMD_{mnemonic.upper()}"
                 else:
-                    mlist = []
-                    inst = 0
-                    for opcode in opcodes:
-                        mlist.append("CMD_" + mnemonic.upper() + "_%d" % inst)
-                        inst += 1
-                    return mlist
+                    return [
+                        f"CMD_{mnemonic.upper()}" + "_%d" % inst
+                        for inst, opcode in enumerate(opcodes)
+                    ]
             else:
                 return None
 

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -380,7 +380,7 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
                     return f"CMD_{mnemonic.upper()}"
                 else:
                     return [
-                        f"CMD_{mnemonic.upper()}" + "_%d" % inst
+                        f"CMD_{mnemonic.upper()}_{inst}"
                         for inst, opcode in enumerate(opcodes)
                     ]
             else:

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/EventVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/EventVisitor.py
@@ -121,23 +121,20 @@ class EventVisitor(AbstractVisitor.AbstractVisitor):
         Defined to generate header for  event python class.
         @param obj: the instance of the event model to operation on.
         """
-        inst = 0
-        for id in obj.get_ids():
+        for inst, id in enumerate(obj.get_ids()):
             c = EventHeader.EventHeader()
             d = datetime.datetime.now()
             c.date = d.strftime("%A, %d %B %Y")
             c.user = getuser()
             c.source = obj.get_xml_filename()
             self._writeTmpl(c, self.__fp[inst], "eventHeaderVisit")
-            inst += 1
 
     def DictBodyVisit(self, obj):
         """
         Defined to generate the body of the  Python event class
         @param obj: the instance of the event model to operation on.
         """
-        inst = 0
-        for id in obj.get_ids():
+        for inst, id in enumerate(obj.get_ids()):
             c = EventBody.EventBody()
             if len(obj.get_ids()) > 1:
                 c.name = obj.get_name() + "_%d" % inst
@@ -151,9 +148,7 @@ class EventVisitor(AbstractVisitor.AbstractVisitor):
 
             c.arglist = []
             c.ser_import_list = []
-            arg_num = 0
-
-            for arg_obj in obj.get_args():
+            for arg_num, arg_obj in enumerate(obj.get_args()):
                 n = arg_obj.get_name()
                 t = arg_obj.get_type()
                 s = arg_obj.get_size()
@@ -185,7 +180,5 @@ class EventVisitor(AbstractVisitor.AbstractVisitor):
                         c.format_string = format_string
 
                 c.arglist.append((n, d, type_string))
-                arg_num += 1
             self._writeTmpl(c, self.__fp[inst], "eventBodyVisit")
             self.__fp[inst].close()
-            inst += 1

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceEventVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceEventVisitor.py
@@ -196,9 +196,7 @@ class InstanceEventVisitor(AbstractVisitor.AbstractVisitor):
 
             c.arglist = []
             c.ser_import_list = []
-            arg_num = 0
-
-            for arg_obj in obj.get_args():
+            for arg_num, arg_obj in enumerate(obj.get_args()):
                 n = arg_obj.get_name()
                 t = arg_obj.get_type()
                 s = arg_obj.get_size()
@@ -230,6 +228,5 @@ class InstanceEventVisitor(AbstractVisitor.AbstractVisitor):
                         c.format_string = format_string
 
                 c.arglist.append((n, d, type_string))
-                arg_num += 1
             self._writeTmpl(c, self.__fp[fname], "eventBodyVisit")
             self.__fp[fname].close()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @ThibFrgsGmz |
|**_Affected Component_**| python autocoder |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to convert the manual loop counter with a call to the built-in function `enumerate()`.

## Rationale

Using the built-in Python function `enumerate()` allows us to generate an index directly, eliminating two lines of code that would otherwise be used to access a loop counter that would tell us the index of the element used.
With this change, we no longer need to consider the i/inst variable, allowing us to focus on the code that really matters.

## Testing/Review Recommendations

void

## Future Work

 void