### PR TITLE
Remove LGTM badges from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # F´: A Flight-Proven, Multi-Platform, Open-Source Flight Software Framework
 
-[![Language grade: C++](https://img.shields.io/lgtm/grade/cpp/g/nasa/fprime.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nasa/fprime/context:cpp)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/nasa/fprime.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nasa/fprime/context:python)
-
 **F´ (F Prime)** is a component-driven framework that enables rapid development and deployment of spaceflight and other embedded software applications. Originally developed at the [Jet Propulsion Laboratory](https://www.jpl.nasa.gov/), F´ has been successfully deployed on several space applications. It is tailored but not limited to small-scale spaceflight systems such as CubeSats, SmallSats, and instruments.
 
 **Please Visit the F´ Website:** [https://nasa.github.io/fprime/](https://nasa.github.io/fprime/).  This website contains project information, user guides, documentation, tutorials, and more!


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| README.md |
|**_Affected Architectures(s)_**| N/A |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| N/A |
|**_Builds Without Errors (y/n)_**| N/A |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

Removes LGTM badges from the project homepage. Currently the badget shows "lgtm invalid".

## Rationale

See:
- https://github.com/nasa/fprime/pull/1739
- https://github.com/nasa/fprime/pull/1744
- https://github.com/nasa/fprime/pull/1745

## Testing/Review Recommendations

I spotted some instructions for LGTM in the code base like :

https://github.com/nasa/fprime/blob/91c578ee37c01ba92e556dbca0287d82f9f18b95/Fw/Types/Serializable.cpp#L60
https://github.com/nasa/fprime/blob/91c578ee37c01ba92e556dbca0287d82f9f18b95/Fw/Types/StringType.cpp#L105
https://github.com/nasa/fprime/blob/91c578ee37c01ba92e556dbca0287d82f9f18b95/Svc/FileDownlink/FileDownlink.cpp#L152
https://github.com/nasa/fprime/blob/91c578ee37c01ba92e556dbca0287d82f9f18b95/Svc/FileDownlink/FileDownlink.cpp#L153

I don't know if we should delete them because they would be deprecated, i.e. I don't know if CodeQL takes them.

## Future Work

None
