### PR TITLE
Fix minor build settings issues

### DIFF
--- a/cmake/prescan.cmake
+++ b/cmake/prescan.cmake
@@ -48,7 +48,6 @@ set(EXCLUDED_CACHE_VARIABLES
 set(TYPES_DISALLOWED_LIST
     INTERNAL
     STATIC
-    UNINITIALIZED
 )
 # Directory in-which to build the prescan directory
 set(PRESCAN_DIR "${CMAKE_BINARY_DIR}/prescan")

--- a/cmake/settings/ini-to-stdio.py
+++ b/cmake/settings/ini-to-stdio.py
@@ -29,7 +29,7 @@ def print_setting(setting: str, value: str = "", ending: str = ";"):
 def print_list_settings(items: List[str]):
     """Print a list of settings of form SETTING=VALUE"""
     for item in items:
-        splits = item.strip().split("=")
+        splits = item.strip().split("=", 1)
         if splits[0] != "":
             print_setting(*splits)
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes two small issues:
1. The prescan sub build does not forward CLI arguments without `:TYPE` as these were type `UNITIALIZED`
2. The CMAKE default settings option was not limited to one `=` split, and thus broke