### PR TITLE
Initialize Array before used

### DIFF
--- a/Autocoders/Python/test/partition/Top.cpp
+++ b/Autocoders/Python/test/partition/Top.cpp
@@ -83,7 +83,7 @@ int main(int argc, char* argv[])  {
 	// Construct the topology here.
 	constructArchitecture();
 	// Ask for input to huey or duey here.
-	char in[80];
+	char in[80] = {};
 	U32 cmd;
 	Fw::String *str;
 	char str2[80];


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Initialize array before using it.

## Rationale

For some compiler, a declared array may not be initialized of initialized to zero. Therefore, using array directly before initializing it is dangerous.

## Testing/Review Recommendations

Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality.

## Future Work

Note any additional work that will be done relating to this issue.
