### PR TITLE
Remove unused FW_FILE_BUFFER_MAX_SIZE define from FpConfig

### DIFF
--- a/config/FpConfig.h
+++ b/config/FpConfig.h
@@ -271,11 +271,6 @@ typedef U16 FwTlmPacketizeIdType;
 #define FW_PARAM_STRING_MAX_SIZE 40  //!< Max size of parameter string type
 #endif
 
-// Specifies the maximum size of a file upload chunk
-#ifndef FW_FILE_BUFFER_MAX_SIZE
-#define FW_FILE_BUFFER_MAX_SIZE 255  //!< Max size of file buffer (i.e. chunk of file)
-#endif
-
 // Specifies the maximum size of a string in an interface call
 #ifndef FW_INTERNAL_INTERFACE_STRING_MAX_SIZE
 #define FW_INTERNAL_INTERFACE_STRING_MAX_SIZE 256  //!< Max size of interface string parameter type

--- a/docs/UsersGuide/dev/configuring-fprime.md
+++ b/docs/UsersGuide/dev/configuring-fprime.md
@@ -342,7 +342,6 @@ are less restrictive in size.
 
 | Macro                      | Definition                                                 | Default | Valid Values     |
 | -------------------------- | -----------------------------------------------------------|---------|------------------|
-| FW_FILE_BUFFER_MAX_SIZE    | Defines buffer and chunk size for file uplink and downlink | 255     | Positive integer |
 | FW_INTERNAL_INTERFACE_STRING_MAX_SIZE | Maximum size for interface string               | 40      | Positive integer |
 
 ### Text Logging


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

I couldn't find any uses of `FW_FILE_BUFFER_MAX_SIZE` constant defined in `FpConfig.h`. Since it's a trivial change, I decided to open a PR and see if it is relevant.

## Future Work

If this PR is merged, these places (and potentially more) should be also changed:
1. [fpp repo / docs/users-guide/examples/impl-abs-type/FpConfig.hpp](https://github.com/fprime-community/fpp/blob/4101243384cf2d472eff7445c8fa75ecaf0879bb/docs/users-guide/examples/impl-abs-type/FpConfig.hpp#L267)
2. [fprime tools / src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/{{cookiecutter.deployment_name}}/Top/{{cookiecutter.deployment_name}}Topology.cpp](https://github.com/fprime-community/fprime-tools/blob/85e7fb084aa6c8c133dea24b94e6fc1b23c365d5/src/fprime/cookiecutter_templates/cookiecutter-fprime-deployment/%7B%7Bcookiecutter.deployment_name%7D%7D/Top/%7B%7Bcookiecutter.deployment_name%7D%7DTopology.cpp#L54)