### PR TITLE
Update of clang tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
+# Clang-tidy configuration used on the whole code base, including tests and flight code
+
 Checks: >
     bugprone-unhandled-self-assignment,
-    misc-no-recursion,
     modernize-deprecated-headers,
     modernize-redundant-void-arg,
     modernize-use-bool-literals,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,10 @@
 Checks: >
     bugprone-unhandled-self-assignment,
+    misc-no-recursion,
     modernize-deprecated-headers,
     modernize-redundant-void-arg,
     modernize-use-bool-literals,
     modernize-use-nullptr,
-    -clang-analyzer-security.insecureAPI.rand
+    readability-braces-around-statements
+    -clang-analyzer-security.insecureAPI.rand,
 WarningsAsErrors: '*'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -101,6 +101,6 @@ jobs:
         fprime-util build --all --ut
     - name: Flight Code Static Analysis
       run: |
-        fprime-util generate -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CXX_CLANG_TIDY="clang-tidy-12;--config-file=$PWD/release.clang-tidy"
+        fprime-util generate -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CXX_CLANG_TIDY="clang-tidy-12;--config-file=$PWD/.clang-tidy"
         fprime-util build --all -j4
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -95,12 +95,14 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install clang-tidy-12
+    # Uses the default configuration file (.clang-tidy)
     - name: General Static Analysis
       run: |
         fprime-util generate --ut -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CXX_CLANG_TIDY=clang-tidy-12
         fprime-util build --all --ut
+    # Uses the release configuration file (release.clang-tidy)
     - name: Flight Code Static Analysis
       run: |
-        fprime-util generate -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CXX_CLANG_TIDY="clang-tidy-12;--config-file=$PWD/.clang-tidy"
+        fprime-util generate -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CXX_CLANG_TIDY="clang-tidy-12;--config-file=$PWD/release.clang-tidy"
         fprime-util build --all -j4
 

--- a/CFDP/Checksum/Checksum.cpp
+++ b/CFDP/Checksum/Checksum.cpp
@@ -90,8 +90,9 @@ namespace CFDP {
     }
 
     // Add the middle words aligned
-    for ( ; index + 4 <= length; index += 4)
+    for ( ; index + 4 <= length; index += 4) {
       addWordAligned(&data[index]);
+    }
 
     // Add the last word unaligned if necessary
     if (index < length) {
@@ -108,8 +109,9 @@ namespace CFDP {
   void Checksum ::
     addWordAligned(const U8 *const word)
   {
-    for (U8 i = 0; i < 4; ++i)
+    for (U8 i = 0; i < 4; ++i) {
       addByteAtOffset(word[i], i);
+    }
   }
 
   void Checksum ::
@@ -124,8 +126,9 @@ namespace CFDP {
     for (U8 i = 0; i < length; ++i) {
       addByteAtOffset(word[i], offset);
       ++offset;
-      if (offset == 4)
+      if (offset == 4) {
         offset = 0;
+      }
     }
   }
 

--- a/Fw/FilePacket/CancelPacket.cpp
+++ b/Fw/FilePacket/CancelPacket.cpp
@@ -43,8 +43,9 @@ namespace Fw {
 
     FW_ASSERT(this->m_header.m_type == T_CANCEL);
 
-    if (serialBuffer.getBuffLeft() != 0)
+    if (serialBuffer.getBuffLeft() != 0) {
       return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
 
     return FW_SERIALIZE_OK;
 

--- a/Fw/FilePacket/DataPacket.cpp
+++ b/Fw/FilePacket/DataPacket.cpp
@@ -56,15 +56,18 @@ namespace Fw {
     FW_ASSERT(this->m_header.m_type == T_DATA);
 
     SerializeStatus status = serialBuffer.deserialize(this->m_byteOffset);
-    if (status != FW_SERIALIZE_OK)
+    if (status != FW_SERIALIZE_OK) {
       return status;
+    }
 
     status = serialBuffer.deserialize(this->m_dataSize);
-    if (status != FW_SERIALIZE_OK)
+    if (status != FW_SERIALIZE_OK) {
       return status;
+    }
 
-    if (serialBuffer.getBuffLeft() != this->m_dataSize)
+    if (serialBuffer.getBuffLeft() != this->m_dataSize) {
       return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
 
     U8 *const addr = serialBuffer.getBuffAddr();
     this->m_data = &addr[this->fixedLengthSize()];
@@ -91,16 +94,19 @@ namespace Fw {
     SerializeStatus status;
 
     status = this->m_header.toSerialBuffer(serialBuffer);
-    if (status != FW_SERIALIZE_OK)
+    if (status != FW_SERIALIZE_OK) {
       return status;
+    }
 
     status = serialBuffer.serialize(this->m_byteOffset);
-    if (status != FW_SERIALIZE_OK)
+    if (status != FW_SERIALIZE_OK) {
       return status;
+    }
 
     status = serialBuffer.serialize(this->m_dataSize);
-    if (status != FW_SERIALIZE_OK)
+    if (status != FW_SERIALIZE_OK) {
       return status;
+    }
 
     status = serialBuffer.pushBytes(this->m_data, this->m_dataSize);
 

--- a/Fw/FilePacket/EndPacket.cpp
+++ b/Fw/FilePacket/EndPacket.cpp
@@ -79,12 +79,14 @@ namespace Fw {
     SerializeStatus status;
 
     status = this->m_header.toSerialBuffer(serialBuffer);
-    if (status != FW_SERIALIZE_OK)
+    if (status != FW_SERIALIZE_OK) {
       return status;
+    }
 
     status = serialBuffer.serialize(this->m_checksumValue);
-    if (status != FW_SERIALIZE_OK)
+    if (status != FW_SERIALIZE_OK) {
       return status;
+    }
 
     return FW_SERIALIZE_OK;
 

--- a/Fw/FilePacket/FilePacket.cpp
+++ b/Fw/FilePacket/FilePacket.cpp
@@ -140,8 +140,10 @@ namespace Fw {
   {
     SerializeStatus status;
     status = this->m_header.fromSerialBuffer(serialBuffer);
-    if (status != FW_SERIALIZE_OK)
+    if (status != FW_SERIALIZE_OK) {
       return status;
+    }
+
     switch (this->m_header.m_type) {
       case T_START:
         status = this->m_startPacket.fromSerialBuffer(serialBuffer);

--- a/Fw/FilePacket/Header.cpp
+++ b/Fw/FilePacket/Header.cpp
@@ -58,12 +58,14 @@ namespace Fw {
     SerializeStatus status;
 
     status = serialBuffer.serialize(type_casted);
-    if (status != FW_SERIALIZE_OK)
+    if (status != FW_SERIALIZE_OK) {
       return status;
+    }
 
     status = serialBuffer.serialize(this->m_sequenceIndex);
-    if (status != FW_SERIALIZE_OK)
+    if (status != FW_SERIALIZE_OK) {
       return status;
+    }
 
     return FW_SERIALIZE_OK;
 

--- a/Fw/FilePacket/PathName.cpp
+++ b/Fw/FilePacket/PathName.cpp
@@ -39,8 +39,10 @@ namespace Fw {
     {
       const SerializeStatus status =
         serialBuffer.deserialize(this->m_length);
-      if (status != FW_SERIALIZE_OK)
+
+      if (status != FW_SERIALIZE_OK) {
         return status;
+      }
     }
 
     {
@@ -48,8 +50,11 @@ namespace Fw {
       U8 bytes[MAX_LENGTH];
       const SerializeStatus status =
         serialBuffer.popBytes(bytes, this->m_length);
-      if (status != FW_SERIALIZE_OK)
+
+      if (status != FW_SERIALIZE_OK) {
         return status;
+      }
+
       this->m_value = reinterpret_cast<const char*>(addrLeft);
     }
 
@@ -64,8 +69,10 @@ namespace Fw {
     {
       const SerializeStatus status =
         serialBuffer.serialize(this->m_length);
-      if (status != FW_SERIALIZE_OK)
+
+      if (status != FW_SERIALIZE_OK) {
         return status;
+      }
     }
 
     {
@@ -73,8 +80,10 @@ namespace Fw {
           reinterpret_cast<const U8 *>(this->m_value),
           this->m_length
       );
-      if (status != FW_SERIALIZE_OK)
+
+      if (status != FW_SERIALIZE_OK) {
         return status;
+      }
     }
 
     return FW_SERIALIZE_OK;

--- a/Fw/FilePacket/StartPacket.cpp
+++ b/Fw/FilePacket/StartPacket.cpp
@@ -57,22 +57,28 @@ namespace Fw {
     {
       const SerializeStatus status =
         serialBuffer.deserialize(this->m_fileSize);
-      if (status != FW_SERIALIZE_OK)
+
+      if (status != FW_SERIALIZE_OK) {
         return status;
+      }
     }
 
     {
       const SerializeStatus status =
         this->m_sourcePath.fromSerialBuffer(serialBuffer);
-      if (status != FW_SERIALIZE_OK)
+
+      if (status != FW_SERIALIZE_OK) {
         return status;
+      }
     }
 
     {
       const SerializeStatus status =
         this->m_destinationPath.fromSerialBuffer(serialBuffer);
-      if (status != FW_SERIALIZE_OK)
+
+      if (status != FW_SERIALIZE_OK) {
         return status;
+      }
     }
 
     return FW_SERIALIZE_OK;
@@ -88,29 +94,37 @@ namespace Fw {
     {
       const SerializeStatus status =
         this->m_header.toSerialBuffer(serialBuffer);
-      if (status != FW_SERIALIZE_OK)
+
+      if (status != FW_SERIALIZE_OK) {
         return status;
+      }
     }
 
     {
       const SerializeStatus status =
         serialBuffer.serialize(this->m_fileSize);
-      if (status != FW_SERIALIZE_OK)
+
+      if (status != FW_SERIALIZE_OK) {
         return status;
+      }
     }
 
     {
       const SerializeStatus status =
         this->m_sourcePath.toSerialBuffer(serialBuffer);
-      if (status != FW_SERIALIZE_OK)
+
+      if (status != FW_SERIALIZE_OK) {
         return status;
+      }
     }
 
     {
       const SerializeStatus status =
         this->m_destinationPath.toSerialBuffer(serialBuffer);
-      if (status != FW_SERIALIZE_OK)
+
+      if (status != FW_SERIALIZE_OK) {
         return status;
+      }
     }
 
     return FW_SERIALIZE_OK;

--- a/Fw/Types/StringBase.hpp
+++ b/Fw/Types/StringBase.hpp
@@ -33,7 +33,7 @@ class StringBase : public Serializable {
     //! This is the max length of the string plus the size of the stored size
     static constexpr SizeType STATIC_SERIALIZED_SIZE(SizeType maxLength  //!< The maximum string length
     ) {
-        return sizeof(FwSizeStoreType) + maxLength;
+        return static_cast<SizeType>(sizeof(FwSizeStoreType)) + maxLength;
     }
 
     //! Get the size of a null-terminated string buffer

--- a/Svc/FileDownlink/File.cpp
+++ b/Svc/FileDownlink/File.cpp
@@ -34,10 +34,11 @@ namespace Svc {
 
     // Set size
     FwSignedSizeType file_size;
-    const Os::FileSystem::Status status = 
+    const Os::FileSystem::Status status =
       Os::FileSystem::getFileSize(sourceFileName, file_size);
-    if (status != Os::FileSystem::OP_OK)
+    if (status != Os::FileSystem::OP_OK) {
       return Os::File::BAD_SIZE;
+    }
     // If the size does not cast cleanly to the desired U32 type, return size error
     if (static_cast<FwSignedSizeType>(static_cast<U32>(file_size)) != file_size) {
         return Os::File::BAD_SIZE;

--- a/release.clang-tidy
+++ b/release.clang-tidy
@@ -1,0 +1,6 @@
+# Clang-tidy configuration used only for flight code
+
+Checks: >
+    -*,
+    misc-no-recursion
+WarningsAsErrors: '*'

--- a/release.clang-tidy
+++ b/release.clang-tidy
@@ -1,5 +1,0 @@
-Checks: >
-    -*,
-    misc-no-recursion,
-    readability-braces-around-statements
-WarningsAsErrors: '*'

--- a/release.clang-tidy
+++ b/release.clang-tidy
@@ -1,4 +1,5 @@
 Checks: >
     -*,
-    misc-no-recursion
+    misc-no-recursion,
+    readability-braces-around-statements
 WarningsAsErrors: '*'


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

- Add clang-tidy check on braces after statements and related flagged errors.
- Merge `release.clang-tidy` into `.clang-tidy` and update CI. Unless it is used for somewhere externally, I do not see the file `.clang-tidy` used anywhere otherwise.
- Also fix an issue in StringBase flagged on my docker image, but not on the CI?

## Rationale

Enforce consistent coding standard

