### PR TITLE
Fix type specifications in framework

### DIFF
--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -8,7 +8,7 @@
 #else // ASSERT is defined
 
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
-#define FILE_NAME_ARG NATIVE_UINT_TYPE
+#define FILE_NAME_ARG U32
 #define FW_ASSERT(cond, ...) \
     ((void) ((cond) ? (0) : \
     (Fw::SwAssert(ASSERT_FILE_ID, __LINE__, ##__VA_ARGS__))))

--- a/Svc/Sched/Sched.fpp
+++ b/Svc/Sched/Sched.fpp
@@ -2,7 +2,7 @@ module Svc {
 
   @ Scheduler Port with order argument
   port Sched(
-              context: U16 @< The call order
+              context: NATIVE_UINT_TYPE @< The call order
             )
 
 }

--- a/config/FpConfig.fpp
+++ b/config/FpConfig.fpp
@@ -2,4 +2,6 @@ type FwEventIdType
 type FwChanIdType
 type FwOpcodeType
 type FwPrmIdType
+type NATIVE_INT_TYPE
+type NATIVE_UINT_TYPE
 type POINTER_CAST


### PR DESCRIPTION
* Correct inconsistencies in uses of types
* ~~Remove NATIVE_INT_TYPE and NATIVE_UINT_TYPE from the FPP model. These are not serializable types, because they have a platform-variable size. They should not appear in FPP models.~~
* ~~Change the use of NATIVE_UINT_TYPE in Svc/Sched to U16. This seems reasonable for now. We can use FwIndexType here, but this will require an update to the FPP code generator. (We should update the FPP code generator to support the new types anyway.)~~

Supersedes #1694.