### PR TITLE
Ignore all HTTP links in Markdown link check

### DIFF
--- a/.github/actions/markdown-check/mlc-config.json
+++ b/.github/actions/markdown-check/mlc-config.json
@@ -4,10 +4,7 @@
         "pattern": "^(https?://)?localhost"
       },
       {
-        "pattern": "https://www.raspberrypi.com/documentation/computers/configuration.html"
-      },
-      {
-        "pattern": "https://en.wikipedia.org/wiki/"
+        "pattern": "https?://"
       }
     ],
     "replacementPatterns": [


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

I propose we ignore all HTTP(s?) links in the Markdown link checks. It has been causing some issues, most of the time the link is just unavailable at the time the check is ran, or some redirect/authentication/unknown issues.

The purpose for which we introduced this check was mostly for checking relative MD links within our docs, which it does well.
If a web link is broken, most of the time the user can make sense of how to get it back. Worst case, we can change it when it gets discovered.

The tradeoff of development time vs. benefit is not clear, so I suggest we drop those checks.