### PR TITLE
Fix #1709 PolyType does not compile when FW_HAS_F64 is undefined

### DIFF
--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -533,6 +533,8 @@ namespace Fw {
             case TYPE_I64:
                 stat = buffer.serialize(this->m_val.i64Val);
                 break;
+#endif
+#if FW_HAS_F64
             case TYPE_F64:
                 stat = buffer.serialize(this->m_val.f64Val);
                 break;
@@ -586,6 +588,8 @@ namespace Fw {
                     return buffer.deserialize(this->m_val.u64Val);
                 case TYPE_I64:
                     return buffer.deserialize(this->m_val.i64Val);
+#endif
+#if FW_HAS_F64
                 case TYPE_F64:
                     return buffer.deserialize(this->m_val.f64Val);
 #endif

--- a/Fw/Types/PolyType.hpp
+++ b/Fw/Types/PolyType.hpp
@@ -113,14 +113,22 @@ namespace Fw {
                 TYPE_NOTYPE, // !< No type stored yet
                 TYPE_U8, // !< U8 type stored
                 TYPE_I8, // !< I8 type stored
+#if FW_HAS_16_BIT
                 TYPE_U16, // !< U16 type stored
                 TYPE_I16, // !< I16 type stored
+#endif
+#if FW_HAS_32_BIT
                 TYPE_U32, // !< U32 type stored
                 TYPE_I32, // !< I32 type stored
+#endif
+#if FW_HAS_64_BIT
                 TYPE_U64, // !< U64 type stored
                 TYPE_I64, // !< I64 type stored
+#endif
                 TYPE_F32, // !< F32 type stored
+#if FW_HAS_F64
                 TYPE_F64, // !< F64 type stored
+#endif
                 TYPE_BOOL, // !< bool type stored
                 TYPE_PTR // !< pointer type stored
             } Type;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| PolyDb/PolyType |
|**_Affected Architectures(s)_**| N/A |
|**_Related Issue(s)_**| #1709 |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to fix #1709.

## Rationale

With the `Ref` deployment, if we don't define FW_HAS_F64, we get the following error in the PolyType module:

```sh
fprime/Fw/Types/PolyType.cpp:592:59: error: ‘union Fw::PolyType::PolyVal’ has no member named ‘f64Val’; did you mean ‘u64Val’?
```

## Testing/Review Recommendations

None

## Future Work

None
