### PR TITLE
Added startup, shutdown methods to IpSocket and added startup as a re…

### DIFF
--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -38,7 +38,7 @@ enum SocketIpStatus {
 };
 
 /**
- * \brief Helper base-class for setting up Berkley sockets
+ * \brief Helper base-class for setting up Berkeley sockets
  *
  * Certain IP headers have conflicting definitions with the m_data member of various types in fprime. TcpHelper
  * separates the ip setup from the incoming Fw::Buffer in the primary component class preventing this collision.

--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -34,6 +34,7 @@ enum SocketIpStatus {
     SOCK_FAILED_TO_LISTEN = -10,             //!< Failed to listen on socket
     SOCK_FAILED_TO_ACCEPT = -11,             //!< Failed to accept connection
     SOCK_SEND_ERROR = -13,                   //!< Failed to send after configured retries
+    SOCK_NOT_STARTED = -14,                  //!< Socket has not been started
 };
 
 /**
@@ -66,6 +67,13 @@ class IpSocket {
      */
     SocketIpStatus configure(const char* hostname, const U16 port, const U32 send_timeout_seconds,
                              const U32 send_timeout_microseconds);
+    /**
+     * \brief Returns true when the socket is started
+     *
+     * Returns true when the socket is started up sufficiently to be actively listening to clients. Returns false
+     * otherwise. This means `startup()` was called and returned success.
+     */
+    bool isStarted();
 
     /**
      * \brief check if IP socket has previously been opened
@@ -77,6 +85,16 @@ class IpSocket {
      * \return true if socket is open, false otherwise
      */
     bool isOpened();
+
+    /**
+     * \brief startup the socket, a no-op on unless this is server
+     *
+     * This will start-up the socket. In the case of most sockets, this is a no-op. On server sockets this binds to the
+     * server address and progresses through the `listen` step such that on `open` new clients may be accepted.
+     *
+     * \return status of startup
+     */
+    virtual SocketIpStatus startup();
 
     /**
      * \brief open the IP socket for communications
@@ -92,6 +110,7 @@ class IpSocket {
      * In the case of server components (TcpServer) this function will block until a client has connected.
      *
      * Note: delegates to openProtocol for protocol specific implementation
+     *
      * \return status of open
      */
     SocketIpStatus open();
@@ -134,6 +153,14 @@ class IpSocket {
      * port (call `shutdown`) but will close the active client connection.
      */
     void close();
+
+    /**
+     * \brief shutdown the socket
+     *
+     * Closes the socket opened by the open call. In this case of the TcpServer, this does close server's listening
+     * port. This will shutdown all clients.
+     */
+    virtual void shutdown();
 
   PROTECTED:
 
@@ -179,6 +206,7 @@ class IpSocket {
     U32 m_timeoutMicroseconds;
     U16 m_port;  //!< IP address port used
     bool m_open; //!< Have we successfully opened
+    bool m_started; //!< Have we successfully started the socket
     char m_hostname[SOCKET_MAX_HOSTNAME_SIZE];  //!< Hostname to supply
 };
 }  // namespace Drv

--- a/Drv/Ip/SocketReadTask.cpp
+++ b/Drv/Ip/SocketReadTask.cpp
@@ -36,6 +36,10 @@ void SocketReadTask::startSocketTask(const Fw::StringBase &name,
     FW_ASSERT(Os::Task::TASK_OK == stat, static_cast<NATIVE_INT_TYPE>(stat));
 }
 
+SocketIpStatus SocketReadTask::startup() {
+    return this->getSocketHandler().startup();
+}
+
 SocketIpStatus SocketReadTask::open() {
     SocketIpStatus status = this->getSocketHandler().open();
     // Call connected any time the open is successful
@@ -43,6 +47,10 @@ SocketIpStatus SocketReadTask::open() {
         this->connected();
     }
     return status;
+}
+
+void SocketReadTask::shutdown() {
+    this->getSocketHandler().shutdown();
 }
 
 void SocketReadTask::close() {
@@ -55,7 +63,7 @@ Os::Task::TaskStatus SocketReadTask::joinSocketTask(void** value_ptr) {
 
 void SocketReadTask::stopSocketTask() {
     this->m_stop = true;
-    this->getSocketHandler().close();  // Break out of any receives
+    this->shutdown();  // Break out of any receives and fully shutdown
 }
 
 void SocketReadTask::readTask(void* pointer) {
@@ -64,10 +72,19 @@ void SocketReadTask::readTask(void* pointer) {
     SocketReadTask* self = reinterpret_cast<SocketReadTask*>(pointer);
     do {
         // Open a network connection if it has not already been open
+        if ((not self->getSocketHandler().isStarted()) and (not self->m_stop) and
+            ((status = self->startup()) != SOCK_SUCCESS)) {
+            Fw::Logger::logMsg("[WARNING] Failed to open port with status %d and errno %d\n", status, errno);
+            Os::Task::delay(SOCKET_RETRY_INTERVAL_MS);
+            continue;
+        }
+
+        // Open a network connection if it has not already been open
         if ((not self->getSocketHandler().isOpened()) and (not self->m_stop) and
             ((status = self->open()) != SOCK_SUCCESS)) {
             Fw::Logger::logMsg("[WARNING] Failed to open port with status %d and errno %d\n", status, errno);
             Os::Task::delay(SOCKET_RETRY_INTERVAL_MS);
+            continue;
         }
 
         // If the network connection is open, read from it
@@ -92,6 +109,6 @@ void SocketReadTask::readTask(void* pointer) {
     // As long as not told to stop, and we are successful interrupted or ordered to retry, keep receiving
     while (not self->m_stop &&
            (status == SOCK_SUCCESS || status == SOCK_INTERRUPTED_TRY_AGAIN || self->m_reconnect));
-    self->getSocketHandler().close(); // Close the handler again, in case it reconnected
+    self->getSocketHandler().shutdown(); // Shutdown the port entirely
 }
 };  // namespace Drv

--- a/Drv/Ip/SocketReadTask.cpp
+++ b/Drv/Ip/SocketReadTask.cpp
@@ -63,7 +63,7 @@ Os::Task::TaskStatus SocketReadTask::joinSocketTask(void** value_ptr) {
 
 void SocketReadTask::stopSocketTask() {
     this->m_stop = true;
-    this->shutdown();  // Break out of any receives and fully shutdown
+    this->getSocketHandler().shutdown();  // Break out of any receives and fully shutdown
 }
 
 void SocketReadTask::readTask(void* pointer) {
@@ -88,7 +88,7 @@ void SocketReadTask::readTask(void* pointer) {
         }
 
         // If the network connection is open, read from it
-        if (self->getSocketHandler().isOpened() and (not self->m_stop)) {
+        if (self->getSocketHandler().isStarted() and self->getSocketHandler().isOpened() and (not self->m_stop)) {
             Fw::Buffer buffer = self->getBuffer();
             U8* data = buffer.getData();
             FW_ASSERT(data);

--- a/Drv/Ip/SocketReadTask.cpp
+++ b/Drv/Ip/SocketReadTask.cpp
@@ -75,7 +75,7 @@ void SocketReadTask::readTask(void* pointer) {
         if ((not self->getSocketHandler().isStarted()) and (not self->m_stop) and
             ((status = self->startup()) != SOCK_SUCCESS)) {
             Fw::Logger::logMsg("[WARNING] Failed to open port with status %d and errno %d\n", status, errno);
-            Os::Task::delay(SOCKET_RETRY_INTERVAL_MS);
+            (void) Os::Task::delay(SOCKET_RETRY_INTERVAL_MS);
             continue;
         }
 
@@ -83,7 +83,7 @@ void SocketReadTask::readTask(void* pointer) {
         if ((not self->getSocketHandler().isOpened()) and (not self->m_stop) and
             ((status = self->open()) != SOCK_SUCCESS)) {
             Fw::Logger::logMsg("[WARNING] Failed to open port with status %d and errno %d\n", status, errno);
-            Os::Task::delay(SOCKET_RETRY_INTERVAL_MS);
+            (void) Os::Task::delay(SOCKET_RETRY_INTERVAL_MS);
             continue;
         }
 

--- a/Drv/Ip/SocketReadTask.hpp
+++ b/Drv/Ip/SocketReadTask.hpp
@@ -58,7 +58,7 @@ class SocketReadTask {
     /**
      * \brief startup the socket for communications
      *
-     * Startus up the socket handler.
+     * Status of the socket handler.
      *
      * Note: this just delegates to the handler
      *

--- a/Drv/Ip/SocketReadTask.hpp
+++ b/Drv/Ip/SocketReadTask.hpp
@@ -56,6 +56,17 @@ class SocketReadTask {
                          const NATIVE_UINT_TYPE cpuAffinity = Os::Task::TASK_DEFAULT);
 
     /**
+     * \brief startup the socket for communications
+     *
+     * Startus up the socket handler.
+     *
+     * Note: this just delegates to the handler
+     *
+     * \return status of open, SOCK_SUCCESS for success, something else on error
+     */
+    SocketIpStatus startup();
+
+    /**
      * \brief open the socket for communications
      *
      * Typically the socket read task will open the connection and keep it open. However, in cases where the read task
@@ -70,12 +81,24 @@ class SocketReadTask {
     /**
      * \brief close the socket communications
      *
-     * Typically stopping the socket read task will close the connection. However, in cases where the read task
-     * will not be started, this function may be used to close the socket.
+     * Typically stopping the socket read task will shutdown the connection. However, in cases where the read task
+     * will not be started, this function may be used to close the socket. This calls a full `close` on the client
+     * socket.
      *
      * Note: this just delegates to the handler
      */
     void close();
+
+    /**
+     * \brief shutdown the socket communications
+     *
+     * Typically stopping the socket read task will shutdown the connection. However, in cases where the read task
+     * will not be started, this function may be used to close the socket. This calls a full `shutdown` on the client
+     * socket.
+     *
+     * Note: this just delegates to the handler
+     */
+    void shutdown();
 
     /**
      * \brief stop the socket read task and close the associated socket.

--- a/Drv/Ip/TcpClientSocket.hpp
+++ b/Drv/Ip/TcpClientSocket.hpp
@@ -35,21 +35,21 @@ class TcpClientSocket : public IpSocket {
      * \param fd: (output) file descriptor opened. Only valid on SOCK_SUCCESS. Otherwise will be invalid
      * \return status of open
      */
-    SocketIpStatus openProtocol(NATIVE_INT_TYPE& fd);
+    SocketIpStatus openProtocol(NATIVE_INT_TYPE& fd) override;
     /**
      * \brief Protocol specific implementation of send.  Called directly with retry from send.
      * \param data: data to send
      * \param size: size of data to send
      * \return: size of data sent, or -1 on error.
      */
-    I32 sendProtocol(const U8* const data, const U32 size);
+    I32 sendProtocol(const U8* const data, const U32 size) override;
     /**
      * \brief Protocol specific implementation of recv.  Called directly with error handling from recv.
      * \param data: data pointer to fill
      * \param size: size of data buffer
      * \return: size of data received, or -1 on error.
      */
-    I32 recvProtocol( U8* const data, const U32 size);
+    I32 recvProtocol( U8* const data, const U32 size) override;
 };
 }  // namespace Drv
 

--- a/Drv/Ip/TcpClientSocket.hpp
+++ b/Drv/Ip/TcpClientSocket.hpp
@@ -18,7 +18,7 @@
 
 namespace Drv {
 /**
- * \brief Helper for setting up Tcp using Berkley sockets as a client
+ * \brief Helper for setting up Tcp using Berkeley sockets as a client
  *
  * Certain IP headers have conflicting definitions with the m_data member of various types in fprime. TcpClientSocket
  * separates the ip setup from the incoming Fw::Buffer in the primary component class preventing this collision.

--- a/Drv/Ip/TcpServerSocket.cpp
+++ b/Drv/Ip/TcpServerSocket.cpp
@@ -75,9 +75,8 @@ SocketIpStatus TcpServerSocket::startup() {
     this->m_lock.lock();
     m_base_fd = serverFd;
     this->m_lock.unLock();
-    this->IpSocket::startup();
 
-    return SOCK_SUCCESS;
+    return this->IpSocket::startup();
 }
 
 void TcpServerSocket::shutdown() {
@@ -105,7 +104,8 @@ SocketIpStatus TcpServerSocket::openProtocol(NATIVE_INT_TYPE& fd) {
     this->m_lock.unLock();
 
     // TCP requires accepting on a the socket to get the client socket file descriptor.
-    if ((clientFd = ::accept(serverFd, nullptr, nullptr)) < 0) {
+    clientFd = ::accept(serverFd, nullptr, nullptr);
+    if (clientFd < 0) {
         return SOCK_FAILED_TO_ACCEPT; // What we have here is a failure to communicate
     }
     // Setup client send timeouts

--- a/Drv/Ip/TcpServerSocket.cpp
+++ b/Drv/Ip/TcpServerSocket.cpp
@@ -94,6 +94,7 @@ void TcpServerSocket::shutdown() {
 SocketIpStatus TcpServerSocket::openProtocol(NATIVE_INT_TYPE& fd) {
     NATIVE_INT_TYPE clientFd = -1;
     NATIVE_INT_TYPE serverFd = -1;
+
     // Check started before allowing open
     if (not this->isStarted()) {
         return SOCK_NOT_STARTED;

--- a/Drv/Ip/TcpServerSocket.cpp
+++ b/Drv/Ip/TcpServerSocket.cpp
@@ -13,7 +13,6 @@
 #include <Fw/Logger/Logger.hpp>
 #include <FpConfig.hpp>
 
-
 #ifdef TGT_OS_TYPE_VXWORKS
     #include <socket.h>
     #include <inetLib.h>
@@ -44,7 +43,6 @@ SocketIpStatus TcpServerSocket::startup() {
     NATIVE_INT_TYPE serverFd = -1;
     struct sockaddr_in address;
     this->close();
-
     // Acquire a socket, or return error
     if ((serverFd = ::socket(AF_INET, SOCK_STREAM, 0)) == -1) {
         return SOCK_FAILED_TO_GET_SOCKET;
@@ -68,27 +66,45 @@ SocketIpStatus TcpServerSocket::startup() {
         ::close(serverFd);
         return SOCK_FAILED_TO_BIND;
     }
-    m_base_fd = serverFd;
     Fw::Logger::logMsg("Listening for single client at %s:%hu\n", reinterpret_cast<POINTER_CAST>(m_hostname), m_port);
     // TCP requires listening on a the socket. Second argument prevents queueing of anything more than a single client.
     if (::listen(serverFd, 0) < 0) {
         ::close(serverFd);
         return SOCK_FAILED_TO_LISTEN; // What we have here is a failure to communicate
     }
+    this->m_lock.lock();
+    m_base_fd = serverFd;
+    this->m_lock.unLock();
+    this->IpSocket::startup();
+
     return SOCK_SUCCESS;
 }
 
 void TcpServerSocket::shutdown() {
-    (void)::shutdown(this->m_base_fd, SHUT_RDWR);
-    (void)::close(this->m_base_fd);
-    m_base_fd = -1;
-    this->close();
+    this->m_lock.lock();
+    if (this->m_base_fd != -1) {
+        (void)::shutdown(this->m_base_fd, SHUT_RDWR);
+        (void)::close(this->m_base_fd);
+        this->m_base_fd = -1;
+    }
+    this->m_lock.unLock();
+    this->IpSocket::shutdown();
 }
 
 SocketIpStatus TcpServerSocket::openProtocol(NATIVE_INT_TYPE& fd) {
     NATIVE_INT_TYPE clientFd = -1;
+    NATIVE_INT_TYPE serverFd = -1;
+    // Check started before allowing open
+    if (not this->isStarted()) {
+        return SOCK_NOT_STARTED;
+    }
+
+    this->m_lock.lock();
+    serverFd = this->m_base_fd;
+    this->m_lock.unLock();
+
     // TCP requires accepting on a the socket to get the client socket file descriptor.
-    if ((clientFd = ::accept(m_base_fd, nullptr, nullptr)) < 0) {
+    if ((clientFd = ::accept(serverFd, nullptr, nullptr)) < 0) {
         return SOCK_FAILED_TO_ACCEPT; // What we have here is a failure to communicate
     }
     // Setup client send timeouts
@@ -96,6 +112,7 @@ SocketIpStatus TcpServerSocket::openProtocol(NATIVE_INT_TYPE& fd) {
         ::close(clientFd);
         return SOCK_FAILED_TO_SET_SOCKET_OPTIONS;
     }
+
     Fw::Logger::logMsg("Accepted client at %s:%hu\n", reinterpret_cast<POINTER_CAST>(m_hostname), m_port);
     fd = clientFd;
     return SOCK_SUCCESS;

--- a/Drv/Ip/TcpServerSocket.hpp
+++ b/Drv/Ip/TcpServerSocket.hpp
@@ -38,14 +38,15 @@ class TcpServerSocket : public IpSocket {
      * connect. This call does not block, block occurs on `open` while waiting to accept incoming clients.
      * \return status of the server socket setup.
      */
-    SocketIpStatus startup();
+    SocketIpStatus startup() override;
 
     /**
-     * \brief Shutdown client socket, and listening server socket
+     * \brief Shutdown and close the server socket followed by the open client
      *
-     *
+     * First, this calls `shutdown` and `close` on the server socket and then calls the close method to `shutdown` and
+     * `close` the client.
      */
-    void shutdown();
+    void shutdown() override;
 
   PROTECTED:
     /**
@@ -53,21 +54,21 @@ class TcpServerSocket : public IpSocket {
      * \param fd: (output) file descriptor opened. Only valid on SOCK_SUCCESS. Otherwise will be invalid
      * \return status of open
      */
-    SocketIpStatus openProtocol(NATIVE_INT_TYPE& fd);
+    SocketIpStatus openProtocol(NATIVE_INT_TYPE& fd) override;
     /**
      * \brief Protocol specific implementation of send.  Called directly with retry from send.
      * \param data: data to send
      * \param size: size of data to send
      * \return: size of data sent, or -1 on error.
      */
-    I32 sendProtocol(const U8* const data, const U32 size);
+    I32 sendProtocol(const U8* const data, const U32 size) override;
     /**
      * \brief Protocol specific implementation of recv.  Called directly with error handling from recv.
      * \param data: data pointer to fill
      * \param size: size of data buffer
      * \return: size of data received, or -1 on error.
      */
-    I32 recvProtocol( U8* const data, const U32 size);
+    I32 recvProtocol( U8* const data, const U32 size) override;
   private:
     NATIVE_INT_TYPE m_base_fd; //!< File descriptor of the listening socket
 };

--- a/Drv/Ip/TcpServerSocket.hpp
+++ b/Drv/Ip/TcpServerSocket.hpp
@@ -18,7 +18,7 @@
 
 namespace Drv {
 /**
- * \brief Helper for setting up Tcp using Berkley sockets as a server
+ * \brief Helper for setting up Tcp using Berkeley sockets as a server
  *
  * Certain IP headers have conflicting definitions with the m_data member of various types in fprime. TcpServerSocket
  * separates the ip setup from the incoming Fw::Buffer in the primary component class preventing this collision.

--- a/Drv/Ip/UdpSocket.hpp
+++ b/Drv/Ip/UdpSocket.hpp
@@ -24,7 +24,7 @@ namespace Drv {
 struct SocketState;
 
 /**
- * \brief Helper for setting up Udp using Berkley sockets as a client
+ * \brief Helper for setting up Udp using Berkeley sockets as a client
  *
  * Certain IP headers have conflicting definitions with the m_data member of various types in fprime. UdpSocket
  * separates the ip setup from the incoming Fw::Buffer in the primary component class preventing this collision.

--- a/Drv/Ip/docs/sdd.md
+++ b/Drv/Ip/docs/sdd.md
@@ -1,7 +1,7 @@
 \page DrvIp Drv::Ip IPv4 Socket Implementations
 # Drv::Ip IPv4 Socket Implementations
 
-This package contains utility classes to help interact with standard IPv4 (Berkley) sockets. These classes implement the
+This package contains utility classes to help interact with standard IPv4 (Berkeley) sockets. These classes implement the
 core features of IPv4. This includes a tcp server socket (Drv::TcpServerSocket), a tcp client socket (Drv::TcpClient)
 and a udp socket (Drv::UdpSocket).  These are not F´ components, but an F´ component wrapper of each exists:
 Drv::TcpClientComponent,  Drv::TcpServerComponent, and Drv::UdpComponent.
@@ -28,7 +28,7 @@ Each of these classes is explained in more detail below.
 
 The Drv::IpSocket class represents the external interface to IPv4 socket components. This class provides a top-level
 interface to IPv4 sockets for connecting, disconnecting, sending, and receiving  using the socket. This implements the
-IPv4 socket protocol as provided by the unix (Berkley) sockets implementation.
+IPv4 socket protocol as provided by the unix (Berkeley) sockets implementation.
 
 High-level interfaces are provided for the standard functions of: `open`, `close`, `send`, and `recv`.  FramingProtocol and
 implementation specific functionality are implemented in derived classes by implementing the pure virtual functions:

--- a/Drv/Ip/test/ut/SocketTestHelper.cpp
+++ b/Drv/Ip/test/ut/SocketTestHelper.cpp
@@ -70,5 +70,15 @@ bool wait_on_change(Drv::IpSocket &socket, bool open, U32 iterations) {
     return false;
 }
 
+bool wait_on_started(Drv::IpSocket &socket, bool open, U32 iterations) {
+    for (U32 i = 0; i < iterations; i++) {
+        if (open == socket.isStarted()) {
+            return true;
+        }
+        Os::Task::delay(10);
+    }
+    return false;
+}
+
 };
 };

--- a/Drv/Ip/test/ut/SocketTestHelper.hpp
+++ b/Drv/Ip/test/ut/SocketTestHelper.hpp
@@ -60,6 +60,11 @@ void send_recv(Drv::IpSocket& sender, Drv::IpSocket& receiver);
  */
 bool wait_on_change(Drv::IpSocket &socket, bool open, U32 iterations);
 
+/**
+ * Wait on started
+*/
+bool wait_on_started(Drv::IpSocket &socket, bool open, U32 iterations);
+
 };
 };
 #endif

--- a/Drv/Ip/test/ut/TestTcp.cpp
+++ b/Drv/Ip/test/ut/TestTcp.cpp
@@ -21,7 +21,7 @@ void test_with_loop(U32 iterations) {
     ASSERT_NE(0, port);
     Drv::TcpServerSocket server;
     server.configure("127.0.0.1", port, 0, 100);
-    server.startup();
+    EXPECT_EQ(server.startup(), Drv::SOCK_SUCCESS);
     Drv::Test::force_recv_timeout(server);
 
     // Loop through a bunch of client disconnects

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -33,14 +33,6 @@ SocketIpStatus TcpServerComponentImpl::configure(const char* hostname,
 
 TcpServerComponentImpl::~TcpServerComponentImpl() {}
 
-SocketIpStatus TcpServerComponentImpl::startup() {
-    return  this->m_socket.startup();
-}
-
-void TcpServerComponentImpl::shutdown() {
-    this->m_socket.shutdown();
-}
-
 // ----------------------------------------------------------------------
 // Implementations for socket read task virtual methods
 // ----------------------------------------------------------------------

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -61,25 +61,6 @@ class TcpServerComponentImpl : public TcpServerComponentBase, public SocketReadT
                              const U16 port,
                              const U32 send_timeout_seconds = SOCKET_SEND_TIMEOUT_SECONDS,
                              const U32 send_timeout_microseconds = SOCKET_SEND_TIMEOUT_MICROSECONDS);
-    /**
-     * \brief startup the TcpServer
-     *
-     * This will launch the TcpServer's internal tcp connection, bind to the port, and listen. This call will *not*
-     * block, nor does it accept incoming connections. It configures the port to listen and then returns. In order to
-     * accept incoming connections the `open` call must be made.  Only when the startup method returns SOCK_SUCCESS has
-     * the server successfully bound to the port/
-     *
-     * \return status of startup. SOCK_SUCCESS on success, something else on error.
-     */
-    SocketIpStatus startup();
-
-    /**
-     * \brief shutdown the TcpServer
-     *
-     * This will shutdown the TcpServer including closing any active client connections, and then closing the listening
-     * port of this server.
-     */
-    void shutdown();
 
   PROTECTED:
     // ----------------------------------------------------------------------

--- a/Drv/TcpServer/test/ut/TcpServerTester.cpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.cpp
@@ -33,14 +33,17 @@ void TcpServerTester ::test_with_loop(U32 iterations, bool recv_thread) {
     ASSERT_NE(0, port);
 
     this->component.configure("127.0.0.1", port, 0, 100);
-    serverStat = this->component.startup();
-    EXPECT_EQ(serverStat, SOCK_SUCCESS);
 
     // Start up a receive thread
     if (recv_thread) {
         Os::TaskString name("receiver thread");
         this->component.startSocketTask(name, true, Os::Task::TASK_DEFAULT, Os::Task::TASK_DEFAULT);
+        EXPECT_TRUE(Drv::Test::wait_on_started(this->component.getSocketHandler(), true, SOCKET_RETRY_INTERVAL_MS/10 + 1));
+    } else {
+        serverStat = this->component.startup();
+        EXPECT_EQ(serverStat, SOCK_SUCCESS);
     }
+    EXPECT_TRUE(component.getSocketHandler().isStarted());
 
     // Loop through a bunch of client disconnects
     for (U32 i = 0; i < iterations && serverStat == SOCK_SUCCESS; i++) {

--- a/Ref/Top/CMakeLists.txt
+++ b/Ref/Top/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MOD_DEPS
   # Communication Implementations
   Drv/Udp
   Drv/TcpClient
+  Drv/TcpServer
 )
 
 register_fprime_module()


### PR DESCRIPTION
…try step

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Briefly, fixes the `TcpServer` such that it will retry both the `listen` and `accept` steps not just the accept step.

More in-depth:

Sockets originally were implemented with `open` and `close` steps.  However, some sockets (like the TcpServer) needed to have `startup` and `showdown` steps too.  This was patched in directly to this socket, which meant that retries on generic sockets didn't handle this case.

This PR adds:
1. `startup` and `shutdown` methods generically to all sockets (with the default being no-op)
2. `isStarted` method to check status
3. Retry start up in the read loop if not started.





