### PR TITLE
lestarch: removing permissions-intensive report step

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -42,18 +42,3 @@ jobs:
           cspell:html/html.txt
           cspell:fullstack/fullstack.txt
         check_extra_dictionaries: ''
-
-  comment:
-    name: Report
-    runs-on: ubuntu-latest
-    needs: spelling
-    permissions:
-      contents: write
-      pull-requests: write
-    if: (success() || failure()) && needs.spelling.outputs.followup
-    steps:
-    - name: comment
-      uses: check-spelling/check-spelling@v0.0.20
-      with:
-        checkout: true
-        task: ${{ needs.spelling.outputs.followup }}


### PR DESCRIPTION
It is very hard to prove this step does not have a vulnerability allowing writ-access.  Scrubbing this step pending deeper security analysis.

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The reporting step of the spell checker requires extended permission that requires and extensive security review.  We were getting security reports on this step, so we are disabling for the time being.

Missspellings are available in the summary section of the job just like compile failures etc.