### PR TITLE
Use fully qualified namespace in AC component `.hpp`

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
@@ -7,8 +7,8 @@
 //
 // ======================================================================
 
-\#ifndef ${name.upper()}_COMP_HPP_
-\#define ${name.upper()}_COMP_HPP_
+\#ifndef ${namespace.upper().replace("::", "_")}_${name.upper()}_COMP_HPP_
+\#define ${namespace.upper().replace("::", "_")}_${name.upper()}_COMP_HPP_
 
 \#include <FpConfig.hpp>
 \#include <Fw/Port/InputSerializePort.hpp>

--- a/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/ComponentVisitorBase.py
@@ -750,8 +750,10 @@ class ComponentVisitorBase(AbstractVisitor.AbstractVisitor):
         c.component_base = c.name() + "ComponentBase"
         if obj.get_namespace() is None:
             c.namespace_list = None
+            c.namespace = ""
         else:
             c.namespace_list = obj.get_namespace().split("::")
+            c.namespace = obj.get_namespace()
         c.user = getuser()
         c.args_string = self.argsString
         c.doxygen_pre_comment = self.doxygenPreComment


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**|@pcrosemurgy |
|**_Affected Component_**| Autocoded component `.hpp` files |
|**_Affected Architectures(s)_**|  Component autocoding |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| n  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR fixes the component `.hpp` autocoder to use the fully qualified namespace. 

## Rationale

Prior to this PR a name collision would occur if a duplicate component name was found. For example: `Svc.Framer` and `Foo.Framer`.

## Testing/Review Recommendations

N/A.

## Future Work

My understanding is this change will be replaced by FPP autocoding in the near future.
