### PR TITLE
Fixes #2146 by correcting #if

### DIFF
--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -402,7 +402,7 @@ namespace Fw {
                 case TYPE_PTR:
                     valIsEqual = (this->m_val.ptrVal == other.m_val.ptrVal);
                     break;
-#if FW_HAS_64_BIT
+#if FW_HAS_F64
                 case TYPE_F64: // fall through, shouldn't test floating point
 #endif
                 case TYPE_F32: // fall through, shouldn't test floating point


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix for issue #2146 