### PR TITLE
	modified:   Drv/TcpClient/TcpClientComponentImpl.cpp

### DIFF
--- a/Drv/TcpClient/TcpClientComponentImpl.cpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.cpp
@@ -42,8 +42,13 @@ IpSocket& TcpClientComponentImpl::getSocketHandler() {
     return m_socket;
 }
 
-Fw::Buffer TcpClientComponentImpl::getBuffer() {
-    return allocate_out(0, 1024);
+// Define a constant for the default buffer size
+static const size_t DEFAULT_BUFFER_SIZE = 1024;
+
+// Modify the function signature to accept the buffer size as an argument
+Fw::Buffer TcpClientComponentImpl::getBuffer(size_t bufferSize = DEFAULT_BUFFER_SIZE) {
+    // Allocate the buffer with the specified size
+    return allocate_out(0, bufferSize);
 }
 
 void TcpClientComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status) {

--- a/Drv/TcpClient/TcpClientComponentImpl.cpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.cpp
@@ -10,6 +10,7 @@
 //
 // ======================================================================
 
+#include <limits>
 #include <Drv/TcpClient/TcpClientComponentImpl.hpp>
 #include <FpConfig.hpp>
 #include "Fw/Types/Assert.hpp"
@@ -31,6 +32,8 @@ SocketIpStatus TcpClientComponentImpl::configure(const char* hostname,
                                                  const U32 send_timeout_microseconds,
                                                  FwSizeType buffer_size) {
 
+    // Check that ensures the configured buffer size fits within the limits fixed-width type, U32                                                
+    FW_ASSERT(buffer_size <= std::numeric_limits<U32>::max(), buffer_size);                                                   
     m_allocation_size = buffer_size; // Store the buffer size
     return m_socket.configure(hostname, port, send_timeout_seconds, send_timeout_microseconds);
 }
@@ -46,7 +49,7 @@ IpSocket& TcpClientComponentImpl::getSocketHandler() {
 }
 
 Fw::Buffer TcpClientComponentImpl::getBuffer() {
-    return allocate_out(0, m_allocation_size);
+    return allocate_out(0, static_cast<U32>(m_allocation_size));
 }
 
 void TcpClientComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status) {

--- a/Drv/TcpClient/TcpClientComponentImpl.cpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.cpp
@@ -28,7 +28,10 @@ TcpClientComponentImpl::TcpClientComponentImpl(const char* const compName)
 SocketIpStatus TcpClientComponentImpl::configure(const char* hostname,
                                                  const U16 port,
                                                  const U32 send_timeout_seconds,
-                                                 const U32 send_timeout_microseconds) {
+                                                 const U32 send_timeout_microseconds,
+                                                 size_t buffer_size) {
+
+    m_allocation_size = buffer_size; // Store the buffer size
     return m_socket.configure(hostname, port, send_timeout_seconds, send_timeout_microseconds);
 }
 
@@ -42,13 +45,8 @@ IpSocket& TcpClientComponentImpl::getSocketHandler() {
     return m_socket;
 }
 
-// Define a constant for the default buffer size
-static const size_t DEFAULT_BUFFER_SIZE = 1024;
-
-// Modify the function signature to accept the buffer size as an argument
-Fw::Buffer TcpClientComponentImpl::getBuffer(size_t bufferSize = DEFAULT_BUFFER_SIZE) {
-    // Allocate the buffer with the specified size
-    return allocate_out(0, bufferSize);
+Fw::Buffer TcpClientComponentImpl::getBuffer() {
+    return allocate_out(0, m_allocation_size);
 }
 
 void TcpClientComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status) {

--- a/Drv/TcpClient/TcpClientComponentImpl.cpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.cpp
@@ -29,7 +29,7 @@ SocketIpStatus TcpClientComponentImpl::configure(const char* hostname,
                                                  const U16 port,
                                                  const U32 send_timeout_seconds,
                                                  const U32 send_timeout_microseconds,
-                                                 size_t buffer_size) {
+                                                 FwSizeType buffer_size) {
 
     m_allocation_size = buffer_size; // Store the buffer size
     return m_socket.configure(hostname, port, send_timeout_seconds, send_timeout_microseconds);

--- a/Drv/TcpClient/TcpClientComponentImpl.cpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.cpp
@@ -33,7 +33,7 @@ SocketIpStatus TcpClientComponentImpl::configure(const char* hostname,
                                                  FwSizeType buffer_size) {
 
     // Check that ensures the configured buffer size fits within the limits fixed-width type, U32                                                
-    FW_ASSERT(buffer_size <= std::numeric_limits<U32>::max(), buffer_size);                                                   
+    FW_ASSERT(buffer_size <= std::numeric_limits<U32>::max(), static_cast<FwAssertArgType>(buffer_size));                                                   
     m_allocation_size = buffer_size; // Store the buffer size
     return m_socket.configure(hostname, port, send_timeout_seconds, send_timeout_microseconds);
 }

--- a/Drv/TcpClient/TcpClientComponentImpl.hpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.hpp
@@ -130,7 +130,7 @@ class TcpClientComponentImpl : public TcpClientComponentBase, public SocketReadT
     Drv::TcpClientSocket m_socket; //!< Socket implementation
 
     // Member variable to store the buffer size
-    size_t m_allocation_size;
+    FwSizeType m_allocation_size;
 };
 
 }  // end namespace Drv

--- a/Drv/TcpClient/TcpClientComponentImpl.hpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.hpp
@@ -61,7 +61,7 @@ class TcpClientComponentImpl : public TcpClientComponentBase, public SocketReadT
                              const U16 port,
                              const U32 send_timeout_seconds = SOCKET_SEND_TIMEOUT_SECONDS,
                              const U32 send_timeout_microseconds = SOCKET_SEND_TIMEOUT_MICROSECONDS,
-                             size_t buffer_size = 1024);
+                             FwSizeType buffer_size = 1024);
 
   PROTECTED:
     // ----------------------------------------------------------------------

--- a/Drv/TcpClient/TcpClientComponentImpl.hpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.hpp
@@ -54,12 +54,14 @@ class TcpClientComponentImpl : public TcpClientComponentBase, public SocketReadT
      * \param send_timeout_seconds: send timeout seconds component. Defaults to: SOCKET_TIMEOUT_SECONDS
      * \param send_timeout_microseconds: send timeout microseconds component. Must be less than 1000000. Defaults to:
      * SOCKET_TIMEOUT_MICROSECONDS
+     * \param buffer_size: size of the buffer to be allocated. Defaults to 1024.
      * \return status of the configure
      */
     SocketIpStatus configure(const char* hostname,
                              const U16 port,
                              const U32 send_timeout_seconds = SOCKET_SEND_TIMEOUT_SECONDS,
-                             const U32 send_timeout_microseconds = SOCKET_SEND_TIMEOUT_MICROSECONDS);
+                             const U32 send_timeout_microseconds = SOCKET_SEND_TIMEOUT_MICROSECONDS,
+                             size_t buffer_size = 1024);
 
   PROTECTED:
     // ----------------------------------------------------------------------
@@ -126,6 +128,9 @@ class TcpClientComponentImpl : public TcpClientComponentBase, public SocketReadT
     Drv::SendStatus send_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer);
 
     Drv::TcpClientSocket m_socket; //!< Socket implementation
+
+    // Member variable to store the buffer size
+    size_t m_allocation_size;
 };
 
 }  // end namespace Drv


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #2074  |
|**_Has Unit Tests (y/n)_**|  no |
|**_Documentation Included (y/n)_**| no |

---
## Change Description

Changed the getBuffer function to have a tunable size. There is a default size of 1024 so that it does not break any existing code.

## Rationale

This removes the need of having to fork off of the fprime repo or autopatch everytime.

## Testing/Review Recommendations

There is no unit tests to see if it'll break anything. Unsure where to begin to test to see.

## Future Work

