### PR TITLE
Fixing port selection in TCP UTs

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -682,6 +682,7 @@ nproc
 npx
 NSHUFF
 NSPACES
+ntohs
 nukenewlines
 numargs
 nxt

--- a/Drv/Ip/CMakeLists.txt
+++ b/Drv/Ip/CMakeLists.txt
@@ -24,19 +24,19 @@ register_fprime_module()
 
 # The PortSelector library and testing helper is only needed on Testing build
 if (BUILD_TESTING)
-	add_library(PortSelector STATIC
+	add_library(SocketTestHelper STATIC
 		"${CMAKE_CURRENT_LIST_DIR}/test/ut/PortSelector.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/test/ut/SocketTestHelper.cpp")
-	target_include_directories(PortSelector PUBLIC
+	target_include_directories(SocketTestHelper PUBLIC
 			"${FPRIME_FRAMEWORK_PATH}/STest"
 			"${FPRIME_FRAMEWORK_PATH}/googletest/googletest/include"
 	)
-	add_dependencies(PortSelector STest Fw_Buffer)
-	target_link_libraries(PortSelector STest Fw_Buffer)
+	add_dependencies(SocketTestHelper STest Fw_Buffer)
+	target_link_libraries(SocketTestHelper STest Fw_Buffer)
 endif()
 
 set(UT_MOD_DEPS
-	PortSelector
+	SocketTestHelper
 )
 
 ### UTs ###

--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -35,6 +35,7 @@ enum SocketIpStatus {
     SOCK_FAILED_TO_ACCEPT = -11,             //!< Failed to accept connection
     SOCK_SEND_ERROR = -13,                   //!< Failed to send after configured retries
     SOCK_NOT_STARTED = -14,                  //!< Socket has not been started
+    SOCK_FAILED_TO_READ_BACK_PORT = -15,     //!< Failed to read back port from connection
 };
 
 /**
@@ -163,6 +164,17 @@ class IpSocket {
     virtual void shutdown();
 
   PROTECTED:
+    /**
+     * \brief Check if the given port is valid for the socket
+     *
+     * Some ports should be allowed for sockets and disabled on others (e.g. port 0 is a valid tcp server port but not a
+     * client. This will check the port and return "true" if the port is valid, or "false" otherwise. In the default
+     * implementation, all ports are considered valid.
+     *
+     * \param port: port to check
+     * \return true if valid, false otherwise
+     */
+    virtual bool isValidPort(U16 port);
 
     /**
      * \brief setup the socket timeout properties of the opened outgoing socket

--- a/Drv/Ip/TcpClientSocket.cpp
+++ b/Drv/Ip/TcpClientSocket.cpp
@@ -12,6 +12,7 @@
 
 #include <Drv/Ip/TcpClientSocket.hpp>
 #include <Fw/Logger/Logger.hpp>
+#include <Fw/Types/Assert.hpp>
 #include <FpConfig.hpp>
 
 #ifdef TGT_OS_TYPE_VXWORKS
@@ -41,6 +42,11 @@ namespace Drv {
 
 TcpClientSocket::TcpClientSocket() : IpSocket() {}
 
+bool TcpClientSocket::isValidPort(U16 port) {
+    return port != 0;
+}
+
+
 SocketIpStatus TcpClientSocket::openProtocol(NATIVE_INT_TYPE& fd) {
     NATIVE_INT_TYPE socketFd = -1;
     struct sockaddr_in address;
@@ -51,7 +57,9 @@ SocketIpStatus TcpClientSocket::openProtocol(NATIVE_INT_TYPE& fd) {
     }
     // Set up the address port and name
     address.sin_family = AF_INET;
+    this->m_lock.lock();
     address.sin_port = htons(this->m_port);
+    this->m_lock.unlock();
 
     // OS specific settings
 #if defined TGT_OS_TYPE_VXWORKS || TGT_OS_TYPE_DARWIN
@@ -75,7 +83,6 @@ SocketIpStatus TcpClientSocket::openProtocol(NATIVE_INT_TYPE& fd) {
         ::close(socketFd);
         return SOCK_FAILED_TO_CONNECT;
     }
-
     fd = socketFd;
     Fw::Logger::logMsg("Connected to %s:%hu as a tcp client\n", reinterpret_cast<POINTER_CAST>(m_hostname), m_port);
     return SOCK_SUCCESS;

--- a/Drv/Ip/TcpClientSocket.hpp
+++ b/Drv/Ip/TcpClientSocket.hpp
@@ -40,7 +40,7 @@ class TcpClientSocket : public IpSocket {
      * \param port: port to check
      * \return true if valid, false otherwise
      */
-    virtual bool isValidPort(U16 port) override;
+    bool isValidPort(U16 port) override;
 
     /**
      * \brief Tcp specific implementation for opening a client socket.

--- a/Drv/Ip/TcpClientSocket.hpp
+++ b/Drv/Ip/TcpClientSocket.hpp
@@ -31,6 +31,18 @@ class TcpClientSocket : public IpSocket {
     TcpClientSocket();
   PROTECTED:
     /**
+     * \brief Check if the given port is valid for the socket
+     *
+     * Some ports should be allowed for sockets and disabled on others (e.g. port 0 is a valid tcp server port but not a
+     * client. This will check the port and return "true" if the port is valid, or "false" otherwise. In the tcp client
+     * implementation, all ports are considered valid except for "0".
+     *
+     * \param port: port to check
+     * \return true if valid, false otherwise
+     */
+    virtual bool isValidPort(U16 port) override;
+
+    /**
      * \brief Tcp specific implementation for opening a client socket.
      * \param fd: (output) file descriptor opened. Only valid on SOCK_SUCCESS. Otherwise will be invalid
      * \return status of open

--- a/Drv/Ip/TcpServerSocket.cpp
+++ b/Drv/Ip/TcpServerSocket.cpp
@@ -11,6 +11,7 @@
 // ======================================================================
 #include <Drv/Ip/TcpServerSocket.hpp>
 #include <Fw/Logger/Logger.hpp>
+#include <Fw/Types/Assert.hpp>
 #include <FpConfig.hpp>
 
 #ifdef TGT_OS_TYPE_VXWORKS
@@ -39,6 +40,13 @@ namespace Drv {
 
 TcpServerSocket::TcpServerSocket() : IpSocket(), m_base_fd(-1) {}
 
+U16 TcpServerSocket::getListenPort() {
+    this->m_lock.lock();
+    U16 port = this->m_port;
+    this->m_lock.unlock();
+    return port;
+}
+
 SocketIpStatus TcpServerSocket::startup() {
     NATIVE_INT_TYPE serverFd = -1;
     struct sockaddr_in address;
@@ -49,7 +57,9 @@ SocketIpStatus TcpServerSocket::startup() {
     }
     // Set up the address port and name
     address.sin_family = AF_INET;
+    this->m_lock.lock();
     address.sin_port = htons(this->m_port);
+    this->m_lock.unlock();
 
     // OS specific settings
 #if defined TGT_OS_TYPE_VXWORKS || TGT_OS_TYPE_DARWIN
@@ -66,14 +76,23 @@ SocketIpStatus TcpServerSocket::startup() {
         ::close(serverFd);
         return SOCK_FAILED_TO_BIND;
     }
-    Fw::Logger::logMsg("Listening for single client at %s:%hu\n", reinterpret_cast<POINTER_CAST>(m_hostname), m_port);
-    // TCP requires listening on a the socket. Second argument prevents queueing of anything more than a single client.
+
+    socklen_t size = sizeof(address);
+    if (::getsockname(serverFd, reinterpret_cast<struct sockaddr *>(&address), &size) == -1) {
+        ::close(serverFd);
+        return SOCK_FAILED_TO_READ_BACK_PORT;
+    }
+    U16 port = ntohs(address.sin_port);
+    Fw::Logger::logMsg("Listening for single client at %s:%hu\n", reinterpret_cast<POINTER_CAST>(m_hostname), port);
+    // TCP requires listening on the socket. Second argument prevents queueing of anything more than a single client.
     if (::listen(serverFd, 0) < 0) {
         ::close(serverFd);
         return SOCK_FAILED_TO_LISTEN; // What we have here is a failure to communicate
     }
+
     this->m_lock.lock();
     m_base_fd = serverFd;
+    m_port = port;
     this->m_lock.unLock();
 
     return this->IpSocket::startup();
@@ -103,7 +122,7 @@ SocketIpStatus TcpServerSocket::openProtocol(NATIVE_INT_TYPE& fd) {
     serverFd = this->m_base_fd;
     this->m_lock.unLock();
 
-    // TCP requires accepting on a the socket to get the client socket file descriptor.
+    // TCP requires accepting on the socket to get the client socket file descriptor.
     clientFd = ::accept(serverFd, nullptr, nullptr);
     if (clientFd < 0) {
         return SOCK_FAILED_TO_ACCEPT; // What we have here is a failure to communicate

--- a/Drv/Ip/TcpServerSocket.hpp
+++ b/Drv/Ip/TcpServerSocket.hpp
@@ -49,7 +49,7 @@ class TcpServerSocket : public IpSocket {
     void shutdown() override;
 
     /**
-     * \breif get the port being listened on
+     * \brief get the port being listened on
      *
      * Most useful when listen was configured to use port "0", this will return the port used for listening after a port
      * has been determined. Will return 0 if the connection has not been setup.

--- a/Drv/Ip/TcpServerSocket.hpp
+++ b/Drv/Ip/TcpServerSocket.hpp
@@ -48,6 +48,16 @@ class TcpServerSocket : public IpSocket {
      */
     void shutdown() override;
 
+    /**
+     * \breif get the port being listened on
+     *
+     * Most useful when listen was configured to use port "0", this will return the port used for listening after a port
+     * has been determined. Will return 0 if the connection has not been setup.
+     *
+     * \return receive port
+     */
+    U16 getListenPort();
+
   PROTECTED:
     /**
      * \brief Tcp specific implementation for opening a client socket connected to this server.

--- a/Drv/Ip/UdpSocket.cpp
+++ b/Drv/Ip/UdpSocket.cpp
@@ -126,7 +126,6 @@ SocketIpStatus UdpSocket::openProtocol(NATIVE_INT_TYPE& fd) {
     struct sockaddr_in address;
 
     this->m_lock.lock();
-    U16 recv_port = this->m_recv_port;
     U16 port = this->m_port;
     this->m_lock.unlock();
 
@@ -172,7 +171,7 @@ SocketIpStatus UdpSocket::openProtocol(NATIVE_INT_TYPE& fd) {
         return status; // Not closing FD as it is still a valid send FD
     }
     this->m_lock.lock();
-    recv_port = this->m_recv_port;
+    U16 recv_port = this->m_recv_port;
     this->m_lock.unlock();
     // Log message for UDP
     if (port == 0) {

--- a/Drv/Ip/UdpSocket.hpp
+++ b/Drv/Ip/UdpSocket.hpp
@@ -47,7 +47,7 @@ class UdpSocket : public IpSocket {
      * and port are configured using the `configureRecv` function call for UDP as it requires separate host/port pairs
      * for outgoing and incoming transmissions. Hostname DNS translation is left up to the caller and thus hostname must
      * be an IP address in dot-notation of the form "x.x.x.x". Port cannot be set to 0 as dynamic port assignment is not
-     * supported.  It is possible to configure the UDP port as a single-direction send port only.
+     * supported on remote ports.  It is possible to configure the UDP port as a single-direction send port only.
      *
      * Note: delegates to `IpSocket::configure`
      *
@@ -66,14 +66,24 @@ class UdpSocket : public IpSocket {
      * Configures the UDP handler to use the given hostname and port for incoming transmissions. Outgoing hostname
      * and port are configured using the `configureSend` function call for UDP as it requires separate host/port pairs
      * for outgoing and incoming transmissions. Hostname DNS translation is left up to the caller and thus hostname must
-     * be an IP address in dot-notation of the form "x.x.x.x". Port cannot be set to 0 as dynamic port assignment is not
-     * supported. It is possible to configure the UDP port as a single-direction receive port only.
+     * be an IP address in dot-notation of the form "x.x.x.x". It is possible to configure the UDP port as a
+     * single-direction receive port only.
      *
      * \param hostname: socket uses for incoming transmissions. Must be of form x.x.x.x
-     * \param port: port socket uses for incoming transmissions. Must NOT be 0.
+     * \param port: port socket uses for incoming transmissions.
      * \return status of configure
      */
     SocketIpStatus configureRecv(const char* hostname, const U16 port);
+
+    /**
+     * \breif get the port being received on
+     *
+     * Most useful when receive was configured to use port "0", this will return the port used for receiving data after
+     * a port has been determined. Will return 0 if the connection has not been setup.
+     *
+     * \return receive port
+     */
+    U16 getRecvPort();
 
   PROTECTED:
 
@@ -88,21 +98,21 @@ class UdpSocket : public IpSocket {
      * \param fd: (output) file descriptor opened. Only valid on SOCK_SUCCESS. Otherwise will be invalid
      * \return status of open
      */
-    SocketIpStatus openProtocol(NATIVE_INT_TYPE& fd);
+    SocketIpStatus openProtocol(NATIVE_INT_TYPE& fd) override;
     /**
      * \brief Protocol specific implementation of send.  Called directly with retry from send.
      * \param data: data to send
      * \param size: size of data to send
      * \return: size of data sent, or -1 on error.
      */
-    I32 sendProtocol(const U8* const data, const U32 size);
+    I32 sendProtocol(const U8* const data, const U32 size) override;
     /**
      * \brief Protocol specific implementation of recv.  Called directly with error handling from recv.
      * \param data: data pointer to fill
      * \param size: size of data buffer
      * \return: size of data received, or -1 on error.
      */
-    I32 recvProtocol( U8* const data, const U32 size);
+    I32 recvProtocol( U8* const data, const U32 size) override;
   private:
     SocketState* m_state; //!< State storage
     U16 m_recv_port;  //!< IP address port used

--- a/Drv/Ip/UdpSocket.hpp
+++ b/Drv/Ip/UdpSocket.hpp
@@ -76,7 +76,7 @@ class UdpSocket : public IpSocket {
     SocketIpStatus configureRecv(const char* hostname, const U16 port);
 
     /**
-     * \breif get the port being received on
+     * \brief get the port being received on
      *
      * Most useful when receive was configured to use port "0", this will return the port used for receiving data after
      * a port has been determined. Will return 0 if the connection has not been setup.

--- a/Drv/Ip/test/ut/PortSelector.cpp
+++ b/Drv/Ip/test/ut/PortSelector.cpp
@@ -38,11 +38,7 @@ U16 get_free_port(bool udp) {
         ::close(socketFd);
         return 0;
     }
-    U16 port = address.sin_port;
-    // Check for root-only-port.  If so, recursively try again.
-    if (port < 1024) {
-        port = get_free_port(udp);
-    }
+    U16 port = ntohs(address.sin_port);
     ::close(socketFd); // Close this recursion's port again, such that we don't infinitely loop
     return port;
 

--- a/Drv/Ip/test/ut/TestTcp.cpp
+++ b/Drv/Ip/test/ut/TestTcp.cpp
@@ -7,7 +7,6 @@
 #include <Drv/Ip/IpSocket.hpp>
 #include <Os/Log.hpp>
 #include <Fw/Logger/Logger.hpp>
-#include <Drv/Ip/test/ut/PortSelector.hpp>
 #include <Drv/Ip/test/ut/SocketTestHelper.hpp>
 
 Os::Log logger;
@@ -17,8 +16,7 @@ void test_with_loop(U32 iterations) {
     Drv::SocketIpStatus status1 = Drv::SOCK_SUCCESS;
     Drv::SocketIpStatus status2 = Drv::SOCK_SUCCESS;
 
-    U16 port =  Drv::Test::get_free_port();
-    ASSERT_NE(0, port);
+    U16 port =  0; // Choose a port
     Drv::TcpServerSocket server;
     server.configure("127.0.0.1", port, 0, 100);
     EXPECT_EQ(server.startup(), Drv::SOCK_SUCCESS);
@@ -27,8 +25,7 @@ void test_with_loop(U32 iterations) {
     // Loop through a bunch of client disconnects
     for (U32 i = 0; i < iterations; i++) {
         Drv::TcpClientSocket client;
-        ASSERT_NE(port, 0);
-        client.configure("127.0.0.1",port,0,100);
+        client.configure("127.0.0.1", server.getListenPort(),0,100);
         status1 = client.open();
         EXPECT_EQ(status1, Drv::SOCK_SUCCESS);
 

--- a/Drv/Ip/test/ut/TestTcp.cpp
+++ b/Drv/Ip/test/ut/TestTcp.cpp
@@ -16,7 +16,7 @@ void test_with_loop(U32 iterations) {
     Drv::SocketIpStatus status1 = Drv::SOCK_SUCCESS;
     Drv::SocketIpStatus status2 = Drv::SOCK_SUCCESS;
 
-    U16 port =  0; // Choose a port
+    U16 port = 0; // Choose a port
     Drv::TcpServerSocket server;
     server.configure("127.0.0.1", port, 0, 100);
     EXPECT_EQ(server.startup(), Drv::SOCK_SUCCESS);

--- a/Drv/Ip/test/ut/TestUdp.cpp
+++ b/Drv/Ip/test/ut/TestUdp.cpp
@@ -16,8 +16,14 @@ void test_with_loop(U32 iterations, bool duplex) {
     Drv::SocketIpStatus status2 = Drv::SOCK_SUCCESS;
 
     // When not duplex, we can allow the OS to choose a port
-    U16 port1 =  (duplex) ? Drv::Test::get_free_port() : 0;
-    U16 port2 =  Drv::Test::get_free_port();
+    U16 port1 = (duplex) ? Drv::Test::get_free_port(true) : 0;
+    U16 port2 = 0;
+    for (U8 i = 0; (i < std::numeric_limits<U8>::max() && port2 == 0 && port2 == port1); i++) {
+        port2 = Drv::Test::get_free_port(true);
+    }
+    if (port2 == port1) {
+        GTEST_SKIP() << "Could not find two unique and available UDP ports. SKipping test.";
+    }
     ASSERT_NE(0, port2);
 
     // Loop through a bunch of client disconnects

--- a/Drv/Ip/test/ut/TestUdp.cpp
+++ b/Drv/Ip/test/ut/TestUdp.cpp
@@ -17,8 +17,8 @@ void test_with_loop(U32 iterations, bool duplex) {
 
     // When not duplex, we can allow the OS to choose a port
     U16 port1 = (duplex) ? Drv::Test::get_free_port(true) : 0;
-    U16 port2 = 0;
-    for (U8 i = 0; (i < std::numeric_limits<U8>::max() && port2 == 0 && port2 == port1); i++) {
+    U16 port2 = port1;
+    for (U8 i = 0; (i < std::numeric_limits<U8>::max()) && (port2 == port1); i++) {
         port2 = Drv::Test::get_free_port(true);
     }
     if (port2 == port1) {

--- a/Drv/TcpClient/CMakeLists.txt
+++ b/Drv/TcpClient/CMakeLists.txt
@@ -29,7 +29,7 @@ set(UT_SOURCE_FILES
 )
 set(UT_MOD_DEPS
 	STest
-	PortSelector
+	SocketTestHelper
 )
 set(UT_AUTO_HELPERS ON)
 register_fprime_ut()

--- a/Drv/TcpClient/test/ut/TcpClientTester.cpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.cpp
@@ -12,7 +12,6 @@
 #include "TcpClientTester.hpp"
 #include "STest/Pick/Pick.hpp"
 #include <Os/Log.hpp>
-#include <Drv/Ip/test/ut/PortSelector.hpp>
 #include <Drv/Ip/test/ut/SocketTestHelper.hpp>
 
 Os::Log logger;
@@ -29,13 +28,12 @@ void TcpClientTester ::test_with_loop(U32 iterations, bool recv_thread) {
     Drv::SocketIpStatus status2 = Drv::SOCK_SUCCESS;
     Drv::SocketIpStatus serverStat = Drv::SOCK_SUCCESS;
 
-    U16 port =  Drv::Test::get_free_port();
-    ASSERT_NE(0, port);
+    U16 port =  0;
 
     Drv::TcpServerSocket server;
     server.configure("127.0.0.1", port, 0, 100);
-    this->component.configure("127.0.0.1", port, 0, 100);
     serverStat = server.startup();
+    this->component.configure("127.0.0.1", server.getListenPort(), 0, 100);
 
     ASSERT_EQ(serverStat, SOCK_SUCCESS)
         << "TCP server startup error: " << strerror(errno) << std::endl

--- a/Drv/TcpServer/CMakeLists.txt
+++ b/Drv/TcpServer/CMakeLists.txt
@@ -29,7 +29,7 @@ set(UT_SOURCE_FILES
 )
 set(UT_MOD_DEPS
 	STest
-	PortSelector
+	SocketTestHelper
 )
 set(UT_AUTO_HELPERS ON)
 register_fprime_ut()

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -37,6 +37,10 @@ TcpServerComponentImpl::~TcpServerComponentImpl() {}
 // Implementations for socket read task virtual methods
 // ----------------------------------------------------------------------
 
+U16 TcpServerComponentImpl::getListenPort() {
+    return m_socket.getListenPort();
+}
+
 IpSocket& TcpServerComponentImpl::getSocketHandler() {
     return m_socket;
 }
@@ -54,7 +58,6 @@ void TcpServerComponentImpl::connected() {
     if (isConnected_ready_OutputPort(0)) {
         this->ready_out(0);
     }
-
 }
 
 // ----------------------------------------------------------------------

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -62,6 +62,16 @@ class TcpServerComponentImpl : public TcpServerComponentBase, public SocketReadT
                              const U32 send_timeout_seconds = SOCKET_SEND_TIMEOUT_SECONDS,
                              const U32 send_timeout_microseconds = SOCKET_SEND_TIMEOUT_MICROSECONDS);
 
+    /**
+     * \breif get the port being listened on
+     *
+     * Most useful when listen was configured to use port "0", this will return the port used for listening after a port
+     * has been determined. Will return 0 if the connection has not been setup.
+     *
+     * \return receive port
+     */
+    U16 getListenPort();
+
   PROTECTED:
     // ----------------------------------------------------------------------
     // Implementations for socket read task virtual methods

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -63,7 +63,7 @@ class TcpServerComponentImpl : public TcpServerComponentBase, public SocketReadT
                              const U32 send_timeout_microseconds = SOCKET_SEND_TIMEOUT_MICROSECONDS);
 
     /**
-     * \breif get the port being listened on
+     * \brief get the port being listened on
      *
      * Most useful when listen was configured to use port "0", this will return the port used for listening after a port
      * has been determined. Will return 0 if the connection has not been setup.

--- a/Drv/TcpServer/test/ut/TcpServerTester.cpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.cpp
@@ -12,7 +12,6 @@
 #include "TcpServerTester.hpp"
 #include "STest/Pick/Pick.hpp"
 #include "Os/Log.hpp"
-#include <Drv/Ip/test/ut/PortSelector.hpp>
 #include <Drv/Ip/test/ut/SocketTestHelper.hpp>
 
 Os::Log logger;
@@ -29,8 +28,7 @@ void TcpServerTester ::test_with_loop(U32 iterations, bool recv_thread) {
     Drv::SocketIpStatus status2 = Drv::SOCK_SUCCESS;
     Drv::SocketIpStatus serverStat = Drv::SOCK_SUCCESS;
 
-    U16 port =  Drv::Test::get_free_port();
-    ASSERT_NE(0, port);
+    U16 port =  0;
 
     this->component.configure("127.0.0.1", port, 0, 100);
 
@@ -50,7 +48,7 @@ void TcpServerTester ::test_with_loop(U32 iterations, bool recv_thread) {
     // Loop through a bunch of client disconnects
     for (U32 i = 0; i < iterations && serverStat == SOCK_SUCCESS; i++) {
         Drv::TcpClientSocket client;
-        client.configure("127.0.0.1", port, 0, 100);
+        client.configure("127.0.0.1", this->component.getListenPort(), 0, 100);
         status2 = client.open();
 
         U32 size = sizeof(m_data_storage);

--- a/Drv/Udp/CMakeLists.txt
+++ b/Drv/Udp/CMakeLists.txt
@@ -29,7 +29,7 @@ set(UT_SOURCE_FILES
 )
 set(UT_MOD_DEPS
 	STest
-	PortSelector
+	SocketTestHelper
 )
 set(UT_AUTO_HELPERS ON)
 register_fprime_ut()

--- a/Drv/Udp/UdpComponentImpl.cpp
+++ b/Drv/Udp/UdpComponentImpl.cpp
@@ -39,6 +39,10 @@ SocketIpStatus UdpComponentImpl::configureRecv(const char* hostname, const U16 p
 
 UdpComponentImpl::~UdpComponentImpl() {}
 
+U16 UdpComponentImpl::getRecvPort() {
+    return this->m_socket.getRecvPort();
+}
+
 // ----------------------------------------------------------------------
 // Implementations for socket read task virtual methods
 // ----------------------------------------------------------------------

--- a/Drv/Udp/UdpComponentImpl.hpp
+++ b/Drv/Udp/UdpComponentImpl.hpp
@@ -74,7 +74,18 @@ class UdpComponentImpl : public UdpComponentBase, public SocketReadTask {
      */
     SocketIpStatus configureRecv(const char* hostname, const U16 port);
 
-  PROTECTED:
+    /**
+     * \breif get the port being received on
+     *
+     * Most useful when receive was configured to use port "0", this will return the port used for receiving data after
+     * a port has been determined. Will return 0 if the connection has not been setup.
+     *
+     * \return receive port
+     */
+    U16 getRecvPort();
+
+
+PROTECTED:
     // ----------------------------------------------------------------------
     // Implementations for socket read task virtual methods
     // ----------------------------------------------------------------------

--- a/Drv/Udp/UdpComponentImpl.hpp
+++ b/Drv/Udp/UdpComponentImpl.hpp
@@ -75,7 +75,7 @@ class UdpComponentImpl : public UdpComponentBase, public SocketReadTask {
     SocketIpStatus configureRecv(const char* hostname, const U16 port);
 
     /**
-     * \breif get the port being received on
+     * \brief get the port being received on
      *
      * Most useful when receive was configured to use port "0", this will return the port used for receiving data after
      * a port has been determined. Will return 0 if the connection has not been setup.

--- a/Drv/Udp/test/ut/UdpTester.cpp
+++ b/Drv/Udp/test/ut/UdpTester.cpp
@@ -29,18 +29,19 @@ void UdpTester::test_with_loop(U32 iterations, bool recv_thread) {
     Drv::SocketIpStatus status1 = Drv::SOCK_SUCCESS;
     Drv::SocketIpStatus status2 = Drv::SOCK_SUCCESS;
 
-    U16 port1 =  Drv::Test::get_free_port(true);
+    U16 port1 = Drv::Test::get_free_port(true);
     ASSERT_NE(0, port1);
-    U16 port2 =  Drv::Test::get_free_port(true);
-    ASSERT_NE(0, port2);
-
-    uint8_t attempt_to_find_available_port = 100;
+    U16 port2 = 0;
+    uint8_t attempt_to_find_available_port = std::numeric_limits<uint8_t>::max();
 
     while ((port1 == port2) && attempt_to_find_available_port > 0)
     {
-        U16 port2 =  Drv::Test::get_free_port(true);
+        port2 = Drv::Test::get_free_port(true);
         ASSERT_NE(0, port2);
         --attempt_to_find_available_port;
+    }
+    if (port2 == port1) {
+        GTEST_SKIP() << "Could not find two unique and available UDP ports. SKipping test.";
     }
     ASSERT_NE(port1, port2);
 

--- a/Drv/Udp/test/ut/UdpTester.cpp
+++ b/Drv/Udp/test/ut/UdpTester.cpp
@@ -31,7 +31,7 @@ void UdpTester::test_with_loop(U32 iterations, bool recv_thread) {
 
     U16 port1 = Drv::Test::get_free_port(true);
     ASSERT_NE(0, port1);
-    U16 port2 = 0;
+    U16 port2 = port1;
     uint8_t attempt_to_find_available_port = std::numeric_limits<uint8_t>::max();
 
     while ((port1 == port2) && attempt_to_find_available_port > 0)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes the TCP port selection problem for TCP UTs.  This was done by:

1. Allowing Tcp and UDP recv to use port "0" (have OS assign port).
2. Add read-back for "0" ports.
3. Supply read-back port to UT as the connection port
4. **Correcting port selection and readback for network byte order**