### PR TITLE
Add Comm Adapter design to ToC

### DIFF
--- a/docs/Design/general.md
+++ b/docs/Design/general.md
@@ -4,6 +4,7 @@ This section of the documentation captures the design and philosophy of F´, the
 viewed through F´. 
 
 
-| Table of Contents                              |
-|------------------------------------------------|
-| [Numerical Types Design](./numerical-types.md) |
+| Table of Contents                                                       |
+|-------------------------------------------------------------------------|
+| [Numerical Types Design](./numerical-types.md)                          |
+| [Communication Adapter Interface](./communication-adapter-interface.md) |


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Architecture_**| docs |

---
## Change Description

Adding https://github.com/nasa/fprime/blob/devel/docs/Design/communication-adapter-interface.md to Design page table of contents.
This page is full of information but currently only referenced in some SDDs. Adding it to the table of contents for better reachability.