### PR TITLE
lestarch: fixing platform print descriptor

### DIFF
--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -10,9 +10,9 @@
 #else
 
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
-#define fileIdFs "Assert file ID 0x%08" PRIx32 ": Line: %" PRI_PlatformUIntType
+#define fileIdFs "Assert file ID 0x%08" PRIx32 ": Line: %" PRI_PlatformUIntType " "
 #else
-#define fileIdFs "Assert file \"%s\": Line: %" PRI_PlatformUIntType
+#define fileIdFs "Assert file \"%s\": Line: %" PRI_PlatformUIntType " "
 #endif
 
 namespace Fw {

--- a/cmake/platform/types/PlatformTypes.hpp
+++ b/cmake/platform/types/PlatformTypes.hpp
@@ -52,7 +52,7 @@ typedef int PlatformIntType;
 #define PRI_PlatformIntType "d"
 
 typedef unsigned int PlatformUIntType;
-#define PRI_PlatformUIntType "ud"
+#define PRI_PlatformUIntType "u"
 
 typedef PlatformIntType PlatformIndexType;
 #define PRI_PlatformIndexType PRI_PlatformIntType


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

"ud" is an invalid printf token.  Should be "d".