### PR TITLE
Add standardization header for PolyDb

### DIFF
--- a/Svc/PolyDb/PolyDb.hpp
+++ b/Svc/PolyDb/PolyDb.hpp
@@ -1,0 +1,17 @@
+// ======================================================================
+// PolyDb.hpp
+// Standardization header for PolyDb
+// ======================================================================
+
+#ifndef Svc_PolyDb_HPP
+#define Svc_PolyDb_HPP
+
+#include "Svc/PolyDb/PolyDbImpl.hpp"
+
+namespace Svc {
+
+  typedef PolyDbImpl PolyDb;
+
+}
+
+#endif


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|EbenezerA99 |
|**_Affected Component_**| Svc/PolyDb |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Added missing standardization header in the polyDb component. 
## Rationale

File is necessary to account for class naming mismatch between PolyDbImpl and PolyDb
## Testing/Review Recommendations

N/A

## Future Work

N/A