### PR TITLE
lestarch: adding join for the UART driver thread

### DIFF
--- a/Drv/LinuxUartDriver/LinuxUartDriver.cpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.cpp
@@ -368,4 +368,8 @@ void LinuxUartDriver ::quitReadThread() {
     this->m_quitReadThread = true;
 }
 
+Os::Task::TaskStatus LinuxUartDriver ::join(void** value_ptr) {
+    return m_readTask.join(value_ptr);
+}
+
 }  // end namespace Drv

--- a/Drv/LinuxUartDriver/LinuxUartDriver.hpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.hpp
@@ -55,6 +55,9 @@ class LinuxUartDriver : public LinuxUartDriverComponentBase {
     //! Quit thread
     void quitReadThread();
 
+    //! Join thread
+    Os::Task::TaskStatus join(void** value_ptr);
+
     //! Destroy object LinuxUartDriver
     //!
     ~LinuxUartDriver();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The `Drv::LinuxUartDriver` was missing a `join` call to its read task.  Thus it could not be cleanly shutdown.  This fixes the missing function.