### PR TITLE
Update/minor fixes gtest

### DIFF
--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -37,18 +37,18 @@ macro(restrict_platforms)
 endmacro()
 
 ####
-# Macro `prevent_prescaning`:
+# Macro `prevent_prescanning`:
 #
 # Prevents a CMakeLists.txt file from being processed in the prescan phase of the project. Will generate fake targets
 # for all those targets specified to ensure that dependencies may be linked to them.
 #
 # Usage:
-#    prevent_prescaning(target1 target2 ...) # Restricts to Linux and Darwin platforms
+#    prevent_prescanning(target1 target2 ...) # Restricts to Linux and Darwin platforms
 #
 # Args:
 #   ARGN: list of targets to synthesize
 #####
-macro(prevent_prescaning)
+macro(prevent_prescanning)
     set(__CHECKER_TARGETS ${ARGN})
     if (DEFINED FPRIME_PRESCAN)
         foreach (__TARGET IN LISTS __CHECKER_TARGETS)

--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -29,11 +29,35 @@ set(FPRIME_AUTOCODER_TARGET_LIST "" CACHE INTERNAL "FPRIME_AUTOCODER_TARGET_LIST
 #####
 macro(restrict_platforms)
     set(__CHECKER ${ARGN})
-     if (NOT CMAKE_SYSTEM_NAME IN_LIST __CHECKER)
-         get_module_name("${CMAKE_CURRENT_LIST_DIR}")
-         message(STATUS "Platform ${CMAKE_SYSTEM_NAME} not supported for module ${MODULE_NAME}")
-         return()
-     endif()
+    if (NOT CMAKE_SYSTEM_NAME IN_LIST __CHECKER)
+        get_module_name("${CMAKE_CURRENT_LIST_DIR}")
+        message(STATUS "Platform ${CMAKE_SYSTEM_NAME} not supported for module ${MODULE_NAME}")
+        return()
+    endif()
+endmacro()
+
+####
+# Macro `prevent_prescaning`:
+#
+# Prevents a CMakeLists.txt file from being processed in the prescan phase of the project. Will generate fake targets
+# for all those targets specified to ensure that dependencies may be linked to them.
+#
+# Usage:
+#    prevent_prescaning(target1 target2 ...) # Restricts to Linux and Darwin platforms
+#
+# Args:
+#   ARGN: list of targets to synthesize
+#####
+macro(prevent_prescaning)
+    set(__CHECKER_TARGETS ${ARGN})
+    if (DEFINED FPRIME_PRESCAN)
+        foreach (__TARGET IN LISTS __CHECKER_TARGETS)
+            add_custom_target(${__TARGET})
+        endforeach()
+        get_module_name("${CMAKE_CURRENT_LIST_DIR}")
+        message(STATUS "Platform ${CMAKE_SYSTEM_NAME} not supported for module ${MODULE_NAME}")
+        return()
+    endif()
 endmacro()
 
 ####

--- a/cmake/googletest-download/CMakeLists.txt.in
+++ b/cmake/googletest-download/CMakeLists.txt.in
@@ -6,8 +6,8 @@ include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           a3460d1
-  SOURCE_DIR        "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-src"
-  BINARY_DIR        "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-build-${TOOLCHAIN_NAME}"
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/gtest/googletest-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/gtest/googletest-build"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""

--- a/cmake/googletest-download/googletest.cmake
+++ b/cmake/googletest-download/googletest.cmake
@@ -1,5 +1,5 @@
 # Download and unpack googletest at configure time if it doesn't exit already
-if (NOT IS_DIRECTORY "${FPRIME_FRAMEWORK_PATH}/gtest/googletest-build-${TOOLCHAIN_NAME}/googletest")
+if (NOT IS_DIRECTORY "${CMAKE_BINARY_DIR}/gtest/googletest-build/googletest")
     configure_file("${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in" googletest-download/CMakeLists.txt)
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
       RESULT_VARIABLE result
@@ -20,8 +20,8 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # Add googletest directly to our build. This defines
 # the gtest and gtest_main targets.
-add_subdirectory(${FPRIME_FRAMEWORK_PATH}/gtest/googletest-src
-	${FPRIME_FRAMEWORK_PATH}/gtest/googletest-build-${TOOLCHAIN_NAME}
+add_subdirectory(${CMAKE_BINARY_DIR}/gtest/googletest-src
+	${CMAKE_BINARY_DIR}/gtest/googletest-build
                  EXCLUDE_FROM_ALL)
 
 # The gtest/gtest_main targets carry header search path


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Moves GTest clone and build into build cache to prevent contention.  Adds `prevent_prescan` guard to stop FPP prescan builds from working in a directory.