### PR TITLE
refactored FW_OBJ_NAME, FW_QUEUE_NAME, and FW_TASK_NAME.

### DIFF
--- a/Fw/Comp/ActiveComponentBase.cpp
+++ b/Fw/Comp/ActiveComponentBase.cpp
@@ -59,7 +59,7 @@ namespace Fw {
 #if FW_OBJECT_NAMES == 1
         taskName = this->getObjName();
 #else
-        char taskNameChar[FW_TASK_NAME_MAX_SIZE];
+        char taskNameChar[FW_TASK_NAME_BUFFER_SIZE];
         (void)snprintf(taskNameChar,sizeof(taskNameChar),"ActComp_%d",Os::Task::getNumTasks());
         taskName = taskNameChar;
 #endif

--- a/Fw/Comp/QueuedComponentBase.cpp
+++ b/Fw/Comp/QueuedComponentBase.cpp
@@ -36,7 +36,7 @@ namespace Fw {
 #if FW_OBJECT_NAMES == 1
         queueName = this->m_objName;
 #else
-        char queueNameChar[FW_QUEUE_NAME_MAX_SIZE];
+        char queueNameChar[FW_QUEUE_NAME_BUFFER_SIZE];
         (void)snprintf(queueNameChar,sizeof(queueNameChar),"CompQ_%d",Os::Queue::getNumQueues());
         queueName = queueNameChar;
 #endif

--- a/Fw/Types/ObjectName.hpp
+++ b/Fw/Types/ObjectName.hpp
@@ -18,7 +18,7 @@ class ObjectName final : public StringBase {
   public:
     enum {
         SERIALIZED_TYPE_ID = FW_TYPEID_OBJECT_NAME,
-        STRING_SIZE = FW_OBJ_NAME_MAX_SIZE,
+        STRING_SIZE = FW_OBJ_NAME_BUFFER_SIZE,
         SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(STRING_SIZE)
     };
 

--- a/Os/QueueString.hpp
+++ b/Os/QueueString.hpp
@@ -15,7 +15,7 @@ namespace Os {
 
 class QueueString final : public Fw::StringBase {
   public:
-    enum { STRING_SIZE = FW_QUEUE_NAME_MAX_SIZE, SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(STRING_SIZE) };
+    enum { STRING_SIZE = FW_QUEUE_NAME_BUFFER_SIZE, SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(STRING_SIZE) };
 
     QueueString() : StringBase() { *this = ""; }
 

--- a/Os/TaskString.hpp
+++ b/Os/TaskString.hpp
@@ -15,7 +15,7 @@ namespace Os {
 
 class TaskString final : public Fw::StringBase {
   public:
-    enum { STRING_SIZE = FW_TASK_NAME_MAX_SIZE, SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(STRING_SIZE) };
+    enum { STRING_SIZE = FW_TASK_NAME_BUFFER_SIZE, SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(STRING_SIZE) };
 
     TaskString() : StringBase() { *this = ""; }
 

--- a/config/FpConfig.h
+++ b/config/FpConfig.h
@@ -227,8 +227,8 @@ typedef FwIndexType FwQueueSizeType;
 
 // The size of the object name stored in the object base class. Larger names will be truncated.
 #if FW_OBJECT_NAMES
-#ifndef FW_OBJ_NAME_MAX_SIZE
-#define FW_OBJ_NAME_MAX_SIZE \
+#ifndef FW_OBJ_NAME_BUFFER_SIZE
+#define FW_OBJ_NAME_BUFFER_SIZE \
     80  //!< Size of object name (if object names enabled). AC Limits to 80, truncation occurs above 80.
 #endif
 #endif
@@ -247,7 +247,7 @@ typedef FwIndexType FwQueueSizeType;
 #define FW_OBJ_SIMPLE_REG_ENTRIES 500  //!< Number of objects stored in simple object registry
 #endif
 // When dumping the contents of the registry, this specifies the size of the buffer used to store object names. Should
-// be >= FW_OBJ_NAME_MAX_SIZE.
+// be >= FW_OBJ_NAME_BUFFER_SIZE.
 #ifndef FW_OBJ_SIMPLE_REG_BUFF_SIZE
 #define FW_OBJ_SIMPLE_REG_BUFF_SIZE 255  //!< Size of object registry dump string
 #endif
@@ -261,13 +261,13 @@ typedef FwIndexType FwQueueSizeType;
 #endif
 
 // Specifies the size of the string holding the queue name for queues
-#ifndef FW_QUEUE_NAME_MAX_SIZE
-#define FW_QUEUE_NAME_MAX_SIZE 80  //!< Max size of message queue name
+#ifndef FW_QUEUE_NAME_BUFFER_SIZE
+#define FW_QUEUE_NAME_BUFFER_SIZE 80  //!< Max size of message queue name
 #endif
 
 // Specifies the size of the string holding the task name for active components and tasks
-#ifndef FW_TASK_NAME_MAX_SIZE
-#define FW_TASK_NAME_MAX_SIZE 80  //!< Max size of task name
+#ifndef FW_TASK_NAME_BUFFER_SIZE
+#define FW_TASK_NAME_BUFFER_SIZE 80  //!< Max size of task name
 #endif
 
 // Specifies the size of the buffer that contains a communications packet.

--- a/docs/UsersGuide/dev/configuring-fprime.md
+++ b/docs/UsersGuide/dev/configuring-fprime.md
@@ -148,12 +148,12 @@ class stores a task name as private data. Table 35 provides the macro for this f
 
 **Table 35.** Macros for object naming, queue naming, and task naming
 
-| Macro                    | Definition                                  | Default | Valid Values      |
-| ------------------------ | ------------------------------------------- |---------|-------------------|
-| FW_OBJECT_NAMES          | Enables storage and retrieval of the name   | 1 (on)  | 0 (off) 1 (on)    |
-| FW_OBJ_NAME_MAX_SIZE     | Size of the buffer storing the object name  | 80      | Positive integer  |
-| FW_QUEUE_NAME_MAX_SIZE   | Size of the buffer storing the queue names  | 80      | Positive integer  |
-| FW_TASK_NAME_MAX_SIZE    | Size of the buffer storing task names       | 80      | Positive integer  |
+| Macro                     | Definition                                  | Default | Valid Values      |
+|---------------------------| ------------------------------------------- |---------|-------------------|
+| FW_OBJECT_NAMES           | Enables storage and retrieval of the name   | 1 (on)  | 0 (off) 1 (on)    |
+| FW_OBJ_NAME_BUFFER_SIZE   | Size of the buffer storing the object name  | 80      | Positive integer  |
+| FW_QUEUE_NAME_BUFFER_SIZE | Size of the buffer storing the queue names  | 80      | Positive integer  |
+| FW_TASK_NAME_BUFFER_SIZE  | Size of the buffer storing task names       | 80      | Positive integer  |
 
 > **Note**
 > The macro `FW_OPTIONAL_NAME("string")` can be used to conditionally return the given
@@ -162,10 +162,10 @@ class stores a task name as private data. Table 35 provides the macro for this f
 
 > **Note**
 > If the size of the string passed to the code-generated component base classes is larger than this size, the
-> string will be truncated. `FW_OBJECT_NAMES` must be turned on for `FW_OBJ_NAME_MAX_SIZ` to have any effect.
+> string will be truncated. `FW_OBJECT_NAMES` must be turned on for `FW_OBJ_NAME_BUFFER_SIZE` to have any effect.
 
 > **Note**
-> `FW_QUEUE_NAME_MAX_SIZE` and `FW_TASK_NAME_MAX_SIZE` are only used if `FW_OBJECT_NAMES` is **turned off**.
+> `FW_QUEUE_NAME_BUFFER_SIZE` and `FW_TASK_NAME_BUFFER_SIZE` are only used if `FW_OBJECT_NAMES` is **turned off**.
 > Otherwise, the supplied object name is used.
 
 #### Object to String


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #2545 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

refactored FW_OBJ_NAME_MAX_SIZE, FW_QUEUE_NAME_MAX_SIZE, and FW_TASK_NAME_MAX_SIZE to reflect the new naming of constants to FW_OBJ_NAME_BUFFER_SIZE, FW_QUEUE_NAME_BUFFER_SIZE, and FW_TASK_NAME_BUFFER_SIZE.

## Rationale

created more clarity for what the constants represent.

## Testing/Review Recommendations

Double-check names as referring to the refactored constants

## Future Work

None expected