### PR TITLE
fixing cppcheck detected issues

### DIFF
--- a/Drv/Ip/SocketReadTask.cpp
+++ b/Drv/Ip/SocketReadTask.cpp
@@ -19,7 +19,7 @@
 
 namespace Drv {
 
-SocketReadTask::SocketReadTask() : m_stop(false) {}
+SocketReadTask::SocketReadTask() : m_reconnect(false), m_stop(false) {}
 
 SocketReadTask::~SocketReadTask() {}
 

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
@@ -49,7 +49,7 @@ namespace Drv {
         }
 
         // TODO check value of len
-        len = snprintf(buf, sizeof(buf), "%d", gpio);
+        len = snprintf(buf, sizeof(buf), "%u", gpio);
         if(write(fd, buf, len) != len) {
             (void) close(fd);
             DEBUG_PRINT("gpio/export error!\n");
@@ -80,7 +80,7 @@ namespace Drv {
         }
 
         // TODO check value of len
-        len = snprintf(buf, sizeof(buf), "%d", gpio);
+        len = snprintf(buf, sizeof(buf), "%u", gpio);
         if(write(fd, buf, len) != len) {
             (void) close(fd);
             DEBUG_PRINT("gpio/unexport error!\n");
@@ -104,7 +104,7 @@ namespace Drv {
         int fd, len;
         char buf[MAX_BUF];
 
-        len = snprintf(buf, sizeof(buf), SYSFS_GPIO_DIR  "/gpio%d/direction", gpio);
+        len = snprintf(buf, sizeof(buf), SYSFS_GPIO_DIR  "/gpio%u/direction", gpio);
         FW_ASSERT(len > 0, len);
 
         fd = open(buf, O_WRONLY);
@@ -190,7 +190,7 @@ namespace Drv {
         FW_ASSERT(edge != nullptr);
         // TODO check that edge has correct values of "none", "rising", or "falling"
 
-        len = snprintf(buf, sizeof(buf), SYSFS_GPIO_DIR "/gpio%d/edge", gpio);
+        len = snprintf(buf, sizeof(buf), SYSFS_GPIO_DIR "/gpio%u/edge", gpio);
         FW_ASSERT(len > 0, len);
 
         fd = open(buf, O_WRONLY);
@@ -219,7 +219,7 @@ namespace Drv {
         int fd, len;
         char buf[MAX_BUF];
 
-        len = snprintf(buf, sizeof(buf), SYSFS_GPIO_DIR "/gpio%d/value", gpio);
+        len = snprintf(buf, sizeof(buf), SYSFS_GPIO_DIR "/gpio%u/value", gpio);
         FW_ASSERT(len > 0, len);
 
         fd = open(buf, O_RDWR | O_NONBLOCK );

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -46,8 +46,8 @@ namespace Drv {
         spi_ioc_transfer tr;
         // Zero for unused fields:
         memset(&tr, 0, sizeof(tr));
-        tr.tx_buf = reinterpret_cast<U64>(writeBuffer.getData());
-        tr.rx_buf = reinterpret_cast<U64>(readBuffer.getData());
+        tr.tx_buf = reinterpret_cast<__u64>(writeBuffer.getData());
+        tr.rx_buf = reinterpret_cast<__u64>(readBuffer.getData());
         tr.len = writeBuffer.getSize();
 /*
             .speed_hz = 0,

--- a/Os/Posix/TaskId.cpp
+++ b/Os/Posix/TaskId.cpp
@@ -13,9 +13,8 @@ extern "C" {
 
 namespace Os
 {
-    TaskId::TaskId()
+    TaskId::TaskId() : id(pthread_self())
     {
-        id = pthread_self();
     }
     TaskId::~TaskId()
     {

--- a/Svc/ComLogger/ComLogger.cpp
+++ b/Svc/ComLogger/ComLogger.cpp
@@ -31,7 +31,7 @@ namespace Svc {
       FW_ASSERT(maxFileSize > sizeof(U16), maxFileSize); // must be a positive integer greater than buffer length size
     }
     else {
-      FW_ASSERT(maxFileSize > sizeof(0), maxFileSize); // must be a positive integer
+      FW_ASSERT(maxFileSize > 0, maxFileSize); // must be a positive integer
     }
     FW_ASSERT(Fw::StringUtils::string_length(incomingFilePrefix, sizeof(this->filePrefix)) < sizeof(this->filePrefix),
       Fw::StringUtils::string_length(incomingFilePrefix, sizeof(this->filePrefix)), sizeof(this->filePrefix)); // ensure that file prefix is not too big

--- a/Svc/Health/HealthComponentImpl.cpp
+++ b/Svc/Health/HealthComponentImpl.cpp
@@ -200,7 +200,7 @@ namespace Svc {
         this->cmdResponse_out(opCode,cmdSeq,Fw::CmdResponse::OK);
     }
 
-    NATIVE_INT_TYPE HealthImpl::findEntry(Fw::CmdStringArg entry) {
+    NATIVE_INT_TYPE HealthImpl::findEntry(const Fw::CmdStringArg& entry) {
 
         // walk through entries
         for (NATIVE_UINT_TYPE tableEntry = 0; tableEntry < NUM_PINGSEND_OUTPUT_PORTS; tableEntry++) {

--- a/Svc/Health/HealthComponentImpl.hpp
+++ b/Svc/Health/HealthComponentImpl.hpp
@@ -142,7 +142,7 @@ namespace Svc {
                 Fw::Enabled::t enabled; //!< if current ping result is checked
             } m_pingTrackerEntries[NUM_PINGSEND_OUTPUT_PORTS];
 
-            NATIVE_INT_TYPE findEntry(Fw::CmdStringArg entry);
+            NATIVE_INT_TYPE findEntry(const Fw::CmdStringArg& entry);
 
             //!  Private member data
             U32 m_numPingEntries; //!< stores number of entries passed to constructor

--- a/Svc/SystemResources/SystemResources.cpp
+++ b/Svc/SystemResources/SystemResources.cpp
@@ -39,10 +39,6 @@ SystemResources ::SystemResources(const char* const compName)
     }
 
     m_cpu_count = (m_cpu_count >= CPU_COUNT) ? CPU_COUNT : m_cpu_count;
-}
-
-void SystemResources ::init(const NATIVE_INT_TYPE instance) {
-    SystemResourcesComponentBase::init(instance);
 
     m_cpu_tlm_functions[0] = &Svc::SystemResources::tlmWrite_CPU_00;
     m_cpu_tlm_functions[1] = &Svc::SystemResources::tlmWrite_CPU_01;
@@ -60,6 +56,10 @@ void SystemResources ::init(const NATIVE_INT_TYPE instance) {
     m_cpu_tlm_functions[13] = &Svc::SystemResources::tlmWrite_CPU_13;
     m_cpu_tlm_functions[14] = &Svc::SystemResources::tlmWrite_CPU_14;
     m_cpu_tlm_functions[15] = &Svc::SystemResources::tlmWrite_CPU_15;
+}
+
+void SystemResources ::init(const NATIVE_INT_TYPE instance) {
+    SystemResourcesComponentBase::init(instance);
 }
 
 SystemResources ::~SystemResources() {}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes the issues detected by CPP check (see #1782 ).  Note the following categories of checks are ignored as they are false-positives:

- Uninitialized Variables of the form U8 buffer[SOME_SIZE]:  it is inefficient to zero a buffer that will just be overwritten
- To many format parameters: it isn't picking up the PRIu32 style format codes
- No assigned in =: we delegate to a `set` method and it cannot follow
- Missing copy constructor/=:  Singleton objects are not copied.
 
We could consider adding `=delete` constructors...to prevent that last one.
