### PR TITLE
Add log on TCP/UDP UT failure and fix UDP UT

### DIFF
--- a/Drv/TcpClient/test/ut/TcpClientTester.cpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.cpp
@@ -36,12 +36,10 @@ void TcpClientTester ::test_with_loop(U32 iterations, bool recv_thread) {
     server.configure("127.0.0.1", port, 0, 100);
     this->component.configure("127.0.0.1", port, 0, 100);
     serverStat = server.startup();
-    if (serverStat != SOCK_SUCCESS)
-    {
-        printf("TCP server startup error: %s\n", strerror(errno));
-        printf("Port: %u\n", port);
-    }
-    ASSERT_EQ(serverStat, SOCK_SUCCESS);
+
+    ASSERT_EQ(serverStat, SOCK_SUCCESS)
+        << "TCP server startup error: " << strerror(errno) << std::endl
+        << "Port: " << port << std::endl;
 
     // Start up a receive thread
     if (recv_thread) {

--- a/Drv/TcpClient/test/ut/TcpClientTester.cpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.cpp
@@ -38,7 +38,7 @@ void TcpClientTester ::test_with_loop(U32 iterations, bool recv_thread) {
     serverStat = server.startup();
     if (serverStat != SOCK_SUCCESS)
     {
-        perror("TCP server startup error");
+        printf("TCP server startup error: %s\n", strerror(errno));
         printf("Port: %u\n", port);
     }
     ASSERT_EQ(serverStat, SOCK_SUCCESS);

--- a/Drv/TcpClient/test/ut/TcpClientTester.cpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.cpp
@@ -36,6 +36,11 @@ void TcpClientTester ::test_with_loop(U32 iterations, bool recv_thread) {
     server.configure("127.0.0.1", port, 0, 100);
     this->component.configure("127.0.0.1", port, 0, 100);
     serverStat = server.startup();
+    if (serverStat != SOCK_SUCCESS)
+    {
+        perror("TCP server startup error");
+        printf("Port: %u\n", port);
+    }
     ASSERT_EQ(serverStat, SOCK_SUCCESS);
 
     // Start up a receive thread

--- a/Drv/TcpServer/test/ut/TcpServerTester.cpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.cpp
@@ -41,7 +41,12 @@ void TcpServerTester ::test_with_loop(U32 iterations, bool recv_thread) {
         EXPECT_TRUE(Drv::Test::wait_on_started(this->component.getSocketHandler(), true, SOCKET_RETRY_INTERVAL_MS/10 + 1));
     } else {
         serverStat = this->component.startup();
-        EXPECT_EQ(serverStat, SOCK_SUCCESS);
+        if (serverStat != SOCK_SUCCESS)
+        {
+            perror("TCP server startup error");
+            printf("Port: %u\n", port);
+        }
+        ASSERT_EQ(serverStat, SOCK_SUCCESS);
     }
     EXPECT_TRUE(component.getSocketHandler().isStarted());
 

--- a/Drv/TcpServer/test/ut/TcpServerTester.cpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.cpp
@@ -41,12 +41,9 @@ void TcpServerTester ::test_with_loop(U32 iterations, bool recv_thread) {
         EXPECT_TRUE(Drv::Test::wait_on_started(this->component.getSocketHandler(), true, SOCKET_RETRY_INTERVAL_MS/10 + 1));
     } else {
         serverStat = this->component.startup();
-        if (serverStat != SOCK_SUCCESS)
-        {
-            printf("TCP server startup error: %s\n", strerror(errno));
-            printf("Port: %u\n", port);
-        }
-        ASSERT_EQ(serverStat, SOCK_SUCCESS);
+        ASSERT_EQ(serverStat, SOCK_SUCCESS)
+            << "TCP server startup error: " << strerror(errno) << std::endl
+            << "Port: " << port << std::endl;
     }
     EXPECT_TRUE(component.getSocketHandler().isStarted());
 

--- a/Drv/TcpServer/test/ut/TcpServerTester.cpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.cpp
@@ -43,7 +43,7 @@ void TcpServerTester ::test_with_loop(U32 iterations, bool recv_thread) {
         serverStat = this->component.startup();
         if (serverStat != SOCK_SUCCESS)
         {
-            perror("TCP server startup error");
+            printf("TCP server startup error: %s\n", strerror(errno));
             printf("Port: %u\n", port);
         }
         ASSERT_EQ(serverStat, SOCK_SUCCESS);

--- a/Drv/Udp/test/ut/UdpTester.cpp
+++ b/Drv/Udp/test/ut/UdpTester.cpp
@@ -59,7 +59,7 @@ void UdpTester::test_with_loop(U32 iterations, bool recv_thread) {
 
         udp2.configureSend("127.0.0.1", port2, 0, 100);
         udp2.configureRecv("127.0.0.1", port1);
-        status2 = udp2.open();;
+        status2 = udp2.open();
 
         EXPECT_EQ(status1, Drv::SOCK_SUCCESS);
         EXPECT_EQ(status2, Drv::SOCK_SUCCESS);

--- a/Drv/Udp/test/ut/UdpTester.cpp
+++ b/Drv/Udp/test/ut/UdpTester.cpp
@@ -68,7 +68,7 @@ void UdpTester::test_with_loop(U32 iterations, bool recv_thread) {
                 printf("Port1: %u\n", port1);
                 printf("Port2: %u\n", port2);
             }
-            ASSERT_EQ(status1, Drv::SOCK_SUCCESS);
+            EXPECT_EQ(status1, Drv::SOCK_SUCCESS);
         } else {
             EXPECT_TRUE(Drv::Test::wait_on_change(this->component.getSocketHandler(), true, SOCKET_RETRY_INTERVAL_MS/10 + 1));
         }
@@ -84,7 +84,7 @@ void UdpTester::test_with_loop(U32 iterations, bool recv_thread) {
             printf("Port1: %u\n", port1);
             printf("Port2: %u\n", port2);
         }
-        ASSERT_EQ(status2, Drv::SOCK_SUCCESS);
+        EXPECT_EQ(status2, Drv::SOCK_SUCCESS);
 
         // If all the opens worked, then run this
         if ((Drv::SOCK_SUCCESS == status1) && (Drv::SOCK_SUCCESS == status2) &&

--- a/Drv/Udp/test/ut/UdpTester.cpp
+++ b/Drv/Udp/test/ut/UdpTester.cpp
@@ -62,13 +62,12 @@ void UdpTester::test_with_loop(U32 iterations, bool recv_thread) {
         // Not testing with reconnect thread, we will need to open ourselves
         if (not recv_thread) {
             status1 = this->component.open();
-            if (status1 != Drv::SOCK_SUCCESS)
-            {
-                printf("UDP socket open error: %s\n", strerror(errno));
-                printf("Port1: %u\n", port1);
-                printf("Port2: %u\n", port2);
-            }
-            EXPECT_EQ(status1, Drv::SOCK_SUCCESS);
+
+            EXPECT_EQ(status1, Drv::SOCK_SUCCESS)
+                << "UDP socket open error: " << strerror(errno)
+                << "Port1: " << port1
+                << "Port2: " << port2;
+
         } else {
             EXPECT_TRUE(Drv::Test::wait_on_change(this->component.getSocketHandler(), true, SOCKET_RETRY_INTERVAL_MS/10 + 1));
         }
@@ -78,13 +77,10 @@ void UdpTester::test_with_loop(U32 iterations, bool recv_thread) {
         udp2.configureRecv("127.0.0.1", port1);
         status2 = udp2.open();
 
-        if (status2 != Drv::SOCK_SUCCESS)
-        {
-            printf("UDP socket open error: %s\n", strerror(errno));
-            printf("Port1: %u\n", port1);
-            printf("Port2: %u\n", port2);
-        }
-        EXPECT_EQ(status2, Drv::SOCK_SUCCESS);
+        EXPECT_EQ(status2, Drv::SOCK_SUCCESS)
+            << "UDP socket open error: " << strerror(errno) << std::endl
+            << "Port1: " << port1 << std::endl
+            << "Port2: " << port2 << std::endl;
 
         // If all the opens worked, then run this
         if ((Drv::SOCK_SUCCESS == status1) && (Drv::SOCK_SUCCESS == status2) &&


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

- Add log on stdout when an error happens in the TCP and UDP UT.
- Fix the following case, where the UDP UT would select twice the same port and fail binding later:
```
[ RUN      ] Nominal.BasicReceiveThread
Setup to send and receive udp to 127.0.0.1:60296
UDP socket open error: Address already in use
Port1: 60296
Port2: 60296
/home/fprime/Drv/Udp/test/ut/UdpTester.cpp:77: Failure
Expected equality of these values:
  status2
    Which is: -9
  Drv::SOCK_SUCCESS
    Which is: 0
[  FAILED  ] Nominal.BasicReceiveThread (10 ms)
```
```
[ RUN      ] Reconnect.MultiMessaging
Setup to send and receive udp to 127.0.0.1:6335
UDP socket open error: Address already in use
Port1: 6335
Port2: 6335
/home/fprime/Drv/Udp/test/ut/UdpTester.cpp:77: Failure
Expected equality of these values:
  status2
    Which is: -9
  Drv::SOCK_SUCCESS
    Which is: 0
[  FAILED  ] Reconnect.MultiMessaging (0 ms)
```

## Rationale

TCP and UDP UT are often failing, and this will give more understanding of the reason of those failures.
