### PR TITLE
Fix generation of fpp-input-list

### DIFF
--- a/cmake/autocoder/fpp.cmake
+++ b/cmake/autocoder/fpp.cmake
@@ -190,7 +190,7 @@ function(fpp_setup_autocode AC_INPUT_FILES)
             list(APPEND GENERATED_CPP "${GENERATED}")
         endif()
     endforeach()
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/fpp-input-list" "${FILE_DEPENDENCIES}")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/fpp-input-list" "${FPP_IMPORTS};${AC_INPUT_FILES}")
     # Add in steps for Ai.xml generation
     if (GENERATED_AI)
         add_custom_command(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| CMake |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/1801 |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Changes the list of files that get written to `fpp-input-list` to get the correct input for `fprime-util fpp-check`. 

## Rationale

See https://github.com/nasa/fprime/issues/1801. 

## Testing/Review Recommendations

Build the Math tutorial and run `fprime-util fpp-check` - confirm that `fpp-input-list` has now the same list of file as running manually [these commands](https://github.com/nasa/fprime/issues/1801#issuecomment-1340239054)
