### PR TITLE
Fix tests failing because of variable optimized out

### DIFF
--- a/Drv/TcpClient/test/ut/Tester.hpp
+++ b/Drv/TcpClient/test/ut/Tester.hpp
@@ -115,7 +115,7 @@ namespace Drv {
       Fw::Buffer m_data_buffer;
       Fw::Buffer m_data_buffer2;
       U8 m_data_storage[SEND_DATA_BUFFER_SIZE];
-      bool m_spinner;
+      std::atomic<bool> m_spinner;
 
   };
 

--- a/Drv/TcpServer/test/ut/Tester.hpp
+++ b/Drv/TcpServer/test/ut/Tester.hpp
@@ -125,7 +125,7 @@ namespace Drv {
       Fw::Buffer m_data_buffer;
       Fw::Buffer m_data_buffer2;
       U8 m_data_storage[SEND_DATA_BUFFER_SIZE];
-      bool m_spinner;
+      std::atomic<bool> m_spinner;
 
   };
 

--- a/Drv/Udp/test/ut/Tester.hpp
+++ b/Drv/Udp/test/ut/Tester.hpp
@@ -126,7 +126,7 @@ namespace Drv {
       Fw::Buffer m_data_buffer;
       Fw::Buffer m_data_buffer2;
       U8 m_data_storage[SEND_DATA_BUFFER_SIZE];
-      bool m_spinner;
+      std::atomic<bool> m_spinner;
   };
 
 } // end namespace Drv


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Drv/TcpClient - Drv/Udp  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The unit tests of Drv/TcpClient and Drv/Udp failed if some optimization flag where used. The cause of the failure was that the `m_spinner` in `while (not m_spinner) {}` was optimized out and so the test was not waiting. Using `std::atomic` m_spinner is never optimized and the test work for any cases.

## Testing/Review Recommendations


## Future Work

