### PR TITLE
Fix MacOS CI

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -30,6 +30,9 @@ jobs:
     - uses: ./.github/actions/setup
     - name: F prime CI step
       run: ./ci/tests/Framework.bash
+      env:
+        # Limit to 2 jobs to avoid resource exhaustion (https://github.com/nasa/fprime/issues/2462)
+        JOBS: 2
     # Archive the outputs
     - name: 'Archive Logs'
       uses: actions/upload-artifact@v3
@@ -51,6 +54,8 @@ jobs:
     - uses: ./.github/actions/setup
     - name: F prime CI step
       run: ./ci/tests/Ref.bash
+      env:
+        JOBS: 2
     # Archive the outputs
     - name: 'Archive Logs'
       uses: actions/upload-artifact@v3
@@ -74,6 +79,8 @@ jobs:
       run: brew install coreutils
     - name: F prime CI step
       run: ./ci/tests/30-ints.bash
+      env:
+        JOBS: 2
     # Archive the outputs
     - name: 'Archive Logs'
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   macOS-Framework:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
     - name: "Checkout F´ Repository"
       uses: actions/checkout@v4
@@ -40,6 +41,7 @@ jobs:
 
   macOS-Ref:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
     - name: "Checkout F´ Repository"
       uses: actions/checkout@v4
@@ -60,6 +62,7 @@ jobs:
 
   macOS-Integration:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
     - name: "Checkout F´ Repository"
       uses: actions/checkout@v4

--- a/ci/tests/fputil.bash
+++ b/ci/tests/fputil.bash
@@ -17,8 +17,7 @@ export FPUTIL_TARGETS=("generate" "generate --ut" "build" "build --all" "check -
 function fputil_action {
     export WORKDIR="${1}"
     export TARGET="${2}"
-    # let JOBS="${JOBS:-$(( ( RANDOM % 9 )  + 1 ))}"
-    let JOBS="2"
+    let JOBS="${JOBS:-$(( ( RANDOM % 100 )  + 1 ))}"
     (
         PLATFORM=""
 
@@ -44,8 +43,7 @@ export -f fputil_action
 ####
 function integration_test {
     export WORKDIR="${1}"
-    # let JOBS="${JOBS:-$(( ( RANDOM % 100 )  + 1 ))}"
-    let JOBS="2"
+    let JOBS="${JOBS:-$(( ( RANDOM % 100 )  + 1 ))}"
 
     CMAKE_EXTRA_SETTINGS=""
     PLATFORM=""

--- a/ci/tests/fputil.bash
+++ b/ci/tests/fputil.bash
@@ -17,7 +17,8 @@ export FPUTIL_TARGETS=("generate" "generate --ut" "build" "build --all" "check -
 function fputil_action {
     export WORKDIR="${1}"
     export TARGET="${2}"
-    let JOBS="${JOBS:-$(( ( RANDOM % 9 )  + 1 ))}"
+    # let JOBS="${JOBS:-$(( ( RANDOM % 9 )  + 1 ))}"
+    let JOBS="2"
     (
         PLATFORM=""
 
@@ -43,7 +44,8 @@ export -f fputil_action
 ####
 function integration_test {
     export WORKDIR="${1}"
-    let JOBS="${JOBS:-$(( ( RANDOM % 100 )  + 1 ))}"
+    # let JOBS="${JOBS:-$(( ( RANDOM % 100 )  + 1 ))}"
+    let JOBS="2"
 
     CMAKE_EXTRA_SETTINGS=""
     PLATFORM=""


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #2462  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Should fix https://github.com/nasa/fprime/issues/2462

Limiting to 2 parallel jobs for macOS CI. Keeping the random(1, 100) for non-macOS runs.
2 was chosen very much arbitrarily as it seems to pass, while I've seen runs with 4 parallel jobs fail. Let me know if you have any input on that value.

## Future Work

Be on the lookout for CI failures.
