### PR TITLE
Add missing dependency for XML generation

### DIFF
--- a/cmake/autocoder/ai_xml.cmake
+++ b/cmake/autocoder/ai_xml.cmake
@@ -108,7 +108,7 @@ function(ai_xml_setup_autocode AC_INPUT_FILE)
             OUTPUT ${GENERATED_FILES}
             COMMAND ${AI_BASE_SCRIPT} --connect_only --xml_topology_dict "${AC_INPUT_FILE}"
             COMMAND ${CMAKE_COMMAND} -E remove ${REMOVALS}
-            DEPENDS "${AC_INPUT_FILE}" "${MODULE_DEPENDENCIES}" "${AC_INPUT_FILE}" "${FILE_DEPENDENCIES}" "${CODEGEN_TARGET}"
+            DEPENDS "${AC_INPUT_FILE}" "${MODULE_DEPENDENCIES}" "${FILE_DEPENDENCIES}" "${CODEGEN_TARGET}"
         )
     else()
         add_custom_command(

--- a/cmake/autocoder/ai_xml.cmake
+++ b/cmake/autocoder/ai_xml.cmake
@@ -108,7 +108,7 @@ function(ai_xml_setup_autocode AC_INPUT_FILE)
             OUTPUT ${GENERATED_FILES}
             COMMAND ${AI_BASE_SCRIPT} --connect_only --xml_topology_dict "${AC_INPUT_FILE}"
             COMMAND ${CMAKE_COMMAND} -E remove ${REMOVALS}
-            DEPENDS "${AC_INPUT_FILE}" "${MODULE_DEPENDENCIES}" "${AC_INPUT_FILE}" "${FILE_DEPENDENCIES}"
+            DEPENDS "${AC_INPUT_FILE}" "${MODULE_DEPENDENCIES}" "${AC_INPUT_FILE}" "${FILE_DEPENDENCIES}" "${CODEGEN_TARGET}"
         )
     else()
         add_custom_command(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F' |
|**_Affected Component_**| Autocoders/codegen |
|**_Related Issue(s)_**|  #2043 |

---
## Change Description

The `codegen.py` utility depends on in-source generated files `Autocoders/Python/src/fprime_ac/generators/templates/**/**.py`.  However, when generating topology XML files like `TopologyAppDictionary`, this dependency is not present. This PR adds the dependency.

There's also a duplicate dependency on `${AC_INPUT_FILE}` so I removed one occurrence.

## Rationale

I was not able to build the Ref app of devel branch with fpp devel branch with error:
```
Traceback (most recent call last):
  File "/zephyr-workspace/fprime-zephyr-app/fprime/fprime/Autocoders/Python/bin/codegen.py", line 28, in <module>
    from fprime_ac.utils import (
  File "/zephyr-workspace/fprime-zephyr-app/fprime/fprime/Autocoders/Python/src/fprime_ac/utils/ArrayGenerator.py", line 18, in <module>
    from fprime_ac.generators.templates.arrays import array_cpp, array_hpp
ImportError: cannot import name 'array_cpp' from 'fprime_ac.generators.templates.arrays' (/zephyr-workspace/fprime-zephyr-app/fprime/fprime/Autocoders/Python/src/fprime_ac/generators/templates/arrays/__init__.py)
gmake[3]: *** [Ref/Top/CMakeFiles/Ref_Top.dir/build.make:203: Ref/Top/RefTopologyAppDictionary.xml] Error 1
gmake[2]: *** [CMakeFiles/Makefile2:8407: Ref/Top/CMakeFiles/Ref_Top.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:2045: CMakeFiles/Ref.dir/rule] Error 2
gmake: *** [Makefile:195: Ref] Error 2
[ERROR] CMake erred with return code 2
```

I bisected the first commit of fpp with which tne build fails, but it doesn't seem fishy: https://github.com/fprime-community/fpp/commit/d1d14aebe06d959568830fdffee418b3f7c7a965

## Future Work

* Get rid of in-source build files #2043
* It would be great to have integration tests for fprime-tools, fpp, and fprime-gds, or even better, a mono repository :))