### PR TITLE
Update/baremetal os fixes

### DIFF
--- a/Os/Baremetal/FileSystem.cpp
+++ b/Os/Baremetal/FileSystem.cpp
@@ -47,5 +47,11 @@ namespace Os {
 		Status getFileCount (const char* directory, U32& fileCount) {
 			return OTHER_ERROR;
 		} //end getFileCount
+        Status appendFile(const char* originPath, const char* destPath, bool createMissingDest) {
+            return OTHER_ERROR;
+        }
+        Status getFreeSpace(const char* path, U64& totalBytes, U64& freeBytes) {
+            return OTHER_ERROR;
+        }
 	} // end FileSystem namespace
 } // end Os namespace

--- a/Svc/ComQueue/ComQueue.fpp
+++ b/Svc/ComQueue/ComQueue.fpp
@@ -26,13 +26,13 @@ module Svc {
       async input port comStatusIn: Fw.SuccessCondition
 
       @ Port array for receiving Fw::ComBuffers
-      async input port comQueueIn: [ComQueueComPorts] Fw.Com
+      async input port comQueueIn: [ComQueueComPorts] Fw.Com drop
 
       @ Port array for receiving Fw::Buffers
-      async input port buffQueueIn: [ComQueueBufferPorts] Fw.BufferSend
+      async input port buffQueueIn: [ComQueueBufferPorts] Fw.BufferSend drop
 
       @ Port for scheduling telemetry output
-      async input port run: Svc.Sched
+      async input port run: Svc.Sched drop
 
       # ----------------------------------------------------------------------
       # Special ports

--- a/Svc/ComStub/ComStub.cpp
+++ b/Svc/ComStub/ComStub.cpp
@@ -27,7 +27,7 @@ ComStub::~ComStub() {}
 // ----------------------------------------------------------------------
 
 Drv::SendStatus ComStub::comDataIn_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& sendBuffer) {
-    FW_ASSERT(!this->m_reinitialize);  // A message should never get here if we need to reinitialize is needed
+    FW_ASSERT(!this->m_reinitialize || !this->isConnected_comStatus_OutputPort(0));  // A message should never get here if we need to reinitialize is needed
     Drv::SendStatus driverStatus = Drv::SendStatus::SEND_RETRY;
     for (NATIVE_UINT_TYPE i = 0; driverStatus == Drv::SendStatus::SEND_RETRY && i < RETRY_LIMIT; i++) {
         driverStatus = this->drvDataOut_out(0, sendBuffer);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes made to the os/baremetal layer:

1. Added missing stub functions
2. Made comQueue drop on overlow (prevent assert->fatal->assert->fatal loop)
3. Made comStub track reinialization only when that port (status) is connected.