### PR TITLE
Explicity add test dependencies to Os_ut_exe

### DIFF
--- a/Os/CMakeLists.txt
+++ b/Os/CMakeLists.txt
@@ -114,7 +114,13 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/OsMutexBasicLockableTest.cpp"
 )
 register_fprime_ut()
-
+if (BUILD_TESTING)
+    foreach (TEST IN ITEMS StubFileTest PosixFileTest)
+       if (TARGET "${TEST}")
+           add_dependencies("Os_ut_exe" "${TEST}")
+       endif()
+    endforeach()
+endif()
 # Second UT Pthreads
 set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/Pthreads/test/ut/BufferQueueTest.cpp"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes #2552.

## Rationale

This adds the necessary dependencies such that the tests always run.