### PR TITLE
Fix bug in Fw::Buffer

### DIFF
--- a/Fw/Buffer/Buffer.cpp
+++ b/Fw/Buffer/Buffer.cpp
@@ -28,11 +28,15 @@ Buffer::Buffer(): Serializable(),
 {}
 
 Buffer::Buffer(const Buffer& src) : Serializable(),
-    m_serialize_repr(src.m_bufferData, src.m_size),
+    m_serialize_repr(),
     m_bufferData(src.m_bufferData),
     m_size(src.m_size),
     m_context(src.m_context)
-{}
+{
+    if(src.m_bufferData != nullptr){
+        this->m_serialize_repr.setExtBuffer(src.m_bufferData, src.m_size);
+    }
+}
 
 Buffer::Buffer(U8* data, U32 size, U32 context) : Serializable(),
     m_serialize_repr(),

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -707,7 +707,7 @@ namespace Fw {
     }
 
     void ExternalSerializeBuffer::setExtBuffer(U8* buffPtr, NATIVE_UINT_TYPE size) {
-        FW_ASSERT(buffPtr);
+        FW_ASSERT(buffPtr != nullptr);
         this->m_buff = buffPtr;
         this->m_buffSize = size;
     }


### PR DESCRIPTION
The copy constructor for `Fw::Buffer` was causing an assertion failure when copying an invalid buffer. I noticed this because I was writing unit tests that passed invalid buffers around, and I saw the assertion failure.

This patch fixes the issue.

Note: For correctness, I had to replace `FW_ASSERT(p)` with `FW_ASSERT(p != nullptr)` in one place. Otherwise we are assuming that `nullptr == 0` which is not guaranteed to be true. We should make this change consistently throughout the framework, but I made the minimal change for now.