### PR TITLE
Removing join after task failed creation. Fixes #1955

### DIFF
--- a/Os/Posix/Task.cpp
+++ b/Os/Posix/Task.cpp
@@ -182,7 +182,6 @@ namespace Os {
         }
         (void)pthread_attr_destroy(&att);
         if (stat != 0) {
-            (void)pthread_join(*tid, nullptr);
             delete tid;
             tid = nullptr;
             Fw::Logger::logMsg("pthread_create: %s. %s\n", reinterpret_cast<POINTER_CAST>(message), reinterpret_cast<POINTER_CAST>(strerror(stat)));


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

When pthread_create fails, the contents of `*thread` is undefined, however; we erroneously pass it to a `pthread_join` after a failure.  This removes that erroneous line.