### PR TITLE
Revise file ID type for FSW assertions

### DIFF
--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -8,7 +8,7 @@
 #else // ASSERT is defined
 
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
-#define FILE_NAME_ARG NATIVE_UINT_TYPE
+#define FILE_NAME_ARG U32
 #define FW_ASSERT(cond, ...) \
     ((void) ((cond) ? (0) : \
     (Fw::SwAssert(ASSERT_FILE_ID, __LINE__, ##__VA_ARGS__))))


### PR DESCRIPTION
The correct type for numeric file IDs is U32, because the file ID is a 32-bit hash. The code being replaced breaks when NATIVE_UINT_TYPE has a bit width smaller than 32.

@LeStarch The other issue we looked at (format of printing assert arguments) is already fixed in devel. The version we looked at was behind the head of devel.