### PR TITLE
Include member array size in dictionary

### DIFF
--- a/Autocoders/Python/src/fprime_ac/utils/TopDictGenerator.py
+++ b/Autocoders/Python/src/fprime_ac/utils/TopDictGenerator.py
@@ -68,6 +68,8 @@ class TopDictGenerator:
                         member_elem.attrib["description"] = member_comment
                     if member_default is not None:
                         member_elem.attrib["default"] = member_default
+                    if member_array_size is not None:
+                        member_elem.attrib["size"] = member_array_size
                     if isinstance(member_type, tuple):
                         type_name = "{}::{}::{}".format(
                             serializable_type,


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds the member array size in dictionary serializable member

## Rationale

When you have a struct with an array member:

```
struct Test {
   a_member: F32,
   another_member: [4] F32
}
```

The `another_member` is encoded the same as `a_member` since the array size is ignored.

This adds a `size` attribute when relevant.

## Future Work

- Does a schema need to be changed somewhere?
- Should we do this with a pseudo array in the dictionary?