### PR TITLE
Fixed copy-paste typos. Should be UDP and not TCP.

### DIFF
--- a/Drv/Udp/docs/sdd.md
+++ b/Drv/Udp/docs/sdd.md
@@ -20,7 +20,7 @@ These responses are an enumeration whose values are described in the following t
 | Drv::SEND_RETRY | Send should be retried, but a subsequent send should return SEND_OK. |
 | Drv::SEND_ERROR | Send produced an error, future sends likely to fail. |
 
-This data is immediately sent out to the remote tcp server with a configured send timeout. See Usage described below.
+This data is immediately sent out to the remote UDP server with a configured send timeout. See Usage described below.
 
 **Callback Formation**
 
@@ -37,8 +37,8 @@ This status is an enumeration whose values are described in the following table:
 
 ## Usage
 
-The Drv::TcpClientComponentImpl must be configured with the address of the remote connection, and the socket must be
-open to begin. Usually, the user runs the Drv::TcpClientComponentImpl engaging its read thread, which will automatically
+The Drv::UdpComponentImpl must be configured with the address of the remote connection, and the socket must be
+open to begin. Usually, the user runs the Drv::UdpComponentImpl engaging its read thread, which will automatically
 open the  connection. The component is passive and has no commands meaning users should `init`,
 `configureSend`/`configureRecv`, and `startSocketTask`. Upon shutdown, the `stopSocketThread` and `joinSocketThread`
 methods should be called to ensure proper resource deallocation. This typical usage is shown in the C++ snippet below.
@@ -47,7 +47,7 @@ Since UDP support single or bidirectional communication, configuring each direct
 methods `configureSend` and `configureRecv`. The user is not required to call both.
 
 ```c++
-Drv::TcpClientComponentImpl comm = Drv::TcpClientComponentImpl("UDp Client");
+Drv::UdpComponentImpl comm = Drv::UdpComponentImpl("UDP Client");
 
 bool constructApp(bool dump, U32 port_number, char* hostname) {
     ...


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes typos in documentation.

## Rationale

Makes the documentation more clear with the typo fixes.

## Testing/Review Recommendations


## Future Work

