### PR TITLE
Fix INI newline processing. Fixes #2630

### DIFF
--- a/cmake/settings/ini.cmake
+++ b/cmake/settings/ini.cmake
@@ -57,6 +57,7 @@ function(ini_to_cache)
         unset(CMAKE_INSTALL_PREFIX CACHE)
     endif()
     # Process line-by-line
+    STRING(REPLACE "\n" ";" INI_OUTPUT "${INI_OUTPUT}")
     foreach(LINE IN LISTS INI_OUTPUT)
         # Skip malformed lines
         if (NOT LINE MATCHES "^[A-Za-z0-9_]+=")


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes newline processing in `ini.cmake`.   Partially addresses #2630.