### PR TITLE
Remove return from last line of void functions

### DIFF
--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -66,8 +66,6 @@ namespace Drv {
         }
         this->m_bytes += readBuffer.getSize();
         this->tlmWrite_SPI_Bytes(this->m_bytes);
-        return;
-
     }
 
     bool LinuxSpiDriverComponentImpl::open(NATIVE_INT_TYPE device,


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Removed unnecessary `return;` statement on the last line of a `void` function.

## Rationale

Improves code consistency (all other void functions in fprime do not include a `return;` on the final line).

## Testing/Review Recommendations

No impact on code logic.
Standard CI tests will suffice.

## Future Work

n/a