### PR TITLE
Remove C linkage with cstring include (`extern "C" { ... }` block) in `Fw/Logger/test/ut/FakeLogger.cpp`

### DIFF
--- a/Fw/Logger/test/ut/FakeLogger.cpp
+++ b/Fw/Logger/test/ut/FakeLogger.cpp
@@ -9,9 +9,6 @@
 #include <gtest/gtest.h>
 #include <Fw/Logger/test/ut/FakeLogger.hpp>
 
-extern "C" {
-    #include <cstring>
-}
 namespace MockLogging {
     Fw::Logger* FakeLogger::s_current = nullptr;
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @Anirban166 |
|**_Affected Component_**| Unit tests for Fw::Logger |
|**_Affected Architectures(s)_**| -/- |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Removes the `extern "C" { ... }` block declaration which contains an include for the `cstring` header.

## Rationale

This construct raises errors (see below<sup>1</sup>) on certain setups (didn't face this while testing on OS X 12.4 with x86_64 clang 13.1.6), has C linkage for a C++ header that isn't required to be shared in translation/compilation units elsewhere, and isn't even required in the file itself (i.e., `#include <cstring>` is also unnecessary for the code in that file, given that there is no functionality imported from the library).

<sup>1</sup>I was checking the tests for `Fw/Logger` on a docker container running Ubuntu 18.04 with x86-64 gcc 7.5, and I ran into conflicting type errors between `cstring` and `string.h`:
```sh
<username>@<containerID/systemname>:~ cd <fprime-checkout>/Fw/Logger && fprime-util check # I already have the UTs generated
[WARNING] /home/user/fprime/settings.ini does not exist
[WARNING] fprime-tools has unexpected version. Expected: 3.1.0 found 3.1.1
[WARNING] fprime-gds has unexpected version. Expected: 3.1.1 found 3.1.2
Consolidate compiler generated dependencies of target Fw_Cfg
[  0%] Built target Fw_Cfg
[ 33%] Built target codegen
Consolidate compiler generated dependencies of target Fw_Types
[ 66%] Built target Fw_Types
Consolidate compiler generated dependencies of target gtest
[ 66%] Built target gtest
Consolidate compiler generated dependencies of target gtest_main
[100%] Built target gtest_main
Consolidate compiler generated dependencies of target STest
[100%] Built target STest
Consolidate compiler generated dependencies of target Fw_Logger
[100%] Built target Fw_Logger
[100%] Building CXX object F-Prime/Fw/Logger/CMakeFiles/Logger_Rules_Testing.dir/test/ut/FakeLogger.cpp.o
In file included from /home/user/fprime/Fw/Logger/test/ut/FakeLogger.cpp:13:
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/cstring:100:3: error: conflicting types for 'memchr'
  memchr(void* __s, int __c, size_t __n)
  ^
/usr/include/string.h:90:14: note: previous declaration is here
extern void *memchr (const void *__s, int __c, size_t __n)
             ^
In file included from /home/user/fprime/Fw/Logger/test/ut/FakeLogger.cpp:13:
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/cstring:104:3: error: conflicting types for 'strchr'
  strchr(char* __s, int __n)
  ^
/usr/include/string.h:225:14: note: previous declaration is here
extern char *strchr (const char *__s, int __c)
             ^
In file included from /home/user/fprime/Fw/Logger/test/ut/FakeLogger.cpp:13:
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/cstring:108:3: error: conflicting types for 'strpbrk'
  strpbrk(char* __s1, const char* __s2)
  ^
/usr/include/string.h:302:14: note: previous declaration is here
extern char *strpbrk (const char *__s, const char *__accept)
             ^
In file included from /home/user/fprime/Fw/Logger/test/ut/FakeLogger.cpp:13:
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/cstring:112:3: error: conflicting types for 'strrchr'
  strrchr(char* __s, int __n)
  ^
/usr/include/string.h:252:14: note: previous declaration is here
extern char *strrchr (const char *__s, int __c)
             ^
In file included from /home/user/fprime/Fw/Logger/test/ut/FakeLogger.cpp:13:
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/cstring:116:3: error: conflicting types for 'strstr'
  strstr(char* __s1, const char* __s2)
  ^
/usr/include/string.h:329:14: note: previous declaration is here
extern char *strstr (const char *__haystack, const char *__needle)
             ^
5 errors generated.
F-Prime/Fw/Logger/CMakeFiles/Logger_Rules_Testing.dir/build.make:75: recipe for target 'F-Prime/Fw/Logger/CMakeFiles/Logger_Rules_Testing.dir/test/ut/FakeLogger.cpp.o' failed
make[3]: *** [F-Prime/Fw/Logger/CMakeFiles/Logger_Rules_Testing.dir/test/ut/FakeLogger.cpp.o] Error 1
CMakeFiles/Makefile2:14510: recipe for target 'F-Prime/Fw/Logger/CMakeFiles/Logger_Rules_Testing.dir/all' failed
make[2]: *** [F-Prime/Fw/Logger/CMakeFiles/Logger_Rules_Testing.dir/all] Error 2
CMakeFiles/Makefile2:14569: recipe for target 'F-Prime/Fw/Logger/CMakeFiles/Fw_Logger_check.dir/rule' failed
make[1]: *** [F-Prime/Fw/Logger/CMakeFiles/Fw_Logger_check.dir/rule] Error 2
Makefile:4950: recipe for target 'Fw_Logger_check' failed
make: *** [Fw_Logger_check] Error 2
[ERROR] CMake erred with return code 2
```
Simply removing the extern block does it:
```sh
<username>@<containerID/systemname>:~/fprime/Fw/Logger$ nano test/ut/FakeLogger.cpp # made changes
<username>@<containerID/systemname>:~/fprime/Fw/Logger$ fprime-util purge && fprime-util generate --ut && fprime-util check
[WARNING] /home/user/fprime/settings.ini does not exist
[WARNING] fprime-tools has unexpected version. Expected: 3.1.0 found 3.1.1
[WARNING] fprime-gds has unexpected version. Expected: 3.1.1 found 3.1.2
[WARNING] /home/user/fprime/settings.ini does not exist
[WARNING] Build cache '/home/user/fprime/build-fprime-automatic-native' invalid or not found. Skipping.
[WARNING] /home/user/fprime/settings.ini does not exist
[INFO] Purge build directory at: /home/user/fprime/build-fprime-automatic-native-ut
Purge this directory (yes/no)? yes
[WARNING] /home/user/fprime/settings.ini does not exist
[WARNING] fprime-tools has unexpected version. Expected: 3.1.0 found 3.1.1
[WARNING] fprime-gds has unexpected version. Expected: 3.1.1 found 3.1.2
[INFO] Generating build directory at: /home/user/fprime/build-fprime-automatic-native-ut
[INFO] Using toolchain file None for platform default
-- The C compiler identification is Clang 9.0.0
-- The CXX compiler identification is Clang 9.0.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Searching for F prime modules in: /home/user/fprime
-- Autocoder constants file: /home/user/fprime/config/AcConstants.ini
-- Configuration header directory: /home/user/fprime/config
-- [python3] python3 found at: /usr/bin/python3
-- [fpp-tools] fpp-depend found at: /usr/local/bin/fpp-depend
-- [fpp-tools] fpp-to-xml found at: /usr/local/bin/fpp-to-xml
-- [fpp-tools] fpp-to-cpp found at: /usr/local/bin/fpp-to-cpp
-- [fpp-tools] fpp-locate-defs found at: /usr/local/bin/fpp-locate-defs
-- Target build toolchain/platform: Linux/Linux
-- Including /home/user/fprime/cmake/platform/Linux.cmake
-- Requiring thread library
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Installation directory: /home/user/fprime/build-artifacts
-- Performing CMake source prescan
-- Performing CMake source prescan - DONE
-- Generating FPP location index
-- Generating FPP location index - DONE
-- Generating FPP dependency caches
-- Generating FPP dependency caches - DONE
-- Found Python: /usr/bin/python3.8 (found version "3.8.0") found components: Interpreter 
-- Adding Library: Autocoders_Python_templates
-- Adding Unit Test: Autocoders_Python_templates_ut_exe

...

-- Adding Library: Utils_Types
-- Adding Unit Test: Types_Circular_Buffer_ut_exe
-- Configuring done
-- Generating done
-- Build files have been written to: /home/user/fprime/build-fprime-automatic-native-ut
[WARNING] /home/user/fprime/settings.ini does not exist
[WARNING] fprime-tools has unexpected version. Expected: 3.1.0 found 3.1.1
[WARNING] fprime-gds has unexpected version. Expected: 3.1.1 found 3.1.2
[  0%] Building CXX object F-Prime/Fw/Cfg/CMakeFiles/Fw_Cfg.dir/ConfigCheck.cpp.o
[  0%] Linking CXX static library ../../../lib/Linux/libFw_Cfg.a
[  0%] Built target Fw_Cfg
[ 33%] Built target codegen
[ 33%] Generating DeserialStatusEnumAi.xml, EnabledEnumAi.xml, SerialStatusEnumAi.xml
[ 33%] Generating DeserialStatusEnumAc.hpp, DeserialStatusEnumAc.cpp
Parsing Enum DeserialStatus
Completed generating files for /home/user/fprime/build-fprime-automatic-native-ut/F-Prime/Fw/Types/DeserialStatusEnumAi.xml Enum XML....
[ 33%] Generating EnabledEnumAc.hpp, EnabledEnumAc.cpp
Parsing Enum Enabled
Completed generating files for /home/user/fprime/build-fprime-automatic-native-ut/F-Prime/Fw/Types/EnabledEnumAi.xml Enum XML....
[ 33%] Generating SerialStatusEnumAc.hpp, SerialStatusEnumAc.cpp
Parsing Enum SerialStatus
Completed generating files for /home/user/fprime/build-fprime-automatic-native-ut/F-Prime/Fw/Types/SerialStatusEnumAi.xml Enum XML....
[ 33%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/Assert.cpp.o
[ 33%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/String.cpp.o
[ 33%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/InternalInterfaceString.cpp.o
[ 33%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/MallocAllocator.cpp.o
[ 33%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/MemAllocator.cpp.o
[ 33%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/PolyType.cpp.o
[ 33%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/SerialBuffer.cpp.o
[ 66%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/Serializable.cpp.o
[ 66%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/StringType.cpp.o
[ 66%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/StringUtils.cpp.o
[ 66%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/DeserialStatusEnumAc.cpp.o
[ 66%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/EnabledEnumAc.cpp.o
[ 66%] Building CXX object F-Prime/Fw/Types/CMakeFiles/Fw_Types.dir/SerialStatusEnumAc.cpp.o
[ 66%] Linking CXX static library ../../../lib/Linux/libFw_Types.a
[ 66%] Built target Fw_Types
Consolidate compiler generated dependencies of target gtest
[ 66%] Linking CXX static library /home/user/fprime/build-fprime-automatic-native-ut/lib/libgtestd.a
[ 66%] Built target gtest
Consolidate compiler generated dependencies of target gtest_main
[100%] Linking CXX static library /home/user/fprime/build-fprime-automatic-native-ut/lib/libgtest_maind.a
[100%] Built target gtest_main
[100%] Building C object F-Prime/STest/CMakeFiles/STest.dir/STest/Random/bsd_random.c.o
[100%] Building CXX object F-Prime/STest/CMakeFiles/STest.dir/STest/Random/Random.cpp.o
[100%] Building CXX object F-Prime/STest/CMakeFiles/STest.dir/STest/Pick/Pick_default.cpp.o
[100%] Building CXX object F-Prime/STest/CMakeFiles/STest.dir/STest/Pick/Pick.cpp.o
[100%] Linking CXX static library ../../lib/Linux/libSTest.a
[100%] Built target STest
[100%] Building CXX object F-Prime/Fw/Logger/CMakeFiles/Fw_Logger.dir/Logger.cpp.o
[100%] Building CXX object F-Prime/Fw/Logger/CMakeFiles/Fw_Logger.dir/LogAssert.cpp.o
[100%] Linking CXX static library ../../../lib/Linux/libFw_Logger.a
[100%] Built target Fw_Logger
[100%] Building CXX object F-Prime/Fw/Logger/CMakeFiles/Logger_Rules_Testing.dir/test/ut/FakeLogger.cpp.o
[100%] Building CXX object F-Prime/Fw/Logger/CMakeFiles/Logger_Rules_Testing.dir/test/ut/LoggerRules.cpp.o
[100%] Building CXX object F-Prime/Fw/Logger/CMakeFiles/Logger_Rules_Testing.dir/test/ut/Main.cpp.o
[100%] Linking CXX executable ../../../bin/Linux/Logger_Rules_Testing
[100%] Built target Logger_Rules_Testing
UpdateCTestConfiguration  from :/home/user/fprime/build-fprime-automatic-native-ut/F-Prime/Fw/Logger/DartConfiguration.tcl
UpdateCTestConfiguration  from :/home/user/fprime/build-fprime-automatic-native-ut/F-Prime/Fw/Logger/DartConfiguration.tcl
Test project /home/user/fprime/build-fprime-automatic-native-ut/F-Prime/Fw/Logger
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: Logger_Rules_Testing

1: Test command: /home/user/fprime/build-fprime-automatic-native-ut/bin/Linux/Logger_Rules_Testing
1: Working Directory: /home/user/fprime/build-fprime-automatic-native-ut/F-Prime/Fw/Logger
1: Test timeout computed to be: 10000000
1: [STest::Random] Generated seed 719213 from system time
1: [==========] Running 4 tests from 1 test suite.
1: [----------] Global test environment set-up.
1: [----------] 4 tests from LoggerTests
1: [ RUN      ] LoggerTests.RandomLoggerTests
1: Ran 10000 steps.
1: [       OK ] LoggerTests.RandomLoggerTests (23 ms)
1: [ RUN      ] LoggerTests.BassicGoodLogger
1: [       OK ] LoggerTests.BassicGoodLogger (0 ms)
1: [ RUN      ] LoggerTests.BassicBadLogger
1: [       OK ] LoggerTests.BassicBadLogger (0 ms)
1: [ RUN      ] LoggerTests.BassicRegLogger
1: [       OK ] LoggerTests.BassicRegLogger (0 ms)
1: [----------] 4 tests from LoggerTests (24 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 4 tests from 1 test suite ran. (24 ms total)
1: [  PASSED  ] 4 tests.
1/1 Test #1: Logger_Rules_Testing .............   Passed    0.04 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.04 sec
[100%] Built target Fw_Logger_check
```