### PR TITLE
F' documentation latest framework label

### DIFF
--- a/docs/v2.0.0/index.md
+++ b/docs/v2.0.0/index.md
@@ -3,7 +3,7 @@ title: "F´ Latest Documentation"
 layout: default
 ---
 
-This is the documentation for the latest F´ framework. It is kept consistent with the `devel` branch.
+This is the documentation for the F´ v2.0.0 release series. To view the latest documentation, visit the [documentation home](..).
 
 | F´ Resources | |
 |---|---|

--- a/docs/v2.0.1/index.md
+++ b/docs/v2.0.1/index.md
@@ -3,7 +3,7 @@ title: "F´ Latest Documentation"
 layout: default
 ---
 
-This is the documentation for the latest F´ framework. It is kept consistent with the `devel` branch.
+This is the documentation for the F´ v2.0.1 release. To view the latest documentation, visit the [documentation home](..).
 
 | F´ Resources | |
 |---|---|

--- a/docs/v2.1.0/index.md
+++ b/docs/v2.1.0/index.md
@@ -3,7 +3,7 @@ title: "F´ Latest Documentation"
 layout: default
 ---
 
-This is the documentation for the latest F´ framework. It is kept consistent with the `devel` branch.
+This is the documentation for the F´ v2.1.0 release series. To view the latest documentation, visit the [documentation home](..).
 
 | F´ Resources | |
 |---|---|

--- a/docs/v3.0.0/index.md
+++ b/docs/v3.0.0/index.md
@@ -3,7 +3,7 @@ title: "F´ Latest Documentation"
 layout: default
 ---
 
-This is the documentation for the latest F´ framework. It is kept consistent with the `devel` branch.
+This is the documentation for the F´ v3.0.0 release series. To view the latest documentation, visit the [documentation home](..).
 
 | F´ Resources | |
 |---|---|


### PR DESCRIPTION
## Change Description

Copied v1.5 documentation notice of later version availability to v2.0 and v3.0.0 series.

## Rationale

This change prevents multiple documentation entries from being labeled as the 'latest'.