### PR TITLE
Fix double-promotion in fprime codebase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,14 @@ add_compile_options(
     -Wno-unused-parameter
 )
 
-# Add -Wshadow and -pedantic only for framework code, not the unit tests
+# Add -Wshadow, -Wconversion and -pedantic only for framework code, not the unit tests
+# TODO: uncomment -Wdouble-promotion once fpp is fixed
 if (NOT BUILD_TESTING)
     add_compile_options(
         -Wshadow
         -pedantic
         -Wconversion
+#        -Wdouble-promotion
     )
 endif()
 

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -639,12 +639,16 @@ void PolyType::toString(StringBase& dest, bool append) const {
 #endif
 #if FW_HAS_F64
         case TYPE_F64:
-            (void)snprintf(valString, sizeof(valString), "%lg ", this->m_val.f64Val);
+            (void)snprintf(valString, sizeof(valString), "%g ", this->m_val.f64Val);
             break;
-#endif
+        case TYPE_F32:
+            (void)snprintf(valString, sizeof(valString), "%g ", static_cast<F64>(this->m_val.f32Val));
+            break;
+#else
         case TYPE_F32:
             (void)snprintf(valString, sizeof(valString), "%g ", this->m_val.f32Val);
             break;
+#endif
         case TYPE_BOOL:
             (void)snprintf(valString, sizeof(valString), "%s ", this->m_val.boolVal ? "T" : "F");
             break;

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -48,7 +48,7 @@ FwSignedSizeType Fw::StringUtils::substring_find(const CHAR* source_string,
         return -1;
     }
     // Confirm that the output type can hold the range of valid results
-    FW_ASSERT((source_size - sub_size) <= std::numeric_limits<FwSignedSizeType>::max());
+    FW_ASSERT(static_cast<FwSignedSizeType>(source_size - sub_size) <= std::numeric_limits<FwSignedSizeType>::max());
 
     // Loop from zero to source_size - sub_size (inclusive)
     for (FwSizeType source_index = 0;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixed a warning of `float` being promoted to `double`.

Fixed `%lg` parameter being used for `double`, instead of `%g`.

Fixed warning on `FW_ASSERT`.

## Rationale

When a `float` is used as a `printf` parameter, it is promoted to `double`, triggering a warning when `-Wdouble-promotion` is used.

## Future Work

FFP is currently generating code for in `Ac.cpp` files which are using `sb.format` and `printf` in the background. 

I had an attempt to fix it in the branch here: https://github.com/nasa/fpp/commit/f495ce1579c275107f2522c859ee4b572dc6f2d1

However, this patch is currently not compatible with all platform. A platform not supporting `double`/`F64` would not work with this change.

I personally don't have a platform that does not support `F64`/`double` types, so I could not check the behavior.