### PR TITLE
Fixing unexport ordering in LinuxGpioDriver

### DIFF
--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -89,8 +89,12 @@ jobs:
           mkdir -p ci-logs
           chmod +x ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker
           fprime-gds --ip-client -d ./build-artifacts/raspberrypi/LedBlinker --logs ./ci-logs &
+          GDS_PID=$!
           sleep 10
+          ps -p "${GDS_PID}" || exit 1
           pytest --dictionary ./build-artifacts/raspberrypi/LedBlinker/dict/LedBlinkerTopologyDictionary.json ./int/led_integration_tests.py
+          pkill -P ${GDS_PID}
+          wait ${GDS_PID}
       - name: 'Archive logs'
         uses: actions/upload-artifact@v3
         if: always()

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
@@ -28,7 +28,7 @@
 #include <fcntl.h>
 #include <poll.h>
 
-#define DEBUG_PRINT(...) Fw::Logger::log(##__VA_ARGS__);
+#define DEBUG_PRINT(...) Fw::Logger::log(##__VA_ARGS__)
 
 namespace Drv {
 

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
@@ -28,7 +28,7 @@
 #include <fcntl.h>
 #include <poll.h>
 
-#define DEBUG_PRINT(...) Fw::Logger::log(##__VA_ARGS__)
+#define DEBUG_PRINT(...) Fw::Logger::log(__VA_ARGS__)
 
 namespace Drv {
 

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverComponentImpl.cpp
@@ -28,8 +28,7 @@
 #include <fcntl.h>
 #include <poll.h>
 
-//#define DEBUG_PRINT(...) printf(##__VA_ARGS__); fflush(stdout)
-#define DEBUG_PRINT(...)
+#define DEBUG_PRINT(...) Fw::Logger::log(##__VA_ARGS__);
 
 namespace Drv {
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Makes Linux GPIO driver close before unexporting the pin.

## Rationale


Unexport should remove the `gpio#` directory in the `/sys/class/gpio` system. However, we did not calls `close` first.  This meant a file descriptor was open for a directory being removed.

Given we have seen many issues with reopening GPIOs, hopefully this will fix the issues.


## Testing/Review Recommendations

Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality.

## Future Work

Note any additional work that will be done relating to this issue.
