### PR TITLE
Add platform guard to CMake API

### DIFF
--- a/Drv/LinuxGpioDriver/CMakeLists.txt
+++ b/Drv/LinuxGpioDriver/CMakeLists.txt
@@ -5,6 +5,10 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
+if (NOT FPRIME_USE_STUBBED_DRIVERS)
+    restrict_platforms(Linux)
+endif()
+
 if(FPRIME_USE_STUBBED_DRIVERS)
     set(SOURCE_FILES
         "${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriver.fpp"
@@ -19,8 +23,6 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
         "${CMAKE_CURRENT_LIST_DIR}/LinuxGpioDriverComponentImpl.cpp"
     )
     register_fprime_module()
-else()
-    message(STATUS "Cannot use ${CMAKE_CURRENT_LIST_DIR} with platform ${CMAKE_SYSTEM_NAME}. Skipping.")
 endif()
 
 

--- a/Drv/LinuxI2cDriver/CMakeLists.txt
+++ b/Drv/LinuxI2cDriver/CMakeLists.txt
@@ -5,6 +5,10 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
+if (NOT FPRIME_USE_STUBBED_DRIVERS)
+    restrict_platforms(Linux)
+endif()
+
 if(FPRIME_USE_STUBBED_DRIVERS)
     add_definitions(-DSTUBBED_LINUX_I2C_DRIVER)
     set(SOURCE_FILES
@@ -18,8 +22,6 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
         "${CMAKE_CURRENT_LIST_DIR}/LinuxI2cDriver.cpp"
     )
     register_fprime_module()
-else()
-    message(STATUS "Cannot use ${CMAKE_CURRENT_LIST_DIR} with platform ${CMAKE_SYSTEM_NAME}. Skipping.")
 endif()
 
 

--- a/Drv/LinuxSpiDriver/CMakeLists.txt
+++ b/Drv/LinuxSpiDriver/CMakeLists.txt
@@ -5,6 +5,9 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
+if (NOT FPRIME_USE_STUBBED_DRIVERS)
+    restrict_platforms(Linux)
+endif()
 if(FPRIME_USE_STUBBED_DRIVERS)
     set(SOURCE_FILES
         "${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriver.fpp"
@@ -19,7 +22,5 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
         "${CMAKE_CURRENT_LIST_DIR}/LinuxSpiDriverComponentImpl.cpp"
     )
     register_fprime_module()
-else()
-    message(STATUS "Cannot use ${CMAKE_CURRENT_LIST_DIR} with platform ${CMAKE_SYSTEM_NAME}. Skipping.")
 endif()
 

--- a/Drv/LinuxUartDriver/CMakeLists.txt
+++ b/Drv/LinuxUartDriver/CMakeLists.txt
@@ -5,14 +5,11 @@
 # MOD_DEPS: (optional) module dependencies
 #
 ####
-set(MOD_DEPS Os)
+restrict_platforms(Linux Darwin)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-    set(SOURCE_FILES
-        "${CMAKE_CURRENT_LIST_DIR}/LinuxUartDriver.fpp"
-        "${CMAKE_CURRENT_LIST_DIR}/LinuxUartDriver.cpp"
-    )
-    register_fprime_module()
-else()
-    message(STATUS "Cannot use ${CMAKE_CURRENT_LIST_DIR} with platform ${CMAKE_SYSTEM_NAME}. Skipping.")
-endif()
+set(MOD_DEPS Os)
+set(SOURCE_FILES
+    "${CMAKE_CURRENT_LIST_DIR}/LinuxUartDriver.fpp"
+    "${CMAKE_CURRENT_LIST_DIR}/LinuxUartDriver.cpp"
+)
+register_fprime_module()

--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -14,6 +14,28 @@
 set(FPRIME_TARGET_LIST "" CACHE INTERNAL "FPRIME_TARGET_LIST: custom fprime targets" FORCE)
 set(FPRIME_UT_TARGET_LIST "" CACHE INTERNAL "FPRIME_UT_TARGET_LIST: custom fprime targets" FORCE)
 set(FPRIME_AUTOCODER_TARGET_LIST "" CACHE INTERNAL "FPRIME_AUTOCODER_TARGET_LIST: custom fprime targets" FORCE)
+
+####
+# Macro `restrict_platforms`:
+#
+# Restricts a CMakeLists.txt file to a given list of platforms. This prevents usage on platforms for which the module
+# is incapable of being used and replaces the historical pattern of an if-tree detecting unsupported platforms.
+#
+# Usage:
+#    restrict_platforms(Linux Darwin) # Restricts to Linux and Darwin platforms
+#
+# Args:
+#   ARGN: list of platforms that are supported
+#####
+macro(restrict_platforms)
+    set(__CHECKER ${ARGN})
+     if (NOT CMAKE_SYSTEM_NAME IN_LIST __CHECKER)
+         get_module_name("${CMAKE_CURRENT_LIST_DIR}")
+         message(STATUS "Platform ${CMAKE_SYSTEM_NAME} not supported for module ${MODULE_NAME}")
+         return()
+     endif()
+endmacro()
+
 ####
 # Function `add_fprime_subdirectory`:
 #


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Not all F´  components are written and developed for all platforms.  This allows users to restrict components to certain supported platforms.

e.g.
```
restrict_platform(Linux)
```
