### PR TITLE
Split fpp-input-list to import and source

### DIFF
--- a/cmake/autocoder/fpp.cmake
+++ b/cmake/autocoder/fpp.cmake
@@ -196,7 +196,8 @@ function(fpp_setup_autocode AC_INPUT_FILES)
             list(APPEND GENERATED_CPP "${GENERATED}")
         endif()
     endforeach()
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/fpp-input-list" "${FPP_IMPORTS};${AC_INPUT_FILES}")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/fpp-import-list" "${FPP_IMPORTS}")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/fpp-source-list" "${AC_INPUT_FILES}")
     # Add in steps for Ai.xml generation
     if (GENERATED_AI)
         add_custom_command(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Split fpp-input-list to import and source files.

## Rationale

`fpp-to-cpp` needs to differentiate between source and import files to generate the correct set of files. The set of files is passed to fprime-tools using the `fpp-input-list`, which used to not differentiate between import and source. Splitting this in 2 different files allows for distinction to be made.

