### PR TITLE
Update sanitizer.cmake logging mode

### DIFF
--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -11,7 +11,7 @@
 #
 # Note: <file_prefix> is a prefix to which the sanitizer will add a unique ID to generate a unique filename.
 # If a relative path is specified, this will be relative to the component's folder **in the build cache** 
-# if using fprime-util check, OR relative to the current directory if runnning a single executable.
+# if using fprime-util check, OR relative to the current directory if running a single executable.
 ####
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -4,9 +4,14 @@
 # Enables sanitizers in the build settings when requested by the user with -DENABLE_SANITIZER_<...>=ON.
 #
 # Sanitizers, by default, output their logs to stderr. To redirect the output to files instead, use the 
-# `log_path` option from the sanitizer <SAN>_OPTION environment variable at runtime. For example, with UBSAN:
-# >>> UBSAN_OPTIONS="log_path=/path/to/output_dir" fprime-util check   (or a single executable file).
-# If a relative path is specified, this will be relative to the test main function's file **in the build cache**.
+# `log_path` option from the sanitizer <SAN>_OPTIONS environment variable at runtime. For example, with UBSAN:
+# >>> UBSAN_OPTIONS="log_path=/path/to/output_dir/file_prefix" fprime-util check
+# or
+# >>> UBSAN_OPTIONS="log_path=/path/to/output_dir/file_prefix" ./path/to/executable
+#
+# Note: <file_prefix> is a prefix to which the sanitizer will add a unique ID to generate a unique filename.
+# If a relative path is specified, this will be relative to the component's folder **in the build cache** 
+# if using fprime-util check, OR relative to the current directory if runnning a single executable.
 ####
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -22,7 +22,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clan
 
     if(ENABLE_SANITIZER_LEAK)
         if(APPLE) 
-            message(WARNING "Leak sanitizer not supported on macOS.")
+            message(STATUS "[WARNING] Leak sanitizer is not supported on macOS")
         else()
             list(APPEND SANITIZERS "leak")
         endif()
@@ -30,7 +30,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clan
 
     if(ENABLE_SANITIZER_THREAD)
         if("address" IN_LIST SANITIZERS OR "leak" IN_LIST SANITIZERS)
-            message(WARNING "Thread sanitizer does not work with Address or Leak sanitizer enabled")
+            message(STATUS "[WARNING] Thread sanitizer does not work with Address or Leak sanitizer enabled")
         else()
             list(APPEND SANITIZERS "thread")
         endif()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| CMake |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/pull/1772 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Rationale

`WARNING` mode on CMake is a little unpredictable regarding the output, and writes to stderr. This is not well suited for the warnings that some sanitizers cannot be enabled. This PR changes those warnings back to STATUS mode, with a warning label in the text.

