### PR TITLE
Change TCPServer backlog to 1

### DIFF
--- a/Drv/Ip/TcpServerSocket.cpp
+++ b/Drv/Ip/TcpServerSocket.cpp
@@ -84,7 +84,7 @@ SocketIpStatus TcpServerSocket::startup() {
     }
     U16 port = ntohs(address.sin_port);
     Fw::Logger::logMsg("Listening for single client at %s:%hu\n", reinterpret_cast<POINTER_CAST>(m_hostname), port);
-    // TCP requires listening on the socket. Second argument sets backlog to 1 since TCP is expecting a client.
+    // TCP requires listening on the socket. Since we only expect a single client, set the TCP backlog (second argument) to 1 to prevent queuing of multiple clients. 
     if (::listen(serverFd, 1) < 0) {
         ::close(serverFd);
         return SOCK_FAILED_TO_LISTEN; // What we have here is a failure to communicate

--- a/Drv/Ip/TcpServerSocket.cpp
+++ b/Drv/Ip/TcpServerSocket.cpp
@@ -84,8 +84,8 @@ SocketIpStatus TcpServerSocket::startup() {
     }
     U16 port = ntohs(address.sin_port);
     Fw::Logger::logMsg("Listening for single client at %s:%hu\n", reinterpret_cast<POINTER_CAST>(m_hostname), port);
-    // TCP requires listening on the socket. Second argument prevents queueing of anything more than a single client.
-    if (::listen(serverFd, 0) < 0) {
+    // TCP requires listening on the socket. Second argument sets backlog to 1 since TCP is expecting a client.
+    if (::listen(serverFd, 1) < 0) {
         ::close(serverFd);
         return SOCK_FAILED_TO_LISTEN; // What we have here is a failure to communicate
     }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|#2603 |
|**_Has Unit Tests (y/n)_**| n|
|**_Documentation Included (y/n)_**|n |

---
## Change Description
Change TCP backlog to 1 from 0 in [TcpServerSocket.cpp](https://github.com/Lex-ari/fprime/blob/8fc4287932e47dbf201047bc4828d6e2dd39b0d3/Drv/Ip/TcpServerSocket.cpp#L88)

## Rationale

Some Linux kernels would accept 0 as a backlog size, which would drop all incoming TCP SYN connections and prevent anything from connecting to FSW. Changing the backlog will allow SYN packets to be accepted.
This issue may have been the cause of #2603 (I am using the exact same hardware).

Huge props to @Joshua-Anderson and @kevin-f-ortega for helping and finding this fix!

## Testing/Review Recommendations

Hardware: Nvidia Jetson Nano 2GB, Ubuntu 18.04, Jetson Linux 4.9.337-tegra R32.7.4
Project and deployment build for aarch64 and running FSW and GDS, verified TCP connection.
May also use other web / Linux tools to connect to the IP and port, with corresponding accept message.
