### PR TITLE
Migrate away from C-style enum constructs for `Os/Queue.hpp`

### DIFF
--- a/Os/Queue.hpp
+++ b/Os/Queue.hpp
@@ -24,7 +24,7 @@ namespace Os {
     class Queue {
         public:
 
-            typedef enum {
+            enum QueueStatus {
                 QUEUE_OK, //!<  message sent/received okay
                 QUEUE_NO_MORE_MSGS, //!<  If non-blocking, all the messages have been drained.
                 QUEUE_UNINITIALIZED, //!<  Queue wasn't initialized successfully
@@ -35,12 +35,12 @@ namespace Os {
                 QUEUE_EMPTY_BUFFER, //!<  supplied buffer is empty
                 QUEUE_FULL, //!< queue was full when attempting to send a message
                 QUEUE_UNKNOWN_ERROR //!<  Unexpected error; can't match with returns
-            } QueueStatus;
+            };
 
-            typedef enum {
+            enum QueueBlocking {
                 QUEUE_BLOCKING, //!<  Queue receive blocks until a message arrives
                 QUEUE_NONBLOCKING //!<  Queue receive always returns even if there is no message
-            } QueueBlocking;
+            };
 
             Queue();
             virtual ~Queue();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|  |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Switch from the `typedef enum { ... } enumName;` construct to `enum enumName { ... };` instead.

## Rationale

`typedef` is not required when declaring enumerations in C++ to avoid the prepended use of the `enum` keyword when using the enum post-declaration.

## Testing/Review Recommendations

Going with [one file per PR](https://github.com/nasa/fprime/discussions/1566#discussioncomment-3199803)!

## Future Work

Making this minor change for similar typedef-aliased enum declarations in other files