### PR TITLE
Use the original sourcing command '.' for compatibility with shells where 'source' isn't defined

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -42,7 +42,7 @@ use the path: `$HOME/fprime-venv`
 
 ```
 python3 -m venv $HOME/fprime-venv
-source $HOME/fprime-venv/bin/activate
+. $HOME/fprime-venv/bin/activate
 pip install -U setuptools setuptools_scm wheel pip
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -46,7 +46,7 @@ python3 -m venv $HOME/fprime-venv
 pip install -U setuptools setuptools_scm wheel pip
 ```
 
-> Note: `source $HOME/fprime-venv/bin/activate` must be run in each new terminal where the user wishes to use the virtual environment.
+> Note: `. $HOME/fprime-venv/bin/activate` must be run in each new terminal where the user wishes to use the virtual environment.
 
 ### Cloning the F´ Repository and Installing F´ Tools
 
@@ -144,7 +144,7 @@ If the user is using a virtual environment and receives the command not found, t
 environment not being sourced in a new terminal. Make sure to source the environment before running:
 
 ```
-source $HOME/fprime-venv/bin/activate
+. $HOME/fprime-venv/bin/activate
 ```
 
 If installing without a virtual environment, PIP occasionally uses `$HOME/.local/bin` as a place to install user tools.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @Anirban166 |
|**_Affected Component_**| -/- |
|**_Affected Architectures(s)_**| -/- |
|**_Related Issue(s)_**| -/- |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Replaced `.` with its alias `source` that is defined when using shells like bash and zsh. 

## Rationale

The `source` command is not recognized while using the default shell, and I found this while I was setting up a virtual python environment for fprime on a Docker container running Linux (Ubuntu 20.04):
```sh
$ sudo python3 -m venv $HOME/fprime-venv
$ source $HOME/fprime-venv/bin/activate
/bin/sh: 47: source: not found
```
The issue resolves if I use `.` instead:
```sh
$ . $HOME/fprime-venv/bin/activate
(fprime-venv) $ 
```
This happens because my shell in the container isn't bash or any other shell implementation with `source` defined to be an alias of `.`:
```sh
$ ps -p $$
  PID TTY          TIME CMD
  832 pts/2    00:00:00 sh
```
It would be better to use just the original shell command for sourcing instead of its alias, so it does not go unrecognized for shells like the default one.