### PR TITLE
Fix CMake `-P` argument

### DIFF
--- a/cmake/target/install.cmake
+++ b/cmake/target/install.cmake
@@ -52,7 +52,7 @@ function(install_add_deployment_target MODULE TARGET SOURCES DEPENDENCIES FULL_D
     )
     install(FILES ${FPRIME_CURRENT_DICTIONARY_FILE} DESTINATION ${TOOLCHAIN_NAME}/${MODULE}/dict COMPONENT ${MODULE})
     add_custom_command(TARGET "${MODULE}" POST_BUILD COMMAND "${CMAKE_COMMAND}"
-            -DCMAKE_INSTALL_COMPONENT=${MODULE} -P${CMAKE_BINARY_DIR}/cmake_install.cmake)
+            -DCMAKE_INSTALL_COMPONENT=${MODULE} -P ${CMAKE_BINARY_DIR}/cmake_install.cmake)
 endfunction()
 
 # Install is per-deployment, a module-by-module variant does not make sense


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Fixes `-P` argument syntax. With CMake (version 3.18.4) a space must be provided after `-P`.
See https://github.com/nasa/fprime/pull/1994/files#r1197366601.

## Future Work

I'm surprised this wasn't caught by CI. May be worth checking what version of CMake CI runs with.