### PR TITLE
Adding modular dependencies to enable compiling with shared libraries

### DIFF
--- a/Drv/DataTypes/CMakeLists.txt
+++ b/Drv/DataTypes/CMakeLists.txt
@@ -10,4 +10,8 @@ set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/DataBuffer.cpp"
 )
 
+set(MOD_DEPS
+    Fw/Port
+)
+
 register_fprime_module()

--- a/Svc/Cycle/CMakeLists.txt
+++ b/Svc/Cycle/CMakeLists.txt
@@ -12,5 +12,6 @@ set(SOURCE_FILES
 )
 set(MOD_DEPS
     Os
+    Fw/Port
 )
 register_fprime_module()

--- a/Svc/Fatal/CMakeLists.txt
+++ b/Svc/Fatal/CMakeLists.txt
@@ -10,4 +10,8 @@ set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/Fatal.fpp"
 )
 
+set(MOD_DEPS
+    Fw/Port
+)
+
 register_fprime_module()

--- a/Svc/FileDownlinkPorts/CMakeLists.txt
+++ b/Svc/FileDownlinkPorts/CMakeLists.txt
@@ -9,4 +9,10 @@
 set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/FileDownlinkPorts.fpp"
 )
+
+set(MOD_DEPS
+    Fw/Types
+    Fw/Port
+)
+
 register_fprime_module()

--- a/Svc/Ping/CMakeLists.txt
+++ b/Svc/Ping/CMakeLists.txt
@@ -10,4 +10,8 @@ set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/Ping.fpp"
 )
 
+set(MOD_DEPS
+    Fw/Port    
+)
+
 register_fprime_module()

--- a/Svc/Sched/CMakeLists.txt
+++ b/Svc/Sched/CMakeLists.txt
@@ -10,4 +10,8 @@ set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/Sched.fpp"
 )
 
+set(MOD_DEPS
+    Fw/Port
+)
+
 register_fprime_module()

--- a/Svc/Seq/CMakeLists.txt
+++ b/Svc/Seq/CMakeLists.txt
@@ -10,4 +10,8 @@ set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/Seq.fpp"
 )
 
+set(MOD_DEPS
+    Fw/Port
+)
+
 register_fprime_module()

--- a/Svc/WatchDog/CMakeLists.txt
+++ b/Svc/WatchDog/CMakeLists.txt
@@ -10,4 +10,8 @@ set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/WatchDog.fpp"
 )
 
+set(MOD_DEPS
+    Fw/Port
+)
+
 register_fprime_module()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Added modular dependencies to CmakeLists.txt for port type folders in `Drv/` and `Svc/` to enable compilation with the cmake flag `BUILD_SHARED_LIBS` set to ON. 

## Rationale

These additions are necessary for users who need to build with shared libs. 

## Testing/Review Recommendations

Built the Ref deployment with and without the `BUILD_SHARED_LIBS` flag, and the deployment builds successfully. I also tested this with an external deployment and it built successfully. However, it is possible that there are additional changes required for other components/ports that were not included in the Ref or my external deployments.

## Future Work

It would be a good idea to include this in the CI workflow so that this functionality is continually supported!
