### PR TITLE
Update/less angry i2c driver

### DIFF
--- a/Drv/I2cDriverPorts/I2cDriverPorts.fpp
+++ b/Drv/I2cDriverPorts/I2cDriverPorts.fpp
@@ -16,7 +16,8 @@ module Drv {
     I2C_ADDRESS_ERR = 1 @< I2C address invalid
     I2C_WRITE_ERR = 2 @< I2C write failed
     I2C_READ_ERR = 3 @< I2C read failed
-    I2C_OTHER_ERR = 4 @< Other errors that don't fit
+    I2C_OPEN_ERR = 4 @< I2C driver failed to open device
+    I2C_OTHER_ERR = 5 @< Other errors that don't fit
   }
 
 }

--- a/Drv/LinuxI2cDriver/LinuxI2cDriver.cpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriver.cpp
@@ -76,7 +76,9 @@ namespace Drv {
     )
   {
       // Make sure file has been opened
-      FW_ASSERT(-1 != this->m_fd);
+      if (-1 == this->m_fd) {
+          return I2cStatus::I2C_OPEN_ERR;
+      }
 
 #if DEBUG_PRINT
       Fw::Logger::logMsg("I2c addr: 0x%02X\n",addr);
@@ -115,7 +117,9 @@ namespace Drv {
     )
   {
       // Make sure file has been opened
-      FW_ASSERT(-1 != this->m_fd);
+      if (-1 == this->m_fd) {
+          return I2cStatus::I2C_OPEN_ERR;
+      }
 
 #if DEBUG_PRINT
       Fw::Logger::logMsg("I2c addr: 0x%02X\n",addr);
@@ -157,6 +161,9 @@ namespace Drv {
   ){
 
     // Make sure file has been opened
+    if (-1 == this->m_fd) {
+        return I2cStatus::I2C_OPEN_ERR;
+    }
     FW_ASSERT(-1 != this->m_fd);
 
     // make sure they are not null pointers
@@ -195,7 +202,7 @@ namespace Drv {
         Fw::Logger::logMsg("Status: %d Errno: %d\n", stat, errno);
       #endif
       //Because we're using ioctl to perform the transaction we dont know exactly the type of error that occurred
-      return Drv::I2cStatus::I2C_OTHER_ERR;
+      return I2cStatus::I2C_OTHER_ERR;
     }
 
 #if DEBUG_PRINT


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Currently the Linux I2C driver fails on an FW_ASSERT when the I2C driver fails to open the device and a subsequent call comes in to read/write.  This proves restricting as often the calls to read/write come from a component not involved in the `open` process and are driven out of the static topology (e.g. a rate group).  Asserting almost guarantees the software cannot and will not run in the event that the I2C device fails to open.

This PR reduces that restriction.  Users can still ASSERT using the following pattern:

```
FW_ASSERT(i2cDriver.open() == SUCCESS)

or 

FW_ASSERT(readI2C_out() != I2cStatus::I2C_OPEN_ERR);
```

But should an assert be declined, the driver itself will report an error and not assert.

## Rationale

Failing to open a file is an error that can occur outside of software.  Communicating this failure to components "managing" I2C devices is convoluted.  Asserting on a device that attempts a read after an open failure doesn't make sense in all cases and thus should not be forced by the I2C implementation.

Users who want asserts can easily replicate the behavior as shown above.

## Testing/Review Recommendations

Should be put in system reference and ensured to function as expected

## Future Work

None.