### PR TITLE
Fix `release/documentation` conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then, create a new project with:
 fprime-util new --project
 ```
 
-See the [HelloWorld Tutorial](https://github.com/fprime-community/fprime-tutorial-hello-world.git) to guide you through all the steps of developing an F´ project.
+See the [HelloWorld Tutorial](https://fprime-community.github.io/fprime-tutorial-hello-world/) to guide you through all the steps of developing an F´ project.
 
 New users are encouraged to read through the [User Guide](https://nasa.github.io/fprime/UsersGuide/guide.html) and explore the [other tutorials](https://nasa.github.io/fprime/Tutorials/README.html).
 

--- a/docs/Tutorials/README.md
+++ b/docs/Tutorials/README.md
@@ -9,18 +9,18 @@ users to learn F´ and walk through the most basic steps in developing an F´ ap
 ## Tutorials Index
 
 1. [HelloWorld](https://fprime-community.github.io/fprime-tutorial-hello-world/): An Introduction to F´
-2. [LedBlinker](https://github.com/fprime-community/fprime-workshop-led-blinker/blob/main/README.md): F´ and Embedded Hardware 
-3. [MathComponent](MathComponent/Tutorial.md)
+2. [LedBlinker](https://fprime-community.github.io/fprime-workshop-led-blinker/): F´ and Embedded Hardware 
+3. [MathComponent](https://fprime-community.github.io/fprime-tutorial-math-component/): Custom Ports and Types
 4. [Cross-Compilation Tutorial](CrossCompilation/Tutorial.md)
+
 
 ## [HelloWorld](https://fprime-community.github.io/fprime-tutorial-hello-world/): An Introduction to F´
 
-The HelloWorld tutorial walks a new users through creating a new project, designing their first F´ component, and testing that
+The HelloWorld tutorial walks new users through creating a new project, designing their first F´ component, and testing that
 component through an F´ deployment. 
 
 
-
-## [LedBlinker](https://github.com/fprime-community/fprime-workshop-led-blinker/blob/main/README.md): F´ and Embedded Hardware 
+## [LedBlinker](https://fprime-community.github.io/fprime-workshop-led-blinker/): F´ and Embedded Hardware 
 
 LedBlinker walks users through developing an F´ project intended for running on embedded hardware. It covers manager components, hardware drivers, and cross-compilation with the goal of blinking an LED on ARM hardware. Events, Telemetry, Commands, and Parameters are covered as well.
 
@@ -35,6 +35,7 @@ LedBlinker walks users through developing an F´ project intended for running on
 7. [Unit-Testing](https://github.com/fprime-community/fprime-workshop-led-blinker/blob/main/docs/unit-testing.md)
 8. [System Testing](https://github.com/fprime-community/fprime-workshop-led-blinker/blob/main/docs/system-testing.md)
 
-## [MathComponent](MathComponent/Tutorial.md): Custom Ports and Types
 
-MathComponent tutorial walks users through constructing a full F´ application including custom Ports, and Enumeration data types. Events, Telemetry, Commands, and Parameters are covered as well. Unit-Testing is also covered.
+## [MathComponent](https://fprime-community.github.io/fprime-tutorial-math-component/): Custom Ports and Types
+
+The MathComponent tutorial walks users through constructing a full F´ application including custom Ports, and Enumeration data types. Events, Telemetry, Commands, and Parameters are covered as well. Unit-Testing is also covered.

--- a/docs/Tutorials/README.md
+++ b/docs/Tutorials/README.md
@@ -8,15 +8,16 @@ users to learn F´ and walk through the most basic steps in developing an F´ ap
 
 ## Tutorials Index
 
-1. [HelloWorld](https://github.com/fprime-community/fprime-tutorial-hello-world.git): An Introduction to F´
+1. [HelloWorld](https://fprime-community.github.io/fprime-tutorial-hello-world/): An Introduction to F´
 2. [LedBlinker](https://github.com/fprime-community/fprime-workshop-led-blinker/blob/main/README.md): F´ and Embedded Hardware 
 3. [MathComponent](MathComponent/Tutorial.md)
 4. [Cross-Compilation Tutorial](CrossCompilation/Tutorial.md)
 
-## [HelloWorld](https://github.com/fprime-community/fprime-tutorial-hello-world.git): An Introduction to F´
+## [HelloWorld](https://fprime-community.github.io/fprime-tutorial-hello-world/): An Introduction to F´
 
-The HelloWorld tutorial walks a new user through creating a new project, their first F´ component, and testing that
-component through an F´ deployment. This tutorial has the following subsections:
+The HelloWorld tutorial walks a new users through creating a new project, designing their first F´ component, and testing that
+component through an F´ deployment. 
+
 
 
 ## [LedBlinker](https://github.com/fprime-community/fprime-workshop-led-blinker/blob/main/README.md): F´ and Embedded Hardware 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Cherry-picked the commits that were causing issues, and applied them on top of `release/documentation`.

## Rationale

A commit was introduced into `release/documentation` that broke the Autodocs CI, as merge conflicts were happening when [merging devel into release/documentation](https://github.com/nasa/fprime/blob/6e799d83dc73175584495144d2231d1f6a3dff82/.github/actions/autodoc.bash#L13-L14). This solves the merge conflict when merging locally - so I'm hoping this should work?

## Future Work

Revisit the whole autodocs pipeline
