### PR TITLE
Fixes to math component tutorial Markdown

### DIFF
--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -768,8 +768,11 @@ set(UT_SOURCE_FILES
 register_fprime_ut()
 ```
 
-**Run the build:**
-Now we can check that the unit test build is working.
+**Generate the unit test stub:**
+We will now generate a stub implementation of the unit tests.
+This stub contains all the boilerplate necessary to write and
+run unit tests against the `MathSender` component.
+In a later step, we will fill in the stub with tests.
 
 1. Run `fprime-util generate --ut` to generate the unit test cache.
 
@@ -796,18 +799,9 @@ set(UT_SOURCE_FILES
 register_fprime_ut()
 ```
 
-**Generate the unit test stub:**
-We will now generate a stub implementation of the unit tests.
-This stub contains all the boilerplate necessary to write and
-run unit tests against the `MathSender` component.
-In a later step, we will fill in the stub with tests.
-
-1. If you have not yet run `fprime-util generate --ut`,
-then do so now.
-This step generates the CMake build cache for the unit
-tests.
-
-1. Run `fprime-util build --ut`.
+**Run the build:**
+Now we can check that the unit test build is working.
+Run `fprime-util build --ut`.
 Everything should build without errors.
 
 **Inspect the generated code:**

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -811,8 +811,8 @@ tests.
 Everything should build without errors.
 
 **Inspect the generated code:**
-The generated code is located at
-`Ref/build-fprime-automatic-native-ut/Ref/MathSender`.
+The unit test build generates some code to support unit testing.
+The code is located at `Ref/build-fprime-automatic-native-ut/Ref/MathSender`.
 This directory contains two auto-generated classes:
 
 1. `MathSenderGTestBase`: This is the direct base

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -752,12 +752,11 @@ in three steps:
 #### 4.5.1. Set Up the Unit Test Environment
 
 **Create the stub Tester class:**
-Do the following in directory `Ref/MathSender`:
-
-1. Run `mkdir -p test/ut` to create the directory where
+In the directory `Ref/MathSender`, run `mkdir -p test/ut`.
+This will create the directory where
 the unit tests will reside.
 
-1. Update Ref/MathSender/CMakeLists.txt:
+**Update Ref/MathSender/CMakeLists.txt:**
 Go back to the directory `Ref/MathSender`.
 Add the following lines to `CMakeLists.txt`:
 

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -586,14 +586,14 @@ After the second command, the build system should
 run for a bit.
 At the end there should be two new files
 in the directory:
-`MathSenderComponentImpl.cpp-template` and
-`MathSenderComponentImpl.hpp-template`.
+`MathSender.cpp-template` and
+`MathSender.hpp-template`.
 
 Run the following commands:
 
 ```bash
-mv MathSenderComponentImpl.cpp-template MathSender.cpp
-mv MathSenderComponentImpl.hpp-template MathSender.hpp
+mv MathSender.cpp-template MathSender.cpp
+mv MathSender.hpp-template MathSender.hpp
 ```
 
 These commands produce a template, or stub implementation,
@@ -775,31 +775,13 @@ Now we can check that the unit test build is working.
 1. Run `fprime-util generate --ut` to generate the unit test cache.
 
 1. Run the command `fprime-util impl --ut`.
-It should generate files `Tester.cpp` and `Tester.hpp`.
+It should generate files `Tester.cpp`, `Tester.hpp`, and `TestMain.cpp`.
 
 1. Move these files to the `test/ut` directory:
 
    ```bash
-   mv Tester.* test/ut
+   mv Tester.* TestMain.cpp test/ut
    ```
-
-**Create a stub main.cpp file:**
-Now go to the directory `Ref/MathSender/test/ut`.
-In that directory, create the file `main.cpp` and add the following contents:
-
-```c++
-#include "Tester.hpp"
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-```
-
-This file is a stub for running tests using the
-[Google Test framework](https://github.com/google/googletest).
-Right now there aren't any tests to run; we will add one
-in the next section.
 
 **Update Ref/MathSender/CMakeLists.txt:**
 Open `MathSender/CMakeLists.txt` and update the definition of
@@ -1544,7 +1526,7 @@ of the function.
 Here we do the following:
 
 1. If the parameter identifier is `PARAMID_FACTOR` (the parameter
-identifier corresponding to the `FACTOR` parameter,
+identifier corresponding to the `FACTOR` parameter),
 then get the parameter value and emit an event report.
 
 1. Otherwise fail an assertion.
@@ -1970,8 +1952,8 @@ add the following lines:
 
 ```fpp
 instance mathSender: Ref.MathSender base id 0xE00 \
-  queue size Default.queueSize \
-  stack size Default.stackSize \
+  queue size Default.QUEUE_SIZE \
+  stack size Default.STACK_SIZE \
   priority 100
 ```
 
@@ -1996,7 +1978,7 @@ add the following lines:
 
 ```fpp
 instance mathReceiver: Ref.MathReceiver base id 0x2700 \
-  queue size Default.queueSize
+  queue size Default.QUEUE_SIZE
 ```
 
 This code defines an instance `mathReceiver` of

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -1037,8 +1037,7 @@ the tests pass.
 Add a test for exercising the scenario in which the `MathReceiver`
 component sends a result back to `MathSender`.
 
-1. Add the following function signature in the "Tests"
-   section of to `Tester.hpp`:
+1. Add the following function signature in the "Tests" section of `Tester.hpp`:
 
    ```c++
    //! Test receipt of a result

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -2042,8 +2042,7 @@ This line adds the connection that drives the `schedIn`
 port of the `mathReceiver` component instance.
 
 **Re-run the check for unconnected ports:**
-When this capability exists, you will be able to see
-that `mathReceiver.schedIn` is now connected
+You should see that `mathReceiver.schedIn` is now connected
 (it no longer appears in the list).
 
 **Add the Math connections:**

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -1809,7 +1809,13 @@ This test is the same as the SUB test, except that it
 uses DIV instead of SUB.
 
 **Write a throttle test:**
-Add the following function to the "Tests" section of `Tester.cpp`:
+Add the following constant definition to the top of the `Tester.cpp` file:
+
+```C++
+#define CMD_SEQ 42
+```
+
+Then add the following function to the "Tests" section of `Tester.cpp`:
 
 ```c++
 void Tester ::

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -774,10 +774,12 @@ This stub contains all the boilerplate necessary to write and
 run unit tests against the `MathSender` component.
 In a later step, we will fill in the stub with tests.
 
-1. Run `fprime-util generate --ut` to generate the unit test cache.
+1. If you have not yet run `fprime-util generate --ut`,
+   then do so now. This step generates the CMake build cache for the unit
+   tests.
 
 1. Run the command `fprime-util impl --ut`.
-It should generate files `Tester.cpp`, `Tester.hpp`, and `TestMain.cpp`.
+   It should generate files `Tester.cpp`, `Tester.hpp`, and `TestMain.cpp`.
 
 1. Move these files to the `test/ut` directory:
 

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -102,7 +102,6 @@ in the [F Prime git repository](https://github.com/nasa/fprime).
 You may also wish to work through the Getting Started tutorial at
 `docs/GettingStarted/Tutorial.md`.
 
-
 **Version control:**
 Working on this tutorial will modify some files under version control
 in the F Prime git repository.

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -102,6 +102,7 @@ in the [F Prime git repository](https://github.com/nasa/fprime).
 You may also wish to work through the Getting Started tutorial at
 `docs/GettingStarted/Tutorial.md`.
 
+
 **Version control:**
 Working on this tutorial will modify some files under version control
 in the F Prime git repository.
@@ -756,7 +757,7 @@ Do the following in directory `Ref/MathSender`:
 1. Run `mkdir -p test/ut` to create the directory where
 the unit tests will reside.
 
-2. Update Ref/MathSender/CMakeLists.txt:
+1. Update Ref/MathSender/CMakeLists.txt:
 Go back to the directory `Ref/MathSender`.
 Add the following lines to `CMakeLists.txt`:
 
@@ -768,19 +769,19 @@ set(UT_SOURCE_FILES
 register_fprime_ut()
 ```
 
-This code tells the build system how to build
-and run the unit tests.
+**Run the build:**
+Now we can check that the unit test build is working.
 
-4. Run `fprime-util generate --ut` to generate the unit test cache.
+1. Run `fprime-util generate --ut` to generate the unit test cache.
 
-5. Run the command `fprime-util impl --ut`.
+1. Run the command `fprime-util impl --ut`.
 It should generate files `Tester.cpp` and `Tester.hpp`.
 
-6. Move these files to the `test/ut` directory:
+1. Move these files to the `test/ut` directory:
 
-```bash
-mv Tester.* test/ut
-```
+   ```bash
+   mv Tester.* test/ut
+   ```
 
 **Create a stub main.cpp file:**
 Now go to the directory `Ref/MathSender/test/ut`.
@@ -800,16 +801,16 @@ This file is a stub for running tests using the
 Right now there aren't any tests to run; we will add one
 in the next section.
 
-7. Add the new files to the build.
+**Update Ref/MathSender/CMakeLists.txt:**
+Open `MathSender/CMakeLists.txt` and update the definition of
+`UT_SOURCE_FILES` by adding your new test files:
 
-Open `MathSender/CMakeLists.txt` and modify the `UT_SOURCE_FILES` by adding
-your new test files:
 ```cmake
 # Register the unit test build
 set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/MathSender.fpp"
-  "${CMAKE_CURRENT_LIST_DIR}/test/ut/main.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/Tester.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/main.cpp"
 )
 register_fprime_ut()
 ```
@@ -1825,12 +1826,6 @@ This test is the same as the SUB test, except that it
 uses DIV instead of SUB.
 
 **Write a throttle test:**
-Add the following to the top of the `Tester.cpp` file:
-
-```C++
-#define CMD_SEQ 42
-```
-
 Add the following function to the "Tests" section of `Tester.cpp`:
 
 ```c++
@@ -2051,13 +2046,12 @@ Those ports will include the ports for the new instances
 Find the line that starts `connections RateGroups`.
 This is the beginning of the definition of the `RateGroups`
 connection graph.
-After the last entry for the `rateGroup1Comp` (rate group 1) add the line:
-```fpp
-rateGroup1Comp.RateGroupMemberOut[5] -> mathReceiver.schedIn
-```
+After the last entry for the `rateGroup1Comp` (rate group 1) add
+the following line:
 
-> You might need to change the array index 5 to be one greater than the previous
-`rateGroup1Comp` index. Otherwise you'll get a duplicate connection error.
+```fpp
+rateGroup1Comp.RateGroupMemberOut -> mathReceiver.schedIn
+```
 
 This line adds the connection that drives the `schedIn`
 port of the `mathReceiver` component instance.
@@ -2308,7 +2302,7 @@ Select the log you wish to inspect from the drop-down menu.
 By default, there is no log selected.
 
 <a name="Conclusion"></a>
-### 8. Conclusion
+## 8. Conclusion
 
 The Math Component tutorial has shown us how to create simple types, ports and
 components for our application using the FPP modeling language. We have learned

--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -796,8 +796,11 @@ set(UT_SOURCE_FILES
 register_fprime_ut()
 ```
 
-**Run the build:**
-Now we can check that the unit test build is working.
+**Generate the unit test stub:**
+We will now generate a stub implementation of the unit tests.
+This stub contains all the boilerplate necessary to write and
+run unit tests against the `MathSender` component.
+In a later step, we will fill in the stub with tests.
 
 1. If you have not yet run `fprime-util generate --ut`,
 then do so now.

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -408,14 +408,14 @@ After the second command, the build system should
 run for a bit.
 At the end there should be two new files
 in the directory:
-`MathSenderComponentImpl.cpp-template` and
-`MathSenderComponentImpl.hpp-template`.
+`MathSender.cpp-template` and
+`MathSender.hpp-template`.
 
 Run the following commands:
 
 ```bash
-mv MathSenderComponentImpl.cpp-template MathSender.cpp
-mv MathSenderComponentImpl.hpp-template MathSender.hpp
+mv MathSender.cpp-template MathSender.cpp
+mv MathSender.hpp-template MathSender.hpp
 ```
 
 These commands produce a template, or stub implementation,
@@ -594,31 +594,13 @@ Now we can check that the unit test build is working.
 1. Run `fprime-util generate --ut` to generate the unit test cache.
 
 1. Run the command `fprime-util impl --ut`.
-It should generate files `Tester.cpp` and `Tester.hpp`.
+It should generate files `Tester.cpp`, `Tester.hpp`, and `TestMain.cpp`.
 
 1. Move these files to the `test/ut` directory:
 
    ```bash
-   mv Tester.* test/ut
+   mv Tester.* TestMain.cpp test/ut
    ```
-
-**Create a stub main.cpp file:**
-Now go to the directory `Ref/MathSender/test/ut`.
-In that directory, create the file `main.cpp` and add the following contents:
-
-```c++
-#include "Tester.hpp"
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-```
-
-This file is a stub for running tests using the
-[Google Test framework](https://github.com/google/googletest).
-Right now there aren't any tests to run; we will add one
-in the next section.
 
 **Update Ref/MathSender/CMakeLists.txt:**
 Open `MathSender/CMakeLists.txt` and update the definition of
@@ -1249,7 +1231,7 @@ of the function.
 Here we do the following:
 
 1. If the parameter identifier is `PARAMID_FACTOR` (the parameter
-identifier corresponding to the `FACTOR` parameter,
+identifier corresponding to the `FACTOR` parameter),
 then get the parameter value and emit an event report.
 
 1. Otherwise fail an assertion.
@@ -1665,8 +1647,8 @@ add the following lines:
 
 ```fpp
 instance mathSender: Ref.MathSender base id 0xE00 \
-  queue size Default.queueSize \
-  stack size Default.stackSize \
+  queue size Default.QUEUE_SIZE \
+  stack size Default.STACK_SIZE \
   priority 100
 ```
 
@@ -1691,7 +1673,7 @@ add the following lines:
 
 ```fpp
 instance mathReceiver: Ref.MathReceiver base id 0x2700 \
-  queue size Default.queueSize
+  queue size Default.QUEUE_SIZE
 ```
 
 This code defines an instance `mathReceiver` of

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -1736,8 +1736,7 @@ This line adds the connection that drives the `schedIn`
 port of the `mathReceiver` component instance.
 
 **Re-run the check for unconnected ports:**
-When this capability exists, you will be able to see
-that `mathReceiver.schedIn` is now connected
+You should see that `mathReceiver.schedIn` is now connected
 (it no longer appears in the list).
 
 **Add the Math connections:**

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -571,12 +571,11 @@ in three steps:
 #### Set Up the Unit Test Environment
 
 **Create the stub Tester class:**
-Do the following in directory `Ref/MathSender`:
-
-1. Run `mkdir -p test/ut` to create the directory where
+In the directory `Ref/MathSender`, run `mkdir -p test/ut`.
+This will create the directory where
 the unit tests will reside.
 
-1. Update Ref/MathSender/CMakeLists.txt:
+**Update Ref/MathSender/CMakeLists.txt:**
 Go back to the directory `Ref/MathSender`.
 Add the following lines to `CMakeLists.txt`:
 

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -1510,7 +1510,13 @@ This test is the same as the SUB test, except that it
 uses DIV instead of SUB.
 
 **Write a throttle test:**
-Add the following function to the "Tests" section of `Tester.cpp`:
+Add the following constant definition to the top of the `Tester.cpp` file:
+
+```C++
+#define CMD_SEQ 42
+```
+
+Then add the following function to the "Tests" section of `Tester.cpp`:
 
 ```c++
 void Tester ::

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -51,7 +51,6 @@ in the [F Prime git repository](https://github.com/nasa/fprime).
 You may also wish to work through the Getting Started tutorial at
 `docs/GettingStarted/Tutorial.md`.
 
-
 **Version control:**
 Working on this tutorial will modify some files under version control
 in the F Prime git repository.

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -630,8 +630,8 @@ tests.
 Everything should build without errors.
 
 **Inspect the generated code:**
-The generated code is located at
-`Ref/build-fprime-automatic-native-ut/Ref/MathSender`.
+The unit test build generates some code to support unit testing.
+The code is located at `Ref/build-fprime-automatic-native-ut/Ref/MathSender`.
 This directory contains two auto-generated classes:
 
 1. `MathSenderGTestBase`: This is the direct base

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -51,15 +51,14 @@ in the [F Prime git repository](https://github.com/nasa/fprime).
 You may also wish to work through the Getting Started tutorial at
 `docs/GettingStarted/Tutorial.md`.
 
-**Git branch:** This tutorial is designed to work on the branch `release/v3.0.0`.
 
-Working on this tutorial will modify some files under version control in the
-F Prime git repository.
+**Version control:**
+Working on this tutorial will modify some files under version control
+in the F Prime git repository.
 Therefore it is a good idea to do this work on a new branch.
 For example:
 
 ```bash
-git checkout release/v3.0.0
 git checkout -b math-tutorial
 ```
 
@@ -394,7 +393,7 @@ for <a href="#types_add">`Ref/MathTypes`</a>.
 ### Build the Stub Implementation
 
 **Run the build:**
-Go into the directory `Ref/MathTypes`.
+Go into the directory `Ref/MathSender`.
 Run the following commands:
 
 ```bash
@@ -577,6 +576,23 @@ Do the following in directory `Ref/MathSender`:
 1. Run `mkdir -p test/ut` to create the directory where
 the unit tests will reside.
 
+1. Update Ref/MathSender/CMakeLists.txt:
+Go back to the directory `Ref/MathSender`.
+Add the following lines to `CMakeLists.txt`:
+
+```cmake
+# Register the unit test build
+set(UT_SOURCE_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/MathSender.fpp"
+)
+register_fprime_ut()
+```
+
+**Run the build:**
+Now we can check that the unit test build is working.
+
+1. Run `fprime-util generate --ut` to generate the unit test cache.
+
 1. Run the command `fprime-util impl --ut`.
 It should generate files `Tester.cpp` and `Tester.hpp`.
 
@@ -588,8 +604,7 @@ It should generate files `Tester.cpp` and `Tester.hpp`.
 
 **Create a stub main.cpp file:**
 Now go to the directory `Ref/MathSender/test/ut`.
-In that directory, create a file `main.cpp` with the
-following contents:
+In that directory, create the file `main.cpp` and add the following contents:
 
 ```c++
 #include "Tester.hpp"
@@ -606,8 +621,8 @@ Right now there aren't any tests to run; we will add one
 in the next section.
 
 **Update Ref/MathSender/CMakeLists.txt:**
-Go back to the directory `Ref/MathSender`.
-Add the following lines to `CMakeLists.txt`:
+Open `MathSender/CMakeLists.txt` and update the definition of
+`UT_SOURCE_FILES` by adding your new test files:
 
 ```cmake
 # Register the unit test build
@@ -618,9 +633,6 @@ set(UT_SOURCE_FILES
 )
 register_fprime_ut()
 ```
-
-This code tells the build system how to build
-and run the unit tests.
 
 **Run the build:**
 Now we can check that the unit test build is working.
@@ -937,7 +949,7 @@ and 10.
    This line tells the build system to make the unit test build
    depend on the `STest` build module.
 
-1. Add `#include STest/Random/Random.hpp` to `main.cpp`.
+1. Add `#include "STest/Random/Random.hpp"` to `main.cpp`.
 
 1. Add the following line to the `main` function of `main.cpp`,
    just before the return statement:
@@ -1712,7 +1724,7 @@ These lines add the `mathSender` and `mathReceiver`
 instances to the topology.
 
 **Check for unconnected ports:**
-Run the following commands:
+Run the following commands in the `Ref/Top` directory:
 
 ```bash
 fprime-util fpp-check -u unconnected.txt
@@ -1728,13 +1740,11 @@ Those ports will include the ports for the new instances
 Find the line that starts `connections RateGroups`.
 This is the beginning of the definition of the `RateGroups`
 connection graph.
-Inside the block of that definition,
-find the line
-`rateGroup1Comp.RateGroupMemberOut[3] -> fileDownlink.Run`.
-After that line, add the line
+After the last entry for the `rateGroup1Comp` (rate group 1) add
+the following line:
 
 ```fpp
-rateGroup1Comp.RateGroupMemberOut[4] -> mathReceiver.schedIn
+rateGroup1Comp.RateGroupMemberOut -> mathReceiver.schedIn
 ```
 
 This line adds the connection that drives the `schedIn`
@@ -1974,3 +1984,17 @@ You can also view these logs via the GDS browser interface.
 Click the Logs tab to go the Logs view.
 Select the log you wish to inspect from the drop-down menu.
 By default, there is no log selected.
+
+## Conclusion
+
+The Math Component tutorial has shown us how to create simple types, ports and
+components for our application using the FPP modeling language. We have learned
+how to use `fprime-util` to generate implementation stubs, the build cache, and
+unit tests. We learned how to define our topology and use tools provided by
+F´ to check and visualize the topology. Lastly, we learned how to use the
+ground system to interact with our deployment.
+
+The user is now directed back to the [Tutorials](../README.md) for further
+reading or to the [Cross-Compilation Tutorial](../CrossCompilation/Tutorial.md)
+for instructions on how to cross-compile the Ref application completed in this
+tutorial for the Raspberry Pi.

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -593,10 +593,12 @@ This stub contains all the boilerplate necessary to write and
 run unit tests against the `MathSender` component.
 In a later step, we will fill in the stub with tests.
 
-1. Run `fprime-util generate --ut` to generate the unit test cache.
+1. If you have not yet run `fprime-util generate --ut`,
+   then do so now. This step generates the CMake build cache for the unit
+   tests.
 
 1. Run the command `fprime-util impl --ut`.
-It should generate files `Tester.cpp`, `Tester.hpp`, and `TestMain.cpp`.
+   It should generate files `Tester.cpp`, `Tester.hpp`, and `TestMain.cpp`.
 
 1. Move these files to the `test/ut` directory:
 

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -854,8 +854,7 @@ the tests pass.
 Add a test for exercising the scenario in which the `MathReceiver`
 component sends a result back to `MathSender`.
 
-1. Add the following function signature in the "Tests"
-   section of to `Tester.hpp`:
+1. Add the following function signature in the "Tests" section of `Tester.hpp`:
 
    ```c++
    //! Test receipt of a result

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -587,8 +587,11 @@ set(UT_SOURCE_FILES
 register_fprime_ut()
 ```
 
-**Run the build:**
-Now we can check that the unit test build is working.
+**Generate the unit test stub:**
+We will now generate a stub implementation of the unit tests.
+This stub contains all the boilerplate necessary to write and
+run unit tests against the `MathSender` component.
+In a later step, we will fill in the stub with tests.
 
 1. Run `fprime-util generate --ut` to generate the unit test cache.
 
@@ -615,18 +618,9 @@ set(UT_SOURCE_FILES
 register_fprime_ut()
 ```
 
-**Generate the unit test stub:**
-We will now generate a stub implementation of the unit tests.
-This stub contains all the boilerplate necessary to write and
-run unit tests against the `MathSender` component.
-In a later step, we will fill in the stub with tests.
-
-1. If you have not yet run `fprime-util generate --ut`,
-then do so now.
-This step generates the CMake build cache for the unit
-tests.
-
-1. Run `fprime-util build --ut`.
+**Run the build:**
+Now we can check that the unit test build is working.
+Run `fprime-util build --ut`.
 Everything should build without errors.
 
 **Inspect the generated code:**

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -615,8 +615,11 @@ set(UT_SOURCE_FILES
 register_fprime_ut()
 ```
 
-**Run the build:**
-Now we can check that the unit test build is working.
+**Generate the unit test stub:**
+We will now generate a stub implementation of the unit tests.
+This stub contains all the boilerplate necessary to write and
+run unit tests against the `MathSender` component.
+In a later step, we will fill in the stub with tests.
 
 1. If you have not yet run `fprime-util generate --ut`,
 then do so now.


### PR DESCRIPTION
This PR implements fixes to the Markdown file for the Math Component tutorial.
* Bring source file back in line with changes to auto-generated file.
* Fix several issues, including issues identified by @LMPS97 