### PR TITLE
Fixed pound-include conditional in PolyType

### DIFF
--- a/Fw/Types/PolyType.hpp
+++ b/Fw/Types/PolyType.hpp
@@ -92,7 +92,7 @@ namespace Fw {
             PolyType(const PolyType &original); //!< copy constructor
             virtual ~PolyType(); //!< destructor
 
-#if FW_SERIALIZABLE_TO_STRING
+#if FW_SERIALIZABLE_TO_STRING || BUILD_UT
             void toString(StringBase& dest, bool append) const; //!< get string representation
             void toString(StringBase& dest) const; //!< get string representation
 #endif


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixed pount-include conditional

## Rationale

fprime-util check --all fails to build when FW_SERIALIZABLE_TO_STRING is disabled.

## Testing/Review Recommendations

Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality.

## Future Work

Note any additional work that will be done relating to this issue.
