### PR TITLE
Baremetal Task priority sorting

### DIFF
--- a/Os/Baremetal/TaskRunner/TaskRunner.cpp
+++ b/Os/Baremetal/TaskRunner/TaskRunner.cpp
@@ -23,7 +23,21 @@ TaskRunner::~TaskRunner() {}
 
 void TaskRunner::addTask(Task* task) {
     FW_ASSERT(m_index < TASK_REGISTRY_CAP);
-    this->m_task_table[m_index] = task;
+
+    BareTaskHandle* new_handle = reinterpret_cast<BareTaskHandle*>(task->getRawHandle());
+    
+    NATIVE_INT_TYPE index;
+    for(index = m_index; index > 0; index--)
+    {
+        BareTaskHandle* curr_handle = reinterpret_cast<BareTaskHandle*>(this->m_task_table[index - 1]->getRawHandle());
+        if(curr_handle->m_priority > new_handle->m_priority)
+        {
+            break;
+        }
+        this->m_task_table[index] = this->m_task_table[index - 1];
+    }
+
+    this->m_task_table[index] = task;
     m_index++;
 }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Baremetal TaskRunner |
|**_Affected Architectures(s)_**| Baremetal |
|**_Related Issue(s)_**| #2108  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Add priority scheduling to baremetal task runner. Task table is now sorted in priority order (greatest -> lowest).

## Rationale

There was no priority scheduling for baremetal.

## Future Work

Round-robin scheduling for tasks with same priority value.
