### PR TITLE
Added a name only constructor to ComLogger

### DIFF
--- a/Svc/ComLogger/ComLogger.cpp
+++ b/Svc/ComLogger/ComLogger.cpp
@@ -38,12 +38,13 @@ namespace Svc {
       Fw::StringUtils::string_length(incomingFilePrefix, sizeof(this->filePrefix)), sizeof(this->filePrefix)); // ensure that file prefix is not too big
 
     // Set the file prefix:
-    Fw::StringUtils::string_copy(this->filePrefix, incomingFilePrefix, sizeof(this->filePrefix));
+    (void)Fw::StringUtils::string_copy(this->filePrefix, incomingFilePrefix, sizeof(this->filePrefix));
   }
 
   ComLogger ::
     ComLogger(const char* compName) :
       ComLoggerComponentBase(compName),
+      filePrefix(),
       maxFileSize(0),
       fileMode(CLOSED),
       byteCount(0),
@@ -76,7 +77,7 @@ namespace Svc {
     FW_ASSERT(Fw::StringUtils::string_length(incomingFilePrefix, sizeof(this->filePrefix)) < sizeof(this->filePrefix),
       Fw::StringUtils::string_length(incomingFilePrefix, sizeof(this->filePrefix)), sizeof(this->filePrefix)); // ensure that file prefix is not too big
 
-    Fw::StringUtils::string_copy(this->filePrefix, incomingFilePrefix, sizeof(this->filePrefix));
+    (void)Fw::StringUtils::string_copy(this->filePrefix, incomingFilePrefix, sizeof(this->filePrefix));
 
     this->initialized = true;
   }

--- a/Svc/ComLogger/ComLogger.cpp
+++ b/Svc/ComLogger/ComLogger.cpp
@@ -28,17 +28,7 @@ namespace Svc {
       storeBufferLength(storeBufferLength),
       initialized(true)
   {
-    if( this->storeBufferLength ) {
-      FW_ASSERT(maxFileSize > sizeof(U16), maxFileSize); // must be a positive integer greater than buffer length size
-    }
-    else {
-      FW_ASSERT(maxFileSize > 0, maxFileSize); // must be a positive integer
-    }
-    FW_ASSERT(Fw::StringUtils::string_length(incomingFilePrefix, sizeof(this->filePrefix)) < sizeof(this->filePrefix),
-      Fw::StringUtils::string_length(incomingFilePrefix, sizeof(this->filePrefix)), sizeof(this->filePrefix)); // ensure that file prefix is not too big
-
-    // Set the file prefix:
-    (void)Fw::StringUtils::string_copy(this->filePrefix, incomingFilePrefix, sizeof(this->filePrefix));
+    this->init_log_file(incomingFilePredix, maxFileSize, storeBufferLength);
   }
 
   ComLogger ::

--- a/Svc/ComLogger/ComLogger.cpp
+++ b/Svc/ComLogger/ComLogger.cpp
@@ -28,7 +28,7 @@ namespace Svc {
       storeBufferLength(storeBufferLength),
       initialized(true)
   {
-    this->init_log_file(incomingFilePredix, maxFileSize, storeBufferLength);
+    this->init_log_file(incomingFilePrefix, maxFileSize, storeBufferLength);
   }
 
   ComLogger ::

--- a/Svc/ComLogger/ComLogger.cpp
+++ b/Svc/ComLogger/ComLogger.cpp
@@ -60,7 +60,7 @@ namespace Svc {
   void ComLogger ::
     init_log_file(const char* incomingFilePrefix, U32 maxFileSize, bool storeBufferLength)
   {
-    FW_ASSERT(incomingFilePrefix != NULL);
+    FW_ASSERT(incomingFilePrefix != nullptr);
     this->maxFileSize = maxFileSize;
     this->storeBufferLength = storeBufferLength;
     if( this->storeBufferLength ) {

--- a/Svc/ComLogger/ComLogger.cpp
+++ b/Svc/ComLogger/ComLogger.cpp
@@ -47,6 +47,8 @@ namespace Svc {
       filePrefix(),
       maxFileSize(0),
       fileMode(CLOSED),
+      fileName(),
+      hashFileName(),
       byteCount(0),
       writeErrorOccurred(false),
       openErrorOccurred(false),
@@ -68,6 +70,7 @@ namespace Svc {
   void ComLogger ::
     init_log_file(const char* incomingFilePrefix, U32 maxFileSize, bool storeBufferLength)
   {
+    FW_ASSERT(incomingFilePrefix != NULL);
     this->maxFileSize = maxFileSize;
     this->storeBufferLength = storeBufferLength;
     if( this->storeBufferLength ) {

--- a/Svc/ComLogger/ComLogger.hpp
+++ b/Svc/ComLogger/ComLogger.hpp
@@ -52,10 +52,22 @@ namespace Svc {
       //                    match to an expected size on the ground during post processing.
       ComLogger(const char* compName, const char* filePrefix, U32 maxFileSize, bool storeBufferLength=true);
 
+      // CONSTRUCTOR:
+      ComLogger(const char* compName);
+
       void init(
           NATIVE_INT_TYPE queueDepth, //!< The queue depth
           NATIVE_INT_TYPE instance //!< The instance number
       );
+
+      // filePrefix: string to prepend the file name with, ie. "thermal_telemetry"
+      // maxFileSize: the maximum size a file should reach before being closed and a new one opened
+      // storeBufferLength: if true, store the length of each com buffer before storing the buffer itself,
+      //                    otherwise just store the com buffer. false might be advantageous in a system
+      //                    where you can ensure that all buffers given to the ComLogger are the same size
+      //                    in which case you do not need the overhead. Or you store an id which you can
+      //                    match to an expected size on the ground during post processing.
+      void init_log_file(const char* filePrefix, U32 maxFileSize, bool storeBufferLength=true);
 
       ~ComLogger();
 
@@ -112,6 +124,7 @@ namespace Svc {
       bool writeErrorOccurred;
       bool openErrorOccurred;
       bool storeBufferLength;
+      bool initialized;
 
       // ----------------------------------------------------------------------
       // File functions:

--- a/Svc/ComLogger/Events.fppi
+++ b/Svc/ComLogger/Events.fppi
@@ -39,4 +39,5 @@ event FileClosed(
 event FileNotInitialized \
   severity warning low \
   id 0x04 \
-  format "Could not open ComLogger file. File not initialized"
+  format "Could not open ComLogger file. File not initialized" \
+  throttle 5

--- a/Svc/ComLogger/Events.fppi
+++ b/Svc/ComLogger/Events.fppi
@@ -35,3 +35,8 @@ event FileClosed(
   severity diagnostic \
   id 0x03 \
   format "File {} closed successfully."
+
+event FileNotInitialized \
+  severity warning low \
+  id 0x04 \
+  format "Could not open ComLogger file. File not initialized"

--- a/Svc/ComLogger/test/ut/Main.cpp
+++ b/Svc/ComLogger/test/ut/Main.cpp
@@ -31,6 +31,16 @@ TEST(Test, closeFileCommand) {
   tester.closeFileCommand();
 }
 
+TEST(Test, testLoggingWithInit) {
+  Svc::Tester tester("Tester", true);
+  tester.testLoggingWithInit();
+}
+
+TEST(Test, noInitError) {
+  Svc::Tester tester("Tester", true);
+  tester.noInitError();
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/Svc/ComLogger/test/ut/Tester.hpp
+++ b/Svc/ComLogger/test/ut/Tester.hpp
@@ -24,6 +24,10 @@ namespace Svc {
 
     public:
       Tester(const char *const compName);
+
+      // This constructor will construct comLogger with its
+      // standard constructor
+      Tester(const char *const compName, bool standardCLInit);
       ~Tester();
 
       void testLogging();
@@ -31,6 +35,8 @@ namespace Svc {
       void openError();
       void writeError();
       void closeFileCommand();
+      void testLoggingWithInit();
+      void noInitError();
     private:
       void connectPorts();
       void initComponents();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @kubiak-jpl |
|**_Affected Component_**| ComLogger |
|**_Affected Architectures(s)_**| N/A |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Updated ComLogger to include a name-only constructor and an additional initialization method

```cpp
ComLogger(const char* compName);
```

```cpp

      // filePrefix: string to prepend the file name with, ie. "thermal_telemetry"
      // maxFileSize: the maximum size a file should reach before being closed and a new one opened
      // storeBufferLength: if true, store the length of each com buffer before storing the buffer itself,
      //                    otherwise just store the com buffer. false might be advantageous in a system
      //                    where you can ensure that all buffers given to the ComLogger are the same size
      //                    in which case you do not need the overhead. Or you store an id which you can
      //                    match to an expected size on the ground during post processing.
      void init_log_file(const char* filePrefix, U32 maxFileSize, bool storeBufferLength=true);
```

Added a new internal state to keep track of initialization. The ComLogger file will not open if `init_log_file` is not called and a WARNING_LO event will be created. Using the old constructor sets this state to initialized by default

Added unit tests to cover the new constructor.

## Rationale

The name-only constructor is necessary to use ComLogger without the need for phases in the topology fpp.

## Testing/Review Recommendations

Updated unit tests

## Future Work

None
