### PR TITLE
Add CMake formatter 

### DIFF
--- a/.cmake-format.yml
+++ b/.cmake-format.yml
@@ -1,0 +1,51 @@
+# https://github.com/cheshirekow/cmake_format
+format:
+  line_width: 120
+  tab_size: 2
+  line_ending: unix
+  bullet_char: '*'
+  enum_char: .
+  separate_ctrl_name_with_space: false
+  separate_fn_name_with_space: false
+  dangle_parens: false
+
+  # If the trailing parenthesis must be 'dangled' on its on
+  # 'line, then align it to this reference: `prefix`: the start'
+  # 'of the statement,  `prefix-indent`: the start of the'
+  # 'statement, plus one indentation  level, `child`: align to'
+  # the column of the arguments
+  dangle_align: prefix
+
+  # If an argument group contains more than this many sub-groups
+  # (parg or kwarg groups) then force it to a vertical layout.
+  max_subgroups_hwrap: 2
+  # If a positional argument group contains more than this many
+  # arguments, then force it to a vertical layout.
+  max_pargs_hwrap: 3
+  # If a cmdline positional group consumes more than this many
+  # lines without nesting, then invalidate the layout (and nest)
+  max_rows_cmdline: 2
+
+  # Format command names consistently as 'lower' or 'upper' case
+  command_case: canonical
+  # Format keywords consistently as 'lower' or 'upper' case
+  # unchanged is valid too
+  keyword_case: 'upper'
+
+  # A list of command names which should always be wrapped
+  always_wrap: []
+
+  # If true, the argument lists which are known to be sortable
+  # will be sorted lexicographically
+  enable_sort: true
+
+  # If true, the parsers may infer whether or not an argument
+  # list is sortable (without annotation).
+  autosort: false
+
+markup:
+  canonicalize_hashrulers: false
+  enable_markup: false
+
+lint:
+  max_statements: 100

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -85,6 +85,8 @@ autogenerator
 AUTOLINK
 autoload
 automodule
+autosort
+autoupdate
 AYYYY
 backend
 backslashreplace
@@ -162,6 +164,7 @@ changeme
 CHANNELID
 chdir
 cheetahtemplate
+cheshirekow
 Chieu
 CHK
 CHNG
@@ -607,6 +610,7 @@ Guire
 handcoded
 hardtoaccess
 hashlib
+hashrulers
 hashvalue
 Heade
 HEADERSIZE
@@ -637,6 +641,7 @@ htons
 huey
 Huynh
 HVisitor
+hwrap
 hxx
 hyperlink
 hyperlinks
@@ -1003,6 +1008,7 @@ Pandian
 PARAMDOC
 params
 PARENB
+parg
 PARODD
 parseable
 pathlib

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,17 @@
+# To use:
+#
+#     pre-commit run -a
+#
+# Or:
+#
+#     pre-commit install  # (runs every time you commit in git)
+#
+# To update this file:
+#
+#     pre-commit autoupdate
+#
+# See https://github.com/pre-commit/pre-commit
+
 repos:
     -   repo: https://github.com/psf/black
         rev: 19.3b0
@@ -9,3 +23,11 @@ repos:
             name: Format Python Code (black) in Gds/
             files: '^Gds/'
             exclude: '^Gds/src/fprime_gds/wxgui/'
+    # CMake formatting
+    -   repo: https://github.com/cheshirekow/cmake-format-precommit
+        rev: v0.6.13
+        hooks:
+        -   id: cmake-format
+            additional_dependencies: [pyyaml]
+            types: [file]
+            files: (\.cmake|CMakeLists.txt)(.in)?$


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| CMake format / precommit |
|**_Affected Architectures(s)_**| None |
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

This PR aims to add [cmake-format](https://github.com/cheshirekow/cmake_format) to the project in order to homogenize all CMake files according to the policy dictated in the [.cmake-format.yml](https://github.com/nasa/fprime/compare/devel...ThibFrgsGmz:fprime:feat/add/cmake-format?expand=1#diff-e0f17eb93a4f1085e8edae759f54c37bdf14facf25040c20159993846de762b5) file.

## Rationale

See above.

## Testing/Review Recommendations

Run `pre-commit run -a` to apply cmake-format and observe the changes.

## Future Work

Maybe add standard hooks:

```yml
- repo: https://github.com/pre-commit/pre-commit-hooks
  rev: "v4.4.0"
  hooks:
  - id: check-added-large-files
  - id: check-case-conflict
  - id: check-docstring-first
  - id: check-merge-conflict
  - id: check-symlinks
  - id: check-toml
  - id: check-yaml
  - id: debug-statements
  - id: end-of-file-fixer
  - id: mixed-line-ending
  - id: requirements-txt-fixer
  - id: trailing-whitespace
```
