### PR TITLE
Tame CI to use fewer parallel jobs

### DIFF
--- a/ci/tests/fputil.bash
+++ b/ci/tests/fputil.bash
@@ -17,7 +17,7 @@ export FPUTIL_TARGETS=("generate" "generate --ut" "build" "build --all" "check -
 function fputil_action {
     export WORKDIR="${1}"
     export TARGET="${2}"
-    let JOBS="${JOBS:-$(( ( RANDOM % 100 )  + 1 ))}"
+    let JOBS="${JOBS:-$(( ( RANDOM % 9 )  + 1 ))}"
     (
         PLATFORM=""
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

CI has been running for ~6hours before timing out.  This could be caused by a large number of parallel jobs being used (and thus slowing down the run substantially.

This reduces the parallel jobs to less than or equal to 9.


## Future Work

Maybe need to go smaller.