### PR TITLE
Disambiguate fpp error messages. Fixes: #2618

### DIFF
--- a/cmake/autocoder/fpp.cmake
+++ b/cmake/autocoder/fpp.cmake
@@ -41,14 +41,19 @@ function(locate_fpp_tools)
                     continue()
                 endif()
                 message(STATUS "[fpp-tools] ${${TOOL}} version ${CMAKE_MATCH_1} not expected version ${FPP_VERSION}")
+                set(FPP_REINSTALL_ERROR_MESSAGE
+                    "fpp-tools version incompatible. Found ${CMAKE_MATCH_1}, expected ${FPP_VERSION}." PARENT_SCOPE
+                )
+            elseif(OUTPUT_TEXT MATCHES "requires 'java'")
                 set(FPP_ERROR_MESSAGE
-                    "fpp-tools version incompatible. Found ${CMAKE_MATCH_1}, expected ${FPP_VERSION}" PARENT_SCOPE
+                        "fpp tools require 'java'. Please install 'java' and ensure it is on your PATH." PARENT_SCOPE
                 )
             else()
-                message(STATUS "[fpp-tools] ${PROGRAM} appears corrupt.")
+                message(STATUS "[fpp-tools] ${PROGRAM} installed incorrectly.")
+                set(FPP_REINSTALL_ERROR_MESSAGE "fpp tools installed incorrectly." PARENT_SCOPE)
             endif()
         else()
-            message(STATUS "[fpp-tools] Could not find ${PROGRAM}")
+            message(STATUS "[fpp-tools] Could not find ${PROGRAM}.")
         endif()
         set(FPP_FOUND FALSE PARENT_SCOPE)
         return()

--- a/cmake/required.cmake
+++ b/cmake/required.cmake
@@ -13,15 +13,18 @@ find_program(FPUTIL NAMES fprime-util)
 
 locate_fpp_tools()
 
-set(TO_INSTALL_MESSAGE "Install with:\n  'pip install -r \"${FPRIME_FRAMEWORK_PATH}/requirements.txt\"'")
-
+set(FRAGMENT "pip install -r \"${FPRIME_FRAMEWORK_PATH}/requirements.txt\"")
+set(TO_INSTALL_MESSAGE "Install with:\n  '${FRAGMENT}'")
+set(TO_REINSTALL "Reinstall with:\n  '${FRAGMENT} -U --force-reinstall'")
 # Check python was found
 if (NOT FPUTIL)
     message(FATAL_ERROR " fprime-util was not found. ${TO_INSTALL_MESSAGE}")
 elseif (NOT PYTHON)
     message(FATAL_ERROR " python3 was not found. Please see: https://www.python.org/downloads/")
 elseif (DEFINED FPP_ERROR_MESSAGE)
-    message(FATAL_ERROR " ${FPP_ERROR_MESSAGE}. ${TO_INSTALL_MESSAGE}")
+    message(FATAL_ERROR " ${FPP_ERROR_MESSAGE}")
+elseif (DEFINED FPP_REINSTALL_ERROR_MESSAGE)
+    message(FATAL_ERROR " ${FPP_REINSTALL_ERROR_MESSAGE}. ${TO_REINSTALL}")
 elseif(NOT FPP_FOUND)
     message(FATAL_ERROR " fpp tools not found. ${TO_INSTALL_MESSAGE}")
 endif()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Cleans-up bad FPP installation errors:
1. Missing Java now reports "missing java"
2. Corrupt now recommends reinstall
3. Missing recommends install

## Rationale

Conflated error messages deconflated.

## Testing/Review Recommendations

Tested the following:

1. Removed `fpp-depend`: missing message reported
2. Invalid binary `fpp-fepend`: invalid install reported, recommend reinstall
3. Installed java wheel w/o Java: requires java reported

## Future Work

Update install guide.