### PR TITLE
Avoid branching (and thus branch prediction) using bitwise operators on boolean primitives

### DIFF
--- a/Fw/Port/PortBase.cpp
+++ b/Fw/Port/PortBase.cpp
@@ -47,13 +47,7 @@ namespace Fw {
     void PortBase::trace() {
         bool do_trace = false;
 
-        if (this->m_ovr_trace) {
-            if (this->m_trace) {
-                do_trace = true;
-            }
-        } else if (PortBase::s_trace) {
-            do_trace = true;
-        }
+        do_trace = ((this->m_ovr_trace & this->m_trace) | (!(this->m_ovr_trace) & PortBase::s_trace));
 
         if (do_trace) {
 #if FW_OBJECT_NAMES == 1


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @Anirban166 |
|**_Affected Component_**| Fw/Port/PortBase |
|**_Affected Architectures(s)_**| Fw |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

A more concise way of representing boolean logic with a branchless version (using bitwise operators) for a code segment that operates on `bool` variables with branching.

## Rationale

A more compact form of this:
```cpp
bool do_trace = false;
... // Procure variables to be put under conditionals
// or initialize them, for e.g.: int a{1}, b{0}, c{1};
if (a) { if (b) do_trace = true; }
else if (c) do_trace = true;
```
would be this:
```cpp
if ((a && b) || (!a && c)) do_trace = true;
// if ((this->m_ovr_trace && this->m_trace) || (!(this->m_ovr_trace) && PortBase::s_trace)) do_trace = true;
```
or without the `if` conditional, simply:
```cpp
do_trace = (a && b) || (!a && c);
// do_trace = ((this->m_ovr_trace && this->m_trace) || (!(this->m_ovr_trace) && PortBase::s_trace));
``` 
And even better would be to use the bitwise operators `|` and `&` instead of the logical `||` and `&&` for better performance: (applicable, given that we are dealing with just booleans under the hood)
```cpp
do_trace = (a & b) | (!a & c);
// do_trace = ((this->m_ovr_trace & this->m_trace) | (!(this->m_ovr_trace) & PortBase::s_trace));
```

## Testing/Review Recommendations

I think code readability would be the con for some, but otherwise, this would be an optimization given that the branching has been eliminated (no `cmp` instructions), which in turn avoids branch prediction on processors - a factor for performance degradation (although, the severity of it would entirely depend on the frequency that the branch being taken gets mispredicted). Let me know if I missed something!

## Future Work

None