### PR TITLE
Updated startIntTask in LinuxGpioDriver to take a stack size argument

### DIFF
--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
@@ -397,10 +397,10 @@ namespace Drv {
   }
 
   Os::Task::TaskStatus LinuxGpioDriverComponentImpl ::
-  startIntTask(NATIVE_UINT_TYPE priority, NATIVE_UINT_TYPE cpuAffinity) {
+  startIntTask(NATIVE_UINT_TYPE priority, NATIVE_UINT_TYPE stackSize, NATIVE_UINT_TYPE cpuAffinity) {
       Os::TaskString name;
       name.format("GPINT_%s",this->getObjName()); // The task name can only be 16 chars including null
-      Os::Task::TaskStatus stat = this->m_intTask.start(name, LinuxGpioDriverComponentImpl::intTaskEntry, this, priority, Os::Task::TASK_DEFAULT, cpuAffinity);
+      Os::Task::TaskStatus stat = this->m_intTask.start(name, LinuxGpioDriverComponentImpl::intTaskEntry, this, priority, stackSize, cpuAffinity);
 
       if (stat != Os::Task::TASK_OK) {
           DEBUG_PRINT("Task start error: %d\n",stat);

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.hpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.hpp
@@ -45,7 +45,9 @@ namespace Drv {
       ~LinuxGpioDriverComponentImpl();
 
       //! Start interrupt task
-      Os::Task::TaskStatus startIntTask(NATIVE_UINT_TYPE priority = Os::Task::TASK_DEFAULT, NATIVE_UINT_TYPE cpuAffinity = Os::Task::TASK_DEFAULT);
+      Os::Task::TaskStatus startIntTask(NATIVE_UINT_TYPE priority = Os::Task::TASK_DEFAULT,
+                                        NATIVE_UINT_TYPE stackSize = Os::Task::TASK_DEFAULT,
+                                        NATIVE_UINT_TYPE cpuAffinity = Os::Task::TASK_DEFAULT);
 
       //! configure GPIO
       enum GpioDirection {

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImplStub.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImplStub.cpp
@@ -44,7 +44,7 @@ namespace Drv {
   }
 
   Os::Task::TaskStatus LinuxGpioDriverComponentImpl ::
-    startIntTask(NATIVE_UINT_TYPE priority, NATIVE_UINT_TYPE cpuAffinity) {
+    startIntTask(NATIVE_UINT_TYPE priority, NATIVE_UINT_TYPE stackSize, NATIVE_UINT_TYPE cpuAffinity) {
      return Os::Task::TASK_OK;
    }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| @kubiak-jpl |
|**_Affected Component_**| LinuxGpioDriver |
|**_Affected Architectures(s)_**| Linux |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

Updates the startIntTask method call in LinuxGpioDriver to include a stack size argument for the new thread. This matches the behavior of the read thread call in LinuxUartDriver.

**The stack size argument was inserted into the middle of the list of arguments to match LinuxUartDriver. However, existing code that uses both priority and CPU affinity arguments will be broken if directly updated**. In practice I am unsure if this is too big of an issue as cpu affinity arguments will likely be invalid stack sizes.

## Rationale

The application author is responsible for setting the stack size of the task, not the framework

## Testing/Review Recommendations

Currently untested. Building LinuxGpioDriver still builds standalone and building this code in an internal project was successful

