### PR TITLE
Add standard FPP types

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -655,6 +655,7 @@ inits
 initstate
 inkscape
 inode
+INOUT
 INPCK
 Inputline
 installable

--- a/Drv/GpioDriverPorts/GpioDriverPorts.fpp
+++ b/Drv/GpioDriverPorts/GpioDriverPorts.fpp
@@ -1,7 +1,7 @@
 module Drv {
 
   port GpioWrite(
-                  state: bool
+                  state: Fw.Logic
                 )
 
 }
@@ -9,7 +9,7 @@ module Drv {
 module Drv {
 
   port GpioRead(
-                 ref state: bool
+                 ref state: Fw.Logic
                )
 
 }

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
@@ -251,7 +251,7 @@ namespace Drv {
   void LinuxGpioDriverComponentImpl ::
     gpioRead_handler(
         const NATIVE_INT_TYPE portNum,
-        bool &state
+        Fw::Logic &state
     )
   {
       FW_ASSERT(this->m_fd != -1);
@@ -262,7 +262,7 @@ namespace Drv {
           this->log_WARNING_HI_GP_ReadError(this->m_gpio,stat);
           return;
       } else {
-          state = val?true:false;
+          state = val ? Fw::Logic::HIGH : Fw::Logic::LOW;
       }
 
   }
@@ -270,14 +270,14 @@ namespace Drv {
   void LinuxGpioDriverComponentImpl ::
     gpioWrite_handler(
         const NATIVE_INT_TYPE portNum,
-        bool state
+        Fw::Logic state
     )
   {
       FW_ASSERT(this->m_fd != -1);
 
       NATIVE_INT_TYPE stat;
 
-      stat = gpio_set_value(this->m_fd,state?1:0);
+      stat = gpio_set_value(this->m_fd,(state == Fw::Logic::HIGH) ? 1 : 0);
 
       if (0 != stat) {
           this->log_WARNING_HI_GP_WriteError(this->m_gpio,stat);

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
@@ -270,7 +270,7 @@ namespace Drv {
   void LinuxGpioDriverComponentImpl ::
     gpioWrite_handler(
         const NATIVE_INT_TYPE portNum,
-        Fw::Logic state
+        const Fw::Logic& state
     )
   {
       FW_ASSERT(this->m_fd != -1);

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.hpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.hpp
@@ -70,14 +70,14 @@ namespace Drv {
       //!
       void gpioRead_handler(
           const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          bool &state
+          Fw::Logic &state
       );
 
       //! Handler implementation for gpioWrite
       //!
       void gpioWrite_handler(
           const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          bool state
+          Fw::Logic state
       );
 
       //! keep GPIO ID

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.hpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.hpp
@@ -77,7 +77,7 @@ namespace Drv {
       //!
       void gpioWrite_handler(
           const NATIVE_INT_TYPE portNum, /*!< The port number*/
-          Fw::Logic state
+          const Fw::Logic& state
       );
 
       //! keep GPIO ID

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImplStub.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImplStub.cpp
@@ -23,7 +23,7 @@ namespace Drv {
   void LinuxGpioDriverComponentImpl ::
     gpioRead_handler(
         const NATIVE_INT_TYPE portNum,
-        bool &state
+        Fw::Logic &state
     )
   {
     // TODO
@@ -32,7 +32,7 @@ namespace Drv {
   void LinuxGpioDriverComponentImpl ::
     gpioWrite_handler(
         const NATIVE_INT_TYPE portNum,
-        bool state
+        const Fw::Logic& state
     )
   {
     // TODO

--- a/Fw/Types/Types.fpp
+++ b/Fw/Types/Types.fpp
@@ -28,4 +28,42 @@ module Fw {
     ENABLED @< Enabled state
   }
 
+  @ On and off states
+  enum On {
+    OFF @< Off state
+    ON @< On state
+  }
+
+  @ Logic states
+  enum Logic {
+    LOW @< Logic low state
+    HIGH @< Logic high state
+  }
+
+  @ Open and closed states
+  enum Open {
+    CLOSED @< Closed state
+    OPEN @< Open state
+  }
+
+  @ Direction states
+  enum Direction {
+    IN @< In direction
+    OUT @< Out direction
+    INOUT @< In/Out direction
+  }
+
+  @ Active and inactive states
+  enum Active {
+    INACTIVE @< Inactive state
+    ACTIVE @< Active state
+  }
+
+  @ Health states
+  enum Health {
+    HEALTHY @< Healthy state
+    SICK @< Sick state
+    FAILED @< Failed state
+  }
+
 }

--- a/RPI/RpiDemo/RpiDemo.fpp
+++ b/RPI/RpiDemo/RpiDemo.fpp
@@ -17,11 +17,6 @@ module RPI {
       PIN_24 = 1
     }
 
-    enum GpioVal {
-      CLEAR = 0
-      SET = 1
-    }
-
     enum LedState {
       BLINKING = 0
       OFF = 1
@@ -108,7 +103,7 @@ module RPI {
     @ Sets a GPIO port value
     async command RD_SetGpio(
                               $output: GpioOutNum @< Output GPIO
-                              value: GpioVal @< GPIO value
+                              value: Fw.Logic @< GPIO value
                             ) \
       opcode 3
 
@@ -147,7 +142,7 @@ module RPI {
     @ GPIO set
     event RD_GpioSetVal(
                          $output: U32 @< The output number
-                         value: GpioVal @< GPIO value
+                         value: Fw.Logic @< GPIO value
                        ) \
       severity activity high \
       id 2 \
@@ -156,7 +151,7 @@ module RPI {
     @ GPIO get
     event RD_GpioGetVal(
                          $output: U32 @< The output number
-                         value: GpioVal @< GPIO value
+                         value: Fw.Logic @< GPIO value
                        ) \
       severity activity high \
       id 3 \

--- a/RPI/RpiDemo/RpiDemoComponentImpl.cpp
+++ b/RPI/RpiDemo/RpiDemoComponentImpl.cpp
@@ -28,7 +28,7 @@ namespace RPI {
     ,m_uartWriteBytes(0)
     ,m_uartReadBytes(0)
     ,m_spiBytes(0)
-    ,m_currLedVal(RpiDemo_GpioVal::CLEAR)
+    ,m_currLedVal(Fw::Logic::LOW)
     ,m_ledOn(true)
     ,m_ledDivider(10) // start at 1Hz
     ,m_1HzTicks(0)
@@ -99,9 +99,9 @@ namespace RPI {
           case RG_CONTEXT_10Hz:
               // Toggle LED value
               if ( (this->m_10HzTicks++%this->m_ledDivider == 0) and this->m_ledOn) {
-                  this->GpioWrite_out(2, (this->m_currLedVal == RpiDemo_GpioVal::SET));
-                  this->m_currLedVal = (this->m_currLedVal == RpiDemo_GpioVal::SET) ?
-                    RpiDemo_GpioVal::CLEAR : RpiDemo_GpioVal::SET;
+                  this->GpioWrite_out(2, this->m_currLedVal);
+                  this->m_currLedVal = (this->m_currLedVal == Fw::Logic::HIGH) ?
+                    Fw::Logic::LOW : Fw::Logic::HIGH;
               }
               break;
           default:
@@ -166,7 +166,7 @@ namespace RPI {
         const FwOpcodeType opCode,
         const U32 cmdSeq,
         RpiDemo_GpioOutNum output, /*!< Output GPIO*/
-        RpiDemo_GpioVal value
+        Fw::Logic value
     )
   {
       NATIVE_INT_TYPE port;
@@ -188,7 +188,7 @@ namespace RPI {
               return;
       }
       // set value of GPIO
-      this->GpioWrite_out(port, (RpiDemo_GpioVal::SET == value.e));
+      this->GpioWrite_out(port, value);
       this->log_ACTIVITY_HI_RD_GpioSetVal(output.e, value);
       this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
   }
@@ -215,12 +215,9 @@ namespace RPI {
               return;
       }
       // get value of GPIO input
-      bool val;
+      Fw::Logic val;
       this->GpioRead_out(port, val);
-      this->log_ACTIVITY_HI_RD_GpioGetVal(
-          input.e,
-          val ? RpiDemo_GpioVal::SET : RpiDemo_GpioVal::CLEAR
-      );
+      this->log_ACTIVITY_HI_RD_GpioGetVal(input.e, val);
       this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
   }
 

--- a/RPI/RpiDemo/RpiDemoComponentImpl.hpp
+++ b/RPI/RpiDemo/RpiDemoComponentImpl.hpp
@@ -98,7 +98,7 @@ namespace RPI {
           const FwOpcodeType opCode, /*!< The opcode*/
           const U32 cmdSeq, /*!< The command sequence number*/
           RpiDemo_GpioOutNum output, /*!< Output GPIO*/
-          RpiDemo_GpioVal value /*!< GPIO value*/
+          Fw::Logic value /*!< GPIO value*/
       ) override;
 
       //! Implementation for RD_GetGpio command handler
@@ -142,7 +142,7 @@ namespace RPI {
       U32 m_uartReadBytes;
       U32 m_spiBytes;
       Fw::TlmString m_lastUartMsg;
-      RpiDemo_GpioVal m_currLedVal;
+      Fw::Logic m_currLedVal;
       // serial buffers
       Fw::Buffer m_recvBuffers[NUM_RPI_UART_BUFFERS];
       BYTE m_uartBuffers[NUM_RPI_UART_BUFFERS][RPI_UART_READ_BUFF_SIZE];


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Fw::Types, Drv::LinuxGpioDriver |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| #1486  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adding standard FPP types as per #1486.

NOTE: This is a breaking change for any deployments using LinuxGpioDriver.
