### PR TITLE
Fix issues in FppTest

### DIFF
--- a/FppTest/struct/NonPrimitiveStructTest.cpp
+++ b/FppTest/struct/NonPrimitiveStructTest.cpp
@@ -26,7 +26,8 @@ class NonPrimitiveStructTest : public ::testing::Test {
 protected:
     void SetUp() override {
         char buf[testString.getCapacity()];
-        FppTest::Utils::setString(buf, sizeof(buf));
+        // Test string must be non-empty
+        FppTest::Utils::setString(buf, sizeof(buf), 1);
         testString = buf;
 
         testEnum = static_cast<StructEnum::T>(STest::Pick::startLength(
@@ -106,7 +107,7 @@ TEST_F(NonPrimitiveStructTest, Default) {
     // Constants
     ASSERT_EQ(
         NonPrimitive::SERIALIZED_SIZE,
-        NonPrimitive::StringSize80::SERIALIZED_SIZE 
+        NonPrimitive::StringSize80::SERIALIZED_SIZE
             + StructEnum::SERIALIZED_SIZE
             + StructArray::SERIALIZED_SIZE
             + Primitive::SERIALIZED_SIZE
@@ -131,12 +132,12 @@ TEST_F(NonPrimitiveStructTest, Default) {
 // Test struct constructors
 TEST_F(NonPrimitiveStructTest, Constructors) {
     // Member constructor
-    NonPrimitive s1(testString, testEnum, testArray, 
+    NonPrimitive s1(testString, testEnum, testArray,
                     testStruct, testU32Arr, testStructArr);
     assertStructMembers(s1);
 
     // Scalar member constructor
-    NonPrimitive s2(testString, testEnum, testArray, 
+    NonPrimitive s2(testString, testEnum, testArray,
                     testStruct, testU32Arr[0], testStructArr[0]);
 
     ASSERT_EQ(s2.getmString(), testString);
@@ -159,7 +160,7 @@ TEST_F(NonPrimitiveStructTest, Constructors) {
 // Test struct assignment operator
 TEST_F(NonPrimitiveStructTest, AssignmentOp) {
     NonPrimitive s1;
-    NonPrimitive s2(testString, testEnum, testArray, 
+    NonPrimitive s2(testString, testEnum, testArray,
                     testStruct, testU32Arr, testStructArr);
 
     // Copy assignment
@@ -225,7 +226,7 @@ TEST_F(NonPrimitiveStructTest, GetterSetterFunctions) {
     NonPrimitive s1, s2;
 
     // Set all members
-    s1.set(testString, testEnum, testArray, 
+    s1.set(testString, testEnum, testArray,
            testStruct, testU32Arr, testStructArr);
     assertStructMembers(s1);
 
@@ -259,7 +260,7 @@ TEST_F(NonPrimitiveStructTest, GetterSetterFunctions) {
 
 // Test struct serialization and deserialization
 TEST_F(NonPrimitiveStructTest, Serialization) {
-    NonPrimitive s(testString, testEnum, testArray, 
+    NonPrimitive s(testString, testEnum, testArray,
                    testStruct, testU32Arr, testStructArr);
     NonPrimitive sCopy;
 
@@ -287,22 +288,22 @@ TEST_F(NonPrimitiveStructTest, Serialization) {
 
     // Test unsuccessful serialization
     assertUnsuccessfulSerialization(s, stringSerializedSize - 1);
-    assertUnsuccessfulSerialization(s, stringSerializedSize 
+    assertUnsuccessfulSerialization(s, stringSerializedSize
             + StructEnum::SERIALIZED_SIZE - 1);
-    assertUnsuccessfulSerialization(s, stringSerializedSize 
+    assertUnsuccessfulSerialization(s, stringSerializedSize
             + StructEnum::SERIALIZED_SIZE + StructArray::SERIALIZED_SIZE - 1);
-    assertUnsuccessfulSerialization(s, stringSerializedSize 
-            + StructEnum::SERIALIZED_SIZE + StructArray::SERIALIZED_SIZE 
+    assertUnsuccessfulSerialization(s, stringSerializedSize
+            + StructEnum::SERIALIZED_SIZE + StructArray::SERIALIZED_SIZE
             + Primitive::SERIALIZED_SIZE - 1);
-    assertUnsuccessfulSerialization(s, stringSerializedSize 
-            + StructEnum::SERIALIZED_SIZE + StructArray::SERIALIZED_SIZE 
+    assertUnsuccessfulSerialization(s, stringSerializedSize
+            + StructEnum::SERIALIZED_SIZE + StructArray::SERIALIZED_SIZE
             + Primitive::SERIALIZED_SIZE + (3 * sizeof(U32)) - 1);
     assertUnsuccessfulSerialization(s, serializedSize - 1);
 }
 
 // Test struct toString() and ostream operator functions
 TEST_F(NonPrimitiveStructTest, ToString) {
-    NonPrimitive s(testString, testEnum, testArray, 
+    NonPrimitive s(testString, testEnum, testArray,
                    testStruct, testU32Arr, testStructArr);
     std::stringstream buf1, buf2;
 
@@ -311,21 +312,21 @@ TEST_F(NonPrimitiveStructTest, ToString) {
     buf2 << "( "
          << "mString = " << testString << ", "
          << "mEnum = " << testEnum << ", "
-         << "mArray = " << testArray << ", "        
-         << "mStruct = " << testStruct << ", "        
-         << "mU32Arr = [ " 
+         << "mArray = " << testArray << ", "
+         << "mStruct = " << testStruct << ", "
+         << "mU32Arr = [ "
          << testU32Arr[0] << ", "
          << testU32Arr[1] << ", "
          << testU32Arr[2] << " ], "
-         << "mStructArr = [ " 
+         << "mStructArr = [ "
          << testStructArr[0] << ", "
          << testStructArr[1] << ", "
          << testStructArr[2] << " ] "
          << " )";
 
     // Truncate string output
-    char buf2Str[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE]; 
-    Fw::StringUtils::string_copy(buf2Str, buf2.str().c_str(), 
+    char buf2Str[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE];
+    Fw::StringUtils::string_copy(buf2Str, buf2.str().c_str(),
                                  FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE);
 
     ASSERT_STREQ(buf1.str().c_str(), buf2Str);

--- a/FppTest/struct/PrimitiveStructTest.cpp
+++ b/FppTest/struct/PrimitiveStructTest.cpp
@@ -39,8 +39,9 @@ protected:
     }
 
     void assertUnsuccessfulSerialization(Primitive& s, U32 bufSize) {
-        U8 data[bufSize];
-        Fw::SerialBuffer buf(data, sizeof(data));
+        // Avoid creating an array of size zero
+        U8 data[bufSize + 1];
+        Fw::SerialBuffer buf(data, bufSize);
         Fw::SerializeStatus status;
 
         // Serialize

--- a/FppTest/utils/Utils.cpp
+++ b/FppTest/utils/Utils.cpp
@@ -10,16 +10,17 @@
 //
 // ======================================================================
 
-#include "STest/Pick/Pick.hpp"
-
 #include <string>
 #include <limits>
 #include <iostream>
 
+#include "Fw/Types/Assert.hpp"
+#include "STest/Pick/Pick.hpp"
+
 namespace FppTest {
-        
+
     namespace Utils {
-    
+
         U8 getNonzeroU8() {
             return static_cast<U8>(STest::Pick::lowerUpper(
                 1,
@@ -38,21 +39,23 @@ namespace FppTest {
             return static_cast<char>(STest::Pick::lowerUpper(32, 127));
         }
 
-        void setString(char* buf, U32 size) {
-            U32 length = STest::Pick::lowerUpper(1, size);
+        void setString(char* buf, FwSizeType capacity, FwSizeType minLength) {
+            FW_ASSERT(buf != nullptr);
+            // capacity must be able to hold a null-terminated string
+            FW_ASSERT(capacity > 0);
+            // min length must fit within capacity
+            FW_ASSERT(minLength < capacity);
+            U32 length = STest::Pick::lowerUpper(minLength, capacity - 1);
 
-            if (length == 0) {
-                buf[0] = 0;
-                return;
-            }
-
-            for (U32 i = 0; i < length - 1; i++) {
+            for (U32 i = 0; i < length; i++) {
+                FW_ASSERT(i < capacity);
                 buf[i] = getChar();
             }
 
-            buf[length-1] = 0;
+            FW_ASSERT(length < capacity);
+            buf[length] = 0;
         }
-        
+
     } // namespace Utils
 
 } // namespace FppTest

--- a/FppTest/utils/Utils.hpp
+++ b/FppTest/utils/Utils.hpp
@@ -26,8 +26,14 @@ namespace FppTest {
         // Returns a random non-null char
         char getChar();
 
-        // Populates buf with a random nonempty string of random length with max length size
-        void setString(char *buf, U32 size);
+        // Populates buf with a random string of random length that fits
+        // within capacity, including the null terminator (i.e., length + 1 <= capacity)
+        void setString(
+            char *buf, //!< The buffer pointer
+            FwSizeType capacity, //!< The buffer capacity
+            FwSizeType minLength = 0 //!< The minimum string length, not including the null terminator
+                                     //!< minLength + 1 must be <= capacity
+        );
             
     } // namespace Utils
 


### PR DESCRIPTION
This PR fixes some issues in FppTest.
1. I noticed that the sanitizer was complaining about an array size of zero. I fixed it.
2. I noticed that a test was assuming a non-empty test string, and it failed in the case where the random test string was empty. I added the constraint that the string must have min length 1.
3. I cleaned up the logic and added some assertions in the function for generating random strings.
4. I removed trailing spaces from the files that I touched.