### PR TITLE
Adding guard to buffer accumulator

### DIFF
--- a/Svc/BufferAccumulator/CMakeLists.txt
+++ b/Svc/BufferAccumulator/CMakeLists.txt
@@ -6,6 +6,8 @@
 #
 # Note: using PROJECT_NAME as EXECUTABLE_NAME
 ####
+restrict_platforms(Linux Darwin) # Uses sys/time
+
 set(SOURCE_FILES
     "${CMAKE_CURRENT_LIST_DIR}/BufferAccumulator.fpp"
     "${CMAKE_CURRENT_LIST_DIR}/BufferAccumulator.cpp"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds a platform guard to BufferAccumulator, which only works on systems using `sys/time.h`