### PR TITLE
(#2465) use u8 instead of char

### DIFF
--- a/Svc/FramingProtocol/FprimeProtocol.cpp
+++ b/Svc/FramingProtocol/FprimeProtocol.cpp
@@ -62,7 +62,7 @@ bool FprimeDeframing::validate(Types::CircularBuffer& ring, U32 size) {
     // Initialize the checksum and loop through all bytes calculating it
     hash.init();
     for (U32 i = 0; i < size; i++) {
-        char byte;
+        U8 byte;
         const Fw::SerializeStatus status = ring.peek(byte, i);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
         hash.update(&byte, 1);
@@ -70,8 +70,8 @@ bool FprimeDeframing::validate(Types::CircularBuffer& ring, U32 size) {
     hash.final(hashBuffer);
     // Now loop through the hash digest bytes and check for equality
     for (U32 i = 0; i < HASH_DIGEST_LENGTH; i++) {
-        char calc = static_cast<char>(hashBuffer.getBuffAddr()[i]);
-        char sent = 0;
+        U8 calc = static_cast<char>(hashBuffer.getBuffAddr()[i]);
+        U8 sent = 0;
         const Fw::SerializeStatus status = ring.peek(sent, size + i);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
         if (calc != sent) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #2465  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Replace usages of `char` with `u8`

## Rationale


## Testing/Review Recommendations

Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality.

## Future Work

Note any additional work that will be done relating to this issue.
