### PR TITLE
Match markdown of Channels with that of Events

### DIFF
--- a/docs/UsersGuide/user/full-intro.md
+++ b/docs/UsersGuide/user/full-intro.md
@@ -52,7 +52,7 @@ between **Components**.  The complete graph or network of **Components** connect
 F´ was built to support **Command and Data Handling** (C&DH) of these space systems as well as instruments running as
 part of these space systems. This means F´ out-of-the-box is designed to handle commands sent from the ground, and
 respond with telemetry to the ground. In F´ this telemetry is broken into **Events** representing the history of actions
-taken by the system, and channels representing the current state of the system broken into named channels that each
+taken by the system, and **Channels** representing the current state of the system broken into named channels that each
 contain a portion of the state. e.g. an **Event** might be "Established Communications" and a **Channel** might be
 "Current Temperature: 3C".
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| NA  |
|**_Has Unit Tests (y/n)_**| n  |
|**_Documentation Included (y/n)_**| y  |

---
## Change Description

This PR changes the formatting in the Full Intro User Guide so the word "channels" is formatted in bold, as was done in the same sentences with the word "Events". Currently, the documentation looks like this:
![image](https://github.com/user-attachments/assets/81738e09-f403-43ac-a32c-2b5af574022e)


## Rationale

Homogenous formatting.

## Testing/Review Recommendations

NA

## Future Work

NA
