### PR TITLE
Static Analysis for JPL Coding Guidelines

### DIFF
--- a/.github/actions/codeql/jpl-standard-pack-1.yml
+++ b/.github/actions/codeql/jpl-standard-pack-1.yml
@@ -1,0 +1,12 @@
+name: "CodeQL JPL Coding Standard - Errors and Warnings"
+
+disable-default-queries: true
+
+packs:
+  # Source of the query pack is https://github.com/github/codeql/tree/main/cpp/ql/src/JPL_C
+  - codeql/cpp-queries:JPL_C
+
+query-filters:
+  - exclude:
+      problem.severity:
+        - recommendation

--- a/.github/actions/codeql/jpl-standard-pack-2.yml
+++ b/.github/actions/codeql/jpl-standard-pack-2.yml
@@ -1,0 +1,20 @@
+name: "CodeQL JPL Coding Standard - Recommendations 1 of 2"
+
+disable-default-queries: true
+
+packs:
+  # Source of the query pack is https://github.com/github/codeql/tree/main/cpp/ql/src/JPL_C
+  - codeql/cpp-queries:JPL_C
+
+query-filters:
+  - exclude:
+      problem.severity:
+        - error
+        - warning
+  # We are excluding the following query because it overflows the limit of
+  # 5000 results that the SARIF upload can handle
+  # This sole query is ran in jpl-standard-pack-3.yml
+  # https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#uploading-a-code-scanning-analysis-with-github-actions
+  - exclude:
+      id:
+        - cpp/jpl-c/basic-int-types

--- a/.github/actions/codeql/jpl-standard-pack-3.yml
+++ b/.github/actions/codeql/jpl-standard-pack-3.yml
@@ -1,0 +1,13 @@
+name: "CodeQL JPL Coding Standard - Recommendations 2 of 2"
+
+disable-default-queries: true
+
+packs:
+  # Source of the query pack is https://github.com/github/codeql/tree/main/cpp/ql/src/JPL_C
+  - codeql/cpp-queries:JPL_C
+
+query-filters:
+  # This will ONLY include the following query
+  - include:
+      id:
+        - cpp/jpl-c/basic-int-types

--- a/.github/workflows/codeql-jpl-standard.yml
+++ b/.github/workflows/codeql-jpl-standard.yml
@@ -1,0 +1,49 @@
+# Semantic code analysis with CodeQL 
+# see https://github.com/github/codeql-action
+
+name: "JPL Coding Standard Scan"
+
+on:
+  push:
+    branches: [ "master", "develop", "jpl-coding-standard" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master", "develop" ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+        config-file: ['jpl-standard-pack-1.yml', 'jpl-standard-pack-2.yml', 'jpl-standard-pack-3.yml']
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        config-file: ./.github/actions/codeql/${{ matrix.config-file }}
+
+    - name: Build
+      run: |
+          python3 -m venv ./fprime-venv
+          . ./fprime-venv/bin/activate
+          pip install -U setuptools setuptools_scm wheel pip
+          pip install -r ./requirements.txt
+          fprime-util generate
+          fprime-util build --all
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-jpl-standard.yml
+++ b/.github/workflows/codeql-jpl-standard.yml
@@ -5,7 +5,7 @@ name: "JPL Coding Standard Scan"
 
 on:
   push:
-    branches: [ "master", "develop", "workflow/jpl-coding-standard" ]
+    branches: [ "master", "develop" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "master", "develop" ]
@@ -34,6 +34,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        # Run jobs in parallel for each config-file
         config-file: ./.github/actions/codeql/${{ matrix.config-file }}
 
     - name: Build

--- a/.github/workflows/codeql-jpl-standard.yml
+++ b/.github/workflows/codeql-jpl-standard.yml
@@ -5,10 +5,10 @@ name: "JPL Coding Standard Scan"
 
 on:
   push:
-    branches: [ "master", "develop" ]
+    branches: [ master, devel ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master", "develop" ]
+    branches: [ master, devel ]
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-jpl-standard.yml
+++ b/.github/workflows/codeql-jpl-standard.yml
@@ -5,7 +5,7 @@ name: "JPL Coding Standard Scan"
 
 on:
   push:
-    branches: [ "master", "develop", "jpl-coding-standard" ]
+    branches: [ "master", "develop", "workflow/jpl-coding-standard" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "master", "develop" ]


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| GitHub Actions |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/1072 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds a GitHub Actions workflow that runs queries to validate the JPL Coding Standards (set of query can be found [here](https://github.com/github/codeql/tree/main/cpp/ql/src/JPL_C)).

## Rationale

See https://github.com/nasa/fprime/issues/1072

## Comments

This one was a little tricky to deal with because a single job can [only upload 5000 alerts at a time](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#uploading-a-code-scanning-analysis-with-github-actions), but we currently get more than 11000 alerts (results should appear in the checks of the PR). I therefore split the workflow in 3 parallel jobs so that each would upload less than 5000:
- [jpl-standard-pack-1.yml](https://github.com/thomas-bc/fprime/pull/1/files#diff-156dc4c819ed24ddb3c03df511ebad8b3e9b0685a5aa7dd4fd03f056ac16fa52) runs queries associated with Warnings and Errors.
- [jpl-standard-pack-2.yml](https://github.com/thomas-bc/fprime/pull/1/files#diff-055d23b75e34cecac69577a74f122e86aed1dc595d4c361b1296b79defc52411) runs queries associated with Recommendations, excluding [cpp/jpl-c/basic-int-types](https://github.com/github/codeql/blob/bbd7e623418e41775c90cfbbe44ad25b3bf9c5e3/cpp/ql/src/JPL_C/LOC-3/Rule%2017/BasicIntTypes.ql)
- [jpl-standard-pack-3.yml](https://github.com/thomas-bc/fprime/pull/1/files#diff-390c142db81b049b512e89ed7a513a8e9b1d16bda61848786f556d0cfd3b4c4f) runs [cpp/jpl-c/basic-int-types](https://github.com/github/codeql/blob/bbd7e623418e41775c90cfbbe44ad25b3bf9c5e3/cpp/ql/src/JPL_C/LOC-3/Rule%2017/BasicIntTypes.ql)

## Future Work

Modify the source code to resolve the warnings where possible in order to better adhere to the standard. Once we get less than 5000 alerts, the parallel jobs introduced in this PR could be reduced to a single job.