### PR TITLE
Build fprime-community projects as part of CI checks

### DIFF
--- a/.github/workflows/build-led-blinker.yml
+++ b/.github/workflows/build-led-blinker.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-workshop-led-blinker
 
-name: LedBlinker Tests
+name: "LedBlinker Tests"
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
     branches: [ master, devel ]
 
 jobs:
-  build:
+  run:
     name: ""
     uses: ./.github/workflows/reusable-builder.yml
     with: 

--- a/.github/workflows/build-led-blinker.yml
+++ b/.github/workflows/build-led-blinker.yml
@@ -16,3 +16,4 @@ jobs:
       target_repository: fprime-community/fprime-workshop-led-blinker
       build_location: LedBlinker
       run_unit_tests: true
+      run_integration_tests: false

--- a/.github/workflows/build-led-blinker.yml
+++ b/.github/workflows/build-led-blinker.yml
@@ -1,8 +1,12 @@
-# See https://github.com/fprime-community/fprime-workshop-led-blinker
+# Builds and runs UTs on https://github.com/fprime-community/fprime-workshop-led-blinker
 
 name: LedBlinker Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master, devel ]
+  pull_request:
+    branches: [ master, devel ]
 
 jobs:
   build:

--- a/.github/workflows/build-led-blinker.yml
+++ b/.github/workflows/build-led-blinker.yml
@@ -1,0 +1,14 @@
+# See https://github.com/fprime-community/fprime-workshop-led-blinker
+
+name: LedBlinker Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ""
+    uses: ./.github/workflows/reusable-builder.yml
+    with: 
+      target_repository: fprime-community/fprime-workshop-led-blinker
+      build_location: LedBlinker
+      run_unit_tests: true

--- a/.github/workflows/build-led-blinker.yml
+++ b/.github/workflows/build-led-blinker.yml
@@ -16,4 +16,3 @@ jobs:
       target_repository: fprime-community/fprime-workshop-led-blinker
       build_location: LedBlinker
       run_unit_tests: true
-      run_integration_tests: false

--- a/.github/workflows/reusable-builder.yml
+++ b/.github/workflows/reusable-builder.yml
@@ -19,11 +19,6 @@ on:
         required: false
         type: boolean
         default: true
-      run_integration_tests:
-        description: "Run an additional job in parallel to run unit tests."
-        required: false
-        type: boolean
-        default: false
       fprime_location:
         description: "Relative path from the external project root to its F´ submodule"
         required: false
@@ -59,16 +54,15 @@ jobs:
         run: |
           pip3 install -r ${{ inputs.fprime_location }}/requirements.txt
         shell: bash
-      - name: "Build Project"
+      - name: "Generate build cache"
         working-directory: ${{ inputs.build_location }}
         run: |
-          fprime-util generate ${{ inputs.target_platform }}
-          fprime-util build ${{ inputs.target_platform }}
+          fprime-util generate ${{ runner.debug == '1' && '--verbose' || '' }} ${{ inputs.target_platform }}
         shell: bash
-      - if: ${{ inputs.run_integration_tests }}
-        name: "Run Integration Tests (Pytest)"
+      - name: "Build"
         working-directory: ${{ inputs.build_location }}
-        run: pytest 
+        run: |
+          fprime-util build ${{ runner.debug == '1' && '--verbose' || '' }} ${{ inputs.target_platform }}
         shell: bash
 
   runUT:
@@ -90,11 +84,19 @@ jobs:
         run: |
           pip3 install -r ${{ inputs.fprime_location }}/requirements.txt
         shell: bash
-      - name: "Build and Run Unit Tests"
+      - name: "Generate UT build cache"
         working-directory: ${{ inputs.build_location }}
         run: |
-          fprime-util generate --ut ${{ inputs.target_platform }}
-          fprime-util build --ut ${{ inputs.target_platform }}
-          fprime-util check ${{ inputs.target_platform }}
+          fprime-util generate --ut ${{ runner.debug == '1' && '--verbose' || '' }} ${{ inputs.target_platform }}
+        shell: bash
+      - name: "Build UTs"
+        working-directory: ${{ inputs.build_location }}
+        run: |
+          fprime-util build --ut ${{ runner.debug == '1' && '--verbose' || '' }} ${{ inputs.target_platform }}
+        shell: bash
+      - name: "Run Unit Tests"
+        working-directory: ${{ inputs.build_location }}
+        run: |
+          fprime-util check ${{ runner.debug == '1' && '--verbose' || '' }} ${{ inputs.target_platform }}
         shell: bash
 

--- a/.github/workflows/reusable-builder.yml
+++ b/.github/workflows/reusable-builder.yml
@@ -27,7 +27,7 @@ on:
       fprime_location:
         required: false
         type: string
-        description: "Relative path from the extenal project root to its F´ submodule"
+        description: "Relative path from the external project root to its F´ submodule"
         default: "./fprime"
       runs_on:
         required: false
@@ -89,7 +89,7 @@ jobs:
         run: |
           pip3 install -r ${{ inputs.fprime_location }}/requirements.txt
         shell: bash
-      - name: "Buld and Run Unit Tests"
+      - name: "Build and Run Unit Tests"
         working-directory: ${{ inputs.build_location }}
         run: |
           fprime-util generate --ut ${{ inputs.target_platform }}

--- a/.github/workflows/reusable-builder.yml
+++ b/.github/workflows/reusable-builder.yml
@@ -60,13 +60,13 @@ jobs:
           fprime-util generate
           fprime-util build
         shell: bash
-      - if: ${{ inputs.run_integration_tests }} != ""
+      - if: ${{ inputs.run_integration_tests }}
         working-directory: ${{ inputs.build_location }}
         run: pytest 
         shell: bash
 
   runUT:
-    if: ${{ inputs.run_unit_tests }} == "true"
+    if: ${{ inputs.run_unit_tests }}
     runs-on: ${{ inputs.runs_on }}
     name: "Run Unit Tests"
     steps:

--- a/.github/workflows/reusable-builder.yml
+++ b/.github/workflows/reusable-builder.yml
@@ -1,49 +1,49 @@
 # This workflow is intended for reuse by other workflows and will not run directly (no triggers).
 # The behavior is to build an external F´ project (e.g. fprime-community/system-reference) using
 # the current F´ version.
-name: 'F´ Project Builder - Reusable Workflow'
+name: "F´ Project Builder - Reusable Workflow"
 
 on:
   workflow_call:
     inputs:
       build_location:
         description: "Path to F´ module to build. E.g. MyDeployment/"
-        type: string
         required: true
+        type: string
       target_repository:
+        description: "Additional external repository to checkout (<owner>/<repo>)"
         required: true
         type: string
-        description: "Additional external repository to checkout (<owner>/<repo>)"
       run_unit_tests:
         description: "Run an additional job in parallel to run unit tests."
-        type: boolean
         required: false
+        type: boolean
         default: true
       run_integration_tests:
         description: "Run an additional job in parallel to run unit tests."
-        type: boolean
         required: false
+        type: boolean
         default: false
       fprime_location:
+        description: "Relative path from the external project root to its F´ submodule"
         required: false
         type: string
-        description: "Relative path from the external project root to its F´ submodule"
         default: "./fprime"
       runs_on:
+        description: "Platform to run on. Defaults to ubuntu-latest"
         required: false
         type: string
-        description: "Platform to run on. Defaults to ubuntu-latest"
         default: "ubuntu-latest"
       target_platform:
+        description: "Target platform to pass to fprime-util"
         required: false
         type: string
-        description: "Target platform to pass to fprime-util"
         default: ""
 
 jobs:
   build:
     runs-on: ${{ inputs.runs_on }}
-    name: "Build F´ Project"
+    name: "Build"
     steps:
       - name: "Checkout target repository"
         uses: actions/checkout@v3
@@ -66,6 +66,7 @@ jobs:
           fprime-util build ${{ inputs.target_platform }}
         shell: bash
       - if: ${{ inputs.run_integration_tests }}
+        name: "Run Integration Tests (Pytest)"
         working-directory: ${{ inputs.build_location }}
         run: pytest 
         shell: bash
@@ -73,7 +74,7 @@ jobs:
   runUT:
     if: ${{ inputs.run_unit_tests }}
     runs-on: ${{ inputs.runs_on }}
-    name: "Run Unit Tests"
+    name: "Unit Tests"
     steps:
       - name: "Checkout target repository"
         uses: actions/checkout@v3

--- a/.github/workflows/reusable-builder.yml
+++ b/.github/workflows/reusable-builder.yml
@@ -34,6 +34,11 @@ on:
         type: string
         description: "Platform to run on. Defaults to ubuntu-latest"
         default: "ubuntu-latest"
+      target_platform:
+        required: false
+        type: string
+        description: "Target platform to pass to fprime-util"
+        default: ""
 
 jobs:
   build:
@@ -57,8 +62,8 @@ jobs:
       - name: "Build Project"
         working-directory: ${{ inputs.build_location }}
         run: |
-          fprime-util generate
-          fprime-util build
+          fprime-util generate ${{ inputs.target_platform }}
+          fprime-util build ${{ inputs.target_platform }}
         shell: bash
       - if: ${{ inputs.run_integration_tests }}
         working-directory: ${{ inputs.build_location }}
@@ -87,8 +92,8 @@ jobs:
       - name: "Buld and Run Unit Tests"
         working-directory: ${{ inputs.build_location }}
         run: |
-          fprime-util generate --ut
-          fprime-util build --ut
-          fprime-util check
+          fprime-util generate --ut ${{ inputs.target_platform }}
+          fprime-util build --ut ${{ inputs.target_platform }}
+          fprime-util check ${{ inputs.target_platform }}
         shell: bash
 

--- a/.github/workflows/reusable-builder.yml
+++ b/.github/workflows/reusable-builder.yml
@@ -1,0 +1,94 @@
+# This workflow is intended for reuse by other workflows and will not run directly (no triggers).
+# The behavior is to build an external F´ project (e.g. fprime-community/system-reference) using
+# the current F´ version.
+name: 'F´ Project Builder - Reusable Workflow'
+
+on:
+  workflow_call:
+    inputs:
+      build_location:
+        description: "Path to F´ module to build. E.g. MyDeployment/"
+        type: string
+        required: true
+      target_repository:
+        required: true
+        type: string
+        description: "Additional external repository to checkout (<owner>/<repo>)"
+      run_unit_tests:
+        description: "Run an additional job in parallel to run unit tests."
+        type: boolean
+        required: false
+        default: true
+      run_integration_tests:
+        description: "Run an additional job in parallel to run unit tests."
+        type: boolean
+        required: false
+        default: false
+      fprime_location:
+        required: false
+        type: string
+        description: "Relative path from the extenal project root to its F´ submodule"
+        default: "./fprime"
+      runs_on:
+        required: false
+        type: string
+        description: "Platform to run on. Defaults to ubuntu-latest"
+        default: "ubuntu-latest"
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runs_on }}
+    name: "Build F´ Project"
+    steps:
+      - name: "Checkout target repository"
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          repository: ${{ inputs.target_repository }}
+      - name: "Overlay current F´ revision"
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          path: ${{ inputs.fprime_location }}
+      - name: "Install requirements.txt"
+        run: |
+          pip3 install -r ${{ inputs.fprime_location }}/requirements.txt
+        shell: bash
+      - name: "Build Project"
+        working-directory: ${{ inputs.build_location }}
+        run: |
+          fprime-util generate
+          fprime-util build
+        shell: bash
+      - if: ${{ inputs.run_integration_tests }} != ""
+        working-directory: ${{ inputs.build_location }}
+        run: pytest 
+        shell: bash
+
+  runUT:
+    if: ${{ inputs.run_unit_tests }} == "true"
+    runs-on: ${{ inputs.runs_on }}
+    name: "Run Unit Tests"
+    steps:
+      - name: "Checkout target repository"
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          repository: ${{ inputs.target_repository }}
+      - name: "Overlay current F´ revision"
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          path: ${{ inputs.fprime_location }}
+      - name: "Install requirements.txt"
+        run: |
+          pip3 install -r ${{ inputs.fprime_location }}/requirements.txt
+        shell: bash
+      - name: "Buld and Run Unit Tests"
+        working-directory: ${{ inputs.build_location }}
+        run: |
+          fprime-util generate --ut
+          fprime-util build --ut
+          fprime-util check
+        shell: bash
+


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| GitHub Actions |
|**_Affected Architectures(s)_**| CI |
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2000    🎉 🍾  |

---
## Change Description

Introduces a [Reusable Workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) (`reusable-builder.yml`) that allows to build and run tests on an external F´ project, with the current revision of F´. This allows, for example, to build and run UTs on [fprime-community/fprime-workshop-led-blinker](https://github.com/fprime-community/fprime-workshop-led-blinker) as part of a CI check on PRs within F´ core.

## Rationale

This is going to help in many ways:
- more testing, that's always good
- will prevent our examples/references from breaking
- improved traceability in changes. If a change is made that breaks an example: first of all we will know (not always obvious), and we can strongly recommend (or better, enforce) that the fprime-community project should be updated.

That could even lead to some sorts of "Migration references" - with our references evolving over time to catch up with the F´ changes - we can diff between releases to show what has changed in how you use F´.

## Testing/Review Recommendations

"Let the CI fly!"
   \- LeStarch 

## Future Work

- Introduce workflows for other projects such as HelloWorld, SystemReference when it's ready, and other projects (incoming BaremetalReference? 👀 )
- Pull out `Ref/` and `RPI/` out of nasa/fprime ?