### PR TITLE
Generalize UT of RateGroupDriver

### DIFF
--- a/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
+++ b/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
@@ -32,7 +32,7 @@ void connectPorts(Svc::RateGroupDriver& impl, Svc::RateGroupDriverImplTester& te
 TEST(RateGroupDriverTest,NominalSchedule) {
 
     Svc::RateGroupDriver::DividerSet dividersSet{};
-    for(FwIndexType i=0; i<Svc::RateGroupDriver::DIVIDER_SIZE; i++)
+    for(FwIndexType i=0; i<static_cast<FwIndexType>(Svc::RateGroupDriver::DIVIDER_SIZE); i++)
     {
         dividersSet.dividers[i] = {i+1, i%2};
     }

--- a/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
+++ b/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
@@ -32,7 +32,7 @@ void connectPorts(Svc::RateGroupDriver& impl, Svc::RateGroupDriverImplTester& te
 TEST(RateGroupDriverTest,NominalSchedule) {
 
     Svc::RateGroupDriver::DividerSet dividersSet{};
-    for(int i=0; i<Svc::RateGroupDriver::DIVIDER_SIZE; i++)
+    for(FwIndexType i=0; i<Svc::RateGroupDriver::DIVIDER_SIZE; i++)
     {
         dividersSet.dividers[i] = {i+1, i%2};
     }

--- a/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
+++ b/Svc/RateGroupDriver/test/ut/RateGroupDriverTester.cpp
@@ -31,7 +31,11 @@ void connectPorts(Svc::RateGroupDriver& impl, Svc::RateGroupDriverImplTester& te
 
 TEST(RateGroupDriverTest,NominalSchedule) {
 
-    Svc::RateGroupDriver::DividerSet dividersSet{{{1, 0}, {2, 1}, {3, 0}}};
+    Svc::RateGroupDriver::DividerSet dividersSet{};
+    for(int i=0; i<Svc::RateGroupDriver::DIVIDER_SIZE; i++)
+    {
+        dividersSet.dividers[i] = {i+1, i%2};
+    }
 
     Svc::RateGroupDriver impl("RateGroupDriver");
     impl.configure(dividersSet);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The UT of `RateGroupDriver` was failing if `RateGroupDriverRateGroupPorts` in `AcConstant.fpp` was different from 3. The new change makes the test work for any value.