### PR TITLE
Fix pedantic warning on assert macro

### DIFF
--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -165,162 +165,10 @@ namespace Fw {
         s_assertHook = this->previousHook;
     }
 
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo) {
-        if (nullptr == s_assertHook) {
-            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
-            defaultReportAssert(
-                file,
-                lineNo,
-                0,
-                0,0,0,0,0,0,
-                assertMsg,sizeof(assertMsg));
-                // print message
-            defaultPrintAssert(assertMsg);
-            assert(0);
-        }
-        else {
-            s_assertHook->reportAssert(
-                file,
-                lineNo,
-                0,
-                0,0,0,0,0,0);
-            s_assertHook->doAssert();
-        }
-        return 0;
-    }
-
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo,
-            FwAssertArgType arg1) {
-        if (nullptr == s_assertHook) {
-            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
-            defaultReportAssert(
-                file,
-                lineNo,
-                1,
-                arg1,0,0,0,0,0,
-                assertMsg,sizeof(assertMsg));
-            // print message
-            defaultPrintAssert(assertMsg);
-            assert(0);
-        }
-        else {
-            s_assertHook->reportAssert(
-                file,
-                lineNo,
-                1,
-                arg1,0,0,0,0,0);
-            s_assertHook->doAssert();
-        }
-        return 0;
-    }
-
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2) {
-        if (nullptr == s_assertHook) {
-            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
-            defaultReportAssert(
-                file,
-                lineNo,
-                2,
-                arg1,arg2,0,0,0,0,
-                assertMsg,sizeof(assertMsg));
-            defaultPrintAssert(assertMsg);
-            assert(0);
-        }
-        else {
-            s_assertHook->reportAssert(
-                file,
-                lineNo,
-                2,
-                arg1,arg2,0,0,0,0);
-            s_assertHook->doAssert();
-        }
-        return 0;
-    }
-
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            FwAssertArgType arg3) {
-        if (nullptr == s_assertHook) {
-            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
-            defaultReportAssert(
-                file,
-                lineNo,
-                3,
-                arg1,arg2,arg3,0,0,0,
-                assertMsg,sizeof(assertMsg));
-            defaultPrintAssert(assertMsg);
-            assert(0);
-        }
-        else {
-            s_assertHook->reportAssert(
-                file,
-                lineNo,
-                3,
-                arg1,arg2,arg3,0,0,0);
-            s_assertHook->doAssert();
-        }
-        return 0;
-    }
-
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            FwAssertArgType arg3,
-            FwAssertArgType arg4) {
-        if (nullptr == s_assertHook) {
-            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
-            defaultReportAssert(
-                file,
-                lineNo,
-                4,
-                arg1,arg2,arg3,arg4,0,0,
-                assertMsg,sizeof(assertMsg));
-            defaultPrintAssert(assertMsg);
-            assert(0);
-        }
-        else {
-            s_assertHook->reportAssert(
-                file,
-                lineNo,
-                4,
-                arg1,arg2,arg3,arg4,0,0);
-            s_assertHook->doAssert();
-        }
-        return 0;
-    }
-
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            FwAssertArgType arg3,
-            FwAssertArgType arg4,
-            FwAssertArgType arg5) {
-        if (nullptr == s_assertHook) {
-            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
-            defaultReportAssert(
-                file,
-                lineNo,
-                5,
-                arg1,arg2,arg3,arg4,arg5,0,
-                assertMsg,sizeof(assertMsg));
-            defaultPrintAssert(assertMsg);
-            assert(0);
-        }
-        else {
-            s_assertHook->reportAssert(
-                file,
-                lineNo,
-                5,
-                arg1,arg2,arg3,arg4,arg5,0);
-            s_assertHook->doAssert();
-        }
-        return 0;
-    }
-
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo,
+    NATIVE_INT_TYPE defaultSwAssert(
+            FILE_NAME_ARG file,
+            NATIVE_UINT_TYPE lineNo,
+            NATIVE_UINT_TYPE numArgs,
             FwAssertArgType arg1,
             FwAssertArgType arg2,
             FwAssertArgType arg3,
@@ -332,7 +180,7 @@ namespace Fw {
             defaultReportAssert(
                 file,
                 lineNo,
-                6,
+                numArgs,
                 arg1,arg2,arg3,arg4,arg5,arg6,
                 assertMsg,sizeof(assertMsg));
             defaultPrintAssert(assertMsg);
@@ -342,11 +190,74 @@ namespace Fw {
             s_assertHook->reportAssert(
                 file,
                 lineNo,
-                6,
+                numArgs,
                 arg1,arg2,arg3,arg4,arg5,arg6);
             s_assertHook->doAssert();
         }
         return 0;
+    }
+
+    NATIVE_INT_TYPE SwAssert(
+            FILE_NAME_ARG file,
+            NATIVE_UINT_TYPE lineNo) {
+        return defaultSwAssert(file, lineNo, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    NATIVE_INT_TYPE SwAssert(
+            FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            NATIVE_UINT_TYPE lineNo) {
+        return defaultSwAssert(file, lineNo, 1, arg1, 0, 0, 0, 0, 0);
+    }
+
+    NATIVE_INT_TYPE SwAssert(
+            FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            NATIVE_UINT_TYPE lineNo) {
+        return defaultSwAssert(file, lineNo, 2, arg1, arg2, 0, 0, 0, 0);
+    }
+
+    NATIVE_INT_TYPE SwAssert(
+            FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            NATIVE_UINT_TYPE lineNo) {
+        return defaultSwAssert(file, lineNo, 3, arg1, arg2, arg3, 0, 0, 0);
+    }
+
+    NATIVE_INT_TYPE SwAssert(
+            FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            NATIVE_UINT_TYPE lineNo) {
+        return defaultSwAssert(file, lineNo, 4, arg1, arg2, arg3, arg4, 0, 0);
+    }
+
+    NATIVE_INT_TYPE SwAssert(
+            FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwAssertArgType arg5,
+            NATIVE_UINT_TYPE lineNo) {
+        return defaultSwAssert(file, lineNo, 5, arg1, arg2, arg3, arg4, arg5, 0);
+    }
+
+    NATIVE_INT_TYPE SwAssert(
+            FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwAssertArgType arg5,
+            FwAssertArgType arg6,
+            NATIVE_UINT_TYPE lineNo) {
+        return defaultSwAssert(file, lineNo, 6, arg1, arg2, arg3, arg4, arg5, arg6);
     }
 }
 

--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -165,6 +165,7 @@ namespace Fw {
         s_assertHook = this->previousHook;
     }
 
+    // Default handler of SwAssert functions
     NATIVE_INT_TYPE defaultSwAssert(
             FILE_NAME_ARG file,
             NATIVE_UINT_TYPE lineNo,

--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -42,18 +42,6 @@
 #endif
 
 namespace Fw {
-    //! Assert default handler
-    NATIVE_INT_TYPE defaultSwAssert(
-            FILE_NAME_ARG file,
-            NATIVE_UINT_TYPE lineNo,
-            NATIVE_UINT_TYPE numArgs,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            FwAssertArgType arg3,
-            FwAssertArgType arg4,
-            FwAssertArgType arg5,
-            FwAssertArgType arg6);
-
     //! Assert with no arguments
     NATIVE_INT_TYPE SwAssert(
         FILE_NAME_ARG file,

--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -7,22 +7,24 @@
     #define FW_ASSERT(...)
 #else // ASSERT is defined
 
+#define FW_ASSERT_FIRST_ARG(ARG_0, ...) ARG_0
+#define FW_ASSERT_NO_FIRST_ARG(ARG_0, ...) __VA_ARGS__
 
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
     #define FILE_NAME_ARG U32
-    #define FW_ASSERT(cond, ...) \
-        ((void) ((cond) ? (0) : \
-        (Fw::SwAssert(ASSERT_FILE_ID, __LINE__, ##__VA_ARGS__))))
+    #define FW_ASSERT(...) \
+        ((void) ((FW_ASSERT_FIRST_ARG(__VA_ARGS__, 0)) ? (0) : \
+        (Fw::SwAssert(ASSERT_FILE_ID, FW_ASSERT_NO_FIRST_ARG(__VA_ARGS__, __LINE__)))))
 #elif FW_ASSERT_LEVEL == FW_RELATIVE_PATH_ASSERT
     #define FILE_NAME_ARG const CHAR*
-    #define FW_ASSERT(cond, ...) \
-        ((void) ((cond) ? (0) : \
-        (Fw::SwAssert(ASSERT_RELATIVE_PATH, __LINE__, ##__VA_ARGS__))))
+    #define FW_ASSERT(...) \
+        ((void) ((FW_ASSERT_FIRST_ARG(__VA_ARGS__, 0)) ? (0) : \
+        (Fw::SwAssert(ASSERT_RELATIVE_PATH, FW_ASSERT_NO_FIRST_ARG(__VA_ARGS__, __LINE__)))))
 #else
     #define FILE_NAME_ARG const CHAR*
-    #define FW_ASSERT(cond, ...) \
-        ((void) ((cond) ? (0) : \
-        (Fw::SwAssert(__FILE__, __LINE__, ##__VA_ARGS__))))
+    #define FW_ASSERT(...) \
+        ((void) ((FW_ASSERT_FIRST_ARG(__VA_ARGS__, 0)) ? (0) : \
+        (Fw::SwAssert(__FILE__, FW_ASSERT_NO_FIRST_ARG(__VA_ARGS__, __LINE__)))))
 #endif
 
 // F' Assertion functions can technically return even though the intention is for the assertion to terminate the program.
@@ -40,13 +42,73 @@
 #endif
 
 namespace Fw {
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN; //!< Assert with no arguments
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, FwAssertArgType arg1) CLANG_ANALYZER_NORETURN; //!< Assert with one argument
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, FwAssertArgType arg1, FwAssertArgType arg2) CLANG_ANALYZER_NORETURN; //!< Assert with two arguments
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, FwAssertArgType arg1, FwAssertArgType arg2, FwAssertArgType arg3) CLANG_ANALYZER_NORETURN; //!< Assert with three arguments
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, FwAssertArgType arg1, FwAssertArgType arg2, FwAssertArgType arg3, FwAssertArgType arg4) CLANG_ANALYZER_NORETURN; //!< Assert with four arguments
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, FwAssertArgType arg1, FwAssertArgType arg2, FwAssertArgType arg3, FwAssertArgType arg4, FwAssertArgType arg5) CLANG_ANALYZER_NORETURN; //!< Assert with five arguments
-    NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo, FwAssertArgType arg1, FwAssertArgType arg2, FwAssertArgType arg3, FwAssertArgType arg4, FwAssertArgType arg5, FwAssertArgType arg6) CLANG_ANALYZER_NORETURN; //!< Assert with six arguments
+    //! Assert default handler
+    NATIVE_INT_TYPE defaultSwAssert(
+            FILE_NAME_ARG file,
+            NATIVE_UINT_TYPE lineNo,
+            NATIVE_UINT_TYPE numArgs,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwAssertArgType arg5,
+            FwAssertArgType arg6);
+
+    //! Assert with no arguments
+    NATIVE_INT_TYPE SwAssert(
+        FILE_NAME_ARG file,
+        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+
+    //! Assert with one argument
+    NATIVE_INT_TYPE SwAssert(
+        FILE_NAME_ARG file,
+        FwAssertArgType arg1,
+        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+
+    //! Assert with two arguments
+    NATIVE_INT_TYPE SwAssert(
+        FILE_NAME_ARG file,
+        FwAssertArgType arg1,
+        FwAssertArgType arg2,
+        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+
+    //! Assert with three arguments
+    NATIVE_INT_TYPE SwAssert(
+        FILE_NAME_ARG file,
+        FwAssertArgType arg1,
+        FwAssertArgType arg2,
+        FwAssertArgType arg3,
+        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+
+    //! Assert with four arguments
+    NATIVE_INT_TYPE SwAssert(
+        FILE_NAME_ARG file,
+        FwAssertArgType arg1,
+        FwAssertArgType arg2,
+        FwAssertArgType arg3,
+        FwAssertArgType arg4,
+        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+
+    //! Assert with five arguments
+    NATIVE_INT_TYPE SwAssert(
+        FILE_NAME_ARG file,
+        FwAssertArgType arg1,
+        FwAssertArgType arg2,
+        FwAssertArgType arg3,
+        FwAssertArgType arg4,
+        FwAssertArgType arg5,
+        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+
+    //! Assert with six arguments
+    NATIVE_INT_TYPE SwAssert(
+        FILE_NAME_ARG file,
+        FwAssertArgType arg1,
+        FwAssertArgType arg2,
+        FwAssertArgType arg3,
+        FwAssertArgType arg4,
+        FwAssertArgType arg5,
+        FwAssertArgType arg6,
+        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
 }
 
 // Base class for declaring an assert hook
@@ -91,4 +153,4 @@ namespace Fw {
 #endif // if ASSERT is defined
 
 
-#endif
+#endif // FW_ASSERT_HPP

--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -7,9 +7,13 @@
     #define FW_ASSERT(...)
 #else // ASSERT is defined
 
+// Return only the first argument passed to the macro.
 #define FW_ASSERT_FIRST_ARG(ARG_0, ...) ARG_0
+// Return all the arguments of the macro, but the first one
 #define FW_ASSERT_NO_FIRST_ARG(ARG_0, ...) __VA_ARGS__
 
+// Passing the __LINE__ argument at the end of the function ensures that
+// the FW_ASSERT_NO_FIRST_ARG macro will never have an empty variadic variable
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
     #define FILE_NAME_ARG U32
     #define FW_ASSERT(...) \


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/discussions/2409 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Fix the pedantic warning due to empty variadic variables in the assert macro.

Also cleaned some of the code in `Assert.cpp` to avoid repeated code.

## Rationale

The new definition is fully compatible with the previous implementation and should solve the issue mentioned in https://github.com/nasa/fprime/discussions/2409
