### PR TITLE
FPP CMake integration

### DIFF
--- a/cmake/autocoder/ai_xml.cmake
+++ b/cmake/autocoder/ai_xml.cmake
@@ -19,11 +19,16 @@ autocoder_setup_for_individual_sources()
 ####
 function(ai_xml_is_supported AC_INPUT_FILE)
     ends_with(IS_SUPPORTED "${AC_INPUT_FILE}" "Ai.xml")
+    set(PREVIOUSLY_GENERATED)
+    if (ARGC GREATER_EQUAL 2)
+        set(PREVIOUSLY_GENERATED ${ARGV2})
+    endif()
+
     # Don't generate cpp/hpp files that have already been generated
     if (IS_SUPPORTED)
         string(REPLACE "Ai.xml" "Ac.cpp" CPP_FILE "${AC_INPUT_FILE}")
         string(REPLACE "Ai.xml" "Ac.hpp" HPP_FILE "${AC_INPUT_FILE}")
-        if(("${CPP_FILE}" IN_LIST ARGN) AND ("${HPP_FILE}" IN_LIST ARGN))
+	if(("${CPP_FILE}" IN_LIST PREVIOUSLY_GENERATED) AND ("${HPP_FILE}" IN_LIST PREVIOUSLY_GENERATED))
             set(IS_SUPPORTED FALSE)
         endif()
     endif()

--- a/cmake/autocoder/ai_xml.cmake
+++ b/cmake/autocoder/ai_xml.cmake
@@ -15,9 +15,20 @@ autocoder_setup_for_individual_sources()
 #
 # Required function, processes ComponentAi.xml files.
 # `AC_INPUT_FILE` potential input to the autocoder
+# ...: any number of arguments representing a list of previously generated files
 ####
 function(ai_xml_is_supported AC_INPUT_FILE)
-    autocoder_support_by_suffix("Ai.xml" "${AC_INPUT_FILE}")
+    ends_with(IS_SUPPORTED "${AC_INPUT_FILE}" "Ai.xml")
+    # Don't generate cpp/hpp files that have already been generated
+    if (IS_SUPPORTED)
+        string(REPLACE "Ai.xml" "Ac.cpp" CPP_FILE "${AC_INPUT_FILE}")
+        string(REPLACE "Ai.xml" "Ac.hpp" HPP_FILE "${AC_INPUT_FILE}")
+        if(("${CPP_FILE}" IN_LIST ARGN) AND ("${HPP_FILE}" IN_LIST ARGN))
+            set(IS_SUPPORTED FALSE)
+        endif()
+    endif()
+    # Note: set in PARENT_SCOPE in macro is intended. Caller **wants** to set IS_SUPPORTED in their parent's scope.
+    set(IS_SUPPORTED "${IS_SUPPORTED}" PARENT_SCOPE)
 endfunction (ai_xml_is_supported)
 
 ####

--- a/cmake/autocoder/autocoder.cmake
+++ b/cmake/autocoder/autocoder.cmake
@@ -192,7 +192,7 @@ function(_filter_sources OUTPUT_NAME GENERATED_SOURCES)
     # Loop over the list and check
     foreach (SOURCE_LIST IN LISTS ARGN)
         foreach(SOURCE IN LISTS SOURCE_LIST)
-            cmake_language(CALL "${AUTOCODER_NAME}_is_supported" "${SOURCE}" ${GENERATED_SOURCES})
+            cmake_language(CALL "${AUTOCODER_NAME}_is_supported" "${SOURCE}" "${GENERATED_SOURCES}")
             if (IS_SUPPORTED)
                 list(APPEND OUTPUT_LIST "${SOURCE}")
             endif()

--- a/cmake/autocoder/autocoder.cmake
+++ b/cmake/autocoder/autocoder.cmake
@@ -55,7 +55,7 @@ function(run_ac AUTOCODER_CMAKE SOURCES GENERATED_SOURCES)
     plugin_include_helper(AUTOCODER_NAME "${AUTOCODER_CMAKE}" is_supported setup_autocode get_generated_files get_dependencies)
     # Normalize and filter source paths so that what we intend to run is in a standard form
     normalize_paths(AC_INPUT_SOURCES "${SOURCES}" "${GENERATED_SOURCES}")
-    _filter_sources(AC_INPUT_SOURCES "${AC_INPUT_SOURCES}")
+    _filter_sources(AC_INPUT_SOURCES "${GENERATED_SOURCES}" "${AC_INPUT_SOURCES}")
 
     # Break early if there are no sources, no need to autocode nothing
     if (NOT AC_INPUT_SOURCES)
@@ -184,14 +184,15 @@ endfunction()
 # including an autocoder's CMake file and thus setting the active autocoder. Helper function.
 #
 # OUTPUT_NAME: name of output variable to set in parent scope
+# GENERATED_SOURCES: sources created by other autocoders
 # ...: any number of arguments containing lists of sources
 ####
-function(_filter_sources OUTPUT_NAME)
+function(_filter_sources OUTPUT_NAME GENERATED_SOURCES)
     set(OUTPUT_LIST)
     # Loop over the list and check
     foreach (SOURCE_LIST IN LISTS ARGN)
         foreach(SOURCE IN LISTS SOURCE_LIST)
-            cmake_language(CALL "${AUTOCODER_NAME}_is_supported" "${SOURCE}")
+            cmake_language(CALL "${AUTOCODER_NAME}_is_supported" "${SOURCE}" "${GENERATED_SOURCES}")
             if (IS_SUPPORTED)
                 list(APPEND OUTPUT_LIST "${SOURCE}")
             endif()

--- a/cmake/autocoder/autocoder.cmake
+++ b/cmake/autocoder/autocoder.cmake
@@ -192,7 +192,7 @@ function(_filter_sources OUTPUT_NAME GENERATED_SOURCES)
     # Loop over the list and check
     foreach (SOURCE_LIST IN LISTS ARGN)
         foreach(SOURCE IN LISTS SOURCE_LIST)
-            cmake_language(CALL "${AUTOCODER_NAME}_is_supported" "${SOURCE}" "${GENERATED_SOURCES}")
+            cmake_language(CALL "${AUTOCODER_NAME}_is_supported" "${SOURCE}" ${GENERATED_SOURCES})
             if (IS_SUPPORTED)
                 list(APPEND OUTPUT_LIST "${SOURCE}")
             endif()


### PR DESCRIPTION
## Change Description

- Add parameter`GENERATED_SOURCES`, a list of sources generated by previous autocoders, to the `_filter_sources` function in `cmake/autocoder/autocoder.cmake`
- Change the `ai_xml_is_supported` function in `cmake/autocoder/ai_xml.cmake` to also filter sources against previously generated sources. This means that XML autocoder will only receive Ai.xml files whose corresponding Ac.cpp and Ac.hpp files have not already been generated by the FPP autocoder, preventing it from overwriting those files.

## Rationale

This change is necessary to support FPP v1.1.0, which will include C++ code generation for FPP enums, arrays, and structs, intended to replace the XML autocoder's C++ code generation for enums, arrays, and structs.
