### PR TITLE
Add `IEEE 754` compliance of the floating point arithmetic

### DIFF
--- a/Fw/Types/BasicTypes.hpp
+++ b/Fw/Types/BasicTypes.hpp
@@ -49,9 +49,23 @@ typedef char CHAR;
   typedef uint64_t       U64; //!< 64-bit unsigned integer
 #endif
 
-typedef float   F32; //!< 32-bit floating point
+typedef float F32;  //!< 32-bit floating point
+#ifndef SKIP_FLOAT_IEEE_754_COMPLIANCE
+  static_assert(   (std::numeric_limits<float>::is_iec559    == true)
+                && (std::numeric_limits<float>::radix        ==    2)
+                && (std::numeric_limits<float>::digits       ==   24)
+                && (std::numeric_limits<float>::max_exponent ==  128),
+                "The 32-bit floating point type does not conform to the IEEE-754 standard.");
+#endif
 #if FW_HAS_F64
-  typedef double  F64; //!< 64-bit floating point
+  typedef double F64;  //!< 64-bit floating point
+# ifndef SKIP_FLOAT_IEEE_754_COMPLIANCE
+    static_assert(   (std::numeric_limits<double>::is_iec559    == true)
+                  && (std::numeric_limits<double>::radix        ==    2)
+                  && (std::numeric_limits<double>::digits       ==   53)
+                  && (std::numeric_limits<double>::max_exponent == 1024),
+                  "The 64-bit floating point type does not conform to the IEEE-754 standard.");
+# endif
 #endif
 
 typedef PlatformIntType NATIVE_INT_TYPE;

--- a/Fw/Types/BasicTypes.hpp
+++ b/Fw/Types/BasicTypes.hpp
@@ -50,7 +50,7 @@ typedef char CHAR;
 #endif
 
 typedef float F32;  //!< 32-bit floating point
-#ifndef SKIP_FLOAT_IEEE_754_COMPLIANCE
+#if !defined(SKIP_FLOAT_IEEE_754_COMPLIANCE) || !SKIP_FLOAT_IEEE_754_COMPLIANCE
   static_assert(   (std::numeric_limits<float>::is_iec559    == true)
                 && (std::numeric_limits<float>::radix        ==    2)
                 && (std::numeric_limits<float>::digits       ==   24)
@@ -59,7 +59,7 @@ typedef float F32;  //!< 32-bit floating point
 #endif
 #if FW_HAS_F64
   typedef double F64;  //!< 64-bit floating point
-# ifndef SKIP_FLOAT_IEEE_754_COMPLIANCE
+# if !defined(SKIP_FLOAT_IEEE_754_COMPLIANCE) || !SKIP_FLOAT_IEEE_754_COMPLIANCE
     static_assert(   (std::numeric_limits<double>::is_iec559    == true)
                   && (std::numeric_limits<double>::radix        ==    2)
                   && (std::numeric_limits<double>::digits       ==   53)

--- a/cmake/platform/types/PlatformTypes.hpp
+++ b/cmake/platform/types/PlatformTypes.hpp
@@ -38,10 +38,11 @@
 #include <cinttypes>
 #include <limits>
 
-#define FW_HAS_64_BIT    1 //!< Architecture supports 64 bit integers
-#define FW_HAS_32_BIT    1 //!< Architecture supports 32 bit integers
-#define FW_HAS_16_BIT    1 //!< Architecture supports 16 bit integers
-#define FW_HAS_F64    1 //!< Architecture supports 64 bit floating point numbers
+#define FW_HAS_64_BIT 1  //!< Architecture supports 64 bit integers
+#define FW_HAS_32_BIT 1  //!< Architecture supports 32 bit integers
+#define FW_HAS_16_BIT 1  //!< Architecture supports 16 bit integers
+#define FW_HAS_F64 1     //!< Architecture supports 64 bit floating point numbers
+#define SKIP_FLOAT_IEEE_754_COMPLIANCE 0  //!<  Check IEEE 754 compliance of floating point arithmetic
 
 // Section 1: Logical Types
 //    fprime requires platform implementors to define logical types for their

--- a/docs/UsersGuide/dev/configuring-fprime.md
+++ b/docs/UsersGuide/dev/configuring-fprime.md
@@ -108,6 +108,16 @@ Example:
 #define FW_HAS_F64 0
 ```
 
+### IEEE 754 compliance of the floating point implementation
+
+Some industrial coding rules for safety and critical systems require floating point implementations to conform to a defined floating point standard, such as IEEE 754. The reason for this is that if the implementation does not conform to a standard, it can lead to problems with the accuracy and reliability of calculations.
+
+By default, F´ checks for IEEE754 compliant floating point arithmetic at compile time. However, if a user does not have a C++11 implementation on their platform that supports IEEE754 floating point arithmetic, an option is provided to bypass this check:
+
+| Macro                           | Definition                                                       | Default | Valid Values   |
+| --------------------------------| -----------------------------------------------------------------|---------|----------------|
+| SKIP_FLOAT_IEEE_754_COMPLIANCE  | Skip IEEE 754 compliance check of floating point implementation. | 0 (off) | 0 (off) 1 (on) |
+
 #### Configured Type Definitions
 
 **WARNING:** To run the system with the standard F´ GDS, these changes need to be made in the python GDS support code

--- a/docs/UsersGuide/dev/configuring-fprime.md
+++ b/docs/UsersGuide/dev/configuring-fprime.md
@@ -40,8 +40,10 @@ Where components allow specific configuration, a `<component>Cfg.hpp` is availab
 
 AcConstants.ini is used to set the constants for the autocoded components provided by the framework. This allows
 projects to appropriately size the number of ports provided by many of the command and data handling components defined
-in the `Svc` package. **Note:** Internal configurations like table sizes are set in the component-specific header as
-these settings aren't autocoded. See: [Component Configuration](#component-configuration)
+in the `Svc` package.
+
+> **Note**
+> Internal configurations like table sizes are set in the component-specific header as these settings aren't autocoded. See: [Component Configuration](#component-configuration)
 
 These settings may need to be increased for large projects with many components, or minimized for projects with a small
 number of components.
@@ -85,8 +87,8 @@ custom types specified in the framework. This section will describe these settin
 
 The architecture is designed to be portable to different processor architectures. Some architectures such as small
 microcontrollers do not support the full range of types. The architecture supports a non-sized integer type named
-NATIVE_INT_TYPE. The NATIVE_INT_TYPE is recommended for code (e.g., loop variables) where a particular size is
-not needed in order to make it more portable. An additional type NATIVE_UINT_TYPE is available for unsigned variables.
+`NATIVE_INT_TYPE`. The `NATIVE_INT_TYPE` is recommended for code (e.g., loop variables) where a particular size is
+not needed in order to make it more portable. An additional type `NATIVE_UINT_TYPE` is available for unsigned variables.
 These types are defined in `Fw/Types/BasicTypes.hpp` and use compiler macros for sizing. See:
 [Primitive Types](./../user/enum-arr-ser.md)
 
@@ -103,7 +105,7 @@ types on/off such that smaller architectures can disable them.  These settings a
 | FW_HAS_F64     | The architecture supports 64-bit double-precision floating point values. | 1 (on)  | 0 (off) 1 (on) |
 
 Example:
-```
+```cpp
 // Turn of 64-bit integers (double)
 #define FW_HAS_F64 0
 ```
@@ -120,9 +122,10 @@ By default, F´ checks for IEEE754 compliant floating point arithmetic at compil
 
 #### Configured Type Definitions
 
-**WARNING:** To run the system with the standard F´ GDS, these changes need to be made in the python GDS support code
-as well as here. This is non-trivial and will be fixed in future releases. Unless the project intended to modify the
-GDS code, or use an alternate GDS for all functions, these settings should be left as their defaults.
+> **Warning**
+> To run the system with the standard F´ GDS, these changes need to be made in the python GDS support code
+> as well as here. This is non-trivial and will be fixed in future releases. Unless the project intended to modify the
+> GDS code, or use an alternate GDS for all functions, these settings should be left as their defaults.
 
 The value which represents a serialized boolean can be set using these macros. This only affects what value is written
 when the boolean is serialized
@@ -154,7 +157,8 @@ correctly, and thus changing these values should be done carefully.
 | FwTimeBaseStoreType         | Type storing F´ timebase enum          | U16     | U8, U16, U32, U64 |
 | FwTimeContextStoreType      | Type storing F´ time context           | U8      | U8, U16, U32, U64 |
 
-**Note:** for a further understanding of timebase and time context, see the next section.
+> **Note**
+> For a further understanding of timebase and time context, see the next section.
 
 #### Time Base and Time Context
 
@@ -166,10 +170,11 @@ can produce a time tag. It lets users of the system see which clock was used whe
 
 Time contexts are another value associated with time.
 
-**WARNING:** Changes to this value must be done in tandem with the F´ GDS for F´ GDS features to work. Thus most
-projects don't modify these settings just like the types defined above.
+> **Warning**
+> Changes to this value must be done in tandem with the F´ GDS for F´ GDS features to work. Thus most
+> projects don't modify these settings just like the types defined above.
 
-```
+```cpp
 enum TimeBase {
     TB_NONE, //!< No time base has been established
     TB_PROC_TIME, //!< Indicates time is processor cycle time. Not tied to external time
@@ -211,26 +216,29 @@ class stores a task name as private data. Table 35 provides the macro for this f
 | FW_QUEUE_NAME_MAX_SIZE   | Size of the buffer storing the queue names  | 80      | Positive integer  |
 | FW_TASK_NAME_MAX_SIZE    | Size of the buffer storing task names       | 80      | Positive integer  |
 
-**Note:** The macro `FW_OPTIONAL_NAME("string")` can be used to conditionally return the given
-string or an empty string depending on whether `FW_OBJECT_NAMES` is on. This can be used to strip
-out component names from code when building without `FW_OBJECT_NAMES`.
+> **Note**
+> The macro `FW_OPTIONAL_NAME("string")` can be used to conditionally return the given
+> string or an empty string depending on whether `FW_OBJECT_NAMES` is on. This can be used to strip
+> out component names from code when building without `FW_OBJECT_NAMES`.
 
-**Note:** If the size of the string passed to the code-generated component base classes is larger than this size, the
-string will be truncated. FW_OBJECT_NAMES must be turned on for FW_OBJ_NAME_MAX_SIZ to have any effect.
+> **Note**
+> If the size of the string passed to the code-generated component base classes is larger than this size, the
+> string will be truncated. `FW_OBJECT_NAMES` must be turned on for `FW_OBJ_NAME_MAX_SIZ` to have any effect.
 
-**Note:** FW_QUEUE_NAME_MAX_SIZE and FW_TASK_NAME_MAX_SIZE are only used if FW_OBJECT_NAMES is **turned off**.
-Otherwise, the supplied object name is used.
+> **Note**
+> `FW_QUEUE_NAME_MAX_SIZE` and `FW_TASK_NAME_MAX_SIZE` are only used if `FW_OBJECT_NAMES` is **turned off**.
+> Otherwise, the supplied object name is used.
 
 #### Object to String
 
-The framework port and object classes have an optional toString() method. This method by default returns the instance
-name of the object, but toString() is defined as a virtual method so a developer class can override this and provide
-custom information. Table 35 provides the macros to configure this feature.
+The framework port and object classes have an optional `toString()` method. This method by default returns the instance
+name of the object, but `toString()` is defined as a virtual method so a developer class can override this and provide
+custom information. Table 36 provides the macros to configure this feature.
 
-**Note:** for these settings to work FW_OBJECT_NAMES must be turned on.
+> **Note**
+> For these settings to work `FW_OBJECT_NAMES` must be turned on.
 
-**Table 36.** Macros for object to
-string.
+**Table 36.** Macros for object to string.
 
 | Macro                                 | Definition                                                  | Default | Valid Values      |
 | ------------------------------------- | ----------------------------------------------------------- |---------|-------------------|
@@ -261,10 +269,10 @@ registry.
 | FW_QUEUE_REGISTRATION         | Enables queue registries.                                                   | 1 (on)  | 0 (off) 1 (on)    |
 | FW_QUEUE_SIMPLE_QUEUE_ENTRIES | The size of the array in the simple object registry used to store queues.   | 100     | Positive integer  |
 
-**Note:** FW_OBJECT_REGISTRATION must be turned on for FW_OBJ_SIMPLE_REG_ENTRIES and
-FW_OBJ_SIMPLE_REG_BUFF_SIZE to have any effect.
+> **Note**
+> `FW_OBJECT_REGISTRATION` must be turned on for `FW_OBJ_SIMPLE_REG_ENTRIES` and `FW_OBJ_SIMPLE_REG_BUFF_SIZE` to have any effect.
 
-**Note:** See table 35 for configuring queue name sizes.
+> **Note** See table 35 for configuring queue name sizes.
 
 
 ### Asserts
@@ -284,11 +292,11 @@ can be configured.
 |                        | FW_FILENAME_ASSERT               | Asserts turned on, __FILE__ macro is used in the assert message    |                    |
 | FW_ASSERT_TEXT_SIZE    | The buffer size used to store the assert message  |                                                   | 120                |
 
-Setting assert level FW_FILEID_ASSERT  saves a lot of code space since no file name is stored. The make system
+Setting assert level `FW_FILEID_ASSERT`  saves a lot of code space since no file name is stored. The make system
 supplies this to the compiler by hashing the file name. The original filename can be recovered by running
 `fprime-util hash-to-file <hash>`.
 
-Setting assert level to FW_ASSERT_TEXT_SIZE can ease debugging asserts, but typically FW_ASSERT_TEXT_SIZE must be
+Setting assert level to `FW_ASSERT_TEXT_SIZE` can ease debugging asserts, but typically `FW_ASSERT_TEXT_SIZE` must be
 increased as most file name paths are longer than 120.
 
 
@@ -337,8 +345,9 @@ the macros to configure this feature.
 | FW_SERIALIZATION_TYPE_ID       | Enables serializing the type ID  | 0 (off) | 0 (off) 1 (on)    |
 | FW_SERIALIZATION_TYPE_ID_BYTES | Defines size of serialization ID | 4       | 1 - 4             |
 
-**Note:** Smaller values for FW_SERIALIZATION_TYPE_ID_BYTES  means that less data storage is needed, but also
-limits the number of types that can be defined. FW_SERIALIZATION_TYPE_ID is required to have type IDs in the buffer and
+> **Note**
+> Smaller values for `FW_SERIALIZATION_TYPE_ID_BYTES` means that less data storage is needed, but also
+limits the number of types that can be defined. `FW_SERIALIZATION_TYPE_ID` is required to have type IDs in the buffer and
 thus to introspect what type is contained in the buffer.
 
 
@@ -349,16 +358,17 @@ through the ground interface, serialized, and more. This section will discuss th
 command, channel, event, parameter, and other buffer size arguments.
 
 The com buffer must be able to store all the other types such that they can all be passed as generic communication. Thus
-FW_COM_BUFFER_MAX_SIZE must be large enough to hold each buffer size **and** the header data for each type. Thus these
-settings are typically derived and this is done by default. **WARNING:** only modify the comm buffer size to ensure that
-there will be no faults in the system.
+`FW_COM_BUFFER_MAX_SIZE` must be large enough to hold each buffer size **and** the header data for each type. Thus these
+settings are typically derived and this is done by default.
+
+> **Warning** only modify the comm buffer size to ensure that there will be no faults in the system.
 
 In all cases, these definitions are global for each type in the system. Thus the buffer **must** be large enough to
 hold the data for the largest of a given type in the system.  An assert will result if the buffer is set too small. i.e.
-the FW_CMD_ARG_BUFFER_MAX_SIZE cannot be smaller than the serialized size of the command with the largest arguments.
+the `FW_CMD_ARG_BUFFER_MAX_SIZE` cannot be smaller than the serialized size of the command with the largest arguments.
 
-These types also provide optional string sizes for their constituent pieces. However, the MAX_STRING_SIZE settings must
-**always** be smaller than the BUFFER_MAX_SIZE. i.e. the command string max size cannot be larger than the command
+These types also provide optional string sizes for their constituent pieces. However, the `MAX_STRING_SIZE` settings must
+**always** be smaller than the `BUFFER_MAX_SIZE`. i.e. the command string max size cannot be larger than the command
 buffer max size, as the string is serialized into the buffer.
 
 Commands serialize argument values into these buffers. Events (aka log events) also serialize just the arguments.
@@ -408,35 +418,41 @@ compiles out the code and format strings for text logging. Table 46 provides the
 | FW_ENABLE_TEXT_LOGGING      | Enables or disables text logging                        | 1 (on)  | 0 (off) 1 (on)   |
 | FW_LOG_TEXT_BUFFER_SIZE     | Maximum size of the textual representation of the event | 256     | Positive integer |
 
-**Note:** the FW_LOG_TEXT_BUFFER_SIZE should be large enough to store the full event including its text format
-string after being populated with arguments.
+> **Note**
+> The `FW_LOG_TEXT_BUFFER_SIZE` should be large enough to store the full event including its text format string after being populated with arguments.
 
 
 ### Misc Configuration Settings
 
 This setting describes some of the other settings available in `FpConfig.hpp` and did not fit in other sections. These
-are described in the tables below. Table 47 describes other user settings.  Table 48 describes settings defined by the
-build system that should never be hand-set.
+are described in the tables below.
 
-**Table 48.** Misc macros available to the user.
+Table 47 describes other user settings.
+
+**Table 47.** Misc macros available to the user.
 
 | Macro                       | Definition                                              | Default | Valid Values     |
 | --------------------------- | --------------------------------------------------------|---------|------------------|
 | FW_CMD_CHECK_RESIDUAL       | Enables command serialization extra bytes check         | 1 (on)  | 0 (off) 1 (on)   |
 | FW_AMPCS_COMPATIBLE         | Adds argument sizes to event argument serialization     | 0 (off) | 0 (off) 1 (on)   |
 
-**Note:** Normally when a command is deserialized, the handler checks to see if there are any leftover bytes in the
+> **Note**
+> Normally when a command is deserialized, the handler checks to see if there are any leftover bytes in the
 buffer. If there are, it assumes that the command was corrupted somehow since the serialized size should match the
 serialized size of the argument list. In some cases, command buffers are padded so the data can be larger than the
-serialized size of the command. Turning FW_CMD_CHECK_RESIDUAL off can disable this check and allow leftover bytes.
+serialized size of the command. Turning `FW_CMD_CHECK_RESIDUAL` off can disable this check and allow leftover bytes.
 
-**Note:** some ground systems require the size of the event argument to be serialized into the buffer instead of
-predicting the size using the dictionary. Setting FW_AMPCS_COMPATIBLE will serialize these sizes into the event buffers
+> **Note**
+> Some ground systems require the size of the event argument to be serialized into the buffer instead of
+predicting the size using the dictionary. Setting `FW_AMPCS_COMPATIBLE` will serialize these sizes into the event buffers
 **and** break compatibility with the F´ ground system as it does not use this feature.
 
-**WARNING:** the following settings are defined by the build system and are in `FpConfig.hpp` to provide a default off
+> **Warning**
+> The following settings are defined by the build system and are in `FpConfig.hpp` to provide a default off
 value. These must be set by the build system as the setting works in unison with other modules that the build system
 includes when enabling these settings.
+
+Table 48 describes settings defined by the build system that should never be hand-set.
 
 **Table 48.** Macros for use by build system only
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| None |
|**_Affected Architectures(s)_**| None |
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Add compile-time check to ensure IEEE-754 compliance of the float.

> **Note** See previous PR attempt: https://github.com/nasa/fprime/pull/1857

## Rationale

According to [AUTOSAR C++14 rules](https://www.autosar.org/fileadmin/standards/adaptive/18-03/AUTOSAR_RS_CPP14Guidelines.pdf):

```
Rule A0-4-1 (required, infrastructure / toolchain, non-automated)
Floating-point implementation shall comply with IEEE 754 standard.

Rationale:
Floating-point arithmetic has a range of problems associated with it. Some of these can
be overcome by using an implementation that conforms to IEEE 754 (IEEE Standard
for Floating-Point Arithmetic).
Note that the rule implies that toolchain, hardware, C++ Standard Library and C++
built-in types (i.e. float, double) will provide full compliance to IEEE 754 standard in
order to use floating-points in the project.
```
See also:

```
- MISRA C++ 2008 [6]: Rule 0-4-3 Floating-point implementations shall comply
with a defined floating-point standard.
- JSF December 2005 [7]: AV Rule 146 Floating point implementations shall
comply with a defined floating point standard.
```

## Testing/Review Recommendations

I took the opportunity to improve a little the readability of the `configure-fprime.md` file - I put the new Note/Warning visualization:

> **Note** this is a not

> **Warning** this is a warning

## Future Work

None
