### PR TITLE
Disable some CI checks on docs updates

### DIFF
--- a/.github/workflows/build-led-blinker.yml
+++ b/.github/workflows/build-led-blinker.yml
@@ -7,6 +7,9 @@ on:
     branches: [ master, devel ]
   pull_request:
     branches: [ master, devel ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   run:

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -8,7 +8,10 @@ on:
   push:
     branches: [ master, devel ]
   pull_request:
-    branches: [ master, devel, release/v3.0.0 ] 
+    branches: [ master, devel, release/v3.0.0 ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/build-test-rpi.yml
+++ b/.github/workflows/build-test-rpi.yml
@@ -9,6 +9,9 @@ on:
     branches: [ master, devel ]
   pull_request:
     branches: [ master, devel, release/v3.0.0 ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 env:
   RPI_TOOLCHAIN_DIR: /tmp/rpi-toolchain
   DICTIONARY_PATH: build-artifacts/raspberrypi/RPI/dict/RPITopologyAppDictionary.xml

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,9 @@ on:
     branches: [ master, devel ]
   pull_request:
     branches: [ master, devel, release/v3.0.0 ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/codeql-jpl-standard.yml
+++ b/.github/workflows/codeql-jpl-standard.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master, devel ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master, devel ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   analyze:

--- a/.github/workflows/cppcheck-scan.yml
+++ b/.github/workflows/cppcheck-scan.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master, devel ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 
 jobs:

--- a/.github/workflows/cpplint-scan.yml
+++ b/.github/workflows/cpplint-scan.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master, devel]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   cpplint:

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master, devel]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
 
 jobs:
   format:

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -1,6 +1,15 @@
 name: Format Python
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master, devel]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master, devel]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
 jobs:
   format:
       name: Format


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| CI |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change description

Disable the build/test/static code analysis checks on PRs that only touch `docs/**` and `**.md` files.

## Rationale

We often get PRs on documentation, which trigger the entire CI check suite. I propose we disable some of those checks on these occasions, which are computationally intensive and quite irrelevant. They also slow down the review process for PRs that could be merged in a matter of minutes.

### **A case _against_ this PR:**
Sometimes checks will fail on documentation PRs for reasons that are unrelated (e.g. the RPI agents are unavailable, something broke upstream/fprime-tools etc...).
The case could be made that we should know as soon as possible when this happens, and therefore we should not disable those checks. Which I don't disagree with tbh. This is up for debate, totally fine if we don't want to accept this change.

