### PR TITLE
Fixing Two Minor CMake Bugs

### DIFF
--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -98,8 +98,9 @@ function(add_fprime_subdirectory FP_SOURCE_DIR)
     set(FPRIME_CURRENT_MODULE "${MODULE_NAME}")
 
     # Unset all variables that carry special meaning as it is dangerous to pass them through
-    init_variables(SOURCE_FILES MOD_DEPS UT_SOURCE_FILES UT_MOD_DEPS EXECUTABLE_NAME)
-
+    foreach (VARIABLE IN ITEMS SOURCE_FILES MOD_DEPS UT_SOURCE_FILES UT_MOD_DEPS EXECUTABLE_NAME)
+        set(${VARIABLE} PARENT_SCOPE)
+    endforeach()
 
     # Check if the binary and source directory are in agreement. If they agree, then normally add
     # the directory, as no adjustments need be made.

--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -31,9 +31,9 @@ set(FPRIME_AUTOCODER_TARGET_LIST "" CACHE INTERNAL "FPRIME_AUTOCODER_TARGET_LIST
 #####
 macro(restrict_platforms)
     set(__CHECKER ${ARGN})
-    if (NOT FPRIME_TOOLCHAIN_NAME IN_LIST __CHECKER AND NOT CMAKE_SYSTEM_NAME IN_LIST __CHECKER)
+    if (NOT FPRIME_TOOLCHAIN_NAME IN_LIST __CHECKER AND NOT FPRIME_PLATFORM IN_LIST __CHECKER)
         get_module_name("${CMAKE_CURRENT_LIST_DIR}")
-        message(STATUS "Neither toolchain ${FPRIME_TOOLCHAIN_NAME} nor platform ${CMAKE_SYSTEM_NAME} supported for module ${MODULE_NAME}")
+        message(STATUS "Neither toolchain ${FPRIME_TOOLCHAIN_NAME} nor platform ${FPRIME_PLATFORM} supported for module ${MODULE_NAME}")
         return()
     endif()
 endmacro()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  ||
|**_Documentation Included (y/n)_**|  |

---
## Change Description

There are two minor CMake bugs:
1. A set of variables was cleared rather than unset
2. CMAKE_SYSTEM_NAME was used instead of FPRIME_PLATFORM after creation of that variable

## Rationale
Bug fixes!

