### PR TITLE
Update dictionary JSON spec field names and examples

### DIFF
--- a/docs/Design/fpp-json-dict.md
+++ b/docs/Design/fpp-json-dict.md
@@ -561,7 +561,7 @@ telemetry Channel1: F64 \
         "name": "c1.Channel1",
         "description": "Telemetry channel 1",
         "type": {
-            "type": "F64",
+            "name": "F64",
             "kind": "float",
             "size": 64
         },
@@ -952,7 +952,7 @@ product container Container2 default priority 10
             "name": "c1.Channel1",
             "description": "Telemetry channel 1",
             "type": {
-                "type": "F64",
+                "name": "F64",
                 "kind": "float",
                 "size": 64
             },

--- a/docs/Design/fpp-json-dict.md
+++ b/docs/Design/fpp-json-dict.md
@@ -38,8 +38,8 @@ This document describes the format of FPP JSON dictionaries.
   - [Telemetry Channels](#telemetry-channels)
   - [Events](#events)
 - [Data Products](#data-products)
-  - [Record](#record)
-  - [Container](#container)
+  - [Records](#records)
+  - [Containers](#containers)
 - [Dictionaries](#dictionaries)
   - [Dictionary Metadata](#dictionary-metadata)
   - [Dictionary Content](#dictionary-content)
@@ -144,6 +144,7 @@ Example JSON of F64
 | ----- | ----------- | ------- | -------- |
 | `name` | **String** representing the FPP type name | bool | true
 | `kind` | **String** representing the kind of type | bool | true |
+| `size` | **Number** of bits supported by the data type  | 8 | true |
 
 ### Boolean Types
 - true
@@ -154,6 +155,7 @@ Example JSON of bool
 {
     "name": "bool",
     "kind": "bool",
+    "size": 8
 }
 ```
 
@@ -162,7 +164,7 @@ Example JSON of bool
 | ----- | ----------- | ------- | -------- |
 | `name` | **String** representing the FPP type name |  string | true |
 | `kind` | **String** representing the kind of type | string | true | 
-| `size` | **Number** of bytes supported by the data type | **Number** in the range [0, 2<sup>31</sup>) | true |
+| `size` | **Number** of bytes supported by the data type | **Number** in the range [0, 2<sup>31</sup>) | false |
 
 ### String Types
 Any sequence of characters
@@ -200,7 +202,7 @@ Example JSON of qualified name
 | `qualifiedName` | **String** representing unique qualified name of element in FPP model | Period separated **String** | true |
 | `size` | Max **Number** of elements that can be in the data structure | **Number** | true |
 | `elementType` | A **JSON dictionary** representing the type of array | **JSON Dictionary** | true
-| `default` | Default array value | Value of type specified in `elementType` | false |
+| `default` | Default array value | Value of type specified in `elementType` | true |
 
 
 Example FPP model with JSON representation:
@@ -234,7 +236,7 @@ module M {
 | `qualifiedName` | String representing unique qualified name of element in FPP model | Period separated **String** | true |
 | `representationType` | The [Type Name](#type-names) of values in the enumeration | [Type Name](#type-names) | true |
 | `identifiers` | Dictionary of identifiers (keys) and numeric values (values) | **JSON Dictionary** | true |
-| `default` | String qualified name of the enumeration value | **String** qualified name | false |
+| `default` | String qualified name of the enumeration value | **String** qualified name | true |
 
 Example FPP model with JSON representation:
 ```
@@ -273,7 +275,7 @@ module M {
 | `type` | [Type Name](#type-names) of member | [Type Name](#type-names) | true |
 | `index` | **Number** index of the struct member | **Number** | true |
 | `size` | **Number** representing the size of the struct member | **Number** | false |
-| `formatSpecifier` | **String** format specifier | **String** | false |
+| `format` | **String** format specifier | **String** | false |
 
 ### Struct Type Definition
 | Field | Description | Options | Required |
@@ -281,7 +283,7 @@ module M {
 | `kind` | String representing the kind of type | struct | true |
 | `qualifiedName` | String representing unique qualified name of element in FPP model | Period separated **String** | true |
 | `members` | JSON dictionary consisting of **String** identifier (key) and [Struct Member](#struct-member) (value) | JSON dictionary | true |
-| `default` | JSON dictionary consisting of **String** identifier (key) and default value (value) | JSON dictionary | false |
+| `default` | JSON dictionary consisting of **String** identifier (key) and default value (value) | JSON dictionary | true |
 
 Example FPP model with JSON representation:
 ```
@@ -313,7 +315,7 @@ module M {
                 "signed": false,
                 "size": 32
             },
-            "formatSpecifier": "the count is {}",
+            "format": "the count is {}",
             "index": 1
         },
         "y": {
@@ -428,14 +430,14 @@ Example JSON of a struct:
 ## Formal Parameters
 | Field | Description | Options | Required |
 | ----- | ----------- | ------- | -------- |
-| `identifier` | **String** identifier | **String** | true |
+| `name` | **String** name | **String** | true |
 | `description` | **String** annotation of parameter | **String** | true |
 | `type` | [Type Name](#type-names) of parameter | [Type Name](#type-names) | true |
-| `ref` | **Boolean** indicating whether the formal parameter is to be passed by referenced when it is used in a synchronous port invocation | **Boolean** | false |
+| `ref` | **Boolean** indicating whether the formal parameter is to be passed by referenced when it is used in a synchronous port invocation | **Boolean** | true |
 
 ```json
 {
-    "identifier": "param1",
+    "name": "param1",
     "description": "Param 1",
     "type": {
         "name": "U32",
@@ -450,33 +452,24 @@ Example JSON of a struct:
 ## Parameters
 | Field | Description | Options | Required |
 | ----- | ----------- | ------- | -------- |
-| `identifier` | **String** qualified name of the parameter | Period separated **String** | true |
+| `name` | **String** qualified name of the parameter | Period separated **String** | true |
 | `description` | **String** annotation of parameter | **String** | true |
 | `type` | [Type Name](#type-names) of the parameter | [Type Name](#type-names) | true |
 | `default` | Default value (of type specified in `type`)  of the parameter | Value of type specified in `type` | false |
-| `numericIdentifier` | **Number** representing the numeric identifier of the parameter | **Number** | false |
-| `setOpcode` | **Number** representing the opcode of the command for setting the parameter | **Number** | false |
-| `saveOpcode` | **Number** representing the opcode of the command for saving the parameter | **Number** | false |
-
+| `id` | **Number** representing the numeric identifier of the parameter | **Number** | true |
 
 Example FPP model with JSON representation:
 ```
-module MyModule {
-    active component FirstComponent {
-        @ This is the annotation for Parameter 1
-        param Parameter1: U32 \
-            id 0x100 \
-            set opcode 0x101 \
-            save opcode 0x102
-
-        ...
-    }
-}
+@ This is the annotation for Parameter 1
+param Parameter1: U32 \
+    id 0x100 \
+    set opcode 0x101 \
+    save opcode 0x102
 ```
 
 ```json
 {
-    "identifier": "MyModule.FirstComponent.Parameter1",
+    "name": "c1.Parameter1",
     "description": "This is the annotation for Parameter 1",
     "type": {
         "name": "U32",
@@ -485,47 +478,39 @@ module MyModule {
         "size": 32
     },
     "default": 0,
-    "numericIdentifier": "256",
-    "setOpcode": "257",
-    "saveOpcode": "258"
+    "id": "256"
 }
 ```
 
 ## Commands
 | Field | Description | Options | Required |
 | ----- | ----------- | ------- | -------- |
-| `identifier` | **String** qualified name of the command | Period separated **String** | true |
+| `name` | **String** qualified name of the command | Period separated **String** | true |
 | `commandKind` | **String** representing the kind of command | async, guarded, sync | true |
 | `opcode` | **Number** command opcode | **Number** | true |
 | `description` | **String** annotation of command | string | true |
 | `formalParams` | Array of [Formal Parameters](#formal-parameters) | Array of [Formal Parameters](#formal-parameters) | true |
-| `priority` | **Number** representing the priority for the command on the input queue | **Number** | false |
-| `queueFullBehavior` | **String** representing the behavior of the command when the input full is queue | assert, block, drop | false |
+| `priority` | **Number** representing the priority for the command on the input queue | **Number** | required for async command kinds |
+| `queueFullBehavior` | **String** representing the behavior of the command when the input full is queue | assert, block, drop | required for async command kinds |
 
 Example FPP model with JSON representation:
 ```
-module MyComponents {
-    active component FirstComponent {
-        @ A sync command with parameters
-        sync command SyncParams(
-            param1: U32 @< Param 1
-            param2: string @< Param 2
-        ) opcode 0x100
-        
-        ...
-    }
-}
+@ A sync command with parameters
+sync command SyncParams(
+    param1: U32 @< Param 1
+    param2: string @< Param 2
+) opcode 0x100
 ```
 
 ```json
 {
-    "identifier": "MyComponents.FirstComponent.SyncParams",
+    "name": "c1.SyncParams",
     "commandKind": "sync",
     "opcode": 256,
     "description": "A sync command with parameters",
     "formalParams": [
         {
-            "identifier": "param1",
+            "name": "param1",
             "description": "Param 1",
             "type": {
                 "name": "U32",
@@ -536,7 +521,7 @@ module MyComponents {
             "ref": false
         },
          {
-            "identifier": "param2",
+            "name": "param2",
             "description": "Param 2",
             "type": {
                 "name": "string",
@@ -552,41 +537,35 @@ module MyComponents {
 ## Telemetry Channels
 | Field | Description | Options | Required |
 | ----- | ----------- | ------- | -------- |
-| `identifier` | **String** qualified name of the telemetry channel | Period separated **String** | true |
+| `name` | **String** qualified name of the telemetry channel | Period separated **String** | true |
 | `description` | **String** annotation of channel | **String** | true |
 | `type` | [Type Name](#type-names) the telemetry channel | [Type Name](#type-names) | true |
-| `numericIdentifier` | **Number** representing numeric identifier | **Number** | true |
-| `telemetryUpdate` | **String** representing when the telemetry channel can update | always, on change | false |
-| `formatString` | **String** format with a single argument (the telemetry channel) | **String** | false |
+| `id` | **Number** representing numeric identifier | **Number** | true |
+| `telemetryUpdate` | **String** representing when the telemetry channel can update | always, on change | true |
+| `format` | **String** format with a single argument (the telemetry channel) | **String** | false |
 | `limit` | **JSON dictionary** consisting of low and high limits | **JSON dictionary** | false |
 
 Example FPP model with JSON representation:
 ```
-module MyModule {
-    active component FirstComponent {
-        @ Telemetry channel 1
-        telemetry Channel1: F64 \
-            id 0x100 \
-            update on change \
-            low { yellow -1, orange -2, red -3 } \
-            high { yellow 1, orange 2, red 3 }
-        
-        ...
-    }
-}
+@ Telemetry channel 1
+telemetry Channel1: F64 \
+    id 0x100 \
+    update on change \
+    low { yellow -1, orange -2, red -3 } \
+    high { yellow 1, orange 2, red 3 }
 ```
 
 ```json
 [
     {
-        "identifier": "MyModule.FirstComponent.Channel1",
+        "name": "c1.Channel1",
         "description": "Telemetry channel 1",
         "type": {
             "type": "F64",
             "kind": "float",
             "size": 64
         },
-        "numericIdentifier": 256,
+        "id": 256,
         "telemetryUpdate": "on change",
         "limit": {
             "low": {
@@ -607,66 +586,57 @@ module MyModule {
 ## Events
 | Field | Description | Options | Required |
 | ----- | ----------- | ------- | -------- |
-| `identifier` | **String** qualified name of the event | Period separated **String** | true |
+| `name` | **String** qualified name of the event | Period separated **String** | true |
 | `description` | **String** annotation of event | **String** | true |
-| `severity` | **String** representing severity of the event | activity high, activity low, command, diagnostic, fatal, warning high, warning low | true |
+| `severity` | **String** representing severity of the event | ACTIVITY_HIGH, ACTIVITY_LOW, COMMAND, DIAGNOSTIC, FATAL, WARNING_HIGH, WARNING_LOW | true |
 | `formalParams` | Array of [Formal Parameters](#formal-parameters) | Array [Formal Parameters](#formal-parameters) | true |
-| `numericIdentifier` | **Number** representing the numeric identifier of the event | **Number** | true |
-| `formatString` | **String** format with event parameters as arguments | **String** | false |
+| `id` | **Number** representing the numeric identifier of the event | **Number** | true |
+| `format` | **String** format with event parameters as arguments | **String** | false |
 | `throttle` | **Number** representing the maximum number of times to emit the event before throttling it | **Number** | false |
 
 
 Example FPP model with JSON representation:
 ```
-module MyModule {
-    active component FirstComponent {
-        @ This is the annotation for Event 0
-        event Event0 \
-            severity activity low \
-            id 0x100 \
-            format "Event 0 occurred"
-        
-        ...
-    }
-}
+@ This is the annotation for Event 0
+event Event0 \
+    severity activity low \
+    id 0x100 \
+    format "Event 0 occurred"
+
+...
 ```
 
 ```json
 {
-    "identifier": "MyModule.FirstComponent.Event0",
+    "name": "c1.Event0",
     "description": "This is the annotation for Event 0",
-    "severity": "activity low",
+    "severity": "ACTIVITY_LOW",
     "formalParams": [],
-    "numericIdentifier": 256,
-    "formatString": "Event 0 occurred",
+    "id": 256,
+    "format": "Event 0 occurred",
 }
 ```
 
 Example FPP model with JSON representation:
 ```
-module MyModule {
-    active component FirstComponent {
-        @ This is the annotation for Event 1
-        @ Sample output: "Event 1 occurred with argument 42"
-        event Event1(
-            arg1: U32 @< Argument 1
-        ) \
-            severity activity high \
-            id 0x101 \
-            format "Event 1 occurred with argument {}"
-        
-        ...
-    }
-}
+@ This is the annotation for Event 1
+@ Sample output: "Event 1 occurred with argument 42"
+event Event1(
+    arg1: U32 @< Argument 1
+) \
+    severity activity high \
+    id 0x101 \
+    format "Event 1 occurred with argument {}"
+
 ```
 ```json
 {
-    "identifier": "MyModule.FirstComponent.Event1",
+    "name": "c1.Event1",
     "description": "This is the annotation for Event 1",
-    "severity": "activity high",
+    "severity": "ACTIVITY_HIGH",
     "formalParams": [
         {
-           "identifier": "arg1",
+           "name": "arg1",
             "description": "Argument 1",
             "type": {
                 "name": "U32",
@@ -677,41 +647,35 @@ module MyModule {
             "ref": false  
         }
     ],
-    "numericIdentifier": 257,
-    "formatString": "Event 1 occurred with argument {}",
+    "id": 257,
+    "format": "Event 1 occurred with argument {}",
 }
 ```
 
 # Data Products
-## Record
+## Records
 | Field | Description | Options | Required |
 | ----- | ----------- | ------- | -------- |
-| `identifier` | **String** qualified name of the record | Period separated **String** | true |
+| `name` | **String** qualified name of the record | Period separated **String** | true |
 | `description` | **String** annotation of record | **String** | true |
 | `type` | [Type Name](#type-names) the record | [Type Name](#type-names) | true |
 | `array` | **Boolean** specifying whether the record stores a variable number of elements | **Boolean** | false |
-| `numericIdentifier` | **Number** representing the numeric identifier of the record | **Number** | true |
+| `id` | **Number** representing the numeric identifier of the record | **Number** | true |
 
 Example FPP model with JSON representation:
 ```
-module MyModule {
-    active component FirstComponent {
-        @ Record 0: A variable number of F32 values
-        @ Implied id is 0x100
-        product record Record0: F32 array
+@ Record 0: A variable number of F32 values
+@ Implied id is 0x100
+product record Record0: F32 array
 
-        @ Record 1: A single U32 value
-        product record Record1: U32 id 0x102
-        
-        ...
-    }
-}
+@ Record 1: A single U32 value
+product record Record1: U32 id 0x102
 ```
 
 ```json
 [
     {
-        "identifier": "MyModule.FirstComponent.Record0",
+        "name": "c1.Record0",
         "description": "Record 0: A variable number of F32 values",
         "type": {
             "name": "F32",
@@ -719,10 +683,10 @@ module MyModule {
             "size": 32
         },
         "array": true,
-        "numericIdentifier": 256 
+        "id": 256 
     },
     {
-        "identifier": "MyModule.FirstComponent.Record1",
+        "name": "c1.Record1",
         "description": "Record 1: A single U32 value",
         "type": {
             "name": "U32",
@@ -731,55 +695,49 @@ module MyModule {
             "size": 32
         },
         "array": false,
-        "numericIdentifier": 258
+        "id": 258
     }      
 ]
 ```
 
-## Container
+## Containers
 | Field | Description | Options | Required |
 | ----- | ----------- | ------- | -------- |
-| `identifier` | **String** qualified name of the container | Period separated **String** | true |
+| `name` | **String** qualified name of the container | Period separated **String** | true |
 | `description` | **String** annotation of container | **String** | true |
-| `numericIdentifier` | **Number** representing the numeric identifier of the record | **Number** | true |
+| `id` | **Number** representing the numeric identifier of the record | **Number** | true |
 | `defaultPriority` | **Number** representing the downlink priority for the container | **Number** | false |
 
 Example FPP model with JSON representation:
 ```
-module MyModule {
-    active component FirstComponent {
-        @ Container 0
-        @ Implied id is 0x100
-        product container Container0
+@ Container 0
+@ Implied id is 0x100
+product container Container0
 
-        @ Container 1
-        product container Container1 id 0x102
+@ Container 1
+product container Container1 id 0x102
 
-        @ Container 2
-        @ Implied id is 0x103
-        product container Container2 default priority 10
-
-        ...
-    }
-}
+@ Container 2
+@ Implied id is 0x103
+product container Container2 default priority 10
 ```
 
 ```json
 [
     {
-       "identifier": "MyModule.FirstComponent.Container0",
+       "name": "c1.Container0",
        "description": "Container 0\nImplied id is 0x100",
-       "numericIdentifier": 256,
+       "id": 256,
     },
     {
-        "identifier": "MyModule.FirstComponent.Container1",
+        "name": "c1.Container1",
         "description": "Container 1",
-        "numericIdentifier": 258,
+        "id": 258,
     },
     {
-        "identifier": "MyModule.FirstComponent.Container2",
+        "name": "c1.Container2",
         "description": "Container 2\nImplied id is 0x103",
-        "numericIdentifier": 3,
+        "id": 3,
         "defaultPriority": 259
     }
 ]
@@ -793,13 +751,14 @@ module MyModule {
 | `frameworkVersion` | **String** representing the F´ framework version (semantic versioning) | **String** | true |
 | `projectVersion` | **String** representing the project version (semantic versioning) | **String** | true |
 | `libraryVersions` | **Array of Strings** corresponding to the version (semantic versioning) of libraries used by the F´ project | **Array of Strings** | true
-
+| `dictionarySpecVersion` | **String** representing the JSON dictionary specification version | **String** | true |
 ```json
 {
     "deploymentName": "MyDeployment",
     "frameworkVersion": "3.3.2",
     "projectVersion": "1.0.0",
-    "libraryVersions": []
+    "libraryVersions": [],
+    "dictionarySpecVersion": "1.0.0"
 }
 ```
 
@@ -807,13 +766,13 @@ module MyModule {
 | Field | Description | Options | Required |
 | ----- | ----------- | ------- | -------- |
 | `metadata` | [Dictionary Metadata](#dictionary-metadata) | [Dictionary Metadata](#dictionary-metadata) | true |
-| `arrays` | Array of [Arrays](#array-type-definition) | Array of [Arrays](#array-type-definition) | true |
-| `enums` | Array of [Enums](#enumeration-type-definition) | Array of [Enums](#enumeration-type-definition) | true |
-| `structs` | Array of [Structs](#struct-type-definition-1) | Array of [Structs](#struct-type-definition-1) | true |
+| `typeDefinitions` | Array of [Arrays](#array-type-definition), [Enums](#enumeration-type-definition), and [Structs](#struct-type-definition-1) | Array of [Arrays](#array-type-definition), [Enums](#enumeration-type-definition), and [Structs](#struct-type-definition-1) | true |
 | `commands` | Array of [Commands](#commands) | Array of [Commands](#commands) | true |
 | `events` | Array of [Events](#events) | Array of [Events](#events) | true |
 | `telemetryChannels` | Array of [Telemetry Channels](#telemetry-channels) | Array of [Telemetry Channels](#telemetry-channels) | true |
 | `parameters` | Array of [Parameters](#parameters) | Array of [Parameters](#parameters) | true |
+| `records` | Array of [Records](#records) | Array of [Records](#records) | true |
+| `containers` | Array of [Containers](#containers) | Array of [Containers](#containers) | true |
 
 ```json
 {
@@ -821,12 +780,13 @@ module MyModule {
         "deploymentName": "MyDeployment",
         "frameworkVersion": "3.3.2",
         "projectVersion": "1.0.0",
-        "libraryVersions": []
+        "libraryVersions": [],
+        "dictionarySpecVersion": "1.0.0"
     },
-    "enums": [
+    "typeDefinitions": [
         {
             "kind": "enum",
-            "qualifiedName": "MyDeployment.M.C1.Status",
+            "qualifiedName": "M.C.Status",
             "representationType": {
                 "name": "I32",
                 "kind": "integer",
@@ -838,13 +798,11 @@ module MyModule {
                 "NO": 1,
                 "MAYBE": 2
             },
-            "default": "MyDeployment.M.C1.Status.MAYBE"
-        }
-    ],
-    "arrays": [
+            "default": "M.C.Status.MAYBE"
+        },
         {
             "kind": "array",
-            "qualifiedName": "MyDeployment.M.C1.A1",
+            "qualifiedName": "M.C.A1",
             "size": 3,
             "elementType": {
                 "name": "U8",
@@ -856,23 +814,21 @@ module MyModule {
         },
         {
             "kind": "array",
-            "qualifiedName": "MyDeployment.M.C1.A2",
+            "qualifiedName": "M.C.A2",
             "size": 5,
             "elementType": {
                 "name": "string",
                 "kind": "string",
             },
             "default": ["a", "b", "c", "d", "e"]
-        }
-    ],
-    "structs": [
+        },
         {
             "kind": "struct",
             "qualifiedName": "M.S1",
             "members": {
                 "w": {
                     "type": {
-                        "name": "MyDeployment.M.C1.S1.w",
+                        "name": "M.C.A1",
                         "kind": "qualifiedIdentifier"
                     },
                     "index": 0,
@@ -885,7 +841,7 @@ module MyModule {
                         "signed": false,
                         "size": 32
                     },
-                    "formatSpecifier": "the count is {}",
+                    "format": "the count is {}",
                     "index": 1
                 },
                 "y": {
@@ -905,14 +861,14 @@ module MyModule {
         },
         {
             "kind": "struct",
-            "qualifiedName": "MyDeployment.M.C1.S2",
+            "qualifiedName": "M.C.S2",
             "members": {
                 "x": {
                     "type": {
                         "name": "string",
                         "kind": "string",
                     },
-                    "formatSpecifier": "the string is {}",
+                    "format": "the string is {}",
                     "index": 0
                 },
             },
@@ -925,11 +881,11 @@ module MyModule {
         {
             "commandKind": "sync",
             "opcode": 257,
-            "identifier": "MyDeployment.MyModule.FirstComponent.SyncParams",
+            "name": "c1.SyncParams",
             "description": "A sync command with parameters",
             "formalParams": [
                 {
-                    "identifier": "param1",
+                    "name": "param1",
                     "description": "Param 1",
                     "type": {
                         "name": "U32",
@@ -940,7 +896,7 @@ module MyModule {
                     "ref": false
                 },
                 {
-                    "identifier": "param2",
+                    "name": "param2",
                     "description": "Param 2",
                     "type": {
                         "name": "string",
@@ -954,28 +910,28 @@ module MyModule {
     ],
     "events": [
         {
-            "identifier": "MyDeployment.MyModule.FirstComponent.Event0",
+            "name": "c1.Event0",
             "description": "This is the annotation for Event 0",
             "severity": "activity low",
             "formalParams": [
                 {
-                    "identifier": "",
+                    "name": "",
                     "description": "",
                     "type": {},
                     "ref": false
                 }
             ],
-            "numericIdentifier": 256,
-            "formatString": "Event 0 occurred",
+            "id": 256,
+            "format": "Event 0 occurred",
             "throttle": ""
         },
         {
-            "identifier": "MyDeployment.MyModule.FirstComponent.Event1",
+            "name": "c1.Event1",
             "description": "This is the annotation for Event 1",
             "severity": "activity high",
             "formalParams": [
                 {
-                "identifier": "arg1",
+                "name": "arg1",
                     "description": "Argument 1",
                     "type": {
                         "name": "U32",
@@ -986,21 +942,21 @@ module MyModule {
                     "ref": false  
                 }
             ],
-            "numericIdentifier": 257,
-            "formatString": "Event 1 occurred with argument {}",
+            "id": 257,
+            "format": "Event 1 occurred with argument {}",
             "throttle": ""
         }
     ],
     "telemetryChannels": [
         {
-            "identifier": "MyDeployment.MyModule.FirstComponent.Channel1",
+            "name": "c1.Channel1",
             "description": "Telemetry channel 1",
             "type": {
                 "type": "F64",
                 "kind": "float",
                 "size": 64
             },
-            "numericIdentifier": 256,
+            "id": 256,
             "telemetryUpdate": "on change",
             "limit": {
                 "low": {
@@ -1018,7 +974,7 @@ module MyModule {
     ],
     "parameters": [
         {
-            "identifier": "MyDeployment.MyModule.FirstComponent.Parameter1",
+            "name": "c1.Parameter1",
             "description": "This is the annotation for Parameter 1",
             "type": {
                 "name": "U32",
@@ -1027,9 +983,28 @@ module MyModule {
                 "size": 32
             },
             "default": 0,
-            "numericIdentifier": 256,
-            "setOpcode": 257,
-            "saveOpcode": 258
+            "id": 256
+        }
+    ],
+    "records": [    
+        {
+            "name": "c1.Record1",
+            "description": "Record 1: A single U32 value",
+            "type": {
+                "name": "U32",
+                "kind": "integer",
+                "signed": false,
+                "size": 32
+            },
+            "array": false,
+            "id": 258
+        }      
+    ],
+    "containers": [
+        {
+            "name": "c1.Container0",
+            "description": "Container 0\nImplied id is 0x100",
+            "id": 256,
         }
     ]
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

- move arrays, structs, and enums into `typeDefinitions`
- rename `formatSpecifier` to `format`
- rename `identifier` to `name`
- shorten `identifier` to `id`
- add bool size
