### PR TITLE
Fixed platform template link in cmake-platforms.md

### DIFF
--- a/docs/UsersGuide/cmake/cmake-platforms.md
+++ b/docs/UsersGuide/cmake/cmake-platforms.md
@@ -12,5 +12,5 @@ In order to create a new platform from scratch, the user can copy "platform.cmak
 out in order to generate the new platform file. It will guide the user through the setup of this
 piece.
 
-To understand the platform template: [Platform Template File](../api/cmake/platform/platform-template.md)
+To understand the platform template: [Platform Template File](https://github.com/nasa/fprime/blob/release/documentation/docs/UsersGuide/api/cmake/platform/platform-template.md)
 To use the template: [fprime Platform Template](https://github.com/nasa/fprime/blob/devel/cmake/platform/platform.cmake.template)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  https://github.com/nasa/fprime/issues/1354|

---
## Change Description

A new link for the platform-template.md file. This file seems to only exist on the release/documentation branch, therefore, the link now points there.

## Rationale

Fixes 404 error when clicking on the old link.