### PR TITLE
Use proper link to integration test guide

### DIFF
--- a/docs/UsersGuide/best/development-practice.md
+++ b/docs/UsersGuide/best/development-practice.md
@@ -206,7 +206,7 @@ To add a component to the topology:
 As the topology comes together, it is helpful to write system-level tests for subsystems of the
 overall deployment. This makes sure that as a system, top-level requirements are met.
 
-The fprime-gds has a python API that can be used to write integration test cases that support sending commands, checking for events, and getting telemetry channel readings. To get started with writing integration tests, check out the [GDS integration test guide](../dev/testAPI/user_guide).
+The fprime-gds has a python API that can be used to write integration test cases that support sending commands, checking for events, and getting telemetry channel readings. To get started with writing integration tests, check out the [GDS integration test guide](../dev/testAPI/user_guide.md).
 
 ## Conclusion
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Gabriel Zayas |
|**_Affected Component_**| None |
|**_Affected Architectures(s)_**| None |
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Fixes a link to the GDS integration test guide.

## Rationale
I was thinking about tackling #1561, but I found that I couldn't access the link to the integration test guide, so I added the fix here.

If you have any pointers for #1561 by the way, I'd be glad to try it out since it has an "Easy First Issue" label.