### PR TITLE
Recursively check for type imports

### DIFF
--- a/Autocoders/Python/bin/codegen.py
+++ b/Autocoders/Python/bin/codegen.py
@@ -502,13 +502,6 @@ def generate_component_instance_dictionary(
         xml_parser_obj = XmlSerializeParser.XmlSerializeParser(
             serializable_file
         )  # Telemetry/Params can only use generated serializable types
-        # check to make sure that the serializables don't have things that channels and parameters can't have
-        # can't have external non-xml members
-        if len(xml_parser_obj.get_include_header_files()):
-            PRINT.info(
-                f"ERROR: Component include serializables cannot use user-defined types. file: {serializable_file}"
-            )
-            sys.exit(-1)
 
         # print xml_parser_obj.get_args()
         parsed_serializable_xml_list.append(xml_parser_obj)
@@ -674,14 +667,6 @@ def generate_component(
         xml_parser_obj = XmlSerializeParser.XmlSerializeParser(
             serializable_file
         )  # Telemetry/Params can only use generated serializable types
-        # check to make sure that the serializables don't have things that channels and parameters can't have
-        # can't have external non-xml members
-        if len(xml_parser_obj.get_include_header_files()):
-            PRINT.info(
-                f"ERROR: Component include serializables cannot use user-defined types. file: {serializable_file}"
-            )
-            sys.exit(-1)
-
         # print xml_parser_obj.get_args()
         parsed_serializable_xml_list.append(xml_parser_obj)
         del xml_parser_obj

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
@@ -160,11 +160,11 @@ class XmlComponentParser:
             if comp_tag.tag == "comment":
                 self.__component.set_comment(comp_tag.text.strip())
             elif comp_tag.tag in (
-                    "include_header",
-                    "import_port_type",
-                    "import_serializable_type",
-                    "import_enum_type",
-                    "import_array_type"
+                "include_header",
+                "import_port_type",
+                "import_serializable_type",
+                "import_enum_type",
+                "import_array_type"
             ):
                 self.__process_import_tag(comp_tag)
             elif comp_tag.tag == "import_dictionary":

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
@@ -95,8 +95,8 @@ class XmlComponentParser:
         else:
             self.__const_parser = None
 
-        xml_parser = etree.XMLParser(remove_comments=True)
-        element_tree = etree.parse(fd, parser=xml_parser)
+        self.__xml_parser = etree.XMLParser(remove_comments=True)
+        element_tree = etree.parse(fd, parser=self.__xml_parser)
         fd.close()  # Close the file, which is only used for the parsing above
 
         # Validate against current schema. if more are imported later in the process, they will be reevaluated
@@ -159,16 +159,14 @@ class XmlComponentParser:
         for comp_tag in component:
             if comp_tag.tag == "comment":
                 self.__component.set_comment(comp_tag.text.strip())
-            elif comp_tag.tag == "include_header":
-                self.__include_header_files.append(comp_tag.text)
-            elif comp_tag.tag == "import_port_type":
-                self.__import_port_type_files.append(comp_tag.text)
-            elif comp_tag.tag == "import_serializable_type":
-                self.__import_serializable_type_files.append(comp_tag.text)
-            elif comp_tag.tag == "import_enum_type":
-                self.__import_enum_type_files.append(comp_tag.text)
-            elif comp_tag.tag == "import_array_type":
-                self.__import_array_type_files.append(comp_tag.text)
+            elif comp_tag.tag in (
+                    "include_header",
+                    "import_port_type",
+                    "import_serializable_type",
+                    "import_enum_type",
+                    "import_array_type"
+            ):
+                self.__process_import_tag(comp_tag)
             elif comp_tag.tag == "import_dictionary":
                 try:
                     dict_file = locate_build_root(comp_tag.text)
@@ -180,7 +178,7 @@ class XmlComponentParser:
                 PRINT.info("Reading external dictionary %s" % dict_file)
                 dict_fd = open(dict_file)
                 _ = etree.XMLParser(remove_comments=True)
-                dict_element_tree = etree.parse(dict_fd, parser=xml_parser)
+                dict_element_tree = etree.parse(dict_fd, parser=self.__xml_parser)
 
                 component.append(dict_element_tree.getroot())
 
@@ -848,7 +846,7 @@ class XmlComponentParser:
                         else:
                             PRINT.info(
                                 "%s: Invalid tag %s in parameter %s"
-                                % (xml_file, comment.tag, n)
+                                % (xml_file, parameter_tag.tag, n)
                             )
                             sys.exit(-1)
                     self.__parameters.append(parameter_obj)
@@ -1128,6 +1126,37 @@ class XmlComponentParser:
             if "::" in t:
                 # PRINT.info("WARNING: Found namespace qualifier in port type definition (name=%s, type=%s) using namespace specified in XXXPortAi.xml file." % (n,t))
                 p.set_type(t.split("::")[-1])
+
+    def __recursive_import_process(self, comp_tag):
+        try:
+            f = locate_build_root(comp_tag.text)
+        except (BuildRootMissingException, BuildRootCollisionException) as bre:
+            stri = "ERROR: Could not find specified dictionary XML file. {}. Error: {}".format(
+                comp_tag.text, str(bre)
+            )
+            raise OSError(stri)
+
+        fd = open(f)
+        _ = etree.XMLParser(remove_comments=True)
+        element_tree = etree.parse(fd, parser=self.__xml_parser)
+
+        for child_tag in element_tree.getroot():
+            self.__process_import_tag(child_tag)
+
+    def __process_import_tag(self, comp_tag):
+        if comp_tag.tag == "include_header":
+            self.__include_header_files.append(comp_tag.text)
+        elif comp_tag.tag == "import_port_type":
+            self.__import_port_type_files.append(comp_tag.text)
+            self.__recursive_import_process(comp_tag)
+        elif comp_tag.tag == "import_serializable_type":
+            self.__import_serializable_type_files.append(comp_tag.text)
+            self.__recursive_import_process(comp_tag)
+        elif comp_tag.tag == "import_enum_type":
+            self.__import_enum_type_files.append(comp_tag.text)
+        elif comp_tag.tag == "import_array_type":
+            self.__import_array_type_files.append(comp_tag.text)
+            self.__recursive_import_process(comp_tag)
 
     def __generate_port_from_role(self, role):
 

--- a/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
+++ b/Autocoders/Python/src/fprime_ac/parsers/XmlComponentParser.py
@@ -164,7 +164,7 @@ class XmlComponentParser:
                 "import_port_type",
                 "import_serializable_type",
                 "import_enum_type",
-                "import_array_type"
+                "import_array_type",
             ):
                 self.__process_import_tag(comp_tag)
             elif comp_tag.tag == "import_dictionary":


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes a bug in the dictionary autocoder where nested imports to types don't make it into the dictionary.

## Rationale

Say you have a complex parameter defined:

```
array CamDistortionParams = [5] F32

struct FisheyeModel {
    fx: F32,    @< X focal length in pixels
    fy: F32,    @< Y focal length center in pixels
    cx: F32,    @< Optical center X coordinate in pixels
    cy: F32,    @< Optical center Y coordinate in pixels
    d: CamDistortionParams  @< Distortion parameters
}
```

Currently the dictionary does not include the `CamDistortionParam` array since its nested inside `FisheyeModel`:

```xml
...
<serializables>
    <serializable type="FisheyeModel">
      <members>
        <member name="fx" format_specifier="%g" description="X focal length in pixels" default="0.0f" type="F32"/>
        <member name="fy" format_specifier="%g" description="Y focal length center in pixels" default="0.0f" type="F32"/>
        <member name="cx" format_specifier="%g" description="Optical center X coordinate in pixels" default="0.0f" type="F32"/>
        <member name="cy" format_specifier="%g" description="Optical center Y coordinate in pixels" default="0.0f" type="F32"/>
        <member name="d" format_specifier="%s" description="Distortion parameters" default="CamDistortionParams(0.0f, 0.0f, 0.0f, 0.0f, 0.0f)" type="CamDistortionParams"/>
      </members>
    </serializable>
</serializables>
  <arrays />
...
```

With this PR, array, serializables, and port definitions are searched recursively for references to other complex types. Now the dictionary includes `CamDistortionParams` as expected:

```xml
...
<serializables>
    <serializable type="FisheyeModel">
      <members>
        <member name="fx" format_specifier="%g" description="X focal length in pixels" default="0.0f" type="F32"/>
        <member name="fy" format_specifier="%g" description="Y focal length center in pixels" default="0.0f" type="F32"/>
        <member name="cx" format_specifier="%g" description="Optical center X coordinate in pixels" default="0.0f" type="F32"/>
        <member name="cy" format_specifier="%g" description="Optical center Y coordinate in pixels" default="0.0f" type="F32"/>
        <member name="d" format_specifier="%s" description="Distortion parameters" default="CamDistortionParams(0.0f, 0.0f, 0.0f, 0.0f, 0.0f)" type="CamDistortionParams"/>
      </members>
    </serializable>
</serializables>
  <arrays>
    <array name="CamDistortionParams" type="F32" type_id="0x47915D1F" size="5" format="%g">
      <defaults>
        <default value="0.0f"/>
        <default value="0.0f"/>
        <default value="0.0f"/>
        <default value="0.0f"/>
        <default value="0.0f"/>
      </defaults>
    </array>
  </arrays>
...
```

## Testing/Review Recommendations

1. Define a complex type (array or struct) referencing another complex
2. Use that type in a parameter, evr, command or tlm
3. Make sure all recursively referenced types are included in the dictionary.

## Future Work

None
