### PR TITLE
Update Github Actions to run on Node 16 instead of Node 12 - Bump to @v3

### DIFF
--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout F´ Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -24,7 +24,7 @@ jobs:
       run: ./ci/tests/Framework.bash
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: ci-framework-logs
@@ -43,7 +43,7 @@ jobs:
       run: ./ci/tests/Ref.bash
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: ci-ref-logs
@@ -64,7 +64,7 @@ jobs:
       run: ./ci/tests/30-ints.bash
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: ci-int-logs

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: "Checkout F´ Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup
@@ -35,7 +35,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: "Checkout F´ Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup
@@ -54,7 +54,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: "Checkout F´ Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup

--- a/.github/workflows/build-test-rpi.yml
+++ b/.github/workflows/build-test-rpi.yml
@@ -47,7 +47,7 @@ jobs:
     needs: RPI
     steps:
     - name: RPI Build Download
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: rpi-build
     - name: RPI Integration Tests

--- a/.github/workflows/build-test-rpi.yml
+++ b/.github/workflows/build-test-rpi.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout F´ Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup

--- a/.github/workflows/build-test-rpi.yml
+++ b/.github/workflows/build-test-rpi.yml
@@ -28,14 +28,14 @@ jobs:
       run: mkdir -p artifact/RPI; cp -rp RPI/test RPI/build-artifacts artifact/RPI; cp -rp ci artifact
     # Build Artifacts
     - name: 'RPI Build Output'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: rpi-build
         path: artifact
         retention-days: 5
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: rpi-logs
@@ -54,7 +54,7 @@ jobs:
       run: chmod +x RPI/build-artifacts/raspberrypi/bin/RPI; /bin/bash ci/tests/RPI-Ints.bash
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: pi-int-logs

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,7 @@ jobs:
       run: ./ci/tests/Framework.bash
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: ci-framework-logs
@@ -43,7 +43,7 @@ jobs:
       run: ./ci/tests/Ref.bash
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: ci-ref-logs
@@ -66,7 +66,7 @@ jobs:
       run: ./ci/tests/30-ints.bash
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: ci-int-logs

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout F´ Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout F´ Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout F´ Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout F´ Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout F´ Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -6,7 +6,7 @@ jobs:
       name: Format
       runs-on: ubuntu-latest
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python 3.7
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| See CI outputs |
|**_Unit Tests Pass (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR updates the NodeJS version of GitHub Actions to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), instead of node12.

## Rationale

Node 12 is no longer supported as of [30 Apr 2022](https://endoflife.date/nodejs), as a result, [GitHub has begun](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) the process of deprecating Node 12 for GitHub Actions.

Several of their actions have already migrated, like `checkout`, `upload`/`download-artifacts`.

GitHub asks Actions maintainers to update their actions to work on Node 16 instead of Node 12.

## Testing/Review Recommendations

See if the CI is still on.

## Future Work

None
