### PR TITLE
Adding scalar type test to type demo

### DIFF
--- a/Ref/TypeDemo/TypeDemo.cpp
+++ b/Ref/TypeDemo/TypeDemo.cpp
@@ -135,4 +135,10 @@ void TypeDemo ::DUMP_FLOATS_cmdHandler(const FwOpcodeType opCode, const U32 cmdS
     this->tlmWrite_FloatSet(invalid);
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }
+
+void TypeDemo ::SEND_SCALARS_cmdHandler(const FwOpcodeType opCode, const U32 cmdSeq, Ref::ScalarStruct scalar_input) {
+    this->log_ACTIVITY_HI_ScalarStructEv(scalar_input);
+    this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
+}
+
 }  // end namespace Ref

--- a/Ref/TypeDemo/TypeDemo.fpp
+++ b/Ref/TypeDemo/TypeDemo.fpp
@@ -35,6 +35,20 @@ module Ref {
 
     @ Set of floating points to emit
     array FloatSet = [3] F32;
+   
+    @ All scalar inputs 
+    struct ScalarStruct {
+        i8: I8,
+        i16: I16,
+        i32: I32,
+        i64: I64,
+        u8: U8,
+        u16: U16,
+        u32: U32,
+        u64: U64,
+        f32: F32,
+        f64: F64
+    }
 
     @ Component to demonstrate multiple type configurations
     passive component TypeDemo {
@@ -216,6 +230,15 @@ module Ref {
 
         @ Dump the float values
         sync command DUMP_FLOATS()
+
+        @ Send scalars
+        sync command SEND_SCALARS(scalar_input: ScalarStruct)
+
+        @ Event for scalar struct
+        event ScalarStructEv(scalar_argument: ScalarStruct) severity activity high \
+            format "ScalarStruct: {}"
+
+
 
         # ----------------------------------------------------------------------
         # Special ports

--- a/Ref/TypeDemo/TypeDemo.hpp
+++ b/Ref/TypeDemo/TypeDemo.hpp
@@ -19,12 +19,12 @@ class TypeDemo : public TypeDemoComponentBase {
 
     //! Construct object TypeDemo
     //!
-    TypeDemo(const char* const compName //!< The component name
+    TypeDemo(const char* const compName  //!< The component name
     );
 
     //! Initialize object TypeDemo
     //!
-    void init(const NATIVE_INT_TYPE instance = 0 //!< The instance number
+    void init(const NATIVE_INT_TYPE instance = 0  //!< The instance number
     );
 
     //! Destroy object TypeDemo
@@ -38,70 +38,70 @@ class TypeDemo : public TypeDemoComponentBase {
 
     //! Implementation for CHOICE command handler
     //! Single choice command
-    void CHOICE_cmdHandler(const FwOpcodeType opCode, //!< The opcode
-                           const U32 cmdSeq,          //!< The command sequence number
+    void CHOICE_cmdHandler(const FwOpcodeType opCode,  //!< The opcode
+                           const U32 cmdSeq,           //!< The command sequence number
                            Ref::Choice choice);
 
     //! Implementation for CHOICES command handler
     //! Multiple choice command via Array
-    void CHOICES_cmdHandler(const FwOpcodeType opCode, //!< The opcode
-                            const U32 cmdSeq,          //!< The command sequence number
+    void CHOICES_cmdHandler(const FwOpcodeType opCode,  //!< The opcode
+                            const U32 cmdSeq,           //!< The command sequence number
                             Ref::ManyChoices choices);
 
     //! Implementation for CHOICES_WITH_FRIENDS command handler
     //! Multiple choice command via Array with a preceding and following argument
-    void CHOICES_WITH_FRIENDS_cmdHandler(const FwOpcodeType opCode, //!< The opcode
-                                         const U32 cmdSeq,          //!< The command sequence number
+    void CHOICES_WITH_FRIENDS_cmdHandler(const FwOpcodeType opCode,  //!< The opcode
+                                         const U32 cmdSeq,           //!< The command sequence number
                                          U8 repeat,
                                          Ref::ManyChoices choices,
                                          U8 repeat_max);
 
     //! Implementation for EXTRA_CHOICES command handler
     //! Multiple choice command via Array
-    void EXTRA_CHOICES_cmdHandler(const FwOpcodeType opCode, //!< The opcode
-                                  const U32 cmdSeq,          //!< The command sequence number
+    void EXTRA_CHOICES_cmdHandler(const FwOpcodeType opCode,  //!< The opcode
+                                  const U32 cmdSeq,           //!< The command sequence number
                                   Ref::TooManyChoices choices);
 
     //! Implementation for EXTRA_CHOICES_WITH_FRIENDS command handler
     //! Too many choices command via Array with a preceding and following argument
-    void EXTRA_CHOICES_WITH_FRIENDS_cmdHandler(const FwOpcodeType opCode, //!< The opcode
-                                               const U32 cmdSeq,          //!< The command sequence number
+    void EXTRA_CHOICES_WITH_FRIENDS_cmdHandler(const FwOpcodeType opCode,  //!< The opcode
+                                               const U32 cmdSeq,           //!< The command sequence number
                                                U8 repeat,
                                                Ref::TooManyChoices choices,
                                                U8 repeat_max);
     //! Implementation for CHOICE_PAIR command handler
     //! Multiple choice command via Structure
-    void CHOICE_PAIR_cmdHandler(const FwOpcodeType opCode, //!< The opcode
-                                const U32 cmdSeq,          //!< The command sequence number
+    void CHOICE_PAIR_cmdHandler(const FwOpcodeType opCode,  //!< The opcode
+                                const U32 cmdSeq,           //!< The command sequence number
                                 Ref::ChoicePair choices);
 
     //! Implementation for CHOICE_PAIR_WITH_FRIENDS command handler
     //! Multiple choices command via Structure with a preceding and following argument
-    void CHOICE_PAIR_WITH_FRIENDS_cmdHandler(const FwOpcodeType opCode, //!< The opcode
-                                             const U32 cmdSeq,          //!< The command sequence number
+    void CHOICE_PAIR_WITH_FRIENDS_cmdHandler(const FwOpcodeType opCode,  //!< The opcode
+                                             const U32 cmdSeq,           //!< The command sequence number
                                              U8 repeat,
                                              Ref::ChoicePair choices,
                                              U8 repeat_max);
     //! Implementation for GLUTTON_OF_CHOICE command handler
     //! Multiple choice command via Complex Structure
-    void GLUTTON_OF_CHOICE_cmdHandler(const FwOpcodeType opCode, //!< The opcode
-                                      const U32 cmdSeq,          //!< The command sequence number
-                                      Ref::ChoiceSlurry choices  //!< A phenomenal amount of choice
+    void GLUTTON_OF_CHOICE_cmdHandler(const FwOpcodeType opCode,  //!< The opcode
+                                      const U32 cmdSeq,           //!< The command sequence number
+                                      Ref::ChoiceSlurry choices   //!< A phenomenal amount of choice
     );
 
     //! Implementation for GLUTTON_OF_CHOICE_WITH_FRIENDS command handler
     //! Multiple choices command via Complex Structure with a preceding and following argument
-    void GLUTTON_OF_CHOICE_WITH_FRIENDS_cmdHandler(const FwOpcodeType opCode, //!< The opcode
-                                                   const U32 cmdSeq,          //!< The command sequence number
-                                                   U8 repeat,                 //!< Number of times to repeat the choices
-                                                   Ref::ChoiceSlurry choices, //!< A phenomenal amount of choice
-                                                   U8 repeat_max              //!< Limit to the number of repetitions
+    void GLUTTON_OF_CHOICE_WITH_FRIENDS_cmdHandler(const FwOpcodeType opCode,  //!< The opcode
+                                                   const U32 cmdSeq,           //!< The command sequence number
+                                                   U8 repeat,  //!< Number of times to repeat the choices
+                                                   Ref::ChoiceSlurry choices,  //!< A phenomenal amount of choice
+                                                   U8 repeat_max               //!< Limit to the number of repetitions
     );
 
     //! Implementation for DUMP_TYPED_PARAMETERS command handler
     //! Dump the typed parameters
-    void DUMP_TYPED_PARAMETERS_cmdHandler(const FwOpcodeType opCode, //!< The opcode
-                                          const U32 cmdSeq           //!< The command sequence number
+    void DUMP_TYPED_PARAMETERS_cmdHandler(const FwOpcodeType opCode,  //!< The opcode
+                                          const U32 cmdSeq            //!< The command sequence number
     );
 
     //! Implementation for DUMP_FLOATS command handler
@@ -109,6 +109,12 @@ class TypeDemo : public TypeDemoComponentBase {
     void DUMP_FLOATS_cmdHandler(const FwOpcodeType opCode, /*!< The opcode*/
                                 const U32 cmdSeq           /*!< The command sequence number*/
     );
+
+    //! Implementation for SEND_SCALARS command handler
+    //! Send scalars
+    void SEND_SCALARS_cmdHandler(const FwOpcodeType opCode, /*!< The opcode*/
+                                 const U32 cmdSeq,          /*!< The command sequence number*/
+                                 Ref::ScalarStruct scalar_input);
 };
 
 }  // end namespace Ref


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds a scalar input type to TypeDemo such that we can cat errors like: https://github.com/nasa/fprime/issues/2273