### PR TITLE
Table of Contents update

### DIFF
--- a/docs/_includes/toc.md
+++ b/docs/_includes/toc.md
@@ -1,15 +1,15 @@
 <h4><a href="/fprime/INSTALL.html">Getting Started</a></h4>
-<ul>
-  <!-- empty list for consistent spacing between items -->
-</ul>
+  <ul>
+    <!-- empty list for consistent spacing between items -->
+  </ul>
 <h4><a href="/fprime/Tutorials/README.html">Tutorials</a></h4>
-<ul>
-  <li><a href="https://fprime-community.github.io/fprime-tutorial-hello-world/">HelloWorld</a></li>
-  <li><a href="https://fprime-community.github.io/fprime-workshop-led-blinker/">LedBlinker</a></li>
-  <li><a href="https://fprime-community.github.io/fprime-tutorial-math-component/">MathComponent</a></li>
-  <li><a href="/fprime/Tutorials/CrossCompilationSetup/">Cross-Compilation Setup Tutorial</a></li>
-  <li><a href="https://fprime-community.github.io/fprime-tutorial-arduino-blinker/">Arduino LedBlinker</a></li>
-</ul>
+  <ul>
+    <li><a href="https://fprime-community.github.io/fprime-tutorial-hello-world/">HelloWorld</a></li>
+    <li><a href="https://fprime-community.github.io/fprime-workshop-led-blinker/">LedBlinker</a></li>
+    <li><a href="https://fprime-community.github.io/fprime-tutorial-math-component/">MathComponent</a></li>
+    <li><a href="/fprime/Tutorials/CrossCompilationSetup/">Cross-Compilation Setup Tutorial</a></li>
+    <li><a href="https://fprime-community.github.io/fprime-tutorial-arduino-blinker/">Arduino LedBlinker</a></li>
+  </ul>
 <h4><a href="/fprime/UsersGuide/guide.html">User Guide</a></h4>
   <ul>
     <details>

--- a/docs/_includes/toc.md
+++ b/docs/_includes/toc.md
@@ -11,88 +11,88 @@
   <li><a href="https://fprime-community.github.io/fprime-tutorial-arduino-blinker/">Arduino LedBlinker</a></li>
 </ul>
 <h4><a href="/fprime/UsersGuide/guide.html">User Guide</a></h4>
-<ul>
-  <details>
-    <summary>Getting Started with F´</summary>
-    <ul>
-      <li><a href="/fprime/">What is F´: a brief introduction</a></li>
-      <li><a href="/fprime/INSTALL.html">Installing F´</a></li>
-      <li><a href="/fprime/UsersGuide/user/autocomplete.html">Installing F´ Console Autocomplete</a></li>
-      <li><a href="/fprime/Tutorials/README.html">Tutorials: A Hands On Guide to F´</a></li>
-    </ul>
-  </details>
-  <details>
-    <summary>F´ Users Manual</summary>
-    <ul>
-      <li><a href="/fprime/UsersGuide/user/full-intro.html">A More Complete Introduction to F´</a></li>
-      <li><a href="/fprime/UsersGuide/user/proj-dep.html">Projects and Deployments</a></li>
-      <li><a href="/fprime/UsersGuide/user/port-comp-top.html">Core Constructs: Ports, Components, and Topologies</a>
-      </li>
-      <li><a href="/fprime/UsersGuide/user/enum-arr-ser.html">Data Types and Data Structures: Primitive Types, Enums,
-          Arrays, and Serializables</a></li>
-      <li><a href="/fprime/UsersGuide/user/cmd-evt-chn-prm.html">Data Constructs: Commands, Events, Channels, and
-          Parameters</a></li>
-      <li><a href="/fprime/UsersGuide/user/unit-testing.html">Unit Testing F´ Components</a></li>
-    </ul>
-  </details>
-  <details>
-    <summary>F´ Best Practices</summary>
-    <ul>
-      <li><a href="/fprime/UsersGuide/best/development-practice.html">F´ Development Process</a></li>
-      <li><a href="/fprime/UsersGuide/best/app-man-drv.html">Application, Manager, Driver Pattern</a></li>
-      <li><a href="/fprime/UsersGuide/best/ground-interface.html">Ground Interface</a></li>
-      <li><a href="/fprime/UsersGuide/best/rate-group.html">Rate Groups and Timeliness</a></li>
-      <li><a href="/fprime/UsersGuide/best/dynamic-memory.html">Dynamic Memory and Buffer Management</a></li>
-      <li><a href="/fprime/UsersGuide/best/hub-pattern.html">A Quick Look at the Hub Pattern</a></li>
-      <li><a href="/fprime/UsersGuide/best/documentation.html">Documenting F´ Projects</a></li>
-      <li><a href="/fprime/UsersGuide/dev/code-style.html">Code and Style Guidelines</a></li>
-    </ul>
-  </details>
-  <details>
-    <summary>F´ Ground Data System (GDS)</summary>
-    <ul>
-      <li><a href="/fprime/UsersGuide/gds/gds-introduction.html">A Brief Guide to the F´ Ground Data System</a></li>
-      <li><a href="/fprime/UsersGuide/gds/gds-cli.html">The Discerning User’s Guide to the F´ GDS CLI</a></li>
-      <li><a href="/fprime/UsersGuide/gds/gds-custom-dashboards.html">The GDS Dashboard</a></li>
-      <li><a href="/fprime/UsersGuide/gds/seqgen.html">Sequencing in F´</a></li>
-    </ul>
-  </details>
-  <details>
-    <summary>Full Development Guides</summary>
-    <ul>
-      <li><a href="/fprime/UsersGuide/dev/configuring-fprime.html">Configuring F´</a></li>
-      <li><a href="/fprime/UsersGuide/user/fpp-user-guide.html">F´ Modeling with FPP</a></li>
-      <li><a href="/fprime/UsersGuide/dev/source-tree.html">A Tour of the Source Tree</a></li>
-      <li><a href="/fprime/UsersGuide/dev/xml-specification.html">F´ XML Specifications</a></li>
-      <li><a href="/fprime/UsersGuide/dev/implementation.html">F´ Implementation Classes</a></li>
-      <li><a href="/fprime/UsersGuide/dev/building-topology.html">Constructing the F´ Topology</a></li>
-      <li><a href="/fprime/UsersGuide/dev/assert.html">Asserts in F´</a></li>
-      <li><a href="/fprime/UsersGuide/dev/gds-dashboard-reference.html">GDS Dashboard Reference</a></li>
-      <li><a href="/fprime/UsersGuide/dev/testAPI/user_guide.html">Integration Test API</a></li>
-      <li><a href="/fprime/UsersGuide/user/v3-migration-guide.html">v3 Migration Guide</a></li>
-    </ul>
-  </details>
-  <details>
-    <summary>Advanced F´ Topics</summary>
-    <ul>
-      <li><a href="/fprime/UsersGuide/dev/py-dev.html">F´ Python Guidelines</a></li>
-      <li><a href="/fprime/UsersGuide/dev/porting-guide.html">Porting F´ To a New Platform</a></li>
-      <li><a href="/fprime/UsersGuide/dev/baremetal-multicore.html">F´ On Baremetal and Multi-Core Systems</a></li>
-      <li><a href="/fprime/UsersGuide/dev/configure-ide.html">Configuring an IDE for Use With F´</a></li>
-      <li><a href="/fprime/UsersGuide/dev/os-docs.html">OS Layer Description</a></li>
-    </ul>
-  </details>
-  <details>
-    <summary>API Documentation</summary>
-    <ul>
-      <li><a href="/fprime/UsersGuide/dev/gds-cli-dev.html">GDS CLI Design</a></li>
-      <li><a href="./api/c++/html/index.html">C++ Documentation</a></li>
-      <li><a href="./api/cmake/API.html">CMake User API</a></li>
-    </ul>
-  </details>
-</ul>
+  <ul>
+    <details>
+      <summary>Getting Started with F´</summary>
+      <ul>
+        <li><a href="/fprime/">What is F´: a brief introduction</a></li>
+        <li><a href="/fprime/INSTALL.html">Installing F´</a></li>
+        <li><a href="/fprime/UsersGuide/user/autocomplete.html">Installing F´ Console Autocomplete</a></li>
+        <li><a href="/fprime/Tutorials/README.html">Tutorials: A Hands On Guide to F´</a></li>
+      </ul>
+    </details>
+    <details>
+      <summary>F´ Users Manual</summary>
+      <ul>
+        <li><a href="/fprime/UsersGuide/user/full-intro.html">A More Complete Introduction to F´</a></li>
+        <li><a href="/fprime/UsersGuide/user/proj-dep.html">Projects and Deployments</a></li>
+        <li><a href="/fprime/UsersGuide/user/port-comp-top.html">Core Constructs: Ports, Components, and Topologies</a>
+        </li>
+        <li><a href="/fprime/UsersGuide/user/enum-arr-ser.html">Data Types and Data Structures: Primitive Types, Enums,
+            Arrays, and Serializables</a></li>
+        <li><a href="/fprime/UsersGuide/user/cmd-evt-chn-prm.html">Data Constructs: Commands, Events, Channels, and
+            Parameters</a></li>
+        <li><a href="/fprime/UsersGuide/user/unit-testing.html">Unit Testing F´ Components</a></li>
+      </ul>
+    </details>
+    <details>
+      <summary>F´ Best Practices</summary>
+      <ul>
+        <li><a href="/fprime/UsersGuide/best/development-practice.html">F´ Development Process</a></li>
+        <li><a href="/fprime/UsersGuide/best/app-man-drv.html">Application, Manager, Driver Pattern</a></li>
+        <li><a href="/fprime/UsersGuide/best/ground-interface.html">Ground Interface</a></li>
+        <li><a href="/fprime/UsersGuide/best/rate-group.html">Rate Groups and Timeliness</a></li>
+        <li><a href="/fprime/UsersGuide/best/dynamic-memory.html">Dynamic Memory and Buffer Management</a></li>
+        <li><a href="/fprime/UsersGuide/best/hub-pattern.html">A Quick Look at the Hub Pattern</a></li>
+        <li><a href="/fprime/UsersGuide/best/documentation.html">Documenting F´ Projects</a></li>
+        <li><a href="/fprime/UsersGuide/dev/code-style.html">Code and Style Guidelines</a></li>
+      </ul>
+    </details>
+    <details>
+      <summary>F´ Ground Data System (GDS)</summary>
+      <ul>
+        <li><a href="/fprime/UsersGuide/gds/gds-introduction.html">A Brief Guide to the F´ Ground Data System</a></li>
+        <li><a href="/fprime/UsersGuide/gds/gds-cli.html">The Discerning User’s Guide to the F´ GDS CLI</a></li>
+        <li><a href="/fprime/UsersGuide/gds/gds-custom-dashboards.html">The GDS Dashboard</a></li>
+        <li><a href="/fprime/UsersGuide/gds/seqgen.html">Sequencing in F´</a></li>
+      </ul>
+    </details>
+    <details>
+      <summary>Full Development Guides</summary>
+      <ul>
+        <li><a href="/fprime/UsersGuide/dev/configuring-fprime.html">Configuring F´</a></li>
+        <li><a href="/fprime/UsersGuide/user/fpp-user-guide.html">F´ Modeling with FPP</a></li>
+        <li><a href="/fprime/UsersGuide/dev/source-tree.html">A Tour of the Source Tree</a></li>
+        <li><a href="/fprime/UsersGuide/dev/xml-specification.html">F´ XML Specifications</a></li>
+        <li><a href="/fprime/UsersGuide/dev/implementation.html">F´ Implementation Classes</a></li>
+        <li><a href="/fprime/UsersGuide/dev/building-topology.html">Constructing the F´ Topology</a></li>
+        <li><a href="/fprime/UsersGuide/dev/assert.html">Asserts in F´</a></li>
+        <li><a href="/fprime/UsersGuide/dev/gds-dashboard-reference.html">GDS Dashboard Reference</a></li>
+        <li><a href="/fprime/UsersGuide/dev/testAPI/user_guide.html">Integration Test API</a></li>
+        <li><a href="/fprime/UsersGuide/user/v3-migration-guide.html">v3 Migration Guide</a></li>
+      </ul>
+    </details>
+    <details>
+      <summary>Advanced F´ Topics</summary>
+      <ul>
+        <li><a href="/fprime/UsersGuide/dev/py-dev.html">F´ Python Guidelines</a></li>
+        <li><a href="/fprime/UsersGuide/dev/porting-guide.html">Porting F´ To a New Platform</a></li>
+        <li><a href="/fprime/UsersGuide/dev/baremetal-multicore.html">F´ On Baremetal and Multi-Core Systems</a></li>
+        <li><a href="/fprime/UsersGuide/dev/configure-ide.html">Configuring an IDE for Use With F´</a></li>
+        <li><a href="/fprime/UsersGuide/dev/os-docs.html">OS Layer Description</a></li>
+      </ul>
+    </details>
+    <details>
+      <summary>API Documentation</summary>
+      <ul>
+        <li><a href="/fprime/UsersGuide/dev/gds-cli-dev.html">GDS CLI Design</a></li>
+        <li><a href="./api/c++/html/index.html">C++ Documentation</a></li>
+        <li><a href="./api/cmake/API.html">CMake User API</a></li>
+      </ul>
+    </details>
+  </ul>
 <h4><a href="/fprime/Design/general.html">Design and Philosophy</a></h4>
-<ul>
-  <li><a href="/fprime/Design/numerical-types.html">Numerical Types Design</a></li>
-  <li><a href="/fprime/Design/communication-adapter-interface.html">Communication Adapter Interface</a></li>
-</ul>
+  <ul>
+    <li><a href="/fprime/Design/numerical-types.html">Numerical Types Design</a></li>
+    <li><a href="/fprime/Design/communication-adapter-interface.html">Communication Adapter Interface</a></li>
+  </ul>

--- a/docs/_includes/toc.md
+++ b/docs/_includes/toc.md
@@ -1,110 +1,98 @@
-
 <h4><a href="/fprime/INSTALL.html">Getting Started</a></h4>
-  <ul>
-    <!-- empty list for consistent spacing between items -->
-  </ul>
+<ul>
+  <!-- empty list for consistent spacing between items -->
+</ul>
 <h4><a href="/fprime/Tutorials/README.html">Tutorials</a></h4>
-    <ul>
-      <li><a href="https://fprime-community.github.io/fprime-tutorial-hello-world/">HelloWorld</a></li>
-      <li><a href="https://fprime-community.github.io/fprime-workshop-led-blinker/">LedBlinker</a></li>
-      <li><a href="https://fprime-community.github.io/fprime-tutorial-math-component/">MathComponent</a></li>
-      <li><a href="/fprime/Tutorials/CrossCompilationSetup/">Cross-Compilation Setup Tutorial</a></li>
-      <li><a href="https://fprime-community.github.io/fprime-tutorial-arduino-blinker/">Arduino LedBlinker</a></li>
-    </ul>
+<ul>
+  <li><a href="https://fprime-community.github.io/fprime-tutorial-hello-world/">HelloWorld</a></li>
+  <li><a href="https://fprime-community.github.io/fprime-workshop-led-blinker/">LedBlinker</a></li>
+  <li><a href="https://fprime-community.github.io/fprime-tutorial-math-component/">MathComponent</a></li>
+  <li><a href="/fprime/Tutorials/CrossCompilationSetup/">Cross-Compilation Setup Tutorial</a></li>
+  <li><a href="https://fprime-community.github.io/fprime-tutorial-arduino-blinker/">Arduino LedBlinker</a></li>
+</ul>
 <h4><a href="/fprime/UsersGuide/guide.html">User Guide</a></h4>
+<ul>
+  <details>
+    <summary>Getting Started with F´</summary>
     <ul>
-        <li>
-          <details>
-            <summary>Getting Started with F´</summary>
-              <ul>
-                <li><a href="/fprime/">What is F´: a brief introduction</a></li>
-                <li><a href="/fprime/INSTALL.html">Installing F´</a></li>
-                <li><a href="/fprime/UsersGuide/user/autocomplete.html">Installing F´ Console Autocomplete</a></li>
-                <li><a href="/fprime/Tutorials/README.html">Tutorials: A Hands On Guide to F´</a></li>
-              </ul>
-          </details>
-        </li>
-        <li>
-          <details>
-            <summary>F´ Users Manual: an in-depth description of F´ concepts</summary>
-              <ul>
-                <li><a href="/fprime/UsersGuide/user/full-intro.html">A More Complete Introduction to F´</a></li>
-                <li><a href="/fprime/UsersGuide/user/proj-dep.html">Projects and Deployments</a></li>
-                <li><a href="/fprime/UsersGuide/user/port-comp-top.html">Core Constructs: Ports, Components, and Topologies</a></li>
-                <li><a href="/fprime/UsersGuide/user/enum-arr-ser.html">Data Types and Data Structures: Primitive Types, Enums, Arrays, and Serializables</a></li>
-                <li><a href="/fprime/UsersGuide/user/cmd-evt-chn-prm.html">Data Constructs: Commands, Events, Channels, and Parameters</a></li>
-                <li><a href="/fprime/UsersGuide/user/unit-testing.html">Unit Testing F´ Components</a></li>
-              </ul>
-          </details>
-        </li>
-        <li>
-          <details>
-            <summary>F´ Best Practices: helpful patterns when developing F´ software</summary>
-              <ul>
-                <li><a href="/fprime/UsersGuide/best/development-practice.html">F´ Development Process</a></li>
-                <li><a href="/fprime/UsersGuide/best/app-man-drv.html">Application, Manager, Driver Pattern</a></li>
-                <li><a href="/fprime/UsersGuide/best/ground-interface.html">Ground Interface</a></li>
-                <li><a href="/fprime/UsersGuide/best/rate-group.html">Rate Groups and Timeliness</a></li>
-                <li><a href="/fprime/UsersGuide/best/dynamic-memory.html">Dynamic Memory and Buffer Management</a></li>
-                <li><a href="/fprime/UsersGuide/best/hub-pattern.html">A Quick Look at the Hub Pattern</a></li>
-                <li><a href="/fprime/UsersGuide/best/documentation.html">Documenting F´ Projects</a></li>
-                <li><a href="/fprime/UsersGuide/dev/code-style.html">Code and Style Guidelines</a></li>
-              </ul>
-          </details>
-        </li>
-        <li>
-          <details>
-            <summary>F´ Ground Data System Tools (GDS)</summary>
-              <ul>
-                <li><a href="/fprime/UsersGuide/gds/gds-introduction.html">A Brief Guide to the F´ Ground Data System</a></li>
-                <li><a href="/fprime/UsersGuide/gds/gds-cli.html">The Discerning User’s Guide to the F´ GDS CLI</a></li>
-                <li><a href="/fprime/UsersGuide/gds/gds-custom-dashboards.html">The GDS Dashboard</a></li>
-                <li><a href="/fprime/UsersGuide/gds/seqgen.html">Sequencing in F´</a></li>
-              </ul>
-          </details>
-        </li>
-        <li>
-          <details>
-            <summary>Full Development Guides: technical details for full F´ implementations</summary>
-              <ul>
-                <li><a href="/fprime/UsersGuide/dev/configuring-fprime.html">Configuring F´</a></li>
-                <li><a href="/fprime/UsersGuide/user/fpp-user-guide.html">F´ Modeling with FPP</a></li>
-                <li><a href="/fprime/UsersGuide/dev/source-tree.html">A Tour of the Source Tree</a></li>
-                <li><a href="/fprime/UsersGuide/dev/xml-specification.html">F´ XML Specifications</a></li>
-                <li><a href="/fprime/UsersGuide/dev/implementation.html">F´ Implementation Classes</a></li>
-                <li><a href="/fprime/UsersGuide/dev/building-topology.html">Constructing the F´ Topology</a></li>
-                <li><a href="/fprime/UsersGuide/dev/assert.html">Asserts in F´</a></li>
-                <li><a href="/fprime/UsersGuide/dev/gds-dashboard-reference.html">GDS Dashboard Reference</a></li>
-                <li><a href="/fprime/UsersGuide/dev/testAPI/user_guide.html">Integration Test API</a></li>
-                <li><a href="/fprime/UsersGuide/user/v3-migration-guide.html">v3 Migration Guide</a></li>
-              </ul>
-          </details>
-        </li>
-        <li>
-          <details>
-            <summary>Advanced F´ Topics:</summary>
-              <ul>
-                <li><a href="/fprime/UsersGuide/dev/py-dev.html">F´ Python Guidelines</a></li>
-                <li><a href="/fprime/UsersGuide/dev/porting-guide.html">Porting F´ To a New Platform</a></li>
-                <li><a href="/fprime/UsersGuide/dev/baremetal-multicore.html">F´ On Baremetal and Multi-Core Systems</a></li>
-                <li><a href="/fprime/UsersGuide/dev/configure-ide.html">Configuring an IDE for Use With F´</a></li>
-                <li><a href="/fprime/UsersGuide/dev/os-docs.html">OS Layer Description</a></li>
-              </ul>
-          </details>
-        </li>
-        <li>
-          <details>
-            <summary>API Documentation</summary>
-              <ul>
-                <li><a href="/fprime/UsersGuide/dev/gds-cli-dev.html">GDS CLI Design</a></li>
-                <li><a href="./api/c++/html/index.html">C++ Documentation</a></li>
-                <li><a href="./api/cmake/API.html">CMake User API</a></li>
-              </ul>
-          </details>
-        </li>
+      <li><a href="/fprime/">What is F´: a brief introduction</a></li>
+      <li><a href="/fprime/INSTALL.html">Installing F´</a></li>
+      <li><a href="/fprime/UsersGuide/user/autocomplete.html">Installing F´ Console Autocomplete</a></li>
+      <li><a href="/fprime/Tutorials/README.html">Tutorials: A Hands On Guide to F´</a></li>
     </ul>
+  </details>
+  <details>
+    <summary>F´ Users Manual</summary>
+    <ul>
+      <li><a href="/fprime/UsersGuide/user/full-intro.html">A More Complete Introduction to F´</a></li>
+      <li><a href="/fprime/UsersGuide/user/proj-dep.html">Projects and Deployments</a></li>
+      <li><a href="/fprime/UsersGuide/user/port-comp-top.html">Core Constructs: Ports, Components, and Topologies</a>
+      </li>
+      <li><a href="/fprime/UsersGuide/user/enum-arr-ser.html">Data Types and Data Structures: Primitive Types, Enums,
+          Arrays, and Serializables</a></li>
+      <li><a href="/fprime/UsersGuide/user/cmd-evt-chn-prm.html">Data Constructs: Commands, Events, Channels, and
+          Parameters</a></li>
+      <li><a href="/fprime/UsersGuide/user/unit-testing.html">Unit Testing F´ Components</a></li>
+    </ul>
+  </details>
+  <details>
+    <summary>F´ Best Practices</summary>
+    <ul>
+      <li><a href="/fprime/UsersGuide/best/development-practice.html">F´ Development Process</a></li>
+      <li><a href="/fprime/UsersGuide/best/app-man-drv.html">Application, Manager, Driver Pattern</a></li>
+      <li><a href="/fprime/UsersGuide/best/ground-interface.html">Ground Interface</a></li>
+      <li><a href="/fprime/UsersGuide/best/rate-group.html">Rate Groups and Timeliness</a></li>
+      <li><a href="/fprime/UsersGuide/best/dynamic-memory.html">Dynamic Memory and Buffer Management</a></li>
+      <li><a href="/fprime/UsersGuide/best/hub-pattern.html">A Quick Look at the Hub Pattern</a></li>
+      <li><a href="/fprime/UsersGuide/best/documentation.html">Documenting F´ Projects</a></li>
+      <li><a href="/fprime/UsersGuide/dev/code-style.html">Code and Style Guidelines</a></li>
+    </ul>
+  </details>
+  <details>
+    <summary>F´ Ground Data System (GDS)</summary>
+    <ul>
+      <li><a href="/fprime/UsersGuide/gds/gds-introduction.html">A Brief Guide to the F´ Ground Data System</a></li>
+      <li><a href="/fprime/UsersGuide/gds/gds-cli.html">The Discerning User’s Guide to the F´ GDS CLI</a></li>
+      <li><a href="/fprime/UsersGuide/gds/gds-custom-dashboards.html">The GDS Dashboard</a></li>
+      <li><a href="/fprime/UsersGuide/gds/seqgen.html">Sequencing in F´</a></li>
+    </ul>
+  </details>
+  <details>
+    <summary>Full Development Guides</summary>
+    <ul>
+      <li><a href="/fprime/UsersGuide/dev/configuring-fprime.html">Configuring F´</a></li>
+      <li><a href="/fprime/UsersGuide/user/fpp-user-guide.html">F´ Modeling with FPP</a></li>
+      <li><a href="/fprime/UsersGuide/dev/source-tree.html">A Tour of the Source Tree</a></li>
+      <li><a href="/fprime/UsersGuide/dev/xml-specification.html">F´ XML Specifications</a></li>
+      <li><a href="/fprime/UsersGuide/dev/implementation.html">F´ Implementation Classes</a></li>
+      <li><a href="/fprime/UsersGuide/dev/building-topology.html">Constructing the F´ Topology</a></li>
+      <li><a href="/fprime/UsersGuide/dev/assert.html">Asserts in F´</a></li>
+      <li><a href="/fprime/UsersGuide/dev/gds-dashboard-reference.html">GDS Dashboard Reference</a></li>
+      <li><a href="/fprime/UsersGuide/dev/testAPI/user_guide.html">Integration Test API</a></li>
+      <li><a href="/fprime/UsersGuide/user/v3-migration-guide.html">v3 Migration Guide</a></li>
+    </ul>
+  </details>
+  <details>
+    <summary>Advanced F´ Topics</summary>
+    <ul>
+      <li><a href="/fprime/UsersGuide/dev/py-dev.html">F´ Python Guidelines</a></li>
+      <li><a href="/fprime/UsersGuide/dev/porting-guide.html">Porting F´ To a New Platform</a></li>
+      <li><a href="/fprime/UsersGuide/dev/baremetal-multicore.html">F´ On Baremetal and Multi-Core Systems</a></li>
+      <li><a href="/fprime/UsersGuide/dev/configure-ide.html">Configuring an IDE for Use With F´</a></li>
+      <li><a href="/fprime/UsersGuide/dev/os-docs.html">OS Layer Description</a></li>
+    </ul>
+  </details>
+  <details>
+    <summary>API Documentation</summary>
+    <ul>
+      <li><a href="/fprime/UsersGuide/dev/gds-cli-dev.html">GDS CLI Design</a></li>
+      <li><a href="./api/c++/html/index.html">C++ Documentation</a></li>
+      <li><a href="./api/cmake/API.html">CMake User API</a></li>
+    </ul>
+  </details>
+</ul>
 <h4><a href="/fprime/Design/general.html">Design and Philosophy</a></h4>
-      <ul>
-        <li><a href="/fprime/Design/numerical-types.html">Numerical Types Design</a></li>
-        <li><a href="/fprime/Design/communication-adapter-interface.html">Communication Adapter Interface</a></li>
-      </ul>
+<ul>
+  <li><a href="/fprime/Design/numerical-types.html">Numerical Types Design</a></li>
+  <li><a href="/fprime/Design/communication-adapter-interface.html">Communication Adapter Interface</a></li>
+</ul>


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The git diff is having a hard time but these are very minor changes:
- removing the extra `<li>` tags so as not to duplicate bullet point and summary
- removing extra text in the user guide titles (e.g. `F´ Users Manual: an in-depth description of F´ concepts` becomes `F´ Users Manual`


**The rich diff (rather than code diff) will do a better job at showing what changed**