### PR TITLE
Improve error display on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ build-fprime-automatic*
 /RPI/bin
 /ci-venv/
 /ci-logs*
+/ci-Framework-logs*
 TesterBase.*
 GTestBase.*
 **/DefaultDict/serializable/*

--- a/ci/helpers.bash
+++ b/ci/helpers.bash
@@ -31,13 +31,26 @@ function fail_and_stop()
     echo -e "${RED}---------------- ERROR ----------------" 1>&2
     echo    "${1}" 1>&2
     echo -e "---------------------------------------${NOCOLOR}" 1>&2
-    LASTLOG=$(ls -td $(find "${LOG_DIR}" -name "*err.log" -type f) | head -1)
-    if [ -f "${LASTLOG}" ]
+    LASTLOG_ERR=$(ls -td $(find "${LOG_DIR}" -name "*err.log" -type f) | head -1)
+
+    if [ -f "${LASTLOG_ERR}" ]
     then
-    
-        echo -e "---------------- STDERR ---------------" 1>&2
-        tail -30 "${LASTLOG}" 1>&2
-        echo -e "---------------------------------------" 1>&2
+        LASTLOG_OUT="${LASTLOG_ERR::-7}out.log" 1>&2
+
+        if [ -f "${LASTLOG_OUT}" ]
+        then
+            echo -e "${RED}---------------- STDOUT ---------------${NOCOLOR}" 1>&2
+            cat "${LASTLOG_OUT}" 1>&2
+            echo -e "${RED}---------------------------------------${NOCOLOR}" 1>&2
+        fi
+
+        echo -e "${RED}---------------- STDOUT ---------------${NOCOLOR}" 1>&2
+        cat "${LASTLOG_ERR}" 1>&2
+        echo -e "${RED}---------------------------------------${NOCOLOR}" 1>&2
+
+        echo -e "${RED}---------------- END ERROR ------------" 1>&2
+        echo    "${1}" 1>&2
+        echo -e "---------------------------------------${NOCOLOR}" 1>&2
     fi
     archive_logs
     exit 1

--- a/ci/helpers.bash
+++ b/ci/helpers.bash
@@ -31,19 +31,24 @@ function fail_and_stop()
     echo -e "${RED}---------------- ERROR ----------------" 1>&2
     echo    "${1}" 1>&2
     echo -e "---------------------------------------${NOCOLOR}" 1>&2
+
+    # Look for an stderr log which is not empty
     LASTLOG_ERR=$(ls -td $(find "${LOG_DIR}" -name "*err.log" -type f) | head -1)
 
     if [ -f "${LASTLOG_ERR}" ]
     then
+        # Check if a related stdout log exist
         LASTLOG_OUT="${LASTLOG_ERR::-7}out.log" 1>&2
 
         if [ -f "${LASTLOG_OUT}" ]
         then
+            # Display stdout log
             echo -e "${RED}---------------- STDOUT ---------------${NOCOLOR}" 1>&2
             cat "${LASTLOG_OUT}" 1>&2
             echo -e "${RED}---------------------------------------${NOCOLOR}" 1>&2
         fi
 
+        # Display stderr log
         echo -e "${RED}---------------- STDOUT ---------------${NOCOLOR}" 1>&2
         cat "${LASTLOG_ERR}" 1>&2
         echo -e "${RED}---------------------------------------${NOCOLOR}" 1>&2

--- a/ci/helpers.bash
+++ b/ci/helpers.bash
@@ -49,7 +49,7 @@ function fail_and_stop()
         fi
 
         # Display stderr log
-        echo -e "${RED}---------------- STDOUT ---------------${NOCOLOR}" 1>&2
+        echo -e "${RED}---------------- STDERR ---------------${NOCOLOR}" 1>&2
         cat "${LASTLOG_ERR}" 1>&2
         echo -e "${RED}---------------------------------------${NOCOLOR}" 1>&2
 

--- a/ci/helpers.bash
+++ b/ci/helpers.bash
@@ -38,7 +38,7 @@ function fail_and_stop()
     if [ -f "${LASTLOG_ERR}" ]
     then
         # Check if a related stdout log exist
-        LASTLOG_OUT="${LASTLOG_ERR::-7}out.log" 1>&2
+        LASTLOG_OUT="${LASTLOG_ERR::-7}out.log"
 
         if [ -f "${LASTLOG_OUT}" ]
         then


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2695 |
|**_Has Unit Tests (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

- Remove stderr log line limit for print
- Display stdout log with before stderr log
- Add CI folder in the .gitignore

This is how the output is now looking like:

```
/home/fprime/ci/tests# ./Framework.bash 
Starting CI test /home/fprime Ref
Testing /home/fprime against fprime-util targets: generate generate --ut build build --all check --all
[INFO] FP Util in /home/fprime running generate
[INFO] FP Util in /home/fprime running generate --ut
[INFO] FP Util in /home/fprime running build with 78 jobs
[INFO] FP Util in /home/fprime running build --all with 78 jobs
[INFO] FP Util in /home/fprime running check --all with 78 jobs
---------------- ERROR ----------------
Failed to run 'check --all' in /home/fprime
---------------------------------------
---------------- STDOUT ---------------
[WARNING] /home/fprime/settings.ini does not exist
[  0%] Generating PolyDbEntryEnumAi.xml, ProcTypeEnumAi.xml
[  0%] Generating FppConstantsAc.cpp, FppConstantsAc.hpp, PolyDbEntryEnumAc.cpp, PolyDbEntryEnumAc.hpp, ProcTypeEnumAc.cpp, ProcTypeEnumAc.hpp
[  0%] Building CXX object F-Prime/STest/CMakeFiles/STest.dir/STest/Pick/Pick_default.cpp.o
[  0%] Building CXX object F-Prime/googletest/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
[  0%] Building C object F-Prime/STest/CMakeFiles/STest.dir/STest/Random/bsd_random.c.o
[  0%] Building CXX object F-Prime/STest/CMakeFiles/STest.dir/STest/Random/Random.cpp.o
[  0%] Building CXX object F-Prime/Os/Posix/CMakeFiles/Os_File_Posix.dir/File.cpp.o
[  0%] Building CXX object F-Prime/Os/Posix/CMakeFiles/Os_File_Posix.dir/errno.cpp.o
[...]
98% tests passed, 1 tests failed out of 58

Total Test time (real) =  31.10 sec

The following tests FAILED:
         14 - Svc_BufferLogger_ut_exe (Failed)
---------------------------------------
---------------- STDERR ---------------
Errors while running CTest
make[3]: *** [CMakeFiles/check.dir/build.make:70: CMakeFiles/check] Error 8
make[2]: *** [CMakeFiles/Makefile2:3097: CMakeFiles/check.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:3104: CMakeFiles/check.dir/rule] Error 2
make: *** [Makefile:582: check] Error 2
[ERROR] CMake erred with return code 2
---------------------------------------
------------- END ERROR ---------------
Failed to run 'check --all' in /home/fprime
---------------------------------------
```

## Rationale

This will make debugging more easy when an error happen on the CI.

## Testing/Review Recommendations

N/A

## Future Work

N/A
