### PR TITLE
Refactor `Os/Linux/SystemResources.cpp`

### DIFF
--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -142,7 +142,7 @@ namespace Os {
         struct sysinfo memory_info;
         int sysinfo_result = 0;
 
-        if (sysinfo_result = sysinfo(&memory_info) != 0) {
+        if ((sysinfo_result = sysinfo(&memory_info)) != 0) {
             return SYSTEM_RESOURCES_ERROR;
         }
 

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -140,9 +140,8 @@ namespace Os {
 
     SystemResources::SystemResourcesStatus SystemResources::getMemUtil(MemUtil& memory_util) {
         struct sysinfo memory_info;
-        int sysinfo_result = 0;
 
-        if ((sysinfo_result = sysinfo(&memory_info)) != 0) {
+        if (sysinfo(&memory_info) != 0) {
             return SYSTEM_RESOURCES_ERROR;
         }
 

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -122,9 +122,10 @@ namespace Os {
         const FwSizeType memory_unit = static_cast<FwSizeType>(memory_info.mem_unit);
 
         // Check for casting and type errors
-        if (((total_ram <= 0) || (static_cast<unsigned long>(total_ram) != memory_info.totalram)) ||
-            ((free_ram <= 0) || (static_cast<unsigned long>(free_ram) != memory_info.freeram)) ||
-            ((memory_unit <= 0) || (static_cast<unsigned int>(memory_unit) != memory_info.mem_unit))) {
+        if ((total_ram <= 0) || (free_ram < 0) || (memory_unit <= 0) ||
+            (static_cast<unsigned long>(total_ram) != memory_info.totalram) ||
+            (static_cast<unsigned long>(free_ram) != memory_info.freeram) ||
+            (static_cast<unsigned int>(memory_unit) != memory_info.mem_unit)) {
             return SYSTEM_RESOURCES_ERROR;
         }
 

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -82,8 +82,10 @@ namespace Os {
     SystemResources::SystemResourcesStatus SystemResources::getMemUtil(MemUtil &memory_util) {
 
         struct sysinfo memory_info;
-        sysinfo(&memory_info);
-        
+
+        if (sysinfo(&memory_info) != 0) {
+            return SYSTEM_RESOURCES_ERROR;
+        }       
 
         const FwSizeType total_ram = static_cast<FwSizeType>(memory_info.totalram);
         const FwSizeType free_ram = static_cast<FwSizeType>(memory_info.freeram);

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -124,7 +124,7 @@ namespace Os {
                                    FwSizeType free_ram,
                                    FwSizeType memory_unit,
                                    const struct sysinfo& memory_info) {
-        return ((total_ram <= 0) || (free_ram < 0) || (memory_unit <= 0) ||
+        return ((total_ram <= 0) || (memory_unit <= 0) ||
                 (static_cast<unsigned long>(total_ram) != memory_info.totalram) ||
                 (static_cast<unsigned long>(free_ram) != memory_info.freeram) ||
                 (static_cast<unsigned int>(memory_unit) != memory_info.mem_unit));

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -10,6 +10,7 @@
 //
 // ======================================================================
 #include <cstdio>
+#include <array>
 #include <sys/sysinfo.h>
 #include <cstring>
 #include <Os/SystemResources.hpp>
@@ -23,9 +24,9 @@ namespace Os {
     }
 
     SystemResources::SystemResourcesStatus SystemResources::getCpuTicks(CpuTicks &cpu_ticks, U32 cpu_index) {
-        char line[512] = {0};
+        std::array<char, 512> line = {0};
         FILE *fp = nullptr;
-        U32 cpu_data[4] = {0};
+        std::array<U32, 4> cpu_data = {};
         U32 cpuCount = 0;
         SystemResources::SystemResourcesStatus status  = SYSTEM_RESOURCES_ERROR;
         U64 cpuUsed = 0;
@@ -34,35 +35,30 @@ namespace Os {
         if ((status = getCpuCount(cpuCount)) != SYSTEM_RESOURCES_OK) {
             return status;
         }
-
         if (cpu_index >= cpuCount) {
             return SYSTEM_RESOURCES_ERROR;
         }
-
         if ((fp = fopen("/proc/stat", "r")) == nullptr) {
-
             return SYSTEM_RESOURCES_ERROR;
-
         }
-
-        if (fgets(line, sizeof(line), fp) == nullptr) { //1st line.  Aggregate cpu line.
+        if (fgets(line.data(), line.size(), fp) == nullptr) { //1st line.  Aggregate cpu line.
             fclose(fp);
             return SYSTEM_RESOURCES_ERROR;
         }
 
         for (U32 i = 0; i < cpu_index + 1; i++) {
-            if (fgets(line, sizeof(line), fp) == nullptr) { //cpu# line
+            if (fgets(line.data(), line.size(), fp) == nullptr) { //cpu# line
                 fclose(fp);
                 return SYSTEM_RESOURCES_ERROR;
             }
             if (i != cpu_index) { continue; }
 
-            if (strncmp(line, "cpu", 3) != 0) {
+            if (strncmp(line.data(), "cpu", 3) != 0) {
                 fclose(fp);
                 return SYSTEM_RESOURCES_ERROR;
             }
             // No string concerns, as string is discarded
-            sscanf(line, "%*s %d %d %d %d", &cpu_data[0],
+            sscanf(line.data(), "%*s %d %d %d %d", &cpu_data[0],
                    &cpu_data[1],
                    &cpu_data[2],
                    &cpu_data[3]); //cpu#: 4 numbers: usr, nice, sys, idle

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -57,7 +57,7 @@ namespace Os {
             }
             if (i != cpu_index) { continue; }
 
-            if (!(line[0] == 'c' && line[1] == 'p' && line[2] == 'u')) {
+            if (strncmp(line, "cpu", 3) != 0) {
                 fclose(fp);
                 return SYSTEM_RESOURCES_ERROR;
             }

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -78,8 +78,11 @@ namespace Os {
 
     SystemResources::SystemResourcesStatus getCpuData(U32 cpu_index, std::array<U32, 4>& cpu_data) {
         FILE* fp = nullptr;
-        if (openProcStatFile(fp) != SystemResources::SYSTEM_RESOURCES_OK ||
-            readProcStatLine(fp, proc_stat_line) != SystemResources::SYSTEM_RESOURCES_OK ||
+        if (openProcStatFile(fp) != SystemResources::SYSTEM_RESOURCES_OK) {
+            return SystemResources::SYSTEM_RESOURCES_ERROR;
+        }
+
+        if (readProcStatLine(fp, proc_stat_line) != SystemResources::SYSTEM_RESOURCES_OK ||
             getCpuDataLine(fp, cpu_index, proc_stat_line) != SystemResources::SYSTEM_RESOURCES_OK ||
             parseCpuData(proc_stat_line, cpu_data) != SystemResources::SYSTEM_RESOURCES_OK) {
             fclose(fp);

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -9,10 +9,10 @@
 // acknowledged.
 //
 // ======================================================================
-#include <cstdio>
 #include <array>
-#include <sys/sysinfo.h>
+#include <cstdio>
 #include <cstring>
+#include <sys/sysinfo.h>
 #include <Os/SystemResources.hpp>
 #include <Fw/Types/Assert.hpp>
 
@@ -23,16 +23,16 @@ std::array<char, LINE_SIZE> proc_stat_line;
 
 namespace Os {
 
-    SystemResources::SystemResourcesStatus SystemResources::getCpuCount(U32 &cpuCount) {
+    SystemResources::SystemResourcesStatus SystemResources::getCpuCount(U32& cpuCount) {
         cpuCount = get_nprocs();
         return SYSTEM_RESOURCES_OK;
     }
 
     SystemResources::SystemResourcesStatus SystemResources::getCpuTicks(CpuTicks &cpu_ticks, U32 cpu_index) {
-        FILE *fp = nullptr;
-        std::array<U32, 4> cpu_data = {0};
-        U32 cpuCount = 0;
         SystemResources::SystemResourcesStatus status  = SYSTEM_RESOURCES_ERROR;
+        std::array<U32, 4> cpu_data = {0};
+        FILE* fp = nullptr;
+        U32 cpuCount = 0;
         U64 cpuUsed = 0;
         U64 cpuTotal = 0;
 
@@ -45,27 +45,27 @@ namespace Os {
         if ((fp = fopen(PROC_STAT_PATH, READ_ONLY)) == nullptr) {
             return SYSTEM_RESOURCES_ERROR;
         }
-        if (fgets(proc_stat_line.data(), proc_stat_line.size(), fp) == nullptr) { //1st line.  Aggregate cpu line.
+        if (fgets(proc_stat_line.data(), proc_stat_line.size(), fp) == nullptr) {  // 1st line.  Aggregate cpu line.
             fclose(fp);
             return SYSTEM_RESOURCES_ERROR;
         }
 
         for (U32 i = 0; i < cpu_index + 1; i++) {
-            if (fgets(proc_stat_line.data(), proc_stat_line.size(), fp) == nullptr) { //cpu# line
+            if (fgets(proc_stat_line.data(), proc_stat_line.size(), fp) == nullptr) {  // cpu# line
                 fclose(fp);
                 return SYSTEM_RESOURCES_ERROR;
             }
-            if (i != cpu_index) { continue; }
+            if (i != cpu_index) {
+                continue;
+            }
 
             if (strncmp(proc_stat_line.data(), "cpu", 3) != 0) {
                 fclose(fp);
                 return SYSTEM_RESOURCES_ERROR;
             }
             // No string concerns, as string is discarded
-            sscanf(proc_stat_line.data(), "%*s %d %d %d %d", &cpu_data[0],
-                   &cpu_data[1],
-                   &cpu_data[2],
-                   &cpu_data[3]); //cpu#: 4 numbers: usr, nice, sys, idle
+            sscanf(proc_stat_line.data(), "%*s %d %d %d %d", &cpu_data[0], &cpu_data[1], &cpu_data[2],
+                   &cpu_data[3]);  // cpu#: 4 numbers: usr, nice, sys, idle
 
             cpuUsed = cpu_data[0] + cpu_data[1] + cpu_data[2];
             cpuTotal = cpu_data[0] + cpu_data[1] + cpu_data[2] + cpu_data[3];
@@ -80,12 +80,11 @@ namespace Os {
     }
 
     SystemResources::SystemResourcesStatus SystemResources::getMemUtil(MemUtil &memory_util) {
-
         struct sysinfo memory_info;
 
         if (sysinfo(&memory_info) != 0) {
             return SYSTEM_RESOURCES_ERROR;
-        }       
+        }
 
         const FwSizeType total_ram = static_cast<FwSizeType>(memory_info.totalram);
         const FwSizeType free_ram = static_cast<FwSizeType>(memory_info.freeram);
@@ -94,8 +93,7 @@ namespace Os {
         // Check for casting and type errors
         if (((total_ram <= 0) || (static_cast<unsigned long>(total_ram) != memory_info.totalram)) ||
             ((free_ram <= 0) || (static_cast<unsigned long>(free_ram) != memory_info.freeram)) ||
-            ((memory_unit <= 0) || (static_cast<unsigned int>(memory_unit) != memory_info.mem_unit))
-        ) {
+            ((memory_unit <= 0) || (static_cast<unsigned int>(memory_unit) != memory_info.mem_unit))) {
             return SYSTEM_RESOURCES_ERROR;
         }
 
@@ -105,8 +103,7 @@ namespace Os {
         }
 
         // Check for overflow in multiplication
-        if (total_ram > (FpLimits::FwSizeType_MAX / memory_unit))
-        {
+        if (total_ram > (FpLimits::FwSizeType_MAX / memory_unit)) {
             return SYSTEM_RESOURCES_ERROR;
         }
 

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -9,17 +9,16 @@
 // acknowledged.
 //
 // ======================================================================
-#include <array>
 #include <cstdio>
 #include <cstring>
 #include <sys/sysinfo.h>
 #include <Os/SystemResources.hpp>
 #include <Fw/Types/Assert.hpp>
 
-#define PROC_STAT_PATH "/proc/stat"
-#define READ_ONLY "r"
-#define LINE_SIZE 256
-std::array<char, LINE_SIZE> proc_stat_line;
+constexpr char PROC_STAT_PATH[] = "/proc/stat";
+constexpr char READ_ONLY[] = "r";
+constexpr int LINE_SIZE = 256;
+char proc_stat_line[LINE_SIZE];
 
 namespace Os {
 
@@ -28,10 +27,10 @@ namespace Os {
         return SYSTEM_RESOURCES_OK;
     }
 
-    U64 getCpuUsed(std::array<U32, 4>& cpu_data) {
+    U64 getCpuUsed(U32 cpu_data[4]) {
         return cpu_data[0] + cpu_data[1] + cpu_data[2];
     }
-    U64 getCpuTotal(std::array<U32, 4>& cpu_data) {
+    U64 getCpuTotal(U32 cpu_data[4]) {
         return cpu_data[0] + cpu_data[1] + cpu_data[2] + cpu_data[3];
     }
 
@@ -42,16 +41,16 @@ namespace Os {
         return SystemResources::SYSTEM_RESOURCES_OK;
     }
 
-    SystemResources::SystemResourcesStatus readProcStatLine(FILE* fp, std::array<char, LINE_SIZE>& proc_stat_line) {
-        if (fgets(proc_stat_line.data(), proc_stat_line.size(), fp) == nullptr) {
+    SystemResources::SystemResourcesStatus readProcStatLine(FILE* fp, char proc_stat_line[LINE_SIZE]) {
+        if (fgets(proc_stat_line, LINE_SIZE, fp) == nullptr) {
             return SystemResources::SYSTEM_RESOURCES_ERROR;
         }
         return SystemResources::SYSTEM_RESOURCES_OK;
     }
 
     SystemResources::SystemResourcesStatus getCpuDataLine(FILE* fp,
-                                                          U32 cpu_index,
-                                                          std::array<char, LINE_SIZE>& proc_stat_line) {
+                                U32 cpu_index,
+                                char proc_stat_line[LINE_SIZE]) {
         for (U32 i = 0; i < cpu_index + 1; i++) {
             if (readProcStatLine(fp, proc_stat_line) != SystemResources::SYSTEM_RESOURCES_OK) {
                 return SystemResources::SYSTEM_RESOURCES_ERROR;
@@ -59,7 +58,7 @@ namespace Os {
             if (i != cpu_index) {
                 continue;
             }
-            if (strncmp(proc_stat_line.data(), "cpu", 3) != 0) {
+            if (strncmp(proc_stat_line, "cpu", 3) != 0) {
                 return SystemResources::SYSTEM_RESOURCES_ERROR;
             }
             break;
@@ -67,16 +66,16 @@ namespace Os {
         return SystemResources::SYSTEM_RESOURCES_OK;
     }
 
-    SystemResources::SystemResourcesStatus parseCpuData(std::array<char, LINE_SIZE>& proc_stat_line,
-                                                        std::array<U32, 4>& cpu_data) {
-        if (sscanf(proc_stat_line.data(), "%*s %d %d %d %d", &cpu_data[0], &cpu_data[1], &cpu_data[2], &cpu_data[3]) !=
+    SystemResources::SystemResourcesStatus parseCpuData(char proc_stat_line[LINE_SIZE],
+                                                    U32 cpu_data[4]) {
+        if (sscanf(proc_stat_line, "%*s %d %d %d %d", &cpu_data[0], &cpu_data[1], &cpu_data[2], &cpu_data[3]) !=
             4) {
             return SystemResources::SYSTEM_RESOURCES_ERROR;
         }
         return SystemResources::SYSTEM_RESOURCES_OK;
     }
 
-    SystemResources::SystemResourcesStatus getCpuData(U32 cpu_index, std::array<U32, 4>& cpu_data) {
+    SystemResources::SystemResourcesStatus getCpuData(U32 cpu_index, U32 cpu_data[4]) {
         FILE* fp = nullptr;
         if (openProcStatFile(fp) != SystemResources::SYSTEM_RESOURCES_OK) {
             return SystemResources::SYSTEM_RESOURCES_ERROR;
@@ -94,7 +93,7 @@ namespace Os {
 
     SystemResources::SystemResourcesStatus SystemResources::getCpuTicks(CpuTicks& cpu_ticks, U32 cpu_index) {
         SystemResources::SystemResourcesStatus status = SYSTEM_RESOURCES_ERROR;
-        std::array<U32, 4> cpu_data = {0};
+        U32 cpu_data[4] = {0};
         U32 cpuCount = 0;
 
         if ((status = getCpuCount(cpuCount)) != SYSTEM_RESOURCES_OK) {

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -114,10 +114,10 @@ namespace Os {
 
 
     U64 getMemoryTotal(FwSizeType total_ram, FwSizeType memory_unit) {
-        return total_ram * memory_unit;
+        return static_cast<U64>(total_ram)*static_cast<U64>(memory_unit);
     }
     U64 getMemoryUsed(FwSizeType total_ram, FwSizeType free_ram, FwSizeType memory_unit) {
-        return (total_ram - free_ram) * memory_unit;
+        return static_cast<U64>((total_ram - free_ram)) * static_cast<U64>(memory_unit);
     }
 
     bool checkCastingAndTypeErrors(FwSizeType total_ram,

--- a/Os/Linux/SystemResources.cpp
+++ b/Os/Linux/SystemResources.cpp
@@ -16,6 +16,9 @@
 #include <Os/SystemResources.hpp>
 #include <Fw/Types/Assert.hpp>
 
+#define PROC_STAT_PATH "/proc/stat"
+#define READ_ONLY "r"
+#define LINE_SIZE 256
 namespace Os {
 
     SystemResources::SystemResourcesStatus SystemResources::getCpuCount(U32 &cpuCount) {
@@ -24,9 +27,9 @@ namespace Os {
     }
 
     SystemResources::SystemResourcesStatus SystemResources::getCpuTicks(CpuTicks &cpu_ticks, U32 cpu_index) {
-        std::array<char, 512> line = {0};
+        std::array<char, LINE_SIZE> line = {0};
         FILE *fp = nullptr;
-        std::array<U32, 4> cpu_data = {};
+        std::array<U32, 4> cpu_data = {0};
         U32 cpuCount = 0;
         SystemResources::SystemResourcesStatus status  = SYSTEM_RESOURCES_ERROR;
         U64 cpuUsed = 0;
@@ -38,7 +41,7 @@ namespace Os {
         if (cpu_index >= cpuCount) {
             return SYSTEM_RESOURCES_ERROR;
         }
-        if ((fp = fopen("/proc/stat", "r")) == nullptr) {
+        if ((fp = fopen(PROC_STAT_PATH, READ_ONLY)) == nullptr) {
             return SYSTEM_RESOURCES_ERROR;
         }
         if (fgets(line.data(), line.size(), fp) == nullptr) { //1st line.  Aggregate cpu line.

--- a/Os/SystemResources.hpp
+++ b/Os/SystemResources.hpp
@@ -49,18 +49,15 @@ SystemResourcesStatus getCpuCount(U32& cpu_count);
  *
  * \param ticks: (output) filled with the tick information for the given CPU
  * \param cpu_index: index for CPU to read
- * \return: SYSTEM_RESOURCES_OK with valid CPU count, SYSTEM_RESOURCES_ERROR when error occurs
+ * \return:  SYSTEM_RESOURCES_ERROR when error occurs, SYSTEM_RESOURCES_OK otherwise.
  */
 SystemResourcesStatus getCpuTicks(CpuTicks& ticks, U32 cpu_index = 0);
 
 /**
- * \brief Calculate the across-all-cpu average tick information
+ * \brief Get system memory usage
  *
- * See `getCpuTicks`. Operates in a similar capacity, but the aggregation is done across all CPUs not for
- * a specific CPU.
- *
- * \param ticks: (output) filled with the tick information for the given CPU
- * \return: SYSTEM_RESOURCES_OK with valid CPU count, SYSTEM_RESOURCES_ERROR when error occurs
+ * \param memory_util: (output) data structure used to store memory usage
+ * \return:  SYSTEM_RESOURCES_ERROR when error occurs, SYSTEM_RESOURCES_OK otherwise.
  */
 SystemResourcesStatus getMemUtil(MemUtil& memory_util);
 }  // namespace SystemResources


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| SystemResources |
|**_Affected Architectures(s)_**| None |
|**_Related Issue(s)_**| None  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| N/A|
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to refactor `Os/Linux/SystemResources` to improve the understanding of the logic. It is close to the Clean Code rules with smaller functions responsible for one thing and keeping a relatively homogeneous level of abstraction.

In `SystemResources::getMemUtil`, the return of the `sysinfo(&memory_info)` call is now checked.

I move the data buffer needed to store a file line into the .bss section. This way, we don't need to allocate it recurrently on the stack.
If we use `Linux/SystemResources`, we will always need this buffer to retrieve information about the processor, so we might as well put it in the BSS.

## Rationale

See above.

Best error handling of `sysinfo` call and best memory usage of large buffer.

## Testing/Review Recommendations

No regression observed when running `fprime-gds`.

## Future Work

Errors must be handled much more finely. Errors are either ERR or OK, it is not possible to know where the error occurred.
