### PR TITLE
Added sleep to avoid test failing because of execution too fast

### DIFF
--- a/Svc/PassiveRateGroup/test/ut/PassiveRateGroupImplTester.cpp
+++ b/Svc/PassiveRateGroup/test/ut/PassiveRateGroupImplTester.cpp
@@ -18,6 +18,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <unistd.h>
 
 namespace Svc {
 
@@ -42,6 +43,8 @@ void PassiveRateGroupTester::from_RateGroupMemberOut_handler(NATIVE_INT_TYPE por
     this->m_callLog[portNum].portCalled = true;
     this->m_callLog[portNum].contextVal = context;
     this->m_callLog[portNum].order = this->m_callOrder++;
+    // Adding a small sleep to ensure that the cycle time is bigger than 0 us
+    usleep(1);
 }
 
 void PassiveRateGroupTester::runNominal(NATIVE_INT_TYPE contexts[],


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Svc.PassiveRateGroup  |

---
## Change Description

I added a sleep of 1us to simulate some work when the port `RateGroupMemberOut` is called.

## Rationale

The UT of `PassiveRateGroup` was, sometimes, failing on my laptop because the `cycle_time` of `PassiveRateGroup::CycleIn_handler` was smaller than 1 us(it was around 700ns). 

The error I was having before the fix :
```
Fprime/Svc/PassiveRateGroup/test/ut/PassiveRateGroupImplTester.cpp:79: Failure
Expected: (this->tlmHistory_MaxCycleTime->at(0).arg) > (0), actual: 0 vs 0
```

