### PR TITLE
Referencing FPP docs in User Guide

### DIFF
--- a/docs/UsersGuide/guide.md
+++ b/docs/UsersGuide/guide.md
@@ -66,14 +66,15 @@ This section is divided into three sub-sections:
     - [Sequencing in F´](./gds/seqgen.md)
 - Full Development Guides: technical details for full F´ implementations
     - [Configuring F´](./dev/configuring-fprime.md)
-    - [v3 Migration Guide](./user/v3-migration-guide.md)
+    - [F´ Modeling with FPP](./user/fpp-user-guide.md)
     - [A Tour of the Source Tree](./dev/source-tree.md)
-    - [F´ XML Specifications](./dev/xml-specification.md):
+    - [F´ XML Specifications](./dev/xml-specification.md)
     - [F´ Implementation Classes](./dev/implementation.md)
     - [Constructing the F´ Topology](./dev/building-topology.md)
     - [Asserts in F´](./dev/assert.md)
     - [GDS Dashboard Reference](./dev/gds-dashboard-reference.md)
     - [Integration Test API](./dev/testAPI/user_guide.md)
+    - [v3 Migration Guide](./user/v3-migration-guide.md)
 - Advanced F´ Topics:
     - [F´ Python Guidelines](./dev/py-dev.md)
     - [Porting F´ To a New Platform](./dev/porting-guide.md)

--- a/docs/UsersGuide/user/fpp-user-guide.md
+++ b/docs/UsersGuide/user/fpp-user-guide.md
@@ -1,0 +1,9 @@
+# F´ Modeling: FPP User Guide
+
+F´ v3 introduced a new way of modeling with F´, the FPP (F Prime Prime) modeling language. The [MathComponent Tutorial](https://fprime-community.github.io/fprime-tutorial-math-component/) is a good introduction to FPP.
+
+To go into more detail, the full FPP documentation can be found here: [FPP Wiki](https://github.com/fprime-community/fpp/wiki).
+
+**Quick links:**
+- [FPP User Guide](https://fprime-community.github.io/fpp/fpp-users-guide.html)
+- [FPP Language Specification](https://fprime-community.github.io/fpp/fpp-spec.html)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Addresses https://github.com/nasa/fprime/issues/2050

## Rationale

FPP has great documentation that was not easy to find browsing through the F´ docs. This PR adds it as a "first class citizen" in the `Full Development Guides` section of the User Guide.
Also moving `Migrating to v3` down the list as it's not something new users should need to worry about.
