### PR TITLE
Fix `Baremetal/FileSystem` `readDirectory()` impl

### DIFF
--- a/Os/Baremetal/FileSystem.cpp
+++ b/Os/Baremetal/FileSystem.cpp
@@ -13,9 +13,11 @@ Status removeDirectory(const char* path) {
     return INVALID_PATH;
 }  // end removeDirectory
 
-Status readDirectory(const char* path, const U32 maxNum, Fw::String fileArray[]) {
+Status readDirectory(const char* path, const U32 maxNum, Fw::String fileArray[], U32& numFiles) {
+    numFiles = 0;
     return OTHER_ERROR;
-}
+}  // end readDirectory
+
 Status removeFile(const char* path) {
     return OTHER_ERROR;
 }  // end removeFile


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

This PR fixes the stub implementation of `readDirectory()` under `Baremetal/Filesystem`.

## Rationale

The implementation does not match the signature in [FileSystem.hpp](https://github.com/nasa/fprime/blob/devel/Os/FileSystem.hpp#L30), which will cause an application using this function to fail to link.

## Testing/Review Recommendations

CI should be testing that all implementations of these multi-target utilities build and link.

## Future Work

N/A