### PR TITLE
Removed a_ prefix on arguments

### DIFF
--- a/Fw/FilePacket/CancelPacket.cpp
+++ b/Fw/FilePacket/CancelPacket.cpp
@@ -18,13 +18,13 @@ namespace Fw {
   void FilePacket::CancelPacket ::
     initialize(const U32 sequenceIndex)
   {
-    this->header.initialize(FilePacket::T_CANCEL, sequenceIndex);
+    this->m_header.initialize(FilePacket::T_CANCEL, sequenceIndex);
   }
 
   U32 FilePacket::CancelPacket ::
     bufferSize() const
   {
-    return this->header.bufferSize();
+    return this->m_header.bufferSize();
   }
 
   SerializeStatus FilePacket::CancelPacket ::
@@ -34,14 +34,14 @@ namespace Fw {
         buffer.getData(),
         buffer.getSize()
     );
-    return this->header.toSerialBuffer(serialBuffer);
+    return this->m_header.toSerialBuffer(serialBuffer);
   }
 
   SerializeStatus FilePacket::CancelPacket ::
     fromSerialBuffer(SerialBuffer& serialBuffer)
   {
 
-    FW_ASSERT(this->header.type == T_CANCEL);
+    FW_ASSERT(this->m_header.m_type == T_CANCEL);
 
     if (serialBuffer.getBuffLeft() != 0)
       return FW_DESERIALIZE_SIZE_MISMATCH;

--- a/Fw/FilePacket/DataPacket.cpp
+++ b/Fw/FilePacket/DataPacket.cpp
@@ -18,25 +18,25 @@ namespace Fw {
   void FilePacket::DataPacket ::
     initialize(
         const U32 sequenceIndex,
-        const U32 a_byteOffset,
-        const U16 a_dataSize,
-        const U8 *const a_data
+        const U32 byteOffset,
+        const U16 dataSize,
+        const U8 *const data
     )
   {
-    this->header.initialize(FilePacket::T_DATA, sequenceIndex);
-    this->byteOffset = a_byteOffset;
-    this->dataSize = a_dataSize;
-    this->data = a_data;
+    this->m_header.initialize(FilePacket::T_DATA, sequenceIndex);
+    this->m_byteOffset = byteOffset;
+    this->m_dataSize = dataSize;
+    this->m_data = data;
   }
 
   U32 FilePacket::DataPacket ::
     bufferSize() const
   {
     return
-      this->header.bufferSize() +
-      sizeof(this->byteOffset) +
-      sizeof(this->dataSize) +
-      this->dataSize;
+      this->m_header.bufferSize() +
+      sizeof(this->m_byteOffset) +
+      sizeof(this->m_dataSize) +
+      this->m_dataSize;
   }
 
   SerializeStatus FilePacket::DataPacket ::
@@ -53,21 +53,21 @@ namespace Fw {
     fromSerialBuffer(SerialBuffer& serialBuffer)
   {
 
-    FW_ASSERT(this->header.type == T_DATA);
+    FW_ASSERT(this->m_header.m_type == T_DATA);
 
-    SerializeStatus status = serialBuffer.deserialize(this->byteOffset);
+    SerializeStatus status = serialBuffer.deserialize(this->m_byteOffset);
     if (status != FW_SERIALIZE_OK)
       return status;
 
-    status = serialBuffer.deserialize(this->dataSize);
+    status = serialBuffer.deserialize(this->m_dataSize);
     if (status != FW_SERIALIZE_OK)
       return status;
 
-    if (serialBuffer.getBuffLeft() != this->dataSize)
+    if (serialBuffer.getBuffLeft() != this->m_dataSize)
       return FW_DESERIALIZE_SIZE_MISMATCH;
 
     U8 *const addr = serialBuffer.getBuffAddr();
-    this->data = &addr[this->fixedLengthSize()];
+    this->m_data = &addr[this->fixedLengthSize()];
 
     return FW_SERIALIZE_OK;
 
@@ -77,32 +77,32 @@ namespace Fw {
     fixedLengthSize() const
   {
     return
-      this->header.bufferSize() +
-      sizeof(this->byteOffset) +
-      sizeof(this->dataSize);
+      this->m_header.bufferSize() +
+      sizeof(this->m_byteOffset) +
+      sizeof(this->m_dataSize);
   }
 
   SerializeStatus FilePacket::DataPacket ::
     toSerialBuffer(SerialBuffer& serialBuffer) const
   {
 
-    FW_ASSERT(this->header.type == T_DATA);
+    FW_ASSERT(this->m_header.m_type == T_DATA);
 
     SerializeStatus status;
 
-    status = this->header.toSerialBuffer(serialBuffer);
+    status = this->m_header.toSerialBuffer(serialBuffer);
     if (status != FW_SERIALIZE_OK)
       return status;
 
-    status = serialBuffer.serialize(this->byteOffset);
+    status = serialBuffer.serialize(this->m_byteOffset);
     if (status != FW_SERIALIZE_OK)
       return status;
 
-    status = serialBuffer.serialize(this->dataSize);
+    status = serialBuffer.serialize(this->m_dataSize);
     if (status != FW_SERIALIZE_OK)
       return status;
 
-    status = serialBuffer.pushBytes(this->data, dataSize);
+    status = serialBuffer.pushBytes(this->m_data, this->m_dataSize);
 
     return status;
 

--- a/Fw/FilePacket/EndPacket.cpp
+++ b/Fw/FilePacket/EndPacket.cpp
@@ -23,14 +23,14 @@ namespace Fw {
         const CFDP::Checksum& checksum
     )
   {
-    this->header.initialize(FilePacket::T_END, sequenceIndex);
+    this->m_header.initialize(FilePacket::T_END, sequenceIndex);
     this->setChecksum(checksum);
   }
 
   U32 FilePacket::EndPacket ::
     bufferSize() const
   {
-    return this->header.bufferSize() + sizeof(this->m_checksumValue);
+    return this->m_header.bufferSize() + sizeof(this->m_checksumValue);
   }
 
   SerializeStatus FilePacket::EndPacket ::
@@ -61,7 +61,7 @@ namespace Fw {
     fromSerialBuffer(SerialBuffer& serialBuffer)
   {
 
-    FW_ASSERT(this->header.type == T_END);
+    FW_ASSERT(this->m_header.m_type == T_END);
 
     const SerializeStatus status =
       serialBuffer.deserialize(this->m_checksumValue);
@@ -74,11 +74,11 @@ namespace Fw {
     toSerialBuffer(SerialBuffer& serialBuffer) const
   {
 
-    FW_ASSERT(this->header.type == T_END);
+    FW_ASSERT(this->m_header.m_type == T_END);
 
     SerializeStatus status;
 
-    status = this->header.toSerialBuffer(serialBuffer);
+    status = this->m_header.toSerialBuffer(serialBuffer);
     if (status != FW_SERIALIZE_OK)
       return status;
 

--- a/Fw/FilePacket/FilePacket.cpp
+++ b/Fw/FilePacket/FilePacket.cpp
@@ -40,28 +40,28 @@ namespace Fw {
   const FilePacket::StartPacket& FilePacket ::
     asStartPacket() const
   {
-    FW_ASSERT(this->m_header.type == T_START);
+    FW_ASSERT(this->m_header.m_type == T_START);
     return this->m_startPacket;
   }
 
   const FilePacket::DataPacket& FilePacket ::
     asDataPacket() const
   {
-    FW_ASSERT(this->m_header.type == T_DATA);
+    FW_ASSERT(this->m_header.m_type == T_DATA);
     return this->m_dataPacket;
   }
 
   const FilePacket::EndPacket& FilePacket ::
     asEndPacket() const
   {
-    FW_ASSERT(this->m_header.type == T_END);
+    FW_ASSERT(this->m_header.m_type == T_END);
     return this->m_endPacket;
   }
 
   const FilePacket::CancelPacket& FilePacket ::
     asCancelPacket() const
   {
-    FW_ASSERT(this->m_header.type == T_CANCEL);
+    FW_ASSERT(this->m_header.m_type == T_CANCEL);
     return this->m_cancelPacket;
   }
 
@@ -69,34 +69,34 @@ namespace Fw {
     fromStartPacket(const StartPacket& startPacket)
   {
     this->m_startPacket = startPacket;
-    this->m_header.type = T_START;
+    this->m_header.m_type = T_START;
   }
 
   void FilePacket ::
     fromDataPacket(const DataPacket& dataPacket)
   {
     this->m_dataPacket = dataPacket;
-    this->m_header.type = T_DATA;
+    this->m_header.m_type = T_DATA;
   }
 
   void FilePacket ::
     fromEndPacket(const EndPacket& endPacket)
   {
     this->m_endPacket = endPacket;
-    this->m_header.type = T_END;
+    this->m_header.m_type = T_END;
   }
 
   void FilePacket ::
     fromCancelPacket(const CancelPacket& cancelPacket)
   {
     this->m_cancelPacket = cancelPacket;
-    this->m_header.type = T_CANCEL;
+    this->m_header.m_type = T_CANCEL;
   }
 
   U32 FilePacket ::
     bufferSize() const
   {
-    switch (this->m_header.type) {
+    switch (this->m_header.m_type) {
       case T_START:
         return this->m_startPacket.bufferSize();
       case T_DATA:
@@ -116,7 +116,7 @@ namespace Fw {
   SerializeStatus FilePacket ::
     toBuffer(Buffer& buffer) const
   {
-    switch (this->m_header.type) {
+    switch (this->m_header.m_type) {
       case T_START:
         return this->m_startPacket.toBuffer(buffer);
       case T_DATA:
@@ -142,7 +142,7 @@ namespace Fw {
     status = this->m_header.fromSerialBuffer(serialBuffer);
     if (status != FW_SERIALIZE_OK)
       return status;
-    switch (this->m_header.type) {
+    switch (this->m_header.m_type) {
       case T_START:
         status = this->m_startPacket.fromSerialBuffer(serialBuffer);
         break;

--- a/Fw/FilePacket/FilePacket.hpp
+++ b/Fw/FilePacket/FilePacket.hpp
@@ -51,23 +51,33 @@ namespace Fw {
           //! The maximum length of a path name
           enum { MAX_LENGTH = 255 };
 
-        public:
+        PRIVATE:
 
           //! The length
-          U8 length;
+          U8 m_length;
 
           //! Pointer to the path value
-          const char *value;
+          const char *m_value;
 
         public:
 
           //! Initialize a PathName
           void initialize(
-              const char *const a_value //! The path value
+              const char *const value //! The path value
           );
 
           //! Compute the buffer size needed to hold this PathName
           U32 bufferSize() const;
+
+          //! Get the length of the path name value
+          U32 getLength(void) const {
+              return this->m_length;
+          };
+
+          //! Get the path name value pointer
+          const char* getValuePointer(void) const {
+              return this->m_value;
+          };
 
         PRIVATE:
 
@@ -84,13 +94,15 @@ namespace Fw {
 
           friend union FilePacket;
 
-        public:
+        PRIVATE:
 
           //! The packet type
-          Type type;
+          Type m_type;
 
           //! The sequence index
-          U32 sequenceIndex;
+          U32 m_sequenceIndex;
+
+        public:
 
           //! Header size
           enum { HEADERSIZE = sizeof(U8) + sizeof(U32) };
@@ -99,8 +111,8 @@ namespace Fw {
 
           //! Initialize a file packet header
           void initialize(
-              const Type a_type, //!< The packet type
-              const U32 a_sequenceIndex //!< The sequence index
+              const Type type, //!< The packet type
+              const U32 sequenceIndex //!< The sequence index
           );
 
           //! Compute the buffer size needed to hold this Header
@@ -112,6 +124,15 @@ namespace Fw {
           //! Write this Header to a SerialBuffer
           SerializeStatus toSerialBuffer(SerialBuffer& serialBuffer) const;
 
+        public:
+          Type getType(void) const {
+              return this->m_type;
+          };
+
+          U32 getSequenceIndex(void) const {
+              return this->m_sequenceIndex;
+          };
+
       };
 
       //! The type of a start packet
@@ -119,27 +140,27 @@ namespace Fw {
 
           friend union FilePacket;
 
-        public:
+        PRIVATE:
 
           //! The packet header
-          Header header;
+          Header m_header;
 
           //! The file size
-          U32 fileSize;
+          U32 m_fileSize;
 
           //! The source path
-          PathName sourcePath;
+          PathName m_sourcePath;
 
           //! The destination path
-          PathName destinationPath;
+          PathName m_destinationPath;
 
         public:
 
           //! Initialize a StartPacket with sequence number 0
           void initialize(
-              const U32 a_fileSize, //!< The file size
-              const char *const a_sourcePath, //!< The source path
-              const char *const a_destinationPath //!< The destination path
+              const U32 fileSize, //!< The file size
+              const char *const sourcePath, //!< The source path
+              const char *const destinationPath //!< The destination path
           );
 
           //! Compute the buffer size needed to hold this StartPacket
@@ -148,6 +169,20 @@ namespace Fw {
           //! Convert this StartPacket to a Buffer
           SerializeStatus toBuffer(Buffer& buffer) const;
 
+          //! Get the destination path
+          const PathName& getDestinationPath() const {
+              return this->m_destinationPath;
+          };
+
+          //! Get the source path
+          const PathName& getSourcePath() const {
+              return this->m_sourcePath;
+          };
+
+          //! Get the file size
+          U32 getFileSize() const {
+              return this->m_fileSize;
+          };
         PRIVATE:
 
           //! Initialize this StartPacket from a SerialBuffer
@@ -163,34 +198,33 @@ namespace Fw {
 
           friend union FilePacket;
 
-        public:
+        PRIVATE:
 
           //! The packet header
-          Header header;
+          Header m_header;
 
           //! The byte offset of the packet data into the destination file
-          U32 byteOffset;
+          U32 m_byteOffset;
 
           //! The size of the file data in the packet
-          U16 dataSize;
+          U16 m_dataSize;
 
           //! Pointer to the file data
-          const U8 *data;
+          const U8 *m_data;
+
+        public:
 
           //! header size
           enum { HEADERSIZE = Header::HEADERSIZE +
               sizeof(U32) +
               sizeof(U16) };
 
-
-        public:
-
           //! Initialize a data packet
           void initialize(
               const U32 sequenceIndex, //!< The sequence index
-              const U32 a_byteOffset, //!< The byte offset
-              const U16 a_dataSize, //!< The data size
-              const U8 *const a_data //!< The file data
+              const U32 byteOffset, //!< The byte offset
+              const U16 dataSize, //!< The data size
+              const U8 *const data //!< The file data
           );
 
           //! Compute the buffer size needed to hold this DataPacket
@@ -199,6 +233,25 @@ namespace Fw {
           //! Convert this DataPacket to a Buffer
           SerializeStatus toBuffer(Buffer& buffer) const;
 
+          //! Get this as a Header
+          const FilePacket::Header& asHeader() const {
+              return this->m_header;
+          };
+
+          //! Get the byte offset
+          U32 getByteOffset() const {
+              return this->m_byteOffset;
+          };
+
+          //! Get the data size
+          U32 getDataSize() const {
+              return this->m_dataSize;
+          };
+
+          //! Get the data pointer
+          const U8* getDataPointer() const {
+              return this->m_data;
+          };
         PRIVATE:
 
           //! Initialize this DataPacket from a SerialBuffer
@@ -217,10 +270,12 @@ namespace Fw {
 
           friend union FilePacket;
 
-        public:
+        PRIVATE:
 
           //! The packet header
-          Header header;
+          Header m_header;
+
+        public:
 
           //! Set the checksum
           void setChecksum(const CFDP::Checksum& checksum);
@@ -234,6 +289,10 @@ namespace Fw {
           //! Convert this EndPacket to a Buffer
           SerializeStatus toBuffer(Buffer& buffer) const;
 
+          //! Get this as a Header
+          const FilePacket::Header& asHeader() const {
+              return this->m_header;
+          };
         public:
 
           //! Initialize an end packet
@@ -260,10 +319,10 @@ namespace Fw {
 
           friend union FilePacket;
 
-        public:
+        PRIVATE:
 
           //! The packet header
-          Header header;
+          Header m_header;
 
         public:
 
@@ -278,6 +337,10 @@ namespace Fw {
           //! Convert this CancelPacket to a Buffer
           SerializeStatus toBuffer(Buffer& buffer) const;
 
+          //! Get this as a Header
+          const FilePacket::Header& asHeader() const {
+              return this->m_header;
+          };
         PRIVATE:
 
           //! Initialize this CancelPacket from a SerialBuffer
@@ -291,7 +354,7 @@ namespace Fw {
       // Constructor
       // ----------------------------------------------------------------------
 
-      FilePacket() { this->m_header.type = T_NONE; }
+      FilePacket() { this->m_header.m_type = T_NONE; }
 
     public:
 

--- a/Fw/FilePacket/FilePacket.hpp
+++ b/Fw/FilePacket/FilePacket.hpp
@@ -74,8 +74,8 @@ namespace Fw {
               return this->m_length;
           };
 
-          //! Get the path name value pointer
-          const char* getValuePointer(void) const {
+          //! Get the path name value
+          const char* getValue(void) const {
               return this->m_value;
           };
 
@@ -248,8 +248,8 @@ namespace Fw {
               return this->m_dataSize;
           };
 
-          //! Get the data pointer
-          const U8* getDataPointer() const {
+          //! Get the data
+          const U8* getData() const {
               return this->m_data;
           };
         PRIVATE:

--- a/Fw/FilePacket/GTest/CancelPacket.cpp
+++ b/Fw/FilePacket/GTest/CancelPacket.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  Fw/FilePacket/GTest/CancelPacket.cpp
 // \author bocchino
 // \brief  Test utilities for data file packets
@@ -7,8 +7,8 @@
 // Copyright (C) 2016, California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #include <Fw/FilePacket/GTest/FilePackets.hpp>
 
@@ -20,9 +20,9 @@ namespace Fw {
       compare(
           const FilePacket::CancelPacket& expected,
           const FilePacket::CancelPacket& actual
-      ) 
+      )
     {
-      FilePackets::Header::compare(expected.header, actual.header);
+      FilePackets::Header::compare(expected.m_header, actual.m_header);
     }
 
   }

--- a/Fw/FilePacket/GTest/DataPacket.cpp
+++ b/Fw/FilePacket/GTest/DataPacket.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  Fw/FilePacket/GTest/DataPacket.cpp
 // \author bocchino
 // \brief  Test utilities for data file packets
@@ -7,8 +7,8 @@
 // Copyright (C) 2016, California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #include <Fw/FilePacket/GTest/FilePackets.hpp>
 #include <Fw/Types/GTest/Bytes.hpp>
@@ -21,12 +21,12 @@ namespace Fw {
       compare(
           const FilePacket::DataPacket& expected,
           const FilePacket::DataPacket& actual
-      ) 
+      )
     {
-      FilePackets::Header::compare(expected.header, actual.header);
-      ASSERT_EQ(expected.byteOffset, actual.byteOffset);
-      Bytes expectedData(expected.data, expected.dataSize);
-      Bytes actualData(actual.data, actual.dataSize);
+      FilePackets::Header::compare(expected.m_header, actual.m_header);
+      ASSERT_EQ(expected.m_byteOffset, actual.m_byteOffset);
+      Bytes expectedData(expected.m_data, expected.m_dataSize);
+      Bytes actualData(actual.m_data, actual.m_dataSize);
       Bytes::compare(expectedData, actualData);
     }
 

--- a/Fw/FilePacket/GTest/EndPacket.cpp
+++ b/Fw/FilePacket/GTest/EndPacket.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  Fw/FilePacket/GTest/EndPacket.cpp
 // \author bocchino
 // \brief  Test utilities for data file packets
@@ -7,8 +7,8 @@
 // Copyright (C) 2016, California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #include <Fw/FilePacket/GTest/FilePackets.hpp>
 #include <CFDP/Checksum/GTest/Checksums.hpp>
@@ -22,9 +22,9 @@ namespace Fw {
       compare(
           const FilePacket::EndPacket& expected,
           const FilePacket::EndPacket& actual
-      ) 
+      )
     {
-      FilePackets::Header::compare(expected.header, actual.header);
+      FilePackets::Header::compare(expected.m_header, actual.m_header);
       CFDP::Checksum expectedChecksum;
       CFDP::Checksum actualChecksum;
       expected.getChecksum(expectedChecksum);

--- a/Fw/FilePacket/GTest/Header.cpp
+++ b/Fw/FilePacket/GTest/Header.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  Fw/FilePacket/GTest/Header.cpp
 // \author bocchino
 // \brief  Test utilities for file packet headers
@@ -7,8 +7,8 @@
 // Copyright (C) 2016, California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #include <Fw/FilePacket/GTest/FilePackets.hpp>
 
@@ -20,10 +20,10 @@ namespace Fw {
       compare(
           const FilePacket::Header& expected,
           const FilePacket::Header& actual
-      ) 
+      )
     {
-      ASSERT_EQ(expected.type, actual.type);
-      ASSERT_EQ(expected.sequenceIndex, actual.sequenceIndex);
+      ASSERT_EQ(expected.m_type, actual.m_type);
+      ASSERT_EQ(expected.m_sequenceIndex, actual.m_sequenceIndex);
     }
 
   }

--- a/Fw/FilePacket/GTest/PathName.cpp
+++ b/Fw/FilePacket/GTest/PathName.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  Fw/FilePacket/GTest/PathName.cpp
 // \author bocchino
 // \brief  Test utilities for start file packets
@@ -7,8 +7,8 @@
 // Copyright (C) 2016, California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #include <Fw/FilePacket/GTest/FilePackets.hpp>
 #include <Fw/Types/GTest/Bytes.hpp>
@@ -21,16 +21,16 @@ namespace Fw {
       compare(
           const FilePacket::PathName& expected,
           const FilePacket::PathName& actual
-      ) 
+      )
     {
-      ASSERT_EQ(expected.length, actual.length);
+      ASSERT_EQ(expected.m_length, actual.m_length);
       Bytes expectedPath(
-          reinterpret_cast<const U8*>(expected.value),
-          expected.length
+          reinterpret_cast<const U8*>(expected.m_value),
+          expected.m_length
       );
       Bytes actualPath(
-          reinterpret_cast<const U8*>(actual.value),
-          actual.length
+          reinterpret_cast<const U8*>(actual.m_value),
+          actual.m_length
       );
       Bytes::compare(expectedPath, actualPath);
     }

--- a/Fw/FilePacket/GTest/StartPacket.cpp
+++ b/Fw/FilePacket/GTest/StartPacket.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  Fw/FilePacket/GTest/StartPacket.cpp
 // \author bocchino
 // \brief  Test utilities for start file packets
@@ -7,8 +7,8 @@
 // Copyright (C) 2016, California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #include <Fw/FilePacket/GTest/FilePackets.hpp>
 #include <Fw/Types/GTest/Bytes.hpp>
@@ -21,12 +21,12 @@ namespace Fw {
       compare(
           const FilePacket::StartPacket& expected,
           const FilePacket::StartPacket& actual
-      ) 
+      )
     {
-      FilePackets::Header::compare(expected.header, actual.header);
-      ASSERT_EQ(expected.fileSize, actual.fileSize);
-      PathName::compare(expected.sourcePath, actual.sourcePath);
-      PathName::compare(expected.destinationPath, actual.destinationPath);
+      FilePackets::Header::compare(expected.m_header, actual.m_header);
+      ASSERT_EQ(expected.m_fileSize, actual.m_fileSize);
+      PathName::compare(expected.m_sourcePath, actual.m_sourcePath);
+      PathName::compare(expected.m_destinationPath, actual.m_destinationPath);
     }
 
   }

--- a/Fw/FilePacket/Header.cpp
+++ b/Fw/FilePacket/Header.cpp
@@ -17,18 +17,18 @@ namespace Fw {
 
   void FilePacket::Header ::
     initialize(
-        const Type a_type,
-        const U32 a_sequenceIndex
+        const Type type,
+        const U32 sequenceIndex
     )
   {
-    this->type = a_type;
-    this->sequenceIndex = a_sequenceIndex;
+    this->m_type = type;
+    this->m_sequenceIndex = sequenceIndex;
   }
 
   U32 FilePacket::Header ::
     bufferSize() const
   {
-    return sizeof(U8) + sizeof(this->sequenceIndex);
+    return sizeof(U8) + sizeof(this->m_sequenceIndex);
   }
 
   SerializeStatus FilePacket::Header ::
@@ -42,9 +42,9 @@ namespace Fw {
     if (status != FW_SERIALIZE_OK) {
       return status;
     }
-    this->type = static_cast<Type>(new_type);
+    this->m_type = static_cast<Type>(new_type);
 
-    status = serialBuffer.deserialize(this->sequenceIndex);
+    status = serialBuffer.deserialize(this->m_sequenceIndex);
 
     return status;
 
@@ -54,14 +54,14 @@ namespace Fw {
     toSerialBuffer(SerialBuffer& serialBuffer) const
   {
 
-    const U8 type_casted = static_cast<U8>(this->type);
+    const U8 type_casted = static_cast<U8>(this->m_type);
     SerializeStatus status;
 
     status = serialBuffer.serialize(type_casted);
     if (status != FW_SERIALIZE_OK)
       return status;
 
-    status = serialBuffer.serialize(this->sequenceIndex);
+    status = serialBuffer.serialize(this->m_sequenceIndex);
     if (status != FW_SERIALIZE_OK)
       return status;
 

--- a/Fw/FilePacket/PathName.cpp
+++ b/Fw/FilePacket/PathName.cpp
@@ -19,17 +19,17 @@
 namespace Fw {
 
   void FilePacket::PathName ::
-    initialize(const char *const a_value)
+    initialize(const char *const value)
   {
-    const U8 new_length = static_cast<U8>(StringUtils::string_length(a_value, MAX_LENGTH));
-    this->length = new_length;
-    this->value = a_value;
+    const U8 length = static_cast<U8>(StringUtils::string_length(value, MAX_LENGTH));
+    this->m_length = length;
+    this->m_value = value;
   }
 
   U32 FilePacket::PathName ::
     bufferSize() const
   {
-    return sizeof(this->length) + this->length;
+    return sizeof(this->m_length) + this->m_length;
   }
 
   SerializeStatus FilePacket::PathName ::
@@ -38,7 +38,7 @@ namespace Fw {
 
     {
       const SerializeStatus status =
-        serialBuffer.deserialize(this->length);
+        serialBuffer.deserialize(this->m_length);
       if (status != FW_SERIALIZE_OK)
         return status;
     }
@@ -47,10 +47,10 @@ namespace Fw {
       const U8* addrLeft = serialBuffer.getBuffAddrLeft();
       U8 bytes[MAX_LENGTH];
       const SerializeStatus status =
-        serialBuffer.popBytes(bytes, this->length);
+        serialBuffer.popBytes(bytes, this->m_length);
       if (status != FW_SERIALIZE_OK)
         return status;
-      this->value = reinterpret_cast<const char*>(addrLeft);
+      this->m_value = reinterpret_cast<const char*>(addrLeft);
     }
 
     return FW_SERIALIZE_OK;
@@ -63,15 +63,15 @@ namespace Fw {
 
     {
       const SerializeStatus status =
-        serialBuffer.serialize(this->length);
+        serialBuffer.serialize(this->m_length);
       if (status != FW_SERIALIZE_OK)
         return status;
     }
 
     {
       const SerializeStatus status = serialBuffer.pushBytes(
-          reinterpret_cast<const U8 *>(this->value),
-          this->length
+          reinterpret_cast<const U8 *>(this->m_value),
+          this->m_length
       );
       if (status != FW_SERIALIZE_OK)
         return status;

--- a/Fw/FilePacket/StartPacket.cpp
+++ b/Fw/FilePacket/StartPacket.cpp
@@ -17,25 +17,24 @@ namespace Fw {
 
   void FilePacket::StartPacket ::
     initialize(
-      const U32 a_fileSize,
-      const char *const a_sourcePath,
-      const char *const a_destinationPath
+      const U32 fileSize,
+      const char *const sourcePath,
+      const char *const destinationPath
     )
   {
-    const FilePacket::Header new_header = { FilePacket::T_START, 0 };
-    this->header = new_header;
-    this->fileSize = a_fileSize;
-    this->sourcePath.initialize(a_sourcePath);
-    this->destinationPath.initialize(a_destinationPath);
+    this->m_header.initialize(FilePacket::T_START, 0);
+    this->m_fileSize = fileSize;
+    this->m_sourcePath.initialize(sourcePath);
+    this->m_destinationPath.initialize(destinationPath);
   }
 
   U32 FilePacket::StartPacket ::
     bufferSize() const
   {
-    return this->header.bufferSize() +
-      sizeof(this->fileSize) +
-      this->sourcePath.bufferSize() +
-      this->destinationPath.bufferSize();
+    return this->m_header.bufferSize() +
+      sizeof(this->m_fileSize) +
+      this->m_sourcePath.bufferSize() +
+      this->m_destinationPath.bufferSize();
   }
 
   SerializeStatus FilePacket::StartPacket ::
@@ -52,25 +51,25 @@ namespace Fw {
     fromSerialBuffer(SerialBuffer& serialBuffer)
   {
 
-    FW_ASSERT(this->header.type == T_START);
+    FW_ASSERT(this->m_header.m_type == T_START);
 
     {
       const SerializeStatus status =
-        serialBuffer.deserialize(this->fileSize);
+        serialBuffer.deserialize(this->m_fileSize);
       if (status != FW_SERIALIZE_OK)
         return status;
     }
 
     {
       const SerializeStatus status =
-        this->sourcePath.fromSerialBuffer(serialBuffer);
+        this->m_sourcePath.fromSerialBuffer(serialBuffer);
       if (status != FW_SERIALIZE_OK)
         return status;
     }
 
     {
       const SerializeStatus status =
-        this->destinationPath.fromSerialBuffer(serialBuffer);
+        this->m_destinationPath.fromSerialBuffer(serialBuffer);
       if (status != FW_SERIALIZE_OK)
         return status;
     }
@@ -83,32 +82,32 @@ namespace Fw {
     toSerialBuffer(SerialBuffer& serialBuffer) const
   {
 
-    FW_ASSERT(this->header.type == T_START);
+    FW_ASSERT(this->m_header.m_type == T_START);
 
     {
       const SerializeStatus status =
-        this->header.toSerialBuffer(serialBuffer);
+        this->m_header.toSerialBuffer(serialBuffer);
       if (status != FW_SERIALIZE_OK)
         return status;
     }
 
     {
       const SerializeStatus status =
-        serialBuffer.serialize(this->fileSize);
+        serialBuffer.serialize(this->m_fileSize);
       if (status != FW_SERIALIZE_OK)
         return status;
     }
 
     {
       const SerializeStatus status =
-        this->sourcePath.toSerialBuffer(serialBuffer);
+        this->m_sourcePath.toSerialBuffer(serialBuffer);
       if (status != FW_SERIALIZE_OK)
         return status;
     }
 
     {
       const SerializeStatus status =
-        this->destinationPath.toSerialBuffer(serialBuffer);
+        this->m_destinationPath.toSerialBuffer(serialBuffer);
       if (status != FW_SERIALIZE_OK)
         return status;
     }

--- a/STest/STest/Rule/Rule.hpp
+++ b/STest/STest/Rule/Rule.hpp
@@ -61,7 +61,7 @@ namespace STest {
       ) = 0;
 
       //! Get rule name
-      char const * getRuleNamePointer() const {
+      char const * getRuleName() const {
         return this->m_name;
       }
 

--- a/STest/STest/Rule/Rule.hpp
+++ b/STest/STest/Rule/Rule.hpp
@@ -27,9 +27,9 @@ namespace STest {
 
       //! Construct object Rule
       Rule(
-          const char *const a_name //!< The name of the rule
+          const char *const name //!< The name of the rule
       ) :
-        name(a_name)
+        m_name(name)
       {
 
       }
@@ -50,7 +50,7 @@ namespace STest {
           State& state //!< The system state
       ) {
         ASSERT_TRUE(this->precondition(state))
-          << "precondition failed applying rule " << this->name;
+          << "precondition failed applying rule " << this->m_name;
         this->action(state);
       }
 
@@ -59,6 +59,11 @@ namespace STest {
       virtual bool precondition(
           const State& state //!< The system state
       ) = 0;
+
+      //! Get rule name
+      char const * getRuleNamePointer() const {
+        return this->m_name;
+      }
 
     protected:
 
@@ -77,8 +82,14 @@ namespace STest {
       // Public member variables
       // ----------------------------------------------------------------------
 
+    private:
+
+      // ----------------------------------------------------------------------
+      // Private member variables
+      // ----------------------------------------------------------------------
+
       //! The name of the rule
-      const char *const name;
+      const char *const m_name;
 
   };
 

--- a/STest/STest/Rule/Rule.hpp
+++ b/STest/STest/Rule/Rule.hpp
@@ -61,7 +61,7 @@ namespace STest {
       ) = 0;
 
       //! Get rule name
-      char const * getRuleName() const {
+      char const * getName() const {
         return this->m_name;
       }
 

--- a/STest/STest/Scenario/RepeatedRuleScenario.hpp
+++ b/STest/STest/Scenario/RepeatedRuleScenario.hpp
@@ -31,7 +31,7 @@ namespace STest {
       RepeatedRuleScenario(
           Rule<State>& rule //!< The rule
       ) :
-        Scenario<State>(rule.name),
+        Scenario<State>(rule.getRuleNamePointer()),
         rule(rule)
       {
 

--- a/STest/STest/Scenario/RepeatedRuleScenario.hpp
+++ b/STest/STest/Scenario/RepeatedRuleScenario.hpp
@@ -31,7 +31,7 @@ namespace STest {
       RepeatedRuleScenario(
           Rule<State>& rule //!< The rule
       ) :
-        Scenario<State>(rule.getRuleNamePointer()),
+        Scenario<State>(rule.getRuleName()),
         rule(rule)
       {
 

--- a/STest/STest/Scenario/RepeatedRuleScenario.hpp
+++ b/STest/STest/Scenario/RepeatedRuleScenario.hpp
@@ -31,7 +31,7 @@ namespace STest {
       RepeatedRuleScenario(
           Rule<State>& rule //!< The rule
       ) :
-        Scenario<State>(rule.getRuleName()),
+        Scenario<State>(rule.getName()),
         rule(rule)
       {
 

--- a/STest/STest/Scenario/Scenario.hpp
+++ b/STest/STest/Scenario/Scenario.hpp
@@ -136,7 +136,7 @@ namespace STest {
           printf(
               "[Scenario %s] Applying rule %s\n",
               this->name,
-              rule.getRuleNamePointer()
+              rule.getRuleName()
           );
         }
         rule.apply(state);

--- a/STest/STest/Scenario/Scenario.hpp
+++ b/STest/STest/Scenario/Scenario.hpp
@@ -136,7 +136,7 @@ namespace STest {
           printf(
               "[Scenario %s] Applying rule %s\n",
               this->name,
-              rule.getRuleName()
+              rule.getName()
           );
         }
         rule.apply(state);

--- a/STest/STest/Scenario/Scenario.hpp
+++ b/STest/STest/Scenario/Scenario.hpp
@@ -136,7 +136,7 @@ namespace STest {
           printf(
               "[Scenario %s] Applying rule %s\n",
               this->name,
-              rule.name
+              rule.getRuleNamePointer()
           );
         }
         rule.apply(state);

--- a/Svc/FileDownlink/File.cpp
+++ b/Svc/FileDownlink/File.cpp
@@ -26,11 +26,11 @@ namespace Svc {
 
     // Set source name
     Fw::LogStringArg sourceLogStringArg(sourceFileName);
-    this->sourceName = sourceLogStringArg;
+    this->m_sourceName = sourceLogStringArg;
 
     // Set dest name
     Fw::LogStringArg destLogStringArg(destFileName);
-    this->destName = destLogStringArg;
+    this->m_destName = destLogStringArg;
 
     // Set size
     FwSizeType file_size;
@@ -42,14 +42,14 @@ namespace Svc {
     if (static_cast<FwSizeType>(static_cast<U32>(file_size)) != file_size) {
         return Os::File::BAD_SIZE;
     }
-    this->size = static_cast<U32>(file_size);
+    this->m_size = static_cast<U32>(file_size);
 
     // Initialize checksum
     CFDP::Checksum checksum;
     this->m_checksum = checksum;
 
     // Open osFile for reading
-    return this->osFile.open(sourceFileName, Os::File::OPEN_READ);
+    return this->m_osFile.open(sourceFileName, Os::File::OPEN_READ);
 
   }
 
@@ -57,24 +57,24 @@ namespace Svc {
     read(
         U8 *const data,
         const U32 byteOffset,
-        const U32 a_size
+        const U32 size
     )
   {
 
     Os::File::Status status;
-    status = this->osFile.seek(byteOffset);
+    status = this->m_osFile.seek(byteOffset);
     if (status != Os::File::OP_OK)
       return status;
 
-    NATIVE_INT_TYPE intSize = a_size;
-    status = this->osFile.read(data, intSize);
+    NATIVE_INT_TYPE intSize = size;
+    status = this->m_osFile.read(data, intSize);
     if (status != Os::File::OP_OK)
       return status;
     // Force a bad size error when the U32 carrying size is bad
-    if (static_cast<U32>(intSize) != a_size) {
+    if (static_cast<U32>(intSize) != size) {
         return Os::File::BAD_SIZE;
     }
-    this->m_checksum.update(data, byteOffset, a_size);
+    this->m_checksum.update(data, byteOffset, size);
 
     return Os::File::OP_OK;
 

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -77,23 +77,21 @@ namespace Svc {
         public:
 
           //! Constructor
-          File() : size(0) { }
-
-        public:
-
-          //! The source file name
-          Fw::LogStringArg sourceName;
-
-          //! The destination file name
-          Fw::LogStringArg destName;
-
-          //! The underlying OS file
-          Os::File osFile;
-
-          //! The file size
-          U32 size;
+          File() : m_size(0) { }
 
         PRIVATE:
+
+          //! The source file name
+          Fw::LogStringArg m_sourceName;
+
+          //! The destination file name
+          Fw::LogStringArg m_destName;
+
+          //! The underlying OS file
+          Os::File m_osFile;
+
+          //! The file size
+          U32 m_size;
 
           //! The checksum for the file
           CFDP::Checksum m_checksum;
@@ -110,12 +108,32 @@ namespace Svc {
           Os::File::Status read(
               U8 *const data,
               const U32 byteOffset,
-              const U32 a_size
+              const U32 size
           );
 
           //! Get the checksum
           void getChecksum(CFDP::Checksum& checksum) {
             checksum = this->m_checksum;
+          }
+
+          //! Get the source file name
+          Fw::LogStringArg& getSourceName(void) {
+            return this->m_sourceName;
+          }
+
+          //! Get the destination file name
+          Fw::LogStringArg& getDestName(void) {
+            return this->m_destName;
+          }
+
+          //! Get the underlying OS file
+          Os::File& getOsFile(void) {
+            return this->m_osFile;
+          }
+
+          //! Get the file size
+          U32 getSize(void) {
+            return this->m_size;
           }
       };
 

--- a/Svc/FileDownlink/Warnings.cpp
+++ b/Svc/FileDownlink/Warnings.cpp
@@ -16,7 +16,7 @@ namespace Svc {
     fileOpenError()
   {
     this->m_fileDownlink->log_WARNING_HI_FileOpenError(
-        this->m_fileDownlink->m_file.sourceName
+        this->m_fileDownlink->m_file.getSourceName()
     );
     this->warning();
   }
@@ -25,8 +25,8 @@ namespace Svc {
     fileRead(const Os::File::Status status)
   {
     this->m_fileDownlink->log_WARNING_HI_FileReadError(
-        this->m_fileDownlink->m_file.sourceName,
-		status
+        this->m_fileDownlink->m_file.getSourceName(),
+		    status
     );
     this->warning();
   }

--- a/Svc/FileDownlink/test/ut/FileBuffer.cpp
+++ b/Svc/FileDownlink/test/ut/FileBuffer.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  FileBuffer.hpp
 // \author bocchino
 // \brief  cpp file for FileDownlinkTester::FileBuffer
@@ -7,7 +7,7 @@
 // Copyright 2009-2015, by the California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// ====================================================================== 
+// ======================================================================
 
 #include <cstring>
 
@@ -19,7 +19,7 @@ namespace Svc {
     FileBuffer(
         const U8 *const data,
         const size_t size
-    ) : 
+    ) :
       index(0)
   {
     this->push(data, size);
@@ -29,17 +29,17 @@ namespace Svc {
   FileDownlinkTester::FileBuffer ::
     FileBuffer(
         const History<Fw::FilePacket::DataPacket>& dataPackets
-    ) : 
+    ) :
       index(0)
   {
     size_t numPackets = dataPackets.size();
     for (size_t i = 0; i < numPackets; ++i) {
       const Fw::FilePacket::DataPacket& dataPacket = dataPackets.at(i);
-      this->push(dataPacket.data, dataPacket.dataSize);
+      this->push(dataPacket.m_data, dataPacket.m_dataSize);
     }
   }
 
-  void FileDownlinkTester::FileBuffer :: 
+  void FileDownlinkTester::FileBuffer ::
     push(
       const U8 *const data,
       const size_t size
@@ -69,7 +69,7 @@ namespace Svc {
     file.close();
 
   }
-          
+
   void FileDownlinkTester::FileBuffer ::
     getChecksum(CFDP::Checksum& checksum)
   {
@@ -79,12 +79,12 @@ namespace Svc {
   }
 
   bool FileDownlinkTester::FileBuffer ::
-    compare(const FileBuffer& fb1, const FileBuffer& fb2) 
+    compare(const FileBuffer& fb1, const FileBuffer& fb2)
   {
 
     if (fb1.index != fb2.index) {
       fprintf(
-          stderr, 
+          stderr,
           "FileBuffer: sizes do not match (%lu vs %lu)\n",
           fb1.index,
           fb2.index

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -679,8 +679,8 @@ namespace Svc {
     Fw::FilePacket filePacket;
     validateFilePacket(buffer, filePacket);
     const Fw::FilePacket::Header& header = filePacket.asHeader();
-    ASSERT_EQ(0U, header.sequenceIndex);
-    ASSERT_EQ(Fw::FilePacket::T_START, header.type);
+    ASSERT_EQ(0U, header.m_sequenceIndex);
+    ASSERT_EQ(Fw::FilePacket::T_START, header.m_type);
   }
 
   void FileDownlinkTester ::
@@ -694,11 +694,11 @@ namespace Svc {
     Fw::FilePacket filePacket;
     validateFilePacket(buffer, filePacket);
     const Fw::FilePacket::Header& header = filePacket.asHeader();
-    ASSERT_EQ(sequenceIndex, header.sequenceIndex);
-    ASSERT_EQ(Fw::FilePacket::T_DATA, header.type);
+    ASSERT_EQ(sequenceIndex, header.m_sequenceIndex);
+    ASSERT_EQ(Fw::FilePacket::T_DATA, header.m_type);
     dataPacket = filePacket.asDataPacket();
-    ASSERT_EQ(byteOffset, dataPacket.byteOffset);
-    byteOffset += dataPacket.dataSize;
+    ASSERT_EQ(byteOffset, dataPacket.m_byteOffset);
+    byteOffset += dataPacket.m_dataSize;
   }
 
   void FileDownlinkTester ::
@@ -711,8 +711,8 @@ namespace Svc {
     Fw::FilePacket filePacket;
     validateFilePacket(buffer, filePacket);
     const Fw::FilePacket::Header& header = filePacket.asHeader();
-    ASSERT_EQ(sequenceIndex, header.sequenceIndex);
-    ASSERT_EQ(Fw::FilePacket::T_END, header.type);
+    ASSERT_EQ(sequenceIndex, header.m_sequenceIndex);
+    ASSERT_EQ(Fw::FilePacket::T_END, header.m_type);
     const Fw::FilePacket::EndPacket endPacket = filePacket.asEndPacket();
     CFDP::Checksum computedChecksum;
     endPacket.getChecksum(computedChecksum);
@@ -728,8 +728,8 @@ namespace Svc {
     Fw::FilePacket filePacket;
     validateFilePacket(buffer, filePacket);
     const Fw::FilePacket::Header& header = filePacket.asHeader();
-    ASSERT_EQ(sequenceIndex, header.sequenceIndex);
-    ASSERT_EQ(Fw::FilePacket::T_CANCEL, header.type);
+    ASSERT_EQ(sequenceIndex, header.m_sequenceIndex);
+    ASSERT_EQ(Fw::FilePacket::T_CANCEL, header.m_type);
   }
 
 }

--- a/Svc/FileUplink/File.cpp
+++ b/Svc/FileUplink/File.cpp
@@ -21,7 +21,7 @@ namespace Svc {
   {
     const U32 length = startPacket.getDestinationPath().getLength();
     char path[Fw::FilePacket::PathName::MAX_LENGTH + 1];
-    memcpy(path, startPacket.getDestinationPath().getValuePointer(), length);
+    memcpy(path, startPacket.getDestinationPath().getValue(), length);
     path[length] = 0;
     Fw::LogStringArg logStringArg(path);
     this->name = logStringArg;

--- a/Svc/FileUplink/File.cpp
+++ b/Svc/FileUplink/File.cpp
@@ -19,13 +19,13 @@ namespace Svc {
   Os::File::Status FileUplink::File ::
     open(const Fw::FilePacket::StartPacket& startPacket)
   {
-    const U32 length = startPacket.destinationPath.length;
+    const U32 length = startPacket.getDestinationPath().getLength();
     char path[Fw::FilePacket::PathName::MAX_LENGTH + 1];
-    memcpy(path, startPacket.destinationPath.value, length);
+    memcpy(path, startPacket.getDestinationPath().getValuePointer(), length);
     path[length] = 0;
     Fw::LogStringArg logStringArg(path);
     this->name = logStringArg;
-    this->size = startPacket.fileSize;
+    this->size = startPacket.getFileSize();
     CFDP::Checksum checksum;
     this->m_checksum = checksum;
     return this->osFile.open(path, Os::File::OPEN_WRITE);

--- a/Svc/FileUplink/FileUplink.cpp
+++ b/Svc/FileUplink/FileUplink.cpp
@@ -62,8 +62,8 @@ namespace Svc {
     if (status != Fw::FW_SERIALIZE_OK) {
         this->log_WARNING_HI_DecodeError(status);
     } else {
-        const Fw::FilePacket::Header& header = filePacket.asHeader();
-        switch (header.type) {
+        Fw::FilePacket::Type header_type = filePacket.asHeader().getType();
+        switch (header_type) {
           case Fw::FilePacket::T_START:
             this->handleStartPacket(filePacket.asStartPacket());
             break;
@@ -129,16 +129,16 @@ namespace Svc {
       this->warnings.invalidReceiveMode(Fw::FilePacket::T_DATA);
       return;
     }
-    const U32 sequenceIndex = dataPacket.header.sequenceIndex;
+    const U32 sequenceIndex = dataPacket.asHeader().getSequenceIndex();
     this->checkSequenceIndex(sequenceIndex);
-    const U32 byteOffset = dataPacket.byteOffset;
-    const U32 dataSize = dataPacket.dataSize;
+    const U32 byteOffset = dataPacket.getByteOffset();
+    const U32 dataSize = dataPacket.getDataSize();
     if (byteOffset + dataSize > this->file.size) {
       this->warnings.packetOutOfBounds(sequenceIndex, this->file.name);
       return;
     }
     const Os::File::Status status = this->file.write(
-        dataPacket.data,
+        dataPacket.getDataPointer(),
         byteOffset,
         dataSize
     );
@@ -153,7 +153,7 @@ namespace Svc {
     this->packetsReceived.packetReceived();
     if (this->receiveMode == DATA) {
       this->filesReceived.fileReceived();
-      this->checkSequenceIndex(endPacket.header.sequenceIndex);
+      this->checkSequenceIndex(endPacket.asHeader().getSequenceIndex());
       this->compareChecksums(endPacket);
       this->log_ACTIVITY_HI_FileReceived(this->file.name);
     }

--- a/Svc/FileUplink/FileUplink.cpp
+++ b/Svc/FileUplink/FileUplink.cpp
@@ -138,7 +138,7 @@ namespace Svc {
       return;
     }
     const Os::File::Status status = this->file.write(
-        dataPacket.getDataPointer(),
+        dataPacket.getData(),
         byteOffset,
         dataSize
     );

--- a/Svc/FileUplink/test/ut/FileUplinkTester.cpp
+++ b/Svc/FileUplink/test/ut/FileUplinkTester.cpp
@@ -608,7 +608,7 @@ namespace Svc {
       this->sequenceIndex++
     };
     Fw::FilePacket::EndPacket endPacket;
-    endPacket.header = header;
+    endPacket.m_header = header;
     endPacket.setChecksum(checksum);
     Fw::FilePacket filePacket;
     filePacket.fromEndPacket(endPacket);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2492 |
|**_Has Unit Tests (y/n)_**| yes |
|**_Documentation Included (y/n)_**| yes |

---
## Change Description

Removed the prefix `_a` previously added in https://github.com/nasa/fprime/pull/2482

Changes:
- Changed public variables of `Fw/FilePacket` and `Svc/FileDownlink` to `PRIVATE` variables

- Changed public variable `name` to private variable `m_name` in `STest/STest/Rule/Rule.hpp`

- Remove object initializion using public variable list in `Svc/FileDownlink/FileDownlink.cpp` and `Fw/FilePacket/StartPacket.cpp`

- Added getters for variables new private variables
The getters have been implemented in the header. Sometimes using references, sometimes copying values.
If it is not standard, I am happy to update it.

- Fixed UT

## Rationale

The `a_` prefix should not be used for arguments

## Testing/Review Recommendations

I am not sure if there are some breaking changes for other projects