### PR TITLE
Update `ActiveTextLogger` naming to match build system naming expectations

### DIFF
--- a/Svc/ActiveTextLogger/ActiveTextLogger.cpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.cpp
@@ -3,7 +3,7 @@
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
 
-#include <Svc/ActiveTextLogger/ActiveTextLoggerImpl.hpp>
+#include <Svc/ActiveTextLogger/ActiveTextLogger.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Logger/Logger.hpp>
 #include <ctime>
@@ -14,19 +14,19 @@ namespace Svc {
     // Initialization/Exiting
     // ----------------------------------------------------------------------
 
-    ActiveTextLoggerComponentImpl::ActiveTextLoggerComponentImpl(const char* name) :
+    ActiveTextLogger::ActiveTextLogger(const char* name) :
         ActiveTextLoggerComponentBase(name),
         m_log_file()
     {
 
     }
 
-    ActiveTextLoggerComponentImpl::~ActiveTextLoggerComponentImpl()
+    ActiveTextLogger::~ActiveTextLogger()
     {
 
     }
 
-    void ActiveTextLoggerComponentImpl::init(NATIVE_INT_TYPE queueDepth, NATIVE_INT_TYPE instance)
+    void ActiveTextLogger::init(NATIVE_INT_TYPE queueDepth, NATIVE_INT_TYPE instance)
     {
         ActiveTextLoggerComponentBase::init(queueDepth,instance);
     }
@@ -35,7 +35,7 @@ namespace Svc {
     // Handlers to implement for typed input ports
     // ----------------------------------------------------------------------
 
-    void ActiveTextLoggerComponentImpl::TextLogger_handler(NATIVE_INT_TYPE portNum,
+    void ActiveTextLogger::TextLogger_handler(NATIVE_INT_TYPE portNum,
                                                   FwEventIdType id,
                                                   Fw::Time &timeTag,
                                                   const Fw::LogSeverity& severity,
@@ -117,7 +117,7 @@ namespace Svc {
     // Internal interface handlers
     // ----------------------------------------------------------------------
 
-    void ActiveTextLoggerComponentImpl::TextQueue_internalInterfaceHandler(const Fw::InternalInterfaceString& text)
+    void ActiveTextLogger::TextQueue_internalInterfaceHandler(const Fw::InternalInterfaceString& text)
     {
 
         // Print to console:
@@ -132,7 +132,7 @@ namespace Svc {
     // Helper Methods
     // ----------------------------------------------------------------------
 
-    bool ActiveTextLoggerComponentImpl::set_log_file(const char* fileName, const U32 maxSize, const U32 maxBackups)
+    bool ActiveTextLogger::set_log_file(const char* fileName, const U32 maxSize, const U32 maxBackups)
     {
         FW_ASSERT(fileName != nullptr);
 

--- a/Svc/ActiveTextLogger/ActiveTextLogger.hpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.hpp
@@ -13,7 +13,7 @@
 
 namespace Svc {
 
-    //! \class ActiveTextLoggerComponentImpl
+    //! \class ActiveTextLoggerComponent
     //! \brief Active text logger component class
     //!
     //! Similarly to the PassiveTextLogger, this component takes log texts
@@ -21,7 +21,7 @@ namespace Svc {
     //! consistent ordering.  It also provides the option to write the text
     //! to a file as well.
 
-    class ActiveTextLoggerComponentImpl: public ActiveTextLoggerComponentBase {
+    class ActiveTextLogger: public ActiveTextLoggerComponentBase {
 
         public:
 
@@ -33,11 +33,11 @@ namespace Svc {
             //!  type conversion.
             //!
             //!  \param compName the component instance name
-            explicit ActiveTextLoggerComponentImpl(const char* compName);
+            explicit ActiveTextLogger(const char* compName);
 
             //!  \brief Component destructor
             //!
-            virtual ~ActiveTextLoggerComponentImpl(); //!< destructor
+            virtual ~ActiveTextLogger(); //!< destructor
 
             //!  \brief Component initialization routine
             //!
@@ -70,12 +70,12 @@ namespace Svc {
         /*! \brief Copy constructor
          *
          */
-        ActiveTextLoggerComponentImpl(const ActiveTextLoggerComponentImpl&);
+        ActiveTextLogger(const ActiveTextLogger&);
 
         /*! \brief Copy assignment operator
          *
          */
-        ActiveTextLoggerComponentImpl& operator=(const ActiveTextLoggerComponentImpl&);
+        ActiveTextLogger& operator=(const ActiveTextLogger&);
 
         // ----------------------------------------------------------------------
         // Constants/Types

--- a/Svc/ActiveTextLogger/CMakeLists.txt
+++ b/Svc/ActiveTextLogger/CMakeLists.txt
@@ -8,7 +8,7 @@
 ####
 set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/ActiveTextLogger.fpp"
-  "${CMAKE_CURRENT_LIST_DIR}/ActiveTextLoggerImpl.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/ActiveTextLogger.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/LogFile.cpp"
 )
 

--- a/Svc/ActiveTextLogger/test/ut/ActiveTextLoggerTester.hpp
+++ b/Svc/ActiveTextLogger/test/ut/ActiveTextLoggerTester.hpp
@@ -7,7 +7,7 @@
 #define TESTER_HPP
 
 #include "ActiveTextLoggerGTestBase.hpp"
-#include "Svc/ActiveTextLogger/ActiveTextLoggerImpl.hpp"
+#include "Svc/ActiveTextLogger/ActiveTextLogger.hpp"
 
 namespace Svc {
 

--- a/Svc/ActiveTextLogger/test/ut/ActiveTextLoggerTester.hpp
+++ b/Svc/ActiveTextLogger/test/ut/ActiveTextLoggerTester.hpp
@@ -60,7 +60,7 @@ namespace Svc {
 
       //! The component under test
       //!
-      ActiveTextLoggerComponentImpl component;
+      ActiveTextLogger component;
 
   };
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  
|**_Has Unit Tests (y/n)_**| Yes
|**_Documentation Included (y/n)_**|  Yes

---
## Change Description

This PR updates file names and `CMakeLists` for `ActiveTextLogger` to conform with what I believe the build system requires. See _Rationale_ below. 

**I could also be completely overlooking a pattern or small detail, so please let me know if this change is unnecessary!** I can't imagine I'm the first person to run into this problem with such a common Component, so I suspect another issue in my configuration might be involved.

## Rationale

Including `ActiveTextLogger` in a topology leads to a compiler error in an auto-coded file:

```
TopologyAc.hpp:16:10: fatal error: Svc/ActiveTextLogger/ActiveTextLogger.hpp: No such file or directory
 #include "Svc/ActiveTextLogger/ActiveTextLogger.hpp"
```

If I change the fpp to use `ActiveTextLoggerImpl`, now the build fails at `fpp-to-cpp`:

```
Declarations.fpp:79.23
instance logText: Svc.ActiveTextLoggerImpl \
                      ^
error: undefined symbol ActiveTextLoggerImpl
```

I think the latest build system expects naming like `Svc/<ComponentName>/<ComponentName>` without the `ComponentImpl` class or `Impl` file suffixes.

## Testing/Review Recommendations

My topology including `ActiveTextLogger` now compiles. `fprime-util check –all` runs with `100% tests passed, 0 tests failed out of 54`.
