### PR TITLE
Make _fprime_packages a folder where all libraries can live

### DIFF
--- a/cmake/FPrime.cmake
+++ b/cmake/FPrime.cmake
@@ -17,6 +17,16 @@ if (IS_DIRECTORY "${FPRIME_PROJECT_ROOT}/cmake")
     list(APPEND CMAKE_MODULE_PATH "${FPRIME_PROJECT_ROOT}/cmake")
 endif()
 
+# for adding libraries from the _fprime_packages directory
+if (IS_DIRECTORY "${FPRIME_PROJECT_ROOT}/_fprime_packages")
+    if (EXISTS "${FPRIME_PROJECT_ROOT}/_fprime_packages/packages.cmake")
+        include("${FPRIME_PROJECT_ROOT}/_fprime_packages/packages.cmake")
+        message(STATUS "[FPRIME] Including libraries from ${FPRIME_PROJECT_ROOT}/_fprime_packages")
+    else()
+        message(WARNING "[FPRIME] ${FPRIME_PROJECT_ROOT}/_fprime_packages/packages.cmake does not exist. Skipping.")
+    endif()
+endif()
+
 # Setup fprime library locations
 list(REMOVE_DUPLICATES FPRIME_LIBRARY_LOCATIONS)
 set(FPRIME_BUILD_LOCATIONS "${FPRIME_FRAMEWORK_PATH}" ${FPRIME_LIBRARY_LOCATIONS} "${FPRIME_PROJECT_ROOT}")


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n/a |

---
## Change Description

Currently, F Prime libraries can be added to F Prime through the `Settings.ini` file. However, it would be nice if there was a specific folder in the root of an F Prime project that would automatically detect and include libraries.

(Thanks [fppm](https://github.com/mosa11aei/fprime-fppm)) If a folder called `_fprime_packages` is detected in the root of your project, and it contains a `packages.cmake` file, all folders in the directory will be added as libraries to F Prime.