### PR TITLE
Feature/no init

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
@@ -244,6 +244,7 @@ namespace ${namespace} {
         const char* compName = "" $doxygen_post_comment("Component name")
     );
 
+  public:
     //! Initialize a ${name}ComponentBase object
     //!
     void init(
@@ -259,6 +260,7 @@ namespace ${namespace} {
 #end if
     );
 
+  PROTECTED:
     //! Destroy a ${name}ComponentBase object
     //!
     virtual ~${name}ComponentBase();

--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
@@ -247,7 +247,7 @@ namespace ${namespace} {
   public:
     //! Initialize a ${name}ComponentBase object
     //!
-    void init(
+    virtual void init(
 #if $kind == "passive":
         NATIVE_INT_TYPE instance = 0 $doxygen_post_comment("The instance number")
 #else if $needs_msg_size:

--- a/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/component/hpp.tmpl
@@ -247,7 +247,7 @@ namespace ${namespace} {
   public:
     //! Initialize a ${name}ComponentBase object
     //!
-    virtual void init(
+    void init(
 #if $kind == "passive":
         NATIVE_INT_TYPE instance = 0 $doxygen_post_comment("The instance number")
 #else if $needs_msg_size:

--- a/Autocoders/Python/src/fprime_ac/generators/templates/impl/cpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/impl/cpp.tmpl
@@ -26,20 +26,6 @@ $emit_non_port_params([ $param_compName ])
 
   }
 
-  void ${name} ::
-    init(
-$emit_non_port_params($params_init_cpp)
-    )
-  {
-#if $kind == "passive"
-    ${component_base}::init(instance);
-#else if $needs_msg_size:
-    ${component_base}::init(queueDepth, msgSize, instance);
-#else
-    ${component_base}::init(queueDepth, instance);
-#end if
-  }
-
   ${name} ::
     ~${name}()
   {

--- a/Autocoders/Python/src/fprime_ac/generators/templates/impl/hpp.tmpl
+++ b/Autocoders/Python/src/fprime_ac/generators/templates/impl/hpp.tmpl
@@ -31,12 +31,6 @@ namespace ${namespace} {
 $emit_non_port_params([ $param_compName ])
       );
 
-      //! Initialize object $name
-      //!
-      void init(
-$emit_non_port_params($params_init_hpp)
-      );
-
       //! Destroy object $name
       //!
       ~${name}();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The component `init` function is now called automatically from within the topology autocoded files. This means that `init` must have a fixed signature.  In typically use cases, `init` only calls the parent's implementation of the `init` function. e.g.

```c++
void Component ::init(...) {
    ComponentComponentBase::init(...);
}
```

This means that end-users are expected to maintain this function, but not touch it.  Current recommendations for generic setup of components is to define a separate `setup()` or `config()` function and call it specifically in the topology with whatever arguments needed.

This implies that the `init` function should entirely be pushed into the autocoded layer.

This PR does several things:
1. Define the autocoded `init` as `public` such that the topology may call this function
~~2. Set `init` as virtual such that the user may safely override it, should it be necessary~~
3. Strip `init` from the component implementation templates such that, by default, the component does not override the `init` function

Item 2 scrubbed as it is could be a potentially breaking change.




