### PR TITLE
Fix FPP syntax in HelloWorld docs

### DIFF
--- a/docs/Tutorials/HelloWorld/HelloWorld.md
+++ b/docs/Tutorials/HelloWorld/HelloWorld.md
@@ -113,12 +113,12 @@ with the following:
 ```
 @ Command to issue greeting with maximum length of 20 characters
 async command SAY_HELLO(
-    greeting: string size 20 @ Greeting to repeat in the Hello event
+    greeting: string size 20 @< Greeting to repeat in the Hello event
 )
 
 @ Greeting event with maximum greeting length of 20 characters
 event Hello(
-    greeting: string size 20 @ Greeting supplied from the SAY_HELLO command
+    greeting: string size 20 @< Greeting supplied from the SAY_HELLO command
 ) severity activity high format "I say: {}"
 
 @ A count of the number of greetings issued


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| JPL Fprime |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  n/a |
|**_Builds Without Errors (y/n)_**| n/a  |
|**_Unit Tests Pass (y/n)_**| n/a |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

When trying to build the HelloWorld project, I ran into an error when executing `fprime-util impl` because the docs contained a syntax error.

## Rationale

Make the HelloWorld fpp example buildable out-of-box.

## Testing/Review Recommendations

I ran `fprime-util impl` without problems after my change. Altough `fpp-check` didn't pass:
```sh
user@tpad:/app/MyComponents/HelloWorld$ fpp-check < HelloWorld.fpp
fpp-check
stdin: 41.9
        time get port timeCaller
        ^
error: undefined symbol Fw
```

I'm very new to fprime so I'm not sure if this is relevant.

## Future Work

