### PR TITLE
Fix missing coverage compilations for unit-test files

### DIFF
--- a/cmake/target/build.cmake
+++ b/cmake/target/build.cmake
@@ -91,6 +91,11 @@ function(build_setup_build_module MODULE SOURCES GENERATED EXCLUDED_SOURCES DEPE
         endif()
     endforeach()
     set_property(TARGET "${MODULE}" PROPERTY FPRIME_TARGET_DEPENDENCIES ${TARGET_DEPENDENCIES})
+    # Special flags applied to modules when compiling with testing enabled
+    if (BUILD_TESTING)
+        target_compile_options("${MODULE}" PRIVATE ${FPRIME_TESTING_REQUIRED_COMPILE_FLAGS})
+        target_link_libraries("${MODULE}" PRIVATE ${FPRIME_TESTING_REQUIRED_LINK_FLAGS})
+    endif()
 endfunction()
 
 ####
@@ -120,11 +125,6 @@ function(build_add_module_target MODULE TARGET SOURCES DEPENDENCIES)
     run_ac_set("${SOURCES}" ${CUSTOM_AUTOCODERS})
     resolve_dependencies(RESOLVED ${DEPENDENCIES} ${AC_DEPENDENCIES} )
     build_setup_build_module("${MODULE}" "${SOURCES}" "${AC_GENERATED}" "${AC_SOURCES}" "${RESOLVED}")
-    # Special flags applied to modules when compiling with testing enabled
-    if (BUILD_TESTING)
-        target_compile_options("${MODULE}" PRIVATE ${FPRIME_TESTING_REQUIRED_COMPILE_FLAGS})
-        target_link_libraries("${MODULE}" PRIVATE ${FPRIME_TESTING_REQUIRED_LINK_FLAGS})
-    endif()
 
     if (CMAKE_DEBUG_OUTPUT)
         introspect("${MODULE}")

--- a/cmake/target/check.cmake
+++ b/cmake/target/check.cmake
@@ -11,9 +11,7 @@
 # - **TARGET_NAME:** target name to be generated
 ####
 function(check_add_global_target TARGET_NAME)
-    add_custom_target(${TARGET_NAME}
-            COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} find . -name "*.gcda" -delete
-            COMMAND ${CMAKE_CTEST_COMMAND})
+    add_custom_target(${TARGET_NAME} COMMAND ${CMAKE_CTEST_COMMAND})
 endfunction(check_add_global_target)
 
 ####
@@ -33,12 +31,18 @@ function(check_add_deployment_target MODULE TARGET SOURCES DEPENDENCIES FULL_DEP
         get_property(DEPENDENCY_UTS TARGET "${DEPENDENCY}" PROPERTY FPRIME_UTS)
         list(APPEND ALL_UTS ${DEPENDENCY_UTS})
     endforeach()
-    string(REPLACE ";" "\\|" JOINED_UTS "${ALL_UTS}")
-    add_custom_target(${MODULE}_${TARGET_NAME}
-        COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} find . -name "*.gcda" -delete
-        COMMAND ${CMAKE_CTEST_COMMAND} -R "${JOINED_UTS}"
-        DEPENDS ${ALL_UTS}
-    )
+    # Only run deployment UTs when some are defined
+    if (ALL_UTS)
+        string(REPLACE ";" "\\|" JOINED_UTS "${ALL_UTS}")
+        add_custom_target(${MODULE}_${TARGET_NAME}
+            COMMAND ${CMAKE_CTEST_COMMAND} -R "${JOINED_UTS}"
+            DEPENDS ${ALL_UTS}
+        )
+    else()
+        add_custom_target(${MODULE}_${TARGET_NAME}
+            COMMAND ${CMAKE_COMMAND} -E echo "No unit tests defined for ${MODULE}"
+        )
+    endif()
 endfunction()
 
 ####
@@ -58,7 +62,6 @@ function(check_add_module_target MODULE_NAME TARGET_NAME SOURCE_FILES DEPENDENCI
     elseif (NOT TARGET ${MODULE_NAME}_${TARGET_NAME})
         add_custom_target(
             "${MODULE_NAME}_${TARGET_NAME}"
-            COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} find . -name "*.gcda" -delete
             COMMAND ${CMAKE_CTEST_COMMAND} --verbose
         )
     endif()

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ Flask-RESTful==0.3.9
 fprime-fpp==1.2.0
 fprime-gds==3.2.0
 fprime-tools==3.2.0
-gcovr==5.2
+gcovr==6.0
 idna==3.4
 importlib-metadata==4.13.0
 iniconfig==2.0.0


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This fixes #1862.  The issue was unit-tests were not being compiled with coverage flags, meaning the profiling was incomplete.

