### PR TITLE
Adding FPRIME_TOOLCHAIN_NAME variable and restrict_platforms support

### DIFF
--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -30,9 +30,9 @@ set(FPRIME_AUTOCODER_TARGET_LIST "" CACHE INTERNAL "FPRIME_AUTOCODER_TARGET_LIST
 #####
 macro(restrict_platforms)
     set(__CHECKER ${ARGN})
-    if (NOT CMAKE_SYSTEM_NAME IN_LIST __CHECKER)
+    if (NOT FPRIME_TOOLCHAIN_NAME IN_LIST __CHECKER AND NOT CMAKE_SYSTEM_NAME IN_LIST __CHECKER)
         get_module_name("${CMAKE_CURRENT_LIST_DIR}")
-        message(STATUS "Platform ${CMAKE_SYSTEM_NAME} not supported for module ${MODULE_NAME}")
+        message(STATUS "Neither toolchain ${FPRIME_TOOLCHAIN_NAME} nor platform ${CMAKE_SYSTEM_NAME} supported for module ${MODULE_NAME}")
         return()
     endif()
 endmacro()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -348,3 +348,12 @@ set(FPRIME_CONFIG_DIR "${FPRIME_CONFIG_DIR}" CACHE PATH "F prime configuration h
 if (NOT DEFINED FPRIME_AC_CONSTANTS_FILE)
     set(FPRIME_AC_CONSTANTS_FILE "${FPRIME_CONFIG_DIR}/AcConstants.ini" CACHE PATH "F prime AC constants.ini file" FORCE)
 endif()
+
+# Set FPRIME_TOOLCHAIN_NAME when not set by toolchain directly
+if (NOT DEFINED FPRIME_TOOLCHAIN_NAME)
+    if (DEFINED CMAKE_TOOLCHAIN_FILE)
+        get_filename_component(FPRIME_TOOLCHAIN_NAME "${CMAKE_TOOLCHAIN_FILE}" NAME_WE CACHE)
+    else()
+        set(FPRIME_TOOLCHAIN_NAME "native" CACHE INTERNAL "Name of toolchain used" FORCE)
+    endif()
+endif()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Calculates `FPRIME_TOOLCHAIN_NAME` from the name of the toolchain supplied, if it isn't already set by the toolcahin file.  Add this variable as a possibility when using `restrict_platforms` such that specific toolchains may be targeted and not just Os level decisions
