### PR TITLE
Raise proper exceptions in python generators

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/AbstractGenerator.py
+++ b/Autocoders/Python/src/fprime_ac/generators/AbstractGenerator.py
@@ -57,7 +57,7 @@ class AbstractGenerator:
         Main execution point.
         Calls the accept method on each visitor to generate the code.
         """
-        raise Exception(
+        raise NotImplementedError(
             "AbstractGenerator.__call__() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -65,7 +65,7 @@ class AbstractGenerator:
         """
         Execute the visit call on this object.
         """
-        raise Exception(
+        raise NotImplementedError(
             "AbstractFace.accept.accept(v) - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -73,6 +73,6 @@ class AbstractGenerator:
         """
         Method to add the visitor to a list of visitors.
         """
-        raise Exception(
+        raise NotImplementedError(
             "AbstractFace.accept.addVisitor(v) - Implementation Error: you must supply your own concrete implementation."
         )

--- a/Autocoders/Python/src/fprime_ac/generators/ChannelBody.py
+++ b/Autocoders/Python/src/fprime_ac/generators/ChannelBody.py
@@ -79,7 +79,7 @@ class ChannelBody:
             DEBUG.error(
                 "ChannelBody.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "ChannelBody.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class ChannelBody:
             DEBUG.error(
                 "ChannelBody.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "ChannelBody.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/ChannelHeader.py
+++ b/Autocoders/Python/src/fprime_ac/generators/ChannelHeader.py
@@ -79,7 +79,7 @@ class ChannelHeader:
             DEBUG.error(
                 "ChannelHeader.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "ChannelHeader.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class ChannelHeader:
             DEBUG.error(
                 "ChannelHeader.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "ChannelHeader.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/CommandBody.py
+++ b/Autocoders/Python/src/fprime_ac/generators/CommandBody.py
@@ -79,7 +79,7 @@ class CommandBody:
             DEBUG.error(
                 "startCommandVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "startCommandVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class CommandBody:
             DEBUG.error(
                 "startCommandVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "startCommandVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/CommandHeader.py
+++ b/Autocoders/Python/src/fprime_ac/generators/CommandHeader.py
@@ -79,7 +79,7 @@ class CommandHeader:
             DEBUG.error(
                 "CommandHeader.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "CommandHeader.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class CommandHeader:
             DEBUG.error(
                 "CommandHeader.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "CommandHeader.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/DictBody.py
+++ b/Autocoders/Python/src/fprime_ac/generators/DictBody.py
@@ -79,7 +79,7 @@ class DictBody:
             DEBUG.error(
                 "DictBodyVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "DictBodyVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class DictBody:
             DEBUG.error(
                 "DictBodyVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "DictBodyVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/DictHeader.py
+++ b/Autocoders/Python/src/fprime_ac/generators/DictHeader.py
@@ -79,7 +79,7 @@ class DictHeader:
             DEBUG.error(
                 "DictHeaderVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "DictHeaderVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class DictHeader:
             DEBUG.error(
                 "DictHeaderVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "DictHeaderVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/DictStart.py
+++ b/Autocoders/Python/src/fprime_ac/generators/DictStart.py
@@ -79,7 +79,7 @@ class DictStart:
             DEBUG.error(
                 "DictStartVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "DictStartVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class DictStart:
             DEBUG.error(
                 "DictStartVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "DictStartVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/EventBody.py
+++ b/Autocoders/Python/src/fprime_ac/generators/EventBody.py
@@ -79,7 +79,7 @@ class EventBody:
             DEBUG.error(
                 "EventBody.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "EventBody.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class EventBody:
             DEBUG.error(
                 "EventBody.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "EventBody.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/EventHeader.py
+++ b/Autocoders/Python/src/fprime_ac/generators/EventHeader.py
@@ -79,7 +79,7 @@ class EventHeader:
             DEBUG.error(
                 "EventHeader.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "EventHeader.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class EventHeader:
             DEBUG.error(
                 "EventHeader.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "EventHeader.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/FinishSource.py
+++ b/Autocoders/Python/src/fprime_ac/generators/FinishSource.py
@@ -79,7 +79,7 @@ class FinishSource:
             DEBUG.error(
                 "FinishSource.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "FinishSource.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class FinishSource:
             DEBUG.error(
                 "FinishSource.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "FinishSource.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/HtmlDocPage.py
+++ b/Autocoders/Python/src/fprime_ac/generators/HtmlDocPage.py
@@ -79,7 +79,7 @@ class HtmlDocPage:
             DEBUG.error(
                 "HtmlDoc.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "HtmlDoc.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class HtmlDocPage:
             DEBUG.error(
                 "HtmlDoc.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "HtmlDoc.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/HtmlStartPage.py
+++ b/Autocoders/Python/src/fprime_ac/generators/HtmlStartPage.py
@@ -79,7 +79,7 @@ class HtmlStartPage:
             DEBUG.error(
                 "HtmlStartPage.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "HtmlStartPage.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class HtmlStartPage:
             DEBUG.error(
                 "HtmlStartPage.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "HtmlStartPage.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/Includes1.py
+++ b/Autocoders/Python/src/fprime_ac/generators/Includes1.py
@@ -79,7 +79,7 @@ class Includes1:
             DEBUG.error(
                 "Includes1.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Includes1.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class Includes1:
             DEBUG.error(
                 "Includes1.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Includes1.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/Includes2.py
+++ b/Autocoders/Python/src/fprime_ac/generators/Includes2.py
@@ -79,7 +79,7 @@ class Includes2:
             DEBUG.error(
                 "Includes2.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Includes2.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class Includes2:
             DEBUG.error(
                 "Includes2.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Includes2.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/InitFiles.py
+++ b/Autocoders/Python/src/fprime_ac/generators/InitFiles.py
@@ -80,7 +80,7 @@ class InitFiles:
             DEBUG.error(
                 "InitFiles.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "InitFiles.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -95,7 +95,7 @@ class InitFiles:
             DEBUG.error(
                 "InitFiles.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "InitFiles.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/InstanceDictBody.py
+++ b/Autocoders/Python/src/fprime_ac/generators/InstanceDictBody.py
@@ -79,7 +79,7 @@ class InstanceDictBody:
             DEBUG.error(
                 "InstanceDictBodyVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "InstanceDictBodyVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class InstanceDictBody:
             DEBUG.error(
                 "InstanceDictBodyVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "InstanceDictBodyVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/InstanceDictHeader.py
+++ b/Autocoders/Python/src/fprime_ac/generators/InstanceDictHeader.py
@@ -79,7 +79,7 @@ class InstanceDictHeader:
             DEBUG.error(
                 "InstanceDictHeaderVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "InstanceDictHeaderVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class InstanceDictHeader:
             DEBUG.error(
                 "InstanceDictHeaderVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "InstanceDictHeaderVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/InstanceDictStart.py
+++ b/Autocoders/Python/src/fprime_ac/generators/InstanceDictStart.py
@@ -79,7 +79,7 @@ class InstanceDictStart:
             DEBUG.error(
                 "InstanceDictStartVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "InstanceDictStartVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class InstanceDictStart:
             DEBUG.error(
                 "InstanceDictStartVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "InstanceDictStartVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/MdDocPage.py
+++ b/Autocoders/Python/src/fprime_ac/generators/MdDocPage.py
@@ -79,7 +79,7 @@ class MdDocPage:
             DEBUG.error(
                 "MdDoc.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "MdDoc.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class MdDocPage:
             DEBUG.error(
                 "MdDoc.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "MdDoc.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/MdStartPage.py
+++ b/Autocoders/Python/src/fprime_ac/generators/MdStartPage.py
@@ -79,7 +79,7 @@ class MdStartPage:
             DEBUG.error(
                 "MDStartPage.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "MdStartPage.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class MdStartPage:
             DEBUG.error(
                 "MdStartPage.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "MdStartPage.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/Namespace.py
+++ b/Autocoders/Python/src/fprime_ac/generators/Namespace.py
@@ -80,7 +80,7 @@ class Namespace:
             DEBUG.error(
                 "Namespace.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Namespace.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -95,7 +95,7 @@ class Namespace:
             DEBUG.error(
                 "Namespace.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Namespace.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/Private.py
+++ b/Autocoders/Python/src/fprime_ac/generators/Private.py
@@ -79,7 +79,7 @@ class Private:
             DEBUG.error(
                 "Private.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Private.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class Private:
             DEBUG.error(
                 "Private.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Private.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/Protected.py
+++ b/Autocoders/Python/src/fprime_ac/generators/Protected.py
@@ -79,7 +79,7 @@ class Protected:
             DEBUG.error(
                 "Protected.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Protected.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class Protected:
             DEBUG.error(
                 "Protected.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Protected.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/Public.py
+++ b/Autocoders/Python/src/fprime_ac/generators/Public.py
@@ -79,7 +79,7 @@ class Public:
             DEBUG.error(
                 "Public.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Public.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class Public:
             DEBUG.error(
                 "Public.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "Public.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/StartChannel.py
+++ b/Autocoders/Python/src/fprime_ac/generators/StartChannel.py
@@ -79,7 +79,7 @@ class StartChannel:
             DEBUG.error(
                 "startChannelVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "startChannelVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class StartChannel:
             DEBUG.error(
                 "startChannelVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "startChannelVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/StartCommand.py
+++ b/Autocoders/Python/src/fprime_ac/generators/StartCommand.py
@@ -79,7 +79,7 @@ class StartCommand:
             DEBUG.error(
                 "startCommandVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "startCommandVisit.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class StartCommand:
             DEBUG.error(
                 "startCommandVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "startCommandVisit.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/StartEvent.py
+++ b/Autocoders/Python/src/fprime_ac/generators/StartEvent.py
@@ -79,7 +79,7 @@ class StartEvent:
             DEBUG.error(
                 "StartEvent.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "StartEvent.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -94,7 +94,7 @@ class StartEvent:
             DEBUG.error(
                 "StartEvent.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "StartEvent.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/StartSource.py
+++ b/Autocoders/Python/src/fprime_ac/generators/StartSource.py
@@ -80,7 +80,7 @@ class StartSource:
             DEBUG.error(
                 "StartSource.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "StartSource.accept() - the given visitor is not a subclass of AbstractVisitor!"
             )
 
@@ -95,7 +95,7 @@ class StartSource:
             DEBUG.error(
                 "StartSource.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
-            raise Exception(
+            raise TypeError(
                 "StartSource.addVisitor(v) - the given visitor is not a subclass of AbstractVisitor!"
             )
 

--- a/Autocoders/Python/src/fprime_ac/generators/formatters.py
+++ b/Autocoders/Python/src/fprime_ac/generators/formatters.py
@@ -705,7 +705,7 @@ class Formatters:
                 "ERROR: DETECTED AN INVALID CHARACTER IN COMMAND STEM NAME (%s)."
                 % name_string
             )
-            raise Exception(
+            raise ValueError(
                 "Fatal error, detected an invalid character in command stem name."
             )
         # All is ok
@@ -728,7 +728,7 @@ class Formatters:
         for c in cmds:
             if sum([int(x == c) for x in cmds]) > 1:
                 PRINT.info("ERROR: DETECTED %s COMMAND STEM NAME REPEATED." % c)
-                raise Exception("Error detected repeated command stem name.")
+                raise ValueError("Error detected repeated command stem name.")
         return True
 
     def evrNamePrefix(self, name):
@@ -1119,14 +1119,14 @@ class Formatters:
                 "ERROR: No left paren in function name passed to formatFun: %s."
                 % one_line
             )
-            raise Exception("No left paren in function name passed to formatFun.")
+            raise ValueError("No left paren in function name passed to formatFun.")
 
         two_chunks = one_line.split("(")
         if len(two_chunks) != 2:
             PRINT.info(
                 "ERROR: Too many left parens in name passed to formatFun: %s" % one_line
             )
-            raise Exception("Too many left parens in name passed to formatFun.")
+            raise ValueError("Too many left parens in name passed to formatFun.")
 
         type_and_name = two_chunks[0]
         args = two_chunks[1]

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/AbstractVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/AbstractVisitor.py
@@ -67,7 +67,7 @@ class AbstractVisitor:
         Defined to generate files for generated code products.
         @param args: the instance of the concrete element to operation on.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# AbstractVisitor.initFilesVisit() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -75,7 +75,7 @@ class AbstractVisitor:
         """
         Defined to generate starting static code within files.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# AbstractVisitor.startSourceFilesVisit() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -85,7 +85,7 @@ class AbstractVisitor:
         Usually used for the base classes but also for Port types
         @param args: the instance of the concrete element to operation on.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# AbstractVisitor.includesVisit1() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -95,7 +95,7 @@ class AbstractVisitor:
         Usually used for data type includes and system includes.
         @param args: the instance of the concrete element to operation on.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# AbstractVisitor.includesVisit2() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -105,7 +105,7 @@ class AbstractVisitor:
         Also any pre-condition code is generated.
         @param args: the instance of the concrete element to operation on.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# AbstractVisitor.namespaceVisit() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -114,7 +114,7 @@ class AbstractVisitor:
         Defined to generate public stuff within a class.
         @param args: the instance of the concrete element to operation on.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# AbstractVisitor.publicVisit() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -123,7 +123,7 @@ class AbstractVisitor:
         Defined to generate protected stuff within a class.
         @param args: the instance of the concrete element to operation on.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# AbstractVisitor.protectedVisit() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -132,7 +132,7 @@ class AbstractVisitor:
         Defined to generate private stuff within a class.
         @param args: the instance of the concrete element to operation on.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# AbstractVisitor.privateVisit() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -140,7 +140,7 @@ class AbstractVisitor:
         """
         Defined to generate ending static code within files.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# AbstractVisitor.endSourceFilesVisit() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -148,7 +148,7 @@ class AbstractVisitor:
         """
         Defined to generate start of command Python class.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# DictStartVisit.startCommandVisit() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -156,7 +156,7 @@ class AbstractVisitor:
         """
         Defined to generate header for Python command class.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# DictStartVisit.commandHeaderVisit() - Implementation Error: you must supply your own concrete implementation."
         )
 
@@ -164,7 +164,7 @@ class AbstractVisitor:
         """
         Defined to generate body for Python command class.
         """
-        raise Exception(
+        raise NotImplementedError(
             "# DictStartVisit.commandBodyVisit() - Implementation Error: you must supply your own concrete implementation."
         )
 

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/CommandVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/CommandVisitor.py
@@ -131,7 +131,7 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
             if len(obj.get_set_opcodes()) == 1:
                 # set/save opcode numbers had better match
                 if len(obj.get_set_opcodes()) != len(obj.get_save_opcodes()):
-                    raise Exception("set/save opcode quantities do not match!")
+                    raise ValueError("set/save opcode quantities do not match!")
                 pyfile = "{}/{}_PRM_SET.py".format(output_dir, self.__stem)
                 fd = open(pyfile, "w")
                 if fd is None:

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceChannelVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceChannelVisitor.py
@@ -176,7 +176,7 @@ class InstanceChannelVisitor(AbstractVisitor.AbstractVisitor):
             c.name = fname
 
             if len(obj.get_ids()) > 1:
-                raise Exception(
+                raise ValueError(
                     "There is more than one event id when creating dictionaries. Check xml of {} or see if multiple explicit IDs exist in the AcConstants.ini file".format(
                         fname
                     )

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceEventVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceEventVisitor.py
@@ -179,7 +179,7 @@ class InstanceEventVisitor(AbstractVisitor.AbstractVisitor):
             c.name = fname
 
             if len(obj.get_ids()) > 1:
-                raise Exception(
+                raise ValueError(
                     "There is more than one event id when creating dictionaries. Check xml of {} or see if multiple explicit IDs exist in the AcConstants.ini file".format(
                         fname
                     )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Change exception classes to less broad. E.g. Exception -> NotImplementedError

## Rationale

Raising and catching `Exception' directly is not recommended in python. There are plenty built in exceptions to be used instead.

## Testing/Review Recommendations

Please refer to python2 docs

https://python.readthedocs.io/en/v2.7.2/library/exceptions.html

## Future Work

Consider migrating to python3, as python2 EOL is already reached.
