### PR TITLE
fixing problems revealed with new port autocoder

### DIFF
--- a/Drv/LinuxUartDriver/LinuxUartDriver.cpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.cpp
@@ -268,7 +268,9 @@ bool LinuxUartDriver::open(const char* const device,
     // All done!
     Fw::LogStringArg _arg = device;
     this->log_ACTIVITY_HI_PortOpened(_arg);
-    this->ready_out(0); // Indicate the driver is connected
+    if (this->isConnected_ready_OutputPort(0)) {
+        this->ready_out(0); // Indicate the driver is connected
+    }
     return true;
 }
 

--- a/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
+++ b/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
@@ -130,6 +130,12 @@ namespace Svc {
       // and this can conflict with the traditionally smaller stack sizes.
       printf("%s\n", msg);
 
+      // Handle the case where the ports aren't connected yet
+      if (not this->isConnected_Log_OutputPort(0)) {
+          assert(0);
+          return;
+      }
+
       switch (numArgs) {
           case 0:
               this->log_FATAL_AF_ASSERT_0(fileArg,lineNo);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

1. AssertFatalAdapter falls back to classical assert when the ports aren't connected yet (system startup)
2. Only invoking `ready_out` when connected/