### PR TITLE
Add parenthesis in conditions

### DIFF
--- a/Drv/TcpClient/test/ut/Tester.cpp
+++ b/Drv/TcpClient/test/ut/Tester.cpp
@@ -64,8 +64,8 @@ void Tester ::test_with_loop(U32 iterations, bool recv_thread) {
         EXPECT_EQ(status2, Drv::SOCK_SUCCESS);
 
         // If all the opens worked, then run this
-        if (Drv::SOCK_SUCCESS == status1 && Drv::SOCK_SUCCESS == status2 &&
-            this->component.getSocketHandler().isOpened()) {
+        if ((Drv::SOCK_SUCCESS == status1) && (Drv::SOCK_SUCCESS == status2) &&
+            (this->component.getSocketHandler().isOpened())) {
             // Force the sockets not to hang, if at all possible
             Drv::Test::force_recv_timeout(this->component.getSocketHandler());
             Drv::Test::force_recv_timeout(server);

--- a/Drv/TcpServer/test/ut/Tester.cpp
+++ b/Drv/TcpServer/test/ut/Tester.cpp
@@ -66,8 +66,8 @@ void Tester ::test_with_loop(U32 iterations, bool recv_thread) {
         EXPECT_EQ(status2, Drv::SOCK_SUCCESS);
 
         // If all the opens worked, then run this
-        if (Drv::SOCK_SUCCESS == status1 && Drv::SOCK_SUCCESS == status2 &&
-            this->component.getSocketHandler().isOpened()) {
+        if ((Drv::SOCK_SUCCESS == status1) && (Drv::SOCK_SUCCESS == status2) &&
+            (this->component.getSocketHandler().isOpened())) {
             // Force the sockets not to hang, if at all possible
             Drv::Test::force_recv_timeout(this->component.getSocketHandler());
             Drv::Test::force_recv_timeout(client);

--- a/Drv/Udp/test/ut/Tester.cpp
+++ b/Drv/Udp/test/ut/Tester.cpp
@@ -69,8 +69,8 @@ void Tester::test_with_loop(U32 iterations, bool recv_thread) {
         EXPECT_EQ(status2, Drv::SOCK_SUCCESS);
 
         // If all the opens worked, then run this
-        if (Drv::SOCK_SUCCESS == status1 && Drv::SOCK_SUCCESS == status2 &&
-            this->component.getSocketHandler().isOpened()) {
+        if ((Drv::SOCK_SUCCESS == status1) && (Drv::SOCK_SUCCESS == status2) &&
+            (this->component.getSocketHandler().isOpened())) {
             // Force the sockets not to hang, if at all possible
             Drv::Test::force_recv_timeout(this->component.getSocketHandler());
             Drv::Test::force_recv_timeout(udp2);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| fprime |
|**_Affected Component_**| N/A |
|**_Affected Architectures(s)_**| N/A |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**|  n |
|**_Builds Without Errors (y/n)_**| N/A |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR adds the parenthesis in the `if` conditions in the following files:

`Drv/TcpClient/test/ut/Tester.cpp` 
`Drv/TcpServer/test/ut/Tester.cpp` 
`Drv/Udp/test/ut/Tester.cpp`

## Rationale

Good __not__ to depend on the operator precedence inside the conditional statements.

## Testing/Review Recommendations

Check the relevant test passes.

## Future Work

N/A