### PR TITLE
FPP v2.0 integration

### DIFF
--- a/FppTest/component/active/test/ut/Tester.hpp
+++ b/FppTest/component/active/test/ut/Tester.hpp
@@ -197,8 +197,6 @@ class Tester : public ActiveTestGTestBase {
                                                       */
     );
 
-    void cmdResponseIn(const FwOpcodeType opCode, const U32 cmdSeq, const Fw::CmdResponse response);
-
   PRIVATE:
     // ----------------------------------------------------------------------
     // Handlers for serial from ports
@@ -277,9 +275,6 @@ class Tester : public ActiveTestGTestBase {
     Fw::SerialBuffer arrayBuf;
     Fw::SerialBuffer structBuf;
     Fw::SerialBuffer serialBuf;
-
-    // Command test values
-    Fw::CmdResponse cmdResp;
 
     // Parameter test values
     FppTest::Types::BoolParam boolPrm;

--- a/FppTest/component/include/typed_ports.fppi
+++ b/FppTest/component/include/typed_ports.fppi
@@ -90,8 +90,6 @@ output port structReturnOut: StructReturn
 # Ports for testing special ports
 # ----------------------------------------------------------------------
 
-sync input port cmdOut: Fw.Cmd
-
 output port prmGetIn: Fw.PrmGet
 
 output port prmSetIn: Fw.PrmSet

--- a/FppTest/component/passive/test/ut/Tester.hpp
+++ b/FppTest/component/passive/test/ut/Tester.hpp
@@ -193,8 +193,6 @@ class Tester : public PassiveTestGTestBase {
                                                       */
     );
 
-    void cmdResponseIn(const FwOpcodeType opCode, const U32 cmdSeq, const Fw::CmdResponse response);
-
   PRIVATE:
     // ----------------------------------------------------------------------
     // Handlers for serial from ports
@@ -267,9 +265,6 @@ class Tester : public PassiveTestGTestBase {
     Fw::SerialBuffer arrayBuf;
     Fw::SerialBuffer structBuf;
     Fw::SerialBuffer serialBuf;
-
-    // Command test values
-    Fw::CmdResponse cmdResp;
 
     // Parameter test values
     FppTest::Types::BoolParam boolPrm;

--- a/FppTest/component/queued/test/ut/Tester.hpp
+++ b/FppTest/component/queued/test/ut/Tester.hpp
@@ -197,8 +197,6 @@ class Tester : public QueuedTestGTestBase {
                                                       */
     );
 
-    void cmdResponseIn(const FwOpcodeType opCode, const U32 cmdSeq, const Fw::CmdResponse response);
-
   PRIVATE:
     // ----------------------------------------------------------------------
     // Handlers for serial from ports
@@ -277,9 +275,6 @@ class Tester : public QueuedTestGTestBase {
     Fw::SerialBuffer arrayBuf;
     Fw::SerialBuffer structBuf;
     Fw::SerialBuffer serialBuf;
-
-    // Command test values
-    Fw::CmdResponse cmdResp;
 
     // Parameter test values
     FppTest::Types::BoolParam boolPrm;

--- a/FppTest/component/tests/AsyncCmdTests.cpp
+++ b/FppTest/component/tests/AsyncCmdTests.cpp
@@ -15,4 +15,4 @@
 #include "Fw/Cmd/CmdArgBuffer.hpp"
 
 CMD_TEST_INVOKE_DEFS_ASYNC
-CMD_TEST_DEFS(Async)
+CMD_TEST_DEFS(Async, _ASYNC)

--- a/FppTest/component/tests/CmdTests.cpp
+++ b/FppTest/component/tests/CmdTests.cpp
@@ -15,4 +15,4 @@
 #include "Fw/Cmd/CmdArgBuffer.hpp"
 
 CMD_TEST_INVOKE_DEFS
-CMD_TEST_DEFS()
+CMD_TEST_DEFS(,)

--- a/FppTest/component/tests/CmdTests.cpp
+++ b/FppTest/component/tests/CmdTests.cpp
@@ -15,4 +15,4 @@
 #include "Fw/Cmd/CmdArgBuffer.hpp"
 
 CMD_TEST_INVOKE_DEFS
-CMD_TEST_DEFS(,)
+CMD_TEST_DEFS(, )

--- a/FppTest/component/tests/CmdTests.hpp
+++ b/FppTest/component/tests/CmdTests.hpp
@@ -182,12 +182,14 @@
                                                                                                          \
         /* Test success */                                                                               \
         this->invoke##ASYNC##Command(data); \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
+        ASSERT_CMD_RESPONSE_SIZE(1); \
+        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_NO_ARGS, 1, Fw::CmdResponse::OK); \
                                                                                                          \
         /* Test too many arguments */                                                                    \
         buf.serialize(0);                                                                                \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_NO_ARGS, buf);                                                \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(2); \
+        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_NO_ARGS, 1, Fw::CmdResponse::FORMAT_ERROR); \
     }                                                                                                    \
                                                                                                          \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& data) { \
@@ -200,38 +202,45 @@
                                                                                                          \
         /* Test incorrect deserialization of first argument */                                           \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(1); \
+        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                          \
         /* Test incorrect deserialization of second argument */                                          \
         buf.serialize(data.args.val1);                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(2); \
+        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                          \
         /* Test incorrect deserialization of third argument */                                           \
         buf.serialize(data.args.val2);                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(3); \
+        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                          \
         /* Test incorrect deserialization of fourth argument */                                          \
         buf.serialize(data.args.val3);                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(4); \
+        ASSERT_CMD_RESPONSE(3, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                          \
         /* Test incorrect deserialization of fifth argument */                                           \
         buf.serialize(data.args.val4);                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(5); \
+        ASSERT_CMD_RESPONSE(4, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                          \
         /* Test incorrect deserialization of sixth argument */                                           \
         buf.serialize(data.args.val5);                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(6); \
+        ASSERT_CMD_RESPONSE(5, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val6);                                                                   \
         this->invoke##ASYNC##Command(data); \
                                                                                                          \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
+        ASSERT_CMD_RESPONSE_SIZE(7); \
+        ASSERT_CMD_RESPONSE(6, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::OK); \
         ASSERT_EQ(component.primitiveCmd.args.val1, data.args.val1);                                     \
         ASSERT_EQ(component.primitiveCmd.args.val2, data.args.val2);                                     \
         ASSERT_EQ(component.primitiveCmd.args.val3, data.args.val3);                                     \
@@ -242,7 +251,8 @@
         /* Test too many arguments */                                                                    \
         buf.serialize(data.args.val5);                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(8); \
+        ASSERT_CMD_RESPONSE(7, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
     }                                                                                                    \
                                                                                                          \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::CmdStringParams& data) { \
@@ -255,25 +265,29 @@
                                                                                                          \
         /* Test incorrect serialization of first argument */                                             \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                                                \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(1); \
+        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                          \
         /* Test incorrect serialization of second argument */                                            \
         buf.serialize(data.args.val1);                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                                                \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(2); \
+        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val2);                                                                   \
         this->invoke##ASYNC##Command(data); \
                                                                                                          \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
+        ASSERT_CMD_RESPONSE_SIZE(3); \
+        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::OK); \
         ASSERT_EQ(component.stringCmd.args.val1, data.args.val1);                                        \
         ASSERT_EQ(component.stringCmd.args.val2, data.args.val2);                                        \
                                                                                                          \
         /* Test too many arguments */                                                                    \
         buf.serialize(data.args.val1);                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                                                \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(4); \
+        ASSERT_CMD_RESPONSE(3, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR); \
     }                                                                                                    \
                                                                                                          \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParam& data) {       \
@@ -286,19 +300,22 @@
                                                                                                          \
         /* Test incorrect serialization of first argument */                                             \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                                                  \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(1); \
+        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val);                                                                    \
         this->invoke##ASYNC##Command(data); \
                                                                                                          \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
+        ASSERT_CMD_RESPONSE_SIZE(2); \
+        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::OK); \
         ASSERT_EQ(component.enumCmd.args.val, data.args.val);                                            \
                                                                                                          \
         /* Test too many arguments */                                                                    \
         buf.serialize(data.args.val);                                                                    \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                                                  \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(3); \
+        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::FORMAT_ERROR); \
     }                                                                                                    \
                                                                                                          \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& data) {      \
@@ -311,19 +328,22 @@
                                                                                                          \
         /* Test incorrect serialization of first argument */                                             \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                                                 \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(1); \
+        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val);                                                                    \
         this->invoke##ASYNC##Command(data); \
                                                                                                          \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
+        ASSERT_CMD_RESPONSE_SIZE(2); \
+        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::OK); \
         ASSERT_EQ(component.arrayCmd.args.val, data.args.val);                                           \
                                                                                                          \
         /* Test too many arguments */                                                                    \
         buf.serialize(data.args.val);                                                                    \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                                                 \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(3); \
+        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::FORMAT_ERROR); \
     }                                                                                                    \
                                                                                                          \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::StructParam& data) {     \
@@ -336,17 +356,20 @@
                                                                                                          \
         /* Test incorrect serialization of first argument */                                             \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                                                \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(1); \
+        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val);                                                                    \
         this->invoke##ASYNC##Command(data); \
                                                                                                          \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
+        ASSERT_CMD_RESPONSE_SIZE(2); \
+        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::OK); \
         ASSERT_EQ(component.structCmd.args.val, data.args.val);                                          \
                                                                                                          \
         /* Test too many arguments */                                                                    \
         buf.serialize(data.args.val);                                                                    \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                                                \
-        ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
+        ASSERT_CMD_RESPONSE_SIZE(3); \
+        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::FORMAT_ERROR); \
     }

--- a/FppTest/component/tests/CmdTests.hpp
+++ b/FppTest/component/tests/CmdTests.hpp
@@ -18,28 +18,28 @@
 
 #define CMD_TEST_INVOKE_DECL(TYPE, ASYNC) void invoke##ASYNC##Command(FppTest::Types::TYPE& data);
 
-#define CMD_TEST_INVOKE_DECLS       \
+#define CMD_TEST_INVOKE_DECLS                                       \
     void invokeCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf); \
-    CMD_TEST_INVOKE_DECL(NoParams, )    \
-    CMD_TEST_INVOKE_DECL(PrimitiveParams, ) \
-    CMD_TEST_INVOKE_DECL(CmdStringParams, )    \
-    CMD_TEST_INVOKE_DECL(EnumParam, )      \
-    CMD_TEST_INVOKE_DECL(ArrayParam, )     \
+    CMD_TEST_INVOKE_DECL(NoParams, )                                \
+    CMD_TEST_INVOKE_DECL(PrimitiveParams, )                         \
+    CMD_TEST_INVOKE_DECL(CmdStringParams, )                         \
+    CMD_TEST_INVOKE_DECL(EnumParam, )                               \
+    CMD_TEST_INVOKE_DECL(ArrayParam, )                              \
     CMD_TEST_INVOKE_DECL(StructParam, )
 
-#define CMD_TEST_INVOKE_DECLS_ASYNC      \
+#define CMD_TEST_INVOKE_DECLS_ASYNC                                      \
     void invokeAsyncCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf); \
-    CMD_TEST_INVOKE_DECL(NoParams, Async)    \
-    CMD_TEST_INVOKE_DECL(PrimitiveParams, Async) \
-    CMD_TEST_INVOKE_DECL(CmdStringParams, Async)    \
-    CMD_TEST_INVOKE_DECL(EnumParam, Async)      \
-    CMD_TEST_INVOKE_DECL(ArrayParam, Async)     \
+    CMD_TEST_INVOKE_DECL(NoParams, Async)                                \
+    CMD_TEST_INVOKE_DECL(PrimitiveParams, Async)                         \
+    CMD_TEST_INVOKE_DECL(CmdStringParams, Async)                         \
+    CMD_TEST_INVOKE_DECL(EnumParam, Async)                               \
+    CMD_TEST_INVOKE_DECL(ArrayParam, Async)                              \
     CMD_TEST_INVOKE_DECL(StructParam, Async)
 
 #define CMD_TEST_DECL(TYPE, ASYNC) void test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::TYPE& data);
 
 #define CMD_TEST_DECLS               \
-    CMD_TEST_INVOKE_DECLS \
+    CMD_TEST_INVOKE_DECLS            \
     CMD_TEST_DECL(NoParams, )        \
     CMD_TEST_DECL(PrimitiveParams, ) \
     CMD_TEST_DECL(CmdStringParams, ) \
@@ -48,7 +48,7 @@
     CMD_TEST_DECL(StructParam, )
 
 #define CMD_TEST_DECLS_ASYNC              \
-    CMD_TEST_INVOKE_DECLS_ASYNC \
+    CMD_TEST_INVOKE_DECLS_ASYNC           \
     CMD_TEST_DECL(NoParams, Async)        \
     CMD_TEST_DECL(PrimitiveParams, Async) \
     CMD_TEST_DECL(CmdStringParams, Async) \
@@ -60,316 +60,300 @@
 // Command test definitions
 // ----------------------------------------------------------------------
 
-#define CMD_TEST_INVOKE_DEFS                                                               \
-    void Tester ::invokeCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf) {    \
-        this->sendRawCmd(opcode, 1, buf);             \
-    } \
-\
-    void Tester ::invokeCommand(FppTest::Types::NoParams& data) {    \
-        this->sendCmd_CMD_NO_ARGS(0, 1);             \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeCommand(FppTest::Types::PrimitiveParams& data) { \
-        this->sendCmd_CMD_PRIMITIVE( \
-            0, \
-            1,  \
-            data.args.val1, \
-            data.args.val2, \
-            data.args.val3, \
-            data.args.val4, \
-            data.args.val5, \
-            data.args.val6 \
-        );           \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeCommand(FppTest::Types::CmdStringParams& data) {    \
-        this->sendCmd_CMD_STRINGS(0, 1, data.args.val1, data.args.val2);             \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeCommand(FppTest::Types::EnumParam& data) {      \
-        this->sendCmd_CMD_ENUM(0, 1, data.args.val);                \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeCommand(FppTest::Types::ArrayParam& data) {     \
-        this->sendCmd_CMD_ARRAY(0, 1, data.args.val);               \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeCommand(FppTest::Types::StructParam& data) {    \
-        this->sendCmd_CMD_STRUCT(0, 1, data.args.val);              \
+#define CMD_TEST_INVOKE_DEFS                                                                              \
+    void Tester ::invokeCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf) {                             \
+        this->sendRawCmd(opcode, 1, buf);                                                                 \
+    }                                                                                                     \
+                                                                                                          \
+    void Tester ::invokeCommand(FppTest::Types::NoParams& data) {                                         \
+        this->sendCmd_CMD_NO_ARGS(0, 1);                                                                  \
+    }                                                                                                     \
+                                                                                                          \
+    void Tester ::invokeCommand(FppTest::Types::PrimitiveParams& data) {                                  \
+        this->sendCmd_CMD_PRIMITIVE(0, 1, data.args.val1, data.args.val2, data.args.val3, data.args.val4, \
+                                    data.args.val5, data.args.val6);                                      \
+    }                                                                                                     \
+                                                                                                          \
+    void Tester ::invokeCommand(FppTest::Types::CmdStringParams& data) {                                  \
+        this->sendCmd_CMD_STRINGS(0, 1, data.args.val1, data.args.val2);                                  \
+    }                                                                                                     \
+                                                                                                          \
+    void Tester ::invokeCommand(FppTest::Types::EnumParam& data) {                                        \
+        this->sendCmd_CMD_ENUM(0, 1, data.args.val);                                                      \
+    }                                                                                                     \
+                                                                                                          \
+    void Tester ::invokeCommand(FppTest::Types::ArrayParam& data) {                                       \
+        this->sendCmd_CMD_ARRAY(0, 1, data.args.val);                                                     \
+    }                                                                                                     \
+                                                                                                          \
+    void Tester ::invokeCommand(FppTest::Types::StructParam& data) {                                      \
+        this->sendCmd_CMD_STRUCT(0, 1, data.args.val);                                                    \
     }
 
-#define CMD_TEST_INVOKE_DEFS_ASYNC                                                              \
-    void Tester ::invokeAsyncCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf) {    \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->sendRawCmd(opcode, 1, buf);             \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
-    }                                                                                           \
-\
-    void Tester ::invokeAsyncCommand(FppTest::Types::NoParams& data) {    \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->sendCmd_CMD_ASYNC_NO_ARGS(0, 1);             \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeAsyncCommand(FppTest::Types::PrimitiveParams& data) { \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->sendCmd_CMD_ASYNC_PRIMITIVE( \
-            0, \
-            1,  \
-            data.args.val1, \
-            data.args.val2, \
-            data.args.val3, \
-            data.args.val4, \
-            data.args.val5, \
-            data.args.val6 \
-        );           \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeAsyncCommand(FppTest::Types::CmdStringParams& data) {    \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->sendCmd_CMD_ASYNC_STRINGS(0, 1, data.args.val1, data.args.val2);             \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeAsyncCommand(FppTest::Types::EnumParam& data) {      \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->sendCmd_CMD_ASYNC_ENUM(0, 1, data.args.val);                \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeAsyncCommand(FppTest::Types::ArrayParam& data) {     \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->sendCmd_CMD_ASYNC_ARRAY(0, 1, data.args.val);               \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeAsyncCommand(FppTest::Types::StructParam& data) {    \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->sendCmd_CMD_ASYNC_STRUCT(0, 1, data.args.val);              \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
+#define CMD_TEST_INVOKE_DEFS_ASYNC                                                                              \
+    void Tester ::invokeAsyncCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf) {                              \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                                      \
+                                                                                                                \
+        this->sendRawCmd(opcode, 1, buf);                                                                       \
+        status = this->doDispatch();                                                                            \
+                                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);                         \
+    }                                                                                                           \
+                                                                                                                \
+    void Tester ::invokeAsyncCommand(FppTest::Types::NoParams& data) {                                          \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                                      \
+                                                                                                                \
+        this->sendCmd_CMD_ASYNC_NO_ARGS(0, 1);                                                                  \
+        status = this->doDispatch();                                                                            \
+                                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);                         \
+    }                                                                                                           \
+                                                                                                                \
+    void Tester ::invokeAsyncCommand(FppTest::Types::PrimitiveParams& data) {                                   \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                                      \
+                                                                                                                \
+        this->sendCmd_CMD_ASYNC_PRIMITIVE(0, 1, data.args.val1, data.args.val2, data.args.val3, data.args.val4, \
+                                          data.args.val5, data.args.val6);                                      \
+        status = this->doDispatch();                                                                            \
+                                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);                         \
+    }                                                                                                           \
+                                                                                                                \
+    void Tester ::invokeAsyncCommand(FppTest::Types::CmdStringParams& data) {                                   \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                                      \
+                                                                                                                \
+        this->sendCmd_CMD_ASYNC_STRINGS(0, 1, data.args.val1, data.args.val2);                                  \
+        status = this->doDispatch();                                                                            \
+                                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);                         \
+    }                                                                                                           \
+                                                                                                                \
+    void Tester ::invokeAsyncCommand(FppTest::Types::EnumParam& data) {                                         \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                                      \
+                                                                                                                \
+        this->sendCmd_CMD_ASYNC_ENUM(0, 1, data.args.val);                                                      \
+        status = this->doDispatch();                                                                            \
+                                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);                         \
+    }                                                                                                           \
+                                                                                                                \
+    void Tester ::invokeAsyncCommand(FppTest::Types::ArrayParam& data) {                                        \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                                      \
+                                                                                                                \
+        this->sendCmd_CMD_ASYNC_ARRAY(0, 1, data.args.val);                                                     \
+        status = this->doDispatch();                                                                            \
+                                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);                         \
+    }                                                                                                           \
+                                                                                                                \
+    void Tester ::invokeAsyncCommand(FppTest::Types::StructParam& data) {                                       \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                                      \
+                                                                                                                \
+        this->sendCmd_CMD_ASYNC_STRUCT(0, 1, data.args.val);                                                    \
+        status = this->doDispatch();                                                                            \
+                                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);                         \
     }
 
-#define CMD_TEST_DEFS(ASYNC, _ASYNC)                                                                             \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& data) {        \
-        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                \
-        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                           \
-                                                                                                         \
-        component.regCommands();                                                                         \
-                                                                                                         \
-        Fw::CmdArgBuffer buf;                                                                            \
-                                                                                                         \
-        /* Test success */                                                                               \
-        this->invoke##ASYNC##Command(data); \
-        ASSERT_CMD_RESPONSE_SIZE(1); \
-        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_NO_ARGS, 1, Fw::CmdResponse::OK); \
-                                                                                                         \
-        /* Test too many arguments */                                                                    \
-        buf.serialize(0);                                                                                \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_NO_ARGS, buf);                                                \
-        ASSERT_CMD_RESPONSE_SIZE(2); \
-        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_NO_ARGS, 1, Fw::CmdResponse::FORMAT_ERROR); \
-    }                                                                                                    \
-                                                                                                         \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& data) { \
-        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                \
-        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                           \
-                                                                                                         \
-        component.regCommands();                                                                         \
-                                                                                                         \
-        Fw::CmdArgBuffer buf;                                                                            \
-                                                                                                         \
-        /* Test incorrect deserialization of first argument */                                           \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_CMD_RESPONSE_SIZE(1); \
+#define CMD_TEST_DEFS(ASYNC, _ASYNC)                                                                        \
+    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& data) {           \
+        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
+        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
+                                                                                                            \
+        component.regCommands();                                                                            \
+                                                                                                            \
+        Fw::CmdArgBuffer buf;                                                                               \
+                                                                                                            \
+        /* Test success */                                                                                  \
+        this->invoke##ASYNC##Command(data);                                                                 \
+        ASSERT_CMD_RESPONSE_SIZE(1);                                                                        \
+        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_NO_ARGS, 1, Fw::CmdResponse::OK);             \
+                                                                                                            \
+        /* Test too many arguments */                                                                       \
+        buf.serialize(0);                                                                                   \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_NO_ARGS, buf);                          \
+        ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
+        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_NO_ARGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
+    }                                                                                                       \
+                                                                                                            \
+    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& data) {    \
+        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
+        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
+                                                                                                            \
+        component.regCommands();                                                                            \
+                                                                                                            \
+        Fw::CmdArgBuffer buf;                                                                               \
+                                                                                                            \
+        /* Test incorrect deserialization of first argument */                                              \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
+        ASSERT_CMD_RESPONSE_SIZE(1);                                                                        \
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
-                                                                                                         \
-        /* Test incorrect deserialization of second argument */                                          \
-        buf.serialize(data.args.val1);                                                                   \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_CMD_RESPONSE_SIZE(2); \
+                                                                                                            \
+        /* Test incorrect deserialization of second argument */                                             \
+        buf.serialize(data.args.val1);                                                                      \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
+        ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
         ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
-                                                                                                         \
-        /* Test incorrect deserialization of third argument */                                           \
-        buf.serialize(data.args.val2);                                                                   \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_CMD_RESPONSE_SIZE(3); \
+                                                                                                            \
+        /* Test incorrect deserialization of third argument */                                              \
+        buf.serialize(data.args.val2);                                                                      \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
+        ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
         ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
-                                                                                                         \
-        /* Test incorrect deserialization of fourth argument */                                          \
-        buf.serialize(data.args.val3);                                                                   \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_CMD_RESPONSE_SIZE(4); \
+                                                                                                            \
+        /* Test incorrect deserialization of fourth argument */                                             \
+        buf.serialize(data.args.val3);                                                                      \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
+        ASSERT_CMD_RESPONSE_SIZE(4);                                                                        \
         ASSERT_CMD_RESPONSE(3, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
-                                                                                                         \
-        /* Test incorrect deserialization of fifth argument */                                           \
-        buf.serialize(data.args.val4);                                                                   \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_CMD_RESPONSE_SIZE(5); \
+                                                                                                            \
+        /* Test incorrect deserialization of fifth argument */                                              \
+        buf.serialize(data.args.val4);                                                                      \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
+        ASSERT_CMD_RESPONSE_SIZE(5);                                                                        \
         ASSERT_CMD_RESPONSE(4, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
-                                                                                                         \
-        /* Test incorrect deserialization of sixth argument */                                           \
-        buf.serialize(data.args.val5);                                                                   \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_CMD_RESPONSE_SIZE(6); \
+                                                                                                            \
+        /* Test incorrect deserialization of sixth argument */                                              \
+        buf.serialize(data.args.val5);                                                                      \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
+        ASSERT_CMD_RESPONSE_SIZE(6);                                                                        \
         ASSERT_CMD_RESPONSE(5, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
-                                                                                                         \
-        /* Test success */                                                                               \
-        buf.serialize(data.args.val6);                                                                   \
-        this->invoke##ASYNC##Command(data); \
-                                                                                                         \
-        ASSERT_CMD_RESPONSE_SIZE(7); \
-        ASSERT_CMD_RESPONSE(6, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::OK); \
-        ASSERT_EQ(component.primitiveCmd.args.val1, data.args.val1);                                     \
-        ASSERT_EQ(component.primitiveCmd.args.val2, data.args.val2);                                     \
-        ASSERT_EQ(component.primitiveCmd.args.val3, data.args.val3);                                     \
-        ASSERT_EQ(component.primitiveCmd.args.val4, data.args.val4);                                     \
-        ASSERT_EQ(component.primitiveCmd.args.val5, data.args.val5);                                     \
-        ASSERT_EQ(component.primitiveCmd.args.val6, data.args.val6);                                     \
-                                                                                                         \
-        /* Test too many arguments */                                                                    \
-        buf.serialize(data.args.val5);                                                                   \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
-        ASSERT_CMD_RESPONSE_SIZE(8); \
+                                                                                                            \
+        /* Test success */                                                                                  \
+        buf.serialize(data.args.val6);                                                                      \
+        this->invoke##ASYNC##Command(data);                                                                 \
+                                                                                                            \
+        ASSERT_CMD_RESPONSE_SIZE(7);                                                                        \
+        ASSERT_CMD_RESPONSE(6, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::OK);           \
+        ASSERT_EQ(component.primitiveCmd.args.val1, data.args.val1);                                        \
+        ASSERT_EQ(component.primitiveCmd.args.val2, data.args.val2);                                        \
+        ASSERT_EQ(component.primitiveCmd.args.val3, data.args.val3);                                        \
+        ASSERT_EQ(component.primitiveCmd.args.val4, data.args.val4);                                        \
+        ASSERT_EQ(component.primitiveCmd.args.val5, data.args.val5);                                        \
+        ASSERT_EQ(component.primitiveCmd.args.val6, data.args.val6);                                        \
+                                                                                                            \
+        /* Test too many arguments */                                                                       \
+        buf.serialize(data.args.val5);                                                                      \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
+        ASSERT_CMD_RESPONSE_SIZE(8);                                                                        \
         ASSERT_CMD_RESPONSE(7, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
-    }                                                                                                    \
-                                                                                                         \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::CmdStringParams& data) { \
-        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                \
-        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                           \
-                                                                                                         \
-        component.regCommands();                                                                         \
-                                                                                                         \
-        Fw::CmdArgBuffer buf;                                                                            \
-                                                                                                         \
-        /* Test incorrect serialization of first argument */                                             \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                                                \
-        ASSERT_CMD_RESPONSE_SIZE(1); \
-        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR); \
-                                                                                                         \
-        /* Test incorrect serialization of second argument */                                            \
-        buf.serialize(data.args.val1);                                                                   \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                                                \
-        ASSERT_CMD_RESPONSE_SIZE(2); \
-        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR); \
-                                                                                                         \
-        /* Test success */                                                                               \
-        buf.serialize(data.args.val2);                                                                   \
-        this->invoke##ASYNC##Command(data); \
-                                                                                                         \
-        ASSERT_CMD_RESPONSE_SIZE(3); \
-        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::OK); \
-        ASSERT_EQ(component.stringCmd.args.val1, data.args.val1);                                        \
-        ASSERT_EQ(component.stringCmd.args.val2, data.args.val2);                                        \
-                                                                                                         \
-        /* Test too many arguments */                                                                    \
-        buf.serialize(data.args.val1);                                                                   \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                                                \
-        ASSERT_CMD_RESPONSE_SIZE(4); \
-        ASSERT_CMD_RESPONSE(3, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR); \
-    }                                                                                                    \
-                                                                                                         \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParam& data) {       \
-        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                \
-        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                           \
-                                                                                                         \
-        component.regCommands();                                                                         \
-                                                                                                         \
-        Fw::CmdArgBuffer buf;                                                                            \
-                                                                                                         \
-        /* Test incorrect serialization of first argument */                                             \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                                                  \
-        ASSERT_CMD_RESPONSE_SIZE(1); \
-        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::FORMAT_ERROR); \
-                                                                                                         \
-        /* Test success */                                                                               \
-        buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##Command(data); \
-                                                                                                         \
-        ASSERT_CMD_RESPONSE_SIZE(2); \
-        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::OK); \
-        ASSERT_EQ(component.enumCmd.args.val, data.args.val);                                            \
-                                                                                                         \
-        /* Test too many arguments */                                                                    \
-        buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                                                  \
-        ASSERT_CMD_RESPONSE_SIZE(3); \
-        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::FORMAT_ERROR); \
-    }                                                                                                    \
-                                                                                                         \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& data) {      \
-        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                \
-        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                           \
-                                                                                                         \
-        component.regCommands();                                                                         \
-                                                                                                         \
-        Fw::CmdArgBuffer buf;                                                                            \
-                                                                                                         \
-        /* Test incorrect serialization of first argument */                                             \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                                                 \
-        ASSERT_CMD_RESPONSE_SIZE(1); \
-        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::FORMAT_ERROR); \
-                                                                                                         \
-        /* Test success */                                                                               \
-        buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##Command(data); \
-                                                                                                         \
-        ASSERT_CMD_RESPONSE_SIZE(2); \
-        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::OK); \
-        ASSERT_EQ(component.arrayCmd.args.val, data.args.val);                                           \
-                                                                                                         \
-        /* Test too many arguments */                                                                    \
-        buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                                                 \
-        ASSERT_CMD_RESPONSE_SIZE(3); \
-        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::FORMAT_ERROR); \
-    }                                                                                                    \
-                                                                                                         \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::StructParam& data) {     \
-        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                \
-        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                           \
-                                                                                                         \
-        component.regCommands();                                                                         \
-                                                                                                         \
-        Fw::CmdArgBuffer buf;                                                                            \
-                                                                                                         \
-        /* Test incorrect serialization of first argument */                                             \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                                                \
-        ASSERT_CMD_RESPONSE_SIZE(1); \
-        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::FORMAT_ERROR); \
-                                                                                                         \
-        /* Test success */                                                                               \
-        buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##Command(data); \
-                                                                                                         \
-        ASSERT_CMD_RESPONSE_SIZE(2); \
-        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::OK); \
-        ASSERT_EQ(component.structCmd.args.val, data.args.val);                                          \
-                                                                                                         \
-        /* Test too many arguments */                                                                    \
-        buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                                                \
-        ASSERT_CMD_RESPONSE_SIZE(3); \
-        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::FORMAT_ERROR); \
+    }                                                                                                       \
+                                                                                                            \
+    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::CmdStringParams& data) {    \
+        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
+        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
+                                                                                                            \
+        component.regCommands();                                                                            \
+                                                                                                            \
+        Fw::CmdArgBuffer buf;                                                                               \
+                                                                                                            \
+        /* Test incorrect serialization of first argument */                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                          \
+        ASSERT_CMD_RESPONSE_SIZE(1);                                                                        \
+        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
+                                                                                                            \
+        /* Test incorrect serialization of second argument */                                               \
+        buf.serialize(data.args.val1);                                                                      \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                          \
+        ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
+        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
+                                                                                                            \
+        /* Test success */                                                                                  \
+        buf.serialize(data.args.val2);                                                                      \
+        this->invoke##ASYNC##Command(data);                                                                 \
+                                                                                                            \
+        ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
+        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::OK);             \
+        ASSERT_EQ(component.stringCmd.args.val1, data.args.val1);                                           \
+        ASSERT_EQ(component.stringCmd.args.val2, data.args.val2);                                           \
+                                                                                                            \
+        /* Test too many arguments */                                                                       \
+        buf.serialize(data.args.val1);                                                                      \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                          \
+        ASSERT_CMD_RESPONSE_SIZE(4);                                                                        \
+        ASSERT_CMD_RESPONSE(3, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
+    }                                                                                                       \
+                                                                                                            \
+    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParam& data) {          \
+        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
+        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
+                                                                                                            \
+        component.regCommands();                                                                            \
+                                                                                                            \
+        Fw::CmdArgBuffer buf;                                                                               \
+                                                                                                            \
+        /* Test incorrect serialization of first argument */                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                             \
+        ASSERT_CMD_RESPONSE_SIZE(1);                                                                        \
+        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::FORMAT_ERROR);      \
+                                                                                                            \
+        /* Test success */                                                                                  \
+        buf.serialize(data.args.val);                                                                       \
+        this->invoke##ASYNC##Command(data);                                                                 \
+                                                                                                            \
+        ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
+        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::OK);                \
+        ASSERT_EQ(component.enumCmd.args.val, data.args.val);                                               \
+                                                                                                            \
+        /* Test too many arguments */                                                                       \
+        buf.serialize(data.args.val);                                                                       \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                             \
+        ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
+        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::FORMAT_ERROR);      \
+    }                                                                                                       \
+                                                                                                            \
+    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& data) {         \
+        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
+        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
+                                                                                                            \
+        component.regCommands();                                                                            \
+                                                                                                            \
+        Fw::CmdArgBuffer buf;                                                                               \
+                                                                                                            \
+        /* Test incorrect serialization of first argument */                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                            \
+        ASSERT_CMD_RESPONSE_SIZE(1);                                                                        \
+        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::FORMAT_ERROR);     \
+                                                                                                            \
+        /* Test success */                                                                                  \
+        buf.serialize(data.args.val);                                                                       \
+        this->invoke##ASYNC##Command(data);                                                                 \
+                                                                                                            \
+        ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
+        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::OK);               \
+        ASSERT_EQ(component.arrayCmd.args.val, data.args.val);                                              \
+                                                                                                            \
+        /* Test too many arguments */                                                                       \
+        buf.serialize(data.args.val);                                                                       \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                            \
+        ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
+        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::FORMAT_ERROR);     \
+    }                                                                                                       \
+                                                                                                            \
+    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::StructParam& data) {        \
+        ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
+        ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
+                                                                                                            \
+        component.regCommands();                                                                            \
+                                                                                                            \
+        Fw::CmdArgBuffer buf;                                                                               \
+                                                                                                            \
+        /* Test incorrect serialization of first argument */                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                           \
+        ASSERT_CMD_RESPONSE_SIZE(1);                                                                        \
+        ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::FORMAT_ERROR);    \
+                                                                                                            \
+        /* Test success */                                                                                  \
+        buf.serialize(data.args.val);                                                                       \
+        this->invoke##ASYNC##Command(data);                                                                 \
+                                                                                                            \
+        ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
+        ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::OK);              \
+        ASSERT_EQ(component.structCmd.args.val, data.args.val);                                             \
+                                                                                                            \
+        /* Test too many arguments */                                                                       \
+        buf.serialize(data.args.val);                                                                       \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                           \
+        ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
+        ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::FORMAT_ERROR);    \
     }

--- a/FppTest/component/tests/CmdTests.hpp
+++ b/FppTest/component/tests/CmdTests.hpp
@@ -157,6 +157,7 @@
 
 #define CMD_TEST_DEFS(ASYNC, _ASYNC)                                                                        \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& data) {           \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \
@@ -177,6 +178,7 @@
     }                                                                                                       \
                                                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& data) {    \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \
@@ -240,6 +242,7 @@
     }                                                                                                       \
                                                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::CmdStringParams& data) {    \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \
@@ -275,6 +278,7 @@
     }                                                                                                       \
                                                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParam& data) {          \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \
@@ -303,6 +307,7 @@
     }                                                                                                       \
                                                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& data) {         \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \
@@ -331,6 +336,7 @@
     }                                                                                                       \
                                                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::StructParam& data) {        \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \

--- a/FppTest/component/tests/CmdTests.hpp
+++ b/FppTest/component/tests/CmdTests.hpp
@@ -16,28 +16,10 @@
 // Command test declarations
 // ----------------------------------------------------------------------
 
-#define CMD_TEST_INVOKE_DECL(TYPE) void invoke##TYPE##Command(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf);
-
-#define CMD_TEST_INVOKE_DECLS       \
-    CMD_TEST_INVOKE_DECL(NoArgs)    \
-    CMD_TEST_INVOKE_DECL(Primitive) \
-    CMD_TEST_INVOKE_DECL(String)    \
-    CMD_TEST_INVOKE_DECL(Enum)      \
-    CMD_TEST_INVOKE_DECL(Array)     \
-    CMD_TEST_INVOKE_DECL(Struct)
-
-#define CMD_TEST_INVOKE_DECLS_ASYNC      \
-    CMD_TEST_INVOKE_DECL(AsyncNoArgs)    \
-    CMD_TEST_INVOKE_DECL(AsyncPrimitive) \
-    CMD_TEST_INVOKE_DECL(AsyncString)    \
-    CMD_TEST_INVOKE_DECL(AsyncEnum)      \
-    CMD_TEST_INVOKE_DECL(AsyncArray)     \
-    CMD_TEST_INVOKE_DECL(AsyncStruct)
-
 #define CMD_TEST_DECL(TYPE, ASYNC) void test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::TYPE& data);
 
 #define CMD_TEST_DECLS               \
-    CMD_TEST_INVOKE_DECLS            \
+    void invokeCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf); \
     CMD_TEST_DECL(NoParams, )        \
     CMD_TEST_DECL(PrimitiveParams, ) \
     CMD_TEST_DECL(CmdStringParams, ) \
@@ -46,7 +28,7 @@
     CMD_TEST_DECL(StructParam, )
 
 #define CMD_TEST_DECLS_ASYNC              \
-    CMD_TEST_INVOKE_DECLS_ASYNC           \
+    void invokeAsyncCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf); \
     CMD_TEST_DECL(NoParams, Async)        \
     CMD_TEST_DECL(PrimitiveParams, Async) \
     CMD_TEST_DECL(CmdStringParams, Async) \
@@ -59,86 +41,21 @@
 // ----------------------------------------------------------------------
 
 #define CMD_TEST_INVOKE_DEFS                                                               \
-    void Tester ::invokeNoArgsCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) {    \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_NO_ARGS, 1, buf);             \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokePrimitiveCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) { \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_PRIMITIVE, 1, buf);           \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeStringCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) {    \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_STRINGS, 1, buf);             \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeEnumCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) {      \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_ENUM, 1, buf);                \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeArrayCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) {     \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_ARRAY, 1, buf);               \
-    }                                                                                      \
-                                                                                           \
-    void Tester ::invokeStructCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) {    \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_STRUCT, 1, buf);              \
-    }
+    void Tester ::invokeCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf) {    \
+        this->sendRawCmd(opcode, 1, buf);             \
+    }                                                                                      
 
 #define CMD_TEST_INVOKE_DEFS_ASYNC                                                              \
-    void Tester ::invokeAsyncNoArgsCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) {    \
+    void Tester ::invokeAsyncCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf) {    \
         Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
                                                                                                 \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_ASYNC_NO_ARGS, 1, buf);            \
+        this->sendRawCmd(opcode, 1, buf);             \
         status = this->doDispatch();                                                            \
                                                                                                 \
         ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
     }                                                                                           \
-                                                                                                \
-    void Tester ::invokeAsyncPrimitiveCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) { \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_ASYNC_PRIMITIVE, 1, buf);          \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
-    }                                                                                           \
-                                                                                                \
-    void Tester ::invokeAsyncStringCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) {    \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_ASYNC_STRINGS, 1, buf);            \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
-    }                                                                                           \
-                                                                                                \
-    void Tester ::invokeAsyncEnumCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) {      \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_ASYNC_ENUM, 1, buf);               \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
-    }                                                                                           \
-                                                                                                \
-    void Tester ::invokeAsyncArrayCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) {     \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_ASYNC_ARRAY, 1, buf);              \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
-    }                                                                                           \
-                                                                                                \
-    void Tester ::invokeAsyncStructCommand(NATIVE_INT_TYPE portNum, Fw::CmdArgBuffer& buf) {    \
-        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
-                                                                                                \
-        this->invoke_to_cmdOut(portNum, component.OPCODE_CMD_ASYNC_STRUCT, 1, buf);             \
-        status = this->doDispatch();                                                            \
-                                                                                                \
-        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
-    }
 
-#define CMD_TEST_DEFS(ASYNC)                                                                             \
+#define CMD_TEST_DEFS(ASYNC, _ASYNC)                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& data) {        \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                           \
@@ -148,12 +65,12 @@
         Fw::CmdArgBuffer buf;                                                                            \
                                                                                                          \
         /* Test success */                                                                               \
-        this->invoke##ASYNC##NoArgsCommand(portNum, buf);                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_NO_ARGS, buf);                                                \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
                                                                                                          \
         /* Test too many arguments */                                                                    \
         buf.serialize(0);                                                                                \
-        this->invoke##ASYNC##NoArgsCommand(portNum, buf);                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_NO_ARGS, buf);                                                \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
     }                                                                                                    \
                                                                                                          \
@@ -166,37 +83,37 @@
         Fw::CmdArgBuffer buf;                                                                            \
                                                                                                          \
         /* Test incorrect deserialization of first argument */                                           \
-        this->invoke##ASYNC##PrimitiveCommand(portNum, buf);                                             \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
                                                                                                          \
         /* Test incorrect deserialization of second argument */                                          \
         buf.serialize(data.args.val1);                                                                   \
-        this->invoke##ASYNC##PrimitiveCommand(portNum, buf);                                             \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
                                                                                                          \
         /* Test incorrect deserialization of third argument */                                           \
         buf.serialize(data.args.val2);                                                                   \
-        this->invoke##ASYNC##PrimitiveCommand(portNum, buf);                                             \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
                                                                                                          \
         /* Test incorrect deserialization of fourth argument */                                          \
         buf.serialize(data.args.val3);                                                                   \
-        this->invoke##ASYNC##PrimitiveCommand(portNum, buf);                                             \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
                                                                                                          \
         /* Test incorrect deserialization of fifth argument */                                           \
         buf.serialize(data.args.val4);                                                                   \
-        this->invoke##ASYNC##PrimitiveCommand(portNum, buf);                                             \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
                                                                                                          \
         /* Test incorrect deserialization of sixth argument */                                           \
         buf.serialize(data.args.val5);                                                                   \
-        this->invoke##ASYNC##PrimitiveCommand(portNum, buf);                                             \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val6);                                                                   \
-        this->invoke##ASYNC##PrimitiveCommand(portNum, buf);                                             \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
                                                                                                          \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
         ASSERT_EQ(component.primitiveCmd.args.val1, data.args.val1);                                     \
@@ -208,7 +125,7 @@
                                                                                                          \
         /* Test too many arguments */                                                                    \
         buf.serialize(data.args.val5);                                                                   \
-        this->invoke##ASYNC##PrimitiveCommand(portNum, buf);                                             \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
     }                                                                                                    \
                                                                                                          \
@@ -221,17 +138,17 @@
         Fw::CmdArgBuffer buf;                                                                            \
                                                                                                          \
         /* Test incorrect serialization of first argument */                                             \
-        this->invoke##ASYNC##StringCommand(portNum, buf);                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                                                \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
                                                                                                          \
         /* Test incorrect serialization of second argument */                                            \
         buf.serialize(data.args.val1);                                                                   \
-        this->invoke##ASYNC##StringCommand(portNum, buf);                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                                                \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val2);                                                                   \
-        this->invoke##ASYNC##StringCommand(portNum, buf);                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                                                \
                                                                                                          \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
         ASSERT_EQ(component.stringCmd.args.val1, data.args.val1);                                        \
@@ -239,7 +156,7 @@
                                                                                                          \
         /* Test too many arguments */                                                                    \
         buf.serialize(data.args.val1);                                                                   \
-        this->invoke##ASYNC##StringCommand(portNum, buf);                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                                                \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
     }                                                                                                    \
                                                                                                          \
@@ -252,19 +169,19 @@
         Fw::CmdArgBuffer buf;                                                                            \
                                                                                                          \
         /* Test incorrect serialization of first argument */                                             \
-        this->invoke##ASYNC##EnumCommand(portNum, buf);                                                  \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                                                  \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##EnumCommand(portNum, buf);                                                  \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                                                  \
                                                                                                          \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
         ASSERT_EQ(component.enumCmd.args.val, data.args.val);                                            \
                                                                                                          \
         /* Test too many arguments */                                                                    \
         buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##EnumCommand(portNum, buf);                                                  \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                                                  \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
     }                                                                                                    \
                                                                                                          \
@@ -277,19 +194,19 @@
         Fw::CmdArgBuffer buf;                                                                            \
                                                                                                          \
         /* Test incorrect serialization of first argument */                                             \
-        this->invoke##ASYNC##ArrayCommand(portNum, buf);                                                 \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                                                 \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##ArrayCommand(portNum, buf);                                                 \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                                                 \
                                                                                                          \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
         ASSERT_EQ(component.arrayCmd.args.val, data.args.val);                                           \
                                                                                                          \
         /* Test too many arguments */                                                                    \
         buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##ArrayCommand(portNum, buf);                                                 \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                                                 \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
     }                                                                                                    \
                                                                                                          \
@@ -302,18 +219,18 @@
         Fw::CmdArgBuffer buf;                                                                            \
                                                                                                          \
         /* Test incorrect serialization of first argument */                                             \
-        this->invoke##ASYNC##StructCommand(portNum, buf);                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                                                \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##StructCommand(portNum, buf);                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                                                \
                                                                                                          \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
         ASSERT_EQ(component.structCmd.args.val, data.args.val);                                          \
                                                                                                          \
         /* Test too many arguments */                                                                    \
         buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##StructCommand(portNum, buf);                                                \
+        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                                                \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::FORMAT_ERROR);                                               \
     }

--- a/FppTest/component/tests/CmdTests.hpp
+++ b/FppTest/component/tests/CmdTests.hpp
@@ -16,10 +16,30 @@
 // Command test declarations
 // ----------------------------------------------------------------------
 
+#define CMD_TEST_INVOKE_DECL(TYPE, ASYNC) void invoke##ASYNC##Command(FppTest::Types::TYPE& data);
+
+#define CMD_TEST_INVOKE_DECLS       \
+    void invokeCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf); \
+    CMD_TEST_INVOKE_DECL(NoParams, )    \
+    CMD_TEST_INVOKE_DECL(PrimitiveParams, ) \
+    CMD_TEST_INVOKE_DECL(CmdStringParams, )    \
+    CMD_TEST_INVOKE_DECL(EnumParam, )      \
+    CMD_TEST_INVOKE_DECL(ArrayParam, )     \
+    CMD_TEST_INVOKE_DECL(StructParam, )
+
+#define CMD_TEST_INVOKE_DECLS_ASYNC      \
+    void invokeAsyncCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf); \
+    CMD_TEST_INVOKE_DECL(NoParams, Async)    \
+    CMD_TEST_INVOKE_DECL(PrimitiveParams, Async) \
+    CMD_TEST_INVOKE_DECL(CmdStringParams, Async)    \
+    CMD_TEST_INVOKE_DECL(EnumParam, Async)      \
+    CMD_TEST_INVOKE_DECL(ArrayParam, Async)     \
+    CMD_TEST_INVOKE_DECL(StructParam, Async)
+
 #define CMD_TEST_DECL(TYPE, ASYNC) void test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::TYPE& data);
 
 #define CMD_TEST_DECLS               \
-    void invokeCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf); \
+    CMD_TEST_INVOKE_DECLS \
     CMD_TEST_DECL(NoParams, )        \
     CMD_TEST_DECL(PrimitiveParams, ) \
     CMD_TEST_DECL(CmdStringParams, ) \
@@ -28,7 +48,7 @@
     CMD_TEST_DECL(StructParam, )
 
 #define CMD_TEST_DECLS_ASYNC              \
-    void invokeAsyncCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf); \
+    CMD_TEST_INVOKE_DECLS_ASYNC \
     CMD_TEST_DECL(NoParams, Async)        \
     CMD_TEST_DECL(PrimitiveParams, Async) \
     CMD_TEST_DECL(CmdStringParams, Async) \
@@ -43,7 +63,40 @@
 #define CMD_TEST_INVOKE_DEFS                                                               \
     void Tester ::invokeCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf) {    \
         this->sendRawCmd(opcode, 1, buf);             \
-    }                                                                                      
+    } \
+\
+    void Tester ::invokeCommand(FppTest::Types::NoParams& data) {    \
+        this->sendCmd_CMD_NO_ARGS(0, 1);             \
+    }                                                                                      \
+                                                                                           \
+    void Tester ::invokeCommand(FppTest::Types::PrimitiveParams& data) { \
+        this->sendCmd_CMD_PRIMITIVE( \
+            0, \
+            1,  \
+            data.args.val1, \
+            data.args.val2, \
+            data.args.val3, \
+            data.args.val4, \
+            data.args.val5, \
+            data.args.val6 \
+        );           \
+    }                                                                                      \
+                                                                                           \
+    void Tester ::invokeCommand(FppTest::Types::CmdStringParams& data) {    \
+        this->sendCmd_CMD_STRINGS(0, 1, data.args.val1, data.args.val2);             \
+    }                                                                                      \
+                                                                                           \
+    void Tester ::invokeCommand(FppTest::Types::EnumParam& data) {      \
+        this->sendCmd_CMD_ENUM(0, 1, data.args.val);                \
+    }                                                                                      \
+                                                                                           \
+    void Tester ::invokeCommand(FppTest::Types::ArrayParam& data) {     \
+        this->sendCmd_CMD_ARRAY(0, 1, data.args.val);               \
+    }                                                                                      \
+                                                                                           \
+    void Tester ::invokeCommand(FppTest::Types::StructParam& data) {    \
+        this->sendCmd_CMD_STRUCT(0, 1, data.args.val);              \
+    }
 
 #define CMD_TEST_INVOKE_DEFS_ASYNC                                                              \
     void Tester ::invokeAsyncCommand(FwOpcodeType opcode, Fw::CmdArgBuffer& buf) {    \
@@ -54,6 +107,69 @@
                                                                                                 \
         ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
     }                                                                                           \
+\
+    void Tester ::invokeAsyncCommand(FppTest::Types::NoParams& data) {    \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
+                                                                                                \
+        this->sendCmd_CMD_ASYNC_NO_ARGS(0, 1);             \
+        status = this->doDispatch();                                                            \
+                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
+    }                                                                                      \
+                                                                                           \
+    void Tester ::invokeAsyncCommand(FppTest::Types::PrimitiveParams& data) { \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
+                                                                                                \
+        this->sendCmd_CMD_ASYNC_PRIMITIVE( \
+            0, \
+            1,  \
+            data.args.val1, \
+            data.args.val2, \
+            data.args.val3, \
+            data.args.val4, \
+            data.args.val5, \
+            data.args.val6 \
+        );           \
+        status = this->doDispatch();                                                            \
+                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
+    }                                                                                      \
+                                                                                           \
+    void Tester ::invokeAsyncCommand(FppTest::Types::CmdStringParams& data) {    \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
+                                                                                                \
+        this->sendCmd_CMD_ASYNC_STRINGS(0, 1, data.args.val1, data.args.val2);             \
+        status = this->doDispatch();                                                            \
+                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
+    }                                                                                      \
+                                                                                           \
+    void Tester ::invokeAsyncCommand(FppTest::Types::EnumParam& data) {      \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
+                                                                                                \
+        this->sendCmd_CMD_ASYNC_ENUM(0, 1, data.args.val);                \
+        status = this->doDispatch();                                                            \
+                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
+    }                                                                                      \
+                                                                                           \
+    void Tester ::invokeAsyncCommand(FppTest::Types::ArrayParam& data) {     \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
+                                                                                                \
+        this->sendCmd_CMD_ASYNC_ARRAY(0, 1, data.args.val);               \
+        status = this->doDispatch();                                                            \
+                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
+    }                                                                                      \
+                                                                                           \
+    void Tester ::invokeAsyncCommand(FppTest::Types::StructParam& data) {    \
+        Fw::QueuedComponentBase::MsgDispatchStatus status;                                      \
+                                                                                                \
+        this->sendCmd_CMD_ASYNC_STRUCT(0, 1, data.args.val);              \
+        status = this->doDispatch();                                                            \
+                                                                                                \
+        ASSERT_EQ(status, Fw::QueuedComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);         \
+    }
 
 #define CMD_TEST_DEFS(ASYNC, _ASYNC)                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& data) {        \
@@ -65,7 +181,7 @@
         Fw::CmdArgBuffer buf;                                                                            \
                                                                                                          \
         /* Test success */                                                                               \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_NO_ARGS, buf);                                                \
+        this->invoke##ASYNC##Command(data); \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
                                                                                                          \
         /* Test too many arguments */                                                                    \
@@ -113,7 +229,7 @@
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val6);                                                                   \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                                             \
+        this->invoke##ASYNC##Command(data); \
                                                                                                          \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
         ASSERT_EQ(component.primitiveCmd.args.val1, data.args.val1);                                     \
@@ -148,7 +264,7 @@
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val2);                                                                   \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                                                \
+        this->invoke##ASYNC##Command(data); \
                                                                                                          \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
         ASSERT_EQ(component.stringCmd.args.val1, data.args.val1);                                        \
@@ -174,7 +290,7 @@
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                                                  \
+        this->invoke##ASYNC##Command(data); \
                                                                                                          \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
         ASSERT_EQ(component.enumCmd.args.val, data.args.val);                                            \
@@ -199,7 +315,7 @@
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                                                 \
+        this->invoke##ASYNC##Command(data); \
                                                                                                          \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
         ASSERT_EQ(component.arrayCmd.args.val, data.args.val);                                           \
@@ -224,7 +340,7 @@
                                                                                                          \
         /* Test success */                                                                               \
         buf.serialize(data.args.val);                                                                    \
-        this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                                                \
+        this->invoke##ASYNC##Command(data); \
                                                                                                          \
         ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);                                                         \
         ASSERT_EQ(component.structCmd.args.val, data.args.val);                                          \

--- a/FppTest/component/tests/CmdTests.hpp
+++ b/FppTest/component/tests/CmdTests.hpp
@@ -157,7 +157,7 @@
 
 #define CMD_TEST_DEFS(ASYNC, _ASYNC)                                                                        \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& data) {           \
-        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \
@@ -178,7 +178,7 @@
     }                                                                                                       \
                                                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& data) {    \
-        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \
@@ -242,7 +242,7 @@
     }                                                                                                       \
                                                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::CmdStringParams& data) {    \
-        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \
@@ -278,7 +278,7 @@
     }                                                                                                       \
                                                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParam& data) {          \
-        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \
@@ -307,7 +307,7 @@
     }                                                                                                       \
                                                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& data) {         \
-        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \
@@ -336,7 +336,7 @@
     }                                                                                                       \
                                                                                                             \
     void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::StructParam& data) {        \
-        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum)); \
+        ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
                                                                                                             \

--- a/FppTest/component/tests/EventTests.cpp
+++ b/FppTest/component/tests/EventTests.cpp
@@ -24,6 +24,8 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& data)
 
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_EventNoArgs_SIZE(1);
+
+    this->printTextLogHistory(stdout);
 }
 
 void Tester ::testEventHelper(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& data, NATIVE_UINT_TYPE size) {
@@ -50,6 +52,8 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams
     // Test throttle reset
     component.log_ACTIVITY_LO_EventPrimitive_ThrottleClear();
     testEventHelper(portNum, data, component.EVENTID_EVENTPRIMITIVE_THROTTLE + 1);
+
+    this->printTextLogHistory(stdout);
 }
 
 void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::LogStringParams& data) {
@@ -58,6 +62,8 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::LogStringParams
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_EventString_SIZE(1);
     ASSERT_EVENTS_EventString(portNum, data.args.val1.toChar(), data.args.val2.toChar());
+
+    this->printTextLogHistory(stdout);
 }
 
 void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParam& data) {
@@ -69,6 +75,8 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParam& data
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_EventEnum_SIZE(1);
     ASSERT_EVENTS_EventEnum(portNum, data.args.val);
+
+    this->printTextLogHistory(stdout);
 }
 
 void Tester ::testEventHelper(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& data, NATIVE_UINT_TYPE size) {
@@ -96,6 +104,8 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& dat
     // Test throttle reset
     component.log_FATAL_EventArray_ThrottleClear();
     testEventHelper(portNum, data, component.EVENTID_EVENTARRAY_THROTTLE + 1);
+
+    this->printTextLogHistory(stdout);
 }
 
 void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::StructParam& data) {
@@ -107,6 +117,8 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::StructParam& da
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_EventStruct_SIZE(1);
     ASSERT_EVENTS_EventStruct(portNum, data.args.val);
+
+    this->printTextLogHistory(stdout);
 }
 
 void Tester ::testEventHelper(NATIVE_INT_TYPE portNum, FppTest::Types::BoolParam& data, NATIVE_UINT_TYPE size) {
@@ -134,4 +146,6 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::BoolParam& data
     // Test throttle reset
     component.log_WARNING_LO_EventBool_ThrottleClear();
     testEventHelper(portNum, data, component.EVENTID_EVENTBOOL_THROTTLE + 1);
+
+    this->printTextLogHistory(stdout);
 }

--- a/FppTest/component/tests/ParamTests.cpp
+++ b/FppTest/component/tests/ParamTests.cpp
@@ -67,7 +67,8 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::BoolPara
     // Test unsuccessful saving of param
     this->sendRawCmd(component.OPCODE_PARAMBOOL_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, component.OPCODE_PARAMBOOL_SAVE, 1, Fw::CmdResponse::EXECUTION_ERROR);
 
     this->connectPrmSetIn();
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
@@ -75,19 +76,22 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::BoolPara
     // Test incorrect deserialization when setting param
     this->sendRawCmd(component.OPCODE_PARAMBOOL_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMBOOL_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
     this->sendRawCmd(component.OPCODE_PARAMBOOL_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(3);
+    ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMBOOL_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
     this->sendRawCmd(component.OPCODE_PARAMBOOL_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(4);
+    ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMBOOL_SAVE, 1, Fw::CmdResponse::OK);
     ASSERT_EQ(boolPrm.args.val, data.args.val);
 }
 
@@ -97,7 +101,8 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::U32Param
     // Test unsuccessful saving of param
     this->sendRawCmd(component.OPCODE_PARAMU32_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, component.OPCODE_PARAMU32_SAVE, 1, Fw::CmdResponse::EXECUTION_ERROR);
 
     this->connectPrmSetIn();
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
@@ -105,19 +110,22 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::U32Param
     // Test incorrect deserialization when setting param
     this->sendRawCmd(component.OPCODE_PARAMU32_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMU32_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
     this->sendRawCmd(component.OPCODE_PARAMU32_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(3);
+    ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMU32_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
     this->sendRawCmd(component.OPCODE_PARAMU32_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(4);
+    ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMU32_SAVE, 1, Fw::CmdResponse::OK);
     ASSERT_EQ(u32Prm.args.val, data.args.val);
 }
 
@@ -127,7 +135,8 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::PrmStrin
     // Test unsuccessful saving of param
     this->sendRawCmd(component.OPCODE_PARAMSTRING_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, component.OPCODE_PARAMSTRING_SAVE, 1, Fw::CmdResponse::EXECUTION_ERROR);
 
     this->connectPrmSetIn();
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
@@ -135,19 +144,22 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::PrmStrin
     // Test incorrect deserialization when setting param
     this->sendRawCmd(component.OPCODE_PARAMSTRING_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMSTRING_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
     this->sendRawCmd(component.OPCODE_PARAMSTRING_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(3);
+    ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMSTRING_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
     this->sendRawCmd(component.OPCODE_PARAMSTRING_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(4);
+    ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMSTRING_SAVE, 1, Fw::CmdResponse::OK);
     ASSERT_EQ(stringPrm.args.val, data.args.val);
 }
 
@@ -157,7 +169,8 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::EnumPara
     // Test unsuccessful saving of param
     this->sendRawCmd(component.OPCODE_PARAMENUM_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, component.OPCODE_PARAMENUM_SAVE, 1, Fw::CmdResponse::EXECUTION_ERROR);
 
     this->connectPrmSetIn();
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
@@ -165,19 +178,22 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::EnumPara
     // Test incorrect deserialization when setting param
     this->sendRawCmd(component.OPCODE_PARAMENUM_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMENUM_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
     this->sendRawCmd(component.OPCODE_PARAMENUM_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(3);
+    ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMENUM_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
     this->sendRawCmd(component.OPCODE_PARAMENUM_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(4);
+    ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMENUM_SAVE, 1, Fw::CmdResponse::OK);
     ASSERT_EQ(enumPrm.args.val, data.args.val);
 }
 
@@ -187,7 +203,8 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayPar
     // Test unsuccessful saving of param
     this->sendRawCmd(component.OPCODE_PARAMARRAY_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, component.OPCODE_PARAMARRAY_SAVE, 1, Fw::CmdResponse::EXECUTION_ERROR);
 
     this->connectPrmSetIn();
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
@@ -195,19 +212,22 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayPar
     // Test incorrect deserialization when setting param
     this->sendRawCmd(component.OPCODE_PARAMARRAY_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMARRAY_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
     this->sendRawCmd(component.OPCODE_PARAMARRAY_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(3);
+    ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMARRAY_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
     this->sendRawCmd(component.OPCODE_PARAMARRAY_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(4);
+    ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMARRAY_SAVE, 1, Fw::CmdResponse::OK);
     ASSERT_EQ(arrayPrm.args.val, data.args.val);
 }
 
@@ -217,7 +237,8 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::StructPa
     // Test unsuccessful saving of param
     this->sendRawCmd(component.OPCODE_PARAMSTRUCT_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, component.OPCODE_PARAMSTRUCT_SAVE, 1, Fw::CmdResponse::EXECUTION_ERROR);
 
     this->connectPrmSetIn();
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
@@ -225,18 +246,21 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::StructPa
     // Test incorrect deserialization when setting param
     this->sendRawCmd(component.OPCODE_PARAMSTRUCT_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMSTRUCT_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
     this->sendRawCmd(component.OPCODE_PARAMSTRUCT_SET, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(3);
+    ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMSTRUCT_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
     this->sendRawCmd(component.OPCODE_PARAMSTRUCT_SAVE, 1, buf);
 
-    ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE_SIZE(4);
+    ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMSTRUCT_SAVE, 1, Fw::CmdResponse::OK);
     ASSERT_EQ(structPrm.args.val, data.args.val);
 }

--- a/FppTest/component/tests/ParamTests.cpp
+++ b/FppTest/component/tests/ParamTests.cpp
@@ -65,7 +65,7 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::BoolPara
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMBOOL_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMBOOL_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
 
@@ -73,19 +73,19 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::BoolPara
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
 
     // Test incorrect deserialization when setting param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMBOOL_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMBOOL_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMBOOL_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMBOOL_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMBOOL_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMBOOL_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
     ASSERT_EQ(boolPrm.args.val, data.args.val);
@@ -95,7 +95,7 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::U32Param
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMU32_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMU32_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
 
@@ -103,19 +103,19 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::U32Param
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
 
     // Test incorrect deserialization when setting param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMU32_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMU32_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMU32_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMU32_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMU32_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMU32_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
     ASSERT_EQ(u32Prm.args.val, data.args.val);
@@ -125,7 +125,7 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::PrmStrin
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMSTRING_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMSTRING_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
 
@@ -133,19 +133,19 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::PrmStrin
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
 
     // Test incorrect deserialization when setting param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMSTRING_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMSTRING_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMSTRING_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMSTRING_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMSTRING_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMSTRING_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
     ASSERT_EQ(stringPrm.args.val, data.args.val);
@@ -155,7 +155,7 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::EnumPara
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMENUM_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMENUM_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
 
@@ -163,19 +163,19 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::EnumPara
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
 
     // Test incorrect deserialization when setting param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMENUM_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMENUM_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMENUM_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMENUM_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMENUM_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMENUM_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
     ASSERT_EQ(enumPrm.args.val, data.args.val);
@@ -185,7 +185,7 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayPar
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMARRAY_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMARRAY_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
 
@@ -193,19 +193,19 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayPar
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
 
     // Test incorrect deserialization when setting param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMARRAY_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMARRAY_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMARRAY_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMARRAY_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMARRAY_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMARRAY_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
     ASSERT_EQ(arrayPrm.args.val, data.args.val);
@@ -215,7 +215,7 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::StructPa
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMSTRUCT_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMSTRUCT_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::EXECUTION_ERROR);
 
@@ -223,19 +223,19 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::StructPa
     ASSERT_TRUE(component.isConnected_prmSetOut_OutputPort(portNum));
 
     // Test incorrect deserialization when setting param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMSTRUCT_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMSTRUCT_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
     buf.serialize(data.args.val);
 
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMSTRUCT_SET, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMSTRUCT_SET, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->invoke_to_cmdOut(portNum, component.OPCODE_PARAMSTRUCT_SAVE, 1, buf);
+    this->sendRawCmd(component.OPCODE_PARAMSTRUCT_SAVE, 1, buf);
 
     ASSERT_EQ(cmdResp, Fw::CmdResponse::OK);
     ASSERT_EQ(structPrm.args.val, data.args.val);

--- a/FppTest/component/tests/ParamTests.cpp
+++ b/FppTest/component/tests/ParamTests.cpp
@@ -80,15 +80,14 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::BoolPara
     ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMBOOL_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
-    buf.serialize(data.args.val);
-
-    this->sendRawCmd(component.OPCODE_PARAMBOOL_SET, 1, buf);
+    this->paramSet_ParamBool(data.args.val, Fw::ParamValid::VALID);
+    this->paramSend_ParamBool(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(3);
     ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMBOOL_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->sendRawCmd(component.OPCODE_PARAMBOOL_SAVE, 1, buf);
+    this->paramSave_ParamBool(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(4);
     ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMBOOL_SAVE, 1, Fw::CmdResponse::OK);
@@ -114,15 +113,14 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::U32Param
     ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMU32_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
-    buf.serialize(data.args.val);
-
-    this->sendRawCmd(component.OPCODE_PARAMU32_SET, 1, buf);
+    this->paramSet_ParamU32(data.args.val, Fw::ParamValid::VALID);
+    this->paramSend_ParamU32(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(3);
     ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMU32_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->sendRawCmd(component.OPCODE_PARAMU32_SAVE, 1, buf);
+    this->paramSave_ParamU32(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(4);
     ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMU32_SAVE, 1, Fw::CmdResponse::OK);
@@ -148,15 +146,14 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::PrmStrin
     ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMSTRING_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
-    buf.serialize(data.args.val);
-
-    this->sendRawCmd(component.OPCODE_PARAMSTRING_SET, 1, buf);
+    this->paramSet_ParamString(data.args.val, Fw::ParamValid::VALID);
+    this->paramSend_ParamString(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(3);
     ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMSTRING_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->sendRawCmd(component.OPCODE_PARAMSTRING_SAVE, 1, buf);
+    this->paramSave_ParamString(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(4);
     ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMSTRING_SAVE, 1, Fw::CmdResponse::OK);
@@ -182,15 +179,14 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::EnumPara
     ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMENUM_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
-    buf.serialize(data.args.val);
-
-    this->sendRawCmd(component.OPCODE_PARAMENUM_SET, 1, buf);
+    this->paramSet_ParamEnum(data.args.val, Fw::ParamValid::VALID);
+    this->paramSend_ParamEnum(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(3);
     ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMENUM_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->sendRawCmd(component.OPCODE_PARAMENUM_SAVE, 1, buf);
+    this->paramSave_ParamEnum(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(4);
     ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMENUM_SAVE, 1, Fw::CmdResponse::OK);
@@ -216,15 +212,14 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayPar
     ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMARRAY_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
-    buf.serialize(data.args.val);
-
-    this->sendRawCmd(component.OPCODE_PARAMARRAY_SET, 1, buf);
+    this->paramSet_ParamArray(data.args.val, Fw::ParamValid::VALID);
+    this->paramSend_ParamArray(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(3);
     ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMARRAY_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->sendRawCmd(component.OPCODE_PARAMARRAY_SAVE, 1, buf);
+    this->paramSave_ParamArray(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(4);
     ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMARRAY_SAVE, 1, Fw::CmdResponse::OK);
@@ -250,15 +245,14 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::StructPa
     ASSERT_CMD_RESPONSE(1, component.OPCODE_PARAMSTRUCT_SET, 1, Fw::CmdResponse::VALIDATION_ERROR);
 
     // Test successful setting of param
-    buf.serialize(data.args.val);
-
-    this->sendRawCmd(component.OPCODE_PARAMSTRUCT_SET, 1, buf);
+    this->paramSet_ParamStruct(data.args.val, Fw::ParamValid::VALID);
+    this->paramSend_ParamStruct(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(3);
     ASSERT_CMD_RESPONSE(2, component.OPCODE_PARAMSTRUCT_SET, 1, Fw::CmdResponse::OK);
 
     // Test successful saving of param
-    this->sendRawCmd(component.OPCODE_PARAMSTRUCT_SAVE, 1, buf);
+    this->paramSave_ParamStruct(0, 1);
 
     ASSERT_CMD_RESPONSE_SIZE(4);
     ASSERT_CMD_RESPONSE(3, component.OPCODE_PARAMSTRUCT_SAVE, 1, Fw::CmdResponse::OK);

--- a/FppTest/component/tests/PortTests.hpp
+++ b/FppTest/component/tests/PortTests.hpp
@@ -93,14 +93,14 @@
 #define PORT_TEST_INVOKE_DEFS(PORT_KIND)                                                                         \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& port) {         \
         ASSERT_TRUE(component.isConnected_noArgsOut_OutputPort(portNum));                                        \
-        ASSERT_TRUE(this->isConnected_to_noArgs##PORT_KIND(portNum));                                        \
+        ASSERT_TRUE(this->isConnected_to_noArgs##PORT_KIND(portNum));                                            \
                                                                                                                  \
         this->invoke_to_noArgs##PORT_KIND(portNum);                                                              \
     }                                                                                                            \
                                                                                                                  \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& port) {  \
         ASSERT_TRUE(component.isConnected_primitiveArgsOut_OutputPort(portNum));                                 \
-        ASSERT_TRUE(this->isConnected_to_primitiveArgs##PORT_KIND(portNum));                                        \
+        ASSERT_TRUE(this->isConnected_to_primitiveArgs##PORT_KIND(portNum));                                     \
                                                                                                                  \
         this->invoke_to_primitiveArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3,        \
                                                  port.args.val4, port.args.val5, port.args.val6);                \
@@ -116,14 +116,14 @@
                                                                                                                  \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParams& port) {       \
         ASSERT_TRUE(component.isConnected_enumArgsOut_OutputPort(portNum));                                      \
-        ASSERT_TRUE(this->isConnected_to_enumArgs##PORT_KIND(portNum));                                        \
+        ASSERT_TRUE(this->isConnected_to_enumArgs##PORT_KIND(portNum));                                          \
                                                                                                                  \
         this->invoke_to_enumArgs##PORT_KIND(portNum, port.args.val1, port.args.val2);                            \
     }                                                                                                            \
                                                                                                                  \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParams& port) {      \
         ASSERT_TRUE(component.isConnected_arrayArgsOut_OutputPort(portNum));                                     \
-        ASSERT_TRUE(this->isConnected_to_arrayArgs##PORT_KIND(portNum));                                        \
+        ASSERT_TRUE(this->isConnected_to_arrayArgs##PORT_KIND(portNum));                                         \
                                                                                                                  \
         this->invoke_to_arrayArgs##PORT_KIND(portNum, port.args.val1, port.args.val2);                           \
     }                                                                                                            \
@@ -138,7 +138,7 @@
 #define PORT_TEST_INVOKE_RETURN_DEFS(PORT_KIND)                                                                       \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::NoParamReturn& port) {         \
         ASSERT_TRUE(component.isConnected_noArgsReturnOut_OutputPort(portNum));                                       \
-        ASSERT_TRUE(this->isConnected_to_noArgsReturn##PORT_KIND(portNum));                                        \
+        ASSERT_TRUE(this->isConnected_to_noArgsReturn##PORT_KIND(portNum));                                           \
                                                                                                                       \
         bool returnVal = this->invoke_to_noArgsReturn##PORT_KIND(portNum);                                            \
                                                                                                                       \
@@ -157,7 +157,7 @@
                                                                                                                       \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::EnumReturn& port) {            \
         ASSERT_TRUE(component.isConnected_enumReturnOut_OutputPort(portNum));                                         \
-        ASSERT_TRUE(this->isConnected_to_enumReturn##PORT_KIND(portNum));                                        \
+        ASSERT_TRUE(this->isConnected_to_enumReturn##PORT_KIND(portNum));                                             \
                                                                                                                       \
         FormalParamEnum returnVal = this->invoke_to_enumReturn##PORT_KIND(portNum, port.args.val1, port.args.val2);   \
                                                                                                                       \
@@ -166,7 +166,7 @@
                                                                                                                       \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayReturn& port) {           \
         ASSERT_TRUE(component.isConnected_arrayReturnOut_OutputPort(portNum));                                        \
-        ASSERT_TRUE(this->isConnected_to_arrayReturn##PORT_KIND(portNum));                                        \
+        ASSERT_TRUE(this->isConnected_to_arrayReturn##PORT_KIND(portNum));                                            \
                                                                                                                       \
         FormalParamArray returnVal = this->invoke_to_arrayReturn##PORT_KIND(portNum, port.args.val1, port.args.val2); \
                                                                                                                       \
@@ -175,7 +175,7 @@
                                                                                                                       \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::StructReturn& port) {          \
         ASSERT_TRUE(component.isConnected_structReturnOut_OutputPort(portNum));                                       \
-        ASSERT_TRUE(this->isConnected_to_structReturn##PORT_KIND(portNum));                                        \
+        ASSERT_TRUE(this->isConnected_to_structReturn##PORT_KIND(portNum));                                           \
                                                                                                                       \
         FormalParamStruct returnVal =                                                                                 \
             this->invoke_to_structReturn##PORT_KIND(portNum, port.args.val1, port.args.val2);                         \
@@ -189,7 +189,7 @@
 
 #define PORT_TEST_INVOKE_SERIAL_HELPER_DEF(PORT_KIND)                                             \
     void Tester ::invoke##PORT_KIND##SerialPort(NATIVE_INT_TYPE portNum, Fw::SerialBuffer& buf) { \
-        ASSERT_TRUE(this->isConnected_to_serial##PORT_KIND(portNum));                                        \
+        ASSERT_TRUE(this->isConnected_to_serial##PORT_KIND(portNum));                             \
         this->invoke_to_serial##PORT_KIND(portNum, buf);                                          \
     }
 
@@ -201,22 +201,22 @@
             case SerialPortIndex::NO_ARGS:                                                \
             case SerialPortIndex::PRIMITIVE:                                              \
             case SerialPortIndex::STRING:                                                 \
-                ASSERT_TRUE(this->isConnected_to_serialAsync(portNum));                                        \
+                ASSERT_TRUE(this->isConnected_to_serialAsync(portNum));                   \
                 this->invoke_to_serialAsync(portNum, buf);                                \
                 break;                                                                    \
                                                                                           \
             case SerialPortIndex::ENUM:                                                   \
-                ASSERT_TRUE(this->isConnected_to_serialAsyncAssert(0));                                        \
+                ASSERT_TRUE(this->isConnected_to_serialAsyncAssert(0));                   \
                 this->invoke_to_serialAsyncAssert(0, buf);                                \
                 break;                                                                    \
                                                                                           \
             case SerialPortIndex::ARRAY:                                                  \
-                ASSERT_TRUE(this->isConnected_to_serialAsyncBlockPriority(0));                                        \
+                ASSERT_TRUE(this->isConnected_to_serialAsyncBlockPriority(0));            \
                 this->invoke_to_serialAsyncBlockPriority(0, buf);                         \
                 break;                                                                    \
                                                                                           \
             case SerialPortIndex::STRUCT:                                                 \
-                ASSERT_TRUE(this->isConnected_to_serialAsyncDropPriority(0));                                        \
+                ASSERT_TRUE(this->isConnected_to_serialAsyncDropPriority(0));             \
                 this->invoke_to_serialAsyncDropPriority(0, buf);                          \
                 break;                                                                    \
         }                                                                                 \

--- a/FppTest/component/tests/PortTests.hpp
+++ b/FppTest/component/tests/PortTests.hpp
@@ -93,12 +93,14 @@
 #define PORT_TEST_INVOKE_DEFS(PORT_KIND)                                                                         \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& port) {         \
         ASSERT_TRUE(component.isConnected_noArgsOut_OutputPort(portNum));                                        \
+        ASSERT_TRUE(this->isConnected_to_noArgs##PORT_KIND(portNum));                                        \
                                                                                                                  \
         this->invoke_to_noArgs##PORT_KIND(portNum);                                                              \
     }                                                                                                            \
                                                                                                                  \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& port) {  \
         ASSERT_TRUE(component.isConnected_primitiveArgsOut_OutputPort(portNum));                                 \
+        ASSERT_TRUE(this->isConnected_to_primitiveArgs##PORT_KIND(portNum));                                        \
                                                                                                                  \
         this->invoke_to_primitiveArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3,        \
                                                  port.args.val4, port.args.val5, port.args.val6);                \
@@ -106,6 +108,7 @@
                                                                                                                  \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::PortStringParams& port) { \
         ASSERT_TRUE(component.isConnected_stringArgsOut_OutputPort(portNum));                                    \
+        ASSERT_TRUE(this->isConnected_to_stringArgs##PORT_KIND(portNum));                                        \
                                                                                                                  \
         this->invoke_to_stringArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3,           \
                                               port.args.val4);                                                   \
@@ -113,18 +116,21 @@
                                                                                                                  \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParams& port) {       \
         ASSERT_TRUE(component.isConnected_enumArgsOut_OutputPort(portNum));                                      \
+        ASSERT_TRUE(this->isConnected_to_enumArgs##PORT_KIND(portNum));                                        \
                                                                                                                  \
         this->invoke_to_enumArgs##PORT_KIND(portNum, port.args.val1, port.args.val2);                            \
     }                                                                                                            \
                                                                                                                  \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParams& port) {      \
         ASSERT_TRUE(component.isConnected_arrayArgsOut_OutputPort(portNum));                                     \
+        ASSERT_TRUE(this->isConnected_to_arrayArgs##PORT_KIND(portNum));                                        \
                                                                                                                  \
         this->invoke_to_arrayArgs##PORT_KIND(portNum, port.args.val1, port.args.val2);                           \
     }                                                                                                            \
                                                                                                                  \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::StructParams& port) {     \
         ASSERT_TRUE(component.isConnected_structArgsOut_OutputPort(portNum));                                    \
+        ASSERT_TRUE(this->isConnected_to_structArgs##PORT_KIND(portNum));                                        \
                                                                                                                  \
         this->invoke_to_structArgs##PORT_KIND(portNum, port.args.val1, port.args.val2);                          \
     }
@@ -132,6 +138,7 @@
 #define PORT_TEST_INVOKE_RETURN_DEFS(PORT_KIND)                                                                       \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::NoParamReturn& port) {         \
         ASSERT_TRUE(component.isConnected_noArgsReturnOut_OutputPort(portNum));                                       \
+        ASSERT_TRUE(this->isConnected_to_noArgsReturn##PORT_KIND(portNum));                                        \
                                                                                                                       \
         bool returnVal = this->invoke_to_noArgsReturn##PORT_KIND(portNum);                                            \
                                                                                                                       \
@@ -140,6 +147,7 @@
                                                                                                                       \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveReturn& port) {       \
         ASSERT_TRUE(component.isConnected_primitiveReturnOut_OutputPort(portNum));                                    \
+        ASSERT_TRUE(this->isConnected_to_primitiveReturn##PORT_KIND(portNum));                                        \
                                                                                                                       \
         U32 returnVal = this->invoke_to_primitiveReturn##PORT_KIND(                                                   \
             portNum, port.args.val1, port.args.val2, port.args.val3, port.args.val4, port.args.val5, port.args.val6); \
@@ -149,6 +157,7 @@
                                                                                                                       \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::EnumReturn& port) {            \
         ASSERT_TRUE(component.isConnected_enumReturnOut_OutputPort(portNum));                                         \
+        ASSERT_TRUE(this->isConnected_to_enumReturn##PORT_KIND(portNum));                                        \
                                                                                                                       \
         FormalParamEnum returnVal = this->invoke_to_enumReturn##PORT_KIND(portNum, port.args.val1, port.args.val2);   \
                                                                                                                       \
@@ -157,6 +166,7 @@
                                                                                                                       \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayReturn& port) {           \
         ASSERT_TRUE(component.isConnected_arrayReturnOut_OutputPort(portNum));                                        \
+        ASSERT_TRUE(this->isConnected_to_arrayReturn##PORT_KIND(portNum));                                        \
                                                                                                                       \
         FormalParamArray returnVal = this->invoke_to_arrayReturn##PORT_KIND(portNum, port.args.val1, port.args.val2); \
                                                                                                                       \
@@ -165,6 +175,7 @@
                                                                                                                       \
     void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::StructReturn& port) {          \
         ASSERT_TRUE(component.isConnected_structReturnOut_OutputPort(portNum));                                       \
+        ASSERT_TRUE(this->isConnected_to_structReturn##PORT_KIND(portNum));                                        \
                                                                                                                       \
         FormalParamStruct returnVal =                                                                                 \
             this->invoke_to_structReturn##PORT_KIND(portNum, port.args.val1, port.args.val2);                         \
@@ -178,6 +189,7 @@
 
 #define PORT_TEST_INVOKE_SERIAL_HELPER_DEF(PORT_KIND)                                             \
     void Tester ::invoke##PORT_KIND##SerialPort(NATIVE_INT_TYPE portNum, Fw::SerialBuffer& buf) { \
+        ASSERT_TRUE(this->isConnected_to_serial##PORT_KIND(portNum));                                        \
         this->invoke_to_serial##PORT_KIND(portNum, buf);                                          \
     }
 
@@ -189,18 +201,22 @@
             case SerialPortIndex::NO_ARGS:                                                \
             case SerialPortIndex::PRIMITIVE:                                              \
             case SerialPortIndex::STRING:                                                 \
+                ASSERT_TRUE(this->isConnected_to_serialAsync(portNum));                                        \
                 this->invoke_to_serialAsync(portNum, buf);                                \
                 break;                                                                    \
                                                                                           \
             case SerialPortIndex::ENUM:                                                   \
+                ASSERT_TRUE(this->isConnected_to_serialAsyncAssert(0));                                        \
                 this->invoke_to_serialAsyncAssert(0, buf);                                \
                 break;                                                                    \
                                                                                           \
             case SerialPortIndex::ARRAY:                                                  \
+                ASSERT_TRUE(this->isConnected_to_serialAsyncBlockPriority(0));                                        \
                 this->invoke_to_serialAsyncBlockPriority(0, buf);                         \
                 break;                                                                    \
                                                                                           \
             case SerialPortIndex::STRUCT:                                                 \
+                ASSERT_TRUE(this->isConnected_to_serialAsyncDropPriority(0));                                        \
                 this->invoke_to_serialAsyncDropPriority(0, buf);                          \
                 break;                                                                    \
         }                                                                                 \

--- a/FppTest/component/tests/TesterHandlers.cpp
+++ b/FppTest/component/tests/TesterHandlers.cpp
@@ -130,11 +130,3 @@ void Tester ::from_serialOut_handler(NATIVE_INT_TYPE portNum,        /*!< The po
 
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
 }
-
-// ----------------------------------------------------------------------
-// Handlers for special from ports
-// ----------------------------------------------------------------------
-
-void Tester ::cmdResponseIn(const FwOpcodeType opCode, const U32 cmdSeq, const Fw::CmdResponse response) {
-    this->cmdResp = response;
-}

--- a/FppTest/component/tests/TesterHelpers.cpp
+++ b/FppTest/component/tests/TesterHelpers.cpp
@@ -117,9 +117,6 @@ void Tester ::connectPorts() {
     // arrayReturnOut
     this->component.set_arrayReturnOut_OutputPort(0, this->get_from_arrayReturnOut(0));
 
-    // cmdIn
-    this->connect_to_cmdOut(0, this->component.get_cmdIn_InputPort(0));
-
     // cmdRegOut
     this->component.set_cmdRegOut_OutputPort(0, this->get_from_cmdRegOut(0));
 


### PR DESCRIPTION
## Change Description

This PR integrates FPP v2.0, which adds support for C++ generation of unit test harness classes, with F Prime.

Unit tests for the FPP unit test autocoder have been added to the existing tests for FPP components.

## Changes to Generated C++ Code for Unit Test Harnesses

### General
- Prepend the component name to the generated file names, e.g. `[ComponentName]TesterBase.cpp` instead of `TesterBase.cpp`. This allows the generation of test harness classes for multiple components within the same directory.

### TesterBase classes
- Reorganize class members (follows the same pattern as the reorganization of class members for component base classes, see #2103)
- Change `typedef struct {...} [name];` to `struct [name] {...};`
- Move initialization of `m_param_[paramName]_valid` variable members from the `init` function to initializer lists in the constructor
- Fix issue where `[portName]_static` and dispatch function implementations for special ports are not generated when the corresponding special port constructs do not appear (e.g. a component contains command ports, but no commands)
- Change `sizeof([serializableType])` to `[serializableType]::SERIALIZED_SIZE` where appropriate in the `dispatchEvents` function

## To do before merging

- [x] Merge unit test code generation into FPP
- [ ] Integrate unit test code generation with fprime tools
- [ ] Create FPP pre-release to test PR
- [ ] Create FPP release v2.0