### PR TITLE
Switching to absolute paths in CMake. Fixes #2449

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -201,7 +201,7 @@ function(normalize_paths OUTPUT_NAME)
     # Loop over the list and check
     foreach (PATH_LIST IN LISTS ARGN)
         foreach(PATH IN LISTS PATH_LIST)
-            get_filename_component(PATH "${PATH}" REALPATH)
+            get_filename_component(PATH "${PATH}" ABSOLUTE)
             list(APPEND OUTPUT_LIST "${PATH}")
         endforeach()
     endforeach()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Switches to using `ABSOLUTE` instead of `REALPATH` within CMake to fix #2449  and step towards correct builds in sym-linked directories.

## Future Work

Note any additional work that will be done relating to this issue.
