### PR TITLE
Add missing include

### DIFF
--- a/config/CmdSplitterCfg.hpp
+++ b/config/CmdSplitterCfg.hpp
@@ -8,6 +8,8 @@
 #ifndef CONFIG_CMD_SPLITTER_CFG_HPP_
 #define CONFIG_CMD_SPLITTER_CFG_HPP_
 
+#include <FpConfig.hpp>
+
 namespace Svc {
 //!< Base value for remote opcodes used by Svc::CmdSplitter
 static const FwOpcodeType CMD_SPLITTER_REMOTE_OPCODE_BASE = 0x10000000;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Affected Component_**|  config |

---
## Change Description

Added missing include.

## Rationale

Some static analysis tools like `clang-tidy` are creating a warning because they cannot find the declaration of `FwOpcodeType`. Moreover, any other config file that uses Fprime types already includes `FpConfig.hpp`.
