### PR TITLE
Correct return type in time.getContext() to fix #1230

### DIFF
--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -144,7 +144,7 @@ namespace Fw {
         return this->m_timeBase;
     }
 
-    U8 Time::getContext() const {
+    FwTimeContextStoreType Time::getContext() const {
         return this->m_timeContext;
     }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix #1230.