### PR TITLE
Update Doxygen config

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -133,3 +133,4 @@
 ^Svc/PrmDb/PrmDb\.hpp$
 ^Svc/TlmChan/TlmChan\.hpp$
 ignore$
+^docs/doxygen/mainpage.md$

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 build*/
 gtest/
+docs-cache/
 
 AutoXML/
 test_harness/src/test_harness-C/application.out
@@ -44,7 +45,7 @@ coverity.out
 .#*
 
 **/docs/*.html
-/docs/UsersGuide/api/cmake/*
+/docs/UsersGuide/api/*
 *-template
 
 logs

--- a/Svc/BufferAccumulator/docs/BufferAccumulator.md
+++ b/Svc/BufferAccumulator/docs/BufferAccumulator.md
@@ -1,4 +1,4 @@
-\page BufferAccumulatorComponent Svc::BufferAccumulator Component
+\page SvcBufferAccumulatorComponent Svc::BufferAccumulator Component
 # BufferAccumulator Component Dictionary
 
 

--- a/Svc/BufferAccumulator/docs/BufferAccumulator.md
+++ b/Svc/BufferAccumulator/docs/BufferAccumulator.md
@@ -1,4 +1,4 @@
-<title>BufferAccumulator Component Dictionary</title>
+\page BufferAccumulatorComponent Svc::BufferAccumulator Component
 # BufferAccumulator Component Dictionary
 
 

--- a/Svc/PassiveRateGroup/docs/sdd.md
+++ b/Svc/PassiveRateGroup/docs/sdd.md
@@ -1,4 +1,4 @@
-<title>PassiveRateGroup Component SDD</title>
+\page RateGroupDriverComponent Svc::RateGroupDriver Component
 # RateGroupDriver Component
 
 ## 1. Introduction

--- a/Svc/PassiveRateGroup/docs/sdd.md
+++ b/Svc/PassiveRateGroup/docs/sdd.md
@@ -1,4 +1,4 @@
-\page RateGroupDriverComponent Svc::RateGroupDriver Component
+\page SvcPassiveRateGroupComponent Svc::PassiveRateGroup Component
 # RateGroupDriver Component
 
 ## 1. Introduction

--- a/Svc/SystemResources/docs/sdd.md
+++ b/Svc/SystemResources/docs/sdd.md
@@ -1,4 +1,4 @@
-\page SystemResourcesComponent Svc::SystemResources Component
+\page SvcSystemResourcesComponent Svc::SystemResources Component
 # SystemResources Component
 
 The system resources component downlinks information about the running F´ system. This information includes:

--- a/Svc/SystemResources/docs/sdd.md
+++ b/Svc/SystemResources/docs/sdd.md
@@ -1,4 +1,5 @@
-# System Resources Component
+\page SystemResourcesComponent Svc::SystemResources Component
+# SystemResources Component
 
 The system resources component downlinks information about the running F´ system. This information includes:
 

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -901,7 +901,8 @@ EXCLUDE                = ./docs/Architecture/ ./docs/UsersGuide/ ./docs/Tutorial
                          ./docs/INSTALL.md ./docs/projects.md ./docs/index.md ./docs/_config.yml \
                          ./docs/upcoming.md ./docs/latest.md ./docs/documentation.md ./docs/features.md \
                          *CMakeFiles/* ./Autocoders ./cmake ./gtest ./Ref ./RPI ./FppTest \
-                         STest ./mk ./README.md ./CONTRIBUTORS.md ./CONTRIBUTING.md ./SECURITY.md 
+                         STest ./mk ./README.md ./CONTRIBUTORS.md ./CONTRIBUTING.md ./SECURITY.md \
+                         ./googletest/
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -38,8 +38,8 @@ PROJECT_NAME           = "F´ Flight Software - C/C++ Documentation"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-# commented out to avoid having to update it every release
-# PROJECT_NUMBER         = NASA-v1.6.0
+# Replaced with version number by ./generate_docs.bash <VERSION>
+PROJECT_NUMBER         = devel
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -38,7 +38,8 @@ PROJECT_NAME           = "F´ Flight Software - C/C++ Documentation"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = NASA-v1.6.0
+# commented out to avoid having to update it every release
+# PROJECT_NUMBER         = NASA-v1.6.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -170,7 +171,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = ./ ./docs-build-for-docs/ ./docs-build-for-docs/F-Prime/ ./Ref/build-fprime-automatic-default/ ./Ref/build-fprime-automatic-default/F-Prime/
+STRIP_FROM_PATH        = ./ ./docs-cache/ ./docs-cache/F-Prime/
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -179,7 +180,7 @@ STRIP_FROM_PATH        = ./ ./docs-build-for-docs/ ./docs-build-for-docs/F-Prime
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = ./ ./docs-build-for-docs/ ./docs-build-for-docs/F-Prime/ ./Ref/build-fprime-automatic-default/ ./Ref/build-fprime-automatic-default/F-Prime/
+STRIP_FROM_INC_PATH    = ./ ./docs-cache/ ./docs-cache/F-Prime/
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -896,10 +897,11 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = ./docs/Architecture/ ./docs/UsersGuide/ ./docs/Tutorials/ ./docs/_data/ \
-                         ./docs/INSTALL.md ./docs/projects.md ./docs/index.md ./docs/_config.yml ./docs/features.md \
-                         *CMakeFiles/* ./Gds ./Fw/Python ./ptf ./Autocoders ./cmake ./gtest ./Ref ./RPI ./metrics \
-                         STest ./mk ./README.md ./CONTRIBUTORS.md
+EXCLUDE                = ./docs/Architecture/ ./docs/UsersGuide/ ./docs/Tutorials/ \
+                         ./docs/INSTALL.md ./docs/projects.md ./docs/index.md ./docs/_config.yml \
+                         ./docs/upcoming.md ./docs/latest.md ./docs/documentation.md ./docs/features.md \
+                         *CMakeFiles/* ./Autocoders ./cmake ./gtest ./Ref ./RPI ./FppTest \
+                         STest ./mk ./README.md ./CONTRIBUTORS.md ./CONTRIBUTING.md ./SECURITY.md 
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -915,7 +917,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */test/* */GTest/* */build-*/* */Autocoders/MagicDrawCompPlugin/* */cmake/* */docs/v*.* */README.md
+EXCLUDE_PATTERNS       = */test/* */GTest/* */build-*/* */cmake/* */docs/v*.* */README.md */docs/_* 
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -918,7 +918,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */test/* */GTest/* */build-*/* */cmake/* */docs/v*.* */README.md */docs/_* 
+EXCLUDE_PATTERNS       = */test/* */GTest/* */build-*/* */cmake/* */docs/v*.* */docs/_* 
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/docs/doxygen/generate_docs.bash
+++ b/docs/doxygen/generate_docs.bash
@@ -65,14 +65,14 @@ function make_version
 # Doxygen generation
 (
     cd "${FPRIME}"
+    DOCS_CACHE="${FPRIME}/docs-cache"
     clobber "${DOXY_OUTPUT}"
     echo "[INFO] Building fprime"
-    (
-        mkdir -p "${FPRIME}/build-fprime-automatic-docs"
-        cd "${FPRIME}/build-fprime-automatic-docs"
-        cmake "${FPRIME}" -DCMAKE_BUILD_TYPE=Release 1>/dev/null
-    )
-    fprime-util build "docs" --all -j32 1> /dev/null
+    rm -rf "${DOCS_CACHE}"
+
+    fprime-util generate --build-cache ${DOCS_CACHE} -DCMAKE_BUILD_TYPE=Release 1>/dev/null
+    fprime-util build --build-cache ${DOCS_CACHE} --all -j32 1> /dev/null
+
     if (( $? != 0 ))
     then
         echo "[ERROR] Failed to build fprime please generate build cache"
@@ -80,7 +80,7 @@ function make_version
     fi
     mkdir -p ${DOXY_OUTPUT}
     ${DOXYGEN} "${FPRIME}/docs/doxygen/Doxyfile"
-    rm -r "${FPRIME}/build-fprime-automatic-docs"
+    rm -r "${DOCS_CACHE}"
 ) || exit 1
 
 # CMake

--- a/docs/doxygen/generate_docs.bash
+++ b/docs/doxygen/generate_docs.bash
@@ -70,7 +70,7 @@ function make_version
     echo "[INFO] Building fprime"
     rm -rf "${DOCS_CACHE}"
 
-    fprime-util generate --build-cache ${DOCS_CACHE} -DCMAKE_BUILD_TYPE=Release 1>/dev/null
+    fprime-util generate --build-cache ${DOCS_CACHE} -DCMAKE_BUILD_TYPE=Release -DFPRIME_SKIP_TOOLS_VERSION_CHECK=ON 1>/dev/null
     fprime-util build --build-cache ${DOCS_CACHE} --all -j32 1> /dev/null
 
     if (( $? != 0 ))
@@ -79,6 +79,13 @@ function make_version
         exit 2
     fi
     mkdir -p ${DOXY_OUTPUT}
+
+    # Replace version number in Doxyfile
+    if [[ "${VERSIONED_OUTPUT}" != "" ]]
+    then
+        sed -i "s/^PROJECT_NUMBER[ ]*=.*$/PROJECT_NUMBER=${VERSIONED_OUTPUT}/g" docs/doxygen/Doxyfile
+    fi
+
     ${DOXYGEN} "${FPRIME}/docs/doxygen/Doxyfile"
     rm -r "${DOCS_CACHE}"
 ) || exit 1

--- a/docs/doxygen/generate_docs.bash
+++ b/docs/doxygen/generate_docs.bash
@@ -52,7 +52,7 @@ function make_version
     then
         mkdir "${FPRIME}/docs/${VERSION}"
         cp "${FPRIME}/docs/latest.md" "${FPRIME}/docs/${VERSION}/index.md"
-        cp -r "${FPRIME}/docs/INSTALL.md" "${FPRIME}/docs/Tutorials" "${FPRIME}/docs/UsersGuide" "${FPRIME}/docs/${VERSION}"
+        cp -r "${FPRIME}/docs/INSTALL.md" "${FPRIME}/docs/Tutorials" "${FPRIME}/docs/UsersGuide" "${FPRIME}/docs/Design" "${FPRIME}/docs/${VERSION}"
         REPLACE='| ['$VERSION' Documentation](https:\/\/nasa.github.io\/fprime\/'$VERSION') |\n'
     else
         echo "No version specified, updating local only"

--- a/docs/doxygen/mainpage.md
+++ b/docs/doxygen/mainpage.md
@@ -1,37 +1,38 @@
  \mainpage
 
-This is the F´ automatically generated documentation. The below guides represent the software
-description documentation (SDD) for the F´ components. Included in the Namespace and Classes sections
-is the documentation of the C++ code.
+This is the F´ automatically generated documentation. 
+The sidebar links point to the software description documentation (SDD) for the F´ components. 
+The below guides, as well as the Namespace and Classes sections, link to the documentation of the C++ code. 
 
 
-\page Fw Fw Components, Ports, and Classes
+
+\subpage Fw Fw Components, Ports, and Classes
 
 The Fw package provides the core classes, components, and ports to support F´. These classes allow
 for the core framework operation. In addition, these include the base classes on which components
 are built.  Finally, of specific interest is Fw::Types providing the cored types in the system.
 
 
-\page Os Os Components Ports and Classes
+\subpage Os Os Components Ports and Classes
 
 The Os package is an operating system abstraction layer. It provides basic Os system functions to
 F´. This includes things like Mutexes, Queues, Tasks, and a File System.
 
 
-\page Svc Svc Components, Ports, and Classes
+\subpage Svc Svc Components, Ports, and Classes
 
 The Svc package provides standard components to support greater F´ applications. This includes
 command and data handling components used for more complete applications.
 
 
-\page Drv Drv Components and Classes
+\subpage Drv Drv Components and Classes
 
 The Drv package provides drivers to support various hardware functions for F´. These drivers 
 include a sample block driver component as well a various drivers that support Linux hardware
 functions.
 
 
-\page Utils Utils Classes
+\subpage Utils Utils Classes
 
 The Utils package provides classes for general applications in F´ projects. These classes are for
 a variety of purposes.

--- a/docs/doxygen/mainpage.md
+++ b/docs/doxygen/mainpage.md
@@ -2,38 +2,168 @@
 
 This is the F´ automatically generated documentation. 
 The sidebar links point to the software description documentation (SDD) for the F´ components. 
-The below guides, as well as the Namespace and Classes sections, link to the documentation of the C++ code. 
+The Namespace and Classes sections link to the documentation of the C++ code. 
 
 
 
-\subpage Fw Fw Components, Ports, and Classes
+\page Fw Fw Components, Ports, and Classes
 
 The Fw package provides the core classes, components, and ports to support F´. These classes allow
 for the core framework operation. In addition, these include the base classes on which components
 are built.  Finally, of specific interest is Fw::Types providing the cored types in the system.
 
+\subpage FwBufferSerializableBufferGetBufferSend
 
-\subpage Os Os Components Ports and Classes
+\subpage FwCmdFwCmdResponseFwCmdReg
+
+\subpage FwComPort
+
+\subpage FwFilePacketClasses
+
+\subpage FwLogLogText
+
+\subpage FwObjClasses
+
+\subpage FwPortClasses
+
+\subpage FwPrmGetPrmSet
+
+\subpage FwTimePort
+
+\subpage FwTlmPort
+
+\subpage FwTypeClasses
+
+
+\page Os Os Components Ports and Classes
 
 The Os package is an operating system abstraction layer. It provides basic Os system functions to
 F´. This includes things like Mutexes, Queues, Tasks, and a File System.
 
+\subpage OsQueue
 
-\subpage Svc Svc Components, Ports, and Classes
+
+\page Svc Svc Components, Ports, and Classes
 
 The Svc package provides standard components to support greater F´ applications. This includes
 command and data handling components used for more complete applications.
 
+\subpage SvcAMPCSSequenceClass
 
-\subpage Drv Drv Components and Classes
+\subpage SvcActiveLoggerComponent
+
+\subpage SvcActiveRateGroupComponent
+
+\subpage SvcActiveTextLoggerComponent
+
+\subpage SvcAssertFatalAdapterComponent
+
+\subpage SvcBufferAccumulatorComponent
+
+\subpage SvcBufferManagerComponent
+
+\subpage SvcBufferRepeaterComponent
+
+\subpage SvcCmdDispatcherComponent
+
+\subpage SvcCmdSequencerComponent
+
+\subpage SvcCmdSequencerFormats
+
+\subpage SvcCmdSplitter
+
+\subpage SvcComLoggerComponent
+
+\subpage SvcComQueueComponent
+
+\subpage SvcComSplitterComponent
+
+\subpage SvcComStubComponent
+
+\subpage SvcDeframerComponent
+
+\subpage SvcFatalHandlerComponent
+
+\subpage SvcFatalPort
+
+\subpage SvcFileDownlinkComponent
+
+\subpage SvcFileManagerComponent
+
+\subpage SvcFileUplinkComponent
+
+\subpage SvcFramerComponent
+
+\subpage SvcFramingProtocol
+
+\subpage SvcGenericHubComponent
+
+\subpage SvcHealthComponent
+
+\subpage SvcPassiveConsoleTextLoggerComponent
+
+\subpage SvcPingPort
+
+\subpage SvcPolyDbComponent
+
+\subpage SvcPolyPort
+
+\subpage SvcPosixTime
+
+\subpage SvcPrmDbComponent
+
+\subpage SvcPassiveRateGroupComponent
+
+\subpage SvcRateGroupDriverComponent
+
+\subpage SvcSchedPort
+
+\subpage SvcStaticMemoryComponent
+
+\subpage SvcSystemResourcesComponent
+
+\subpage SvcTlmChanComponent
+
+\subpage SvcTlmPacketizerComponent
+
+\subpage SvcTlmPacketizerComponentDictionary
+
+\subpage SvcWatchDogPort
+
+
+\page Drv Drv Components and Classes
 
 The Drv package provides drivers to support various hardware functions for F´. These drivers 
 include a sample block driver component as well a various drivers that support Linux hardware
 functions.
 
+\subpage DrvBlockDriverComponent
 
-\subpage Utils Utils Classes
+\subpage DrvByteStreamDriverModel
+
+\subpage DrvIp
+
+\subpage DrvStreamCrossover
+
+\subpage DrvTcpClient
+
+\subpage DrvTcpServer
+
+\subpage DrvUdp
+
+
+
+\page Utils Utils Classes
 
 The Utils package provides classes for general applications in F´ projects. These classes are for
 a variety of purposes.
 
+\subpage UtilsHashClass
+
+\subpage UtilsLockGuardClass
+
+\subpage UtilsRateLimiterClass
+
+\subpage UtilsTokenBucketClass
+
+\subpage UtilsTypesLibrary

--- a/docs/doxygen/mainpage.md
+++ b/docs/doxygen/mainpage.md
@@ -11,105 +11,17 @@ The Fw package provides the core classes, components, and ports to support F´. 
 for the core framework operation. In addition, these include the base classes on which components
 are built.  Finally, of specific interest is Fw::Types providing the cored types in the system.
 
-\subpage FwBufferSerializableBufferGetBufferSend
-
-\subpage FwCmdFwCmdResponseFwCmdReg
-
-\subpage FwComPort
-
-\subpage FwFilePacketClasses
-
-\subpage FwLogLogText
-
-\subpage FwObjClasses
-
-\subpage FwPortClasses
-
-\subpage FwPrmGetPrmSet
-
-\subpage FwTimePort
-
-\subpage FwTlmPort
-
-\subpage FwTypeClasses
-
 
 \page Os Os Components Ports and Classes
 
 The Os package is an operating system abstraction layer. It provides basic Os system functions to
 F´. This includes things like Mutexes, Queues, Tasks, and a File System.
 
-\subpage OsQueue
-
 
 \page Svc Svc Components, Ports, and Classes
 
 The Svc package provides standard components to support greater F´ applications. This includes
 command and data handling components used for more complete applications.
-
-\subpage SvcAMPCSSequenceClass
-
-\subpage SvcActiveLoggerComponent
-
-\subpage SvcActiveRateGroupComponent
-
-\subpage SvcActiveTextLoggerComponent
-
-\subpage SvcAssertFatalAdapterComponent
-
-\subpage SvcBufferManagerComponent
-
-\subpage SvcCmdDispatcherComponent
-
-\subpage SvcCmdSequencerComponent
-
-\subpage SvcDeframerComponent
-
-\subpage SvcFatalHandlerComponent
-
-\subpage SvcFatalPort
-
-\subpage SvcFileDownlinkComponent
-
-\subpage SvcFileManagerComponent
-
-\subpage SvcFileUplinkComponent
-
-\subpage SvcFramerComponent
-
-\subpage SvcFramingProtocol
-
-\subpage SvcGenericHubComponent
-
-\subpage SvcGenericRepeaterComponent
-
-\subpage SvcHealthComponent
-
-\subpage SvcLinuxTimeComponent
-
-\subpage SvcPassiveConsoleTextLoggerComponent
-
-\subpage SvcPingPort
-
-\subpage SvcPolyDbComponent
-
-\subpage SvcPolyPort
-
-\subpage SvcPrmDbComponent
-
-\subpage SvcRateGroupDriverComponent
-
-\subpage SvcSchedPort
-
-\subpage SvcStaticMemoryComponent
-
-\subpage SvcTlmChanComponent
-
-\subpage SvcTlmPacketizerComponent
-
-\subpage SvcTlmPacketizerComponentDictionary
-
-\subpage SvcWatchDogPort
 
 
 \page Drv Drv Components and Classes
@@ -118,30 +30,9 @@ The Drv package provides drivers to support various hardware functions for F´. 
 include a sample block driver component as well a various drivers that support Linux hardware
 functions.
 
-\subpage DrvBlockDriverComponent
-
-\subpage DrvByteStreamDriverModel
-
-\subpage DrvIp
-
-\subpage DrvTcpClient
-
-\subpage DrvTcpServer
-
-\subpage DrvUartFramerComponent
-
-\subpage DrvUdp
-
 
 \page Utils Utils Classes
 
 The Utils package provides classes for general applications in F´ projects. These classes are for
 a variety of purposes.
 
-\subpage UtilsHashClass
-
-\subpage UtilsLockGuardClass
-
-\subpage UtilsRateLimiterClass
-
-\subpage UtilsTokenBucketClass


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Updates a couple things with regards to Doxygen. I believe no autocoded files were being processed, as `build-*` directories [were being excluded](https://github.com/nasa/fprime/blob/1b3e9e53d5b68c55c931ee19246b01d41be26901/docs/doxygen/Doxyfile#L920-L921). Fixed by renaming the build cache.

Also removing the `\subpage` directives as those were going stale and are un-maintainable. Each subpage includes a link to an auto-generated page that list all the classes within, so they weren't needed anyways. 


## Rationale

Fixes https://github.com/nasa/fprime/issues/1989
