### PR TITLE
fixes old autocoder printf types to newly setup types

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
@@ -447,7 +447,7 @@ namespace ${namespace} {
       (void) snprintf(
           portName,
           sizeof(portName),
-          "%s_${instance}_InputPort[%d]",
+          "%s_${instance}_InputPort[%" PRI_FwIndexType "]",
           this->m_objName,
           port
       );
@@ -474,7 +474,7 @@ namespace ${namespace} {
       (void) snprintf(
           portName,
           sizeof(portName),
-          "%s_${instance}_OutputPort[%d]",
+          "%s_${instance}_OutputPort[%" PRI_FwIndexType "]",
           this->m_objName,
           port
       );

--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
@@ -430,8 +430,8 @@ namespace ${namespace} {
 #for $instance, $type, $sync, $priority, $full, $role, $max_num in $input_ports:
     // Connect input port $instance
     for (
-        NATIVE_INT_TYPE port = 0;
-        port < this->getNum_${instance}_InputPorts();
+        FwIndexType port = 0;
+        port < static_cast<FwIndexType>(this->getNum_${instance}_InputPorts());
         port++
     ) {
 
@@ -463,8 +463,8 @@ namespace ${namespace} {
 \#if FW_ENABLE_TEXT_LOGGING == 1
   #end if
     for (
-        NATIVE_INT_TYPE port = 0;
-        port < this->getNum_${instance}_OutputPorts();
+        FwIndexType port = 0;
+        port < static_cast<FwIndexType>(this->getNum_${instance}_OutputPorts());
         port++
     ) {
       this->m_${instance}_OutputPort[port].init();

--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/cpp.tmpl
@@ -430,8 +430,8 @@ namespace ${namespace} {
 #for $instance, $type, $sync, $priority, $full, $role, $max_num in $input_ports:
     // Connect input port $instance
     for (
-        FwIndexType port = 0;
-        port < static_cast<FwIndexType>(this->getNum_${instance}_InputPorts());
+        PlatformIntType port = 0;
+        port < static_cast<PlatformIntType>(this->getNum_${instance}_InputPorts());
         port++
     ) {
 
@@ -447,7 +447,7 @@ namespace ${namespace} {
       (void) snprintf(
           portName,
           sizeof(portName),
-          "%s_${instance}_InputPort[%" PRI_FwIndexType "]",
+          "%s_${instance}_InputPort[%" PRI_PlatformIntType "]",
           this->m_objName,
           port
       );
@@ -463,8 +463,8 @@ namespace ${namespace} {
 \#if FW_ENABLE_TEXT_LOGGING == 1
   #end if
     for (
-        FwIndexType port = 0;
-        port < static_cast<FwIndexType>(this->getNum_${instance}_OutputPorts());
+        PlatformIntType port = 0;
+        port < static_cast<PlatformIntType>(this->getNum_${instance}_OutputPorts());
         port++
     ) {
       this->m_${instance}_OutputPort[port].init();
@@ -474,7 +474,7 @@ namespace ${namespace} {
       (void) snprintf(
           portName,
           sizeof(portName),
-          "%s_${instance}_OutputPort[%" PRI_FwIndexType "]",
+          "%s_${instance}_OutputPort[%" PRI_PlatformIntType "]",
           this->m_objName,
           port
       );

--- a/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
@@ -121,8 +121,8 @@ $emit_cpp_params([ $param_instance ])
 \#if FW_ENABLE_TEXT_LOGGING == 1
   #end if
     for (
-        FwIndexType _port = 0;
-        _port < static_cast<FwIndexType>(this->getNum_from_${instance}());
+        PlatformIntType _port = 0;
+        _port < static_cast<PlatformIntType>(this->getNum_from_${instance}());
         ++_port
     ) {
 
@@ -139,7 +139,7 @@ $emit_cpp_params([ $param_instance ])
       (void) snprintf(
           _portName,
           sizeof(_portName),
-          "%s_${port_name}[%" PRI_FwIndexType "]",
+          "%s_${port_name}[%" PRI_PlatformIntType "]",
           this->m_objName,
           _port
       );
@@ -157,8 +157,8 @@ $emit_cpp_params([ $param_instance ])
     // Initialize output port $instance
 
     for (
-        FwIndexType _port = 0;
-        _port < static_cast<FwIndexType>(this->getNum_to_${instance}());
+        PlatformIntType _port = 0;
+        _port < static_cast<PlatformIntType>(this->getNum_to_${instance}());
         ++_port
     ) {
       this->m_to_${instance}[_port].init();
@@ -168,7 +168,7 @@ $emit_cpp_params([ $param_instance ])
       snprintf(
           _portName,
           sizeof(_portName),
-          "%s_to_${instance}[%" PRI_FwIndexType "]",
+          "%s_to_${instance}[%" PRI_PlatformIntType "]",
           this->m_objName,
           _port
       );

--- a/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
@@ -139,7 +139,7 @@ $emit_cpp_params([ $param_instance ])
       (void) snprintf(
           _portName,
           sizeof(_portName),
-          "%s_${port_name}[%d]",
+          "%s_${port_name}[%" PRI_FwIndexType "]",
           this->m_objName,
           _port
       );
@@ -168,7 +168,7 @@ $emit_cpp_params([ $param_instance ])
       snprintf(
           _portName,
           sizeof(_portName),
-          "%s_to_${instance}[%d]",
+          "%s_to_${instance}[%" PRI_FwIndexType "]",
           this->m_objName,
           _port
       );
@@ -861,7 +861,7 @@ $emit_cpp_params([ $param_instance, $param_cmdSeq ] + $get_command_params($mnemo
         const Fw::SerializeStatus _status = val.deserialize(arg);
     #end if
         if (_status != Fw::FW_SERIALIZE_OK) {
-          printf("Error deserializing ${tlm_name}: %d\n", _status);
+          printf("Error deserializing ${tlm_name}: %" PRI_FwChanIdType "\n", _status);
           return;
         }
     #if $typeinfo == "enum":
@@ -1114,7 +1114,7 @@ $emit_cpp_params([ $param_const_timeTag, $param_val ])
 
     fprintf(
         file,
-        "EVENT: (%d) (%d:%d,%d) %s: %s\n",
+        "EVENT: (%" PRI_FwEventIdType ") (%" PRI_FwTimeBaseStoreType ":%" PRIu32 ",%" PRIu32 ") %s: %s\n",
         e.id,
         const_cast<TextLogEntry&>(e).timeTag.getTimeBase(),
         const_cast<TextLogEntry&>(e).timeTag.getSeconds(),

--- a/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
@@ -861,7 +861,7 @@ $emit_cpp_params([ $param_instance, $param_cmdSeq ] + $get_command_params($mnemo
         const Fw::SerializeStatus _status = val.deserialize(arg);
     #end if
         if (_status != Fw::FW_SERIALIZE_OK) {
-          printf("Error deserializing ${tlm_name}: %" PRI_FwChanIdType "\n", _status);
+          printf("Error deserializing ${tlm_name}: %d\n", _status);
           return;
         }
     #if $typeinfo == "enum":

--- a/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/test/cpp.tmpl
@@ -121,8 +121,8 @@ $emit_cpp_params([ $param_instance ])
 \#if FW_ENABLE_TEXT_LOGGING == 1
   #end if
     for (
-        NATIVE_INT_TYPE _port = 0;
-        _port < this->getNum_from_${instance}();
+        FwIndexType _port = 0;
+        _port < static_cast<FwIndexType>(this->getNum_from_${instance}());
         ++_port
     ) {
 
@@ -157,8 +157,8 @@ $emit_cpp_params([ $param_instance ])
     // Initialize output port $instance
 
     for (
-        NATIVE_INT_TYPE _port = 0;
-        _port < this->getNum_to_${instance}();
+        FwIndexType _port = 0;
+        _port < static_cast<FwIndexType>(this->getNum_to_${instance}());
         ++_port
     ) {
       this->m_to_${instance}[_port].init();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes the old autocoder output to use correct `printf` output specifiers for the new types system.