### PR TITLE
Switch to Github Actions Code Scanner

### DIFF
--- a/.github/actions/codeql/security-pack.yml
+++ b/.github/actions/codeql/security-pack.yml
@@ -1,0 +1,19 @@
+name: "CodeQL security and quality"
+
+queries: 
+  - uses: security-and-quality
+
+query-filters:
+  - include: 
+      id: cpp/incorrect-not-operator-usage
+  - include: 
+      tags contain: correctness
+  - include: 
+      tags contain: reliability
+
+paths-ignore:
+  - docs/
+  - cmake/docs/
+  - cmake/test/
+  - Autocoders/Python/src/fprime_ac/utils/DiffAndRename.py
+  - Autocoders/Python/src/fprime_ac/utils/pyparsing.py

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -206,6 +206,7 @@ cntx
 cobj
 CODEFILE
 codegen
+codeql
 colno
 COLORSTYLE
 colorwheel

--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -5,10 +5,10 @@ name: "CodeQL Security Scan"
 
 on:
   push:
-    branches: [ "master", "develop" ]
+    branches: [ master, devel ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master", "develop" ]
+    branches: [ master, devel ]
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -1,0 +1,50 @@
+# Semantic code analysis with CodeQL 
+# see https://github.com/github/codeql-action
+
+name: "CodeQL Security Scan"
+
+on:
+  push:
+    branches: [ "master", "develop" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master", "develop" ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        config-file: ./.github/actions/codeql/security-pack.yml
+        
+    - if: ${{ matrix.language == 'cpp' }}
+      name: Build
+      run: |
+          python3 -m venv ./fprime-venv
+          . ./fprime-venv/bin/activate
+          pip install -U setuptools setuptools_scm wheel pip
+          pip install -r ./requirements.txt
+          fprime-util generate
+          fprime-util build --all
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/Autocoders/Python/src/fprime_ac/generators/formatters.py
+++ b/Autocoders/Python/src/fprime_ac/generators/formatters.py
@@ -1318,10 +1318,7 @@ class Formatters:
         and no '_' in string form.
         """
         mod_id_list = mod_id.strip("_").split("_")
-        if len(mod_id_list) == 1:
-            mod_id_cap = mod_id[0].upper() + mod_id[1:]
-        elif len(mod_id_list) == 2:
-            mod_id_cap = [x[0].upper() + x[1:] for x in mod_id_list]
+        mod_id_cap = [x[0].upper() + x[1:] for x in mod_id_list]
         # size of mod_id list error in subThreadDir method.
         mod_id_cap_str = "".join(mod_id_cap)
         return mod_id_cap_str


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| Github Actions |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/1693 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**| |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds a Github Actions workflow that runs the same queries as the current LGTM set up.

## Rationale

[lgtm.com](lgtm.com) will be shut down at the end of the year.

## Future Work

We may want to remove the LGTM configuration files once it's fully shut down.


## Additional comments
I currently have it set up to run on each commit and pull request to `master` and `devel` as I see this seems to be the convention in the workflows of this repo, but we could restrict to only running when source files are modified.

Here's the result of the queries [on Github Actions results](https://github.com/thomas-bc/fprime/security/code-scanning?query=is%3Aopen+branch%3Agh-code-scanner). Comparing to [the LGTM results](https://lgtm.com/projects/g/nasa/fprime/alerts/?mode=tree), we see the same warnings with an additional 2 on the Github Actions side.
