### PR TITLE
Add Java requirement to install guide

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -27,9 +27,10 @@ Requirements:
 3. [CMake 3.16](https://cmake.org/download/) or newer. CLI tool must be available on the system path.
 4. CLang or GNU C and C++ compilers (e.g. gcc and g++)
 5. [Python 3.8+](https://www.python.org/downloads/), virtual environments, and PIP
-6. Java for build machine architectures other than x86_64 and aarch64
 
-> Latest versions of PIP are strongly recommended, as this will install native packages with improved performance and no dependency on Java. See [Recommended PIP Versions](#recommended-pip-versions)
+> Latest versions of PIP are strongly recommended. See [Recommended PIP Versions](#recommended-pip-versions)
+
+> For build host architectures other than x86_64 or aarch64, and systems with older PIP versions, Java is required
 
 > Ubuntu and Debian users should see notes on [Python installation](#ubuntu-debian-java-and-python-pip)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -27,6 +27,7 @@ Requirements:
 3. [CMake 3.16](https://cmake.org/download/) or newer. CLI tool must be available on the system path.
 4. CLang or GNU C and C++ compilers (e.g. gcc and g++)
 5. [Python 3.8+](https://www.python.org/downloads/), virtual environments, and PIP
+6. Java for build machine architectures other than x86_64 and aarch64
 
 > Latest versions of PIP are strongly recommended, as this will install native packages with improved performance and no dependency on Java. See [Recommended PIP Versions](#recommended-pip-versions)
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix install guide to include Java for non-x86_64/aarch64 systems.