### PR TITLE
Make `Framer.comStatusIn` port `sync`, avoid mutual exclusion locking

### DIFF
--- a/Svc/Framer/Framer.fpp
+++ b/Svc/Framer/Framer.fpp
@@ -40,7 +40,7 @@ module Svc {
 
     @ Port receiving the general status from the downstream component
     @ indicating it is ready or not-ready for more input
-    guarded input port comStatusIn: Fw.SuccessCondition
+    sync input port comStatusIn: Fw.SuccessCondition
 
     @ Port receiving indicating the status of framer for receiving more data
     output port comStatusOut: Fw.SuccessCondition


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| `Framer` |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This change allows the `Framer.comStatusIn` port to be called synchronously. Previously, a deadlock situation occurred when routing
```
      radio.comStatus -> framer.comStatusIn
      framer.comStatusOut -> comQueue.comStatusIn
```
due to this port being `guarded`.

## Verification

Tested with the topology above. Downlink worked as expected with F' GDS.