### PR TITLE
fixing sprintf deprecation on macOs

### DIFF
--- a/Svc/ActiveTextLogger/test/ut/Tester.cpp
+++ b/Svc/ActiveTextLogger/test/ut/Tester.cpp
@@ -103,7 +103,7 @@ namespace Svc {
           if (stream1) {
               std::cout << "readLine: " << buf << std::endl;
               char textStr[512];
-              sprintf(textStr,
+              snprintf(textStr, sizeof(textStr),
                       "EVENT: (%d) (%d:%d,%d) %s: %s",
                        id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severityString,text.toChar());
               ASSERT_EQ(0,strcmp(textStr,buf));
@@ -144,7 +144,7 @@ namespace Svc {
               // Verify new printed line
               else {
                   char textStr[512];
-                  sprintf(textStr,
+                  snprintf(textStr, sizeof(textStr),
                           "EVENT: (%d) (%d:%d,%d) %s: %s",
                            id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severityString,text.toChar());
                   ASSERT_EQ(0,strcmp(textStr,buf));
@@ -206,7 +206,7 @@ namespace Svc {
           if (stream1) {
               std::cout << "readLine: " << buf << std::endl;
               char textStr[512];
-              sprintf(textStr,
+              snprintf(textStr, sizeof(textStr),
                       "EVENT: (%d) (%d:%d,%d) %s: %s",
                        id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severityString,text.toChar());
               ASSERT_EQ(0,strcmp(textStr,buf));
@@ -316,7 +316,7 @@ namespace Svc {
 
           stat = this->component.set_log_file(baseName,50);
 
-          sprintf(baseNameWithSuffix,"%s%d",baseName,i);
+          snprintf(baseNameWithSuffix, sizeof(baseNameWithSuffix), "%s%d",baseName,i);
           ASSERT_TRUE(stat);
           ASSERT_TRUE(this->component.m_log_file.m_openFile);
           ASSERT_EQ(0,strcmp(baseNameWithSuffix,this->component.m_log_file.m_fileName.toChar()));
@@ -327,7 +327,7 @@ namespace Svc {
       // Create 11th which will fail and re-use the original:
       stat = this->component.set_log_file(baseName,50);
 
-      sprintf(baseNameWithSuffix,"%s%d",baseName,i);
+      snprintf(baseNameWithSuffix, sizeof(baseNameWithSuffix), "%s%d",baseName,i);
       ASSERT_TRUE(stat);
       ASSERT_TRUE(this->component.m_log_file.m_openFile);
       printf("<< %s %s\n",baseName,this->component.m_log_file.m_fileName.toChar());
@@ -341,7 +341,7 @@ namespace Svc {
       remove(longFileNameDup);
       remove(baseName);
       for (i = 0; i < 10; ++i) {
-          sprintf(baseNameWithSuffix,"%s%d",baseName,i);
+          snprintf(baseNameWithSuffix, sizeof(baseNameWithSuffix), "%s%d",baseName,i);
           remove(baseNameWithSuffix);
       }
 

--- a/Svc/Health/test/ut/Tester.cpp
+++ b/Svc/Health/test/ut/Tester.cpp
@@ -260,7 +260,7 @@ namespace Svc {
 
       for (NATIVE_UINT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
           char name[80];
-          sprintf(name,"task%d",port);
+          snprintf(name, sizeof(name), "task%d",port);
           ASSERT_EVENTS_HLTH_PING_WARN(port,name);
       }
 
@@ -294,7 +294,7 @@ namespace Svc {
 
       for (NATIVE_UINT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
           char name[80];
-          sprintf(name,"task%d",port);
+          snprintf(name, sizeof(name), "task%d",port);
           ASSERT_EVENTS_HLTH_PING_WARN(port,name);
       }
 
@@ -316,7 +316,7 @@ namespace Svc {
 
       for (NATIVE_UINT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
           char name[80];
-          sprintf(name,"task%d",port);
+          snprintf(name, sizeof(name), "task%d",port);
           ASSERT_EVENTS_HLTH_PING_LATE(port,name);
       }
 
@@ -346,7 +346,7 @@ namespace Svc {
       ASSERT_EVENTS_HLTH_PING_WARN_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
       for (NATIVE_INT_TYPE entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
           char name[80];
-          sprintf(name,"task%d",entry);
+          snprintf(name, sizeof(name), "task%d",entry);
           ASSERT_EVENTS_HLTH_PING_WARN(entry, name);
       }
 
@@ -406,7 +406,7 @@ namespace Svc {
       ASSERT_EVENTS_HLTH_PING_LATE_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
       for (NATIVE_INT_TYPE entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
           char name[80];
-          sprintf(name,"task%d",entry);
+          snprintf(name,sizeof(name), "task%d",entry);
           ASSERT_EVENTS_HLTH_PING_LATE(entry,name);
       }
 
@@ -435,7 +435,7 @@ namespace Svc {
           }
           // disable entry
           char name[80];
-          sprintf(name,"task%d",entry);
+          snprintf(name, sizeof(name), "task%d",entry);
           Fw::CmdStringArg task(name);
           this->sendCmd_HLTH_PING_ENABLE(0,10,name,Fw::Enabled::DISABLED);
           this->dispatchAll();
@@ -495,7 +495,7 @@ namespace Svc {
           ASSERT_EQ(this->pingEntries[entry].warnCycles,Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS+entry);
           ASSERT_EQ(this->pingEntries[entry].fatalCycles,Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS*2+entry+1);
           char name[80];
-          sprintf(name,"task%d",entry);
+          snprintf(name, sizeof(name), "task%d",entry);
           Fw::CmdStringArg task(name);
           this->sendCmd_HLTH_CHNG_PING(0,10,task,
                   Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS*4+entry,
@@ -656,7 +656,7 @@ namespace Svc {
       ASSERT_EVENTS_HLTH_PING_WRONG_KEY_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
       for (NATIVE_INT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
           char name[80];
-          sprintf(name,"task%d",port);
+          snprintf(name, sizeof(name), "task%d",port);
           ASSERT_EVENTS_HLTH_PING_WRONG_KEY(port,name,FLAG_KEY_VALUE);
       }
 
@@ -748,7 +748,7 @@ namespace Svc {
       ASSERT_EVENTS_SIZE(1);
       ASSERT_EVENTS_HLTH_PING_WARN_SIZE(1);
       char name[80];
-      sprintf(name,"task%d",Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS-1);
+      snprintf(name, sizeof(name), "task%d",Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS-1);
       ASSERT_EVENTS_HLTH_PING_WARN(0,name);
       ASSERT_TLM_SIZE(1);
       ASSERT_TLM_PingLateWarnings_SIZE(1);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes #1821 