### PR TITLE
changing SIGSEGV for SIGABRT to remove segfault without core dump

### DIFF
--- a/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
+++ b/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
@@ -29,7 +29,7 @@ namespace Svc {
         Fw::Logger::logMsg("FATAL %d handled.\n",Id,0,0,0,0,0);
         (void)Os::Task::delay(1000);
         Fw::Logger::logMsg("Exiting with segfault and core dump file.\n",0,0,0,0,0,0);
-        (void)raise( SIGSEGV );
+        (void)raise( SIGABRT );
         exit(1);
     }
 

--- a/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
+++ b/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
@@ -28,7 +28,7 @@ namespace Svc {
         // for **nix, delay then exit with error code
         Fw::Logger::logMsg("FATAL %d handled.\n",Id,0,0,0,0,0);
         (void)Os::Task::delay(1000);
-        Fw::Logger::logMsg("Exiting with segfault and core dump file.\n",0,0,0,0,0,0);
+        Fw::Logger::logMsg("Exiting with abort signal and core dump file.\n",0,0,0,0,0,0);
         (void)raise( SIGABRT );
         exit(1);
     }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

SIGSEGV -> SIGABRT in asserts.

## Rationale

Seg faulting in assert handling code was presumably done to ensure a core-dump file. However, multiple sources show that this is done also in the case of a SIGABRT.  We using SIGSEGV, however; real errors causing segmentation faults are masked as the assert is expected to force a false seg fault.

Use SIGABRT, it is functional without confusing.