### PR TITLE
Replace NULL with nullptr

### DIFF
--- a/STest/STest/Scenario/ConditionalIteratedScenario.hpp
+++ b/STest/STest/Scenario/ConditionalIteratedScenario.hpp
@@ -61,7 +61,7 @@ namespace STest {
       Scenario<State>* nextScenario_IteratedScenario(
           State& state //!< The system state
       ) {
-        Scenario<State>* scenario = NULL;
+        Scenario<State>* scenario = nullptr;
         if (!this->condition_ConditionalIteratedScenario(state)) {
           this->done = true;
         }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @Anirban166 |
|**_Affected Component_**| N/A |
|**_Affected Architectures(s)_**| STest |
|**_Related Issue(s)_**| -/- |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Change `NULL` to `nullptr`.

## Rationale

Since C++11, using a nullptr over NULL is the de facto standard since:
- The former provides a type-safe representation of an empty/null pointer (both raw and smart pointers), automatically (defined using templates, evaluated during compile-time) deducing the correct type depending upon the type of the instance it is being assigned to.
- The latter might not be valid in some cases depending on where it is used, as it has no return type resolving logic under the hood and is implementation specific at times (this macro is usually defined to be either an integer literal with the value 0, or a pure rvalue of type `std::nullptr_t`; if it has to be a macro for consistency then `#define NULL nullptr` is how they put it so as to align with the former).

## Testing/Review Recommendations

void

## Future Work

((void*)0)
