### PR TITLE
Adjust spacing in Assert.cpp

### DIFF
--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -10,9 +10,9 @@
 #else
 
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
-#define fileIdFs "Assert file ID 0x%08" PRIx32 ": Line: %" PRI_PlatformUIntType " "
+#define fileIdFs "Assert file ID 0x%08" PRIx32 ": Line: %" PRI_PlatformUIntType
 #else
-#define fileIdFs "Assert file \"%s\": Line: %" PRI_PlatformUIntType " "
+#define fileIdFs "Assert file \"%s\": Line: %" PRI_PlatformUIntType
 #endif
 
 namespace Fw {
@@ -44,7 +44,7 @@ namespace Fw {
                 (void) snprintf(
                     destBuffer,
                     buffSize,
-                    fileIdFs "%" PRI_FwAssertArgType,
+                    fileIdFs " %" PRI_FwAssertArgType,
                     file,
                     lineNo,
                     arg1
@@ -54,7 +54,7 @@ namespace Fw {
                 (void) snprintf(
                     destBuffer,
                     buffSize,
-                    fileIdFs "%" PRI_FwAssertArgType " %" PRI_FwAssertArgType,
+                    fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType,
                     file,
                     lineNo,
                     arg1, arg2
@@ -64,7 +64,7 @@ namespace Fw {
                 (void) snprintf(
                     destBuffer,
                     buffSize,
-                    fileIdFs "%" PRI_FwAssertArgType " %" PRI_FwAssertArgType
+                    fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
                       " %" PRI_FwAssertArgType,
                     file,
                     lineNo,
@@ -75,7 +75,7 @@ namespace Fw {
                 (void) snprintf(
                     destBuffer,
                     buffSize,
-                    fileIdFs "%" PRI_FwAssertArgType " %" PRI_FwAssertArgType
+                    fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
                       " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType,
                     file,
                     lineNo,
@@ -85,7 +85,7 @@ namespace Fw {
                 (void) snprintf(
                     destBuffer,
                     buffSize,
-                    fileIdFs "%" PRI_FwAssertArgType " %" PRI_FwAssertArgType
+                    fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
                       " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
                       " %" PRI_FwAssertArgType,
                     file,
@@ -97,7 +97,7 @@ namespace Fw {
                 (void) snprintf(
                     destBuffer,
                     buffSize,
-                    fileIdFs "%" PRI_FwAssertArgType " %" PRI_FwAssertArgType
+                    fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
                       " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
                       " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType,
                     file,


### PR DESCRIPTION
There should not be a space at the end of the zero-arg assert failure message. The spaces should go before the arguments.