### PR TITLE
Improve support for serializable values in text logging

### DIFF
--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -19,7 +19,7 @@ namespace Fw {
     Serializable::~Serializable() {
     }
 
-#if FW_SERIALIZABLE_TO_STRING || BUILD_UT
+#if FW_SERIALIZABLE_TO_STRING || FW_ENABLE_TEXT_LOGGING || BUILD_UT
 
     void Serializable::toString(StringBase& text) const {
         text = "NOSPEC"; // set to not specified.

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -25,7 +25,7 @@ namespace Fw {
         public:
             virtual SerializeStatus serialize(SerializeBufferBase& buffer) const = 0; //!< serialize contents
             virtual SerializeStatus deserialize(SerializeBufferBase& buffer) = 0; //!< deserialize to contents
-#if FW_SERIALIZABLE_TO_STRING || BUILD_UT
+#if FW_SERIALIZABLE_TO_STRING || FW_ENABLE_TEXT_LOGGING || BUILD_UT
             virtual void toString(StringBase& text) const; //!< generate text from serializable
 #endif
 


### PR DESCRIPTION
## Change Description

Added `FW_ENABLE_TEXT_LOGGING` guard around `Fw::Serializable::toString()` function. This fixes compilation errors when `FW_ENABLE_TEXT_LOGGING` is on and `FW_SERIALIZATION_TO_STRING` is off. In this case, calling `toString()` will return the placeholder value `NOSPEC` for arrays and structs, and the numerical value of the enum for enums. This PR and fprime-community/fpp#233 will resolve issue #903.