### PR TITLE
Adding `fflush` call to posix console

### DIFF
--- a/Os/Posix/Console.cpp
+++ b/Os/Posix/Console.cpp
@@ -19,6 +19,7 @@ void PosixConsole::writeMessage(const CHAR *message, const FwSizeType size) {
     FwSizeType capped_size = (size <= std::numeric_limits<size_t>::max()) ? size : std::numeric_limits<size_t>::max();
     if (message != nullptr) {
         (void)::fwrite(message, sizeof(CHAR), static_cast<size_t>(capped_size), this->m_handle.m_file_descriptor);
+        (void)::fflush(this->m_handle.m_file_descriptor);
     }
 }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adding `fflush` call to posix console. This replicates the original behavior in the OSAL layer.

## Rationale

`Os::Console` should be write-call buffered. 

## Testing/Review Recommendations

Does the full log file appear?

## Future Work

Note any additional work that will be done relating to this issue.
