### PR TITLE
Added SSL Error description and resolution in troubleshooting section …

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -179,3 +179,22 @@ Many operating systems offer python PIP packages through their package manager (
 recommend avoiding those packages, but rather installing from PIP in a virtual environment. The reason for this is that
 the version of the python package from the OS may not be the required version that the python project depends on. Thus,
 users may choose to install F´ into a virtual environment. This is outside the scope of this document.
+
+### SSL Error with Python 3.6+ on macOS
+
+The version of openSSL bundled with Python 3.6+ requires access to macOS's root certificates. If the following error is 
+encountered while installing fprime: 
+
+```
+Failed find expected download: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get 
+local issuer certificate
+```
+
+Then run the following command in a macOS terminal to install necessary certificates: 
+
+```
+cd /Applications/Python\ 3.X/
+./Install\ Certificates.command
+```
+
+After running above command, re-try installing fprime.  


### PR DESCRIPTION
…of INSTALL.md file

| | |
|:---|:---|
|**_Originating Project/Creator_**| @arizvi786 |
|**_Affected Component_**|  N/A|
|**_Affected Architectures(s)_**|  N/A|
|**_Related Issue(s)_**|  N/A|
|**_Has Unit Tests (y/n)_**|  N/A|
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  y |

---
## Change Description

Updated troubleshooting section in INSTALL.md file to indicate open SSL error encountered on macOS

## Rationale

Document troubleshooting steps taken to resolve open SSL error when installing fprime on macOS.

## Testing/Review Recommendations

This resolution worked to install fprime successfully on a Mac M1 system.

## Future Work

N/A