### PR TITLE
Remove unnecessary checks in python generators

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ChannelVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ChannelVisitor.py
@@ -99,8 +99,6 @@ class ChannelVisitor(AbstractVisitor.AbstractVisitor):
         if len(obj.get_ids()) == 1:
             pyfile = "{}/{}.py".format(output_dir, obj.get_name())
             fd = open(pyfile, "w")
-            if fd is None:
-                raise Exception(f"Could not open {pyfile} file.")
             self.__fp.append(fd)
         else:
             inst = 0
@@ -109,8 +107,6 @@ class ChannelVisitor(AbstractVisitor.AbstractVisitor):
                 inst += 1
                 DEBUG.info(f"Open file: {pyfile}")
                 fd = open(pyfile, "w")
-                if fd is None:
-                    raise Exception(f"Could not open {pyfile} file.")
                 DEBUG.info(f"Completed {pyfile} open")
                 self.__fp.append(fd)
 

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/CommandVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/CommandVisitor.py
@@ -108,8 +108,6 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
             if len(obj.get_opcodes()) == 1:
                 pyfile = "{}/{}.py".format(output_dir, obj.get_mnemonic())
                 fd = open(pyfile, "w")
-                if fd is None:
-                    raise Exception(f"Could not open {pyfile} file.")
                 self.__fp1.append(fd)
             else:
                 inst = 0
@@ -118,8 +116,6 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                     inst += 1
                     DEBUG.info(f"Open file: {pyfile}")
                     fd = open(pyfile, "w")
-                    if fd is None:
-                        raise Exception(f"Could not open {pyfile} file.")
                     DEBUG.info(f"Completed {pyfile} open")
                     self.__fp1.append(fd)
         elif type(obj) is Parameter.Parameter:
@@ -134,14 +130,10 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                     raise Exception("set/save opcode quantities do not match!")
                 pyfile = "{}/{}_PRM_SET.py".format(output_dir, self.__stem)
                 fd = open(pyfile, "w")
-                if fd is None:
-                    raise Exception(f"Could not open {pyfile} file.")
                 self.__fp1.append(fd)
 
                 pyfile = "{}/{}_PRM_SAVE.py".format(output_dir, self.__stem)
                 fd = open(pyfile, "w")
-                if fd is None:
-                    raise Exception(f"Could not open {pyfile} file.")
                 self.__fp2.append(fd)
             else:
                 inst = 0
@@ -149,16 +141,12 @@ class CommandVisitor(AbstractVisitor.AbstractVisitor):
                     pyfile = "%s/%s_%d_PRM_SET.py" % (output_dir, self.__stem, inst)
                     DEBUG.info(f"Open file: {pyfile}")
                     fd = open(pyfile, "w")
-                    if fd is None:
-                        raise Exception(f"Could not open {pyfile} file.")
                     self.__fp1.append(fd)
                     DEBUG.info(f"Completed {pyfile} open")
 
                     pyfile = "%s/%s_%d_PRM_SAVE.py" % (output_dir, self.__stem, inst)
                     DEBUG.info(f"Open file: {pyfile}")
                     fd = open(pyfile, "w")
-                    if fd is None:
-                        raise Exception(f"Could not open {pyfile} file.")
                     self.__fp2.append(fd)
                     inst += 1
                     DEBUG.info(f"Completed {pyfile} open")

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -865,8 +865,6 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
         """
         DEBUG.info("Open file: %s" % filename)
         self.__fp = open(filename, "w")
-        if self.__fp is None:
-            raise Exception("Could not open file %s") % filename
         DEBUG.info("Completed")
 
     def initFilesVisit(self, obj):

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/EventVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/EventVisitor.py
@@ -101,8 +101,6 @@ class EventVisitor(AbstractVisitor.AbstractVisitor):
         if len(obj.get_ids()) == 1:
             pyfile = "{}/{}.py".format(output_dir, obj.get_name())
             fd = open(pyfile, "w")
-            if fd is None:
-                raise Exception(f"Could not open {pyfile} file.")
             self.__fp.append(fd)
         else:
             inst = 0
@@ -111,8 +109,6 @@ class EventVisitor(AbstractVisitor.AbstractVisitor):
                 inst += 1
                 DEBUG.info(f"Open file: {pyfile}")
                 fd = open(pyfile, "w")
-                if fd is None:
-                    raise Exception(f"Could not open {pyfile} file.")
                 DEBUG.info(f"Completed {pyfile} open")
                 self.__fp.append(fd)
 

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceChannelVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceChannelVisitor.py
@@ -125,8 +125,6 @@ class InstanceChannelVisitor(AbstractVisitor.AbstractVisitor):
             pyfile = "{}/{}.py".format(output_dir, fname)
             DEBUG.info("Open file: {}".format(pyfile))
             fd = open(pyfile, "w")
-            if fd is None:
-                raise Exception("Could not open {} file.".format(pyfile))
             DEBUG.info("Completed {} open".format(pyfile))
             self.__fp[fname] = fd
 

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceCommandVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceCommandVisitor.py
@@ -138,8 +138,6 @@ class InstanceCommandVisitor(AbstractVisitor.AbstractVisitor):
                 pyfile = "{}/{}.py".format(output_dir, fname)
                 DEBUG.info("Open file: {}".format(pyfile))
                 fd = open(pyfile, "w")
-                if fd is None:
-                    raise Exception("Could not open {} file.".format(pyfile))
                 DEBUG.info("Completed {} open".format(pyfile))
                 self.__fp1[fname] = fd
 
@@ -164,16 +162,12 @@ class InstanceCommandVisitor(AbstractVisitor.AbstractVisitor):
                 pyfile = "{}/{}_PRM_SET.py".format(output_dir, fname)
                 DEBUG.info("Open file: {}".format(pyfile))
                 fd = open(pyfile, "w")
-                if fd is None:
-                    raise Exception("Could not open {} file.".format(pyfile))
                 self.__fp1[fname] = fd
                 DEBUG.info("Completed {} open".format(pyfile))
 
                 pyfile = "{}/{}_PRM_SAVE.py".format(output_dir, fname)
                 DEBUG.info("Open file: {}".format(pyfile))
                 fd = open(pyfile, "w")
-                if fd is None:
-                    raise Exception("Could not open {} file.".format(pyfile))
                 self.__fp2[fname] = fd
                 DEBUG.info("Completed {} open".format(pyfile))
 

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceEventVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceEventVisitor.py
@@ -127,8 +127,6 @@ class InstanceEventVisitor(AbstractVisitor.AbstractVisitor):
             pyfile = "{}/{}.py".format(output_dir, fname)
             DEBUG.info("Open file: {}".format(pyfile))
             fd = open(pyfile, "w")
-            if fd is None:
-                raise Exception("Could not open {} file.".format(pyfile))
             DEBUG.info("Completed {} open".format(pyfile))
             self.__fp[fname] = fd
 

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceSerializableVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceSerializableVisitor.py
@@ -189,8 +189,6 @@ class InstanceSerializableVisitor(AbstractVisitor.AbstractVisitor):
         # Open file for writing here...
         DEBUG.info(f"Open file: {pyfile}")
         self.__fp = open(pyfile, "w")
-        if self.__fp is None:
-            raise Exception("Could not open %s file.") % pyfile
         DEBUG.info("Completed")
 
     def startSourceFilesVisit(self, obj):

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyCppVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyCppVisitor.py
@@ -128,8 +128,6 @@ class InstanceTopologyCppVisitor(AbstractVisitor.AbstractVisitor):
             # Open file for writing here...
             DEBUG.info("Open file: %s" % filename)
             self.__fp = open(filename, "w")
-            if self.__fp is None:
-                raise Exception("Could not open %s file.") % filename
             DEBUG.info("Completed")
         else:
             PRINT.info("ERROR: NO COMPONENTS FOUND IN TOPOLOGY XML FILE...")

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/InstanceTopologyHVisitor.py
@@ -128,8 +128,6 @@ class InstanceTopologyHVisitor(AbstractVisitor.AbstractVisitor):
             # Open file for writing here...
             DEBUG.info("Open file: %s" % filename)
             self.__fp = open(filename, "w")
-            if self.__fp is None:
-                raise Exception("Could not open %s file.") % filename
             DEBUG.info("Completed")
         else:
             PRINT.info("ERROR: NO COMPONENTS FOUND IN TOPOLOGY XML FILE...")

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/PortCppVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/PortCppVisitor.py
@@ -195,8 +195,6 @@ class PortCppVisitor(AbstractVisitor.AbstractVisitor):
         # Open file for writing here...
         DEBUG.info("Open file: %s" % filename)
         self.__fp = open(filename, "w")
-        if self.__fp is None:
-            raise Exception("Could not open %s file.") % filename
         DEBUG.info("Completed")
 
     def startSourceFilesVisit(self, obj):

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
@@ -255,8 +255,6 @@ class PortHVisitor(AbstractVisitor.AbstractVisitor):
         # Open file for writing here...
         DEBUG.info("Open file: %s" % filename)
         self.__fp = open(filename, "w")
-        if self.__fp is None:
-            raise Exception("Could not open %s file.") % filename
         DEBUG.info("Completed")
 
     def startSourceFilesVisit(self, obj):

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/SerialCppVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/SerialCppVisitor.py
@@ -250,8 +250,6 @@ class SerialCppVisitor(AbstractVisitor.AbstractVisitor):
         # Open file for writing here...
         DEBUG.info("Open file: %s" % filename)
         self.__fp = open(filename, "w")
-        if self.__fp is None:
-            raise Exception("Could not open %s file.") % filename
         DEBUG.info("Completed")
 
     def startSourceFilesVisit(self, obj):

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/SerialHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/SerialHVisitor.py
@@ -256,8 +256,6 @@ class SerialHVisitor(AbstractVisitor.AbstractVisitor):
         # Open file for writing here...
         DEBUG.info("Open file: %s" % filename)
         self.__fp = open(filename, "w")
-        if self.__fp is None:
-            raise Exception("Could not open %s file.") % filename
         DEBUG.info("Completed")
 
     def startSourceFilesVisit(self, obj):

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/SerializableVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/SerializableVisitor.py
@@ -189,8 +189,6 @@ class SerializableVisitor(AbstractVisitor.AbstractVisitor):
         # Open file for writing here...
         DEBUG.info(f"Open file: {pyfile}")
         self.__fp = open(pyfile, "w")
-        if self.__fp is None:
-            raise Exception("Could not open %s file.") % pyfile
         DEBUG.info("Completed")
 
     def startSourceFilesVisit(self, obj):

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyCppVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyCppVisitor.py
@@ -128,8 +128,6 @@ class TopologyCppVisitor(AbstractVisitor.AbstractVisitor):
             # Open file for writing here...
             DEBUG.info("Open file: %s" % filename)
             self.__fp = open(filename, "w")
-            if self.__fp is None:
-                raise Exception("Could not open %s file.") % filename
             DEBUG.info("Completed")
         else:
             PRINT.info("ERROR: NO COMPONENTS FOUND IN TOPOLOGY XML FILE...")

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyHVisitor.py
@@ -128,8 +128,6 @@ class TopologyHVisitor(AbstractVisitor.AbstractVisitor):
             # Open file for writing here...
             DEBUG.info("Open file: %s" % filename)
             self.__fp = open(filename, "w")
-            if self.__fp is None:
-                raise Exception("Could not open %s file.") % filename
             DEBUG.info("Completed")
         else:
             PRINT.info("ERROR: NO COMPONENTS FOUND IN TOPOLOGY XML FILE...")

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyIDVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/TopologyIDVisitor.py
@@ -115,8 +115,6 @@ class TopologyIDVisitor(AbstractVisitor.AbstractVisitor):
             # Open file for writing here...
             DEBUG.info("Open file: %s" % filename)
             self.__fp = open(filename, "w")
-            if self.__fp is None:
-                raise Exception("Could not open %s file.") % filename
             DEBUG.info("Completed")
         else:
             PRINT.info("ERROR: NO COMPONENTS FOUND IN TOPOLOGY XML FILE...")


### PR DESCRIPTION
There is no need to check returned value of built
in function `open'. Documentation says:

>  If the file cannot be opened, IOError is raised.

https://docs.python.org/2/library/functions.html#open

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Remove unnecessary checks of opened files in python generators

## Rationale

Built in function `open' will never return None, it will raise an exception if file cannot be opened.

## Testing/Review Recommendations

Refer to python documentation: https://docs.python.org/2/library/functions.html#open
