### PR TITLE
Fix typos in MathComponent tutorial #1929

### DIFF
--- a/docs/Tutorials/MathComponent/Tutorial.md
+++ b/docs/Tutorials/MathComponent/Tutorial.md
@@ -2088,7 +2088,7 @@ of the Ref topology.
 
 **Generate the layout:**
 For this step, we will use the F Prime Layout (FPL) tool.
-If FPL is not installed on your system, then install it how:
+If FPL is not installed on your system, then install it now:
 clone [this repository](https://github.com/fprime-community/fprime-layout)
 and follow the instructions.
 

--- a/docs/Tutorials/MathComponent/md/Tutorial.md
+++ b/docs/Tutorials/MathComponent/md/Tutorial.md
@@ -1778,7 +1778,7 @@ of the Ref topology.
 
 **Generate the layout:**
 For this step, we will use the F Prime Layout (FPL) tool.
-If FPL is not installed on your system, then install it how:
+If FPL is not installed on your system, then install it now:
 clone [this repository](https://github.com/fprime-community/fprime-layout)
 and follow the instructions.
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| fprime |
|**_Affected Component_**|  docs/Tutorials/MathComponent |
|**_Affected Architectures(s)_**|N/A|
|**_Related Issue(s)_**| #1929  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| N/A |
|**_Unit Tests Pass (y/n)_**| N/A|
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

Change the typo `how` to `now`

## Rationale

In `docs/Tutorials/MathComponent/Tutorial.md`  and `docs/Tutorials/MathComponent/md/Tutorial.md`, line 2113 and line 1788, ends with `how` when it should say `now`.

## Testing/Review Recommendations

N/A

## Future Work

N/A