### PR TITLE
Fix CI bash script for macOS

### DIFF
--- a/ci/helpers.bash
+++ b/ci/helpers.bash
@@ -38,7 +38,10 @@ function fail_and_stop()
     if [ -f "${LASTLOG_ERR}" ]
     then
         # Check if a related stdout log exist
-        LASTLOG_OUT="${LASTLOG_ERR::-7}out.log"
+        # Mac OS does not support negative length
+        # so LASTLOG_ERR::-7 cannot be used here
+        LASTLOG_ERR_LENGTH=${#LASTLOG_ERR}
+        LASTLOG_OUT="${LASTLOG_ERR:0:LASTLOG_ERR_LENGTH-7}out.log"
 
         if [ -f "${LASTLOG_OUT}" ]
         then


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Small change of the bash script to display errors happening on the CI. The bash version used on the Mac OS CI does not support negative values (See https://github.com/nasa/fprime/actions/runs/8902005968/job/24448082623 for the error, and https://github.com/nasa/fprime/actions/runs/8903107367/job/24450396620 for the fix)