### PR TITLE
enhanced watchdogtimer capabilities

### DIFF
--- a/Os/Linux/WatchdogTimer.cpp
+++ b/Os/Linux/WatchdogTimer.cpp
@@ -1,4 +1,5 @@
 #include <Os/WatchdogTimer.hpp>
+#include <Fw/Types/Assert.hpp>
 
 namespace Os {
 
@@ -26,12 +27,9 @@ namespace Os {
         return WATCHDOG_CANCEL_ERROR;
     }
 
-    void* WatchdogTimer::getParameter() {
-        return m_parameter;
-    }
-
-    WatchdogTimer::WatchdogCb WatchdogTimer::getCallback() {
-        return m_cb;
+    void WatchdogTimer::expire() {
+        FW_ASSERT(m_cb != nullptr);
+        m_cb(m_parameter);
     }
 
 }

--- a/Os/Linux/WatchdogTimer.cpp
+++ b/Os/Linux/WatchdogTimer.cpp
@@ -26,6 +26,14 @@ namespace Os {
         return WATCHDOG_CANCEL_ERROR;
     }
 
+    void* WatchdogTimer::getParameter() {
+        return m_parameter;
+    }
+
+    WatchdogTimer::WatchdogCb WatchdogTimer::getCallback() {
+        return m_cb;
+    }
+
 }
 
 

--- a/Os/WatchdogTimer.hpp
+++ b/Os/WatchdogTimer.hpp
@@ -31,6 +31,10 @@ namespace Os {
 
             WatchdogStatus cancel(); //!< cancel timer
 
+            void* getParameter(); //!< Getter for parameter
+
+            WatchdogCb getCallback(); //!< Getter for function callback pointer
+
 
         private:
 

--- a/Os/WatchdogTimer.hpp
+++ b/Os/WatchdogTimer.hpp
@@ -31,10 +31,7 @@ namespace Os {
 
             WatchdogStatus cancel(); //!< cancel timer
 
-            void* getParameter(); //!< Getter for parameter
-
-            WatchdogCb getCallback(); //!< Getter for function callback pointer
-
+            void expire(); //!< Invoke the callback function with m_parameter
 
         private:
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Kevin |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adding two getters in WatchdogTimers.

## Rationale

I discovered these two getters were missing when working with the WatchdogTimer. These two getters are needed in my VxWorks project.

## Testing/Review Recommendations



## Future Work


