### PR TITLE
Add CI on release branches

### DIFF
--- a/.github/actions/autodoc.bash
+++ b/.github/actions/autodoc.bash
@@ -8,9 +8,9 @@ cd "$GITHUB_WORKSPACE"
 REMOTE="${1:-origin}"
 git config --local user.email "nasa-fprime[bot]@users.noreply.github.com"
 git config --local user.name "nasa-fprime[bot]"
-git fetch "${REMOTE}" release/documentation
+git fetch "${REMOTE}" docs/auto-documentation
 git fetch "${REMOTE}" devel
-git checkout release/documentation
+git checkout docs/auto-documentation
 GIT_EDITOR=true git merge "${REMOTE}"/devel
 ${GITHUB_WORKSPACE}/docs/doxygen/generate_docs.bash
 git add -Af "${GITHUB_WORKSPACE}/docs"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 | | |
 |:---|:---|
 |**_Related Issue(s)_**|  |
-|**_Has Unit Tests (y/n)_**|  ||
+|**_Has Unit Tests (y/n)_**|  |
 |**_Documentation Included (y/n)_**|  |
 
 ---

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -6,10 +6,10 @@ name: macOS-CI
 # events but only for the master branch
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -6,9 +6,10 @@ name: macOS-CI
 # events but only for the master branch
 on:
   push:
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
   pull_request:
-    branches: [ master, devel ]
+    # The branches below must be a subset of the branches above
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/build-test-rpi.yml
+++ b/.github/workflows/build-test-rpi.yml
@@ -6,10 +6,10 @@ name: RPI-CI
 # events but only for the master branch
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/build-test-rpi.yml
+++ b/.github/workflows/build-test-rpi.yml
@@ -6,9 +6,10 @@ name: RPI-CI
 # events but only for the master branch
 on:
   push:
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
   pull_request:
-    branches: [ master, devel ]
+    # The branches below must be a subset of the branches above
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,9 +6,10 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
   pull_request:
-    branches: [ master, devel ]
+    # The branches below must be a subset of the branches above
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,10 +6,10 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/codeql-jpl-standard.yml
+++ b/.github/workflows/codeql-jpl-standard.yml
@@ -5,10 +5,10 @@ name: "JPL Coding Standard Scan"
 
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/codeql-jpl-standard.yml
+++ b/.github/workflows/codeql-jpl-standard.yml
@@ -5,10 +5,10 @@ name: "JPL Coding Standard Scan"
 
 on:
   push:
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -5,10 +5,10 @@ name: "CodeQL Security Scan"
 
 on:
   push:
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -5,10 +5,10 @@ name: "CodeQL Security Scan"
 
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/cppcheck-scan.yml
+++ b/.github/workflows/cppcheck-scan.yml
@@ -3,10 +3,10 @@ name: "Cppcheck Scan"
 
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/cppcheck-scan.yml
+++ b/.github/workflows/cppcheck-scan.yml
@@ -3,10 +3,10 @@ name: "Cppcheck Scan"
 
 on:
   push:
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/cpplint-scan.yml
+++ b/.github/workflows/cpplint-scan.yml
@@ -2,10 +2,10 @@ name: "Cpplint Scan"
 
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/cpplint-scan.yml
+++ b/.github/workflows/cpplint-scan.yml
@@ -2,10 +2,10 @@ name: "Cpplint Scan"
 
 on:
   push:
-    branches: [master, devel]
+    branches: [ devel, release/* ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master, devel ]
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/ext-build-hello-world.yml
+++ b/.github/workflows/ext-build-hello-world.yml
@@ -4,9 +4,10 @@ name: "Tutorial: HelloWorld"
 
 on:
   push:
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
   pull_request:
-    branches: [ master, devel ]
+    # The branches below must be a subset of the branches above
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/ext-build-hello-world.yml
+++ b/.github/workflows/ext-build-hello-world.yml
@@ -4,10 +4,10 @@ name: "Tutorial: HelloWorld"
 
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/ext-build-led-blinker.yml
+++ b/.github/workflows/ext-build-led-blinker.yml
@@ -4,9 +4,10 @@ name: "Tutorial: LedBlinker"
 
 on:
   push:
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
   pull_request:
-    branches: [ master, devel ]
+    # The branches below must be a subset of the branches above
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/ext-build-led-blinker.yml
+++ b/.github/workflows/ext-build-led-blinker.yml
@@ -4,10 +4,10 @@ name: "Tutorial: LedBlinker"
 
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/ext-build-math-comp.yml
+++ b/.github/workflows/ext-build-math-comp.yml
@@ -4,10 +4,10 @@ name: "Tutorial: MathComponent"
 
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/ext-build-math-comp.yml
+++ b/.github/workflows/ext-build-math-comp.yml
@@ -4,9 +4,10 @@ name: "Tutorial: MathComponent"
 
 on:
   push:
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
   pull_request:
-    branches: [ master, devel ]
+    # The branches below must be a subset of the branches above
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -5,9 +5,10 @@ name: "RPI LedBlinker"
 
 on:
   push:
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
   pull_request:
-    branches: [ master, devel ]
+    # The branches below must be a subset of the branches above
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -5,10 +5,10 @@ name: "RPI LedBlinker"
 
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/fpp-tests.yml
+++ b/.github/workflows/fpp-tests.yml
@@ -2,10 +2,10 @@ name: "FppTest"
 
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/fpp-tests.yml
+++ b/.github/workflows/fpp-tests.yml
@@ -2,9 +2,10 @@ name: "FppTest"
 
 on:
   push:
-    branches: [ master, devel ]
+    branches: [ devel, release/* ]
   pull_request:
-    branches: [ master, devel ]
+    # The branches below must be a subset of the branches above
+    branches: [ devel, release/* ]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -2,10 +2,10 @@ name: Format Python
 
 on:
   push:
-    branches: [master, devel]
+    branches: [ devel, release/* ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master, devel]
+    branches: [ devel, release/* ]
 
 jobs:
   format:

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -2,10 +2,10 @@ name: Format Python
 
 on:
   push:
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ devel, release/* ]
+    branches: [ devel, release/** ]
 
 jobs:
   format:

--- a/docs/UsersGuide/cmake/cmake-platforms.md
+++ b/docs/UsersGuide/cmake/cmake-platforms.md
@@ -8,5 +8,5 @@ Build flags and other includes can be added in to support different compile-time
 
 In order to create a new platform from scratch, the user can copy "platform.cmake.template" and fill it out to generate the new platform file. It will guide the user through the setup of this piece.
 
-To understand the platform template: [Platform Template File](https://github.com/nasa/fprime/blob/release/documentation/docs/UsersGuide/api/cmake/platform/platform-template.md)
+To understand the platform template: [Platform Template File](https://github.com/nasa/fprime/blob/docs/auto-documentation/docs/UsersGuide/api/cmake/platform/platform-template.md)
 To use the template: [fprime Platform Template](https://github.com/nasa/fprime/blob/devel/cmake/platform/platform.cmake.template)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2411 |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

- Add `release/*` branches in CI, for both pushes and PR to those branches.
- rename `release/documentation` branch `docs/auto-documentation`

## Rationale

Easier release hotfix.

## Future Work

- double check that the bot pushes to `docs/auto-documentation` successfully
- **switch source branch for GH Pages build https://github.com/nasa/fprime/settings/pages**
- once things are confirmed to be working successfully, delete `release/documentation` branch
