### PR TITLE
Update install guide to use fprime-bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ Learn more about F' key features [here](https://nasa.github.io/fprime/features.h
 
 ## Getting Started
 
-To get started with F´, install the F´ toolset with:
+To get started with F´, install the F´ bootstrapping tool with:
 ```
-pip install fprime-tools
+pip install fprime-bootstrap
 ```
 
 Then, create a new project with:
 ```
-fprime-util new --project
+fprime-bootstrap project
 ```
 
 See the [HelloWorld Tutorial](https://fprime-community.github.io/fprime-tutorial-hello-world/) to guide you through all the steps of developing an F´ project.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -38,47 +38,45 @@ Requirements:
 > Other OS-specific notes are in the [Troubleshooting](#Troubleshooting) section below.
 
 
+## Creating a new F´ Project
 
-## Setting Up the Development Environment
+The ecosystem of tools supporting F´ is installed as Python packages available via PIP. These packages are installed in a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/) by the F´ Bootstrap tool. It is recommended to have one virtual environment per project.
 
-The ecosystem of tools supporting F´ is installed as python packages available via PIP. To setup F´ tools, you should create a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/), activate it, and install the latest version of fprime-tools.
+### 1. Install the F´ Bootstrap tool
 
-1. Create the virtual environment:
-
-```bash
-python3 -m venv fprime-venv
+The F´ Bootstrap tool is responsible for creating a new F´ project and installing the Python dependencies within the project's virtual environment. Install the fprime-bootstrap tool with:
 ```
-> You should create a new virtual environment for each new F´ project. The name `fprime-venv` may be changed.
-
-2. Activate the virtual environment
-
-```bash
-. fprime-venv/bin/activate
+pip install fprime-bootstrap
 ```
-> Remember to activate the virtual environment whenever you work with this F´  project.
 
-2. Install F´  tools
-```
-pip install -U fprime-tools
-```
 > Some macOS users see an SSL error. [Correct the SSL error](#ssl-error-with-python-37-on-macos) and rerun the above command.
 
-## Creating a New Project
+### 2. Create a new project
 
-The entrypoint to developing with F´ is creating a new project. This will clone the F´ repository and install the full tool suite of the specified version for working with the selected version of F´.
+The entrypoint to developing with F´ is creating a new project. This will clone the F´ repository and install the full tool suite of the specified version for working with the selected version of F´. To create a new project, run:
 ```
-fprime-util new --project
+fprime-bootstrap project
 ```
 
 This command will ask for some input. Sample responses are below:
 ```
-project_name [MyProject]: MyProject
-fprime_branch_or_tag [devel]: devel
-Select install_venv:
-1 - yes
-2 - no
-Choose from 1, 2 [1]: 1
+  [1/1] Project name (MyProject): MyProject
 ```
+
+This commands perform the following actions:
+- Create a new git repository with the standard F´ project structure
+- Create a new virtual environment within the project and install dependencies
+
+
+### 3. Activate the virtual environment
+
+Once the project is created, activate the virtual environment to use the F´ tool suite.
+
+```
+cd MyProject
+. fprime-venv/bin/activate
+```
+> Always remember to activate the virtual environment whenever you work with this F´  project.
 
 Next steps: [HelloWorld Tutorial](https://fprime-community.github.io/fprime-tutorial-hello-world/)
 
@@ -105,9 +103,7 @@ This section will add some known hints to trouble-shooting with the installation
 If the user is using a virtual environment and receives the 'command not found', the problem is likely caused by the environment not being sourced in a new terminal. Make sure to source the environment before running:
 
 ```
-. /path/to/venv/bin/activate
-e.g.
-. $HOME/fprime-venv/bin/activate
+. <path/to/project>/fprime-venv/bin/activate
 ```
 
 If installing without a virtual environment, PIP occasionally uses `$HOME/.local/bin` as a place to install user tools. Users running without virtual environments should add this directory to the path.

--- a/docs/UsersGuide/dev/py-dev.md
+++ b/docs/UsersGuide/dev/py-dev.md
@@ -2,6 +2,11 @@
 
 This guide describes the guidelines for developing Python code to be used with F´. This is done when contributing to the
 F´ Python code and is recommended for project Python code as well.
+Start by cloning the F´ repositories you wish to work on, e.g.
+
+```
+git clone https://github.com/fprime-community/fprime-gds
+```
 
 ## Required Development Installs
 
@@ -9,8 +14,11 @@ Setup the virtual environment per the install guide using the small additions be
 facilitate Python development.
 
 ```bash
-pip install -e fprime/Fw/Python[dev]
-pip install -e fprime/Gds/
+pip install -e ./fprime-gds
+```
+or
+```
+pip install -e ./fprime-tools
 ```
 
 After you have installed the python packages you need to set up pre-commit hooks using the following command. This
@@ -25,12 +33,12 @@ pre-commit install
 Probably one of the most important parts of developing code is to ensure Python unit tests pass. We use pytest:
 
 ```bash
-cd fprime/Fw/Python/
+cd fprime-tools
 pytest
 ```
 
 ```bash
-cd fprime/Gds/
+cd fprime-gds
 pytest
 ```
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---

# Do not merge until we formally release fprime-bootstrap

## Change Description

fprime-bootstrap available at https://github.com/fprime-community/fprime-bootstrap (not released yet)


## Rationale

See https://github.com/nasa/fprime/issues/2477


## Future Work

Update tutorials to make sure they reference the install guide, instead of write their own instructions
https://github.com/fprime-community/fprime-tutorial-math-component/pull/25 
https://github.com/fprime-community/fprime-workshop-led-blinker/pull/57 
https://github.com/fprime-community/fprime-tutorial-hello-world/pull/17

