### PR TITLE
cleans up assert level definitions, adds in relative asserts

### DIFF
--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -4,19 +4,25 @@
 #include <FpConfig.hpp>
 
 #if FW_ASSERT_LEVEL == FW_NO_ASSERT
-#define FW_ASSERT(...)
+    #define FW_ASSERT(...)
 #else // ASSERT is defined
 
+
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
-#define FILE_NAME_ARG U32
-#define FW_ASSERT(cond, ...) \
-    ((void) ((cond) ? (0) : \
-    (Fw::SwAssert(ASSERT_FILE_ID, __LINE__, ##__VA_ARGS__))))
+    #define FILE_NAME_ARG U32
+    #define FW_ASSERT(cond, ...) \
+        ((void) ((cond) ? (0) : \
+        (Fw::SwAssert(ASSERT_FILE_ID, __LINE__, ##__VA_ARGS__))))
+#elif FW_ASSERT_LEVEL == FW_RELATIVE_PATH_ASSERT
+    #define FILE_NAME_ARG const CHAR*
+    #define FW_ASSERT(cond, ...) \
+        ((void) ((cond) ? (0) : \
+        (Fw::SwAssert(ASSERT_RELATIVE_PATH, __LINE__, ##__VA_ARGS__))))
 #else
-#define FILE_NAME_ARG const CHAR*
-#define FW_ASSERT(cond, ...) \
-    ((void) ((cond) ? (0) : \
-    (Fw::SwAssert(__FILE__, __LINE__, ##__VA_ARGS__))))
+    #define FILE_NAME_ARG const CHAR*
+    #define FW_ASSERT(cond, ...) \
+        ((void) ((cond) ? (0) : \
+        (Fw::SwAssert(__FILE__, __LINE__, ##__VA_ARGS__))))
 #endif
 
 // F' Assertion functions can technically return even though the intention is for the assertion to terminate the program.
@@ -81,8 +87,6 @@ namespace Fw {
             // the previous assert hook
             AssertHook *previousHook;
     };
-
-
 }
 #endif // if ASSERT is defined
 

--- a/Fw/Types/BasicTypes.hpp
+++ b/Fw/Types/BasicTypes.hpp
@@ -26,7 +26,7 @@ extern "C" {
 #define FW_NO_ASSERT                        1   //!< Asserts turned off
 #define FW_FILEID_ASSERT                    2   //!< File ID used - requires -DASSERT_FILE_ID=somevalue to be set on the compile command line
 #define FW_FILENAME_ASSERT                  3   //!< Uses the file path in the assert - image stores filenames
-#define FW_RELATIVE_PATH_ASSERT             4   //!< Uses a relative file path (within fprime/fprime library) for assert. - requires -DASSERT_RELATIVE_PATH=somepath to be set on the compile command line
+#define FW_RELATIVE_PATH_ASSERT             4   //!< Uses a relative file path (within fprime/fprime library) for assert. - requires -DASSERT_RELATIVE_PATH=path to be set on the compile command line
 
 /*----------------------------------------------------------------------------*/
 typedef int8_t          I8; //!< 8-bit signed integer

--- a/Fw/Types/BasicTypes.hpp
+++ b/Fw/Types/BasicTypes.hpp
@@ -23,6 +23,11 @@ extern "C" {
   #error Unsupported compiler!
 #endif
 
+#define FW_NO_ASSERT                        1   //!< Asserts turned off
+#define FW_FILEID_ASSERT                    2   //!< File ID used - requires -DASSERT_FILE_ID=somevalue to be set on the compile command line
+#define FW_FILENAME_ASSERT                  3   //!< Uses the file path in the assert - image stores filenames
+#define FW_RELATIVE_PATH_ASSERT             4   //!< Uses a relative file path (within fprime/fprime library) for assert. - requires -DASSERT_RELATIVE_PATH=somepath to be set on the compile command line
+
 /*----------------------------------------------------------------------------*/
 typedef int8_t          I8; //!< 8-bit signed integer
 typedef uint8_t         U8; //!< 8-bit unsigned integer

--- a/cmake/target/build.cmake
+++ b/cmake/target/build.cmake
@@ -63,7 +63,7 @@ function(build_setup_build_module MODULE SOURCES GENERATED EXCLUDED_SOURCES DEPE
         )
         # Setup the hash file for our sources
         foreach(SRC_FILE IN LISTS MODULE_SOURCES)
-            set_hash_flag("${SRC_FILE}")
+            set_assert_flags("${SRC_FILE}")
         endforeach()
     endif()
     # Includes the source, so that the Ac files can include source headers

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -489,7 +489,7 @@ endfunction(get_expected_tool_version)
 #
 # Adds a -DASSERT_FILE_ID=(First 8 digits of MD5) to each source file, and records the output in
 # hashes.txt. This allows for asserts on file ID not string. Also adds the -DASSERT_RELATIVE_PATH
-# flag for handling relative path asseerts.
+# flag for handling relative path asserts.
 ####
 function(set_assert_flags SRC)
     get_filename_component(FPRIME_CLOSEST_BUILD_ROOT_ABS "${FPRIME_CLOSEST_BUILD_ROOT}" ABSOLUTE)

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -485,19 +485,20 @@ function(get_expected_tool_version VID FILL_VARIABLE)
 endfunction(get_expected_tool_version)
 
 ####
-# Function `set_hash_flag`:
+# Function `set_assert_flags`:
 #
 # Adds a -DASSERT_FILE_ID=(First 8 digits of MD5) to each source file, and records the output in
-# hashes.txt. This allows for asserts on file ID not string.
+# hashes.txt. This allows for asserts on file ID not string. Also adds the -DASSERT_RELATIVE_PATH
+# flag for handling relative path asseerts.
 ####
-function(set_hash_flag SRC)
+function(set_assert_flags SRC)
     get_filename_component(FPRIME_CLOSEST_BUILD_ROOT_ABS "${FPRIME_CLOSEST_BUILD_ROOT}" ABSOLUTE)
     string(REPLACE "${FPRIME_CLOSEST_BUILD_ROOT_ABS}/" "" SHORT_SRC "${SRC}")
     string(MD5 HASH_VAL "${SHORT_SRC}")
     string(SUBSTRING "${HASH_VAL}" 0 8 HASH_32)
     file(APPEND "${CMAKE_BINARY_DIR}/hashes.txt" "${SHORT_SRC}: 0x${HASH_32}\n")
-    SET_SOURCE_FILES_PROPERTIES(${SRC} PROPERTIES COMPILE_FLAGS -DASSERT_FILE_ID="0x${HASH_32}")
-endfunction(set_hash_flag)
+    SET_SOURCE_FILES_PROPERTIES(${SRC} PROPERTIES COMPILE_FLAGS "-DASSERT_FILE_ID=0x${HASH_32} -DASSERT_RELATIVE_PATH='\"${SHORT_SRC}\"'")
+endfunction(set_assert_flags)
 
 
 ####

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -493,7 +493,10 @@ endfunction(get_expected_tool_version)
 ####
 function(set_assert_flags SRC)
     get_filename_component(FPRIME_CLOSEST_BUILD_ROOT_ABS "${FPRIME_CLOSEST_BUILD_ROOT}" ABSOLUTE)
+    get_filename_component(FPRIME_PROJECT_ROOT_ABS "${FPRIME_PROJECT_ROOT}" ABSOLUTE)
     string(REPLACE "${FPRIME_CLOSEST_BUILD_ROOT_ABS}/" "" SHORT_SRC "${SRC}")
+    string(REPLACE "${FPRIME_PROJECT_ROOT_ABS}/" "" SHORT_SRC "${SHORT_SRC}")
+
     string(MD5 HASH_VAL "${SHORT_SRC}")
     string(SUBSTRING "${HASH_VAL}" 0 8 HASH_32)
     file(APPEND "${CMAKE_BINARY_DIR}/hashes.txt" "${SHORT_SRC}: 0x${HASH_32}\n")

--- a/config/FpConfig.hpp
+++ b/config/FpConfig.hpp
@@ -189,13 +189,12 @@ struct FpLimits : BasicLimits {
  #endif
 #endif
 
-// Turn asserts on or off
-
-#define FW_NO_ASSERT                        1   //!< Asserts turned off
-#define FW_FILEID_ASSERT                    2   //!< File ID used - requires -DASSERT_FILE_ID=somevalue to be set on the compile command line
-#define FW_FILENAME_ASSERT                  3   //!< Uses the file name in the assert - image stores filenames
+// Set assertion form. Options:
+//   1. FW_NO_ASSERT: assertions are compiled out
+//   2. FW_FILEID_ASSERT: asserts report a file CRC and line number
+//   3. FW_FILENAME_ASSERT: asserts report a file path (__FILE__) and line number
+//   4. FW_RELATIVE_PATH_ASSERT: asserts report a relative path within F´ or F´ library and line number
 #define FW_ASSERT_DFL_MSG_LEN               256 //!< Maximum assert message length when using the default assert handler
-
 #ifndef FW_ASSERT_LEVEL
 #define FW_ASSERT_LEVEL                     FW_FILENAME_ASSERT //!< Defines the type of assert used
 #endif


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Minor cleanup to asserts:

1. Moves assert-level definitions to "BasicTypes.hpp" such that a project need to remember to define those tokens to use them.  
2. Refactors that `#if` block in `Assert.hpp` to make it easer to understand the divisions
3. Adds in `FW_RELATIVE_PATH_ASSERT` that prints assert strings as seen below

![assert-relative](https://user-images.githubusercontent.com/995330/200913231-00d81576-beaa-485c-bbf2-8c1f287bab9a.png)

