### PR TITLE
Fix crosscompiler path in tutorial

### DIFF
--- a/docs/Tutorials/CrossCompilationSetup/CrossCompilationSetupTutorial.md
+++ b/docs/Tutorials/CrossCompilationSetup/CrossCompilationSetupTutorial.md
@@ -54,7 +54,7 @@ Next, ensure that the ARM toolchains were installed properly. To test, run the f
 # For  64-bit ARM hardware
 /opt/toolchains/bin/aarch64-none-linux-gnu-gcc -v 
 # For 32-bit ARM hardware
-/opt/toolchains/bin/arm-linux-gnueabi-gcc -v
+/opt/toolchains/bin/arm-none-linux-gnueabihf-gcc -v
 ```
  Any output other than "file/command not found" is good.
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

We've had a couple reports of this mismatch in the name of the crosscompiler... so let's fix it

Fix https://github.com/nasa/fprime/issues/2596 https://github.com/nasa/fprime/issues/2350