### PR TITLE
Add SPI Mode Enum to LinuxSpiDriver

### DIFF
--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -100,6 +100,10 @@ namespace Drv {
         /*
          * SPI Mode 0, 1, 2, 3
          */
+
+        //Assert that the device SPI Mode is in the correct range
+        FW_ASSERT(spiMode >= SpiMode::SPI_MODE_0 || spiMode <= SpiMode::SPI_MODE_3);
+
         U8 mode = spiMode; // Mode Select (CPOL = 0/1, CPHA = 0/1)
         ret = ioctl(fd, SPI_IOC_WR_MODE, &mode);
         if (ret == -1) {

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -115,7 +115,7 @@ namespace Drv {
                 mode = SPI_MODE_3;
             default:
                 //Assert if the device SPI Mode is not in the correct range
-                FW_ASSERT(spiMode >= SpiMode::SPI_MODE_0 || spiMode <= SpiMode::SPI_MODE_3);                
+                FW_ASSERT(0, spiMode);                
                 break;
         }
 

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -70,7 +70,8 @@ namespace Drv {
 
     bool LinuxSpiDriverComponentImpl::open(NATIVE_INT_TYPE device,
                                            NATIVE_INT_TYPE select,
-                                           SpiFrequency clock) {
+                                           SpiFrequency clock,
+                                           SpiMode spiMode) {
 
         this->m_device = device;
         this->m_select = select;
@@ -97,9 +98,9 @@ namespace Drv {
 
         // Configure:
         /*
-         * SPI Mode 0
+         * SPI Mode 0, 1, 2, 3
          */
-        U8 mode = SPI_MODE_0; // Mode 0 (CPOL = 0, CPHA = 0)
+        U8 mode = spiMode; // Mode Select (CPOL = 0/1, CPHA = 0/1)
         ret = ioctl(fd, SPI_IOC_WR_MODE, &mode);
         if (ret == -1) {
             DEBUG_PRINT("ioctl SPI_IOC_WR_MODE fd %d failed. %d\n",fd,errno);

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -101,10 +101,24 @@ namespace Drv {
          * SPI Mode 0, 1, 2, 3
          */
 
-        //Assert that the device SPI Mode is in the correct range
-        FW_ASSERT(spiMode >= SpiMode::SPI_MODE_0 || spiMode <= SpiMode::SPI_MODE_3);
+        U8 mode; // Mode Select (CPOL = 0/1, CPHA = 0/1)
+        switch(spiMode) {
+            case SpiMode::SPI_MODE_0:
+                mode = SPI_MODE_0;
+                break;
+            case SpiMode::SPI_MODE_1:
+                mode = SPI_MODE_1;
+                break;
+            case SpiMode::SPI_MODE_2:
+                mode = SPI_MODE_2;
+            case SpiMode::SPI_MODE_3:
+                mode = SPI_MODE_3;
+            default:
+                //Assert if the device SPI Mode is not in the correct range
+                FW_ASSERT(spiMode >= SpiMode::SPI_MODE_0 || spiMode <= SpiMode::SPI_MODE_3);                
+                break;
+        }
 
-        U8 mode = spiMode; // Mode Select (CPOL = 0/1, CPHA = 0/1)
         ret = ioctl(fd, SPI_IOC_WR_MODE, &mode);
         if (ret == -1) {
             DEBUG_PRINT("ioctl SPI_IOC_WR_MODE fd %d failed. %d\n",fd,errno);

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -103,16 +103,18 @@ namespace Drv {
 
         U8 mode; // Mode Select (CPOL = 0/1, CPHA = 0/1)
         switch(spiMode) {
-            case SpiMode::SPI_MODE_0:
+            case SpiMode::SPI_MODE_CPOL_LOW_CPHA_LOW:
                 mode = SPI_MODE_0;
                 break;
-            case SpiMode::SPI_MODE_1:
+            case SpiMode::SPI_MODE_CPOL_LOW_CPHA_HIGH:
                 mode = SPI_MODE_1;
                 break;
-            case SpiMode::SPI_MODE_2:
+            case SpiMode::SPI_MODE_CPOL_HIGH_CPHA_LOW:
                 mode = SPI_MODE_2;
-            case SpiMode::SPI_MODE_3:
+                break;
+            case SpiMode::SPI_MODE_CPOL_HIGH_CPHA_HIGH:
                 mode = SPI_MODE_3;
+                break;
             default:
                 //Assert if the device SPI Mode is not in the correct range
                 FW_ASSERT(0, spiMode);                

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
@@ -36,19 +36,25 @@ namespace Drv {
     /**
      * SPI Mode Select
      *
-     * Defines the Clock Polarity and Phase for each SPI Transaction.
-     * Mode 0: (CPOL = 0, CPHA = 0) 
-     * Mode 1: (CPOL = 0, CPHA = 1)
-     * Mode 2: (CPOL = 1, CPHA = 0)
-     * Mode 3: (CPOL = 1, CPHA = 1) 
+     * Defines the SPI Clock Polarity and Phase for each SPI Transaction.
+     * 
+     * SPI Clock Polarity(CPOL): Defines clock polarity as idle low (CPOL = 0) or idle high(CPOL = 1)
+     * SPI Clock Phase(CPHA): Defines if data is shifted out on the rising clock edge and sampled 
+     *                        on the falling clock edge(CPHA = 0) or if data is shifted out on the 
+     *                        falling clock edge and sampled on the rising clock edge(CPHA=1)
+     * 
+     * SPI Mode 0: (CPOL = 0, CPHA = 0) 
+     * SPI Mode 1: (CPOL = 0, CPHA = 1)
+     * SPI Mode 2: (CPOL = 1, CPHA = 0)
+     * SPI Mode 3: (CPOL = 1, CPHA = 1) 
      * 
      */
     enum SpiMode
     {
-        SPI_MODE_0 = 0,
-        SPI_MODE_1 = 1,
-        SPI_MODE_2 = 2,
-        SPI_MODE_3 = 3,
+        SPI_MODE_CPOL_LOW_CPHA_LOW,
+        SPI_MODE_CPOL_LOW_CPHA_HIGH,
+        SPI_MODE_CPOL_HIGH_CPHA_LOW,
+        SPI_MODE_CPOL_HIGH_CPHA_HIGH,
     };
 
     class LinuxSpiDriverComponentImpl: public LinuxSpiDriverComponentBase {
@@ -78,7 +84,7 @@ namespace Drv {
             bool open(NATIVE_INT_TYPE device,
                       NATIVE_INT_TYPE select,
                       SpiFrequency clock,
-                      SpiMode spiMode = SpiMode::SPI_MODE_0);
+                      SpiMode spiMode = SpiMode::SPI_MODE_CPOL_LOW_CPHA_LOW);
 
         PRIVATE:
 

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
@@ -78,7 +78,7 @@ namespace Drv {
             bool open(NATIVE_INT_TYPE device,
                       NATIVE_INT_TYPE select,
                       SpiFrequency clock,
-                      SpiMode spiMode);
+                      SpiMode spiMode = SpiMode::SPI_MODE_0);
 
         PRIVATE:
 

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
@@ -43,18 +43,13 @@ namespace Drv {
      *                        on the falling clock edge(CPHA = 0) or if data is shifted out on the 
      *                        falling clock edge and sampled on the rising clock edge(CPHA=1)
      * 
-     * SPI Mode 0: (CPOL = 0, CPHA = 0) 
-     * SPI Mode 1: (CPOL = 0, CPHA = 1)
-     * SPI Mode 2: (CPOL = 1, CPHA = 0)
-     * SPI Mode 3: (CPOL = 1, CPHA = 1) 
-     * 
      */
     enum SpiMode
     {
-        SPI_MODE_CPOL_LOW_CPHA_LOW,
-        SPI_MODE_CPOL_LOW_CPHA_HIGH,
-        SPI_MODE_CPOL_HIGH_CPHA_LOW,
-        SPI_MODE_CPOL_HIGH_CPHA_HIGH,
+        SPI_MODE_CPOL_LOW_CPHA_LOW, ///< (CPOL = 0, CPHA = 0) 
+        SPI_MODE_CPOL_LOW_CPHA_HIGH,///< (CPOL = 0, CPHA = 1)
+        SPI_MODE_CPOL_HIGH_CPHA_LOW,///< (CPOL = 1, CPHA = 0)
+        SPI_MODE_CPOL_HIGH_CPHA_HIGH,///< (CPOL = 1, CPHA = 1)
     };
 
     class LinuxSpiDriverComponentImpl: public LinuxSpiDriverComponentBase {

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
@@ -33,6 +33,24 @@ namespace Drv {
        SPI_FREQUENCY_20MHZ = 20000000UL,
     };
 
+    /**
+     * SPI Mode Select
+     *
+     * Defines the Clock Polarity and Phase for each SPI Transaction.
+     * Mode 0: (CPOL = 0, CPHA = 0) 
+     * Mode 1: (CPOL = 0, CPHA = 1)
+     * Mode 2: (CPOL = 1, CPHA = 0)
+     * Mode 3: (CPOL = 1, CPHA = 1) 
+     * 
+     */
+    enum SpiMode
+    {
+        SPI_MODE_0 = 0,
+        SPI_MODE_1 = 1,
+        SPI_MODE_2 = 2,
+        SPI_MODE_3 = 3,
+    };
+
     class LinuxSpiDriverComponentImpl: public LinuxSpiDriverComponentBase {
 
         public:
@@ -59,7 +77,8 @@ namespace Drv {
             //! Open device
             bool open(NATIVE_INT_TYPE device,
                       NATIVE_INT_TYPE select,
-                      SpiFrequency clock);
+                      SpiFrequency clock,
+                      SpiMode spiMode);
 
         PRIVATE:
 

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImplStub.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImplStub.cpp
@@ -17,7 +17,8 @@ namespace Drv {
 
     bool LinuxSpiDriverComponentImpl::open(NATIVE_INT_TYPE device,
                                            NATIVE_INT_TYPE select,
-                                           SpiFrequency clock) {
+                                           SpiFrequency clock,
+                                           SpiMode spiMode) {
         //TODO: fill this function out
         return false;
     }


### PR DESCRIPTION
SPI Modes specify the clock polarity for each transaction. The default Fprime LinuxSpiDriver assumed SPI Mode 0. This should be generalized to account for SPI devices with different clock polarity and phases.

| | |
|:---|:---|
|**_Originating Project/Creator_**|SRH/Mohit Singh |
|**_Affected Component_**| Drv::LinuxSpiDriver |
|**_Affected Architectures(s)_**| SRH MPPT Tester |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**| y |

---
## Change Description
Add a SPI Mode Enumeration to the LinuxSpiDriver Component Implementation, and include the SpiMode as a formal parameter in the `LinuxSpiDriverComponentImpl::open()` function . 

## Rationale
This allows for SPI devices with a different clock phase and polarity to be properly integrated with F-Prime, without having to modify the component implementation. Previously, the SPI Mode for any SPI device was assumed to be SPI mode 0. This implies a clock phase=0 and a clock polarity=0, which is not always true. 

## Testing/Review Recommendations
The implementation has been tested with SPI Mode 0 and SPI Mode 1 devices and works correctly. 

## Future Work
In addition to SPI Modes, the Linux SPI implementations include several additional parameters, such as `SPI_CS_HIGH`, `SPI_LSB_FIRST`, and the bits per word for each SPI Transaction. These parameters generally do not change for most SPI devices, but it might make sense to give the user ability to configure these parameters when opening a SPI device in FPrime. 
