### PR TITLE
Add built-in types to FPP model

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
@@ -178,8 +178,6 @@ class PortHVisitor(AbstractVisitor.AbstractVisitor):
                 "bool",
                 "FwBuffSizeType",
                 "FwChanIdType",
-                "FwDpBuffSizeType",
-                "FwDpIdType",
                 "FwEnumStoreType",
                 "FwEventIdType",
                 "FwIndexType",

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
@@ -176,13 +176,23 @@ class PortHVisitor(AbstractVisitor.AbstractVisitor):
                 "F32",
                 "F64",
                 "bool",
-                "FwOpcodeType",
+                "FwBuffSizeType",
                 "FwChanIdType",
+                "FwDpBuffSizeType",
+                "FwDpIdType",
+                "FwEnumStoreType",
                 "FwEventIdType",
+                "FwIndexType",
+                "FwOpcodeType",
+                "FwPacketDescriptorType",
                 "FwPrmIdType",
+                "FwSizeType",
+                "FwTimeBaseStoreType",
+                "FwTimeContextStoreType",
+                "FwTlmPacketizeIdType",
                 "NATIVE_INT_TYPE",
                 "NATIVE_UINT_TYPE",
-                "POINTER_CAST",
+                "POINTER_CAST"
             ]:
                 t = "sizeof(" + t + cl
             else:

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
@@ -190,7 +190,7 @@ class PortHVisitor(AbstractVisitor.AbstractVisitor):
                 "FwTlmPacketizeIdType",
                 "NATIVE_INT_TYPE",
                 "NATIVE_UINT_TYPE",
-                "POINTER_CAST"
+                "POINTER_CAST",
             ]:
                 t = "sizeof(" + t + cl
             else:

--- a/Autocoders/Python/src/fprime_ac/utils/TypesList.py
+++ b/Autocoders/Python/src/fprime_ac/utils/TypesList.py
@@ -16,12 +16,23 @@ types_list = [
 
 # additional types allowed in ports
 port_types_list = [
-    "FwOpcodeType",
+    "FwBuffSizeType",
     "FwChanIdType",
+    "FwDpBuffSizeType",
+    "FwDpIdType",
+    "FwEnumStoreType",
     "FwEventIdType",
+    "FwIndexType",
+    "FwOpcodeType",
+    "FwPacketDescriptorType",
     "FwPrmIdType",
+    "FwSizeType",
+    "FwTimeBaseStoreType",
+    "FwTimeContextStoreType",
+    "FwTlmPacketizeIdType",
     "NATIVE_INT_TYPE",
     "NATIVE_UINT_TYPE",
+    "POINTER_CAST"
 ]
 
 

--- a/Autocoders/Python/src/fprime_ac/utils/TypesList.py
+++ b/Autocoders/Python/src/fprime_ac/utils/TypesList.py
@@ -18,8 +18,6 @@ types_list = [
 port_types_list = [
     "FwBuffSizeType",
     "FwChanIdType",
-    "FwDpBuffSizeType",
-    "FwDpIdType",
     "FwEnumStoreType",
     "FwEventIdType",
     "FwIndexType",

--- a/Autocoders/Python/src/fprime_ac/utils/TypesList.py
+++ b/Autocoders/Python/src/fprime_ac/utils/TypesList.py
@@ -30,7 +30,7 @@ port_types_list = [
     "FwTlmPacketizeIdType",
     "NATIVE_INT_TYPE",
     "NATIVE_UINT_TYPE",
-    "POINTER_CAST"
+    "POINTER_CAST",
 ]
 
 

--- a/config/FpConfig.fpp
+++ b/config/FpConfig.fpp
@@ -1,7 +1,15 @@
-type FwEventIdType
+type FwBuffSizeType
 type FwChanIdType
+type FwEnumStoreType
+type FwEventIdType
+type FwIndexType
 type FwOpcodeType
+type FwPacketDescriptorType
 type FwPrmIdType
+type FwSizeType
+type FwTimeBaseStoreType
+type FwTimeContextStoreType
+type FwTlmPacketizeIdType
 type NATIVE_INT_TYPE
 type NATIVE_UINT_TYPE
 type POINTER_CAST


### PR DESCRIPTION
This PR adds several F Prime built-in types to the FPP model. With the next version of FPP, per https://github.com/fprime-community/fpp/issues/201, these types will be known to fpp-to-cpp.