### PR TITLE
Remove ctor and dtor from IntervalTimer implementation for Baremetal

### DIFF
--- a/Os/Baremetal/IntervalTimer.cpp
+++ b/Os/Baremetal/IntervalTimer.cpp
@@ -2,10 +2,6 @@
 #include <Fw/Types/Assert.hpp>
 
 namespace Os {
-    IntervalTimer::IntervalTimer() {}
-
-    IntervalTimer::~IntervalTimer() {}
-
     void IntervalTimer::getRawTime(RawTime& time) {
         time.lower = 0;
         time.upper = 0;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Constructor and destructor are defined here: https://github.com/nasa/fprime/blob/4f65e1ef3fa3aa44e132e6d9e7b885e840162630/Os/IntervalTimerCommon.cpp#L19-L24. 

This removes the errant implementation of them in the baremetal stub.
