### PR TITLE
Adding telemetry and event automatic processing for GenericHub

### DIFF
--- a/Svc/GenericHub/CMakeLists.txt
+++ b/Svc/GenericHub/CMakeLists.txt
@@ -21,4 +21,5 @@ set(UT_MOD_DEPS
     Fw/Com
     STest
 )
+
 register_fprime_ut()

--- a/Svc/GenericHub/GenericHub.fpp
+++ b/Svc/GenericHub/GenericHub.fpp
@@ -4,6 +4,22 @@ module Svc {
   passive component GenericHub {
 
     # ----------------------------------------------------------------------
+    # Mimic Ports
+    # ----------------------------------------------------------------------
+
+    @ Telemetry input port for mimicking an event processor
+    guarded input port TlmRecv: Fw.Tlm
+
+    @ Event input port for mimicking an event processor
+    guarded input port LogRecv: Fw.Log
+
+    @ Cross-hub event output port
+    output port LogSend:  Fw.Log
+
+    @ Cross-hub telemetry output port
+    output port TlmSend: Fw.Tlm
+
+    # ----------------------------------------------------------------------
     # General Ports
     # ----------------------------------------------------------------------
 

--- a/Svc/GenericHub/GenericHub.fpp
+++ b/Svc/GenericHub/GenericHub.fpp
@@ -8,10 +8,10 @@ module Svc {
     # ----------------------------------------------------------------------
 
     @ Telemetry input port for mimicking an event processor
-    guarded input port TlmRecv: Fw.Tlm
+    sync input port TlmRecv: Fw.Tlm
 
     @ Event input port for mimicking an event processor
-    guarded input port LogRecv: Fw.Log
+    sync input port LogRecv: Fw.Log
 
     @ Cross-hub event output port
     output port LogSend:  Fw.Log
@@ -24,13 +24,13 @@ module Svc {
     # ----------------------------------------------------------------------
 
     @ Input array of generic ports to shuttle to the other side of the hub connection
-    guarded input port portIn: [GenericHubInputPorts] serial
+    sync input port portIn: [GenericHubInputPorts] serial
 
     @ Output array of generic ports shuttled from the other side of the hub connection
     output port portOut: [GenericHubOutputPorts] serial
 
     @ Input array of generic ports shuttling in copy-free buffers form external sources
-    guarded input port buffersIn: [GenericHubInputBuffers] Fw.BufferSend
+    sync input port buffersIn: [GenericHubInputBuffers] Fw.BufferSend
 
     @ Output array of generic ports shuttling in copy-free buffers form external sources
     output port buffersOut: [GenericHubOutputBuffers] Fw.BufferSend

--- a/Svc/GenericHub/GenericHubComponentImpl.cpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.cpp
@@ -150,10 +150,10 @@ void GenericHubComponentImpl ::LogRecv_handler(const NATIVE_INT_TYPE portNum,
     U8 buffer[sizeof(FwEventIdType) + Fw::Time::SERIALIZED_SIZE + Fw::LogSeverity::SERIALIZED_SIZE + FW_LOG_BUFFER_MAX_SIZE];
     Fw::ExternalSerializeBuffer serializer(buffer, sizeof(buffer));
     serializer.resetSer();
-    serializer.serialize(id);
-    serializer.serialize(timeTag);
-    serializer.serialize(severity);
-    serializer.serialize(args);
+    FW_ASSERT(serializer.serialize(id) == Fw::SerializeStatus::FW_SERIALIZE_OK);;
+    FW_ASSERT(serializer.serialize(timeTag) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(serializer.serialize(severity) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(serializer.serialize(args) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     U32 size = serializer.getBuffLength();
     this->send_data(HubType::HUB_TYPE_EVENT, portNum, buffer, size);
 
@@ -166,9 +166,9 @@ void GenericHubComponentImpl ::TlmRecv_handler(const NATIVE_INT_TYPE portNum,
     U8 buffer[sizeof(FwChanIdType) + Fw::Time::SERIALIZED_SIZE + FW_TLM_BUFFER_MAX_SIZE];
     Fw::ExternalSerializeBuffer serializer(buffer, sizeof(buffer));
     serializer.resetSer();
-    serializer.serialize(id);
-    serializer.serialize(timeTag);
-    serializer.serialize(val);
+    FW_ASSERT(serializer.serialize(id) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(serializer.serialize(timeTag) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(serializer.serialize(val) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     U32 size = serializer.getBuffLength();
     this->send_data(HubType::HUB_TYPE_CHANNEL, portNum, buffer, size);
 }

--- a/Svc/GenericHub/GenericHubComponentImpl.cpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.cpp
@@ -10,10 +10,10 @@
 //
 // ======================================================================
 
+#include <FpConfig.hpp>
 #include <Svc/GenericHub/GenericHubComponentImpl.hpp>
 #include "Fw/Logger/Logger.hpp"
 #include "Fw/Types/Assert.hpp"
-#include <FpConfig.hpp>
 
 // Required port serialization or the hub cannot work
 static_assert(FW_PORT_SERIALIZATION, "FW_PORT_SERIALIZATION must be enabled to use GenericHub");
@@ -50,7 +50,6 @@ void GenericHubComponentImpl ::send_data(const HubType type,
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
     outgoing.setSize(serialize.getBuffLength());
     dataOut_out(0, outgoing);
-
 }
 
 // ----------------------------------------------------------------------
@@ -62,8 +61,7 @@ void GenericHubComponentImpl ::buffersIn_handler(const NATIVE_INT_TYPE portNum, 
     bufferDeallocate_out(0, fwBuffer);
 }
 
-void GenericHubComponentImpl ::dataIn_handler(const NATIVE_INT_TYPE portNum,
-                                              Fw::Buffer& fwBuffer) {
+void GenericHubComponentImpl ::dataIn_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
     HubType type = HUB_TYPE_MAX;
     U32 type_in = 0;
     U32 port = 0;
@@ -96,11 +94,83 @@ void GenericHubComponentImpl ::dataIn_handler(const NATIVE_INT_TYPE portNum,
         status = wrapper.setBuffLen(rawSize);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
         portOut_out(port, wrapper);
+        // Deallocate the existing buffer
         dataInDeallocate_out(0, fwBuffer);
     } else if (type == HUB_TYPE_BUFFER) {
+        // Fw::Buffers can reuse the existing data buffer as the storage type!  No deallocation done.
         fwBuffer.set(rawData, rawSize, fwBuffer.getContext());
         buffersOut_out(port, fwBuffer);
+    } else if (type == HUB_TYPE_EVENT) {
+        FwEventIdType id;
+        Fw::Time timeTag;
+        Fw::LogSeverity severity;
+        Fw::LogBuffer args;
+
+        // Deserialize tokens for events
+        status = incoming.deserialize(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        status = incoming.deserialize(timeTag);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        status = incoming.deserialize(severity);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        status = incoming.deserialize(args);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+
+        // Send it!
+        this->LogSend_out(port, id, timeTag, severity, args);
+
+        // Deallocate the existing buffer
+        dataInDeallocate_out(0, fwBuffer);
+    } else if (type == HUB_TYPE_CHANNEL) {
+        FwChanIdType id;
+        Fw::Time timeTag;
+        Fw::TlmBuffer val;
+
+        // Deserialize tokens for channels
+        status = incoming.deserialize(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        status = incoming.deserialize(timeTag);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        status = incoming.deserialize(val);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+
+        // Send it!
+        this->TlmSend_out(port, id, timeTag, val);
+
+        // Deallocate the existing buffer
+        dataInDeallocate_out(0, fwBuffer);
     }
+}
+
+void GenericHubComponentImpl ::LogRecv_handler(const NATIVE_INT_TYPE portNum,
+                                  FwEventIdType id,
+                                  Fw::Time& timeTag,
+                                  const Fw::LogSeverity& severity,
+                                  Fw::LogBuffer& args) {
+    U8 buffer[sizeof(FwEventIdType) + Fw::Time::SERIALIZED_SIZE + Fw::LogSeverity::SERIALIZED_SIZE + FW_LOG_BUFFER_MAX_SIZE];
+    Fw::ExternalSerializeBuffer serializer(buffer, sizeof(buffer));
+    serializer.resetSer();
+    serializer.serialize(id);
+    serializer.serialize(timeTag);
+    serializer.serialize(severity);
+    serializer.serialize(args);
+    U32 size = serializer.getBuffLength();
+    this->send_data(HubType::HUB_TYPE_EVENT, portNum, buffer, size);
+
+}
+
+void GenericHubComponentImpl ::TlmRecv_handler(const NATIVE_INT_TYPE portNum,
+                                  FwChanIdType id,
+                                  Fw::Time& timeTag,
+                                  Fw::TlmBuffer& val) {
+    U8 buffer[sizeof(FwChanIdType) + Fw::Time::SERIALIZED_SIZE + FW_TLM_BUFFER_MAX_SIZE];
+    Fw::ExternalSerializeBuffer serializer(buffer, sizeof(buffer));
+    serializer.resetSer();
+    serializer.serialize(id);
+    serializer.serialize(timeTag);
+    serializer.serialize(val);
+    U32 size = serializer.getBuffLength();
+    this->send_data(HubType::HUB_TYPE_CHANNEL, portNum, buffer, size);
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/GenericHub/GenericHubComponentImpl.hpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.hpp
@@ -27,6 +27,8 @@ class GenericHubComponentImpl : public GenericHubComponentBase {
     enum HubType {
         HUB_TYPE_PORT,    //!< Port type transmission
         HUB_TYPE_BUFFER,  //!< Buffer type transmission
+        HUB_TYPE_EVENT,   //!< Event transmission
+        HUB_TYPE_CHANNEL, //!< Telemetry channel type
         HUB_TYPE_MAX
     };
 
@@ -63,6 +65,23 @@ class GenericHubComponentImpl : public GenericHubComponentBase {
     //!
     void dataIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
                         Fw::Buffer& fwBuffer);
+
+    //! Handler implementation for LogRecv
+    //!
+    void LogRecv_handler(const NATIVE_INT_TYPE portNum,   /*!< The port number*/
+                         FwEventIdType id,                /*!< Log ID */
+                         Fw::Time& timeTag,               /*!< Time Tag */
+                         const Fw::LogSeverity& severity, /*!< The severity argument */
+                         Fw::LogBuffer& args              /*!< Buffer containing serialized log entry */
+    );
+
+    //! Handler implementation for TlmRecv
+    //!
+    void TlmRecv_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                         FwChanIdType id,               /*!< Telemetry Channel ID */
+                         Fw::Time& timeTag,             /*!< Time Tag */
+                         Fw::TlmBuffer& val             /*!< Buffer containing serialized telemetry value */
+    );
 
     // ----------------------------------------------------------------------
     // Handler implementations for user-defined serial input ports

--- a/Svc/GenericHub/docs/sdd.md
+++ b/Svc/GenericHub/docs/sdd.md
@@ -23,6 +23,9 @@ It is also essential that users never pass a **pointer** into the generic hub, a
 leaves the current address space. A sample configuration is shown below. Finally, the generic hub is bidirectional, so it
 can operate on inputs and produce outputs as long as its remote counterpart is hooked up in parallel.
 
+The hub also provides specific handlers for events and telemetry such that it can be used with telemetry and event
+pattern specifiers in the topology.
+
 ### Example Formations
 
 This section shows how to set up the generic hub component. It is broken into several separate views. This first shows
@@ -65,11 +68,21 @@ GenericHubOutputBuffers = 10
 
 The above configuration may be used with both deployments hubs as the input/output pairs match.
 
+To use the hub in a pattern specifier, include this in your topology:
+
+```
+    event connections instance hub
+    telemetry connections instance hub
+```
+
 ## Idiosyncrasies 
 
 Currently, the `Drv::ByteStreamDriverModel` can report errors and failures. This generic hub component drops these errors.
 Users who expect the driver to error should adapt this component to handle this issue. Future versions of this component
 may correct this issue by calling to a fault port on error.
+
+Connections are still required from the telemetry and event output ports to the system-wide event log and telemetry
+handling components as the hub is not designed to look like a telemetry nor event source.
 
 ## Requirements
 
@@ -86,3 +99,4 @@ may correct this issue by calling to a fault port on error.
 |---|---|
 | 2020-12-21 | Initial Draft |
 | 2021-01-29 | Updated |
+| 2023-06-09 | Added telemetry and event helpers |

--- a/Svc/GenericHub/test/ut/TestMain.cpp
+++ b/Svc/GenericHub/test/ut/TestMain.cpp
@@ -20,6 +20,16 @@ TEST(Nominal, TestRandomIo) {
     tester.test_random_io();
 }
 
+TEST(Nominal, TestEvents) {
+    Svc::Tester tester;
+    tester.test_events();
+}
+
+TEST(Nominal, TestTelemetry) {
+    Svc::Tester tester;
+    tester.test_telemetry();
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/GenericHub/test/ut/Tester.hpp
+++ b/Svc/GenericHub/test/ut/Tester.hpp
@@ -52,10 +52,38 @@ class Tester : public GenericHubGTestBase {
     //!
     void test_random_io();
 
+    //! Test of telemetry in-out
+    //!
+    void test_telemetry();
+
+    //! Test of event in-out
+    //!
+    void test_events();
+
+
+
   private:
     // ----------------------------------------------------------------------
     // Handlers for typed from ports
     // ----------------------------------------------------------------------
+
+    //! Handler for from_LogSend
+    //!
+    void from_LogSend_handler(const NATIVE_INT_TYPE portNum,   /*!< The port number*/
+                              FwEventIdType id,                /*!< Log ID */
+                              Fw::Time& timeTag,               /*!< Time Tag  */
+                              const Fw::LogSeverity& severity, /*!< The severity argument */
+                              Fw::LogBuffer& args              /*!< Buffer containing serialized log entry */
+    );
+
+    //! Handler for from_TlmSend
+    //!
+    void from_TlmSend_handler(
+          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          FwChanIdType id, /*!< Telemetry Channel ID */
+          Fw::Time &timeTag, /*!< Time Tag */
+          Fw::TlmBuffer &val /*!< Buffer containing serialized telemetry value */
+    );
 
     //! Handler for from_buffersOut
     //!
@@ -97,6 +125,8 @@ class Tester : public GenericHubGTestBase {
     void send_random_comm(U32 port);
 
     void send_random_buffer(U32 port);
+
+    void random_fill(Fw::SerializeBufferBase& buffer, U32 max_size);
 
     // ----------------------------------------------------------------------
     // Helper methods


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

GenericHub's difficult in deployment comes from primarily from the specific wrangling of standard types across the hub.  This PR adds in dedicated telemetry and event processing  such that the hub can be used with FPP pattern specifiers when connecting components to it. 


