### PR TITLE
Fixing the U64 vs FwSizeType argument change

### DIFF
--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -234,15 +234,16 @@ namespace Svc {
     Fw::LogStringArg logStringFileName(fileName.toChar());
     this->log_ACTIVITY_HI_FileSizeStarted(logStringFileName);
 
-    U64 size;
+    FwSizeType size_arg;
     const Os::FileSystem::Status status =
-      Os::FileSystem::getFileSize(fileName.toChar(), size);
+      Os::FileSystem::getFileSize(fileName.toChar(), size_arg);
     if (status != Os::FileSystem::OP_OK) {
       this->log_WARNING_HI_FileSizeError(
           logStringFileName,
           status
       );
     } else {
+      U64 size = static_cast<U64>(size_arg);
       this->log_ACTIVITY_HI_FileSizeSucceeded(logStringFileName, size);
     }
     this->emitTelemetry(status);

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -65,7 +65,7 @@ namespace Svc {
           const FwOpcodeType opCode, //!< The opcode
           const U32 cmdSeq, //!< The command sequence number
           const Fw::CmdStringArg& fileName, //!< The file to remove
-          const bool ignoreErrors //!< Ignore non-existent files
+          const bool ignoreErrors //!< Ignore missing files
       );
 
       //! Implementation for MoveFile command handler


### PR DESCRIPTION
The code changed in the time the PR was being reviewed.  This should fix the discrepancy.

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes a minor breakage that got by CI.

In the time that the PR was being reviewed, an function changed arguments.  CI did not rerun, and got merged as success.  Also the spell checker changed and flagged some new problems.



Note: this is why we run CI post-merges.


