### PR TITLE
Improve `getMemUtil()` of the OSAL Linux port

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -493,6 +493,7 @@ fprofile
 fptr
 fputil
 fpv
+freeram
 Fregoso
 frontend
 frox
@@ -1401,6 +1402,7 @@ TOTALFF
 TOTALISFLOGEVENTMSG
 TOTALISFTELMMSG
 TOTALQUEUEFULL
+totalram
 TOUPPER
 transcoding
 treeview

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -9,10 +9,8 @@
 // acknowledged.
 //
 // ======================================================================
-#include <cstdio>              /* fopen() */
-#include <cstdlib>             /* scanf */
-#include <sys/vfs.h>            /* statfs() */
-#include <sys/sysinfo.h>		/* get_nprocs() */
+#include <cstdio>
+#include <sys/sysinfo.h>
 #include <cstring>
 #include <Os/SystemResources.hpp>
 #include <Fw/Types/Assert.hpp>

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -82,31 +82,17 @@ namespace Os {
     }
 
     SystemResources::SystemResourcesStatus SystemResources::getMemUtil(MemUtil &memory_util) {
-        FILE *fp = nullptr;
-        NATIVE_INT_TYPE total = 0;
-        NATIVE_INT_TYPE free = 0;
-        // Fallbacks
-        memory_util.total = 1;
-        memory_util.used = 1;
 
-        fp = fopen("/proc/meminfo", "r");
-        if (fp == nullptr) {
+        struct sysinfo memory_info;
+        sysinfo(&memory_info);
+        
+        if (memory_info.totalram < memory_info.freeram) {
             return SYSTEM_RESOURCES_ERROR;
         }
-        // No string concerns as strings discarded
-        if (fscanf(fp, "%*s %d %*s", &total) != 1 ||  /* 1st line is MemTotal */
-            fscanf(fp, "%*s %d", &free) != 1) {   /* 2nd line is MemFree */
-            fclose(fp);
-            return SYSTEM_RESOURCES_ERROR;
-        }
-        fclose(fp);
 
-        // Check results
-        if (total < 0 or free < 0 or total < free) {
-            return SYSTEM_RESOURCES_ERROR;
-        }
-        memory_util.total = static_cast<U64>(total) * 1024; // KB to Bytes
-        memory_util.used = static_cast<U64>(total - free) * 1024;
+        memory_util.total = static_cast<U64>(memory_info.totalram * memory_info.mem_unit); 
+        memory_util.used = static_cast<U64>((memory_info.totalram - memory_info.freeram) * memory_info.mem_unit);
+
         return SYSTEM_RESOURCES_OK;
     }
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| OSAL/Linux/`getMemUtil()` |
|**_Affected Architectures(s)_**| OSAL |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to improve the implementation of `getMemUtil()` of the OSAL Linux port.

## Rationale

To retrieve this type of information it is better to call the syscall `sysinfo()` (see [here](https://man7.org/linux/man-pages/man2/sysinfo.2.html)) than to read `/proc/meminfo` and parse its contents.

## Testing/Review Recommendations

I don't know if we should take into account the swap in the calculations and therefore bring up the total and used virtual memory.

If we wanted to have the total amount of virtual memory, it would be :

```cpp
  U64 totalVirtualMem = memory_info.totalram;
  totalVirtualMem += memory_info.totalswap;
  totalVirtualMem *= memory_info.mem_unit;
```

If we wanted to have the total amount of virtual memory used, it would be :

```cpp
  U64 virtualMemUsed = memory_info.totalram - memory_info.freeram;
  virtualMemUsed += memory_info.totalswap - memory_info.freeswap;
  virtualMemUsed *= memory_info.mem_unit;
```

## Future Work

Given the memory footprint and the frequency with which the function is triggered, it would be better to allocate the `memory_info` structure at compile time in the `BSS` segment.
