### PR TITLE
Fixing undefined behavior in lib CRC

### DIFF
--- a/Utils/Hash/libcrc/lib_crc.c
+++ b/Utils/Hash/libcrc/lib_crc.c
@@ -194,7 +194,9 @@ unsigned short update_crc_16( unsigned short crc, char c ) {
     if ( ! crc_tab16_init ) init_crc16_tab();
 
     tmp =  crc       ^ short_c;
-    crc = (crc >> 8) ^ crc_tab16[ tmp & 0xff ];
+    // Note: when masking by 0xff, range is limited to unsigned char
+    //       which fits within unsigned int.
+    crc = (crc >> 8) ^ crc_tab16[ (unsigned int)(tmp & 0xff) ];
 
     return crc;
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

A lack of casting in libcrc tripped the undefined behavior and address sanitizers when running `update_crc_16`.  This occurs when the result is `-1` and passed as an index. By forcing a cast to `unsigned int`, the index should be guided back into a non-negative range.

## Future Work

We should search for and possible baseline a flight-quality implementation of CRCs/