### PR TITLE
Add nav bar 3/3: add _includes/toc.md

### DIFF
--- a/docs/_includes/toc.md
+++ b/docs/_includes/toc.md
@@ -1,25 +1,17 @@
 
-<details>
-  <summary><a href="/fprime/INSTALL.html">Install</a></summary>
+<h4><a href="/fprime/INSTALL.html">Getting Started</a></h4>
+  <ul>
+    <!-- empty list for consistent spacing between items -->
+  </ul>
+<h4><a href="/fprime/Tutorials/README.html">Tutorials</a></h4>
     <ul>
-      <li><a href="/fprime/INSTALL.html">Installing F´</a></li>
-      <li><a href="/fprime/UsersGuide/user/autocomplete.html">Installing F´ Console Autocomplete</a></li>
+      <li><a href="https://fprime-community.github.io/fprime-tutorial-hello-world/">HelloWorld</a></li>
+      <li><a href="https://fprime-community.github.io/fprime-workshop-led-blinker/">LedBlinker</a></li>
+      <li><a href="https://fprime-community.github.io/fprime-tutorial-math-component/">MathComponent</a></li>
+      <li><a href="/fprime/Tutorials/CrossCompilationSetup/">Cross-Compilation Setup Tutorial</a></li>
+      <li><a href="https://fprime-community.github.io/fprime-tutorial-arduino-blinker/">Arduino LedBlinker</a></li>
     </ul>
-</details>
-
-<details>
-  <summary><a href="/fprime/Tutorials/README.html">Tutorials</a></summary>
-    <ul>
-      <li><a href="https://fprime-community.github.io/fprime-tutorial-hello-world/">HelloWorld</a>: An Introduction to F´</li>
-      <li><a href="https://fprime-community.github.io/fprime-workshop-led-blinker/">LedBlinker</a>: F´ and Embedded Hardware</li>
-      <li><a href="https://fprime-community.github.io/fprime-tutorial-math-component/">MathComponent</a>: Custom Ports and Types</li>
-      <li><a href="/fprime/Tutorials/CrossCompilationSetup/">Cross-Compilation Setup Tutorial</a>: Set up a cross-compilation environment</li>
-      <li><a href="https://fprime-community.github.io/fprime-tutorial-arduino-blinker/">Arduino LedBlinker</a>: Cross-Compile LedBlinker for Arduinos</li>
-    </ul>
-</details>
-
-<details>
-  <summary><a href="/fprime/UsersGuide/guide.html">User Guide</a></summary>
+<h4><a href="/fprime/UsersGuide/guide.html">User Guide</a></h4>
     <ul>
         <li>
           <details>
@@ -111,11 +103,8 @@
           </details>
         </li>
     </ul>
-</details>
-<details>
-  <summary><a href="/fprime/Design/general.html">Design and Philosophy</a></summary>
-    <ul>
-      <li><a href="/fprime/Design/numerical-types.html">Numerical Types Design</a></li>
-      <li><a href="/fprime/Design/communication-adapter-interface.html">Communication Adapter Interface</a></li>
-    </ul>
-</details>
+<h4><a href="/fprime/Design/general.html">Design and Philosophy</a></h4>
+      <ul>
+        <li><a href="/fprime/Design/numerical-types.html">Numerical Types Design</a></li>
+        <li><a href="/fprime/Design/communication-adapter-interface.html">Communication Adapter Interface</a></li>
+      </ul>

--- a/docs/_includes/toc.md
+++ b/docs/_includes/toc.md
@@ -1,0 +1,121 @@
+
+<details>
+  <summary><a href="/fprime/INSTALL.html">Install</a></summary>
+    <ul>
+      <li><a href="/fprime/INSTALL.html">Installing F´</a></li>
+      <li><a href="/fprime/UsersGuide/user/autocomplete.html">Installing F´ Console Autocomplete</a></li>
+    </ul>
+</details>
+
+<details>
+  <summary><a href="/fprime/Tutorials/README.html">Tutorials</a></summary>
+    <ul>
+      <li><a href="https://fprime-community.github.io/fprime-tutorial-hello-world/">HelloWorld</a>: An Introduction to F´</li>
+      <li><a href="https://fprime-community.github.io/fprime-workshop-led-blinker/">LedBlinker</a>: F´ and Embedded Hardware</li>
+      <li><a href="https://fprime-community.github.io/fprime-tutorial-math-component/">MathComponent</a>: Custom Ports and Types</li>
+      <li><a href="/fprime/Tutorials/CrossCompilationSetup/">Cross-Compilation Setup Tutorial</a>: Set up a cross-compilation environment</li>
+      <li><a href="https://fprime-community.github.io/fprime-tutorial-arduino-blinker/">Arduino LedBlinker</a>: Cross-Compile LedBlinker for Arduinos</li>
+    </ul>
+</details>
+
+<details>
+  <summary><a href="/fprime/UsersGuide/guide.html">User Guide</a></summary>
+    <ul>
+        <li>
+          <details>
+            <summary>Getting Started with F´</summary>
+              <ul>
+                <li><a href="/fprime/">What is F´: a brief introduction</a></li>
+                <li><a href="/fprime/INSTALL.html">Installing F´</a></li>
+                <li><a href="/fprime/UsersGuide/user/autocomplete.html">Installing F´ Console Autocomplete</a></li>
+                <li><a href="/fprime/Tutorials/README.html">Tutorials: A Hands On Guide to F´</a></li>
+              </ul>
+          </details>
+        </li>
+        <li>
+          <details>
+            <summary>F´ Users Manual: an in-depth description of F´ concepts</summary>
+              <ul>
+                <li><a href="/fprime/UsersGuide/user/full-intro.html">A More Complete Introduction to F´</a></li>
+                <li><a href="/fprime/UsersGuide/user/proj-dep.html">Projects and Deployments</a></li>
+                <li><a href="/fprime/UsersGuide/user/port-comp-top.html">Core Constructs: Ports, Components, and Topologies</a></li>
+                <li><a href="/fprime/UsersGuide/user/enum-arr-ser.html">Data Types and Data Structures: Primitive Types, Enums, Arrays, and Serializables</a></li>
+                <li><a href="/fprime/UsersGuide/user/cmd-evt-chn-prm.html">Data Constructs: Commands, Events, Channels, and Parameters</a></li>
+                <li><a href="/fprime/UsersGuide/user/unit-testing.html">Unit Testing F´ Components</a></li>
+              </ul>
+          </details>
+        </li>
+        <li>
+          <details>
+            <summary>F´ Best Practices: helpful patterns when developing F´ software</summary>
+              <ul>
+                <li><a href="/fprime/UsersGuide/best/development-practice.html">F´ Development Process</a></li>
+                <li><a href="/fprime/UsersGuide/best/app-man-drv.html">Application, Manager, Driver Pattern</a></li>
+                <li><a href="/fprime/UsersGuide/best/ground-interface.html">Ground Interface</a></li>
+                <li><a href="/fprime/UsersGuide/best/rate-group.html">Rate Groups and Timeliness</a></li>
+                <li><a href="/fprime/UsersGuide/best/dynamic-memory.html">Dynamic Memory and Buffer Management</a></li>
+                <li><a href="/fprime/UsersGuide/best/hub-pattern.html">A Quick Look at the Hub Pattern</a></li>
+                <li><a href="/fprime/UsersGuide/best/documentation.html">Documenting F´ Projects</a></li>
+                <li><a href="/fprime/UsersGuide/dev/code-style.html">Code and Style Guidelines</a></li>
+              </ul>
+          </details>
+        </li>
+        <li>
+          <details>
+            <summary>F´ Ground Data System Tools (GDS)</summary>
+              <ul>
+                <li><a href="/fprime/UsersGuide/gds/gds-introduction.html">A Brief Guide to the F´ Ground Data System</a></li>
+                <li><a href="/fprime/UsersGuide/gds/gds-cli.html">The Discerning User’s Guide to the F´ GDS CLI</a></li>
+                <li><a href="/fprime/UsersGuide/gds/gds-custom-dashboards.html">The GDS Dashboard</a></li>
+                <li><a href="/fprime/UsersGuide/gds/seqgen.html">Sequencing in F´</a></li>
+              </ul>
+          </details>
+        </li>
+        <li>
+          <details>
+            <summary>Full Development Guides: technical details for full F´ implementations</summary>
+              <ul>
+                <li><a href="/fprime/UsersGuide/dev/configuring-fprime.html">Configuring F´</a></li>
+                <li><a href="/fprime/UsersGuide/user/fpp-user-guide.html">F´ Modeling with FPP</a></li>
+                <li><a href="/fprime/UsersGuide/dev/source-tree.html">A Tour of the Source Tree</a></li>
+                <li><a href="/fprime/UsersGuide/dev/xml-specification.html">F´ XML Specifications</a></li>
+                <li><a href="/fprime/UsersGuide/dev/implementation.html">F´ Implementation Classes</a></li>
+                <li><a href="/fprime/UsersGuide/dev/building-topology.html">Constructing the F´ Topology</a></li>
+                <li><a href="/fprime/UsersGuide/dev/assert.html">Asserts in F´</a></li>
+                <li><a href="/fprime/UsersGuide/dev/gds-dashboard-reference.html">GDS Dashboard Reference</a></li>
+                <li><a href="/fprime/UsersGuide/dev/testAPI/user_guide.html">Integration Test API</a></li>
+                <li><a href="/fprime/UsersGuide/user/v3-migration-guide.html">v3 Migration Guide</a></li>
+              </ul>
+          </details>
+        </li>
+        <li>
+          <details>
+            <summary>Advanced F´ Topics:</summary>
+              <ul>
+                <li><a href="/fprime/UsersGuide/dev/py-dev.html">F´ Python Guidelines</a></li>
+                <li><a href="/fprime/UsersGuide/dev/porting-guide.html">Porting F´ To a New Platform</a></li>
+                <li><a href="/fprime/UsersGuide/dev/baremetal-multicore.html">F´ On Baremetal and Multi-Core Systems</a></li>
+                <li><a href="/fprime/UsersGuide/dev/configure-ide.html">Configuring an IDE for Use With F´</a></li>
+                <li><a href="/fprime/UsersGuide/dev/os-docs.html">OS Layer Description</a></li>
+              </ul>
+          </details>
+        </li>
+        <li>
+          <details>
+            <summary>API Documentation</summary>
+              <ul>
+                <li><a href="/fprime/UsersGuide/dev/gds-cli-dev.html">GDS CLI Design</a></li>
+                <li><a href="./api/c++/html/index.html">C++ Documentation</a></li>
+                <li><a href="./api/cmake/API.html">CMake User API</a></li>
+              </ul>
+          </details>
+        </li>
+    </ul>
+</details>
+<details>
+  <summary><a href="/fprime/Design/general.html">Design and Philosophy</a></summary>
+    <ul>
+      <li><a href="/fprime/Design/numerical-types.html">Numerical Types Design</a></li>
+      <li><a href="/fprime/Design/communication-adapter-interface.html">Communication Adapter Interface</a></li>
+    </ul>
+</details>


### PR DESCRIPTION
| | |
|:---|:---|
|**_Christian Sears_**| |
|**_docs_**|  |
|**_Affected Architectures(s)_**|  |
|**_#2100_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y)_**|  |

---
## Change Description

This PR creates a new directory and file within that dir: _includes/toc.md. The file gets referenced in the updated default.html, in the fprime-theme repo. toc.md contains the actual contents of the nav bar. In the future, when y'all need to add/remove items in the nav bar, you can use this file to do so.

## Rationale

Per issue #2100, this is 3/3 pull requests that, if merged, will add a nav bar to the F' site, like the one shown here:   (The other 2 PRs are for the fprime-theme repo.) This might be obvious but if you accept this PR, _please merge this one last_ since doing so will trigger a run of `pages build and deployment`.

## Testing/Review Recommendations

Since this simply adds a new file and dir, which aren't referenced anywhere else in this repo, I don't think it can really cause any issues. I'd recommend taking a closer look at my PRs to the fprime-theme, repo, and reviewing the affect of those changes, again, by checking out my fork's site here: https://chr1st1ansears.github.io/fprime/

## Future Work

I noticed that your pages for the tutorials seem to exist in another repo, and they don't reference fprime-community/fprime-theme/_layouts/default.html. So to get the nav bar to appear on those pages, a reference to that default.html file will need to be added to the tutorials' MD files. Also, this is super specific, but if you visit certain pages on a phone, like the Numerical Types Design page, then the formatting gets messed up, whether you have my nav bar added or not. It seems to have something to do with the tables. So that also might be worth looking into down the road.  
