### PR TITLE
Fix copying of data product containers

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -268,13 +268,14 @@ doxyindexer
 doxyrules
 doxysearch
 Doxywizard
-DPCFG
-dpi
+dpc
 DPCAT
 DPCATALOG
+DPCFG
+dpi
 DPMANAGER
-DPWRITER
 dps
+DPWRITER
 DRAINBUFFERS
 drv
 dsdl
@@ -314,6 +315,7 @@ errmsg
 ERRORCHECK
 errornum
 ert
+esb
 ethanchee
 etime
 eturn
@@ -433,8 +435,8 @@ Guire
 handcoded
 hardtoaccess
 hashvalue
-HEADERSIZE
 hdr
+HEADERSIZE
 headlessly
 heapifying
 hexid
@@ -1000,10 +1002,10 @@ subgrouping
 subhist
 subhistory
 subpage
-suseconds
 subseconds
 subtargets
 suppr
+suseconds
 SVCLOGFILE
 SVCLOGFILEL
 svipc

--- a/FppTest/dp/DpTest.cpp
+++ b/FppTest/dp/DpTest.cpp
@@ -23,6 +23,7 @@ DpTest::DpTest(const char* const compName,
                const DataArrayRecordData& dataArrayRecordData,
                const Fw::StringBase& a_stringRecordData)
     : DpTestComponentBase(compName),
+      m_container(),
       u32RecordData(u32RecordData),
       dataRecordData(dataRecordData),
       u8ArrayRecordData(u8ArrayRecordData),
@@ -60,45 +61,40 @@ void DpTest::schedIn_handler(const NATIVE_INT_TYPE portNum, U32 context) {
     this->dpRequest_Container6(CONTAINER_6_DATA_SIZE);
     // Get a buffer for Container 1
     {
-        DpContainer container;
-        Fw::Success status = this->dpGet_Container1(CONTAINER_1_DATA_SIZE, container);
+        Fw::Success status = this->dpGet_Container1(CONTAINER_1_DATA_SIZE, this->m_container);
         FW_ASSERT(status == Fw::Success::SUCCESS, status);
         // Check the container
-        this->checkContainer(container, ContainerId::Container1, CONTAINER_1_PACKET_SIZE,
+        this->checkContainer(this->m_container, ContainerId::Container1, CONTAINER_1_PACKET_SIZE,
                              DpTest::ContainerPriority::Container1);
     }
     // Get a buffer for Container 2
     {
-        DpContainer container;
-        Fw::Success status = this->dpGet_Container2(CONTAINER_2_DATA_SIZE, container);
+        Fw::Success status = this->dpGet_Container2(CONTAINER_2_DATA_SIZE, this->m_container);
         FW_ASSERT(status == Fw::Success::SUCCESS);
         // Check the container
-        this->checkContainer(container, ContainerId::Container2, CONTAINER_2_PACKET_SIZE,
+        this->checkContainer(this->m_container, ContainerId::Container2, CONTAINER_2_PACKET_SIZE,
                              DpTest::ContainerPriority::Container2);
     }
     // Get a buffer for Container 3
     {
-        DpContainer container;
-        Fw::Success status = this->dpGet_Container3(CONTAINER_3_DATA_SIZE, container);
+        Fw::Success status = this->dpGet_Container3(CONTAINER_3_DATA_SIZE, this->m_container);
         // This one should fail
         FW_ASSERT(status == Fw::Success::FAILURE);
     }
     // Get a buffer for Container 4
     {
-        DpContainer container;
-        Fw::Success status = this->dpGet_Container4(CONTAINER_4_DATA_SIZE, container);
+        Fw::Success status = this->dpGet_Container4(CONTAINER_4_DATA_SIZE, this->m_container);
         FW_ASSERT(status == Fw::Success::SUCCESS);
         // Check the container
-        this->checkContainer(container, ContainerId::Container4, CONTAINER_4_PACKET_SIZE,
+        this->checkContainer(this->m_container, ContainerId::Container4, CONTAINER_4_PACKET_SIZE,
                              DpTest::ContainerPriority::Container4);
     }
     // Get a buffer for Container 5
     {
-        DpContainer container;
-        Fw::Success status = this->dpGet_Container5(CONTAINER_5_DATA_SIZE, container);
+        Fw::Success status = this->dpGet_Container5(CONTAINER_5_DATA_SIZE, this->m_container);
         FW_ASSERT(status == Fw::Success::SUCCESS);
         // Check the container
-        this->checkContainer(container, ContainerId::Container5, CONTAINER_5_PACKET_SIZE,
+        this->checkContainer(this->m_container, ContainerId::Container5, CONTAINER_5_PACKET_SIZE,
                              DpTest::ContainerPriority::Container5);
     }
 }
@@ -108,104 +104,118 @@ void DpTest::schedIn_handler(const NATIVE_INT_TYPE portNum, U32 context) {
 // ----------------------------------------------------------------------
 
 void DpTest ::dpRecv_Container1_handler(DpContainer& container, Fw::Success::T status) {
+    // Test container assignment
+    this->m_container = container;
     if (status == Fw::Success::SUCCESS) {
         auto serializeStatus = Fw::FW_SERIALIZE_OK;
         for (FwSizeType i = 0; i < CONTAINER_1_DATA_SIZE; ++i) {
-            serializeStatus = container.serializeRecord_U32Record(this->u32RecordData);
+            serializeStatus = this->m_container.serializeRecord_U32Record(this->u32RecordData);
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
             FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
         }
         // Use the time stamp from the time get port
-        this->dpSend(container);
+        this->dpSend(this->m_container);
     }
 }
 
 void DpTest ::dpRecv_Container2_handler(DpContainer& container, Fw::Success::T status) {
+    // Test container assignment
+    this->m_container = container;
     if (status == Fw::Success::SUCCESS) {
         const DpTest_Data dataRecord(this->dataRecordData);
         auto serializeStatus = Fw::FW_SERIALIZE_OK;
         for (FwSizeType i = 0; i < CONTAINER_2_DATA_SIZE; ++i) {
-            serializeStatus = container.serializeRecord_DataRecord(dataRecord);
+            serializeStatus = this->m_container.serializeRecord_DataRecord(dataRecord);
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
             FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
         }
         // Provide an explicit time stamp
-        this->dpSend(container, this->sendTime);
+        this->dpSend(this->m_container, this->sendTime);
     }
 }
 
 void DpTest ::dpRecv_Container3_handler(DpContainer& container, Fw::Success::T status) {
+    // Test container assignment
+    this->m_container = container;
     if (status == Fw::Success::SUCCESS) {
         auto serializeStatus = Fw::FW_SERIALIZE_OK;
         for (FwSizeType i = 0; i < CONTAINER_3_DATA_SIZE; ++i) {
-            serializeStatus =
-                container.serializeRecord_U8ArrayRecord(this->u8ArrayRecordData.data(), this->u8ArrayRecordData.size());
+            serializeStatus = this->m_container.serializeRecord_U8ArrayRecord(this->u8ArrayRecordData.data(),
+                                                                              this->u8ArrayRecordData.size());
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
             FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
         }
         // Use the time stamp from the time get port
-        this->dpSend(container);
+        this->dpSend(this->m_container);
     }
 }
 
 void DpTest ::dpRecv_Container4_handler(DpContainer& container, Fw::Success::T status) {
+    // Test container assignment
+    this->m_container = container;
     if (status == Fw::Success::SUCCESS) {
         auto serializeStatus = Fw::FW_SERIALIZE_OK;
         for (FwSizeType i = 0; i < CONTAINER_4_DATA_SIZE; ++i) {
-            serializeStatus = container.serializeRecord_U32ArrayRecord(this->u32ArrayRecordData.data(),
-                                                                       this->u32ArrayRecordData.size());
+            serializeStatus = this->m_container.serializeRecord_U32ArrayRecord(this->u32ArrayRecordData.data(),
+                                                                               this->u32ArrayRecordData.size());
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
             FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
         }
         // Use the time stamp from the time get port
-        this->dpSend(container);
+        this->dpSend(this->m_container);
     }
 }
 
 void DpTest ::dpRecv_Container5_handler(DpContainer& container, Fw::Success::T status) {
+    // Test container assignment
+    this->m_container = container;
     if (status == Fw::Success::SUCCESS) {
         auto serializeStatus = Fw::FW_SERIALIZE_OK;
         for (FwSizeType i = 0; i < CONTAINER_5_DATA_SIZE; ++i) {
-            serializeStatus = container.serializeRecord_DataArrayRecord(this->dataArrayRecordData.data(),
-                                                                        this->dataArrayRecordData.size());
+            serializeStatus = this->m_container.serializeRecord_DataArrayRecord(this->dataArrayRecordData.data(),
+                                                                                this->dataArrayRecordData.size());
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
             FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
         }
         // Use the time stamp from the time get port
-        this->dpSend(container);
+        this->dpSend(this->m_container);
     }
 }
 
 void DpTest ::dpRecv_Container6_handler(DpContainer& container, Fw::Success::T status) {
+    // Test container assignment
+    this->m_container = container;
     if (status == Fw::Success::SUCCESS) {
         auto serializeStatus = Fw::FW_SERIALIZE_OK;
         for (FwSizeType i = 0; i < CONTAINER_6_DATA_SIZE; ++i) {
-            serializeStatus = container.serializeRecord_StringRecord(this->stringRecordData);
+            serializeStatus = this->m_container.serializeRecord_StringRecord(this->stringRecordData);
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
             FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
         }
         // Use the time stamp from the time get port
-        this->dpSend(container);
+        this->dpSend(this->m_container);
     }
 }
 
 void DpTest ::dpRecv_Container7_handler(DpContainer& container, Fw::Success::T status) {
+    // Test container assignment
+    this->m_container = container;
     if (status == Fw::Success::SUCCESS) {
         auto serializeStatus = Fw::FW_SERIALIZE_OK;
         for (FwSizeType i = 0; i < CONTAINER_7_DATA_SIZE; ++i) {
-            serializeStatus = container.serializeRecord_StringArrayRecord(
+            serializeStatus = this->m_container.serializeRecord_StringArrayRecord(
                 this->stringArrayRecordData, FW_NUM_ARRAY_ELEMENTS(this->stringArrayRecordData));
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
@@ -213,7 +223,7 @@ void DpTest ::dpRecv_Container7_handler(DpContainer& container, Fw::Success::T s
             FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
         }
         // Use the time stamp from the time get port
-        this->dpSend(container);
+        this->dpSend(this->m_container);
     }
 }
 

--- a/FppTest/dp/DpTest.hpp
+++ b/FppTest/dp/DpTest.hpp
@@ -156,6 +156,9 @@ class DpTest : public DpTestComponentBase {
     // Private member variables
     // ----------------------------------------------------------------------
 
+    //! Stored container
+    DpContainer m_container;
+
     //! U32Record data
     const U32 u32RecordData;
 

--- a/Fw/Buffer/test/ut/TestBuffer.cpp
+++ b/Fw/Buffer/test/ut/TestBuffer.cpp
@@ -83,21 +83,19 @@ void test_representations() {
     }
     Fw::SerializeStatus stat = sbb.serialize(100);
     ASSERT_NE(stat, Fw::FW_SERIALIZE_OK);
+
     // And that another call to repr resets it
-    sbb = buffer.getSerializeRepr();
     sbb.resetSer();
     ASSERT_EQ(sbb.serialize(0), Fw::FW_SERIALIZE_OK);
 
     // Now deserialize all the things
     U32 out;
-    sbb = buffer.getSerializeRepr();
     sbb.setBuffLen(buffer.getSize());
     for (U32 i = 0; i < sizeof(data)/4; i++) {
         ASSERT_EQ(sbb.deserialize(out), Fw::FW_SERIALIZE_OK);
         ASSERT_EQ(i, out);
     }
     ASSERT_NE(sbb.deserialize(out), Fw::FW_SERIALIZE_OK);
-    sbb = buffer.getSerializeRepr();
     sbb.setBuffLen(buffer.getSize());
     ASSERT_EQ(sbb.deserialize(out), Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(0, out);

--- a/Fw/Dp/DpContainer.hpp
+++ b/Fw/Dp/DpContainer.hpp
@@ -59,7 +59,7 @@ class DpContainer {
 
   public:
     // ----------------------------------------------------------------------
-    // Constructor
+    // Constructors and destructors
     // ----------------------------------------------------------------------
 
     //! Constructor for initialized container
@@ -69,6 +69,17 @@ class DpContainer {
 
     //! Constructor for container with default initialization
     DpContainer();
+
+    //! Destructor
+    virtual ~DpContainer() {}
+
+  protected:
+    // ----------------------------------------------------------------------
+    // Protected operators
+    // ----------------------------------------------------------------------
+
+    //! Copy assignment operator
+    DpContainer& operator=(const DpContainer& src) = default;
 
   public:
     // ----------------------------------------------------------------------
@@ -260,7 +271,9 @@ class DpContainer {
     Buffer m_buffer;
 
     //! The data buffer
-    Fw::ExternalSerializeBuffer m_dataBuffer;
+    //! We use member copy semantics because m_dataBuffer points into m_buffer,
+    //! which is owned by this object
+    Fw::ExternalSerializeBufferWithMemberCopy m_dataBuffer;
 };
 
 }  // end namespace Fw

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -194,9 +194,8 @@ class SerializeBufferBase {
     SerializeBufferBase();  //!< default constructor
 
   PRIVATE:
-    // A no-implementation copy constructor here will prevent the default copy constructor from being called
-    // accidentally, and without an implementation it will create an error for the developer instead.
-    SerializeBufferBase(const SerializeBufferBase& src);  //!< constructor with buffer as source
+    //! deleted copy constructor
+    SerializeBufferBase(const SerializeBufferBase& src) = delete;
 
     void copyFrom(const SerializeBufferBase& src);  //!< copy data from source buffer
     Serializable::SizeType m_serLoc;                //!< current offset in buffer of serialized data
@@ -239,9 +238,7 @@ class ExternalSerializeBufferWithDataCopy final : public ExternalSerializeBuffer
         : ExternalSerializeBuffer(buffPtr, size) {}
     ExternalSerializeBufferWithDataCopy() : ExternalSerializeBuffer() {}
     ~ExternalSerializeBufferWithDataCopy() {}
-    explicit ExternalSerializeBufferWithDataCopy(const SerializeBufferBase& src) {
-        (void)SerializeBufferBase::operator=(src);
-    }
+    ExternalSerializeBufferWithDataCopy(const SerializeBufferBase& src) = delete;
     ExternalSerializeBufferWithDataCopy& operator=(SerializeBufferBase& src) {
         (void)SerializeBufferBase::operator=(src);
         return *this;

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -256,9 +256,8 @@ class ExternalSerializeBufferWithMemberCopy final : public ExternalSerializeBuff
         : ExternalSerializeBuffer(buffPtr, size) {}
     ExternalSerializeBufferWithMemberCopy() : ExternalSerializeBuffer() {}
     ~ExternalSerializeBufferWithMemberCopy() {}
-    explicit ExternalSerializeBufferWithMemberCopy(const ExternalSerializeBufferWithMemberCopy& src) {
-        (void)operator=(src);
-    }
+    explicit ExternalSerializeBufferWithMemberCopy(const ExternalSerializeBufferWithMemberCopy& src)
+        : ExternalSerializeBuffer(src.m_buff, src.m_buffSize) {}
     ExternalSerializeBufferWithMemberCopy& operator=(const ExternalSerializeBufferWithMemberCopy& src) {
         // Ward against self-assignment
         if (this != &src) {

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -194,8 +194,9 @@ class SerializeBufferBase {
     SerializeBufferBase();  //!< default constructor
 
   PRIVATE:
-    //! deleted copy constructor
-    SerializeBufferBase(const SerializeBufferBase& src) = delete;
+    // Copy constructor can be used only by the implementation
+    SerializeBufferBase(const SerializeBufferBase& src);  //!< constructor with buffer as source
+
 
     void copyFrom(const SerializeBufferBase& src);  //!< copy data from source buffer
     Serializable::SizeType m_serLoc;                //!< current offset in buffer of serialized data

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -52,9 +52,10 @@ class Serialization {
 };
 
 class SerializeBufferBase {
-  public:
-    SerializeBufferBase& operator=(const SerializeBufferBase& src);  //!< equal operator
+  protected:
+    SerializeBufferBase& operator=(const SerializeBufferBase& src);  //!< copy assignment operator
 
+  public:
     virtual ~SerializeBufferBase();  //!< destructor
 
     // Serialization for built-in types
@@ -188,6 +189,7 @@ class SerializeBufferBase {
     bool operator==(const SerializeBufferBase& other) const;
     friend std::ostream& operator<<(std::ostream& os, const SerializeBufferBase& buff);
 #endif
+
   PROTECTED:
     SerializeBufferBase();  //!< default constructor
 
@@ -201,28 +203,73 @@ class SerializeBufferBase {
     Serializable::SizeType m_deserLoc;              //!< current offset for deserialization
 };
 
-// Helper class for building buffers with external storage
+// Helper classes for building buffers with external storage
 
+//! External serialize buffer with no copy semantics
 class ExternalSerializeBuffer : public SerializeBufferBase {
   public:
-    ExternalSerializeBuffer(U8* buffPtr, Serializable::SizeType size);  //!< construct with external buffer
-    ExternalSerializeBuffer();                                          //!< default constructor
-    void setExtBuffer(U8* buffPtr, Serializable::SizeType size);        //!< Set the external buffer
-    void clear();                                                       //!< clear external buffer
+    ExternalSerializeBuffer(U8* buffPtr, Serializable::SizeType size);     //!< construct with external buffer
+    ExternalSerializeBuffer();                                             //!< default constructor
+    ~ExternalSerializeBuffer() {}                                          //!< destructor
+    void setExtBuffer(U8* buffPtr, Serializable::SizeType size);           //!< Set the external buffer
+    void clear();                                                          //!< clear external buffer
+    ExternalSerializeBuffer(const ExternalSerializeBuffer& src) = delete;  //!< deleted copy constructor
 
     // pure virtual functions
     Serializable::SizeType getBuffCapacity() const;
     U8* getBuffAddr();
     const U8* getBuffAddr() const;
 
-  PRIVATE:
-    // no copying
-    ExternalSerializeBuffer(ExternalSerializeBuffer& other);
-    ExternalSerializeBuffer(ExternalSerializeBuffer* other);
+    //! deleted copy assignment operator
+    ExternalSerializeBuffer& operator=(const SerializeBufferBase& src) = delete;
 
-    // private data
+  PROTECTED:
+    // data members
     U8* m_buff;                         //!< pointer to external buffer
     Serializable::SizeType m_buffSize;  //!< size of external buffer
+};
+
+//! External serialize buffer with data copy semantics
+//!
+//! Use this when the object esb on the left-hand side of an assignment esb = sbb
+//! is guaranteed to have a valid buffer
+class ExternalSerializeBufferWithDataCopy final : public ExternalSerializeBuffer {
+  public:
+    ExternalSerializeBufferWithDataCopy(U8* buffPtr, Serializable::SizeType size)
+        : ExternalSerializeBuffer(buffPtr, size) {}
+    ExternalSerializeBufferWithDataCopy() : ExternalSerializeBuffer() {}
+    ~ExternalSerializeBufferWithDataCopy() {}
+    explicit ExternalSerializeBufferWithDataCopy(const SerializeBufferBase& src) {
+        (void)SerializeBufferBase::operator=(src);
+    }
+    ExternalSerializeBufferWithDataCopy& operator=(SerializeBufferBase& src) {
+        (void)SerializeBufferBase::operator=(src);
+        return *this;
+    }
+};
+
+//! External serialize buffer with member copy semantics
+//!
+//! Use this when the object esb1 on the left-hand side of an assignment esb1 = esb2
+//! has an invalid buffer, and you want to move the buffer of esb2 into it.
+//! In this case there should usually be no more uses of esb2 after the assignment.
+class ExternalSerializeBufferWithMemberCopy final : public ExternalSerializeBuffer {
+  public:
+    ExternalSerializeBufferWithMemberCopy(U8* buffPtr, Serializable::SizeType size)
+        : ExternalSerializeBuffer(buffPtr, size) {}
+    ExternalSerializeBufferWithMemberCopy() : ExternalSerializeBuffer() {}
+    ~ExternalSerializeBufferWithMemberCopy() {}
+    explicit ExternalSerializeBufferWithMemberCopy(const ExternalSerializeBufferWithMemberCopy& src) {
+        (void)operator=(src);
+    }
+    ExternalSerializeBufferWithMemberCopy& operator=(const ExternalSerializeBufferWithMemberCopy& src) {
+        // Ward against self-assignment
+        if (this != &src) {
+            this->m_buff = src.m_buff;
+            this->m_buffSize = src.m_buffSize;
+        }
+        return *this;
+    }
 };
 
 }  // namespace Fw


### PR DESCRIPTION
This PR fixes an issue with copying data product containers. A `DpContainer` contains an `Fw::ExternalSerializeBuffer` as a member that provides a view into the `Fw::Buffer` that it owns. When a `DpContainer`was copied via copy construction or copy assignment, the `ExternalSerializeBuffer` member was not being copied correctly.

I did the following:
* Delete the copy assignment operator from `ExternalSerializeBuffer`.
* Add two new derived classes of `ExternalSerializeBuffer`: `ExternalSerializeBufferWithDataCopy` and `ExternalSerializeBufferWithMemberCopy`. Each derived class adds just that kind of copy semantics to the base class.
* Revise `DpContainer` so that the `ExternalSerializeBuffer` has type `ExternalSerializeBufferWithMemberCopy`. The slice is owned by the `DpContainer`, so this is the behavior we want.
* Revise the tests in `FppTest/dp` to verify that the container assignment is working.
* Make the copy assignment operator of `SerializeBufferBase` protected, so that assigning into a `SerializeBufferBase` reference is not allowed.
* Revise a unit test that was assigning into a `SerializeBufferBase` reference, in a way that was not necessary.

@timcanham This PR pulls out the changes that I submitted to your DpCatalog branch. I thought it would be good to make a separate PR to mainline with just these changes.