### PR TITLE
feat(ci): migrate to uv for faster python deps installation

### DIFF
--- a/.github/workflows/codeql-jpl-standard.yml
+++ b/.github/workflows/codeql-jpl-standard.yml
@@ -44,10 +44,9 @@ jobs:
 
     - name: Build
       run: |
-          python3 -m venv ./fprime-venv
-          . ./fprime-venv/bin/activate
-          pip install -U setuptools setuptools_scm wheel pip
-          pip install -r ./requirements.txt
+          python -m venv /opt/venv && export PATH="/opt/venv/bin:$PATH"
+          python -m uv pip install -U setuptools setuptools_scm wheel pip uv
+          python -m uv pip install -r ./requirements.txt
           fprime-util generate
           fprime-util build --all
 

--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -43,10 +43,9 @@ jobs:
     - if: ${{ matrix.language == 'cpp' }}
       name: Build
       run: |
-          python3 -m venv ./fprime-venv
-          . ./fprime-venv/bin/activate
-          pip install -U setuptools setuptools_scm wheel pip
-          pip install -r ./requirements.txt
+          python -m venv /opt/venv && export PATH="/opt/venv/bin:$PATH"
+          python -m uv pip install -U setuptools setuptools_scm wheel pip uv
+          python -m uv pip install -r ./requirements.txt
           fprime-util generate
           fprime-util build --all
     - name: Perform CodeQL Analysis

--- a/.github/workflows/fpp-tests.yml
+++ b/.github/workflows/fpp-tests.yml
@@ -24,7 +24,9 @@ jobs:
           submodules: true
       - name: "Install requirements.txt"
         run: |
-          pip3 install -r ./requirements.txt
+          python -m venv /opt/venv && export PATH="/opt/venv/bin:$PATH"
+          python -m pip install -U pip uv
+          python -m uv pip install -r ./requirements.txt
         shell: bash
       - name: "Generate UT build cache"
         working-directory: ./FppTest

--- a/.github/workflows/pip-check.yml
+++ b/.github/workflows/pip-check.yml
@@ -26,4 +26,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
+          python -m venv /opt/venv && export PATH="/opt/venv/bin:$PATH"
+          python -m pip install -U pip uv
+          python -m uv pip install -r requirements.txt

--- a/.github/workflows/reusable-project-builder.yml
+++ b/.github/workflows/reusable-project-builder.yml
@@ -59,7 +59,9 @@ jobs:
           path: ${{ inputs.fprime_location }}
       - name: "Install requirements.txt"
         run: |
-          pip3 install -r ${{ inputs.fprime_location }}/requirements.txt
+          python -m venv /opt/venv && export PATH="/opt/venv/bin:$PATH"
+          python -m pip install -U pip uv
+          python -m uv pip install -r ${{ inputs.fprime_location }}/requirements.txt
         shell: bash
       - name: "Generate build cache"
         working-directory: ${{ inputs.build_location }}
@@ -90,7 +92,9 @@ jobs:
           path: ${{ inputs.fprime_location }}
       - name: "Install requirements.txt"
         run: |
-          pip3 install -r ${{ inputs.fprime_location }}/requirements.txt
+          python -m venv /opt/venv && export PATH="/opt/venv/bin:$PATH"
+          python -m pip install -U pip uv
+          python -m uv pip install -r ${{ inputs.fprime_location }}/requirements.txt
         shell: bash
       - name: "Generate UT build cache"
         working-directory: ${{ inputs.build_location }}


### PR DESCRIPTION
## Change Description

This PR aims to migrate the python dependency installation to [`uv`](https://github.com/astral-sh/uv) from `pip`. [uv](https://github.com/astral-sh/uv) backed by [Astral](https://astral.sh/), the creators of [Ruff](https://github.com/astral-sh/ruff), is an extremely fast Python package installer and resolver, written in Rust. According to their open-source benchmarks they are [10-100x faster](https://github.com/astral-sh/uv/blob/main/BENCHMARKS.md) than pip and pip-tools (pip-compile and pip-sync).

## Rationale

This change will enable faster CI runs and therefore faster feedback to streamline the contribution workflow.

## Testing/Review Recommendations

uv has been adopted by popular repositories such as [diffusers](https://github.com/huggingface/diffusers) with [observed performance boost](https://x.com/RisingSayak/status/1763037626372632884?s=20).

## Future Work

There are some other workflow files which also use pip such as `python-format` but I avoided making those changes in this PR. If the maintainers find it useful other workflows using `pip` can be updated to use `pip`
