### PR TITLE
Automatically compute bounds for configurable integer types

### DIFF
--- a/config/FpConfig.hpp
+++ b/config/FpConfig.hpp
@@ -12,6 +12,7 @@
 #ifndef _FW_CONFIG_HPP_
 #define _FW_CONFIG_HPP_
 #include <Fw/Types/BasicTypes.hpp>
+#include <limits>
 
 typedef PlatformIndexType FwIndexType;
 #define PRI_FwIndexType PRI_PlatformIndexType


### PR DESCRIPTION
The file FpConfig.hpp defines

1. Some type aliases for configurable integer types.
2. For each type alias in item (1), a pair of constants representing the minimum and maximum values of the type.

In the current head of devel, items (1) and (2) are kept in sync by hand, and nothing checks that they are in sync. This is error-prone.

This PR adds a macro for computing (2) automatically, so that the user can just update (1), and the compiler will keep (2) in sync.