### PR TITLE
Add sanitizer options

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -297,6 +297,7 @@ deframer
 deframing
 delchars
 delitem
+DENABLE
 deployables
 DEPRECATEDLIST
 deps
@@ -519,6 +520,7 @@ frontend
 frox
 frsize
 fsanitize
+fsanitizers
 fscanf
 fstream
 fstrength
@@ -1174,6 +1176,7 @@ rxor
 saddr
 Saikiran
 Sanchit
+sanitizers
 sats
 savelist
 saveop
@@ -1488,6 +1491,7 @@ typeslist
 typetoken
 tzinfo
 uart
+UBSAN
 ubuntu
 ucf
 Uchenik

--- a/cmake/FPrime.cmake
+++ b/cmake/FPrime.cmake
@@ -22,6 +22,7 @@ message(STATUS "Searching for F prime modules in: ${FPRIME_BUILD_LOCATIONS}")
 message(STATUS "Autocoder constants file: ${FPRIME_AC_CONSTANTS_FILE}")
 message(STATUS "Configuration header directory: ${FPRIME_CONFIG_DIR}")
 
+include(sanitizers) # Enable sanitizers if they are requested
 include(required)
 include(prescan) #Must come after required if tools detection is to be inherited
 include(platform/platform)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -181,6 +181,70 @@ option(FPRIME_SKIP_TOOLS_VERSION_CHECK "Skip the version checking of tools" OFF)
 ####
 option(FPRIME_CHECK_FRAMEWORK_VERSION "(Internal) Check framework version when building." OFF)
 
+####
+# `ENABLE_SANITIZER_ADDRESS:`
+#
+# Enables Google's AddressSanitizer. AddressSanitizer is a memory error detector for C/C++.
+# More information: https://github.com/google/sanitizers/wiki/AddressSanitizer
+# Practically, this adds the -fsanitizers=address flag to both the compiler and linker for the whole build.
+#
+# **Values:**
+# - ON: enables AddressSanitizer.
+# - OFF: (default) does not enable AddressSanitizer.
+#
+# e.g. `-DENABLE_SANITIZER_ADDRESS=ON`
+####
+option(ENABLE_SANITIZER_ADDRESS "Enable address sanitizer" OFF)
+
+####
+# `ENABLE_SANITIZER_LEAK:`
+#
+# Enables Google's LeakSanitizer. LeakSanitizer is a memory leak detector which is integrated into AddressSanitizer.
+# More information: https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer
+# Practically, this adds the -fsanitizers=leak flag to both the compiler and linker for the whole build.
+# 
+# Note: LeakSanitizer is not available on macOS. Use AddressSanitizer instead.
+#
+# **Values:**
+# - ON: enables LeakSanitizer.
+# - OFF: (default) does not enable LeakSanitizer.
+#
+# e.g. `-DENABLE_SANITIZER_LEAK=ON`
+####
+option(ENABLE_SANITIZER_LEAK "Enable leak sanitizer" OFF)
+
+####
+# `ENABLE_SANITIZER_UNDEFINED_BEHAVIOR:`
+#
+# Enables Google's UndefinedBehaviorSanitizer. UndefinedBehaviorSanitizer is an undefined behavior detector.
+# More information: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
+# Practically, this adds the -fsanitizers=undefined flag to both the compiler and linker for the whole build.
+#
+# **Values:**
+# - ON: enables UndefinedBehaviorSanitizer.
+# - OFF: (default) does not enable UndefinedBehaviorSanitizer.
+#
+# e.g. `-DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON`
+####
+option(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR "Enable undefined behavior sanitizer" OFF)
+
+####
+# `ENABLE_SANITIZER_THREAD:`
+#
+# Enables Google's ThreadSanitizer. ThreadSanitizer is a tool that detects data races.
+# More information: https://clang.llvm.org/docs/ThreadSanitizer.html
+# Practically, this adds the -fsanitizers=thread flag to both the compiler and linker for the whole build.
+# 
+# Note: ThreadSanitizer does not work with Address or Leak sanitizer enabled
+#
+# **Values:**
+# - ON: enables ThreadSanitizer.
+# - OFF: (default) does not enable ThreadSanitizer.
+#
+# e.g. `-DENABLE_SANITIZER_THREAD=ON`
+####
+option(ENABLE_SANITIZER_THREAD "Enable thread sanitizer" OFF)
+
 # Backwards compatibility, when build type=TESTING BUILD_TESTING is on
 string(TOUPPER "${CMAKE_BUILD_TYPE}" FPRIME_BUILD_TYPE)
 if (FPRIME_BUILD_TYPE STREQUAL "TESTING")

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -1,0 +1,46 @@
+####
+# sanitizers.cmake:
+#
+# Enables sanitizers in the build settings when requested by the user with -DENABLE_SANITIZER_<...>=ON.
+#
+# Sanitizers, by default, output their logs to stderr. To redirect the output to files instead, use the 
+# `log_path` option from the sanitizer <SAN>_OPTION environment variable at runtime. For example, with UBSAN:
+# >>> UBSAN_OPTIONS="log_path=/path/to/output_dir" fprime-util check   (or a single executable file).
+# If a relative path is specified, this will be relative to the test main function's file **in the build cache**.
+####
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+    set(SANITIZERS)
+
+    if(ENABLE_SANITIZER_ADDRESS)
+        list(APPEND SANITIZERS "address")
+    endif()
+
+    if(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR)
+        list(APPEND SANITIZERS "undefined")
+    endif()
+
+    if(ENABLE_SANITIZER_LEAK)
+        if(APPLE) 
+            message(WARNING "Leak sanitizer not supported on macOS.")
+        else()
+            list(APPEND SANITIZERS "leak")
+        endif()
+    endif()
+
+    if(ENABLE_SANITIZER_THREAD)
+        if("address" IN_LIST SANITIZERS OR "leak" IN_LIST SANITIZERS)
+            message(WARNING "Thread sanitizer does not work with Address or Leak sanitizer enabled")
+        else()
+            list(APPEND SANITIZERS "thread")
+        endif()
+    endif()
+
+    list(JOIN SANITIZERS "," LIST_OF_SANITIZERS)
+
+    if(LIST_OF_SANITIZERS AND NOT "${LIST_OF_SANITIZERS}" STREQUAL "")
+            message(STATUS "Enabled the following sanitizers: ${LIST_OF_SANITIZERS}")
+            add_compile_options(-fsanitize=${LIST_OF_SANITIZERS})
+            add_link_options(-fsanitize=${LIST_OF_SANITIZERS})
+    endif()
+endif()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| CMake |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/1085 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adding options to enable the compilers' native sanitizers to run on FPrime builds, eventually phasing off the need for Valgrind.

## Rationale

See https://github.com/nasa/fprime/issues/1085

## Future Work

- Remove Valgrind related things (e.g. `check_leak` target).
- Add an option to fprime-tools in the likes of `fprime-util generate --sanitize` to enable the commonly used sanitizers.
