### PR TITLE
Format cpp and hpp files in Fw/Types

### DIFF
--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -13,272 +13,181 @@
 
 namespace Fw {
 
-    void defaultPrintAssert(const CHAR* msg) {
-        (void)fprintf(stderr,"%s\n", msg);
-    }
-
-    void defaultReportAssert
-            (
-            FILE_NAME_ARG file,
-            NATIVE_UINT_TYPE lineNo,
-            NATIVE_UINT_TYPE numArgs,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            FwAssertArgType arg3,
-            FwAssertArgType arg4,
-            FwAssertArgType arg5,
-            FwAssertArgType arg6,
-            CHAR* destBuffer,
-            NATIVE_INT_TYPE buffSize
-            ) {
-
-        switch (numArgs) {
-            case 0:
-                (void) snprintf(destBuffer, buffSize, fileIdFs, file, lineNo);
-                break;
-            case 1:
-                (void) snprintf(
-                    destBuffer,
-                    buffSize,
-                    fileIdFs " %" PRI_FwAssertArgType,
-                    file,
-                    lineNo,
-                    arg1
-                );
-                break;
-            case 2:
-                (void) snprintf(
-                    destBuffer,
-                    buffSize,
-                    fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType,
-                    file,
-                    lineNo,
-                    arg1, arg2
-                );
-                break;
-            case 3:
-                (void) snprintf(
-                    destBuffer,
-                    buffSize,
-                    fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
-                      " %" PRI_FwAssertArgType,
-                    file,
-                    lineNo,
-                    arg1, arg2, arg3
-                );
-                break;
-            case 4:
-                (void) snprintf(
-                    destBuffer,
-                    buffSize,
-                    fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
-                      " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType,
-                    file,
-                    lineNo,
-                    arg1, arg2, arg3, arg4);
-                break;
-            case 5:
-                (void) snprintf(
-                    destBuffer,
-                    buffSize,
-                    fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
-                      " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
-                      " %" PRI_FwAssertArgType,
-                    file,
-                    lineNo,
-                    arg1, arg2, arg3, arg4, arg5
-                );
-                break;
-            case 6:
-                (void) snprintf(
-                    destBuffer,
-                    buffSize,
-                    fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
-                      " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
-                      " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType,
-                    file,
-                    lineNo,
-                    arg1, arg2, arg3, arg4, arg5, arg6
-                );
-                break;
-            default: // in an assert already, what can we do?
-                break;
-        }
-
-        // null terminate
-        destBuffer[buffSize-1] = 0;
-
-    }
-
-    void AssertHook::printAssert(const CHAR* msg) {
-        defaultPrintAssert(msg);
-    }
-
-    void AssertHook::reportAssert
-        (
-            FILE_NAME_ARG file,
-            NATIVE_UINT_TYPE lineNo,
-            NATIVE_UINT_TYPE numArgs,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            FwAssertArgType arg3,
-            FwAssertArgType arg4,
-            FwAssertArgType arg5,
-            FwAssertArgType arg6
-         )
-    {
-        CHAR destBuffer[FW_ASSERT_DFL_MSG_LEN];
-        defaultReportAssert
-        (
-            file,
-            lineNo,
-            numArgs,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            destBuffer,
-            sizeof(destBuffer)
-         );
-        // print message
-        this->printAssert(destBuffer);
-    }
-
-    void AssertHook::doAssert() {
-        assert(0);
-    }
-
-    STATIC AssertHook* s_assertHook = nullptr;
-
-    void AssertHook::registerHook() {
-        this->previousHook = s_assertHook;
-        s_assertHook = this;
-    }
-
-    void AssertHook::deregisterHook() {
-        s_assertHook = this->previousHook;
-    }
-
-    // Default handler of SwAssert functions
-    NATIVE_INT_TYPE defaultSwAssert(
-            FILE_NAME_ARG file,
-            NATIVE_UINT_TYPE lineNo,
-            NATIVE_UINT_TYPE numArgs,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            FwAssertArgType arg3,
-            FwAssertArgType arg4,
-            FwAssertArgType arg5,
-            FwAssertArgType arg6) {
-        if (nullptr == s_assertHook) {
-            CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
-            defaultReportAssert(
-                file,
-                lineNo,
-                numArgs,
-                arg1,arg2,arg3,arg4,arg5,arg6,
-                assertMsg,sizeof(assertMsg));
-            defaultPrintAssert(assertMsg);
-            assert(0);
-        }
-        else {
-            s_assertHook->reportAssert(
-                file,
-                lineNo,
-                numArgs,
-                arg1,arg2,arg3,arg4,arg5,arg6);
-            s_assertHook->doAssert();
-        }
-        return 0;
-    }
-
-    NATIVE_INT_TYPE SwAssert(
-            FILE_NAME_ARG file,
-            NATIVE_UINT_TYPE lineNo) {
-        return defaultSwAssert(file, lineNo, 0, 0, 0, 0, 0, 0, 0);
-    }
-
-    NATIVE_INT_TYPE SwAssert(
-            FILE_NAME_ARG file,
-            FwAssertArgType arg1,
-            NATIVE_UINT_TYPE lineNo) {
-        return defaultSwAssert(file, lineNo, 1, arg1, 0, 0, 0, 0, 0);
-    }
-
-    NATIVE_INT_TYPE SwAssert(
-            FILE_NAME_ARG file,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            NATIVE_UINT_TYPE lineNo) {
-        return defaultSwAssert(file, lineNo, 2, arg1, arg2, 0, 0, 0, 0);
-    }
-
-    NATIVE_INT_TYPE SwAssert(
-            FILE_NAME_ARG file,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            FwAssertArgType arg3,
-            NATIVE_UINT_TYPE lineNo) {
-        return defaultSwAssert(file, lineNo, 3, arg1, arg2, arg3, 0, 0, 0);
-    }
-
-    NATIVE_INT_TYPE SwAssert(
-            FILE_NAME_ARG file,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            FwAssertArgType arg3,
-            FwAssertArgType arg4,
-            NATIVE_UINT_TYPE lineNo) {
-        return defaultSwAssert(file, lineNo, 4, arg1, arg2, arg3, arg4, 0, 0);
-    }
-
-    NATIVE_INT_TYPE SwAssert(
-            FILE_NAME_ARG file,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            FwAssertArgType arg3,
-            FwAssertArgType arg4,
-            FwAssertArgType arg5,
-            NATIVE_UINT_TYPE lineNo) {
-        return defaultSwAssert(file, lineNo, 5, arg1, arg2, arg3, arg4, arg5, 0);
-    }
-
-    NATIVE_INT_TYPE SwAssert(
-            FILE_NAME_ARG file,
-            FwAssertArgType arg1,
-            FwAssertArgType arg2,
-            FwAssertArgType arg3,
-            FwAssertArgType arg4,
-            FwAssertArgType arg5,
-            FwAssertArgType arg6,
-            NATIVE_UINT_TYPE lineNo) {
-        return defaultSwAssert(file, lineNo, 6, arg1, arg2, arg3, arg4, arg5, arg6);
-    }
+void defaultPrintAssert(const CHAR* msg) {
+    (void)fprintf(stderr, "%s\n", msg);
 }
+
+void defaultReportAssert(FILE_NAME_ARG file,
+                         NATIVE_UINT_TYPE lineNo,
+                         NATIVE_UINT_TYPE numArgs,
+                         FwAssertArgType arg1,
+                         FwAssertArgType arg2,
+                         FwAssertArgType arg3,
+                         FwAssertArgType arg4,
+                         FwAssertArgType arg5,
+                         FwAssertArgType arg6,
+                         CHAR* destBuffer,
+                         NATIVE_INT_TYPE buffSize) {
+    switch (numArgs) {
+        case 0:
+            (void)snprintf(destBuffer, buffSize, fileIdFs, file, lineNo);
+            break;
+        case 1:
+            (void)snprintf(destBuffer, buffSize, fileIdFs " %" PRI_FwAssertArgType, file, lineNo, arg1);
+            break;
+        case 2:
+            (void)snprintf(destBuffer, buffSize, fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType, file,
+                           lineNo, arg1, arg2);
+            break;
+        case 3:
+            (void)snprintf(destBuffer, buffSize,
+                           fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType, file,
+                           lineNo, arg1, arg2, arg3);
+            break;
+        case 4:
+            (void)snprintf(destBuffer, buffSize,
+                           fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
+                                    " %" PRI_FwAssertArgType,
+                           file, lineNo, arg1, arg2, arg3, arg4);
+            break;
+        case 5:
+            (void)snprintf(destBuffer, buffSize,
+                           fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
+                                    " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType,
+                           file, lineNo, arg1, arg2, arg3, arg4, arg5);
+            break;
+        case 6:
+            (void)snprintf(destBuffer, buffSize,
+                           fileIdFs " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType
+                                    " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType " %" PRI_FwAssertArgType,
+                           file, lineNo, arg1, arg2, arg3, arg4, arg5, arg6);
+            break;
+        default:  // in an assert already, what can we do?
+            break;
+    }
+
+    // null terminate
+    destBuffer[buffSize - 1] = 0;
+}
+
+void AssertHook::printAssert(const CHAR* msg) {
+    defaultPrintAssert(msg);
+}
+
+void AssertHook::reportAssert(FILE_NAME_ARG file,
+                              NATIVE_UINT_TYPE lineNo,
+                              NATIVE_UINT_TYPE numArgs,
+                              FwAssertArgType arg1,
+                              FwAssertArgType arg2,
+                              FwAssertArgType arg3,
+                              FwAssertArgType arg4,
+                              FwAssertArgType arg5,
+                              FwAssertArgType arg6) {
+    CHAR destBuffer[FW_ASSERT_DFL_MSG_LEN];
+    defaultReportAssert(file, lineNo, numArgs, arg1, arg2, arg3, arg4, arg5, arg6, destBuffer, sizeof(destBuffer));
+    // print message
+    this->printAssert(destBuffer);
+}
+
+void AssertHook::doAssert() {
+    assert(0);
+}
+
+STATIC AssertHook* s_assertHook = nullptr;
+
+void AssertHook::registerHook() {
+    this->previousHook = s_assertHook;
+    s_assertHook = this;
+}
+
+void AssertHook::deregisterHook() {
+    s_assertHook = this->previousHook;
+}
+
+// Default handler of SwAssert functions
+NATIVE_INT_TYPE defaultSwAssert(FILE_NAME_ARG file,
+                                NATIVE_UINT_TYPE lineNo,
+                                NATIVE_UINT_TYPE numArgs,
+                                FwAssertArgType arg1,
+                                FwAssertArgType arg2,
+                                FwAssertArgType arg3,
+                                FwAssertArgType arg4,
+                                FwAssertArgType arg5,
+                                FwAssertArgType arg6) {
+    if (nullptr == s_assertHook) {
+        CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
+        defaultReportAssert(file, lineNo, numArgs, arg1, arg2, arg3, arg4, arg5, arg6, assertMsg, sizeof(assertMsg));
+        defaultPrintAssert(assertMsg);
+        assert(0);
+    } else {
+        s_assertHook->reportAssert(file, lineNo, numArgs, arg1, arg2, arg3, arg4, arg5, arg6);
+        s_assertHook->doAssert();
+    }
+    return 0;
+}
+
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo) {
+    return defaultSwAssert(file, lineNo, 0, 0, 0, 0, 0, 0, 0);
+}
+
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, FwAssertArgType arg1, NATIVE_UINT_TYPE lineNo) {
+    return defaultSwAssert(file, lineNo, 1, arg1, 0, 0, 0, 0, 0);
+}
+
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, FwAssertArgType arg1, FwAssertArgType arg2, NATIVE_UINT_TYPE lineNo) {
+    return defaultSwAssert(file, lineNo, 2, arg1, arg2, 0, 0, 0, 0);
+}
+
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file,
+                         FwAssertArgType arg1,
+                         FwAssertArgType arg2,
+                         FwAssertArgType arg3,
+                         NATIVE_UINT_TYPE lineNo) {
+    return defaultSwAssert(file, lineNo, 3, arg1, arg2, arg3, 0, 0, 0);
+}
+
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file,
+                         FwAssertArgType arg1,
+                         FwAssertArgType arg2,
+                         FwAssertArgType arg3,
+                         FwAssertArgType arg4,
+                         NATIVE_UINT_TYPE lineNo) {
+    return defaultSwAssert(file, lineNo, 4, arg1, arg2, arg3, arg4, 0, 0);
+}
+
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file,
+                         FwAssertArgType arg1,
+                         FwAssertArgType arg2,
+                         FwAssertArgType arg3,
+                         FwAssertArgType arg4,
+                         FwAssertArgType arg5,
+                         NATIVE_UINT_TYPE lineNo) {
+    return defaultSwAssert(file, lineNo, 5, arg1, arg2, arg3, arg4, arg5, 0);
+}
+
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file,
+                         FwAssertArgType arg1,
+                         FwAssertArgType arg2,
+                         FwAssertArgType arg3,
+                         FwAssertArgType arg4,
+                         FwAssertArgType arg5,
+                         FwAssertArgType arg6,
+                         NATIVE_UINT_TYPE lineNo) {
+    return defaultSwAssert(file, lineNo, 6, arg1, arg2, arg3, arg4, arg5, arg6);
+}
+}  // namespace Fw
 
 // define C asserts.
 extern "C" {
-    NATIVE_INT_TYPE CAssert0(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo);
+NATIVE_INT_TYPE CAssert0(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo);
 }
 
 NATIVE_INT_TYPE CAssert0(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo) {
     if (nullptr == Fw::s_assertHook) {
         CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
-        Fw::defaultReportAssert(
-            file,
-            lineNo,
-            0,
-            0,0,0,0,0,0,
-            assertMsg,sizeof(assertMsg));
-    }
-    else {
-        Fw::s_assertHook->reportAssert(
-            file,
-            lineNo,
-            0,
-            0,0,0,0,0,0);
+        Fw::defaultReportAssert(file, lineNo, 0, 0, 0, 0, 0, 0, 0, assertMsg, sizeof(assertMsg));
+    } else {
+        Fw::s_assertHook->reportAssert(file, lineNo, 0, 0, 0, 0, 0, 0, 0);
         Fw::s_assertHook->doAssert();
     }
     return 0;

--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -9,40 +9,42 @@
 #define FW_ASSERT_NO_FIRST_ARG(ARG_0, ...) __VA_ARGS__
 
 #if FW_ASSERT_LEVEL == FW_NO_ASSERT
-    // Users may override the NO_ASSERT case should they choose
-    #ifndef FW_ASSERT
-    #define FW_ASSERT(...) ((void)(FW_ASSERT_FIRST_ARG(__VA_ARGS__)))
-    #endif
-    #define FILE_NAME_ARG const CHAR*
-#else // ASSERT is defined
-
+// Users may override the NO_ASSERT case should they choose
+#ifndef FW_ASSERT
+#define FW_ASSERT(...) ((void)(FW_ASSERT_FIRST_ARG(__VA_ARGS__)))
+#endif
+#define FILE_NAME_ARG const CHAR*
+#else  // ASSERT is defined
 
 // Passing the __LINE__ argument at the end of the function ensures that
 // the FW_ASSERT_NO_FIRST_ARG macro will never have an empty variadic variable
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
-    #define FILE_NAME_ARG U32
-    #define FW_ASSERT(...) \
-        ((void) ((FW_ASSERT_FIRST_ARG(__VA_ARGS__, 0)) ? (0) : \
-        (Fw::SwAssert(ASSERT_FILE_ID, FW_ASSERT_NO_FIRST_ARG(__VA_ARGS__, __LINE__)))))
+#define FILE_NAME_ARG U32
+#define FW_ASSERT(...)                            \
+    ((void)((FW_ASSERT_FIRST_ARG(__VA_ARGS__, 0)) \
+                ? (0)                             \
+                : (Fw::SwAssert(ASSERT_FILE_ID, FW_ASSERT_NO_FIRST_ARG(__VA_ARGS__, __LINE__)))))
 #elif FW_ASSERT_LEVEL == FW_RELATIVE_PATH_ASSERT
-    #define FILE_NAME_ARG const CHAR*
-    #define FW_ASSERT(...) \
-        ((void) ((FW_ASSERT_FIRST_ARG(__VA_ARGS__, 0)) ? (0) : \
-        (Fw::SwAssert(ASSERT_RELATIVE_PATH, FW_ASSERT_NO_FIRST_ARG(__VA_ARGS__, __LINE__)))))
+#define FILE_NAME_ARG const CHAR*
+#define FW_ASSERT(...)                            \
+    ((void)((FW_ASSERT_FIRST_ARG(__VA_ARGS__, 0)) \
+                ? (0)                             \
+                : (Fw::SwAssert(ASSERT_RELATIVE_PATH, FW_ASSERT_NO_FIRST_ARG(__VA_ARGS__, __LINE__)))))
 #else
-    #define FILE_NAME_ARG const CHAR*
-    #define FW_ASSERT(...) \
-        ((void) ((FW_ASSERT_FIRST_ARG(__VA_ARGS__, 0)) ? (0) : \
-        (Fw::SwAssert(__FILE__, FW_ASSERT_NO_FIRST_ARG(__VA_ARGS__, __LINE__)))))
+#define FILE_NAME_ARG const CHAR*
+#define FW_ASSERT(...)                            \
+    ((void)((FW_ASSERT_FIRST_ARG(__VA_ARGS__, 0)) \
+                ? (0)                             \
+                : (Fw::SwAssert(__FILE__, FW_ASSERT_NO_FIRST_ARG(__VA_ARGS__, __LINE__)))))
 #endif
-#endif // if ASSERT is defined
+#endif  // if ASSERT is defined
 
-// F' Assertion functions can technically return even though the intention is for the assertion to terminate the program.
-// This breaks static analysis depending on assertions, since the analyzer has to assume the assertion will return.
-// When supported, annotate assertion functions as noreturn when statically analyzing.
+// F' Assertion functions can technically return even though the intention is for the assertion to terminate the
+// program. This breaks static analysis depending on assertions, since the analyzer has to assume the assertion will
+// return. When supported, annotate assertion functions as noreturn when statically analyzing.
 #ifndef CLANG_ANALYZER_NORETURN
 #ifndef __has_feature
-  #define __has_feature(x) 0  // Compatibility with non-clang compilers.
+#define __has_feature(x) 0  // Compatibility with non-clang compilers.
 #endif
 #if __has_feature(attribute_analyzer_noreturn)
 #define CLANG_ANALYZER_NORETURN __attribute__((analyzer_noreturn))
@@ -52,101 +54,87 @@
 #endif
 
 namespace Fw {
-    //! Assert with no arguments
-    NATIVE_INT_TYPE SwAssert(
-        FILE_NAME_ARG file,
-        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+//! Assert with no arguments
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
 
-    //! Assert with one argument
-    NATIVE_INT_TYPE SwAssert(
-        FILE_NAME_ARG file,
-        FwAssertArgType arg1,
-        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+//! Assert with one argument
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, FwAssertArgType arg1, NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
 
-    //! Assert with two arguments
-    NATIVE_INT_TYPE SwAssert(
-        FILE_NAME_ARG file,
-        FwAssertArgType arg1,
-        FwAssertArgType arg2,
-        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+//! Assert with two arguments
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file, FwAssertArgType arg1, FwAssertArgType arg2, NATIVE_UINT_TYPE lineNo)
+    CLANG_ANALYZER_NORETURN;
 
-    //! Assert with three arguments
-    NATIVE_INT_TYPE SwAssert(
-        FILE_NAME_ARG file,
-        FwAssertArgType arg1,
-        FwAssertArgType arg2,
-        FwAssertArgType arg3,
-        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+//! Assert with three arguments
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file,
+                         FwAssertArgType arg1,
+                         FwAssertArgType arg2,
+                         FwAssertArgType arg3,
+                         NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
 
-    //! Assert with four arguments
-    NATIVE_INT_TYPE SwAssert(
-        FILE_NAME_ARG file,
-        FwAssertArgType arg1,
-        FwAssertArgType arg2,
-        FwAssertArgType arg3,
-        FwAssertArgType arg4,
-        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+//! Assert with four arguments
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file,
+                         FwAssertArgType arg1,
+                         FwAssertArgType arg2,
+                         FwAssertArgType arg3,
+                         FwAssertArgType arg4,
+                         NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
 
-    //! Assert with five arguments
-    NATIVE_INT_TYPE SwAssert(
-        FILE_NAME_ARG file,
-        FwAssertArgType arg1,
-        FwAssertArgType arg2,
-        FwAssertArgType arg3,
-        FwAssertArgType arg4,
-        FwAssertArgType arg5,
-        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+//! Assert with five arguments
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file,
+                         FwAssertArgType arg1,
+                         FwAssertArgType arg2,
+                         FwAssertArgType arg3,
+                         FwAssertArgType arg4,
+                         FwAssertArgType arg5,
+                         NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
 
-    //! Assert with six arguments
-    NATIVE_INT_TYPE SwAssert(
-        FILE_NAME_ARG file,
-        FwAssertArgType arg1,
-        FwAssertArgType arg2,
-        FwAssertArgType arg3,
-        FwAssertArgType arg4,
-        FwAssertArgType arg5,
-        FwAssertArgType arg6,
-        NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
-}
+//! Assert with six arguments
+NATIVE_INT_TYPE SwAssert(FILE_NAME_ARG file,
+                         FwAssertArgType arg1,
+                         FwAssertArgType arg2,
+                         FwAssertArgType arg3,
+                         FwAssertArgType arg4,
+                         FwAssertArgType arg5,
+                         FwAssertArgType arg6,
+                         NATIVE_UINT_TYPE lineNo) CLANG_ANALYZER_NORETURN;
+}  // namespace Fw
 
 // Base class for declaring an assert hook
 // Each of the base class functions can be overridden
 // or used by derived classes.
 
 namespace Fw {
-    // Base class for declaring an assert hook
-    class AssertHook {
-        public:
-            AssertHook() : previousHook(nullptr) {}; //!< constructor
-            virtual ~AssertHook() {}; //!< destructor
-            // override this function to intercept asserts
-            virtual void reportAssert(
-                    FILE_NAME_ARG file,
-                    NATIVE_UINT_TYPE lineNo,
-                    NATIVE_UINT_TYPE numArgs,
-                    FwAssertArgType arg1,
-                    FwAssertArgType arg2,
-                    FwAssertArgType arg3,
-                    FwAssertArgType arg4,
-                    FwAssertArgType arg5,
-                    FwAssertArgType arg6
-                    );
-            // default reportAssert() will call this when the message is built
-            // override it to do another kind of print. printf by default
-            virtual void printAssert(const CHAR* msg);
-            // do assert action. By default, calls assert.
-            // Called after reportAssert()
-            virtual void doAssert();
-            // register the hook
-            void registerHook();
-            // deregister the hook
-            void deregisterHook();
+// Base class for declaring an assert hook
+class AssertHook {
+  public:
+    AssertHook() : previousHook(nullptr){};  //!< constructor
+    virtual ~AssertHook(){};                 //!< destructor
+    // override this function to intercept asserts
+    virtual void reportAssert(FILE_NAME_ARG file,
+                              NATIVE_UINT_TYPE lineNo,
+                              NATIVE_UINT_TYPE numArgs,
+                              FwAssertArgType arg1,
+                              FwAssertArgType arg2,
+                              FwAssertArgType arg3,
+                              FwAssertArgType arg4,
+                              FwAssertArgType arg5,
+                              FwAssertArgType arg6);
+    // default reportAssert() will call this when the message is built
+    // override it to do another kind of print. printf by default
+    virtual void printAssert(const CHAR* msg);
+    // do assert action. By default, calls assert.
+    // Called after reportAssert()
+    virtual void doAssert();
+    // register the hook
+    void registerHook();
+    // deregister the hook
+    void deregisterHook();
 
-        protected:
-        private:
-            // the previous assert hook
-            AssertHook *previousHook;
-    };
-}
+  protected:
+  private:
+    // the previous assert hook
+    AssertHook* previousHook;
+};
+}  // namespace Fw
 
-#endif // FW_ASSERT_HPP
+#endif  // FW_ASSERT_HPP

--- a/Fw/Types/ByteArray.hpp
+++ b/Fw/Types/ByteArray.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  ByteArray.hpp
 // \author bocchino
 // \brief  hpp file for ByteArray type
@@ -7,8 +7,8 @@
 // Copyright (C) 2016 California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef Fw_ByteArray_HPP
 #define Fw_ByteArray_HPP
@@ -17,39 +17,32 @@
 
 namespace Fw {
 
-  //! \class ByteArray
-  //! \brief A variable-length byte array
-  //!
-  struct ByteArray {
+//! \class ByteArray
+//! \brief A variable-length byte array
+//!
+struct ByteArray {
+    // ----------------------------------------------------------------------
+    // Construction
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Construction 
-      // ----------------------------------------------------------------------
+    //! Construct a ByteArray
+    //!
+    ByteArray(U8* const bytes,  //!< Pointer to the bytes
+              const U32 size    //!< The array size
+              )
+        : bytes(bytes), size(size) {}
 
-      //! Construct a ByteArray
-      //!
-      ByteArray(
-          U8 *const bytes, //!< Pointer to the bytes
-          const U32 size //!< The array size
-      ) :
-        bytes(bytes),
-        size(size)
-      {
+    // ----------------------------------------------------------------------
+    // Data
+    // ----------------------------------------------------------------------
 
-      }
+    //! The bytes
+    U8* const bytes;
 
-      // ----------------------------------------------------------------------
-      // Data 
-      // ----------------------------------------------------------------------
+    //! The size
+    const U32 size;
+};
 
-      //! The bytes
-      U8 *const bytes;
-
-      //! The size
-      const U32 size;
-
-  };
-
-}
+}  // namespace Fw
 
 #endif

--- a/Fw/Types/ConstByteArray.hpp
+++ b/Fw/Types/ConstByteArray.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  ConstByteArray.hpp
 // \author bocchino
 // \brief  hpp file for ConstByteArray type
@@ -7,8 +7,8 @@
 // Copyright (C) 2016 California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef Fw_ConstByteArray_HPP
 #define Fw_ConstByteArray_HPP
@@ -17,39 +17,32 @@
 
 namespace Fw {
 
-  //! \class ConstByteArray
-  //! \brief A variable-length byte array with constant access
-  //!
-  struct ConstByteArray {
+//! \class ConstByteArray
+//! \brief A variable-length byte array with constant access
+//!
+struct ConstByteArray {
+    // ----------------------------------------------------------------------
+    // Construction
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Construction 
-      // ----------------------------------------------------------------------
+    //! Construct a ConstByteArray
+    //!
+    ConstByteArray(const U8* const bytes,  //!< Pointer to the bytes
+                   const U32 size          //!< The array size
+                   )
+        : bytes(bytes), size(size) {}
 
-      //! Construct a ConstByteArray
-      //!
-      ConstByteArray(
-          const U8 *const bytes, //!< Pointer to the bytes
-          const U32 size //!< The array size
-      ) :
-        bytes(bytes),
-        size(size)
-      {
+    // ----------------------------------------------------------------------
+    // Data
+    // ----------------------------------------------------------------------
 
-      }
+    //! The bytes
+    const U8* const bytes;
 
-      // ----------------------------------------------------------------------
-      // Data 
-      // ----------------------------------------------------------------------
+    //! The size
+    const U32 size;
+};
 
-      //! The bytes
-      const U8 *const bytes;
-
-      //! The size
-      const U32 size;
-
-  };
-
-}
+}  // namespace Fw
 
 #endif

--- a/Fw/Types/EightyCharString.cpp
+++ b/Fw/Types/EightyCharString.cpp
@@ -3,53 +3,52 @@
 
 namespace Fw {
 
-    EightyCharString::EightyCharString(const char* src) : StringBase() {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
-    }
-
-    EightyCharString::EightyCharString(const StringBase& src) : StringBase() {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-    }
-
-    EightyCharString::EightyCharString(const EightyCharString& src) : StringBase() {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-    }
-
-    EightyCharString::EightyCharString() : StringBase() {
-        this->m_buf[0] = 0;
-    }
-
-    EightyCharString& EightyCharString::operator=(const EightyCharString& other) {
-        if(this == &other) {
-            return *this;
-        }
-
-        (void) Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-        return *this;
-    }
-
-    EightyCharString& EightyCharString::operator=(const StringBase& other) {
-        if(this == &other) {
-            return *this;
-        }
-
-        (void) Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-        return *this;
-    }
-
-    EightyCharString& EightyCharString::operator=(const char* other) {
-        (void) Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
-        return *this;
-    }
-
-    EightyCharString::~EightyCharString() {
-    }
-
-    const char* EightyCharString::toChar() const {
-        return this->m_buf;
-    }
-
-    NATIVE_UINT_TYPE EightyCharString::getCapacity() const {
-        return STRING_SIZE;
-    }
+EightyCharString::EightyCharString(const char* src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
 }
+
+EightyCharString::EightyCharString(const StringBase& src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+}
+
+EightyCharString::EightyCharString(const EightyCharString& src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+}
+
+EightyCharString::EightyCharString() : StringBase() {
+    this->m_buf[0] = 0;
+}
+
+EightyCharString& EightyCharString::operator=(const EightyCharString& other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    (void)Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+    return *this;
+}
+
+EightyCharString& EightyCharString::operator=(const StringBase& other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    (void)Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+    return *this;
+}
+
+EightyCharString& EightyCharString::operator=(const char* other) {
+    (void)Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+    return *this;
+}
+
+EightyCharString::~EightyCharString() {}
+
+const char* EightyCharString::toChar() const {
+    return this->m_buf;
+}
+
+NATIVE_UINT_TYPE EightyCharString::getCapacity() const {
+    return STRING_SIZE;
+}
+}  // namespace Fw

--- a/Fw/Types/EightyCharString.hpp
+++ b/Fw/Types/EightyCharString.hpp
@@ -2,36 +2,34 @@
 #define FW_EIGHTY_CHAR_STRING_TYPE_HPP
 
 #include <FpConfig.hpp>
-#include <Fw/Types/StringType.hpp>
 #include <Fw/Cfg/SerIds.hpp>
+#include <Fw/Types/StringType.hpp>
 
 namespace Fw {
 
-    class EightyCharString : public Fw::StringBase {
-        public:
-
-            enum {
-                SERIALIZED_TYPE_ID = FW_TYPEID_EIGHTY_CHAR_STRING, //!< typeid for string type
-                STRING_SIZE = 80, //!< Storage for string
-                SERIALIZED_SIZE = STRING_SIZE + sizeof(FwBuffSizeType) //!< Serialized size is size of buffer + size field
-            };
-
-            EightyCharString(const char* src); //!< char* source constructor
-            EightyCharString(const StringBase& src); //!< other string constructor
-            EightyCharString(const EightyCharString& src); //!< EightyCharString string constructor
-            EightyCharString(); //!< default constructor
-            EightyCharString& operator=(const EightyCharString& other); //!< assignment operator
-            EightyCharString& operator=(const StringBase& other); //!< other string assignment operator
-            EightyCharString& operator=(const char* other); //!< char* assignment operator
-            ~EightyCharString(); //!< destructor
-
-            const char* toChar() const; //!< gets char buffer
-            NATIVE_UINT_TYPE getCapacity() const; //!< return buffer size
-
-        private:
-
-            char m_buf[STRING_SIZE]; //!< storage for string data
+class EightyCharString : public Fw::StringBase {
+  public:
+    enum {
+        SERIALIZED_TYPE_ID = FW_TYPEID_EIGHTY_CHAR_STRING,      //!< typeid for string type
+        STRING_SIZE = 80,                                       //!< Storage for string
+        SERIALIZED_SIZE = STRING_SIZE + sizeof(FwBuffSizeType)  //!< Serialized size is size of buffer + size field
     };
-}
+
+    EightyCharString(const char* src);                           //!< char* source constructor
+    EightyCharString(const StringBase& src);                     //!< other string constructor
+    EightyCharString(const EightyCharString& src);               //!< EightyCharString string constructor
+    EightyCharString();                                          //!< default constructor
+    EightyCharString& operator=(const EightyCharString& other);  //!< assignment operator
+    EightyCharString& operator=(const StringBase& other);        //!< other string assignment operator
+    EightyCharString& operator=(const char* other);              //!< char* assignment operator
+    ~EightyCharString();                                         //!< destructor
+
+    const char* toChar() const;            //!< gets char buffer
+    NATIVE_UINT_TYPE getCapacity() const;  //!< return buffer size
+
+  private:
+    char m_buf[STRING_SIZE];  //!< storage for string data
+};
+}  // namespace Fw
 
 #endif

--- a/Fw/Types/GTest/Bytes.cpp
+++ b/Fw/Types/GTest/Bytes.cpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  ASTERIA/Types/GTest/Bytes.cpp
 // \author bocchino
 // \brief  cpp file for Bytes
@@ -7,27 +7,21 @@
 // Copyright (C) 2016, California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #include <Fw/Types/GTest/Bytes.hpp>
 
 namespace Fw {
 
-  namespace GTest {
+namespace GTest {
 
-    void Bytes ::
-      compare(
-          const Bytes& expected,
-          const Bytes& actual
-      ) 
-    {
-      ASSERT_EQ(expected.size, actual.size);
-      for (size_t i = 0; i < expected.size; ++i)
-        ASSERT_EQ(expected.bytes[i], actual.bytes[i])
-          << "At i=" << i << "\n";
-    }
-
-  }
-
+void Bytes ::compare(const Bytes& expected, const Bytes& actual) {
+    ASSERT_EQ(expected.size, actual.size);
+    for (size_t i = 0; i < expected.size; ++i)
+        ASSERT_EQ(expected.bytes[i], actual.bytes[i]) << "At i=" << i << "\n";
 }
+
+}  // namespace GTest
+
+}  // namespace Fw

--- a/Fw/Types/GTest/Bytes.hpp
+++ b/Fw/Types/GTest/Bytes.hpp
@@ -1,4 +1,4 @@
-// ====================================================================== 
+// ======================================================================
 // \title  Fw/Types/GTest/Bytes.hpp
 // \author bocchino
 // \brief  hpp file for Bytes
@@ -7,8 +7,8 @@
 // Copyright (C) 2016 California Institute of Technology.
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
-// 
-// ====================================================================== 
+//
+// ======================================================================
 
 #ifndef Fw_GTest_Bytes_HPP
 #define Fw_GTest_Bytes_HPP
@@ -18,46 +18,35 @@
 
 namespace Fw {
 
-  namespace GTest {
+namespace GTest {
 
-    //! \class Bytes
-    //! \brief A byte string for testing
-    //!
-    class Bytes {
+//! \class Bytes
+//! \brief A byte string for testing
+//!
+class Bytes {
+  public:
+    //! Construct a Bytes object
+    Bytes(const U8* const bytes,  //!< The byte array
+          const size_t size       //!< The size
+          )
+        : bytes(bytes), size(size) {}
 
-      public:
+  public:
+    //! Compare two Bytes objects
+    static void compare(const Bytes& expected,  //! Expected value
+                        const Bytes& actual     //! Actual value
+    );
 
-        //! Construct a Bytes object
-        Bytes(
-            const U8 *const bytes, //!< The byte array
-            const size_t size //!< The size
-        ) :
-          bytes(bytes),
-          size(size)
-        {
+  private:
+    //! The bytes
+    const U8* const bytes;
 
-        }
+    //! The size
+    const size_t size;
+};
 
-      public:
+};  // namespace GTest
 
-        //! Compare two Bytes objects
-        static void compare(
-            const Bytes& expected, //! Expected value
-            const Bytes& actual //! Actual value
-        );
-
-      private:
-
-        //! The bytes
-        const U8 *const bytes;
-
-        //! The size
-        const size_t size;
-
-    };
-
-  };
-
-}
+}  // namespace Fw
 
 #endif

--- a/Fw/Types/InternalInterfaceString.cpp
+++ b/Fw/Types/InternalInterfaceString.cpp
@@ -3,53 +3,52 @@
 
 namespace Fw {
 
-    InternalInterfaceString::InternalInterfaceString(const char* src) : StringBase()  {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
-    }
-
-    InternalInterfaceString::InternalInterfaceString(const StringBase& src) : StringBase()  {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-    }
-
-    InternalInterfaceString::InternalInterfaceString(const InternalInterfaceString& src) : StringBase()  {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-    }
-
-    InternalInterfaceString::InternalInterfaceString() : StringBase()  {
-        this->m_buf[0] = 0;
-    }
-
-    InternalInterfaceString& InternalInterfaceString::operator=(const InternalInterfaceString& other) {
-        if(this == &other) {
-            return *this;
-        }
-
-        (void) Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-        return *this;
-    }
-
-    InternalInterfaceString& InternalInterfaceString::operator=(const StringBase& other) {
-        if(this == &other) {
-            return *this;
-        }
-
-        (void) Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-        return *this;
-    }
-
-    InternalInterfaceString& InternalInterfaceString::operator=(const char* other) {
-        (void) Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
-        return *this;
-    }
-
-    InternalInterfaceString::~InternalInterfaceString() {
-    }
-
-    const char* InternalInterfaceString::toChar() const {
-        return this->m_buf;
-    }
-
-    NATIVE_UINT_TYPE InternalInterfaceString::getCapacity() const {
-        return FW_INTERNAL_INTERFACE_STRING_MAX_SIZE;
-    }
+InternalInterfaceString::InternalInterfaceString(const char* src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
 }
+
+InternalInterfaceString::InternalInterfaceString(const StringBase& src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+}
+
+InternalInterfaceString::InternalInterfaceString(const InternalInterfaceString& src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+}
+
+InternalInterfaceString::InternalInterfaceString() : StringBase() {
+    this->m_buf[0] = 0;
+}
+
+InternalInterfaceString& InternalInterfaceString::operator=(const InternalInterfaceString& other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    (void)Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+    return *this;
+}
+
+InternalInterfaceString& InternalInterfaceString::operator=(const StringBase& other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    (void)Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+    return *this;
+}
+
+InternalInterfaceString& InternalInterfaceString::operator=(const char* other) {
+    (void)Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+    return *this;
+}
+
+InternalInterfaceString::~InternalInterfaceString() {}
+
+const char* InternalInterfaceString::toChar() const {
+    return this->m_buf;
+}
+
+NATIVE_UINT_TYPE InternalInterfaceString::getCapacity() const {
+    return FW_INTERNAL_INTERFACE_STRING_MAX_SIZE;
+}
+}  // namespace Fw

--- a/Fw/Types/InternalInterfaceString.hpp
+++ b/Fw/Types/InternalInterfaceString.hpp
@@ -2,35 +2,34 @@
 #define FW_INTERNAL_INTERFACE_STRING_TYPE_HPP
 
 #include <FpConfig.hpp>
-#include <Fw/Types/StringType.hpp>
 #include <Fw/Cfg/SerIds.hpp>
+#include <Fw/Types/StringType.hpp>
 
 namespace Fw {
 
-    class InternalInterfaceString : public Fw::StringBase {
-        public:
-
-            enum {
-                SERIALIZED_TYPE_ID = FW_TYPEID_INTERNAL_INTERFACE_STRING, //!< typeid for string type
-                SERIALIZED_SIZE = FW_INTERNAL_INTERFACE_STRING_MAX_SIZE + sizeof(FwBuffSizeType) //!< Serialized size is size of buffer + size field
-            };
-
-            InternalInterfaceString(const char* src); //!< char* source constructor
-            InternalInterfaceString(const StringBase& src); //!< other string constructor
-            InternalInterfaceString(const InternalInterfaceString& src); //!< other string constructor
-            InternalInterfaceString(); //!< default constructor
-            InternalInterfaceString& operator=(const InternalInterfaceString& other); //!< assignment operator
-            InternalInterfaceString& operator=(const StringBase& other); //!< other string assignment operator
-            InternalInterfaceString& operator=(const char* other); //!< char* assignment operator
-            ~InternalInterfaceString(); //!< destructor
-
-            const char* toChar() const; //!< gets char buffer
-            NATIVE_UINT_TYPE getCapacity() const; //!< return buffer size
-
-        private:
-
-            char m_buf[FW_INTERNAL_INTERFACE_STRING_MAX_SIZE]; //!< storage for string data
+class InternalInterfaceString : public Fw::StringBase {
+  public:
+    enum {
+        SERIALIZED_TYPE_ID = FW_TYPEID_INTERNAL_INTERFACE_STRING,  //!< typeid for string type
+        SERIALIZED_SIZE = FW_INTERNAL_INTERFACE_STRING_MAX_SIZE +
+                          sizeof(FwBuffSizeType)  //!< Serialized size is size of buffer + size field
     };
-}
 
-#endif // FW_INTERNAL_INTERFACE_STRING_TYPE_HPP
+    InternalInterfaceString(const char* src);                                  //!< char* source constructor
+    InternalInterfaceString(const StringBase& src);                            //!< other string constructor
+    InternalInterfaceString(const InternalInterfaceString& src);               //!< other string constructor
+    InternalInterfaceString();                                                 //!< default constructor
+    InternalInterfaceString& operator=(const InternalInterfaceString& other);  //!< assignment operator
+    InternalInterfaceString& operator=(const StringBase& other);               //!< other string assignment operator
+    InternalInterfaceString& operator=(const char* other);                     //!< char* assignment operator
+    ~InternalInterfaceString();                                                //!< destructor
+
+    const char* toChar() const;            //!< gets char buffer
+    NATIVE_UINT_TYPE getCapacity() const;  //!< return buffer size
+
+  private:
+    char m_buf[FW_INTERNAL_INTERFACE_STRING_MAX_SIZE];  //!< storage for string data
+};
+}  // namespace Fw
+
+#endif  // FW_INTERNAL_INTERFACE_STRING_TYPE_HPP

--- a/Fw/Types/MallocAllocator.cpp
+++ b/Fw/Types/MallocAllocator.cpp
@@ -15,25 +15,23 @@
 
 namespace Fw {
 
-    MallocAllocator::MallocAllocator() {
-    }
+MallocAllocator::MallocAllocator() {}
 
-    MallocAllocator::~MallocAllocator() {
-    }
+MallocAllocator::~MallocAllocator() {}
 
-    void *MallocAllocator::allocate(const NATIVE_UINT_TYPE identifier, NATIVE_UINT_TYPE &size, bool& recoverable) {
-        // don't use identifier
-        // heap memory is never recoverable
-        recoverable = false;
-        void *mem = ::malloc(size);
-        if (nullptr == mem) {
-            size = 0; // set to zero if can't get memory
-        }
-        return mem;
+void* MallocAllocator::allocate(const NATIVE_UINT_TYPE identifier, NATIVE_UINT_TYPE& size, bool& recoverable) {
+    // don't use identifier
+    // heap memory is never recoverable
+    recoverable = false;
+    void* mem = ::malloc(size);
+    if (nullptr == mem) {
+        size = 0;  // set to zero if can't get memory
     }
+    return mem;
+}
 
-    void MallocAllocator::deallocate(const NATIVE_UINT_TYPE identifier, void* ptr) {
-        ::free(ptr);
-    }
+void MallocAllocator::deallocate(const NATIVE_UINT_TYPE identifier, void* ptr) {
+    ::free(ptr);
+}
 
 } /* namespace Fw */

--- a/Fw/Types/MallocAllocator.hpp
+++ b/Fw/Types/MallocAllocator.hpp
@@ -17,39 +17,34 @@
 
 namespace Fw {
 
-    /*!
-     *
-     * This class is an implementation of the MemAllocator base class.
-     * It uses the heap as the memory source.
-     *
-     * Since it is heap space, the identifier is unused, and memory is never recoverable.
-     *
-     */
+/*!
+ *
+ * This class is an implementation of the MemAllocator base class.
+ * It uses the heap as the memory source.
+ *
+ * Since it is heap space, the identifier is unused, and memory is never recoverable.
+ *
+ */
 
-    class MallocAllocator: public MemAllocator {
-        public:
-            MallocAllocator();
-            virtual ~MallocAllocator();
-            //! Allocate memory
-            /*!
-             * \param identifier the memory segment identifier (not used)
-             * \param size the requested size (not changed)
-             * \param recoverable - flag to indicate the memory could be recoverable (always set to false)
-             * \return the pointer to memory. Zero if unable to allocate.
-             */
-            void *allocate(
-                    const NATIVE_UINT_TYPE identifier,
-                    NATIVE_UINT_TYPE &size,
-                    bool& recoverable);
-            //! Deallocate memory
-            /*!
-             * \param identifier the memory segment identifier (not used)
-             * \param ptr the pointer to memory returned by allocate()
-             */
-            void deallocate(
-                    const NATIVE_UINT_TYPE identifier,
-                    void* ptr);
-    };
+class MallocAllocator : public MemAllocator {
+  public:
+    MallocAllocator();
+    virtual ~MallocAllocator();
+    //! Allocate memory
+    /*!
+     * \param identifier the memory segment identifier (not used)
+     * \param size the requested size (not changed)
+     * \param recoverable - flag to indicate the memory could be recoverable (always set to false)
+     * \return the pointer to memory. Zero if unable to allocate.
+     */
+    void* allocate(const NATIVE_UINT_TYPE identifier, NATIVE_UINT_TYPE& size, bool& recoverable);
+    //! Deallocate memory
+    /*!
+     * \param identifier the memory segment identifier (not used)
+     * \param ptr the pointer to memory returned by allocate()
+     */
+    void deallocate(const NATIVE_UINT_TYPE identifier, void* ptr);
+};
 
 } /* namespace Fw */
 

--- a/Fw/Types/MemAllocator.cpp
+++ b/Fw/Types/MemAllocator.cpp
@@ -14,10 +14,8 @@
 
 namespace Fw {
 
-    MemAllocator::MemAllocator() {
-    }
+MemAllocator::MemAllocator() {}
 
-    MemAllocator::~MemAllocator() {
-    }
+MemAllocator::~MemAllocator() {}
 
 } /* namespace Fw */

--- a/Fw/Types/MemAllocator.hpp
+++ b/Fw/Types/MemAllocator.hpp
@@ -43,34 +43,31 @@
 
 namespace Fw {
 
-    class MemAllocator {
-        public:
-            //! Allocate memory
-            /*!
-             * \param identifier the memory segment identifier, each identifier is to be used in once single allocation
-             * \param size the requested size - changed to actual if different
-             * \param recoverable - flag to indicate the memory could be recoverable
-             * \return the pointer to memory. Zero if unable to allocate
-             */
-            virtual void *allocate(
-                    const NATIVE_UINT_TYPE identifier,
-                    NATIVE_UINT_TYPE &size,
-                    bool& recoverable)=0;
-            //! Deallocate memory
-            /*!
-             * \param identifier the memory segment identifier, each identifier is to be used in once single allocation
-             * \param ptr the pointer to memory returned by allocate()
-             */
-            virtual void deallocate(
-                    const NATIVE_UINT_TYPE identifier,
-                    void* ptr)=0;
-        protected:
-            MemAllocator();
-            virtual ~MemAllocator();
-        private:
-            MemAllocator(MemAllocator&); //!< disable
-            MemAllocator(MemAllocator*); //!< disable
-    };
+class MemAllocator {
+  public:
+    //! Allocate memory
+    /*!
+     * \param identifier the memory segment identifier, each identifier is to be used in once single allocation
+     * \param size the requested size - changed to actual if different
+     * \param recoverable - flag to indicate the memory could be recoverable
+     * \return the pointer to memory. Zero if unable to allocate
+     */
+    virtual void* allocate(const NATIVE_UINT_TYPE identifier, NATIVE_UINT_TYPE& size, bool& recoverable) = 0;
+    //! Deallocate memory
+    /*!
+     * \param identifier the memory segment identifier, each identifier is to be used in once single allocation
+     * \param ptr the pointer to memory returned by allocate()
+     */
+    virtual void deallocate(const NATIVE_UINT_TYPE identifier, void* ptr) = 0;
+
+  protected:
+    MemAllocator();
+    virtual ~MemAllocator();
+
+  private:
+    MemAllocator(MemAllocator&);  //!< disable
+    MemAllocator(MemAllocator*);  //!< disable
+};
 
 } /* namespace Fw */
 

--- a/Fw/Types/MmapAllocator.cpp
+++ b/Fw/Types/MmapAllocator.cpp
@@ -10,39 +10,36 @@
  *
  */
 
-#include <Fw/Types/MmapAllocator.hpp>
-#include <cstdlib>
 #include <sys/mman.h>
 #include <Fw/Types/Assert.hpp>
+#include <Fw/Types/MmapAllocator.hpp>
+#include <cstdlib>
 
 namespace Fw {
 
-    MmapAllocator::MmapAllocator() : m_length(0) {
+MmapAllocator::MmapAllocator() : m_length(0) {}
+
+MmapAllocator::~MmapAllocator() {}
+
+void* MmapAllocator::allocate(const NATIVE_UINT_TYPE identifier, NATIVE_UINT_TYPE& size, bool& recoverable) {
+    void* addr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (addr == MAP_FAILED) {
+        size = 0;
+        return nullptr;
     }
+    this->m_length = size;
 
-    MmapAllocator::~MmapAllocator() {
+    // mmap memory is never recoverable
+    recoverable = false;
+
+    return addr;
+}
+
+void MmapAllocator::deallocate(const NATIVE_UINT_TYPE identifier, void* ptr) {
+    if (this->m_length) {
+        int stat = munmap(ptr, this->m_length);
+        FW_ASSERT(stat == 0, stat);
     }
-
-    void *MmapAllocator::allocate(const NATIVE_UINT_TYPE identifier, NATIVE_UINT_TYPE &size, bool& recoverable) {
-        void* addr = mmap(nullptr, size, PROT_READ | PROT_WRITE,
-                             MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-        if (addr == MAP_FAILED) {
-            size = 0;
-            return nullptr;
-        }
-        this->m_length = size;
-
-        // mmap memory is never recoverable
-        recoverable = false;
-
-        return addr;
-    }
-
-    void MmapAllocator::deallocate(const NATIVE_UINT_TYPE identifier, void* ptr) {
-        if (this->m_length) {
-            int stat = munmap(ptr, this->m_length);
-            FW_ASSERT(stat == 0, stat);
-        }
-    }
+}
 
 } /* namespace Fw */

--- a/Fw/Types/MmapAllocator.hpp
+++ b/Fw/Types/MmapAllocator.hpp
@@ -17,30 +17,30 @@
 
 namespace Fw {
 
-    //! Fw::MmapAllocator is an implementation of the Fw::MemAllocator interface that back memory with a read and write
-    //! capable anonymous memory mapped region. This class is currently not useful for mapping to a file.
-    class MmapAllocator: public MemAllocator {
-        public:
-            //! Constructor with no arguments
-            //!
-            MmapAllocator();
-            //! Destructor with no arguments
-            virtual ~MmapAllocator();
+//! Fw::MmapAllocator is an implementation of the Fw::MemAllocator interface that back memory with a read and write
+//! capable anonymous memory mapped region. This class is currently not useful for mapping to a file.
+class MmapAllocator : public MemAllocator {
+  public:
+    //! Constructor with no arguments
+    //!
+    MmapAllocator();
+    //! Destructor with no arguments
+    virtual ~MmapAllocator();
 
-            //! Allocate memory using the mmap allocator
-            //! \param identifier: identifier to use with allocation
-            //! \param size: size of memory to be allocated
-            //! \param recoverable: (output) is this memory recoverable after a reset. Always false for mmap.
-            void *allocate(const NATIVE_UINT_TYPE identifier, NATIVE_UINT_TYPE &size, bool& recoverable);
+    //! Allocate memory using the mmap allocator
+    //! \param identifier: identifier to use with allocation
+    //! \param size: size of memory to be allocated
+    //! \param recoverable: (output) is this memory recoverable after a reset. Always false for mmap.
+    void* allocate(const NATIVE_UINT_TYPE identifier, NATIVE_UINT_TYPE& size, bool& recoverable);
 
-            //! Deallocation of memory using the mmap allocator
-            //! \param identifier: identifier used at allocation
-            //! \param ptr: pointer to memory being deallocated
-            void deallocate(const NATIVE_UINT_TYPE identifier, void* ptr);
+    //! Deallocation of memory using the mmap allocator
+    //! \param identifier: identifier used at allocation
+    //! \param ptr: pointer to memory being deallocated
+    void deallocate(const NATIVE_UINT_TYPE identifier, void* ptr);
 
-        private:
-            NATIVE_UINT_TYPE m_length;
-    };
+  private:
+    NATIVE_UINT_TYPE m_length;
+};
 
 } /* namespace Fw */
 

--- a/Fw/Types/ObjectName.cpp
+++ b/Fw/Types/ObjectName.cpp
@@ -3,53 +3,52 @@
 
 namespace Fw {
 
-    ObjectName::ObjectName(const CHAR* src) : StringBase() {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
-    }
-
-    ObjectName::ObjectName(const StringBase& src) : StringBase() {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-    }
-
-    ObjectName::ObjectName(const ObjectName& src) : StringBase() {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-    }
-
-    ObjectName::ObjectName() : StringBase() {
-        this->m_buf[0] = 0;
-    }
-
-    ObjectName& ObjectName::operator=(const ObjectName& other) {
-        if(this == &other) {
-            return *this;
-        }
-
-        (void) Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-        return *this;
-    }
-
-    ObjectName& ObjectName::operator=(const StringBase& other) {
-        if(this == &other) {
-            return *this;
-        }
-
-        (void) Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-        return *this;
-    }
-
-    ObjectName& ObjectName::operator=(const CHAR* other) {
-        (void) Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
-        return *this;
-    }
-
-    ObjectName::~ObjectName() {
-    }
-
-    const CHAR* ObjectName::toChar() const {
-        return this->m_buf;
-    }
-
-    NATIVE_UINT_TYPE ObjectName::getCapacity() const {
-        return STRING_SIZE;
-    }
+ObjectName::ObjectName(const CHAR* src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
 }
+
+ObjectName::ObjectName(const StringBase& src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+}
+
+ObjectName::ObjectName(const ObjectName& src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+}
+
+ObjectName::ObjectName() : StringBase() {
+    this->m_buf[0] = 0;
+}
+
+ObjectName& ObjectName::operator=(const ObjectName& other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    (void)Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+    return *this;
+}
+
+ObjectName& ObjectName::operator=(const StringBase& other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    (void)Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+    return *this;
+}
+
+ObjectName& ObjectName::operator=(const CHAR* other) {
+    (void)Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+    return *this;
+}
+
+ObjectName::~ObjectName() {}
+
+const CHAR* ObjectName::toChar() const {
+    return this->m_buf;
+}
+
+NATIVE_UINT_TYPE ObjectName::getCapacity() const {
+    return STRING_SIZE;
+}
+}  // namespace Fw

--- a/Fw/Types/ObjectName.hpp
+++ b/Fw/Types/ObjectName.hpp
@@ -2,36 +2,34 @@
 #define FW_OBJECT_NAME_TYPE_HPP
 
 #include <FpConfig.hpp>
-#include <Fw/Types/StringType.hpp>
 #include <Fw/Cfg/SerIds.hpp>
+#include <Fw/Types/StringType.hpp>
 
 namespace Fw {
 
-    class ObjectName : public Fw::StringBase {
-        public:
-
-            enum {
-                SERIALIZED_TYPE_ID = FW_TYPEID_OBJECT_NAME, //!< typeid for string type
-                STRING_SIZE = FW_OBJ_NAME_MAX_SIZE, //!< Storage for string
-                SERIALIZED_SIZE = STRING_SIZE + sizeof(FwBuffSizeType) //!< Serialized size is size of buffer + size field
-            };
-
-            explicit ObjectName(const CHAR* src); //!< char* source constructor
-            explicit ObjectName(const StringBase& src); //!< StringBase string constructor
-            ObjectName(const ObjectName& src); //!< ObjectName string constructor
-            ObjectName(); //!< default constructor
-            ObjectName& operator=(const ObjectName& other); //!< assignment operator
-            ObjectName& operator=(const StringBase& other); //!< StringBase string assignment operator
-            ObjectName& operator=(const CHAR* other); //!< char* assignment operator
-            ~ObjectName(); //!< destructor
-
-            const CHAR* toChar() const; //!< gets char buffer
-            NATIVE_UINT_TYPE getCapacity() const; //!< return buffer size
-
-        private:
-
-            CHAR m_buf[STRING_SIZE]; //!< storage for string data
+class ObjectName : public Fw::StringBase {
+  public:
+    enum {
+        SERIALIZED_TYPE_ID = FW_TYPEID_OBJECT_NAME,             //!< typeid for string type
+        STRING_SIZE = FW_OBJ_NAME_MAX_SIZE,                     //!< Storage for string
+        SERIALIZED_SIZE = STRING_SIZE + sizeof(FwBuffSizeType)  //!< Serialized size is size of buffer + size field
     };
-}
+
+    explicit ObjectName(const CHAR* src);            //!< char* source constructor
+    explicit ObjectName(const StringBase& src);      //!< StringBase string constructor
+    ObjectName(const ObjectName& src);               //!< ObjectName string constructor
+    ObjectName();                                    //!< default constructor
+    ObjectName& operator=(const ObjectName& other);  //!< assignment operator
+    ObjectName& operator=(const StringBase& other);  //!< StringBase string assignment operator
+    ObjectName& operator=(const CHAR* other);        //!< char* assignment operator
+    ~ObjectName();                                   //!< destructor
+
+    const CHAR* toChar() const;            //!< gets char buffer
+    NATIVE_UINT_TYPE getCapacity() const;  //!< return buffer size
+
+  private:
+    CHAR m_buf[STRING_SIZE];  //!< storage for string data
+};
+}  // namespace Fw
 
 #endif

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -1,681 +1,670 @@
-#include <Fw/Types/PolyType.hpp>
 #include <Fw/Types/Assert.hpp>
+#include <Fw/Types/PolyType.hpp>
 #include <cstdio>
 #define __STDC_FORMAT_MACROS
 
 namespace Fw {
 
-    // U8 methods
+// U8 methods
 
-    PolyType::PolyType() {
-        this->m_dataType = TYPE_NOTYPE;
-    }
+PolyType::PolyType() {
+    this->m_dataType = TYPE_NOTYPE;
+}
 
-    PolyType::PolyType(U8 val) {
-        this->m_dataType = TYPE_U8;
-        this->m_val.u8Val = val;
-    }
+PolyType::PolyType(U8 val) {
+    this->m_dataType = TYPE_U8;
+    this->m_val.u8Val = val;
+}
 
-    PolyType::operator U8() {
-        FW_ASSERT(TYPE_U8 == this->m_dataType);
-        return this->m_val.u8Val;
-    }
+PolyType::operator U8() {
+    FW_ASSERT(TYPE_U8 == this->m_dataType);
+    return this->m_val.u8Val;
+}
 
-    void PolyType::get(U8& val) {
-        FW_ASSERT(TYPE_U8 == this->m_dataType);
-        val = this->m_val.u8Val;
-    }
+void PolyType::get(U8& val) {
+    FW_ASSERT(TYPE_U8 == this->m_dataType);
+    val = this->m_val.u8Val;
+}
 
-    bool PolyType::isU8() {
-        return (TYPE_U8 == this->m_dataType);
-    }
+bool PolyType::isU8() {
+    return (TYPE_U8 == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(U8 other) {
-        this->m_dataType = TYPE_U8;
-        this->m_val.u8Val = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(U8 other) {
+    this->m_dataType = TYPE_U8;
+    this->m_val.u8Val = other;
+    return *this;
+}
 
-    // I8 methods
+// I8 methods
 
-    PolyType::PolyType(I8 val) {
-        this->m_dataType = TYPE_I8;
-        this->m_val.i8Val = val;
-    }
+PolyType::PolyType(I8 val) {
+    this->m_dataType = TYPE_I8;
+    this->m_val.i8Val = val;
+}
 
-    PolyType::operator I8() {
-        FW_ASSERT(TYPE_I8 == this->m_dataType);
-        return this->m_val.i8Val;
-    }
+PolyType::operator I8() {
+    FW_ASSERT(TYPE_I8 == this->m_dataType);
+    return this->m_val.i8Val;
+}
 
-    void PolyType::get(I8& val) {
-        FW_ASSERT(TYPE_I8 == this->m_dataType);
-        val = this->m_val.i8Val;
-    }
+void PolyType::get(I8& val) {
+    FW_ASSERT(TYPE_I8 == this->m_dataType);
+    val = this->m_val.i8Val;
+}
 
-    bool PolyType::isI8() {
-        return (TYPE_I8 == this->m_dataType);
-    }
+bool PolyType::isI8() {
+    return (TYPE_I8 == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(I8 other) {
-        this->m_dataType = TYPE_I8;
-        this->m_val.i8Val = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(I8 other) {
+    this->m_dataType = TYPE_I8;
+    this->m_val.i8Val = other;
+    return *this;
+}
 
 #if FW_HAS_16_BIT
 
-    // U16 methods
+// U16 methods
 
-    PolyType::PolyType(U16 val) {
-        this->m_dataType = TYPE_U16;
-        this->m_val.u16Val = val;
-    }
+PolyType::PolyType(U16 val) {
+    this->m_dataType = TYPE_U16;
+    this->m_val.u16Val = val;
+}
 
-    PolyType::operator U16() {
-        FW_ASSERT(TYPE_U16 == this->m_dataType);
-        return this->m_val.u16Val;
-    }
+PolyType::operator U16() {
+    FW_ASSERT(TYPE_U16 == this->m_dataType);
+    return this->m_val.u16Val;
+}
 
-    void PolyType::get(U16& val) {
-        FW_ASSERT(TYPE_U16 == this->m_dataType);
-        val = this->m_val.u16Val;
-    }
+void PolyType::get(U16& val) {
+    FW_ASSERT(TYPE_U16 == this->m_dataType);
+    val = this->m_val.u16Val;
+}
 
-    bool PolyType::isU16() {
-        return (TYPE_U16 == this->m_dataType);
-    }
+bool PolyType::isU16() {
+    return (TYPE_U16 == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(U16 other) {
-        this->m_dataType = TYPE_U16;
-        this->m_val.u16Val = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(U16 other) {
+    this->m_dataType = TYPE_U16;
+    this->m_val.u16Val = other;
+    return *this;
+}
 
-    // I16 methods
+// I16 methods
 
-    PolyType::PolyType(I16 val) {
-        this->m_dataType = TYPE_I16;
-        this->m_val.i16Val = val;
-    }
+PolyType::PolyType(I16 val) {
+    this->m_dataType = TYPE_I16;
+    this->m_val.i16Val = val;
+}
 
-    PolyType::operator I16() {
-        FW_ASSERT(TYPE_I16 == this->m_dataType);
-        return this->m_val.i16Val;
-    }
+PolyType::operator I16() {
+    FW_ASSERT(TYPE_I16 == this->m_dataType);
+    return this->m_val.i16Val;
+}
 
-    void PolyType::get(I16& val) {
-        FW_ASSERT(TYPE_I16 == this->m_dataType);
-        val = this->m_val.i16Val;
-    }
+void PolyType::get(I16& val) {
+    FW_ASSERT(TYPE_I16 == this->m_dataType);
+    val = this->m_val.i16Val;
+}
 
-    bool PolyType::isI16() {
-        return (TYPE_I16 == this->m_dataType);
-    }
+bool PolyType::isI16() {
+    return (TYPE_I16 == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(I16 other) {
-        this->m_dataType = TYPE_I16;
-        this->m_val.i16Val = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(I16 other) {
+    this->m_dataType = TYPE_I16;
+    this->m_val.i16Val = other;
+    return *this;
+}
 
 #endif
 
 #if FW_HAS_32_BIT
 
-    // U32 methods
+// U32 methods
 
-    PolyType::PolyType(U32 val) {
-        this->m_dataType = TYPE_U32;
-        this->m_val.u32Val = val;
-    }
+PolyType::PolyType(U32 val) {
+    this->m_dataType = TYPE_U32;
+    this->m_val.u32Val = val;
+}
 
-    PolyType::operator U32() {
-        FW_ASSERT(TYPE_U32 == this->m_dataType);
-        return this->m_val.u32Val;
-    }
+PolyType::operator U32() {
+    FW_ASSERT(TYPE_U32 == this->m_dataType);
+    return this->m_val.u32Val;
+}
 
-    void PolyType::get(U32& val) {
-        FW_ASSERT(TYPE_U32 == this->m_dataType);
-        val = this->m_val.u32Val;
-    }
+void PolyType::get(U32& val) {
+    FW_ASSERT(TYPE_U32 == this->m_dataType);
+    val = this->m_val.u32Val;
+}
 
-    bool PolyType::isU32() {
-        return (TYPE_U32 == this->m_dataType);
-    }
+bool PolyType::isU32() {
+    return (TYPE_U32 == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(U32 other) {
-        this->m_dataType = TYPE_U32;
-        this->m_val.u32Val = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(U32 other) {
+    this->m_dataType = TYPE_U32;
+    this->m_val.u32Val = other;
+    return *this;
+}
 
-    // I32 methods
+// I32 methods
 
-    PolyType::PolyType(I32 val) {
-        this->m_dataType = TYPE_I32;
-        this->m_val.i32Val = val;
-    }
+PolyType::PolyType(I32 val) {
+    this->m_dataType = TYPE_I32;
+    this->m_val.i32Val = val;
+}
 
-    PolyType::operator I32() {
-        FW_ASSERT(TYPE_I32 == this->m_dataType);
-        return this->m_val.i32Val;
-    }
+PolyType::operator I32() {
+    FW_ASSERT(TYPE_I32 == this->m_dataType);
+    return this->m_val.i32Val;
+}
 
-    void PolyType::get(I32& val) {
-        FW_ASSERT(TYPE_I32 == this->m_dataType);
-        val = this->m_val.i32Val;
-    }
+void PolyType::get(I32& val) {
+    FW_ASSERT(TYPE_I32 == this->m_dataType);
+    val = this->m_val.i32Val;
+}
 
-    bool PolyType::isI32() {
-        return (TYPE_I32 == this->m_dataType);
-    }
+bool PolyType::isI32() {
+    return (TYPE_I32 == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(I32 other) {
-        this->m_dataType = TYPE_I32;
-        this->m_val.i32Val = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(I32 other) {
+    this->m_dataType = TYPE_I32;
+    this->m_val.i32Val = other;
+    return *this;
+}
 
 #endif
 #if FW_HAS_64_BIT
 
-    // U64 methods
+// U64 methods
 
-    PolyType::PolyType(U64 val) {
-        this->m_dataType = TYPE_U64;
-        this->m_val.u64Val = val;
-    }
+PolyType::PolyType(U64 val) {
+    this->m_dataType = TYPE_U64;
+    this->m_val.u64Val = val;
+}
 
-    PolyType::operator U64() {
-        FW_ASSERT(TYPE_U64 == this->m_dataType);
-        return this->m_val.u64Val;
-    }
+PolyType::operator U64() {
+    FW_ASSERT(TYPE_U64 == this->m_dataType);
+    return this->m_val.u64Val;
+}
 
-    void PolyType::get(U64& val) {
-        FW_ASSERT(TYPE_U64 == this->m_dataType);
-        val = this->m_val.u64Val;
-    }
+void PolyType::get(U64& val) {
+    FW_ASSERT(TYPE_U64 == this->m_dataType);
+    val = this->m_val.u64Val;
+}
 
-    bool PolyType::isU64() {
-        return (TYPE_U64 == this->m_dataType);
-    }
+bool PolyType::isU64() {
+    return (TYPE_U64 == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(U64 other) {
-        this->m_dataType = TYPE_U64;
-        this->m_val.u64Val = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(U64 other) {
+    this->m_dataType = TYPE_U64;
+    this->m_val.u64Val = other;
+    return *this;
+}
 
-    // I64 methods
+// I64 methods
 
-    PolyType::PolyType(I64 val) {
-        this->m_dataType = TYPE_I64;
-        this->m_val.u64Val = val;
-    }
+PolyType::PolyType(I64 val) {
+    this->m_dataType = TYPE_I64;
+    this->m_val.u64Val = val;
+}
 
-    PolyType::operator I64() {
-        FW_ASSERT(TYPE_I64 == this->m_dataType);
-        return this->m_val.i64Val;
-    }
+PolyType::operator I64() {
+    FW_ASSERT(TYPE_I64 == this->m_dataType);
+    return this->m_val.i64Val;
+}
 
-    void PolyType::get(I64& val) {
-        FW_ASSERT(TYPE_I64 == this->m_dataType);
-        val = this->m_val.i64Val;
-    }
+void PolyType::get(I64& val) {
+    FW_ASSERT(TYPE_I64 == this->m_dataType);
+    val = this->m_val.i64Val;
+}
 
-    bool PolyType::isI64() {
-        return (TYPE_I64 == this->m_dataType);
-    }
+bool PolyType::isI64() {
+    return (TYPE_I64 == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(I64 other) {
-        this->m_dataType = TYPE_I64;
-        this->m_val.i64Val = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(I64 other) {
+    this->m_dataType = TYPE_I64;
+    this->m_val.i64Val = other;
+    return *this;
+}
 
 #endif
 
 #if FW_HAS_F64
 
-    PolyType::PolyType(F64 val) {
-        this->m_dataType = TYPE_F64;
-        this->m_val.f64Val = val;
-    }
+PolyType::PolyType(F64 val) {
+    this->m_dataType = TYPE_F64;
+    this->m_val.f64Val = val;
+}
 
-    PolyType::operator F64() {
-        FW_ASSERT(TYPE_F64 == this->m_dataType);
-        return this->m_val.f64Val;
-    }
+PolyType::operator F64() {
+    FW_ASSERT(TYPE_F64 == this->m_dataType);
+    return this->m_val.f64Val;
+}
 
-    void PolyType::get(F64& val) {
-        FW_ASSERT(TYPE_F64 == this->m_dataType);
-        val = this->m_val.f64Val;
-    }
+void PolyType::get(F64& val) {
+    FW_ASSERT(TYPE_F64 == this->m_dataType);
+    val = this->m_val.f64Val;
+}
 
-    bool PolyType::isF64() {
-        return (TYPE_F64 == this->m_dataType);
-    }
+bool PolyType::isF64() {
+    return (TYPE_F64 == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(F64 other) {
-        this->m_dataType = TYPE_F64;
-        this->m_val.f64Val = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(F64 other) {
+    this->m_dataType = TYPE_F64;
+    this->m_val.f64Val = other;
+    return *this;
+}
 
 #endif
-    PolyType::PolyType(F32 val) {
-        this->m_dataType = TYPE_F32;
-        this->m_val.f32Val = val;
-    }
+PolyType::PolyType(F32 val) {
+    this->m_dataType = TYPE_F32;
+    this->m_val.f32Val = val;
+}
 
-    PolyType::operator F32() {
-        FW_ASSERT(TYPE_F32 == this->m_dataType);
-        return this->m_val.f32Val;
-    }
+PolyType::operator F32() {
+    FW_ASSERT(TYPE_F32 == this->m_dataType);
+    return this->m_val.f32Val;
+}
 
-    void PolyType::get(F32& val) {
-        FW_ASSERT(TYPE_F32 == this->m_dataType);
-        val = this->m_val.f32Val;
-    }
+void PolyType::get(F32& val) {
+    FW_ASSERT(TYPE_F32 == this->m_dataType);
+    val = this->m_val.f32Val;
+}
 
-    bool PolyType::isF32() {
-        return (TYPE_F32 == this->m_dataType);
-    }
+bool PolyType::isF32() {
+    return (TYPE_F32 == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(F32 other) {
-        this->m_dataType = TYPE_F32;
-        this->m_val.f32Val = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(F32 other) {
+    this->m_dataType = TYPE_F32;
+    this->m_val.f32Val = other;
+    return *this;
+}
 
-    PolyType::PolyType(bool val) {
-        this->m_dataType = TYPE_BOOL;
-        this->m_val.boolVal = val;
-    }
+PolyType::PolyType(bool val) {
+    this->m_dataType = TYPE_BOOL;
+    this->m_val.boolVal = val;
+}
 
-    PolyType::operator bool() {
-        FW_ASSERT(TYPE_BOOL == this->m_dataType);
-        return this->m_val.boolVal;
-    }
+PolyType::operator bool() {
+    FW_ASSERT(TYPE_BOOL == this->m_dataType);
+    return this->m_val.boolVal;
+}
 
-    void PolyType::get(bool& val) {
-        FW_ASSERT(TYPE_BOOL == this->m_dataType);
-        val = this->m_val.boolVal;
-    }
+void PolyType::get(bool& val) {
+    FW_ASSERT(TYPE_BOOL == this->m_dataType);
+    val = this->m_val.boolVal;
+}
 
-    bool PolyType::isBool() {
-        return (TYPE_BOOL == this->m_dataType);
-    }
+bool PolyType::isBool() {
+    return (TYPE_BOOL == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(bool other) {
-        this->m_dataType = TYPE_BOOL;
-        this->m_val.boolVal = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(bool other) {
+    this->m_dataType = TYPE_BOOL;
+    this->m_val.boolVal = other;
+    return *this;
+}
 
-    PolyType::PolyType(void* val) {
-        this->m_dataType = TYPE_PTR;
-        this->m_val.ptrVal = val;
-    }
+PolyType::PolyType(void* val) {
+    this->m_dataType = TYPE_PTR;
+    this->m_val.ptrVal = val;
+}
 
-    PolyType::operator void*() {
-        FW_ASSERT(TYPE_PTR == this->m_dataType);
-        return this->m_val.ptrVal;
-    }
+PolyType::operator void*() {
+    FW_ASSERT(TYPE_PTR == this->m_dataType);
+    return this->m_val.ptrVal;
+}
 
-    void PolyType::get(void*& val) {
-        FW_ASSERT(TYPE_PTR == this->m_dataType);
-        val = this->m_val.ptrVal;
-    }
+void PolyType::get(void*& val) {
+    FW_ASSERT(TYPE_PTR == this->m_dataType);
+    val = this->m_val.ptrVal;
+}
 
-    bool PolyType::isPtr() {
-        return (TYPE_PTR == this->m_dataType);
-    }
+bool PolyType::isPtr() {
+    return (TYPE_PTR == this->m_dataType);
+}
 
-    PolyType& PolyType::operator=(void* other) {
-        this->m_dataType = TYPE_PTR;
-        this->m_val.ptrVal = other;
-        return *this;
-    }
+PolyType& PolyType::operator=(void* other) {
+    this->m_dataType = TYPE_PTR;
+    this->m_val.ptrVal = other;
+    return *this;
+}
 
-    PolyType::PolyType(const PolyType &original) : Fw::Serializable() {
-        this->m_dataType = original.m_dataType;
-        this->m_val = original.m_val;
-    }
+PolyType::PolyType(const PolyType& original) : Fw::Serializable() {
+    this->m_dataType = original.m_dataType;
+    this->m_val = original.m_val;
+}
 
-    PolyType::~PolyType() {
-    }
+PolyType::~PolyType() {}
 
-    PolyType& PolyType::operator=(const PolyType &src) {
-        this->m_dataType = src.m_dataType;
-        this->m_val = src.m_val;
-        return *this;
-    }
+PolyType& PolyType::operator=(const PolyType& src) {
+    this->m_dataType = src.m_dataType;
+    this->m_val = src.m_val;
+    return *this;
+}
 
-    bool PolyType::operator!=(const PolyType &other) const {
-        return !operator==(other);
-    }
+bool PolyType::operator!=(const PolyType& other) const {
+    return !operator==(other);
+}
 
-    bool PolyType::operator==(const PolyType &other) const {
-
-        // if type doesn't match, not equal
-        if (this->m_dataType != other.m_dataType) {
-            return false;
-        } else {
+bool PolyType::operator==(const PolyType& other) const {
+    // if type doesn't match, not equal
+    if (this->m_dataType != other.m_dataType) {
+        return false;
+    } else {
         // check based on type
-            bool valIsEqual = false;
-            switch (this->m_dataType) {
-                case TYPE_U8:
-                    valIsEqual = (this->m_val.u8Val == other.m_val.u8Val);
-                    break;
-                case TYPE_I8:
-                    valIsEqual = (this->m_val.i8Val == other.m_val.i8Val);
-                    break;
-#if FW_HAS_16_BIT
-                case TYPE_U16:
-                    valIsEqual = (this->m_val.u16Val == other.m_val.u16Val);
-                    break;
-                case TYPE_I16:
-                    valIsEqual = (this->m_val.i16Val == other.m_val.i16Val);
-                    break;
-#endif
-#if FW_HAS_32_BIT
-                case TYPE_U32:
-                    valIsEqual = (this->m_val.u32Val == other.m_val.u32Val);
-                    break;
-                case TYPE_I32:
-                    valIsEqual = (this->m_val.i32Val == other.m_val.i32Val);
-                    break;
-#endif
-#if FW_HAS_64_BIT
-                case TYPE_U64:
-                    valIsEqual = (this->m_val.u64Val == other.m_val.u64Val);
-                    break;
-                case TYPE_I64:
-                    valIsEqual = (this->m_val.i64Val == other.m_val.i64Val);
-                    break;
-#endif
-                case TYPE_BOOL:
-                    valIsEqual = (this->m_val.boolVal == other.m_val.boolVal);
-                    break;
-                case TYPE_PTR:
-                    valIsEqual = (this->m_val.ptrVal == other.m_val.ptrVal);
-                    break;
-#if FW_HAS_F64
-                case TYPE_F64: // fall through, shouldn't test floating point
-#endif
-                case TYPE_F32: // fall through, shouldn't test floating point
-                case TYPE_NOTYPE:
-                    valIsEqual = false;
-                    break;
-                default:
-                    FW_ASSERT(0,static_cast<FwAssertArgType>(this->m_dataType));
-                    return false; // for compiler
-                }
-            return valIsEqual;
-        }
-
-    }
-
-    bool PolyType::operator<(const PolyType &other) const {
-
-        // if type doesn't match, not equal
-        if (this->m_dataType != other.m_dataType) {
-            return false;
-        } else {
-            // check based on type
-            bool result = false;
-            switch (this->m_dataType) {
-                case TYPE_U8:
-                    result = (this->m_val.u8Val < other.m_val.u8Val);
-                    break;
-                case TYPE_I8:
-                    result = (this->m_val.i8Val < other.m_val.i8Val);
-                    break;
-#if FW_HAS_16_BIT
-                case TYPE_U16:
-                    result = (this->m_val.u16Val < other.m_val.u16Val);
-                    break;
-                case TYPE_I16:
-                    result = (this->m_val.i16Val < other.m_val.i16Val);
-                    break;
-#endif
-#if FW_HAS_32_BIT
-                case TYPE_U32:
-                    result = (this->m_val.u32Val < other.m_val.u32Val);
-                    break;
-                case TYPE_I32:
-                    result = (this->m_val.i32Val < other.m_val.i32Val);
-                    break;
-#endif
-#if FW_HAS_64_BIT
-                case TYPE_U64:
-                    result = (this->m_val.u64Val < other.m_val.u64Val);
-                    break;
-                case TYPE_I64:
-                    result = (this->m_val.i64Val < other.m_val.i64Val);
-                    break;
-#endif
-#if FW_HAS_F64
-                case TYPE_F64:
-                    result = (this->m_val.f64Val < other.m_val.f64Val);
-                    break;
-#endif
-                case TYPE_F32:
-                    result = (this->m_val.f32Val < other.m_val.f32Val);
-                    break;
-                case TYPE_PTR:
-                    result = (this->m_val.ptrVal < other.m_val.ptrVal);
-                    break;
-                case TYPE_BOOL: // fall through, shouldn't test bool
-                case TYPE_NOTYPE:
-                    result = false;
-                    break;
-                default:
-                    FW_ASSERT(0,static_cast<FwAssertArgType>(this->m_dataType));
-                    return false; // for compiler
-            }
-            return result;
-        }
-
-    }
-
-    bool PolyType::operator>(const PolyType &other) const {
-        return other.operator<(*this);
-    }
-
-    bool PolyType::operator>=(const PolyType &other) const {
-        return (this->operator>(other)) || (this->operator==(other));
-    }
-
-    bool PolyType::operator<=(const PolyType &other) const {
-        return (this->operator<(other)) || (this->operator==(other));
-    }
-
-
-    SerializeStatus PolyType::serialize(SerializeBufferBase& buffer) const {
-
-        // store type
-        SerializeStatus stat = buffer.serialize(static_cast<FwEnumStoreType> (this->m_dataType));
-        if(stat != FW_SERIALIZE_OK) {
-            return stat;
-        }
-
-        // switch on type
+        bool valIsEqual = false;
         switch (this->m_dataType) {
             case TYPE_U8:
-                stat = buffer.serialize(this->m_val.u8Val);
+                valIsEqual = (this->m_val.u8Val == other.m_val.u8Val);
                 break;
             case TYPE_I8:
-                stat = buffer.serialize(this->m_val.i8Val);
+                valIsEqual = (this->m_val.i8Val == other.m_val.i8Val);
                 break;
 #if FW_HAS_16_BIT
             case TYPE_U16:
-                stat = buffer.serialize(this->m_val.u16Val);
+                valIsEqual = (this->m_val.u16Val == other.m_val.u16Val);
                 break;
             case TYPE_I16:
-                stat = buffer.serialize(this->m_val.i16Val);
+                valIsEqual = (this->m_val.i16Val == other.m_val.i16Val);
                 break;
 #endif
 #if FW_HAS_32_BIT
             case TYPE_U32:
-                stat = buffer.serialize(this->m_val.u32Val);
+                valIsEqual = (this->m_val.u32Val == other.m_val.u32Val);
                 break;
             case TYPE_I32:
-                stat = buffer.serialize(this->m_val.i32Val);
+                valIsEqual = (this->m_val.i32Val == other.m_val.i32Val);
                 break;
 #endif
 #if FW_HAS_64_BIT
             case TYPE_U64:
-                stat = buffer.serialize(this->m_val.u64Val);
+                valIsEqual = (this->m_val.u64Val == other.m_val.u64Val);
                 break;
             case TYPE_I64:
-                stat = buffer.serialize(this->m_val.i64Val);
+                valIsEqual = (this->m_val.i64Val == other.m_val.i64Val);
+                break;
+#endif
+            case TYPE_BOOL:
+                valIsEqual = (this->m_val.boolVal == other.m_val.boolVal);
+                break;
+            case TYPE_PTR:
+                valIsEqual = (this->m_val.ptrVal == other.m_val.ptrVal);
+                break;
+#if FW_HAS_F64
+            case TYPE_F64:  // fall through, shouldn't test floating point
+#endif
+            case TYPE_F32:  // fall through, shouldn't test floating point
+            case TYPE_NOTYPE:
+                valIsEqual = false;
+                break;
+            default:
+                FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_dataType));
+                return false;  // for compiler
+        }
+        return valIsEqual;
+    }
+}
+
+bool PolyType::operator<(const PolyType& other) const {
+    // if type doesn't match, not equal
+    if (this->m_dataType != other.m_dataType) {
+        return false;
+    } else {
+        // check based on type
+        bool result = false;
+        switch (this->m_dataType) {
+            case TYPE_U8:
+                result = (this->m_val.u8Val < other.m_val.u8Val);
+                break;
+            case TYPE_I8:
+                result = (this->m_val.i8Val < other.m_val.i8Val);
+                break;
+#if FW_HAS_16_BIT
+            case TYPE_U16:
+                result = (this->m_val.u16Val < other.m_val.u16Val);
+                break;
+            case TYPE_I16:
+                result = (this->m_val.i16Val < other.m_val.i16Val);
+                break;
+#endif
+#if FW_HAS_32_BIT
+            case TYPE_U32:
+                result = (this->m_val.u32Val < other.m_val.u32Val);
+                break;
+            case TYPE_I32:
+                result = (this->m_val.i32Val < other.m_val.i32Val);
+                break;
+#endif
+#if FW_HAS_64_BIT
+            case TYPE_U64:
+                result = (this->m_val.u64Val < other.m_val.u64Val);
+                break;
+            case TYPE_I64:
+                result = (this->m_val.i64Val < other.m_val.i64Val);
                 break;
 #endif
 #if FW_HAS_F64
             case TYPE_F64:
-                stat = buffer.serialize(this->m_val.f64Val);
+                result = (this->m_val.f64Val < other.m_val.f64Val);
                 break;
 #endif
             case TYPE_F32:
-                stat = buffer.serialize(this->m_val.f32Val);
-                break;
-            case TYPE_BOOL:
-                stat = buffer.serialize(this->m_val.boolVal);
+                result = (this->m_val.f32Val < other.m_val.f32Val);
                 break;
             case TYPE_PTR:
-                stat = buffer.serialize(this->m_val.ptrVal);
+                result = (this->m_val.ptrVal < other.m_val.ptrVal);
+                break;
+            case TYPE_BOOL:  // fall through, shouldn't test bool
+            case TYPE_NOTYPE:
+                result = false;
                 break;
             default:
-                stat = FW_SERIALIZE_FORMAT_ERROR;
-                break;
-            }
+                FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_dataType));
+                return false;  // for compiler
+        }
+        return result;
+    }
+}
 
+bool PolyType::operator>(const PolyType& other) const {
+    return other.operator<(*this);
+}
+
+bool PolyType::operator>=(const PolyType& other) const {
+    return (this->operator>(other)) || (this->operator==(other));
+}
+
+bool PolyType::operator<=(const PolyType& other) const {
+    return (this->operator<(other)) || (this->operator==(other));
+}
+
+SerializeStatus PolyType::serialize(SerializeBufferBase& buffer) const {
+    // store type
+    SerializeStatus stat = buffer.serialize(static_cast<FwEnumStoreType>(this->m_dataType));
+    if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
 
-    SerializeStatus PolyType::deserialize(SerializeBufferBase& buffer) {
-        // get type
-        FwEnumStoreType des;
-        SerializeStatus stat = buffer.deserialize(des);
-
-        if (stat != FW_SERIALIZE_OK) {
-            return stat;
-        } else {
-            this->m_dataType = static_cast<Type>(des);
-            // switch on type
-            switch (this->m_dataType) {
-                case TYPE_U8:
-                    return buffer.deserialize(this->m_val.u8Val);
-                case TYPE_I8:
-                    return buffer.deserialize(this->m_val.i8Val);
+    // switch on type
+    switch (this->m_dataType) {
+        case TYPE_U8:
+            stat = buffer.serialize(this->m_val.u8Val);
+            break;
+        case TYPE_I8:
+            stat = buffer.serialize(this->m_val.i8Val);
+            break;
 #if FW_HAS_16_BIT
-                case TYPE_U16:
-                    return buffer.deserialize(this->m_val.u16Val);
-                case TYPE_I16:
-                    return buffer.deserialize(this->m_val.i16Val);
+        case TYPE_U16:
+            stat = buffer.serialize(this->m_val.u16Val);
+            break;
+        case TYPE_I16:
+            stat = buffer.serialize(this->m_val.i16Val);
+            break;
 #endif
 #if FW_HAS_32_BIT
-                case TYPE_U32:
-                    return buffer.deserialize(this->m_val.u32Val);
-                case TYPE_I32:
-                    return buffer.deserialize(this->m_val.i32Val);
+        case TYPE_U32:
+            stat = buffer.serialize(this->m_val.u32Val);
+            break;
+        case TYPE_I32:
+            stat = buffer.serialize(this->m_val.i32Val);
+            break;
 #endif
 #if FW_HAS_64_BIT
-                case TYPE_U64:
-                    return buffer.deserialize(this->m_val.u64Val);
-                case TYPE_I64:
-                    return buffer.deserialize(this->m_val.i64Val);
+        case TYPE_U64:
+            stat = buffer.serialize(this->m_val.u64Val);
+            break;
+        case TYPE_I64:
+            stat = buffer.serialize(this->m_val.i64Val);
+            break;
 #endif
 #if FW_HAS_F64
-                case TYPE_F64:
-                    return buffer.deserialize(this->m_val.f64Val);
+        case TYPE_F64:
+            stat = buffer.serialize(this->m_val.f64Val);
+            break;
 #endif
-                case TYPE_F32:
-                    return buffer.deserialize(this->m_val.f32Val);
-                case TYPE_BOOL:
-                    return buffer.deserialize(this->m_val.boolVal);
-                case TYPE_PTR:
-                    return buffer.deserialize(this->m_val.ptrVal);
-                default:
-                    return FW_DESERIALIZE_FORMAT_ERROR;
-            }
-        }
-
+        case TYPE_F32:
+            stat = buffer.serialize(this->m_val.f32Val);
+            break;
+        case TYPE_BOOL:
+            stat = buffer.serialize(this->m_val.boolVal);
+            break;
+        case TYPE_PTR:
+            stat = buffer.serialize(this->m_val.ptrVal);
+            break;
+        default:
+            stat = FW_SERIALIZE_FORMAT_ERROR;
+            break;
     }
 
-#if FW_SERIALIZABLE_TO_STRING || BUILD_UT
+    return stat;
+}
 
-    void PolyType::toString(StringBase& dest) const {
-    	this->toString(dest,false);
-    }
+SerializeStatus PolyType::deserialize(SerializeBufferBase& buffer) {
+    // get type
+    FwEnumStoreType des;
+    SerializeStatus stat = buffer.deserialize(des);
 
-    void PolyType::toString(StringBase& dest, bool append) const {
-
-        char valString[80];
+    if (stat != FW_SERIALIZE_OK) {
+        return stat;
+    } else {
+        this->m_dataType = static_cast<Type>(des);
+        // switch on type
         switch (this->m_dataType) {
             case TYPE_U8:
-                (void) snprintf(valString, sizeof(valString), "%" PRIu8 " ", this->m_val.u8Val);
-                break;
+                return buffer.deserialize(this->m_val.u8Val);
             case TYPE_I8:
-                (void) snprintf(valString, sizeof(valString), "%" PRId8 " ", this->m_val.i8Val);
-                break;
+                return buffer.deserialize(this->m_val.i8Val);
 #if FW_HAS_16_BIT
             case TYPE_U16:
-                (void) snprintf(valString, sizeof(valString), "%" PRIu16 " ", this->m_val.u16Val);
-                break;
+                return buffer.deserialize(this->m_val.u16Val);
             case TYPE_I16:
-                (void) snprintf(valString, sizeof(valString), "%" PRId16 " ", this->m_val.i16Val);
-                break;
+                return buffer.deserialize(this->m_val.i16Val);
 #endif
 #if FW_HAS_32_BIT
             case TYPE_U32:
-                (void) snprintf(valString, sizeof(valString), "%" PRIu32 " ", this->m_val.u32Val);
-                break;
+                return buffer.deserialize(this->m_val.u32Val);
             case TYPE_I32:
-                (void) snprintf(valString, sizeof(valString), "%" PRId32 " ", this->m_val.i32Val);
-                break;
+                return buffer.deserialize(this->m_val.i32Val);
 #endif
 #if FW_HAS_64_BIT
             case TYPE_U64:
-                (void) snprintf(valString, sizeof(valString), "%" PRIu64 " ", this->m_val.u64Val);
-                break;
+                return buffer.deserialize(this->m_val.u64Val);
             case TYPE_I64:
-            	(void) snprintf(valString, sizeof(valString), "%" PRId64 " ", this->m_val.i64Val);
-                break;
+                return buffer.deserialize(this->m_val.i64Val);
 #endif
 #if FW_HAS_F64
             case TYPE_F64:
-                (void) snprintf(valString, sizeof(valString), "%lg ", this->m_val.f64Val);
-                break;
+                return buffer.deserialize(this->m_val.f64Val);
 #endif
             case TYPE_F32:
-                (void) snprintf(valString, sizeof(valString), "%g ", this->m_val.f32Val);
-                break;
+                return buffer.deserialize(this->m_val.f32Val);
             case TYPE_BOOL:
-                (void) snprintf(valString, sizeof(valString), "%s ", this->m_val.boolVal?"T":"F");
-                break;
+                return buffer.deserialize(this->m_val.boolVal);
             case TYPE_PTR:
-                (void) snprintf(valString, sizeof(valString), "%p ", this->m_val.ptrVal);
-                break;
+                return buffer.deserialize(this->m_val.ptrVal);
             default:
-                (void) snprintf(valString, sizeof(valString), "%s ", "NT");
-                break;
+                return FW_DESERIALIZE_FORMAT_ERROR;
         }
-
-        // NULL terminate
-        valString[sizeof(valString)-1] = 0;
-
-        if (append) {
-            dest += valString;
-        } else {
-            dest = valString;
-        }
-
     }
-
-#endif
 }
 
+#if FW_SERIALIZABLE_TO_STRING || BUILD_UT
+
+void PolyType::toString(StringBase& dest) const {
+    this->toString(dest, false);
+}
+
+void PolyType::toString(StringBase& dest, bool append) const {
+    char valString[80];
+    switch (this->m_dataType) {
+        case TYPE_U8:
+            (void)snprintf(valString, sizeof(valString), "%" PRIu8 " ", this->m_val.u8Val);
+            break;
+        case TYPE_I8:
+            (void)snprintf(valString, sizeof(valString), "%" PRId8 " ", this->m_val.i8Val);
+            break;
+#if FW_HAS_16_BIT
+        case TYPE_U16:
+            (void)snprintf(valString, sizeof(valString), "%" PRIu16 " ", this->m_val.u16Val);
+            break;
+        case TYPE_I16:
+            (void)snprintf(valString, sizeof(valString), "%" PRId16 " ", this->m_val.i16Val);
+            break;
+#endif
+#if FW_HAS_32_BIT
+        case TYPE_U32:
+            (void)snprintf(valString, sizeof(valString), "%" PRIu32 " ", this->m_val.u32Val);
+            break;
+        case TYPE_I32:
+            (void)snprintf(valString, sizeof(valString), "%" PRId32 " ", this->m_val.i32Val);
+            break;
+#endif
+#if FW_HAS_64_BIT
+        case TYPE_U64:
+            (void)snprintf(valString, sizeof(valString), "%" PRIu64 " ", this->m_val.u64Val);
+            break;
+        case TYPE_I64:
+            (void)snprintf(valString, sizeof(valString), "%" PRId64 " ", this->m_val.i64Val);
+            break;
+#endif
+#if FW_HAS_F64
+        case TYPE_F64:
+            (void)snprintf(valString, sizeof(valString), "%lg ", this->m_val.f64Val);
+            break;
+#endif
+        case TYPE_F32:
+            (void)snprintf(valString, sizeof(valString), "%g ", this->m_val.f32Val);
+            break;
+        case TYPE_BOOL:
+            (void)snprintf(valString, sizeof(valString), "%s ", this->m_val.boolVal ? "T" : "F");
+            break;
+        case TYPE_PTR:
+            (void)snprintf(valString, sizeof(valString), "%p ", this->m_val.ptrVal);
+            break;
+        default:
+            (void)snprintf(valString, sizeof(valString), "%s ", "NT");
+            break;
+    }
+
+    // NULL terminate
+    valString[sizeof(valString) - 1] = 0;
+
+    if (append) {
+        dest += valString;
+    } else {
+        dest = valString;
+    }
+}
+
+#endif
+}  // namespace Fw

--- a/Fw/Types/PolyType.hpp
+++ b/Fw/Types/PolyType.hpp
@@ -2,172 +2,167 @@
 #define FW_POLY_TYPE_HPP
 
 #include <FpConfig.hpp>
-#include <Fw/Types/StringType.hpp>
-#include <Fw/Types/Serializable.hpp>
 #include <Fw/Cfg/SerIds.hpp>
+#include <Fw/Types/Serializable.hpp>
+#include <Fw/Types/StringType.hpp>
 
 namespace Fw {
 
-    class PolyType : public Serializable {
-        public:
+class PolyType : public Serializable {
+  public:
+    PolyType(U8 val);             //!< U8 constructor
+    operator U8();                //!< U8 cast operator
+    void get(U8& val);            //!< U8 accessor
+    bool isU8();                  //!< U8 checker
+    PolyType& operator=(U8 val);  //!< U8 operator=
 
-            PolyType(U8 val); //!< U8 constructor
-            operator U8(); //!< U8 cast operator
-            void get(U8& val); //!< U8 accessor
-            bool isU8(); //!< U8 checker
-            PolyType& operator=(U8 val); //!< U8 operator=
-
-            PolyType(I8 val); //!< I8 constructor
-            operator I8(); //!< I8 cast operator
-            void get(I8& val); //!< I8 accessor
-            bool isI8(); //!< I8 checker
-            PolyType& operator=(I8 val); //!< I8 operator=
+    PolyType(I8 val);             //!< I8 constructor
+    operator I8();                //!< I8 cast operator
+    void get(I8& val);            //!< I8 accessor
+    bool isI8();                  //!< I8 checker
+    PolyType& operator=(I8 val);  //!< I8 operator=
 
 #if FW_HAS_16_BIT
-            PolyType(U16 val); //!< U16 constructor
-            operator U16(); //!< U16 cast operator
-            void get(U16& val); //!< U16 accessor
-            bool isU16(); //!< U16 checker
-            PolyType& operator=(U16 val); //!< I8 operator=
+    PolyType(U16 val);             //!< U16 constructor
+    operator U16();                //!< U16 cast operator
+    void get(U16& val);            //!< U16 accessor
+    bool isU16();                  //!< U16 checker
+    PolyType& operator=(U16 val);  //!< I8 operator=
 
-            PolyType(I16 val); //!< I16 constructor
-            operator I16(); //!< I16 cast operator
-            void get(I16& val); //!< I16 accessor
-            bool isI16(); //!< I16 checker
-            PolyType& operator=(I16 val); //!< I16 operator=
+    PolyType(I16 val);             //!< I16 constructor
+    operator I16();                //!< I16 cast operator
+    void get(I16& val);            //!< I16 accessor
+    bool isI16();                  //!< I16 checker
+    PolyType& operator=(I16 val);  //!< I16 operator=
 #endif
 #if FW_HAS_32_BIT
-            PolyType(U32 val); //!< U32 constructor
-            operator U32(); //!< U32 cast operator
-            void get(U32& val); //!< U32 accessor
-            bool isU32(); //!< U32 checker
-            PolyType& operator=(U32 val); //!< U32 operator=
+    PolyType(U32 val);             //!< U32 constructor
+    operator U32();                //!< U32 cast operator
+    void get(U32& val);            //!< U32 accessor
+    bool isU32();                  //!< U32 checker
+    PolyType& operator=(U32 val);  //!< U32 operator=
 
-            PolyType(I32 val); //!< I32 constructor
-            operator I32(); //!< I32 cast operator
-            void get(I32& val); //!< I32 accessor
-            bool isI32(); //!< I32 checker
-            PolyType& operator=(I32 val); //!< I32 operator=
+    PolyType(I32 val);             //!< I32 constructor
+    operator I32();                //!< I32 cast operator
+    void get(I32& val);            //!< I32 accessor
+    bool isI32();                  //!< I32 checker
+    PolyType& operator=(I32 val);  //!< I32 operator=
 #endif
 #if FW_HAS_64_BIT
-            PolyType(U64 val); //!< U64 constructor
-            operator U64(); //!< U64 cast operator
-            void get(U64& val); //!< U64 accessor
-            bool isU64(); //!< U64 checker
-            PolyType& operator=(U64 val); //!< U64 operator=
+    PolyType(U64 val);             //!< U64 constructor
+    operator U64();                //!< U64 cast operator
+    void get(U64& val);            //!< U64 accessor
+    bool isU64();                  //!< U64 checker
+    PolyType& operator=(U64 val);  //!< U64 operator=
 
-            PolyType(I64 val); //!< I64 constructor
-            operator I64(); //!< I64 cast operator
-            void get(I64& val); //!< I64 accessor
-            bool isI64(); //!< I64 checker
-            PolyType& operator=(I64 val); //!< I64 operator=
+    PolyType(I64 val);             //!< I64 constructor
+    operator I64();                //!< I64 cast operator
+    void get(I64& val);            //!< I64 accessor
+    bool isI64();                  //!< I64 checker
+    PolyType& operator=(I64 val);  //!< I64 operator=
 #endif
 
 #if FW_HAS_F64
-            PolyType(F64 val); //!< F64 constructor
-            operator F64(); //!< F64 cast operator
-            void get(F64& val); //!< F64 accessor
-            bool isF64(); //!< F64 checker
-            PolyType& operator=(F64 val); //!< F64 operator=
+    PolyType(F64 val);             //!< F64 constructor
+    operator F64();                //!< F64 cast operator
+    void get(F64& val);            //!< F64 accessor
+    bool isF64();                  //!< F64 checker
+    PolyType& operator=(F64 val);  //!< F64 operator=
 #endif
-            PolyType(F32 val); //!< F32 constructor
-            operator F32(); //!< F32 cast operator
-            void get(F32& val); //!< F32 accessor
-            bool isF32(); //!< F32 checker
-            PolyType& operator=(F32 val); //!< F32 operator=
+    PolyType(F32 val);             //!< F32 constructor
+    operator F32();                //!< F32 cast operator
+    void get(F32& val);            //!< F32 accessor
+    bool isF32();                  //!< F32 checker
+    PolyType& operator=(F32 val);  //!< F32 operator=
 
-            PolyType(bool val); //!< bool constructor
-            operator bool(); //!< bool cast operator
-            void get(bool& val); //!< bool accessor
-            bool isBool(); //!< bool checker
-            PolyType& operator=(bool val); //!< bool operator=
+    PolyType(bool val);             //!< bool constructor
+    operator bool();                //!< bool cast operator
+    void get(bool& val);            //!< bool accessor
+    bool isBool();                  //!< bool checker
+    PolyType& operator=(bool val);  //!< bool operator=
 
-            PolyType(void* val); //!< void* constructor.
-            operator void*(); //!< void* cast operator
-            void get(void*& val); //!< void* accessor
-            bool isPtr(); //!< void* checker
-            PolyType& operator=(void* val); //!< void* operator=
+    PolyType(void* val);             //!< void* constructor.
+    operator void*();                //!< void* cast operator
+    void get(void*& val);            //!< void* accessor
+    bool isPtr();                    //!< void* checker
+    PolyType& operator=(void* val);  //!< void* operator=
 
-            PolyType(); //!< default constructor
-            PolyType(const PolyType &original); //!< copy constructor
-            virtual ~PolyType(); //!< destructor
+    PolyType();                          //!< default constructor
+    PolyType(const PolyType& original);  //!< copy constructor
+    virtual ~PolyType();                 //!< destructor
 
 #if FW_SERIALIZABLE_TO_STRING || BUILD_UT
-            void toString(StringBase& dest, bool append) const; //!< get string representation
-            void toString(StringBase& dest) const; //!< get string representation
+    void toString(StringBase& dest, bool append) const;  //!< get string representation
+    void toString(StringBase& dest) const;               //!< get string representation
 #endif
 
-            PolyType& operator=(const PolyType &src); //!< PolyType operator=
-            bool operator<(const PolyType &other) const; //!< PolyType operator<
-            bool operator>(const PolyType &other) const; //!< PolyType operator>
-            bool operator>=(const PolyType &other) const; //!< PolyType operator>=
-            bool operator<=(const PolyType &other) const; //!< PolyType operator<=
-            bool operator==(const PolyType &other) const; //!< PolyType operator==
-            bool operator!=(const PolyType &other) const; //!< PolyType operator!=
-            SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< Serialize function
-            SerializeStatus deserialize(SerializeBufferBase& buffer); //!< Deserialize function
+    PolyType& operator=(const PolyType& src);                      //!< PolyType operator=
+    bool operator<(const PolyType& other) const;                   //!< PolyType operator<
+    bool operator>(const PolyType& other) const;                   //!< PolyType operator>
+    bool operator>=(const PolyType& other) const;                  //!< PolyType operator>=
+    bool operator<=(const PolyType& other) const;                  //!< PolyType operator<=
+    bool operator==(const PolyType& other) const;                  //!< PolyType operator==
+    bool operator!=(const PolyType& other) const;                  //!< PolyType operator!=
+    SerializeStatus serialize(SerializeBufferBase& buffer) const;  //!< Serialize function
+    SerializeStatus deserialize(SerializeBufferBase& buffer);      //!< Deserialize function
 
-        PRIVATE:
-
-            typedef enum {
-                TYPE_NOTYPE, // !< No type stored yet
-                TYPE_U8, // !< U8 type stored
-                TYPE_I8, // !< I8 type stored
+  PRIVATE:
+    typedef enum {
+        TYPE_NOTYPE,  // !< No type stored yet
+        TYPE_U8,      // !< U8 type stored
+        TYPE_I8,      // !< I8 type stored
 #if FW_HAS_16_BIT
-                TYPE_U16, // !< U16 type stored
-                TYPE_I16, // !< I16 type stored
+        TYPE_U16,  // !< U16 type stored
+        TYPE_I16,  // !< I16 type stored
 #endif
 #if FW_HAS_32_BIT
-                TYPE_U32, // !< U32 type stored
-                TYPE_I32, // !< I32 type stored
+        TYPE_U32,  // !< U32 type stored
+        TYPE_I32,  // !< I32 type stored
 #endif
 #if FW_HAS_64_BIT
-                TYPE_U64, // !< U64 type stored
-                TYPE_I64, // !< I64 type stored
+        TYPE_U64,  // !< U64 type stored
+        TYPE_I64,  // !< I64 type stored
 #endif
-                TYPE_F32, // !< F32 type stored
+        TYPE_F32,  // !< F32 type stored
 #if FW_HAS_F64
-                TYPE_F64, // !< F64 type stored
+        TYPE_F64,  // !< F64 type stored
 #endif
-                TYPE_BOOL, // !< bool type stored
-                TYPE_PTR // !< pointer type stored
-            } Type;
+        TYPE_BOOL,  // !< bool type stored
+        TYPE_PTR    // !< pointer type stored
+    } Type;
 
-            Type m_dataType; //!< member that indicates type being stored
+    Type m_dataType;  //!< member that indicates type being stored
 
-            union PolyVal {
-                    U8 u8Val; //!< U8 data storage
-                    I8 i8Val; //!< I8 data storage
+    union PolyVal {
+        U8 u8Val;  //!< U8 data storage
+        I8 i8Val;  //!< I8 data storage
 #if FW_HAS_16_BIT
-                    U16 u16Val; //!< U16 data storage
-                    I16 i16Val; //!< I16 data storage
+        U16 u16Val;  //!< U16 data storage
+        I16 i16Val;  //!< I16 data storage
 #endif
 #if FW_HAS_32_BIT
-                    U32 u32Val; //!< U32 data storage
-                    I32 i32Val; //!< I32 data storage
+        U32 u32Val;  //!< U32 data storage
+        I32 i32Val;  //!< I32 data storage
 #endif
 #if FW_HAS_64_BIT
-                    U64 u64Val; //!< U64 data storage
-                    I64 i64Val; //!< I64 data storage
+        U64 u64Val;  //!< U64 data storage
+        I64 i64Val;  //!< I64 data storage
 #endif
 #if FW_HAS_F64
-                    F64 f64Val; //!< F64 data storage
+        F64 f64Val;  //!< F64 data storage
 #endif
-                    F32 f32Val; // !< F32 data storage
-                    void* ptrVal; // !< pointer data storage
-                    bool boolVal; // !< bool data storage
-            } m_val; // !< stores data value
+        F32 f32Val;    // !< F32 data storage
+        void* ptrVal;  // !< pointer data storage
+        bool boolVal;  // !< bool data storage
+    } m_val;           // !< stores data value
 
-        public:
-
-            enum {
-                SERIALIZED_TYPE_ID = FW_TYPEID_POLY, //!< typeid for PolyType
-                SERIALIZED_SIZE = sizeof(FwEnumStoreType) + sizeof(PolyVal) //!< stored serialized size
-            };
-
-
+  public:
+    enum {
+        SERIALIZED_TYPE_ID = FW_TYPEID_POLY,                         //!< typeid for PolyType
+        SERIALIZED_SIZE = sizeof(FwEnumStoreType) + sizeof(PolyVal)  //!< stored serialized size
     };
+};
 
-}
+}  // namespace Fw
 
 #endif

--- a/Fw/Types/SerialBuffer.cpp
+++ b/Fw/Types/SerialBuffer.cpp
@@ -10,59 +10,38 @@
 //
 // ======================================================================
 
-#include "Fw/Types/SerialBuffer.hpp"
 #include "Fw/Types/Assert.hpp"
+#include "Fw/Types/SerialBuffer.hpp"
 
 namespace Fw {
 
-  SerialBuffer ::
-    SerialBuffer(
-        U8 *const data,
-        const U32 capacity
-    ) :
-      m_data(data),
-      m_capacity(capacity)
-  {
+SerialBuffer ::SerialBuffer(U8* const data, const U32 capacity) : m_data(data), m_capacity(capacity) {}
 
-  }
-
-  NATIVE_UINT_TYPE SerialBuffer ::
-    getBuffCapacity() const
-  {
+NATIVE_UINT_TYPE SerialBuffer ::getBuffCapacity() const {
     return m_capacity;
-  }
+}
 
-  U8* SerialBuffer ::
-    getBuffAddr()
-  {
+U8* SerialBuffer ::getBuffAddr() {
     return m_data;
-  }
+}
 
-  const U8* SerialBuffer ::
-    getBuffAddr() const
-  {
+const U8* SerialBuffer ::getBuffAddr() const {
     return m_data;
-  }
+}
 
-  void SerialBuffer ::
-    fill()
-  {
+void SerialBuffer ::fill() {
     const SerializeStatus status = this->setBuffLen(this->m_capacity);
     FW_ASSERT(status == FW_SERIALIZE_OK);
-  }
+}
 
-  SerializeStatus SerialBuffer ::
-    pushBytes(const U8 *const addr, const NATIVE_UINT_TYPE n)
-  {
+SerializeStatus SerialBuffer ::pushBytes(const U8* const addr, const NATIVE_UINT_TYPE n) {
     // "true" means "just push the bytes"
     return this->serialize(const_cast<U8*>(addr), n, true);
-  }
+}
 
-  SerializeStatus SerialBuffer ::
-    popBytes(U8 *const addr, NATIVE_UINT_TYPE n)
-  {
+SerializeStatus SerialBuffer ::popBytes(U8* const addr, NATIVE_UINT_TYPE n) {
     // "true" means "just pop the bytes"
     return this->deserialize(addr, n, true);
-  }
-
 }
+
+}  // namespace Fw

--- a/Fw/Types/SerialBuffer.hpp
+++ b/Fw/Types/SerialBuffer.hpp
@@ -18,73 +18,62 @@
 
 namespace Fw {
 
-  //! \class SerialBuffer
-  //! \brief A variable-length serializable buffer
-  //!
-  class SerialBuffer :
-    public SerializeBufferBase
-  {
+//! \class SerialBuffer
+//! \brief A variable-length serializable buffer
+//!
+class SerialBuffer : public SerializeBufferBase {
+  public:
+    // ----------------------------------------------------------------------
+    // Construction
+    // ----------------------------------------------------------------------
 
-    public:
+    //! Construct a SerialBuffer
+    //!
+    SerialBuffer(U8* const data,     //!< Pointer to the data
+                 const U32 capacity  //!< The buffer capacity
+    );
 
-      // ----------------------------------------------------------------------
-      // Construction
-      // ----------------------------------------------------------------------
+  public:
+    // ----------------------------------------------------------------------
+    // Pure virtual methods from SerializeBufferBase
+    // ----------------------------------------------------------------------
 
-      //! Construct a SerialBuffer
-      //!
-      SerialBuffer(
-          U8 *const data, //!< Pointer to the data
-          const U32 capacity //!< The buffer capacity
-      );
+    NATIVE_UINT_TYPE getBuffCapacity() const;
 
-    public:
+    U8* getBuffAddr();
 
-      // ----------------------------------------------------------------------
-      // Pure virtual methods from SerializeBufferBase
-      // ----------------------------------------------------------------------
+    const U8* getBuffAddr() const;
 
-      NATIVE_UINT_TYPE getBuffCapacity() const;
+  public:
+    // ----------------------------------------------------------------------
+    // Public instance methods
+    // ----------------------------------------------------------------------
 
-      U8* getBuffAddr();
+    //! Fill the buffer to capacity with preexisting data
+    void fill();
 
-      const U8* getBuffAddr() const;
+    //! Push n bytes onto the buffer
+    SerializeStatus pushBytes(const U8* const addr,     //!< Address of bytes to push
+                              const NATIVE_UINT_TYPE n  //!< Number of bytes
+    );
 
-    public:
+    //! Pop n bytes off the buffer
+    SerializeStatus popBytes(U8* const addr,     //!< Address of bytes to pop
+                             NATIVE_UINT_TYPE n  //!< Number of bytes to pop
+    );
 
-      // ----------------------------------------------------------------------
-      // Public instance methods
-      // ----------------------------------------------------------------------
+  private:
+    // ----------------------------------------------------------------------
+    // Data
+    // ----------------------------------------------------------------------
 
-      //! Fill the buffer to capacity with preexisting data
-      void fill();
+    //! The data
+    U8* const m_data;
 
-      //! Push n bytes onto the buffer
-      SerializeStatus pushBytes(
-          const U8 *const addr, //!< Address of bytes to push
-          const NATIVE_UINT_TYPE n //!< Number of bytes
-      );
+    //! The capacity
+    const U32 m_capacity;
+};
 
-      //! Pop n bytes off the buffer
-      SerializeStatus popBytes(
-          U8 *const addr, //!< Address of bytes to pop
-          NATIVE_UINT_TYPE n //!< Number of bytes to pop
-      );
-
-    private:
-
-      // ----------------------------------------------------------------------
-      // Data
-      // ----------------------------------------------------------------------
-
-      //! The data
-      U8 *const m_data;
-
-      //! The capacity
-      const U32 m_capacity;
-
-  };
-
-}
+}  // namespace Fw
 
 #endif

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -1,810 +1,786 @@
-#include <Fw/Types/Serializable.hpp>
-#include <cstring> // memcpy
+#include <FpConfig.hpp>
 #include <Fw/Types/Assert.hpp>
+#include <Fw/Types/Serializable.hpp>
 #include <Fw/Types/StringType.hpp>
 #include <cstdio>
-#include <FpConfig.hpp>
+#include <cstring>  // memcpy
 #ifdef BUILD_UT
-#include <iomanip>
 #include <Fw/Types/String.hpp>
+#include <iomanip>
 #endif
 
 // Some macros/functions to optimize for architectures
 
 namespace Fw {
 
-    Serializable::Serializable() {
-    }
+Serializable::Serializable() {}
 
-    Serializable::~Serializable() {
-    }
+Serializable::~Serializable() {}
 
 #if FW_SERIALIZABLE_TO_STRING || FW_ENABLE_TEXT_LOGGING || BUILD_UT
 
-    void Serializable::toString(StringBase& text) const {
-        text = "NOSPEC"; // set to not specified.
-    }
+void Serializable::toString(StringBase& text) const {
+    text = "NOSPEC";  // set to not specified.
+}
 
 #endif
 
 #ifdef BUILD_UT
-    std::ostream& operator<<(std::ostream& os, const Serializable& val) {
-        Fw::String out;
-        val.toString(out);
+std::ostream& operator<<(std::ostream& os, const Serializable& val) {
+    Fw::String out;
+    val.toString(out);
 
-        os << out;
+    os << out;
 
-        return os;
-    }
+    return os;
+}
 #endif
 
-    SerializeBufferBase::SerializeBufferBase() :
-            m_serLoc(0), m_deserLoc(0) {
+SerializeBufferBase::SerializeBufferBase() : m_serLoc(0), m_deserLoc(0) {}
+
+SerializeBufferBase::~SerializeBufferBase() {}
+
+void SerializeBufferBase::copyFrom(const SerializeBufferBase& src) {
+    this->m_serLoc = src.m_serLoc;
+    this->m_deserLoc = src.m_deserLoc;
+    FW_ASSERT(src.getBuffAddr());
+    FW_ASSERT(this->getBuffAddr());
+    // destination has to be same or bigger
+    FW_ASSERT(src.getBuffLength() <= this->getBuffCapacity(), src.getBuffLength(), this->getBuffLength());
+    (void)memcpy(this->getBuffAddr(), src.getBuffAddr(), this->m_serLoc);
+}
+
+// Copy constructor doesn't make sense in this virtual class as there is nothing to copy. Derived classes should
+// call the empty constructor and then call their own copy function
+SerializeBufferBase& SerializeBufferBase::operator=(const SerializeBufferBase& src) {  // lgtm[cpp/rule-of-two]
+    this->copyFrom(src);
+    return *this;
+}
+
+// serialization routines
+
+SerializeStatus SerializeBufferBase::serialize(U8 val) {
+    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
+    FW_ASSERT(this->getBuffAddr());
+    this->getBuffAddr()[this->m_serLoc] = val;
+    this->m_serLoc += sizeof(val);
+    this->m_deserLoc = 0;
 
-    SerializeBufferBase::~SerializeBufferBase() {
+    return FW_SERIALIZE_OK;
+}
+
+SerializeStatus SerializeBufferBase::serialize(I8 val) {
+    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
+    FW_ASSERT(this->getBuffAddr());
+    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val);
+    this->m_serLoc += sizeof(val);
+    this->m_deserLoc = 0;
+    return FW_SERIALIZE_OK;
+}
 
-    void SerializeBufferBase::copyFrom(const SerializeBufferBase& src) {
-        this->m_serLoc = src.m_serLoc;
-        this->m_deserLoc = src.m_deserLoc;
-        FW_ASSERT(src.getBuffAddr());
-        FW_ASSERT(this->getBuffAddr());
-        // destination has to be same or bigger
-        FW_ASSERT(src.getBuffLength() <= this->getBuffCapacity(),src.getBuffLength(),this->getBuffLength());
-        (void) memcpy(this->getBuffAddr(),src.getBuffAddr(),this->m_serLoc);
+#if FW_HAS_16_BIT == 1
+SerializeStatus SerializeBufferBase::serialize(U16 val) {
+    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 8);
+    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val);
+    this->m_serLoc += sizeof(val);
+    this->m_deserLoc = 0;
+    return FW_SERIALIZE_OK;
+}
 
-    // Copy constructor doesn't make sense in this virtual class as there is nothing to copy. Derived classes should
-    // call the empty constructor and then call their own copy function
-    SerializeBufferBase& SerializeBufferBase::operator=(const SerializeBufferBase &src) { // lgtm[cpp/rule-of-two]
-        this->copyFrom(src);
-        return *this;
+SerializeStatus SerializeBufferBase::serialize(I16 val) {
+    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
-
-    // serialization routines
-
-    SerializeStatus SerializeBufferBase::serialize(U8 val) {
-        if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-        FW_ASSERT(this->getBuffAddr());
-        this->getBuffAddr()[this->m_serLoc] = val;
-        this->m_serLoc += sizeof(val);
-        this->m_deserLoc = 0;
-
-        return FW_SERIALIZE_OK;
-    }
-
-    SerializeStatus SerializeBufferBase::serialize(I8 val) {
-        if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-        FW_ASSERT(this->getBuffAddr());
-        this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val);
-        this->m_serLoc += sizeof(val);
-        this->m_deserLoc = 0;
-        return FW_SERIALIZE_OK;
-    }
-
-#if FW_HAS_16_BIT==1
-    SerializeStatus SerializeBufferBase::serialize(U16 val) {
-        if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 8);
-        this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val);
-        this->m_serLoc += sizeof(val);
-        this->m_deserLoc = 0;
-        return FW_SERIALIZE_OK;
-    }
-
-    SerializeStatus SerializeBufferBase::serialize(I16 val) {
-        if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 8);
-        this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val);
-        this->m_serLoc += sizeof(val);
-        this->m_deserLoc = 0;
-        return FW_SERIALIZE_OK;
-    }
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 8);
+    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val);
+    this->m_serLoc += sizeof(val);
+    this->m_deserLoc = 0;
+    return FW_SERIALIZE_OK;
+}
 #endif
-#if FW_HAS_32_BIT==1
-    SerializeStatus SerializeBufferBase::serialize(U32 val) {
-        if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 24);
-        this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 16);
-        this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 8);
-        this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val);
-        this->m_serLoc += sizeof(val);
-        this->m_deserLoc = 0;
-        return FW_SERIALIZE_OK;
+#if FW_HAS_32_BIT == 1
+SerializeStatus SerializeBufferBase::serialize(U32 val) {
+    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 24);
+    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 16);
+    this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 8);
+    this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val);
+    this->m_serLoc += sizeof(val);
+    this->m_deserLoc = 0;
+    return FW_SERIALIZE_OK;
+}
 
-    SerializeStatus SerializeBufferBase::serialize(I32 val) {
-        if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 24);
-        this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 16);
-        this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 8);
-        this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val);
-        this->m_serLoc += sizeof(val);
-        this->m_deserLoc = 0;
-        return FW_SERIALIZE_OK;
+SerializeStatus SerializeBufferBase::serialize(I32 val) {
+    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 24);
+    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 16);
+    this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 8);
+    this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val);
+    this->m_serLoc += sizeof(val);
+    this->m_deserLoc = 0;
+    return FW_SERIALIZE_OK;
+}
 #endif
 
-#if FW_HAS_64_BIT==1
-    SerializeStatus SerializeBufferBase::serialize(U64 val) {
-        if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 56);
-        this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 48);
-        this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 40);
-        this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val >> 32);
-        this->getBuffAddr()[this->m_serLoc + 4] = static_cast<U8>(val >> 24);
-        this->getBuffAddr()[this->m_serLoc + 5] = static_cast<U8>(val >> 16);
-        this->getBuffAddr()[this->m_serLoc + 6] = static_cast<U8>(val >> 8);
-        this->getBuffAddr()[this->m_serLoc + 7] = static_cast<U8>(val);
-        this->m_serLoc += sizeof(val);
-        this->m_deserLoc = 0;
-        return FW_SERIALIZE_OK;
+#if FW_HAS_64_BIT == 1
+SerializeStatus SerializeBufferBase::serialize(U64 val) {
+    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 56);
+    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 48);
+    this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 40);
+    this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val >> 32);
+    this->getBuffAddr()[this->m_serLoc + 4] = static_cast<U8>(val >> 24);
+    this->getBuffAddr()[this->m_serLoc + 5] = static_cast<U8>(val >> 16);
+    this->getBuffAddr()[this->m_serLoc + 6] = static_cast<U8>(val >> 8);
+    this->getBuffAddr()[this->m_serLoc + 7] = static_cast<U8>(val);
+    this->m_serLoc += sizeof(val);
+    this->m_deserLoc = 0;
+    return FW_SERIALIZE_OK;
+}
 
-    SerializeStatus SerializeBufferBase::serialize(I64 val) {
-        if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 56);
-        this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 48);
-        this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 40);
-        this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val >> 32);
-        this->getBuffAddr()[this->m_serLoc + 4] = static_cast<U8>(val >> 24);
-        this->getBuffAddr()[this->m_serLoc + 5] = static_cast<U8>(val >> 16);
-        this->getBuffAddr()[this->m_serLoc + 6] = static_cast<U8>(val >> 8);
-        this->getBuffAddr()[this->m_serLoc + 7] = static_cast<U8>(val);
-        this->m_serLoc += sizeof(val);
-        this->m_deserLoc = 0;
-        return FW_SERIALIZE_OK;
+SerializeStatus SerializeBufferBase::serialize(I64 val) {
+    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 56);
+    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 48);
+    this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 40);
+    this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val >> 32);
+    this->getBuffAddr()[this->m_serLoc + 4] = static_cast<U8>(val >> 24);
+    this->getBuffAddr()[this->m_serLoc + 5] = static_cast<U8>(val >> 16);
+    this->getBuffAddr()[this->m_serLoc + 6] = static_cast<U8>(val >> 8);
+    this->getBuffAddr()[this->m_serLoc + 7] = static_cast<U8>(val);
+    this->m_serLoc += sizeof(val);
+    this->m_deserLoc = 0;
+    return FW_SERIALIZE_OK;
+}
 #endif
 
 #if FW_HAS_F64 && FW_HAS_64_BIT
 
-    SerializeStatus SerializeBufferBase::serialize(F64 val) {
-        // floating point values need to be byte-swapped as well, so copy to U64 and use that routine
-        U64 u64Val;
-        (void) memcpy(&u64Val, &val, sizeof(val));
-        return this->serialize(u64Val);
-
-    }
+SerializeStatus SerializeBufferBase::serialize(F64 val) {
+    // floating point values need to be byte-swapped as well, so copy to U64 and use that routine
+    U64 u64Val;
+    (void)memcpy(&u64Val, &val, sizeof(val));
+    return this->serialize(u64Val);
+}
 
 #endif
 
-    SerializeStatus SerializeBufferBase::serialize(F32 val) {
+SerializeStatus SerializeBufferBase::serialize(F32 val) {
+    // floating point values need to be byte-swapped as well, so copy to U32 and use that routine
+    U32 u32Val;
+    (void)memcpy(&u32Val, &val, sizeof(val));
+    return this->serialize(u32Val);
+}
 
-        // floating point values need to be byte-swapped as well, so copy to U32 and use that routine
-        U32 u32Val;
-        (void) memcpy(&u32Val, &val, sizeof(val));
-        return this->serialize(u32Val);
-
+SerializeStatus SerializeBufferBase::serialize(bool val) {
+    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(U8)) - 1 >= this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
 
-    SerializeStatus SerializeBufferBase::serialize(bool val) {
-        if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(U8)) - 1 >= this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-
-        FW_ASSERT(this->getBuffAddr());
-        if (val) {
-            this->getBuffAddr()[this->m_serLoc + 0] = FW_SERIALIZE_TRUE_VALUE;
-        } else {
-            this->getBuffAddr()[this->m_serLoc + 0] = FW_SERIALIZE_FALSE_VALUE;
-        }
-
-        this->m_serLoc += sizeof(U8);
-        this->m_deserLoc = 0;
-        return FW_SERIALIZE_OK;
+    FW_ASSERT(this->getBuffAddr());
+    if (val) {
+        this->getBuffAddr()[this->m_serLoc + 0] = FW_SERIALIZE_TRUE_VALUE;
+    } else {
+        this->getBuffAddr()[this->m_serLoc + 0] = FW_SERIALIZE_FALSE_VALUE;
     }
 
-    SerializeStatus SerializeBufferBase::serialize(const void* val) {
-        if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(void*)) - 1
-                >= this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
+    this->m_serLoc += sizeof(U8);
+    this->m_deserLoc = 0;
+    return FW_SERIALIZE_OK;
+}
 
-        return this->serialize(reinterpret_cast<POINTER_CAST>(val));
-
+SerializeStatus SerializeBufferBase::serialize(const void* val) {
+    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(void*)) - 1 >= this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
 
-    SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::SizeType length) {
-        return this->serialize(buff, static_cast<FwSizeType>(length), Serialization::INCLUDE_LENGTH);
-    }
+    return this->serialize(reinterpret_cast<POINTER_CAST>(val));
+}
 
-    SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::SizeType length, bool noLength) {
-        return this->serialize(buff, static_cast<FwSizeType>(length), noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
-    }
+SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::SizeType length) {
+    return this->serialize(buff, static_cast<FwSizeType>(length), Serialization::INCLUDE_LENGTH);
+}
 
-    SerializeStatus SerializeBufferBase::serialize(const U8* buff, FwSizeType length, Fw::Serialization::t mode) {
-        // First serialize length
-        SerializeStatus stat;
-        if (mode == Serialization::INCLUDE_LENGTH) {
-            stat = this->serialize(static_cast<FwSizeStoreType>(length));
-            if (stat != FW_SERIALIZE_OK) {
-                return stat;
-            }
-        }
+SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::SizeType length, bool noLength) {
+    return this->serialize(buff, static_cast<FwSizeType>(length),
+                           noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
+}
 
-        // make sure we have enough space
-        if (this->m_serLoc + length > this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-
-        // copy buffer to our buffer
-        (void) memcpy(&this->getBuffAddr()[this->m_serLoc], buff, length);
-        this->m_serLoc += length;
-        this->m_deserLoc = 0;
-
-        return FW_SERIALIZE_OK;
-    }
-
-    SerializeStatus SerializeBufferBase::serialize(const Serializable &val) {
-        return val.serialize(*this);
-    }
-
-    SerializeStatus SerializeBufferBase::serialize(
-            const SerializeBufferBase& val) {
-        Serializable::SizeType size = val.getBuffLength();
-        if (this->m_serLoc + size + static_cast<Serializable::SizeType>(sizeof(FwSizeStoreType))
-                > this->getBuffCapacity()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-
-        // First, serialize size
-        SerializeStatus stat = this->serialize(static_cast<FwSizeStoreType>(size));
+SerializeStatus SerializeBufferBase::serialize(const U8* buff, FwSizeType length, Fw::Serialization::t mode) {
+    // First serialize length
+    SerializeStatus stat;
+    if (mode == Serialization::INCLUDE_LENGTH) {
+        stat = this->serialize(static_cast<FwSizeStoreType>(length));
         if (stat != FW_SERIALIZE_OK) {
             return stat;
         }
-
-        FW_ASSERT(this->getBuffAddr());
-        FW_ASSERT(val.getBuffAddr());
-        // serialize buffer
-        (void) memcpy(&this->getBuffAddr()[this->m_serLoc], val.getBuffAddr(), size);
-        this->m_serLoc += size;
-        this->m_deserLoc = 0;
-
-        return FW_SERIALIZE_OK;
     }
 
-    SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size) {
-        SerializeStatus status = FW_SERIALIZE_OK;
-        if ((size < std::numeric_limits<FwSizeStoreType>::min()) || (size > std::numeric_limits<FwSizeStoreType>::max())) {
-            status = FW_SERIALIZE_FORMAT_ERROR;
-        }
-        if (status == FW_SERIALIZE_OK) {
-            status = this->serialize(static_cast<FwSizeStoreType>(size));
-        }
-        return status;
+    // make sure we have enough space
+    if (this->m_serLoc + length > this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
 
-    // deserialization routines
+    // copy buffer to our buffer
+    (void)memcpy(&this->getBuffAddr()[this->m_serLoc], buff, length);
+    this->m_serLoc += length;
+    this->m_deserLoc = 0;
 
-    SerializeStatus SerializeBufferBase::deserialize(U8 &val) {
-        // check for room
-        if (this->getBuffLength() == this->m_deserLoc) {
-            return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-        // read from current location
-        FW_ASSERT(this->getBuffAddr());
-        val = this->getBuffAddr()[this->m_deserLoc + 0];
-        this->m_deserLoc += sizeof(val);
-        return FW_SERIALIZE_OK;
+    return FW_SERIALIZE_OK;
+}
+
+SerializeStatus SerializeBufferBase::serialize(const Serializable& val) {
+    return val.serialize(*this);
+}
+
+SerializeStatus SerializeBufferBase::serialize(const SerializeBufferBase& val) {
+    Serializable::SizeType size = val.getBuffLength();
+    if (this->m_serLoc + size + static_cast<Serializable::SizeType>(sizeof(FwSizeStoreType)) >
+        this->getBuffCapacity()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
     }
 
-    SerializeStatus SerializeBufferBase::deserialize(I8 &val) {
-        // check for room
-        if (this->getBuffLength() == this->m_deserLoc) {
-            return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-        // read from current location
-        FW_ASSERT(this->getBuffAddr());
-        val = static_cast<I8>(this->getBuffAddr()[this->m_deserLoc + 0]);
-        this->m_deserLoc += sizeof(val);
-        return FW_SERIALIZE_OK;
+    // First, serialize size
+    SerializeStatus stat = this->serialize(static_cast<FwSizeStoreType>(size));
+    if (stat != FW_SERIALIZE_OK) {
+        return stat;
     }
 
-#if FW_HAS_16_BIT==1
-    SerializeStatus SerializeBufferBase::deserialize(U16 &val) {
-        // check for room
-        if (this->getBuffLength() == this->m_deserLoc) {
-            return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-        // read from current location
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        val = static_cast<U16>(
-            ((this->getBuffAddr()[this->m_deserLoc + 1]) << 0) |
-            ((this->getBuffAddr()[this->m_deserLoc + 0]) << 8)
-        );
-        this->m_deserLoc += sizeof(val);
-        return FW_SERIALIZE_OK;
-    }
+    FW_ASSERT(this->getBuffAddr());
+    FW_ASSERT(val.getBuffAddr());
+    // serialize buffer
+    (void)memcpy(&this->getBuffAddr()[this->m_serLoc], val.getBuffAddr(), size);
+    this->m_serLoc += size;
+    this->m_deserLoc = 0;
 
-    SerializeStatus SerializeBufferBase::deserialize(I16 &val) {
-        // check for room
-        if (this->getBuffLength() == this->m_deserLoc) {
-            return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-        // read from current location
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        val = static_cast<I16>(
-            ((this->getBuffAddr()[this->m_deserLoc + 1]) << 0) |
-            ((this->getBuffAddr()[this->m_deserLoc + 0]) << 8)
-        );
-        this->m_deserLoc += sizeof(val);
-        return FW_SERIALIZE_OK;
+    return FW_SERIALIZE_OK;
+}
+
+SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size) {
+    SerializeStatus status = FW_SERIALIZE_OK;
+    if ((size < std::numeric_limits<FwSizeStoreType>::min()) || (size > std::numeric_limits<FwSizeStoreType>::max())) {
+        status = FW_SERIALIZE_FORMAT_ERROR;
     }
+    if (status == FW_SERIALIZE_OK) {
+        status = this->serialize(static_cast<FwSizeStoreType>(size));
+    }
+    return status;
+}
+
+// deserialization routines
+
+SerializeStatus SerializeBufferBase::deserialize(U8& val) {
+    // check for room
+    if (this->getBuffLength() == this->m_deserLoc) {
+        return FW_DESERIALIZE_BUFFER_EMPTY;
+    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+    // read from current location
+    FW_ASSERT(this->getBuffAddr());
+    val = this->getBuffAddr()[this->m_deserLoc + 0];
+    this->m_deserLoc += sizeof(val);
+    return FW_SERIALIZE_OK;
+}
+
+SerializeStatus SerializeBufferBase::deserialize(I8& val) {
+    // check for room
+    if (this->getBuffLength() == this->m_deserLoc) {
+        return FW_DESERIALIZE_BUFFER_EMPTY;
+    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+    // read from current location
+    FW_ASSERT(this->getBuffAddr());
+    val = static_cast<I8>(this->getBuffAddr()[this->m_deserLoc + 0]);
+    this->m_deserLoc += sizeof(val);
+    return FW_SERIALIZE_OK;
+}
+
+#if FW_HAS_16_BIT == 1
+SerializeStatus SerializeBufferBase::deserialize(U16& val) {
+    // check for room
+    if (this->getBuffLength() == this->m_deserLoc) {
+        return FW_DESERIALIZE_BUFFER_EMPTY;
+    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+    // read from current location
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    val = static_cast<U16>(((this->getBuffAddr()[this->m_deserLoc + 1]) << 0) |
+                           ((this->getBuffAddr()[this->m_deserLoc + 0]) << 8));
+    this->m_deserLoc += sizeof(val);
+    return FW_SERIALIZE_OK;
+}
+
+SerializeStatus SerializeBufferBase::deserialize(I16& val) {
+    // check for room
+    if (this->getBuffLength() == this->m_deserLoc) {
+        return FW_DESERIALIZE_BUFFER_EMPTY;
+    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+    // read from current location
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    val = static_cast<I16>(((this->getBuffAddr()[this->m_deserLoc + 1]) << 0) |
+                           ((this->getBuffAddr()[this->m_deserLoc + 0]) << 8));
+    this->m_deserLoc += sizeof(val);
+    return FW_SERIALIZE_OK;
+}
 #endif
-#if FW_HAS_32_BIT==1
-    SerializeStatus SerializeBufferBase::deserialize(U32 &val) {
-        // check for room
-        if (this->getBuffLength() == this->m_deserLoc) {
-            return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-        // read from current location
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        val = (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 0)
-                | (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8)
-                | (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16)
-                | (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
-        this->m_deserLoc += sizeof(val);
-        return FW_SERIALIZE_OK;
+#if FW_HAS_32_BIT == 1
+SerializeStatus SerializeBufferBase::deserialize(U32& val) {
+    // check for room
+    if (this->getBuffLength() == this->m_deserLoc) {
+        return FW_DESERIALIZE_BUFFER_EMPTY;
+    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
     }
+    // read from current location
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    val = (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 0) |
+          (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8) |
+          (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16) |
+          (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
+    this->m_deserLoc += sizeof(val);
+    return FW_SERIALIZE_OK;
+}
 
-    SerializeStatus SerializeBufferBase::deserialize(I32 &val) {
-        // check for room
-        if (this->getBuffLength() == this->m_deserLoc) {
-            return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-        // read from current location
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        val = (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 0)
-                | (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8)
-                | (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16)
-                | (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
-        this->m_deserLoc += sizeof(val);
-        return FW_SERIALIZE_OK;
+SerializeStatus SerializeBufferBase::deserialize(I32& val) {
+    // check for room
+    if (this->getBuffLength() == this->m_deserLoc) {
+        return FW_DESERIALIZE_BUFFER_EMPTY;
+    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
     }
+    // read from current location
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    val = (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 0) |
+          (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8) |
+          (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16) |
+          (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
+    this->m_deserLoc += sizeof(val);
+    return FW_SERIALIZE_OK;
+}
 #endif
 
-#if FW_HAS_64_BIT==1
+#if FW_HAS_64_BIT == 1
 
-    SerializeStatus SerializeBufferBase::deserialize(U64 &val) {
-        // check for room
-        if (this->getBuffLength() == this->m_deserLoc) {
-            return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-        // read from current location
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        val = (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 0)
-                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8)
-                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 16)
-                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 24)
-                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 32)
-                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 40)
-                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48)
-                | (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
-
-        this->m_deserLoc += sizeof(val);
-        return FW_SERIALIZE_OK;
+SerializeStatus SerializeBufferBase::deserialize(U64& val) {
+    // check for room
+    if (this->getBuffLength() == this->m_deserLoc) {
+        return FW_DESERIALIZE_BUFFER_EMPTY;
+    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
     }
+    // read from current location
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    val = (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 0) |
+          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8) |
+          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 16) |
+          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 24) |
+          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 32) |
+          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 40) |
+          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48) |
+          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
 
-    SerializeStatus SerializeBufferBase::deserialize(I64 &val) {
-        // check for room
-        if (this->getBuffLength() == this->m_deserLoc) {
-            return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-        // read from current location
-        FW_ASSERT(this->getBuffAddr());
-        // MSB first
-        val = (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 0)
-                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8)
-                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 16)
-                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 24)
-                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 32)
-                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 40)
-                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48)
-                | (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
-        this->m_deserLoc += sizeof(val);
-        return FW_SERIALIZE_OK;
+    this->m_deserLoc += sizeof(val);
+    return FW_SERIALIZE_OK;
+}
+
+SerializeStatus SerializeBufferBase::deserialize(I64& val) {
+    // check for room
+    if (this->getBuffLength() == this->m_deserLoc) {
+        return FW_DESERIALIZE_BUFFER_EMPTY;
+    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
     }
+    // read from current location
+    FW_ASSERT(this->getBuffAddr());
+    // MSB first
+    val = (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 0) |
+          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8) |
+          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 16) |
+          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 24) |
+          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 32) |
+          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 40) |
+          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48) |
+          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
+    this->m_deserLoc += sizeof(val);
+    return FW_SERIALIZE_OK;
+}
 #endif
 
 #if FW_HAS_F64
 
-    SerializeStatus SerializeBufferBase::deserialize(F64 &val) {
-
-        // deserialize as 64-bit int to handle endianness
-        U64 tempVal;
-        SerializeStatus stat = this->deserialize(tempVal);
-        if (stat != FW_SERIALIZE_OK) {
-            return stat;
-        }
-        // copy to argument
-        (void) memcpy(&val, &tempVal, sizeof(val));
-
-        return FW_SERIALIZE_OK;
-    }
-
-#endif
-
-    SerializeStatus SerializeBufferBase::deserialize(bool &val) {
-        // check for room
-        if (this->getBuffLength() == this->m_deserLoc) {
-            return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(U8))) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-        // read from current location
-        FW_ASSERT(this->getBuffAddr());
-        if (FW_SERIALIZE_TRUE_VALUE == this->getBuffAddr()[this->m_deserLoc + 0]) {
-            val = true;
-        } else if (FW_SERIALIZE_FALSE_VALUE == this->getBuffAddr()[this->m_deserLoc + 0]) {
-            val = false;
-        } else {
-            return FW_DESERIALIZE_FORMAT_ERROR;
-        }
-
-        this->m_deserLoc += sizeof(U8);
-        return FW_SERIALIZE_OK;
-    }
-
-    SerializeStatus SerializeBufferBase::deserialize(void*& val) {
-        // Deserialize as pointer cast, then convert to void*
-        PlatformPointerCastType pointerCastVal = 0;
-        const SerializeStatus stat = this->deserialize(pointerCastVal);
-        if (stat == FW_SERIALIZE_OK) {
-            val = reinterpret_cast<void*>(pointerCastVal);
-        }
+SerializeStatus SerializeBufferBase::deserialize(F64& val) {
+    // deserialize as 64-bit int to handle endianness
+    U64 tempVal;
+    SerializeStatus stat = this->deserialize(tempVal);
+    if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
+    // copy to argument
+    (void)memcpy(&val, &tempVal, sizeof(val));
 
-    SerializeStatus SerializeBufferBase::deserialize(F32 &val) {
-        // deserialize as 64-bit int to handle endianness
-        U32 tempVal;
-        SerializeStatus stat = this->deserialize(tempVal);
-        if (stat != FW_SERIALIZE_OK) {
-            return stat;
-        }
-        (void) memcpy(&val, &tempVal, sizeof(val));
-
-        return FW_SERIALIZE_OK;
-    }
-
-    SerializeStatus SerializeBufferBase::deserialize(U8* buff, Serializable::SizeType& length) {
-        FwSizeType length_in_out = static_cast<FwSizeType>(length);
-        SerializeStatus status = this->deserialize(buff, length_in_out, Serialization::INCLUDE_LENGTH);
-        length = static_cast<Serializable::SizeType>(length_in_out);
-        return status;
-    }
-
-    SerializeStatus SerializeBufferBase::deserialize(U8* buff, Serializable::SizeType& length, bool noLength) {
-        FwSizeType length_in_out = static_cast<FwSizeType>(length);
-        SerializeStatus status = this->deserialize(buff, length_in_out, noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
-        length = static_cast<Serializable::SizeType>(length_in_out);
-        return status;
-    }
-
-    SerializeStatus SerializeBufferBase::deserialize(U8* buff, FwSizeType& length, Serialization::t mode) {
-
-        FW_ASSERT(this->getBuffAddr());
-
-        if (mode == Serialization::INCLUDE_LENGTH) {
-            FwSizeStoreType storedLength;
-
-            SerializeStatus stat = this->deserialize(storedLength);
-
-            if (stat != FW_SERIALIZE_OK) {
-                return stat;
-            }
-
-            // make sure it fits
-            if ((storedLength > this->getBuffLeft()) or (storedLength > length)) {
-                return FW_DESERIALIZE_SIZE_MISMATCH;
-            }
-
-            (void) memcpy(buff, &this->getBuffAddr()[this->m_deserLoc], storedLength);
-
-            length = static_cast<FwSizeType>(storedLength);
-
-        } else {
-            // make sure enough is left
-            if (length > this->getBuffLeft()) {
-                return FW_DESERIALIZE_SIZE_MISMATCH;
-            }
-
-            (void) memcpy(buff, &this->getBuffAddr()[this->m_deserLoc], length);
-        }
-
-        this->m_deserLoc += length;
-        return FW_SERIALIZE_OK;
-    }
-
-    SerializeStatus SerializeBufferBase::deserialize(Serializable &val) {
-        return val.deserialize(*this);
-    }
-
-    SerializeStatus SerializeBufferBase::deserialize(SerializeBufferBase& val) {
-
-        FW_ASSERT(val.getBuffAddr());
-        SerializeStatus stat = FW_SERIALIZE_OK;
-
-        FwSizeStoreType storedLength;
-
-        stat = this->deserialize(storedLength);
-
-        if (stat != FW_SERIALIZE_OK) {
-            return stat;
-        }
-
-        // make sure destination has enough room
-
-        if ((storedLength > val.getBuffCapacity()) or (storedLength > this->getBuffLeft()) ) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-
-        FW_ASSERT(this->getBuffAddr());
-        (void) memcpy(val.getBuffAddr(), &this->getBuffAddr()[this->m_deserLoc],
-                storedLength);
-
-        stat = val.setBuffLen(storedLength);
-
-        if (stat != FW_SERIALIZE_OK) {
-            return stat;
-        }
-
-        this->m_deserLoc += storedLength;
-
-        return FW_SERIALIZE_OK;
-    }
-
-    SerializeStatus SerializeBufferBase::deserializeSize(FwSizeType& size) {
-        FwSizeStoreType storedSize = 0;
-        Fw::SerializeStatus status = this->deserialize(storedSize);
-        if (status == FW_SERIALIZE_OK) {
-            size = static_cast<FwSizeType>(storedSize);
-        }
-        return status;
-    }
-
-    void SerializeBufferBase::resetSer() {
-        this->m_deserLoc = 0;
-        this->m_serLoc = 0;
-    }
-
-    void SerializeBufferBase::resetDeser() {
-        this->m_deserLoc = 0;
-    }
-
-    SerializeStatus SerializeBufferBase::serializeSkip(FwSizeType numBytesToSkip)
-    {
-        Fw::SerializeStatus status = FW_SERIALIZE_OK;
-        // compute new deser loc
-        const FwSizeType newSerLoc = this->m_serLoc + numBytesToSkip;
-        // check for room
-        if (newSerLoc <= this->getBuffCapacity()) {
-            // update deser loc
-            this->m_serLoc = newSerLoc;
-        }
-        else {
-            status = FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-        return status;
-    }
-
-    SerializeStatus SerializeBufferBase::deserializeSkip(FwSizeType numBytesToSkip)
-    {
-        // check for room
-        if (this->getBuffLength() == this->m_deserLoc) {
-            return FW_DESERIALIZE_BUFFER_EMPTY;
-        } else if (this->getBuffLength() - this->m_deserLoc < numBytesToSkip) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-        // update location in buffer to skip the value
-        this->m_deserLoc += numBytesToSkip;
-        return FW_SERIALIZE_OK;
-    }
-
-    SerializeStatus SerializeBufferBase::moveSerToOffset(FwSizeType offset) {
-        // Reset serialization
-        this->resetSer();
-        // Advance to offset
-        return this->serializeSkip(offset);
-    }
-    SerializeStatus SerializeBufferBase::moveDeserToOffset(FwSizeType offset) {
-        // Reset deserialization
-        this->resetDeser();
-        // Advance to offset
-        return this->deserializeSkip(offset);
-    }
-
-    Serializable::SizeType SerializeBufferBase::getBuffLength() const {
-        return this->m_serLoc;
-    }
-
-    SerializeStatus SerializeBufferBase::setBuff(const U8* src, Serializable::SizeType length) {
-        if (this->getBuffCapacity() < length) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        } else {
-            FW_ASSERT(src);
-            FW_ASSERT(this->getBuffAddr());
-            memcpy(this->getBuffAddr(), src, length);
-            this->m_serLoc = length;
-            this->m_deserLoc = 0;
-            return FW_SERIALIZE_OK;
-        }
-    }
-
-    SerializeStatus SerializeBufferBase::setBuffLen(Serializable::SizeType length) {
-        if (this->getBuffCapacity() < length) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        } else {
-            this->m_serLoc = length;
-            this->m_deserLoc = 0;
-            return FW_SERIALIZE_OK;
-        }
-    }
-
-    Serializable::SizeType SerializeBufferBase::getBuffLeft() const {
-        return this->m_serLoc - this->m_deserLoc;
-    }
-
-    SerializeStatus SerializeBufferBase::copyRaw(SerializeBufferBase& dest, Serializable::SizeType size) {
-        // make sure there is sufficient size in destination
-        if (dest.getBuffCapacity() < size) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-        // otherwise, set destination buffer to data from deserialization pointer plus size
-        SerializeStatus stat = dest.setBuff(&this->getBuffAddr()[this->m_deserLoc],size);
-        if (stat == FW_SERIALIZE_OK) {
-            this->m_deserLoc += size;
-        }
-        return stat;
-
-    }
-
-    SerializeStatus SerializeBufferBase::copyRawOffset(SerializeBufferBase& dest, Serializable::SizeType size) {
-        // make sure there is sufficient size in destination
-        if (dest.getBuffCapacity() < size + dest.getBuffLength()) {
-            return FW_SERIALIZE_NO_ROOM_LEFT;
-        }
-        // make sure there is sufficient buffer in source
-        if (this->getBuffLeft() < size) {
-            return FW_DESERIALIZE_SIZE_MISMATCH;
-        }
-
-        // otherwise, serialize bytes to destination without writing length
-        SerializeStatus stat = dest.serialize(&this->getBuffAddr()[this->m_deserLoc], size, true);
-        if (stat == FW_SERIALIZE_OK) {
-            this->m_deserLoc += size;
-        }
-        return stat;
-
-    }
-
-    // return address of buffer not yet deserialized. This is used
-    // to copy the remainder of a buffer.
-    const U8* SerializeBufferBase::getBuffAddrLeft() const {
-        return &this->getBuffAddr()[this->m_deserLoc];
-    }
-
-    //!< gets address of end of serialization. Used to manually place data at the end
-    U8* SerializeBufferBase::getBuffAddrSer() {
-        return &this->getBuffAddr()[this->m_serLoc];
-    }
-
-#ifdef BUILD_UT
-    bool SerializeBufferBase::operator==(const SerializeBufferBase& other) const {
-        if (this->getBuffLength() != other.getBuffLength()) {
-            return false;
-        }
-
-        const U8* us = this->getBuffAddr();
-        const U8* them = other.getBuffAddr();
-
-        FW_ASSERT(us);
-        FW_ASSERT(them);
-
-        for (Serializable::SizeType byte = 0; byte < this->getBuffLength(); byte++) {
-            if (us[byte] != them[byte]) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    std::ostream& operator<<(std::ostream& os, const SerializeBufferBase& buff) {
-
-        const U8* us = buff.getBuffAddr();
-
-        FW_ASSERT(us);
-
-        for (Serializable::SizeType byte = 0; byte < buff.getBuffLength(); byte++) {
-            os << "[" << std::setw(2) << std::hex << std::setfill('0') << us[byte] << "]" << std::dec;
-        }
-
-        return os;
-    }
-#endif
-
-    ExternalSerializeBuffer::ExternalSerializeBuffer(U8* buffPtr, Serializable::SizeType size) {
-        this->setExtBuffer(buffPtr,size);
-    }
-
-    ExternalSerializeBuffer::ExternalSerializeBuffer() {
-        this->clear();
-    }
-
-    void ExternalSerializeBuffer::setExtBuffer(U8* buffPtr, Serializable::SizeType size) {
-        FW_ASSERT(buffPtr != nullptr);
-        this->m_buff = buffPtr;
-        this->m_buffSize = size;
-    }
-
-    void ExternalSerializeBuffer::clear() {
-        this->m_buff = nullptr;
-        this->m_buffSize = 0;
-    }
-
-    Serializable::SizeType ExternalSerializeBuffer::getBuffCapacity() const {
-        return this->m_buffSize;
-    }
-
-    U8* ExternalSerializeBuffer::getBuffAddr() {
-        return this->m_buff;
-    }
-
-    const U8* ExternalSerializeBuffer::getBuffAddr() const {
-        return this->m_buff;
-    }
-
+    return FW_SERIALIZE_OK;
 }
 
+#endif
+
+SerializeStatus SerializeBufferBase::deserialize(bool& val) {
+    // check for room
+    if (this->getBuffLength() == this->m_deserLoc) {
+        return FW_DESERIALIZE_BUFFER_EMPTY;
+    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(U8))) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+    // read from current location
+    FW_ASSERT(this->getBuffAddr());
+    if (FW_SERIALIZE_TRUE_VALUE == this->getBuffAddr()[this->m_deserLoc + 0]) {
+        val = true;
+    } else if (FW_SERIALIZE_FALSE_VALUE == this->getBuffAddr()[this->m_deserLoc + 0]) {
+        val = false;
+    } else {
+        return FW_DESERIALIZE_FORMAT_ERROR;
+    }
+
+    this->m_deserLoc += sizeof(U8);
+    return FW_SERIALIZE_OK;
+}
+
+SerializeStatus SerializeBufferBase::deserialize(void*& val) {
+    // Deserialize as pointer cast, then convert to void*
+    PlatformPointerCastType pointerCastVal = 0;
+    const SerializeStatus stat = this->deserialize(pointerCastVal);
+    if (stat == FW_SERIALIZE_OK) {
+        val = reinterpret_cast<void*>(pointerCastVal);
+    }
+    return stat;
+}
+
+SerializeStatus SerializeBufferBase::deserialize(F32& val) {
+    // deserialize as 64-bit int to handle endianness
+    U32 tempVal;
+    SerializeStatus stat = this->deserialize(tempVal);
+    if (stat != FW_SERIALIZE_OK) {
+        return stat;
+    }
+    (void)memcpy(&val, &tempVal, sizeof(val));
+
+    return FW_SERIALIZE_OK;
+}
+
+SerializeStatus SerializeBufferBase::deserialize(U8* buff, Serializable::SizeType& length) {
+    FwSizeType length_in_out = static_cast<FwSizeType>(length);
+    SerializeStatus status = this->deserialize(buff, length_in_out, Serialization::INCLUDE_LENGTH);
+    length = static_cast<Serializable::SizeType>(length_in_out);
+    return status;
+}
+
+SerializeStatus SerializeBufferBase::deserialize(U8* buff, Serializable::SizeType& length, bool noLength) {
+    FwSizeType length_in_out = static_cast<FwSizeType>(length);
+    SerializeStatus status =
+        this->deserialize(buff, length_in_out, noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
+    length = static_cast<Serializable::SizeType>(length_in_out);
+    return status;
+}
+
+SerializeStatus SerializeBufferBase::deserialize(U8* buff, FwSizeType& length, Serialization::t mode) {
+    FW_ASSERT(this->getBuffAddr());
+
+    if (mode == Serialization::INCLUDE_LENGTH) {
+        FwSizeStoreType storedLength;
+
+        SerializeStatus stat = this->deserialize(storedLength);
+
+        if (stat != FW_SERIALIZE_OK) {
+            return stat;
+        }
+
+        // make sure it fits
+        if ((storedLength > this->getBuffLeft()) or (storedLength > length)) {
+            return FW_DESERIALIZE_SIZE_MISMATCH;
+        }
+
+        (void)memcpy(buff, &this->getBuffAddr()[this->m_deserLoc], storedLength);
+
+        length = static_cast<FwSizeType>(storedLength);
+
+    } else {
+        // make sure enough is left
+        if (length > this->getBuffLeft()) {
+            return FW_DESERIALIZE_SIZE_MISMATCH;
+        }
+
+        (void)memcpy(buff, &this->getBuffAddr()[this->m_deserLoc], length);
+    }
+
+    this->m_deserLoc += length;
+    return FW_SERIALIZE_OK;
+}
+
+SerializeStatus SerializeBufferBase::deserialize(Serializable& val) {
+    return val.deserialize(*this);
+}
+
+SerializeStatus SerializeBufferBase::deserialize(SerializeBufferBase& val) {
+    FW_ASSERT(val.getBuffAddr());
+    SerializeStatus stat = FW_SERIALIZE_OK;
+
+    FwSizeStoreType storedLength;
+
+    stat = this->deserialize(storedLength);
+
+    if (stat != FW_SERIALIZE_OK) {
+        return stat;
+    }
+
+    // make sure destination has enough room
+
+    if ((storedLength > val.getBuffCapacity()) or (storedLength > this->getBuffLeft())) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+
+    FW_ASSERT(this->getBuffAddr());
+    (void)memcpy(val.getBuffAddr(), &this->getBuffAddr()[this->m_deserLoc], storedLength);
+
+    stat = val.setBuffLen(storedLength);
+
+    if (stat != FW_SERIALIZE_OK) {
+        return stat;
+    }
+
+    this->m_deserLoc += storedLength;
+
+    return FW_SERIALIZE_OK;
+}
+
+SerializeStatus SerializeBufferBase::deserializeSize(FwSizeType& size) {
+    FwSizeStoreType storedSize = 0;
+    Fw::SerializeStatus status = this->deserialize(storedSize);
+    if (status == FW_SERIALIZE_OK) {
+        size = static_cast<FwSizeType>(storedSize);
+    }
+    return status;
+}
+
+void SerializeBufferBase::resetSer() {
+    this->m_deserLoc = 0;
+    this->m_serLoc = 0;
+}
+
+void SerializeBufferBase::resetDeser() {
+    this->m_deserLoc = 0;
+}
+
+SerializeStatus SerializeBufferBase::serializeSkip(FwSizeType numBytesToSkip) {
+    Fw::SerializeStatus status = FW_SERIALIZE_OK;
+    // compute new deser loc
+    const FwSizeType newSerLoc = this->m_serLoc + numBytesToSkip;
+    // check for room
+    if (newSerLoc <= this->getBuffCapacity()) {
+        // update deser loc
+        this->m_serLoc = newSerLoc;
+    } else {
+        status = FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+SerializeStatus SerializeBufferBase::deserializeSkip(FwSizeType numBytesToSkip) {
+    // check for room
+    if (this->getBuffLength() == this->m_deserLoc) {
+        return FW_DESERIALIZE_BUFFER_EMPTY;
+    } else if (this->getBuffLength() - this->m_deserLoc < numBytesToSkip) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+    // update location in buffer to skip the value
+    this->m_deserLoc += numBytesToSkip;
+    return FW_SERIALIZE_OK;
+}
+
+SerializeStatus SerializeBufferBase::moveSerToOffset(FwSizeType offset) {
+    // Reset serialization
+    this->resetSer();
+    // Advance to offset
+    return this->serializeSkip(offset);
+}
+SerializeStatus SerializeBufferBase::moveDeserToOffset(FwSizeType offset) {
+    // Reset deserialization
+    this->resetDeser();
+    // Advance to offset
+    return this->deserializeSkip(offset);
+}
+
+Serializable::SizeType SerializeBufferBase::getBuffLength() const {
+    return this->m_serLoc;
+}
+
+SerializeStatus SerializeBufferBase::setBuff(const U8* src, Serializable::SizeType length) {
+    if (this->getBuffCapacity() < length) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
+    } else {
+        FW_ASSERT(src);
+        FW_ASSERT(this->getBuffAddr());
+        memcpy(this->getBuffAddr(), src, length);
+        this->m_serLoc = length;
+        this->m_deserLoc = 0;
+        return FW_SERIALIZE_OK;
+    }
+}
+
+SerializeStatus SerializeBufferBase::setBuffLen(Serializable::SizeType length) {
+    if (this->getBuffCapacity() < length) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
+    } else {
+        this->m_serLoc = length;
+        this->m_deserLoc = 0;
+        return FW_SERIALIZE_OK;
+    }
+}
+
+Serializable::SizeType SerializeBufferBase::getBuffLeft() const {
+    return this->m_serLoc - this->m_deserLoc;
+}
+
+SerializeStatus SerializeBufferBase::copyRaw(SerializeBufferBase& dest, Serializable::SizeType size) {
+    // make sure there is sufficient size in destination
+    if (dest.getBuffCapacity() < size) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    // otherwise, set destination buffer to data from deserialization pointer plus size
+    SerializeStatus stat = dest.setBuff(&this->getBuffAddr()[this->m_deserLoc], size);
+    if (stat == FW_SERIALIZE_OK) {
+        this->m_deserLoc += size;
+    }
+    return stat;
+}
+
+SerializeStatus SerializeBufferBase::copyRawOffset(SerializeBufferBase& dest, Serializable::SizeType size) {
+    // make sure there is sufficient size in destination
+    if (dest.getBuffCapacity() < size + dest.getBuffLength()) {
+        return FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    // make sure there is sufficient buffer in source
+    if (this->getBuffLeft() < size) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+
+    // otherwise, serialize bytes to destination without writing length
+    SerializeStatus stat = dest.serialize(&this->getBuffAddr()[this->m_deserLoc], size, true);
+    if (stat == FW_SERIALIZE_OK) {
+        this->m_deserLoc += size;
+    }
+    return stat;
+}
+
+// return address of buffer not yet deserialized. This is used
+// to copy the remainder of a buffer.
+const U8* SerializeBufferBase::getBuffAddrLeft() const {
+    return &this->getBuffAddr()[this->m_deserLoc];
+}
+
+//!< gets address of end of serialization. Used to manually place data at the end
+U8* SerializeBufferBase::getBuffAddrSer() {
+    return &this->getBuffAddr()[this->m_serLoc];
+}
+
+#ifdef BUILD_UT
+bool SerializeBufferBase::operator==(const SerializeBufferBase& other) const {
+    if (this->getBuffLength() != other.getBuffLength()) {
+        return false;
+    }
+
+    const U8* us = this->getBuffAddr();
+    const U8* them = other.getBuffAddr();
+
+    FW_ASSERT(us);
+    FW_ASSERT(them);
+
+    for (Serializable::SizeType byte = 0; byte < this->getBuffLength(); byte++) {
+        if (us[byte] != them[byte]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::ostream& operator<<(std::ostream& os, const SerializeBufferBase& buff) {
+    const U8* us = buff.getBuffAddr();
+
+    FW_ASSERT(us);
+
+    for (Serializable::SizeType byte = 0; byte < buff.getBuffLength(); byte++) {
+        os << "[" << std::setw(2) << std::hex << std::setfill('0') << us[byte] << "]" << std::dec;
+    }
+
+    return os;
+}
+#endif
+
+ExternalSerializeBuffer::ExternalSerializeBuffer(U8* buffPtr, Serializable::SizeType size) {
+    this->setExtBuffer(buffPtr, size);
+}
+
+ExternalSerializeBuffer::ExternalSerializeBuffer() {
+    this->clear();
+}
+
+void ExternalSerializeBuffer::setExtBuffer(U8* buffPtr, Serializable::SizeType size) {
+    FW_ASSERT(buffPtr != nullptr);
+    this->m_buff = buffPtr;
+    this->m_buffSize = size;
+}
+
+void ExternalSerializeBuffer::clear() {
+    this->m_buff = nullptr;
+    this->m_buffSize = 0;
+}
+
+Serializable::SizeType ExternalSerializeBuffer::getBuffCapacity() const {
+    return this->m_buffSize;
+}
+
+U8* ExternalSerializeBuffer::getBuffAddr() {
+    return this->m_buff;
+}
+
+const U8* ExternalSerializeBuffer::getBuffAddr() const {
+    return this->m_buff;
+}
+
+}  // namespace Fw

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -10,215 +10,220 @@
 
 namespace Fw {
 
-    class StringBase; //!< forward declaration for string
-    typedef enum {
-        FW_SERIALIZE_OK, //!< Serialization/Deserialization operation was successful
-        FW_SERIALIZE_FORMAT_ERROR, //!< Data was the wrong format (e.g. wrong packet type)
-        FW_SERIALIZE_NO_ROOM_LEFT,  //!< No room left in the buffer to serialize data
-        FW_DESERIALIZE_BUFFER_EMPTY, //!< Deserialization buffer was empty when trying to read more data
-        FW_DESERIALIZE_FORMAT_ERROR, //!< Deserialization data had incorrect values (unexpected data types)
-        FW_DESERIALIZE_SIZE_MISMATCH, //!< Data was left in the buffer, but not enough to deserialize
-        FW_DESERIALIZE_TYPE_MISMATCH //!< Deserialized type ID didn't match
-    } SerializeStatus;
-    class SerializeBufferBase; //!< forward declaration
+class StringBase;  //!< forward declaration for string
+typedef enum {
+    FW_SERIALIZE_OK,               //!< Serialization/Deserialization operation was successful
+    FW_SERIALIZE_FORMAT_ERROR,     //!< Data was the wrong format (e.g. wrong packet type)
+    FW_SERIALIZE_NO_ROOM_LEFT,     //!< No room left in the buffer to serialize data
+    FW_DESERIALIZE_BUFFER_EMPTY,   //!< Deserialization buffer was empty when trying to read more data
+    FW_DESERIALIZE_FORMAT_ERROR,   //!< Deserialization data had incorrect values (unexpected data types)
+    FW_DESERIALIZE_SIZE_MISMATCH,  //!< Data was left in the buffer, but not enough to deserialize
+    FW_DESERIALIZE_TYPE_MISMATCH   //!< Deserialized type ID didn't match
+} SerializeStatus;
+class SerializeBufferBase;  //!< forward declaration
 
-    class Serializable {
-        public:
-            // Size type for backwards compatibility
-            using SizeType = NATIVE_UINT_TYPE;
-        public:
-            virtual SerializeStatus serialize(SerializeBufferBase& buffer) const = 0; //!< serialize contents
-            virtual SerializeStatus deserialize(SerializeBufferBase& buffer) = 0; //!< deserialize to contents
+class Serializable {
+  public:
+    // Size type for backwards compatibility
+    using SizeType = NATIVE_UINT_TYPE;
+
+  public:
+    virtual SerializeStatus serialize(SerializeBufferBase& buffer) const = 0;  //!< serialize contents
+    virtual SerializeStatus deserialize(SerializeBufferBase& buffer) = 0;      //!< deserialize to contents
 #if FW_SERIALIZABLE_TO_STRING || FW_ENABLE_TEXT_LOGGING || BUILD_UT
-            virtual void toString(StringBase& text) const; //!< generate text from serializable
+    virtual void toString(StringBase& text) const;  //!< generate text from serializable
 #endif
 
 #ifdef BUILD_UT
-            friend std::ostream& operator<<(std::ostream& os, const Serializable& val);
+    friend std::ostream& operator<<(std::ostream& os, const Serializable& val);
 #endif
 
-        protected:
-            Serializable(); //!< Default constructor
-            virtual ~Serializable(); //!< destructor
+  protected:
+    Serializable();           //!< Default constructor
+    virtual ~Serializable();  //!< destructor
+};
+
+class Serialization {
+  public:
+    enum t {
+        INCLUDE_LENGTH,  //!< Include length as first token in serialization
+        OMIT_LENGTH      //!< Omit length from serialization
     };
+};
 
-    class Serialization {
-      public:
-        enum t {
-            INCLUDE_LENGTH, //!< Include length as first token in serialization
-            OMIT_LENGTH //!< Omit length from serialization
-        };
-    };
+class SerializeBufferBase {
+  public:
+    SerializeBufferBase& operator=(const SerializeBufferBase& src);  //!< equal operator
 
-    class SerializeBufferBase {
-        public:
+    virtual ~SerializeBufferBase();  //!< destructor
 
-            SerializeBufferBase& operator=(const SerializeBufferBase &src); //!< equal operator
+    // Serialization for built-in types
 
-            virtual ~SerializeBufferBase(); //!< destructor
+    SerializeStatus serialize(U8 val);  //!< serialize 8-bit unsigned int
+    SerializeStatus serialize(I8 val);  //!< serialize 8-bit signed int
 
-            // Serialization for built-in types
-
-            SerializeStatus serialize(U8 val); //!< serialize 8-bit unsigned int
-            SerializeStatus serialize(I8 val); //!< serialize 8-bit signed int
-
-#if FW_HAS_16_BIT==1
-            SerializeStatus serialize(U16 val); //!< serialize 16-bit unsigned int
-            SerializeStatus serialize(I16 val); //!< serialize 16-bit signed int
+#if FW_HAS_16_BIT == 1
+    SerializeStatus serialize(U16 val);  //!< serialize 16-bit unsigned int
+    SerializeStatus serialize(I16 val);  //!< serialize 16-bit signed int
 #endif
-#if FW_HAS_32_BIT==1
-            SerializeStatus serialize(U32 val); //!< serialize 32-bit unsigned int
-            SerializeStatus serialize(I32 val); //!< serialize 32-bit signed int
+#if FW_HAS_32_BIT == 1
+    SerializeStatus serialize(U32 val);  //!< serialize 32-bit unsigned int
+    SerializeStatus serialize(I32 val);  //!< serialize 32-bit signed int
 #endif
-#if FW_HAS_64_BIT==1
-            SerializeStatus serialize(U64 val); //!< serialize 64-bit unsigned int
-            SerializeStatus serialize(I64 val); //!< serialize 64-bit signed int
+#if FW_HAS_64_BIT == 1
+    SerializeStatus serialize(U64 val);  //!< serialize 64-bit unsigned int
+    SerializeStatus serialize(I64 val);  //!< serialize 64-bit signed int
 #endif
-            SerializeStatus serialize(F32 val); //!< serialize 32-bit floating point
+    SerializeStatus serialize(F32 val);  //!< serialize 32-bit floating point
 #if FW_HAS_F64
-            SerializeStatus serialize(F64 val); //!< serialize 64-bit floating point
+    SerializeStatus serialize(F64 val);  //!< serialize 64-bit floating point
 #endif
-            SerializeStatus serialize(bool val); //!< serialize boolean
+    SerializeStatus serialize(bool val);  //!< serialize boolean
 
-            SerializeStatus serialize(const void* val); //!< serialize pointer (careful, only pointer value, not contents are serialized)
+    SerializeStatus serialize(
+        const void* val);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
 
-            //! serialize data buffer
-            SerializeStatus serialize(const U8* buff, NATIVE_UINT_TYPE length, bool noLength);
-            //! serialize data buffer
-            SerializeStatus serialize(const U8* buff, NATIVE_UINT_TYPE length);
+    //! serialize data buffer
+    SerializeStatus serialize(const U8* buff, NATIVE_UINT_TYPE length, bool noLength);
+    //! serialize data buffer
+    SerializeStatus serialize(const U8* buff, NATIVE_UINT_TYPE length);
 
-            //! \brief serialize a byte buffer of a given length
-            //!
-            //! Serialize bytes from `buff` up to `length`.  If `serializationMode` is set to `INCLUDE_LENGTH` then the
-            //! length is included as the first token. Length may be omitted with `OMIT_LENGTH`.
-            //!
-            //! \param buff: buffer to serialize
-            //! \param length: length of data to serialize
-            //! \param mode: serialization type
-            //! \return status of serialization
-            SerializeStatus serialize(const U8* buff, FwSizeType length, Serialization::t mode);
+    //! \brief serialize a byte buffer of a given length
+    //!
+    //! Serialize bytes from `buff` up to `length`.  If `serializationMode` is set to `INCLUDE_LENGTH` then the
+    //! length is included as the first token. Length may be omitted with `OMIT_LENGTH`.
+    //!
+    //! \param buff: buffer to serialize
+    //! \param length: length of data to serialize
+    //! \param mode: serialization type
+    //! \return status of serialization
+    SerializeStatus serialize(const U8* buff, FwSizeType length, Serialization::t mode);
 
-            SerializeStatus serialize(const SerializeBufferBase& val); //!< serialize a serialized buffer
+    SerializeStatus serialize(const SerializeBufferBase& val);  //!< serialize a serialized buffer
 
-            SerializeStatus serialize(const Serializable &val); //!< serialize an object derived from serializable base class
+    SerializeStatus serialize(const Serializable& val);  //!< serialize an object derived from serializable base class
 
-            SerializeStatus serializeSize(const FwSizeType size); //!< serialize a size value
+    SerializeStatus serializeSize(const FwSizeType size);  //!< serialize a size value
 
-            // Deserialization for built-in types
+    // Deserialization for built-in types
 
-            SerializeStatus deserialize(U8 &val); //!< deserialize 8-bit unsigned int
-            SerializeStatus deserialize(I8 &val); //!< deserialize 8-bit signed int
+    SerializeStatus deserialize(U8& val);  //!< deserialize 8-bit unsigned int
+    SerializeStatus deserialize(I8& val);  //!< deserialize 8-bit signed int
 
-#if FW_HAS_16_BIT==1
-            SerializeStatus deserialize(U16 &val); //!< deserialize 16-bit unsigned int
-            SerializeStatus deserialize(I16 &val); //!< deserialize 16-bit signed int
+#if FW_HAS_16_BIT == 1
+    SerializeStatus deserialize(U16& val);  //!< deserialize 16-bit unsigned int
+    SerializeStatus deserialize(I16& val);  //!< deserialize 16-bit signed int
 #endif
 
-#if FW_HAS_32_BIT==1
-            SerializeStatus deserialize(U32 &val); //!< deserialize 32-bit unsigned int
-            SerializeStatus deserialize(I32 &val); //!< deserialize 32-bit signed int
+#if FW_HAS_32_BIT == 1
+    SerializeStatus deserialize(U32& val);  //!< deserialize 32-bit unsigned int
+    SerializeStatus deserialize(I32& val);  //!< deserialize 32-bit signed int
 #endif
-#if FW_HAS_64_BIT==1
-            SerializeStatus deserialize(U64 &val); //!< deserialize 64-bit unsigned int
-            SerializeStatus deserialize(I64 &val); //!< deserialize 64-bit signed int
+#if FW_HAS_64_BIT == 1
+    SerializeStatus deserialize(U64& val);  //!< deserialize 64-bit unsigned int
+    SerializeStatus deserialize(I64& val);  //!< deserialize 64-bit signed int
 #endif
-            SerializeStatus deserialize(F32 &val); //!< deserialize 32-bit floating point
+    SerializeStatus deserialize(F32& val);  //!< deserialize 32-bit floating point
 #if FW_HAS_F64
-            SerializeStatus deserialize(F64 &val); //!< deserialize 64-bit floating point
+    SerializeStatus deserialize(F64& val);  //!< deserialize 64-bit floating point
 #endif
-            SerializeStatus deserialize(bool &val); //!< deserialize boolean
+    SerializeStatus deserialize(bool& val);  //!< deserialize boolean
 
-            SerializeStatus deserialize(void*& val); //!< deserialize point value (careful, pointer value only, not contents)
+    SerializeStatus deserialize(void*& val);  //!< deserialize point value (careful, pointer value only, not contents)
 
-            //! deserialize data buffer
-            SerializeStatus deserialize(U8* buff, NATIVE_UINT_TYPE& length, bool noLength);
+    //! deserialize data buffer
+    SerializeStatus deserialize(U8* buff, NATIVE_UINT_TYPE& length, bool noLength);
 
-            //! deserialize data buffer
-            SerializeStatus deserialize(U8* buff, NATIVE_UINT_TYPE& length);
-            //! \brief deserialize a byte buffer of a given length
-            //!
-            //! Deserialize bytes into `buff` of `length` bytes.  If `serializationMode` is set to `INCLUDE_LENGTH` then
-            //! the length is deserialized first followed by the bytes. Length may be omitted with `OMIT_LENGTH` and
-            //! in this case `length` bytes will be deserialized. `length` will be filled with the amount of data
-            //! deserialized.
-            //!
-            //! \param buff: buffer to hold deserialized data
-            //! \param length: length of data to deserialize length is filled with deserialized length
-            //! \param mode: deserialization type
-            //! \return status of serialization
-            SerializeStatus deserialize(U8* buff, FwSizeType& length, Serialization::t mode);
+    //! deserialize data buffer
+    SerializeStatus deserialize(U8* buff, NATIVE_UINT_TYPE& length);
+    //! \brief deserialize a byte buffer of a given length
+    //!
+    //! Deserialize bytes into `buff` of `length` bytes.  If `serializationMode` is set to `INCLUDE_LENGTH` then
+    //! the length is deserialized first followed by the bytes. Length may be omitted with `OMIT_LENGTH` and
+    //! in this case `length` bytes will be deserialized. `length` will be filled with the amount of data
+    //! deserialized.
+    //!
+    //! \param buff: buffer to hold deserialized data
+    //! \param length: length of data to deserialize length is filled with deserialized length
+    //! \param mode: deserialization type
+    //! \return status of serialization
+    SerializeStatus deserialize(U8* buff, FwSizeType& length, Serialization::t mode);
 
-            SerializeStatus deserialize(Serializable &val);  //!< deserialize an object derived from serializable base class
+    SerializeStatus deserialize(Serializable& val);  //!< deserialize an object derived from serializable base class
 
-            SerializeStatus deserialize(SerializeBufferBase& val);  //!< serialize a serialized buffer
+    SerializeStatus deserialize(SerializeBufferBase& val);  //!< serialize a serialized buffer
 
-            SerializeStatus deserializeSize(FwSizeType& size); //!< deserialize a size value
+    SerializeStatus deserializeSize(FwSizeType& size);  //!< deserialize a size value
 
-            void resetSer(); //!< reset to beginning of buffer to reuse for serialization
-            void resetDeser(); //!< reset deserialization to beginning
+    void resetSer();    //!< reset to beginning of buffer to reuse for serialization
+    void resetDeser();  //!< reset deserialization to beginning
 
-            SerializeStatus moveSerToOffset(FwSizeType offset); //!< Moves serialization to the specified offset
-            SerializeStatus moveDeserToOffset(FwSizeType offset); //!< Moves deserialization to the specified offset
+    SerializeStatus moveSerToOffset(FwSizeType offset);    //!< Moves serialization to the specified offset
+    SerializeStatus moveDeserToOffset(FwSizeType offset);  //!< Moves deserialization to the specified offset
 
-            SerializeStatus serializeSkip(FwSizeType numBytesToSkip); //!< Skips the number of specified bytes for serialization
-            SerializeStatus deserializeSkip(FwSizeType numBytesToSkip); //!< Skips the number of specified bytes for deserialization
-            virtual Serializable::SizeType getBuffCapacity() const = 0; //!< returns capacity, not current size, of buffer
-            Serializable::SizeType getBuffLength() const; //!< returns current buffer size
-            Serializable::SizeType getBuffLeft() const; //!< returns how much deserialization buffer is left
-            virtual U8* getBuffAddr() = 0; //!< gets buffer address for data filling
-            virtual const U8* getBuffAddr() const = 0; //!< gets buffer address for data reading, const version
-            const U8* getBuffAddrLeft() const; //!< gets address of remaining non-deserialized data.
-            U8* getBuffAddrSer(); //!< gets address of end of serialization. DANGEROUS! Need to know max buffer size and adjust when done
-            SerializeStatus setBuff(const U8* src, Serializable::SizeType length); //!< sets buffer contents and size
-            SerializeStatus setBuffLen(Serializable::SizeType length); //!< sets buffer length manually after filling with data
-            SerializeStatus copyRaw(SerializeBufferBase& dest, Serializable::SizeType size); //!< directly copies buffer without looking for a size in the stream.
-                                                                                      // Will increment deserialization pointer
-            SerializeStatus copyRawOffset(SerializeBufferBase& dest, Serializable::SizeType size); //!< directly copies buffer without looking for a size in the stream.
-                                                                                    // Will increment deserialization pointer
-
+    SerializeStatus serializeSkip(
+        FwSizeType numBytesToSkip);  //!< Skips the number of specified bytes for serialization
+    SerializeStatus deserializeSkip(
+        FwSizeType numBytesToSkip);  //!< Skips the number of specified bytes for deserialization
+    virtual Serializable::SizeType getBuffCapacity() const = 0;  //!< returns capacity, not current size, of buffer
+    Serializable::SizeType getBuffLength() const;                //!< returns current buffer size
+    Serializable::SizeType getBuffLeft() const;                  //!< returns how much deserialization buffer is left
+    virtual U8* getBuffAddr() = 0;                               //!< gets buffer address for data filling
+    virtual const U8* getBuffAddr() const = 0;  //!< gets buffer address for data reading, const version
+    const U8* getBuffAddrLeft() const;          //!< gets address of remaining non-deserialized data.
+    U8* getBuffAddrSer();  //!< gets address of end of serialization. DANGEROUS! Need to know max buffer size and adjust
+                           //!< when done
+    SerializeStatus setBuff(const U8* src, Serializable::SizeType length);  //!< sets buffer contents and size
+    SerializeStatus setBuffLen(Serializable::SizeType length);  //!< sets buffer length manually after filling with data
+    SerializeStatus copyRaw(
+        SerializeBufferBase& dest,
+        Serializable::SizeType size);  //!< directly copies buffer without looking for a size in the stream.
+                                       // Will increment deserialization pointer
+    SerializeStatus copyRawOffset(
+        SerializeBufferBase& dest,
+        Serializable::SizeType size);  //!< directly copies buffer without looking for a size in the stream.
+                                       // Will increment deserialization pointer
 
 #ifdef BUILD_UT
-            bool operator==(const SerializeBufferBase& other) const;
-            friend std::ostream& operator<<(std::ostream& os, const SerializeBufferBase& buff);
+    bool operator==(const SerializeBufferBase& other) const;
+    friend std::ostream& operator<<(std::ostream& os, const SerializeBufferBase& buff);
 #endif
-        PROTECTED:
+  PROTECTED:
+    SerializeBufferBase();  //!< default constructor
 
-            SerializeBufferBase(); //!< default constructor
+  PRIVATE:
+    // A no-implementation copy constructor here will prevent the default copy constructor from being called
+    // accidentally, and without an implementation it will create an error for the developer instead.
+    SerializeBufferBase(const SerializeBufferBase& src);  //!< constructor with buffer as source
 
-        PRIVATE:
-            // A no-implementation copy constructor here will prevent the default copy constructor from being called
-            // accidentally, and without an implementation it will create an error for the developer instead.
-            SerializeBufferBase(const SerializeBufferBase &src); //!< constructor with buffer as source
+    void copyFrom(const SerializeBufferBase& src);  //!< copy data from source buffer
+    Serializable::SizeType m_serLoc;                //!< current offset in buffer of serialized data
+    Serializable::SizeType m_deserLoc;              //!< current offset for deserialization
+};
 
-            void copyFrom(const SerializeBufferBase& src); //!< copy data from source buffer
-            Serializable::SizeType m_serLoc; //!< current offset in buffer of serialized data
-            Serializable::SizeType m_deserLoc; //!< current offset for deserialization
-    };
+// Helper class for building buffers with external storage
 
-    // Helper class for building buffers with external storage
+class ExternalSerializeBuffer : public SerializeBufferBase {
+  public:
+    ExternalSerializeBuffer(U8* buffPtr, Serializable::SizeType size);  //!< construct with external buffer
+    ExternalSerializeBuffer();                                          //!< default constructor
+    void setExtBuffer(U8* buffPtr, Serializable::SizeType size);        //!< Set the external buffer
+    void clear();                                                       //!< clear external buffer
 
-    class ExternalSerializeBuffer : public SerializeBufferBase {
-        public:
-            ExternalSerializeBuffer(U8* buffPtr, Serializable::SizeType size); //!< construct with external buffer
-            ExternalSerializeBuffer(); //!< default constructor
-            void setExtBuffer(U8* buffPtr, Serializable::SizeType size); //!< Set the external buffer
-            void clear(); //!< clear external buffer
+    // pure virtual functions
+    Serializable::SizeType getBuffCapacity() const;
+    U8* getBuffAddr();
+    const U8* getBuffAddr() const;
 
-            // pure virtual functions
-            Serializable::SizeType getBuffCapacity() const;
-            U8* getBuffAddr();
-            const U8* getBuffAddr() const ;
+  PRIVATE:
+    // no copying
+    ExternalSerializeBuffer(ExternalSerializeBuffer& other);
+    ExternalSerializeBuffer(ExternalSerializeBuffer* other);
 
-        PRIVATE:
+    // private data
+    U8* m_buff;                         //!< pointer to external buffer
+    Serializable::SizeType m_buffSize;  //!< size of external buffer
+};
 
-            // no copying
-            ExternalSerializeBuffer(ExternalSerializeBuffer& other);
-            ExternalSerializeBuffer(ExternalSerializeBuffer* other);
-
-            // private data
-            U8* m_buff; //!< pointer to external buffer
-            Serializable::SizeType m_buffSize; //!< size of external buffer
-    };
-
-}
+}  // namespace Fw
 #endif

--- a/Fw/Types/String.cpp
+++ b/Fw/Types/String.cpp
@@ -3,53 +3,52 @@
 
 namespace Fw {
 
-    String::String(const char* src) : StringBase() {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
-    }
-
-    String::String(const StringBase& src) : StringBase() {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-    }
-
-    String::String(const String& src) : StringBase() {
-        (void) Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-    }
-
-    String::String() : StringBase() {
-        this->m_buf[0] = 0;
-    }
-
-    String& String::operator=(const String& other) {
-        if(this == &other) {
-            return *this;
-        }
-
-        (void) Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-        return *this;
-    }
-
-    String& String::operator=(const StringBase& other) {
-        if(this == &other) {
-            return *this;
-        }
-
-        (void) Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-        return *this;
-    }
-
-    String& String::operator=(const char* other) {
-        (void) Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
-        return *this;
-    }
-
-    String::~String() {
-    }
-
-    const char* String::toChar() const {
-        return this->m_buf;
-    }
-
-    NATIVE_UINT_TYPE String::getCapacity() const {
-        return STRING_SIZE;
-    }
+String::String(const char* src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
 }
+
+String::String(const StringBase& src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+}
+
+String::String(const String& src) : StringBase() {
+    (void)Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+}
+
+String::String() : StringBase() {
+    this->m_buf[0] = 0;
+}
+
+String& String::operator=(const String& other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    (void)Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+    return *this;
+}
+
+String& String::operator=(const StringBase& other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    (void)Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
+    return *this;
+}
+
+String& String::operator=(const char* other) {
+    (void)Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+    return *this;
+}
+
+String::~String() {}
+
+const char* String::toChar() const {
+    return this->m_buf;
+}
+
+NATIVE_UINT_TYPE String::getCapacity() const {
+    return STRING_SIZE;
+}
+}  // namespace Fw

--- a/Fw/Types/String.hpp
+++ b/Fw/Types/String.hpp
@@ -2,36 +2,34 @@
 #define FW_FIXED_LENGTH_STRING_TYPE_HPP
 
 #include <FpConfig.hpp>
-#include <Fw/Types/StringType.hpp>
 #include <Fw/Cfg/SerIds.hpp>
+#include <Fw/Types/StringType.hpp>
 
 namespace Fw {
 
-    class String : public Fw::StringBase {
-        public:
-
-            enum {
-                SERIALIZED_TYPE_ID = FW_TYPEID_FIXED_LENGTH_STRING, //!< typeid for string type
-                STRING_SIZE = FW_FIXED_LENGTH_STRING_SIZE, //!< Storage for string
-                SERIALIZED_SIZE = STRING_SIZE + sizeof(FwBuffSizeType) //!< Serialized size is size of buffer + size field
-            };
-
-            String(const char* src); //!< char* source constructor
-            String(const StringBase& src); //!< other string constructor
-            String(const String& src); //!< String string constructor
-            String(); //!< default constructor
-            String& operator=(const String& other); //!< assignment operator
-            String& operator=(const StringBase& other); //!< other string assignment operator
-            String& operator=(const char* other); //!< char* assignment operator
-            ~String(); //!< destructor
-
-            const char* toChar() const; //!< gets char buffer
-            NATIVE_UINT_TYPE getCapacity() const ; //!< return buffer size
-
-        private:
-
-            char m_buf[STRING_SIZE]; //!< storage for string data
+class String : public Fw::StringBase {
+  public:
+    enum {
+        SERIALIZED_TYPE_ID = FW_TYPEID_FIXED_LENGTH_STRING,     //!< typeid for string type
+        STRING_SIZE = FW_FIXED_LENGTH_STRING_SIZE,              //!< Storage for string
+        SERIALIZED_SIZE = STRING_SIZE + sizeof(FwBuffSizeType)  //!< Serialized size is size of buffer + size field
     };
-}
+
+    String(const char* src);                     //!< char* source constructor
+    String(const StringBase& src);               //!< other string constructor
+    String(const String& src);                   //!< String string constructor
+    String();                                    //!< default constructor
+    String& operator=(const String& other);      //!< assignment operator
+    String& operator=(const StringBase& other);  //!< other string assignment operator
+    String& operator=(const char* other);        //!< char* assignment operator
+    ~String();                                   //!< destructor
+
+    const char* toChar() const;            //!< gets char buffer
+    NATIVE_UINT_TYPE getCapacity() const;  //!< return buffer size
+
+  private:
+    char m_buf[STRING_SIZE];  //!< storage for string data
+};
+}  // namespace Fw
 
 #endif

--- a/Fw/Types/StringType.cpp
+++ b/Fw/Types/StringType.cpp
@@ -10,135 +10,130 @@
  *
  */
 
-#include <Fw/Types/StringType.hpp>
 #include <Fw/Types/Assert.hpp>
+#include <Fw/Types/StringType.hpp>
 #include <Fw/Types/StringUtils.hpp>
-#include <cstring>
-#include <cstdio>
 #include <cstdarg>
+#include <cstdio>
+#include <cstring>
 
 namespace Fw {
 
-    StringBase::StringBase() {
+StringBase::StringBase() {}
+
+StringBase::~StringBase() {}
+
+const CHAR* StringBase::operator+=(const CHAR* src) {
+    this->appendBuff(src, StringUtils::string_length(src, this->getCapacity()));
+    return this->toChar();
+}
+
+const StringBase& StringBase::operator+=(const StringBase& src) {
+    this->appendBuff(src.toChar(), src.length());
+    return *this;
+}
+
+bool StringBase::operator==(const StringBase& other) const {
+    SizeType len = this->length();
+    if (len != other.length()) {
+        return false;
+    } else {
+        return this->operator==(other.toChar());
+    }
+}
+
+bool StringBase::operator==(const CHAR* other) const {
+    const CHAR* const us = this->toChar();
+    if ((us == nullptr) or (other == nullptr)) {
+        return false;
     }
 
-    StringBase::~StringBase() {
-    }
+    const SizeType capacity = this->getCapacity();
+    const size_t result = strncmp(us, other, capacity);
+    return (result == 0);
+}
 
-    const CHAR* StringBase::operator+=(const CHAR* src) {
-        this->appendBuff(src, StringUtils::string_length(src, this->getCapacity()));
-        return this->toChar();
-    }
+void StringBase::format(const CHAR* formatString, ...) {
+    CHAR* us = const_cast<CHAR*>(this->toChar());
+    SizeType cap = this->getCapacity();
+    FW_ASSERT(us);
+    va_list args;
+    va_start(args, formatString);
+    (void)vsnprintf(us, cap, formatString, args);
+    va_end(args);
+    // null terminate
+    us[cap - 1] = 0;
+}
 
-    const StringBase& StringBase::operator+=(const StringBase& src) {
-        this->appendBuff(src.toChar(), src.length());
-        return *this;
-    }
+bool StringBase::operator!=(const StringBase& other) const {
+    return !operator==(other);
+}
 
-    bool StringBase::operator==(const StringBase& other) const {
-        SizeType len = this->length();
-        if (len != other.length()) {
-            return false;
-        } else {
-            return this->operator==(other.toChar());
-        }
-    }
-
-    bool StringBase::operator==(const CHAR* other) const {
-
-        const CHAR *const us = this->toChar();
-        if ((us == nullptr) or (other == nullptr)) {
-            return false;
-        }
-
-        const SizeType capacity = this->getCapacity();
-        const size_t result = strncmp(us, other, capacity);
-        return (result == 0);
-
-    }
-
-    void StringBase::format(const CHAR* formatString, ...) {
-        CHAR* us = const_cast<CHAR*>(this->toChar());
-        SizeType cap = this->getCapacity();
-        FW_ASSERT(us);
-        va_list args;
-        va_start(args, formatString);
-        (void) vsnprintf(us, cap, formatString, args);
-        va_end(args);
-        // null terminate
-        us[cap - 1] = 0;
-    }
-
-    bool StringBase::operator!=(const StringBase& other) const {
-        return !operator==(other);
-    }
-
-    bool StringBase::operator!=(const CHAR* other) const {
-        return !operator==(other);
-    }
+bool StringBase::operator!=(const CHAR* other) const {
+    return !operator==(other);
+}
 
 #if FW_SERIALIZABLE_TO_STRING || BUILD_UT
-    void StringBase::toString(StringBase& text) const {
-        text = *this;
-    }
+void StringBase::toString(StringBase& text) const {
+    text = *this;
+}
 #endif
 
 #ifdef BUILD_UT
-    std::ostream& operator<<(std::ostream& os, const StringBase& str)
-    {
-        os << str.toChar();
-        return os;
-    }
+std::ostream& operator<<(std::ostream& os, const StringBase& str) {
+    os << str.toChar();
+    return os;
+}
 #endif
 
-    StringBase& StringBase::operator=(const StringBase& other) {
-        if(this == &other) {
-            return *this;
-        }
-
-        (void) Fw::StringUtils::string_copy(const_cast<char *>(this->toChar()), other.toChar(), this->getCapacity());
+StringBase& StringBase::operator=(const StringBase& other) {
+    if (this == &other) {
         return *this;
     }
 
-    // Copy constructor doesn't make sense in this virtual class as there is nothing to copy. Derived classes should
-    // call the empty constructor and then call their own copy function
-    StringBase& StringBase::operator=(const CHAR* other) { // lgtm[cpp/rule-of-two]
-        (void) Fw::StringUtils::string_copy(const_cast<char *>(this->toChar()), other, this->getCapacity());
-        return *this;
-    }
-
-    void StringBase::appendBuff(const CHAR* buff, SizeType size) {
-        const SizeType capacity = this->getCapacity();
-        const SizeType length = this->length();
-        FW_ASSERT(capacity > length, capacity, length);
-        // Subtract 1 to leave space for null terminator
-        SizeType remaining = capacity - length - 1;
-        if(size < remaining) {
-            remaining = size;
-        }
-        FW_ASSERT(remaining < capacity, remaining, capacity);
-        (void) strncat(const_cast<CHAR*>(this->toChar()), buff, remaining);
-    }
-
-    StringBase::SizeType StringBase::length() const {
-        return static_cast<SizeType>(StringUtils::string_length(this->toChar(),this->getCapacity()));
-    }
-
-    SerializeStatus StringBase::serialize(SerializeBufferBase& buffer) const {
-        return buffer.serialize(reinterpret_cast<const U8*>(this->toChar()),this->length());
-    }
-
-    SerializeStatus StringBase::serialize(SerializeBufferBase& buffer, SizeType maxLength) const {
-        SizeType len = FW_MIN(maxLength,this->length());
-        return buffer.serialize(reinterpret_cast<const U8*>(this->toChar()), len);
-    }
-
-    SerializeStatus StringBase::deserialize(SerializeBufferBase& buffer) {
-        SizeType maxSize = this->getCapacity() - 1;
-        CHAR* raw = const_cast<CHAR*>(this->toChar());
-        SerializeStatus stat = buffer.deserialize(reinterpret_cast<U8*>(raw),maxSize);
-        // Null terminate deserialized string
-        raw[maxSize] = 0;
-        return stat;
-    }
+    (void)Fw::StringUtils::string_copy(const_cast<char*>(this->toChar()), other.toChar(), this->getCapacity());
+    return *this;
 }
+
+// Copy constructor doesn't make sense in this virtual class as there is nothing to copy. Derived classes should
+// call the empty constructor and then call their own copy function
+StringBase& StringBase::operator=(const CHAR* other) {  // lgtm[cpp/rule-of-two]
+    (void)Fw::StringUtils::string_copy(const_cast<char*>(this->toChar()), other, this->getCapacity());
+    return *this;
+}
+
+void StringBase::appendBuff(const CHAR* buff, SizeType size) {
+    const SizeType capacity = this->getCapacity();
+    const SizeType length = this->length();
+    FW_ASSERT(capacity > length, capacity, length);
+    // Subtract 1 to leave space for null terminator
+    SizeType remaining = capacity - length - 1;
+    if (size < remaining) {
+        remaining = size;
+    }
+    FW_ASSERT(remaining < capacity, remaining, capacity);
+    (void)strncat(const_cast<CHAR*>(this->toChar()), buff, remaining);
+}
+
+StringBase::SizeType StringBase::length() const {
+    return static_cast<SizeType>(StringUtils::string_length(this->toChar(), this->getCapacity()));
+}
+
+SerializeStatus StringBase::serialize(SerializeBufferBase& buffer) const {
+    return buffer.serialize(reinterpret_cast<const U8*>(this->toChar()), this->length());
+}
+
+SerializeStatus StringBase::serialize(SerializeBufferBase& buffer, SizeType maxLength) const {
+    SizeType len = FW_MIN(maxLength, this->length());
+    return buffer.serialize(reinterpret_cast<const U8*>(this->toChar()), len);
+}
+
+SerializeStatus StringBase::deserialize(SerializeBufferBase& buffer) {
+    SizeType maxSize = this->getCapacity() - 1;
+    CHAR* raw = const_cast<CHAR*>(this->toChar());
+    SerializeStatus stat = buffer.deserialize(reinterpret_cast<U8*>(raw), maxSize);
+    // Null terminate deserialized string
+    raw[maxSize] = 0;
+    return stat;
+}
+}  // namespace Fw

--- a/Fw/Types/StringType.hpp
+++ b/Fw/Types/StringType.hpp
@@ -20,48 +20,48 @@
 #endif
 
 namespace Fw {
-    class StringBase : public Serializable {
-        public:
-            using SizeType = NATIVE_UINT_TYPE;
-            virtual const CHAR* toChar() const = 0; //<! Convert to a C-style char*
-            virtual SizeType getCapacity() const = 0; //!< return size of buffer
-            SizeType length() const;  //!< Get length of string
+class StringBase : public Serializable {
+  public:
+    using SizeType = NATIVE_UINT_TYPE;
+    virtual const CHAR* toChar() const = 0;    //<! Convert to a C-style char*
+    virtual SizeType getCapacity() const = 0;  //!< return size of buffer
+    SizeType length() const;                   //!< Get length of string
 
-            const CHAR* operator+=(const CHAR* src); //!< Concatenate a CHAR*
-            const StringBase& operator+=(const StringBase& src); //!< Concatenate a StringBase
-            bool operator==(const StringBase& other) const; //!< Check for equality with StringBase
-            bool operator==(const CHAR* other) const; //!< Check for equality with CHAR*
-            bool operator!=(const StringBase& other) const; //!< Inequality with StringBase
-            bool operator!=(const CHAR* other) const; //!< Inequality with CHAR*
-            StringBase& operator=(const CHAR* src); //!< Assign CHAR*
-            StringBase& operator=(const StringBase& src); //!< Assign another StringBase
+    const CHAR* operator+=(const CHAR* src);              //!< Concatenate a CHAR*
+    const StringBase& operator+=(const StringBase& src);  //!< Concatenate a StringBase
+    bool operator==(const StringBase& other) const;       //!< Check for equality with StringBase
+    bool operator==(const CHAR* other) const;             //!< Check for equality with CHAR*
+    bool operator!=(const StringBase& other) const;       //!< Inequality with StringBase
+    bool operator!=(const CHAR* other) const;             //!< Inequality with CHAR*
+    StringBase& operator=(const CHAR* src);               //!< Assign CHAR*
+    StringBase& operator=(const StringBase& src);         //!< Assign another StringBase
 
-            void format(const CHAR* formatString, ...); //!< write formatted string to buffer
+    void format(const CHAR* formatString, ...);  //!< write formatted string to buffer
 
-            virtual SerializeStatus serialize(SerializeBufferBase& buffer) const; //!< serialization function
-            virtual SerializeStatus serialize(SerializeBufferBase& buffer, SizeType maxLen) const; //!< serialization function
-            virtual SerializeStatus deserialize(SerializeBufferBase& buffer); //!< deserialization function
+    virtual SerializeStatus serialize(SerializeBufferBase& buffer) const;                   //!< serialization function
+    virtual SerializeStatus serialize(SerializeBufferBase& buffer, SizeType maxLen) const;  //!< serialization function
+    virtual SerializeStatus deserialize(SerializeBufferBase& buffer);  //!< deserialization function
 
 #ifdef BUILD_UT
-            // to support GoogleTest framework in unit tests
-            friend std::ostream& operator<<(std::ostream& os, const StringBase& str);
+    // to support GoogleTest framework in unit tests
+    friend std::ostream& operator<<(std::ostream& os, const StringBase& str);
 #endif
 #if FW_SERIALIZABLE_TO_STRING || BUILD_UT
-            void toString(StringBase& text) const; //!< write string with contents
+    void toString(StringBase& text) const;  //!< write string with contents
 #endif
 
-        protected:
-            StringBase();
-            virtual ~StringBase();
+  protected:
+    StringBase();
+    virtual ~StringBase();
 
-            void appendBuff(const CHAR* buff, SizeType size);
+    void appendBuff(const CHAR* buff, SizeType size);
 
-        private:
-            // A no-implementation copy constructor here will prevent the default copy constructor from being called
-            // accidentally, and without an implementation it will create an error for the developer instead.
-            StringBase(const StringBase &src); //!< constructor with buffer as source
-    };
+  private:
+    // A no-implementation copy constructor here will prevent the default copy constructor from being called
+    // accidentally, and without an implementation it will create an error for the developer instead.
+    StringBase(const StringBase& src);  //!< constructor with buffer as source
+};
 
-}
+}  // namespace Fw
 
 #endif

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -1,10 +1,10 @@
-#include "StringUtils.hpp"
 #include <Fw/Types/Assert.hpp>
 #include <cstring>
+#include "StringUtils.hpp"
 
 char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 num) {
     // Handle self-copy and 0 bytes copy
-    if(destination == source || num == 0) {
+    if (destination == source || num == 0) {
         return destination;
     }
     FW_ASSERT(source != nullptr);

--- a/Fw/Types/StringUtils.hpp
+++ b/Fw/Types/StringUtils.hpp
@@ -32,6 +32,6 @@ char* string_copy(char* destination, const char* source, U32 num);
  */
 U32 string_length(const CHAR* source, U32 max_len);
 
-}       // namespace StringUtils
-}       // namespace Fw
+}  // namespace StringUtils
+}  // namespace Fw
 #endif  // FW_STRINGUTILS_HPP

--- a/Fw/Types/default/DefaultTypes.hpp
+++ b/Fw/Types/default/DefaultTypes.hpp
@@ -7,7 +7,7 @@
  */
 #include <limits>
 /**
-* Default implementation for deprecated (see note)
+ * Default implementation for deprecated (see note)
  */
 #ifndef PLATFORM_INT_TYPE_DEFINED
 typedef int PlatformIntType;
@@ -17,9 +17,8 @@ extern const PlatformIntType PlatformIntType_MAX;
 #define PRI_PlatformIntType "d"
 #endif
 
-
 /**
-* Default implementation for deprecated (see note)
+ * Default implementation for deprecated (see note)
  */
 #ifndef PLATFORM_UINT_TYPE_DEFINED
 typedef unsigned int PlatformUIntType;
@@ -30,8 +29,8 @@ extern const PlatformUIntType PlatformUIntType_MAX;
 #endif
 
 /**
-* Default implementation for ports indices
-*/
+ * Default implementation for ports indices
+ */
 #ifndef PLATFORM_INDEX_TYPE_DEFINED
 typedef PlatformIntType PlatformIndexType;
 extern const PlatformIndexType PlatformIndexType_MIN;
@@ -41,8 +40,8 @@ extern const PlatformIndexType PlatformIndexType_MAX;
 #endif
 
 /**
-* Default implementation for sizes
-*/
+ * Default implementation for sizes
+ */
 #ifndef PLATFORM_SIZE_TYPE_DEFINED
 typedef PlatformUIntType PlatformSizeType;
 extern const PlatformSizeType PlatformSizeType_MIN;
@@ -52,8 +51,8 @@ extern const PlatformSizeType PlatformSizeType_MAX;
 #endif
 
 /**
-* Default implementation for argument to fw_assert
-*/
+ * Default implementation for argument to fw_assert
+ */
 #ifndef PLATFORM_ASSERT_ARG_TYPE_DEFINED
 typedef PlatformIntType PlatformAssertArgType;
 extern const PlatformAssertArgType PlatformAssertArgType_MIN;
@@ -63,35 +62,35 @@ extern const PlatformAssertArgType PlatformAssertArgType_MAX;
 #endif
 
 /**
-* Default implementation for pointers stored as integers
-*/
+ * Default implementation for pointers stored as integers
+ */
 #ifndef PLATFORM_POINTER_CAST_TYPE_DEFINED
-  // Check for __SIZEOF_POINTER__ or cause error
-  #ifndef __SIZEOF_POINTER__
-    #error "Compiler does not support __SIZEOF_POINTER__, cannot use default for PlatformPointerCastType"
-  #endif
+// Check for __SIZEOF_POINTER__ or cause error
+#ifndef __SIZEOF_POINTER__
+#error "Compiler does not support __SIZEOF_POINTER__, cannot use default for PlatformPointerCastType"
+#endif
 
-  // Pointer sizes are determined by size of compiler
-  #if __SIZEOF_POINTER__ == 8
-    typedef uint64_t PlatformPointerCastType;
-    extern const PlatformPointerCastType PlatformPointerCastType_MIN;
-    extern const PlatformPointerCastType PlatformPointerCastType_MAX;
-    #define PRI_PlatformPointerCastType PRIx64
-  #elif __SIZEOF_POINTER__ == 4
-    typedef uint32_t PlatformPointerCastType;
-    extern const PlatformPointerCastType PlatformPointerCastType_MIN;
-    extern const PlatformPointerCastType PlatformPointerCastType_MAX;
-    #define PRI_PlatformPointerCastType PRIx32
-  #elif __SIZEOF_POINTER__ == 2
-    typedef uint16_t PlatformPointerCastType;
-    extern const PlatformPointerCastType PlatformPointerCastType_MIN;
-    extern const PlatformPointerCastType PlatformPointerCastType_MAX;
-    #define PRI_PlatformPointerCastType PRIx16
-  #else
-    typedef uint8_t PlatformPointerCastType;
-    extern const PlatformPointerCastType PlatformPointerCastType_MIN;
-    extern const PlatformPointerCastType PlatformPointerCastType_MAX;
-    #define PRI_PlatformPointerCastType PRIx8
-  #endif
-  #define PLATFORM_POINTER_CAST_TYPE_DEFINED
+// Pointer sizes are determined by size of compiler
+#if __SIZEOF_POINTER__ == 8
+typedef uint64_t PlatformPointerCastType;
+extern const PlatformPointerCastType PlatformPointerCastType_MIN;
+extern const PlatformPointerCastType PlatformPointerCastType_MAX;
+#define PRI_PlatformPointerCastType PRIx64
+#elif __SIZEOF_POINTER__ == 4
+typedef uint32_t PlatformPointerCastType;
+extern const PlatformPointerCastType PlatformPointerCastType_MIN;
+extern const PlatformPointerCastType PlatformPointerCastType_MAX;
+#define PRI_PlatformPointerCastType PRIx32
+#elif __SIZEOF_POINTER__ == 2
+typedef uint16_t PlatformPointerCastType;
+extern const PlatformPointerCastType PlatformPointerCastType_MIN;
+extern const PlatformPointerCastType PlatformPointerCastType_MAX;
+#define PRI_PlatformPointerCastType PRIx16
+#else
+typedef uint8_t PlatformPointerCastType;
+extern const PlatformPointerCastType PlatformPointerCastType_MIN;
+extern const PlatformPointerCastType PlatformPointerCastType_MAX;
+#define PRI_PlatformPointerCastType PRIx8
+#endif
+#define PLATFORM_POINTER_CAST_TYPE_DEFINED
 #endif

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -1,20 +1,18 @@
 #include <FpConfig.hpp>
-#include <Fw/Types/Serializable.hpp>
-#include <Os/IntervalTimer.hpp>
-#include <Os/InterruptLock.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <Fw/Types/String.hpp>
 #include <Fw/Types/InternalInterfaceString.hpp>
+#include <Fw/Types/MallocAllocator.hpp>
 #include <Fw/Types/ObjectName.hpp>
 #include <Fw/Types/PolyType.hpp>
-#include <Fw/Types/MallocAllocator.hpp>
+#include <Fw/Types/Serializable.hpp>
+#include <Fw/Types/String.hpp>
+#include <Os/InterruptLock.hpp>
+#include <Os/IntervalTimer.hpp>
 //
 // Created by mstarch on 12/7/20.
 //
-#include <cstring>
 #include <Fw/Types/StringUtils.hpp>
-
-
+#include <cstring>
 
 #include <cstdio>
 #include <cstring>
@@ -28,24 +26,24 @@
 
 #include <gtest/gtest.h>
 
-class SerializeTestBuffer: public Fw::SerializeBufferBase {
-    public:
-        NATIVE_UINT_TYPE getBuffCapacity() const { // !< returns capacity, not current size, of buffer
-            return sizeof(m_testBuff);
-        }
+class SerializeTestBuffer : public Fw::SerializeBufferBase {
+  public:
+    NATIVE_UINT_TYPE getBuffCapacity() const {  // !< returns capacity, not current size, of buffer
+        return sizeof(m_testBuff);
+    }
 
-        U8* getBuffAddr() { // !< gets buffer address for data filling
-            return m_testBuff;
-        }
-        const U8* getBuffAddr() const { // !< gets buffer address for data reading
-            return m_testBuff;
-        }
-    private:
-        U8 m_testBuff[255];
+    U8* getBuffAddr() {  // !< gets buffer address for data filling
+        return m_testBuff;
+    }
+    const U8* getBuffAddr() const {  // !< gets buffer address for data reading
+        return m_testBuff;
+    }
+
+  private:
+    U8 m_testBuff[255];
 };
 
-TEST(SerializationTest,Serialization1) {
-
+TEST(SerializationTest, Serialization1) {
     printf("Testing Serialization code\n");
 
     SerializeTestBuffer buff;
@@ -61,83 +59,78 @@ TEST(SerializationTest,Serialization1) {
     Fw::SerializeStatus stat1;
     Fw::SerializeStatus stat2;
 
-// Test chars
+    // Test chars
     buff.resetSer();
     stat1 = buff.serialize(u8t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(0xAB,ptr[0]);
-    ASSERT_EQ(1,buff.m_serLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(0xAB, ptr[0]);
+    ASSERT_EQ(1, buff.m_serLoc);
     stat2 = buff.deserialize(u8t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(1,buff.m_deserLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(1, buff.m_deserLoc);
 
-    ASSERT_EQ(u8t2,u8t1);
+    ASSERT_EQ(u8t2, u8t1);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", u8t1, u8t2, stat1,
-            stat2);
+    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", u8t1, u8t2, stat1, stat2);
     printf("I8 Test\n");
 #endif
 
     buff.resetSer();
-    ASSERT_EQ(0,buff.m_serLoc);
-    ASSERT_EQ(0,buff.m_deserLoc);
+    ASSERT_EQ(0, buff.m_serLoc);
+    ASSERT_EQ(0, buff.m_deserLoc);
 
     I8 i8t1 = 0xFF;
     I8 i8t2 = 0;
 
     stat1 = buff.serialize(i8t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(1,buff.m_serLoc);
-    ASSERT_EQ(0xFF,ptr[0]);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(1, buff.m_serLoc);
+    ASSERT_EQ(0xFF, ptr[0]);
     stat2 = buff.deserialize(i8t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i8t1,i8t2);
-    ASSERT_EQ(1,buff.m_deserLoc);
-
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i8t1, i8t2);
+    ASSERT_EQ(1, buff.m_deserLoc);
 
     buff.resetSer();
-    ASSERT_EQ(0,buff.m_serLoc);
-    ASSERT_EQ(0,buff.m_deserLoc);
+    ASSERT_EQ(0, buff.m_serLoc);
+    ASSERT_EQ(0, buff.m_deserLoc);
 
     // double check negative numbers
     i8t1 = -100;
     i8t2 = 0;
 
     stat1 = buff.serialize(i8t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(1,buff.m_serLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(1, buff.m_serLoc);
     stat2 = buff.deserialize(i8t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i8t1,i8t2);
-    ASSERT_EQ(1,buff.m_deserLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i8t1, i8t2);
+    ASSERT_EQ(1, buff.m_deserLoc);
 
-
-    #if DEBUG_VERBOSE
-    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", i8t1, i8t2, stat1,
-            stat2);
+#if DEBUG_VERBOSE
+    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", i8t1, i8t2, stat1, stat2);
     printf("U16 Test\n");
 #endif
 
     U16 u16t1 = 0xABCD;
     U16 u16t2 = 0;
 
-// Test shorts
+    // Test shorts
 
     buff.resetSer();
     stat1 = buff.serialize(u16t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(2,buff.m_serLoc);
-    ASSERT_EQ(0xAB,ptr[0]);
-    ASSERT_EQ(0xCD,ptr[1]);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(2, buff.m_serLoc);
+    ASSERT_EQ(0xAB, ptr[0]);
+    ASSERT_EQ(0xCD, ptr[1]);
     stat2 = buff.deserialize(u16t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u16t1,u16t2);
-    ASSERT_EQ(2,buff.m_deserLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u16t1, u16t2);
+    ASSERT_EQ(2, buff.m_deserLoc);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", u16t1, u16t2, stat1,
-            stat2);
+    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", u16t1, u16t2, stat1, stat2);
     printf("I16 test\n");
 #endif
 
@@ -146,15 +139,15 @@ TEST(SerializationTest,Serialization1) {
 
     buff.resetSer();
     stat1 = buff.serialize(i16t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(2,buff.m_serLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(2, buff.m_serLoc);
     // 2s complement
-    ASSERT_EQ(0xAB,ptr[0]);
-    ASSERT_EQ(0xCD,ptr[1]);
+    ASSERT_EQ(0xAB, ptr[0]);
+    ASSERT_EQ(0xCD, ptr[1]);
     stat2 = buff.deserialize(i16t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i16t1,i16t2);
-    ASSERT_EQ(2,buff.m_deserLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i16t1, i16t2);
+    ASSERT_EQ(2, buff.m_deserLoc);
 
     // double check negative number
     i16t1 = -1000;
@@ -162,17 +155,15 @@ TEST(SerializationTest,Serialization1) {
 
     buff.resetSer();
     stat1 = buff.serialize(i16t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(2,buff.m_serLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(2, buff.m_serLoc);
     stat2 = buff.deserialize(i16t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i16t1,i16t2);
-    ASSERT_EQ(2,buff.m_deserLoc);
-
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i16t1, i16t2);
+    ASSERT_EQ(2, buff.m_deserLoc);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", i16t1, i16t2, stat1,
-            stat2);
+    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", i16t1, i16t2, stat1, stat2);
 
     printf("U32 Test\n");
 #endif
@@ -180,24 +171,23 @@ TEST(SerializationTest,Serialization1) {
     U32 u32t1 = 0xABCDEF12;
     U32 u32t2 = 0;
 
-// Test ints
+    // Test ints
 
     buff.resetSer();
     stat1 = buff.serialize(u32t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(4,buff.m_serLoc);
-    ASSERT_EQ(0xAB,ptr[0]);
-    ASSERT_EQ(0xCD,ptr[1]);
-    ASSERT_EQ(0xEF,ptr[2]);
-    ASSERT_EQ(0x12,ptr[3]);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(4, buff.m_serLoc);
+    ASSERT_EQ(0xAB, ptr[0]);
+    ASSERT_EQ(0xCD, ptr[1]);
+    ASSERT_EQ(0xEF, ptr[2]);
+    ASSERT_EQ(0x12, ptr[3]);
     stat2 = buff.deserialize(u32t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u32t1,u32t2);
-    ASSERT_EQ(4,buff.m_deserLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u32t1, u32t2);
+    ASSERT_EQ(4, buff.m_deserLoc);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", u32t1, u32t2, stat1,
-            stat2);
+    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", u32t1, u32t2, stat1, stat2);
     printf("I32 Test\n");
 #endif
 
@@ -206,16 +196,16 @@ TEST(SerializationTest,Serialization1) {
 
     buff.resetSer();
     stat1 = buff.serialize(i32t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(4,buff.m_serLoc);
-    ASSERT_EQ(0xAB,ptr[0]);
-    ASSERT_EQ(0xCD,ptr[1]);
-    ASSERT_EQ(0xEF,ptr[2]);
-    ASSERT_EQ(0x12,ptr[3]);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(4, buff.m_serLoc);
+    ASSERT_EQ(0xAB, ptr[0]);
+    ASSERT_EQ(0xCD, ptr[1]);
+    ASSERT_EQ(0xEF, ptr[2]);
+    ASSERT_EQ(0x12, ptr[3]);
     stat2 = buff.deserialize(i32t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(4,buff.m_deserLoc);
-    ASSERT_EQ(i32t1,i32t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(4, buff.m_deserLoc);
+    ASSERT_EQ(i32t1, i32t2);
 
     // double check negative number
     i32t1 = -1000000;
@@ -223,17 +213,15 @@ TEST(SerializationTest,Serialization1) {
 
     buff.resetSer();
     stat1 = buff.serialize(i32t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(4,buff.m_serLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(4, buff.m_serLoc);
     stat2 = buff.deserialize(i32t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(4,buff.m_deserLoc);
-    ASSERT_EQ(i32t1,i32t2);
-
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(4, buff.m_deserLoc);
+    ASSERT_EQ(i32t1, i32t2);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", i32t1, i32t2, stat1,
-            stat2);
+    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", i32t1, i32t2, stat1, stat2);
 
     printf("U64 Test\n");
 #endif
@@ -241,28 +229,27 @@ TEST(SerializationTest,Serialization1) {
     U64 u64t1 = 0x0123456789ABCDEF;
     U64 u64t2 = 0;
 
-// Test ints
+    // Test ints
 
     buff.resetSer();
     stat1 = buff.serialize(u64t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(8,buff.m_serLoc);
-    ASSERT_EQ(0x01,ptr[0]);
-    ASSERT_EQ(0x23,ptr[1]);
-    ASSERT_EQ(0x45,ptr[2]);
-    ASSERT_EQ(0x67,ptr[3]);
-    ASSERT_EQ(0x89,ptr[4]);
-    ASSERT_EQ(0xAB,ptr[5]);
-    ASSERT_EQ(0xCD,ptr[6]);
-    ASSERT_EQ(0xEF,ptr[7]);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(8, buff.m_serLoc);
+    ASSERT_EQ(0x01, ptr[0]);
+    ASSERT_EQ(0x23, ptr[1]);
+    ASSERT_EQ(0x45, ptr[2]);
+    ASSERT_EQ(0x67, ptr[3]);
+    ASSERT_EQ(0x89, ptr[4]);
+    ASSERT_EQ(0xAB, ptr[5]);
+    ASSERT_EQ(0xCD, ptr[6]);
+    ASSERT_EQ(0xEF, ptr[7]);
     stat2 = buff.deserialize(u64t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u64t1,u64t2);
-    ASSERT_EQ(8,buff.m_deserLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u64t1, u64t2);
+    ASSERT_EQ(8, buff.m_deserLoc);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %lld out: %lld stat1: %d stat2: %d\n", u64t1, u64t2, stat1,
-            stat2);
+    printf("Val: in: %lld out: %lld stat1: %d stat2: %d\n", u64t1, u64t2, stat1, stat2);
     printf("I64 Test\n");
 #endif
 
@@ -271,20 +258,20 @@ TEST(SerializationTest,Serialization1) {
 
     buff.resetSer();
     stat1 = buff.serialize(i64t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(8,buff.m_serLoc);
-    ASSERT_EQ(0x01,ptr[0]);
-    ASSERT_EQ(0x23,ptr[1]);
-    ASSERT_EQ(0x45,ptr[2]);
-    ASSERT_EQ(0x67,ptr[3]);
-    ASSERT_EQ(0x89,ptr[4]);
-    ASSERT_EQ(0xAB,ptr[5]);
-    ASSERT_EQ(0xCD,ptr[6]);
-    ASSERT_EQ(0xEF,ptr[7]);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(8, buff.m_serLoc);
+    ASSERT_EQ(0x01, ptr[0]);
+    ASSERT_EQ(0x23, ptr[1]);
+    ASSERT_EQ(0x45, ptr[2]);
+    ASSERT_EQ(0x67, ptr[3]);
+    ASSERT_EQ(0x89, ptr[4]);
+    ASSERT_EQ(0xAB, ptr[5]);
+    ASSERT_EQ(0xCD, ptr[6]);
+    ASSERT_EQ(0xEF, ptr[7]);
     stat2 = buff.deserialize(i64t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i64t1,i64t2);
-    ASSERT_EQ(8,buff.m_deserLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i64t1, i64t2);
+    ASSERT_EQ(8, buff.m_deserLoc);
 
     // double check negative number
     i64t1 = -1000000000000;
@@ -292,17 +279,15 @@ TEST(SerializationTest,Serialization1) {
 
     buff.resetSer();
     stat1 = buff.serialize(i64t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(8,buff.m_serLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(8, buff.m_serLoc);
     stat2 = buff.deserialize(i64t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i64t1,i64t2);
-    ASSERT_EQ(8,buff.m_deserLoc);
-
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i64t1, i64t2);
+    ASSERT_EQ(8, buff.m_deserLoc);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %lld out: %lld stat1: %d stat2: %d\n", i64t1, i64t2, stat1,
-            stat2);
+    printf("Val: in: %lld out: %lld stat1: %d stat2: %d\n", i64t1, i64t2, stat1, stat2);
 
     printf("F32 Test\n");
 #endif
@@ -310,24 +295,23 @@ TEST(SerializationTest,Serialization1) {
     F32 f32t1 = -1.23;
     F32 f32t2 = 0;
 
-// Test ints
+    // Test ints
 
     buff.resetSer();
     stat1 = buff.serialize(f32t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(4,buff.m_serLoc);
-    ASSERT_EQ(0xBF,ptr[0]);
-    ASSERT_EQ(0x9D,ptr[1]);
-    ASSERT_EQ(0x70,ptr[2]);
-    ASSERT_EQ(0xA4,ptr[3]);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(4, buff.m_serLoc);
+    ASSERT_EQ(0xBF, ptr[0]);
+    ASSERT_EQ(0x9D, ptr[1]);
+    ASSERT_EQ(0x70, ptr[2]);
+    ASSERT_EQ(0xA4, ptr[3]);
     stat2 = buff.deserialize(f32t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_FLOAT_EQ(f32t1,f32t2);
-    ASSERT_EQ(4,buff.m_deserLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_FLOAT_EQ(f32t1, f32t2);
+    ASSERT_EQ(4, buff.m_deserLoc);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %f out: %f stat1: %d stat2: %d\n", f32t1, f32t2, stat1,
-            stat2);
+    printf("Val: in: %f out: %f stat1: %d stat2: %d\n", f32t1, f32t2, stat1, stat2);
     printf("F64 Test\n");
 #endif
 
@@ -336,24 +320,23 @@ TEST(SerializationTest,Serialization1) {
 
     buff.resetSer();
     stat1 = buff.serialize(f64t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
-    ASSERT_EQ(8,buff.m_serLoc);
-    ASSERT_EQ(0x40,ptr[0]);
-    ASSERT_EQ(0x59,ptr[1]);
-    ASSERT_EQ(0x0E,ptr[2]);
-    ASSERT_EQ(0xDB,ptr[3]);
-    ASSERT_EQ(0x78,ptr[4]);
-    ASSERT_EQ(0x26,ptr[5]);
-    ASSERT_EQ(0x8B,ptr[6]);
-    ASSERT_EQ(0xA6,ptr[7]);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    ASSERT_EQ(8, buff.m_serLoc);
+    ASSERT_EQ(0x40, ptr[0]);
+    ASSERT_EQ(0x59, ptr[1]);
+    ASSERT_EQ(0x0E, ptr[2]);
+    ASSERT_EQ(0xDB, ptr[3]);
+    ASSERT_EQ(0x78, ptr[4]);
+    ASSERT_EQ(0x26, ptr[5]);
+    ASSERT_EQ(0x8B, ptr[6]);
+    ASSERT_EQ(0xA6, ptr[7]);
     stat2 = buff.deserialize(f64t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_DOUBLE_EQ(f32t1,f32t2);
-    ASSERT_EQ(8,buff.m_deserLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_DOUBLE_EQ(f32t1, f32t2);
+    ASSERT_EQ(8, buff.m_deserLoc);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %lf out: %lf stat1: %d stat2: %d\n", f64t1, f64t2, stat1,
-            stat2);
+    printf("Val: in: %lf out: %lf stat1: %d stat2: %d\n", f64t1, f64t2, stat1, stat2);
     printf("bool Test\n");
 #endif
 
@@ -362,14 +345,14 @@ TEST(SerializationTest,Serialization1) {
 
     buff.resetSer();
     stat1 = buff.serialize(boolt1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat2 = buff.deserialize(boolt2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(boolt1,boolt2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(boolt1, boolt2);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %s out: %s stat1: %d stat2: %d\n",
-            boolt1 ? "TRUE" : "FALSE", boolt2 ? "TRUE" : "FALSE", stat1, stat2);
+    printf("Val: in: %s out: %s stat1: %d stat2: %d\n", boolt1 ? "TRUE" : "FALSE", boolt2 ? "TRUE" : "FALSE", stat1,
+           stat2);
     printf("Pointer Test\n");
 #endif
 
@@ -379,68 +362,65 @@ TEST(SerializationTest,Serialization1) {
 
     buff.resetSer();
     stat1 = buff.serialize(ptrt1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat2 = buff.deserialize(ptrt2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(ptrt1,ptrt2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(ptrt1, ptrt2);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %p out: %p stat1: %d stat2: %d\n",
-            ptrt1, ptrt2, stat1, stat2);
+    printf("Val: in: %p out: %p stat1: %d stat2: %d\n", ptrt1, ptrt2, stat1, stat2);
 
     printf("Skip deserialization Tests\n");
 #endif
 
-// Test sizes
+    // Test sizes
 
     FwSizeType size1 = std::numeric_limits<FwSizeStoreType>::max();
     FwSizeType size2 = 0;
 
     buff.resetSer();
     stat1 = buff.serializeSize(size1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat2 = buff.deserializeSize(size2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u64t1,u64t2);
-    ASSERT_EQ(sizeof(FwSizeStoreType),buff.m_deserLoc);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u64t1, u64t2);
+    ASSERT_EQ(sizeof(FwSizeStoreType), buff.m_deserLoc);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %" PRI_FwSizeType " out: %" PRI_FwSizeType " stat1: %d stat2: %d\n",
-        size1, size2, stat1, stat2);
+    printf("Val: in: %" PRI_FwSizeType " out: %" PRI_FwSizeType " stat1: %d stat2: %d\n", size1, size2, stat1, stat2);
     printf("Size Test\n");
 #endif
 
-
-// Test skipping:
+    // Test skipping:
 
     buff.resetSer();
     stat1 = buff.serialize(u32t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat2 = buff.serialize(u32t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
 
     // should fail:
     stat1 = buff.deserializeSkip(10);
-    ASSERT_EQ(Fw::FW_DESERIALIZE_SIZE_MISMATCH,stat1);
+    ASSERT_EQ(Fw::FW_DESERIALIZE_SIZE_MISMATCH, stat1);
 
     // skip everything:
     stat1 = buff.deserializeSkip(4);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat2 = buff.deserializeSkip(4);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
 
     // should fail:
     stat1 = buff.deserializeSkip(4);
-    ASSERT_EQ(Fw::FW_DESERIALIZE_BUFFER_EMPTY,stat1);
+    ASSERT_EQ(Fw::FW_DESERIALIZE_BUFFER_EMPTY, stat1);
 
     // skip half/read half:
     buff.resetDeser();
     stat1 = buff.deserializeSkip(4);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     U32 u32val;
     stat2 = buff.deserialize(u32val);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u32t2,u32val);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u32t2, u32val);
 
 #if DEBUG_VERBOSE
     printf("\nDeserialization Tests\n");
@@ -448,7 +428,7 @@ TEST(SerializationTest,Serialization1) {
 
     SerializeTestBuffer buff2;
 
-// Do a series of serializations
+    // Do a series of serializations
     u8t2 = 0;
     i8t2 = 0;
     u16t2 = 0;
@@ -464,29 +444,29 @@ TEST(SerializationTest,Serialization1) {
 
     buff.resetSer();
     stat1 = buff.serialize(u8t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff.serialize(i8t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff.serialize(u16t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff.serialize(i16t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff.serialize(u32t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff.serialize(i32t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff.serialize(u64t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff.serialize(i64t1);
     printf("i64t1 in stat: %d\n", stat1);
     stat1 = buff.serialize(f32t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff.serialize(f64t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff.serialize(boolt1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff.serialize(ptrt1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
 
     // TKC - commented out due to fprime-util choking on output
     // std::cout << "Buffer contents: " << buff << std::endl;
@@ -494,70 +474,70 @@ TEST(SerializationTest,Serialization1) {
     // Serialize second buffer and test for equality
     buff2.resetSer();
     stat1 = buff2.serialize(u8t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff2.serialize(i8t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff2.serialize(u16t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff2.serialize(i16t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff2.serialize(u32t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff2.serialize(i32t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff2.serialize(u64t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff2.serialize(i64t1);
     printf("i64t1 in stat: %d\n", stat1);
     stat1 = buff2.serialize(f32t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff2.serialize(f64t1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff2.serialize(boolt1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     stat1 = buff2.serialize(ptrt1);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat1);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
 
-    ASSERT_EQ(buff,buff2);
+    ASSERT_EQ(buff, buff2);
 
     // deserialize
 
     stat2 = buff.deserialize(u8t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u8t1,u8t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u8t1, u8t2);
     stat2 = buff.deserialize(i8t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i8t1,i8t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i8t1, i8t2);
     stat2 = buff.deserialize(u16t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u16t1,u16t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u16t1, u16t2);
     stat2 = buff.deserialize(i16t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i16t1,i16t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i16t1, i16t2);
     stat2 = buff.deserialize(u32t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u32t1,u32t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u32t1, u32t2);
     stat2 = buff.deserialize(i32t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i32t1,i32t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i32t1, i32t2);
     stat2 = buff.deserialize(u64t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u64t1,u64t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u64t1, u64t2);
     stat2 = buff.deserialize(i64t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i64t1,i64t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i64t1, i64t2);
     stat2 = buff.deserialize(f32t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_FLOAT_EQ(f32t1,f32t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_FLOAT_EQ(f32t1, f32t2);
     stat2 = buff.deserialize(f64t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_DOUBLE_EQ(f64t1,f64t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_DOUBLE_EQ(f64t1, f64t2);
     stat2 = buff.deserialize(boolt2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(boolt1,boolt2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(boolt1, boolt2);
     stat2 = buff.deserialize(ptrt2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(ptrt1,ptrt2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(ptrt1, ptrt2);
 
 // reset and deserialize again
 #if DEBUG_VERBOSE
@@ -580,41 +560,41 @@ TEST(SerializationTest,Serialization1) {
     ptrt2 = nullptr;
 
     stat2 = buff.deserialize(u8t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u8t1,u8t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u8t1, u8t2);
     stat2 = buff.deserialize(i8t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i8t1,i8t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i8t1, i8t2);
     stat2 = buff.deserialize(u16t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u16t1,u16t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u16t1, u16t2);
     stat2 = buff.deserialize(i16t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i16t1,i16t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i16t1, i16t2);
     stat2 = buff.deserialize(u32t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u32t1,u32t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u32t1, u32t2);
     stat2 = buff.deserialize(i32t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i32t1,i32t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i32t1, i32t2);
     stat2 = buff.deserialize(u64t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(u64t1,u64t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u64t1, u64t2);
     stat2 = buff.deserialize(i64t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(i64t1,i64t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i64t1, i64t2);
     stat2 = buff.deserialize(f32t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_FLOAT_EQ(f32t1,f32t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_FLOAT_EQ(f32t1, f32t2);
     stat2 = buff.deserialize(f64t2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_DOUBLE_EQ(f64t1,f64t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_DOUBLE_EQ(f64t1, f64t2);
     stat2 = buff.deserialize(boolt2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(boolt1,boolt2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(boolt1, boolt2);
     stat2 = buff.deserialize(ptrt2);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK,stat2);
-    ASSERT_EQ(ptrt1,ptrt2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(ptrt1, ptrt2);
 
     // serialize string
     Fw::String str1;
@@ -625,41 +605,39 @@ TEST(SerializationTest,Serialization1) {
     buff.resetSer();
     str1.serialize(buff);
     str2.deserialize(buff);
-    ASSERT_EQ(str1,str2);
-
-
+    ASSERT_EQ(str1, str2);
 }
 
 struct TestStruct {
-        U32 m_u32;
-        U16 m_u16;
-        U8 m_u8;
-        F32 m_f32;
-        U8 m_buff[25];
+    U32 m_u32;
+    U16 m_u16;
+    U8 m_u8;
+    F32 m_f32;
+    U8 m_buff[25];
 };
 
-class MySerializable: public Fw::Serializable {
-    public:
-        Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const {
-            buffer.serialize(m_testStruct.m_u32);
-            buffer.serialize(m_testStruct.m_u16);
-            buffer.serialize(m_testStruct.m_u8);
-            buffer.serialize(m_testStruct.m_f32);
-            buffer.serialize(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
-            return Fw::FW_SERIALIZE_OK;
-        }
+class MySerializable : public Fw::Serializable {
+  public:
+    Fw::SerializeStatus serialize(Fw::SerializeBufferBase& buffer) const {
+        buffer.serialize(m_testStruct.m_u32);
+        buffer.serialize(m_testStruct.m_u16);
+        buffer.serialize(m_testStruct.m_u8);
+        buffer.serialize(m_testStruct.m_f32);
+        buffer.serialize(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
+        return Fw::FW_SERIALIZE_OK;
+    }
 
-        Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer) {
+    Fw::SerializeStatus deserialize(Fw::SerializeBufferBase& buffer) {
+        buffer.serialize(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
+        buffer.serialize(m_testStruct.m_f32);
+        buffer.serialize(m_testStruct.m_u8);
+        buffer.serialize(m_testStruct.m_u16);
+        buffer.serialize(m_testStruct.m_u32);
+        return Fw::FW_SERIALIZE_OK;
+    }
 
-            buffer.serialize(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
-            buffer.serialize(m_testStruct.m_f32);
-            buffer.serialize(m_testStruct.m_u8);
-            buffer.serialize(m_testStruct.m_u16);
-            buffer.serialize(m_testStruct.m_u32);
-            return Fw::FW_SERIALIZE_OK;
-        }
-    private:
-        TestStruct m_testStruct;
+  private:
+    TestStruct m_testStruct;
 };
 
 TEST(PerformanceTest, SerPerfTest) {
@@ -683,10 +661,8 @@ TEST(PerformanceTest, SerPerfTest) {
     timer.stop();
     intLock.unLock();
 
-    printf("%d iterations took %d us (%f each).\n", iterations,
-            timer.getDiffUsec(),
-            static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iterations));
-
+    printf("%d iterations took %d us (%f each).\n", iterations, timer.getDiffUsec(),
+           static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iterations));
 }
 
 TEST(PerformanceTest, StructCopyTest) {
@@ -701,8 +677,7 @@ TEST(PerformanceTest, StructCopyTest) {
 
     I32 iterations = 1000000;
     for (I32 iter = 0; iter < iterations; iter++) {
-
-// simulate the incoming MSL-style call by doing member assignments
+        // simulate the incoming MSL-style call by doing member assignments
         ts.m_u32 = 0;
         ts.m_u16 = 0;
         ts.m_u8 = 0;
@@ -716,14 +691,11 @@ TEST(PerformanceTest, StructCopyTest) {
     timer.stop();
     intLock.unLock();
 
-    printf("%d iterations took %d us (%f each).\n", iterations,
-            timer.getDiffUsec(),
-            static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iterations));
-
+    printf("%d iterations took %d us (%f each).\n", iterations, timer.getDiffUsec(),
+           static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iterations));
 }
 
 TEST(PerformanceTest, ClassCopyTest) {
-
     char buff[sizeof(MySerializable)];
     MySerializable ms;
 
@@ -742,10 +714,8 @@ TEST(PerformanceTest, ClassCopyTest) {
     timer.stop();
     intLock.unLock();
 
-    printf("%d iterations took %d us (%f each).\n", iterations,
-            timer.getDiffUsec(),
-            static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iterations));
-
+    printf("%d iterations took %d us (%f each).\n", iterations, timer.getDiffUsec(),
+           static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iterations));
 }
 
 void printSizes() {
@@ -754,112 +724,85 @@ void printSizes() {
 }
 
 void AssertTest() {
-
     printf("Assert Tests\n");
 
     // Since native FW_ASSERT actually asserts,
     // manually test by setting arguments to
     // unequal values below one by one
-//    FW_ASSERT(0 == 1);
-//    FW_ASSERT(0 == 1, 1);
-//    FW_ASSERT(0 == 1, 1, 2);
-//    FW_ASSERT(0 == 1, 1, 2, 3);
-//    FW_ASSERT(0 == 1, 1, 2, 3, 4);
-//    FW_ASSERT(0 == 1, 1, 2, 3, 4, 5);
-//    FW_ASSERT(0 == 1, 1, 2, 3, 4, 5, 6);
+    //    FW_ASSERT(0 == 1);
+    //    FW_ASSERT(0 == 1, 1);
+    //    FW_ASSERT(0 == 1, 1, 2);
+    //    FW_ASSERT(0 == 1, 1, 2, 3);
+    //    FW_ASSERT(0 == 1, 1, 2, 3, 4);
+    //    FW_ASSERT(0 == 1, 1, 2, 3, 4, 5);
+    //    FW_ASSERT(0 == 1, 1, 2, 3, 4, 5, 6);
 
     // Define an Assert handler
     class TestAssertHook : public Fw::AssertHook {
-        public:
-            TestAssertHook() {}
-            virtual ~TestAssertHook() {}
-            void reportAssert(
-                                FILE_NAME_ARG file,
-                                NATIVE_UINT_TYPE lineNo,
-                                NATIVE_UINT_TYPE numArgs,
-                                FwAssertArgType arg1,
-                                FwAssertArgType arg2,
-                                FwAssertArgType arg3,
-                                FwAssertArgType arg4,
-                                FwAssertArgType arg5,
-                                FwAssertArgType arg6
-                                ) {
-                this->m_file = file;
-                this->m_lineNo = lineNo;
-                this->m_numArgs = numArgs;
-                this->m_arg1 = arg1;
-                this->m_arg2 = arg2;
-                this->m_arg3 = arg3;
-                this->m_arg4 = arg4;
-                this->m_arg5 = arg5;
-                this->m_arg6 = arg6;
+      public:
+        TestAssertHook() {}
+        virtual ~TestAssertHook() {}
+        void reportAssert(FILE_NAME_ARG file,
+                          NATIVE_UINT_TYPE lineNo,
+                          NATIVE_UINT_TYPE numArgs,
+                          FwAssertArgType arg1,
+                          FwAssertArgType arg2,
+                          FwAssertArgType arg3,
+                          FwAssertArgType arg4,
+                          FwAssertArgType arg5,
+                          FwAssertArgType arg6) {
+            this->m_file = file;
+            this->m_lineNo = lineNo;
+            this->m_numArgs = numArgs;
+            this->m_arg1 = arg1;
+            this->m_arg2 = arg2;
+            this->m_arg3 = arg3;
+            this->m_arg4 = arg4;
+            this->m_arg5 = arg5;
+            this->m_arg6 = arg6;
+        };
 
-            };
+        void doAssert() { this->m_asserted = true; }
 
-            void doAssert() {
-                this->m_asserted = true;
-            }
+        FILE_NAME_ARG getFile() { return this->m_file; }
 
-            FILE_NAME_ARG getFile() {
-                return this->m_file;
-            }
+        NATIVE_UINT_TYPE getLineNo() { return this->m_lineNo; }
 
-            NATIVE_UINT_TYPE getLineNo() {
-                return this->m_lineNo;
-            }
+        NATIVE_UINT_TYPE getNumArgs() { return this->m_numArgs; }
 
-            NATIVE_UINT_TYPE getNumArgs() {
-                return this->m_numArgs;
-            }
+        FwAssertArgType getArg1() { return this->m_arg1; }
 
-            FwAssertArgType getArg1() {
-                return this->m_arg1;
-            }
+        FwAssertArgType getArg2() { return this->m_arg2; }
 
-            FwAssertArgType getArg2() {
-                return this->m_arg2;
-            }
+        FwAssertArgType getArg3() { return this->m_arg3; }
 
-            FwAssertArgType getArg3() {
-                return this->m_arg3;
-            }
+        FwAssertArgType getArg4() { return this->m_arg4; }
 
-            FwAssertArgType getArg4() {
-                return this->m_arg4;
-            }
+        FwAssertArgType getArg5() { return this->m_arg5; }
 
-            FwAssertArgType getArg5() {
-                return this->m_arg5;
-            }
+        FwAssertArgType getArg6() { return this->m_arg6; }
 
-            FwAssertArgType getArg6() {
-                return this->m_arg6;
-            }
+        bool asserted() {
+            bool didAssert = this->m_asserted;
+            this->m_asserted = false;
+            return didAssert;
+        }
 
-            bool asserted() {
-                bool didAssert = this->m_asserted;
-                this->m_asserted = false;
-                return didAssert;
-            }
-
-
-        private:
-
+      private:
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
-            FILE_NAME_ARG m_file = 0;
+        FILE_NAME_ARG m_file = 0;
 #else
-            FILE_NAME_ARG m_file = nullptr;
+        FILE_NAME_ARG m_file = nullptr;
 #endif
-            NATIVE_UINT_TYPE m_lineNo = 0;
-            NATIVE_UINT_TYPE m_numArgs = 0;
-            FwAssertArgType m_arg1 = 0;
-            FwAssertArgType m_arg2 = 0;
-            FwAssertArgType m_arg3 = 0;
-            FwAssertArgType m_arg4 = 0;
-            FwAssertArgType m_arg5 = 0;
-            FwAssertArgType m_arg6 = 0;
-            bool m_asserted = false;
-
+        NATIVE_UINT_TYPE m_lineNo = 0;
+        NATIVE_UINT_TYPE m_numArgs = 0;
+        FwAssertArgType m_arg1 = 0;
+        FwAssertArgType m_arg2 = 0;
+        FwAssertArgType m_arg3 = 0;
+        FwAssertArgType m_arg4 = 0;
+        FwAssertArgType m_arg5 = 0;
+        FwAssertArgType m_arg6 = 0;
+        bool m_asserted = false;
     };
 
     // register the class
@@ -871,106 +814,105 @@ void AssertTest() {
 #if FW_ASSERT_LEVEL != FW_NO_ASSERT
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ(0u,hook.getNumArgs());
+    ASSERT_EQ(0u, hook.getNumArgs());
 #else
     // assert does not fire when asserts are off
     ASSERT_FALSE(hook.asserted());
 #endif
 
     // issue an assert
-    FW_ASSERT(0,1);
+    FW_ASSERT(0, 1);
 #if FW_ASSERT_LEVEL != FW_NO_ASSERT
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ(1u,hook.getNumArgs());
-    ASSERT_EQ(1u,hook.getArg1());
+    ASSERT_EQ(1u, hook.getNumArgs());
+    ASSERT_EQ(1u, hook.getArg1());
 #else
     // assert does not fire when asserts are off
     ASSERT_FALSE(hook.asserted());
 #endif
 
     // issue an assert
-    FW_ASSERT(0,1,2);
+    FW_ASSERT(0, 1, 2);
 #if FW_ASSERT_LEVEL != FW_NO_ASSERT
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ(2u,hook.getNumArgs());
-    ASSERT_EQ(1u,hook.getArg1());
-    ASSERT_EQ(2u,hook.getArg2());
+    ASSERT_EQ(2u, hook.getNumArgs());
+    ASSERT_EQ(1u, hook.getArg1());
+    ASSERT_EQ(2u, hook.getArg2());
 #else
     // assert does not fire when asserts are off
     ASSERT_FALSE(hook.asserted());
 #endif
 
     // issue an assert
-    FW_ASSERT(0,1,2,3);
+    FW_ASSERT(0, 1, 2, 3);
 #if FW_ASSERT_LEVEL != FW_NO_ASSERT
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ(3u,hook.getNumArgs());
-    ASSERT_EQ(1u,hook.getArg1());
-    ASSERT_EQ(2u,hook.getArg2());
-    ASSERT_EQ(3u,hook.getArg3());
+    ASSERT_EQ(3u, hook.getNumArgs());
+    ASSERT_EQ(1u, hook.getArg1());
+    ASSERT_EQ(2u, hook.getArg2());
+    ASSERT_EQ(3u, hook.getArg3());
 #else
     // assert does not fire when asserts are off
     ASSERT_FALSE(hook.asserted());
 #endif
 
     // issue an assert
-    FW_ASSERT(0,1,2,3,4);
+    FW_ASSERT(0, 1, 2, 3, 4);
 #if FW_ASSERT_LEVEL != FW_NO_ASSERT
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ(4u,hook.getNumArgs());
-    ASSERT_EQ(1u,hook.getArg1());
-    ASSERT_EQ(2u,hook.getArg2());
-    ASSERT_EQ(3u,hook.getArg3());
-    ASSERT_EQ(4u,hook.getArg4());
+    ASSERT_EQ(4u, hook.getNumArgs());
+    ASSERT_EQ(1u, hook.getArg1());
+    ASSERT_EQ(2u, hook.getArg2());
+    ASSERT_EQ(3u, hook.getArg3());
+    ASSERT_EQ(4u, hook.getArg4());
 #else
     // assert does not fire when asserts are off
     ASSERT_FALSE(hook.asserted());
 #endif
 
     // issue an assert
-    FW_ASSERT(0,1,2,3,4,5);
+    FW_ASSERT(0, 1, 2, 3, 4, 5);
 #if FW_ASSERT_LEVEL != FW_NO_ASSERT
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ(5u,hook.getNumArgs());
-    ASSERT_EQ(1u,hook.getArg1());
-    ASSERT_EQ(2u,hook.getArg2());
-    ASSERT_EQ(3u,hook.getArg3());
-    ASSERT_EQ(4u,hook.getArg4());
-    ASSERT_EQ(5u,hook.getArg5());
+    ASSERT_EQ(5u, hook.getNumArgs());
+    ASSERT_EQ(1u, hook.getArg1());
+    ASSERT_EQ(2u, hook.getArg2());
+    ASSERT_EQ(3u, hook.getArg3());
+    ASSERT_EQ(4u, hook.getArg4());
+    ASSERT_EQ(5u, hook.getArg5());
 #else
     // assert does not fire when asserts are off
     ASSERT_FALSE(hook.asserted());
 #endif
 
     // issue an assert
-    FW_ASSERT(0,1,2,3,4,5,6);
+    FW_ASSERT(0, 1, 2, 3, 4, 5, 6);
 #if FW_ASSERT_LEVEL != FW_NO_ASSERT
     // hook should have intercepted it
     ASSERT_TRUE(hook.asserted());
-    ASSERT_EQ(6u,hook.getNumArgs());
-    ASSERT_EQ(1u,hook.getArg1());
-    ASSERT_EQ(2u,hook.getArg2());
-    ASSERT_EQ(3u,hook.getArg3());
-    ASSERT_EQ(4u,hook.getArg4());
-    ASSERT_EQ(5u,hook.getArg5());
-    ASSERT_EQ(6u,hook.getArg6());
+    ASSERT_EQ(6u, hook.getNumArgs());
+    ASSERT_EQ(1u, hook.getArg1());
+    ASSERT_EQ(2u, hook.getArg2());
+    ASSERT_EQ(3u, hook.getArg3());
+    ASSERT_EQ(4u, hook.getArg4());
+    ASSERT_EQ(5u, hook.getArg5());
+    ASSERT_EQ(6u, hook.getArg6());
 #else
     // assert does not fire when asserts are off
     ASSERT_FALSE(hook.asserted());
 #endif
-
 }
 
 TEST(TypesTest, CheckAssertTest) {
     AssertTest();
 }
 
-TEST(TypesTest,PolyTest) {
+TEST(TypesTest, PolyTest) {
     Fw::String str;
 
     // U8 Type  ===============================================================
@@ -1172,88 +1114,79 @@ TEST(TypesTest,PolyTest) {
     outPtr = (ptPtr = inPtr);
     ASSERT_EQ(static_cast<void*>(ptPtr), inPtr);
     ASSERT_EQ(outPtr, inPtr);
-
 }
 
-TEST(TypesTest,EightyCharTest) {
-
+TEST(TypesTest, EightyCharTest) {
     Fw::String str;
     str = "foo";
     Fw::String str2;
     str2 = "foo";
-    ASSERT_EQ(str,str2);
-    ASSERT_EQ(str,"foo");
+    ASSERT_EQ(str, str2);
+    ASSERT_EQ(str, "foo");
     str2 = "doodie";
-    ASSERT_NE(str,str2);
+    ASSERT_NE(str, str2);
 
     Fw::String str3 = str;
     str3 += str2;
-    ASSERT_EQ(str3,"foodoodie");
+    ASSERT_EQ(str3, "foodoodie");
 
     str3 += "hoo";
-    ASSERT_EQ(str3,"foodoodiehoo");
-
+    ASSERT_EQ(str3, "foodoodiehoo");
 
     Fw::String copyStr("ASTRING");
-    ASSERT_EQ(copyStr,"ASTRING");
+    ASSERT_EQ(copyStr, "ASTRING");
     Fw::String copyStr2 = "ASTRING";
-    ASSERT_EQ(copyStr2,"ASTRING");
+    ASSERT_EQ(copyStr2, "ASTRING");
     Fw::String copyStr3(copyStr2);
-    ASSERT_EQ(copyStr3,"ASTRING");
+    ASSERT_EQ(copyStr3, "ASTRING");
 
     Fw::InternalInterfaceString ifstr("IfString");
     Fw::String if2(ifstr);
 
-    ASSERT_EQ(ifstr,if2);
-    ASSERT_EQ(if2,"IfString");
-
+    ASSERT_EQ(ifstr, if2);
+    ASSERT_EQ(if2, "IfString");
 
     std::cout << "Stream: " << str2 << std::endl;
 
     // Make our own short string
-
-
 }
 
-TEST(TypesTest,ObjectNameTest) {
+TEST(TypesTest, ObjectNameTest) {
     Fw::ObjectName str;
     str = "foo";
     Fw::ObjectName str2;
     str2 = "foo";
-    ASSERT_EQ(str,str2);
-    ASSERT_EQ(str,"foo");
+    ASSERT_EQ(str, str2);
+    ASSERT_EQ(str, "foo");
     str2 = "_bar";
-    ASSERT_NE(str,str2);
+    ASSERT_NE(str, str2);
 
     Fw::ObjectName str3 = str;
     str3 += str2;
-    ASSERT_EQ(str3,"foo_bar");
+    ASSERT_EQ(str3, "foo_bar");
 
     str3 += "_foo";
-    ASSERT_EQ(str3,"foo_bar_foo");
-
+    ASSERT_EQ(str3, "foo_bar_foo");
 
     Fw::ObjectName copyStr("ASTRING");
-    ASSERT_EQ(copyStr,"ASTRING");
+    ASSERT_EQ(copyStr, "ASTRING");
     Fw::ObjectName copyStr2(copyStr);
-    ASSERT_EQ(copyStr2,"ASTRING");
+    ASSERT_EQ(copyStr2, "ASTRING");
 
     Fw::InternalInterfaceString ifstr("IfString");
     Fw::ObjectName if2(ifstr);
 
-    ASSERT_EQ(ifstr,if2);
-    ASSERT_EQ(if2,"IfString");
+    ASSERT_EQ(ifstr, if2);
+    ASSERT_EQ(if2, "IfString");
 }
 
-TEST(TypesTest,StringFormatTest) {
+TEST(TypesTest, StringFormatTest) {
     Fw::String str;
-    str.format("Int %d String %s",10,"foo");
+    str.format("Int %d String %s", 10, "foo");
     ASSERT_STREQ(str.toChar(), "Int 10 String foo");
 }
 
 TEST(PerformanceTest, F64SerPerfTest) {
-
-
     SerializeTestBuffer buff;
 
 #if DEBUG_VERBOSE
@@ -1268,33 +1201,30 @@ TEST(PerformanceTest, F64SerPerfTest) {
     Os::IntervalTimer timer;
     timer.start();
 
-
     for (NATIVE_INT_TYPE iter = 0; iter < iters; iter++) {
-		buff.resetSer();
-		buff.serialize(in);
-		buff.deserialize(out);
+        buff.resetSer();
+        buff.serialize(in);
+        buff.deserialize(out);
     }
 
     timer.stop();
 
-    printf("%d iterations took %d us (%f us each).\n", iters,
-            timer.getDiffUsec(),
-            static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iters));
-
+    printf("%d iterations took %d us (%f us each).\n", iters, timer.getDiffUsec(),
+           static_cast<F32>(timer.getDiffUsec()) / static_cast<F32>(iters));
 }
 
-TEST(AllocatorTest,MallocAllocatorTest) {
+TEST(AllocatorTest, MallocAllocatorTest) {
     // Since it is a wrapper around malloc, the test consists of requesting
     // memory and verifying a non-zero pointer, unchanged size, and not recoverable.
     Fw::MallocAllocator allocator;
-    NATIVE_UINT_TYPE size = 100; // one hundred bytes
+    NATIVE_UINT_TYPE size = 100;  // one hundred bytes
     bool recoverable;
-    void *ptr = allocator.allocate(10,size,recoverable);
-    ASSERT_EQ(100,size);
-    ASSERT_NE(ptr,nullptr);
+    void* ptr = allocator.allocate(10, size, recoverable);
+    ASSERT_EQ(100, size);
+    ASSERT_NE(ptr, nullptr);
     ASSERT_FALSE(recoverable);
     // deallocate memory
-    allocator.deallocate(100,ptr);
+    allocator.deallocate(100, ptr);
 }
 
 TEST(Nominal, string_copy) {
@@ -1354,11 +1284,11 @@ TEST(Nominal, string_len) {
 }
 
 TEST(OffNominal, string_len_zero) {
-  const char* test_string = "abc123";
-  ASSERT_EQ(Fw::StringUtils::string_length(test_string, 0), 0);
+    const char* test_string = "abc123";
+    ASSERT_EQ(Fw::StringUtils::string_length(test_string, 0), 0);
 }
 
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Reformatting improves the readability of the code. If we do it module by module, the impact should be minimal. `Fw/Types` seems like a logical place to start. 

If someone is developing `Fw/Types` with the old formatting, that person just needs to reformat the code being developed before diffing or making a PR against the new formatting. The catch is that because of the idiosyncratic use of the preprocessor symbols `PRIVATE` and `PROTECTED` in F Prime, you can't just run clang-format. Here is the script that I use to work around this issue:
```bash
#!/bin/sh -e

# ----------------------------------------------------------------------
# fprime-format-cpp
# Use clang-format to format C++ files for F Prime
# ----------------------------------------------------------------------

format()
{
  sed -e 's;^[ \t]*PROTECTED[ \t]*:;protected: // fprime-format-cpp;' -e 's;^[ \t]*PRIVATE[ \t]*:;private: // fprime-format-cpp;' | \
  clang-format --style=file | \
  sed -e 's;protected: *// fprime-format-cpp;PROTECTED:;' -e 's;private: *// fprime-format-cpp;PRIVATE:;'
}

if test $# -eq 0
then
  format
else
  for file in "$@"
  do
    cp "$file" "$file.bak"
    format < "$file.bak" > "$file"
  done
fi
```
I call this tool `fprime-format-cpp`. When run anywhere in the F Prime repo, it picks up the formatting configuration stored in `[fprime-root]/.clang-format`, so the formatting should be consistent for all users. It's designed so that you can run it inside a text editor (e.g., vi or VS Code) or in batch mode on the command line.

Here is how you can reformat all the files in a build module:
```bash
% fprime-format-cpp `find . -name '*.hpp' -or -name '*.cpp'`
```

I recommend that we put `fprime-format-cpp`, or something like it, into the repo so users can use it to format their code.