### PR TITLE
Remove versions from SystemResources and updates to Version component

### DIFF
--- a/Ref/Top/RefPackets.xml
+++ b/Ref/Top/RefPackets.xml
@@ -72,12 +72,7 @@
         <channel name="systemResources.NON_VOLATILE_FREE"/>
     </packet>
 
-    <packet name="SystemRes2" id="6" level="2">
-        <channel name="systemResources.FRAMEWORK_VERSION"/>
-        <channel name="systemResources.PROJECT_VERSION"/>
-    </packet>
-
-    <packet name="SystemRes3" id="7" level="2">
+    <packet name="SystemRes3" id="6" level="2">
         <channel name="systemResources.CPU"/>
         <channel name="systemResources.CPU_00"/>
         <channel name="systemResources.CPU_01"/>

--- a/Svc/SystemResources/CMakeLists.txt
+++ b/Svc/SystemResources/CMakeLists.txt
@@ -12,7 +12,6 @@ set(SOURCE_FILES
 )
 set(MOD_DEPS
   Os
-  version 
 )
 register_fprime_module()
 ### UTs ###

--- a/Svc/SystemResources/SystemResources.cpp
+++ b/Svc/SystemResources/SystemResources.cpp
@@ -1,4 +1,3 @@
-// ======================================================================
 // \title  SystemResourcesComponentImpl.cpp
 // \author sfregoso
 // \brief  cpp file for SystemResources component implementation class
@@ -12,7 +11,6 @@
 
 #include <cmath>  //isnan()
 #include <Svc/SystemResources/SystemResources.hpp>
-#include <versions/version.hpp>
 #include <FpConfig.hpp>
 
 namespace Svc {
@@ -73,7 +71,6 @@ void SystemResources ::run_handler(const NATIVE_INT_TYPE portNum, U32 tick_time_
         Cpu();
         Mem();
         PhysMem();
-        Version();
     }
 }
 
@@ -85,15 +82,6 @@ void SystemResources ::ENABLE_cmdHandler(const FwOpcodeType opCode,
                                          const U32 cmdSeq,
                                          SystemResourceEnabled enable) {
     m_enable = (enable == SystemResourceEnabled::ENABLED);
-    this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
-}
-
-void SystemResources ::VERSION_cmdHandler(const FwOpcodeType opCode, const U32 cmdSeq) {
-    Fw::LogStringArg version_string(Project::Version::FRAMEWORK_VERSION);
-    this->log_ACTIVITY_LO_FRAMEWORK_VERSION(version_string);
-
-    version_string = Project::Version::PROJECT_VERSION;
-    this->log_ACTIVITY_LO_PROJECT_VERSION(version_string);
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }
 
@@ -151,11 +139,4 @@ void SystemResources::PhysMem() {
     }
 }
 
-void SystemResources::Version() {
-    Fw::TlmString version_string(Project::Version::FRAMEWORK_VERSION);
-    this->tlmWrite_FRAMEWORK_VERSION(version_string);
-
-    version_string= Project::Version::PROJECT_VERSION;
-    this->tlmWrite_PROJECT_VERSION(version_string);
-}
 }  // end namespace Svc

--- a/Svc/SystemResources/SystemResources.cpp
+++ b/Svc/SystemResources/SystemResources.cpp
@@ -1,3 +1,4 @@
+// ======================================================================
 // \title  SystemResourcesComponentImpl.cpp
 // \author sfregoso
 // \brief  cpp file for SystemResources component implementation class

--- a/Svc/SystemResources/SystemResources.fpp
+++ b/Svc/SystemResources/SystemResources.fpp
@@ -42,26 +42,6 @@ module Svc {
                           ) \
       opcode 0
 
-    @ Report version as EVR
-    guarded command VERSION \
-      opcode 1
-
-    @ Version of the git repository.
-    event FRAMEWORK_VERSION(
-                   version: string size 40 @< version string
-                 ) \
-      severity activity low \
-      id 0 \
-      format "Framework Version: [{}]"
-
-    @ Version of the git repository.
-    event PROJECT_VERSION(
-                   version: string size 40 @< version string
-                 ) \
-      severity activity low \
-      id 1 \
-      format "Project Version: [{}]"
-
     @ Total system memory in KB
     telemetry MEMORY_TOTAL: U64 id 0 \
       format "{} KB"
@@ -128,12 +108,6 @@ module Svc {
 
     @ System's CPU Percentage
     telemetry CPU_15: F32 id 20 format "{.2f} percent"
-
-    @ Software framework version
-    telemetry FRAMEWORK_VERSION: string size 40 id 21
-
-    @ Software project version
-    telemetry PROJECT_VERSION: string size 40 id 22
 
   }
 

--- a/Svc/SystemResources/SystemResources.hpp
+++ b/Svc/SystemResources/SystemResources.hpp
@@ -67,17 +67,11 @@ class SystemResources : public SystemResourcesComponentBase {
         SystemResourceEnabled enable /*!< whether or not system resource telemetry is enabled*/
     );
 
-    //! Implementation for VERSION command handler
-    //! Report version as EVR
-    void VERSION_cmdHandler(const FwOpcodeType opCode, /*!< The opcode*/
-                            const U32 cmdSeq           /*!< The command sequence number*/
-    );
 
   private:
     void Cpu();
     void Mem();
     void PhysMem();
-    void Version();
     F32 compCpuUtil(Os::SystemResources::CpuTicks current, Os::SystemResources::CpuTicks previous);
 
 

--- a/Svc/SystemResources/docs/sdd.md
+++ b/Svc/SystemResources/docs/sdd.md
@@ -3,10 +3,9 @@
 
 The system resources component downlinks information about the running F´ system. This information includes:
 
-1. System and Software version
-2. Free Memory
-3. CPU load
-4. Disk space
+1. Free Memory
+2. CPU load
+3. Disk space
 
 These items are downlinked as telemetry channels in response to a rate group port invocation.
 

--- a/Svc/SystemResources/test/ut/SystemResourcesTestMain.cpp
+++ b/Svc/SystemResources/test/ut/SystemResourcesTestMain.cpp
@@ -14,11 +14,6 @@ TEST(OffNominal, Disabled) {
     tester.test_disable_enable();
 }
 
-TEST(Nominal, Events) {
-    Svc::SystemResourcesTester tester;
-    tester.test_version_evr();
-}
-
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/SystemResources/test/ut/SystemResourcesTester.cpp
+++ b/Svc/SystemResources/test/ut/SystemResourcesTester.cpp
@@ -11,7 +11,6 @@
 // ======================================================================
 
 #include "SystemResourcesTester.hpp"
-#include "versions/version.hpp"
 #define INSTANCE 0
 #define MAX_HISTORY_SIZE 100
 
@@ -111,13 +110,7 @@ void SystemResourcesTester ::test_tlm(bool enabled) {
                     ASSERT_TLM_NON_VOLATILE_FREE_SIZE(0);
                     ASSERT_TLM_NON_VOLATILE_TOTAL_SIZE(0);
                 }
-                ASSERT_TLM_FRAMEWORK_VERSION_SIZE((enabled) ? 1 : 0);
-                ASSERT_TLM_PROJECT_VERSION_SIZE((enabled) ? 1 : 0);
-                if (enabled) {
-                    ASSERT_TLM_FRAMEWORK_VERSION(0, Project::Version::FRAMEWORK_VERSION);
-                    ASSERT_TLM_PROJECT_VERSION(0, Project::Version::PROJECT_VERSION);
-                }
-                ASSERT_TLM_SIZE((enabled) ? (count + 3) : 0); // CPU count channels + avg + 2 ver
+                ASSERT_TLM_SIZE((enabled) ? (count + 1) : 0); // CPU count channels + avg + 2 ver
                 break;
         }
     }
@@ -128,14 +121,6 @@ void SystemResourcesTester ::test_disable_enable() {
     this->test_tlm(false);
     this->sendCmd_ENABLE(0, 0, SystemResourceEnabled::ENABLED);
     this->test_tlm(true);
-}
-
-void SystemResourcesTester ::test_version_evr() {
-    this->sendCmd_VERSION(0, 0);
-    ASSERT_EVENTS_FRAMEWORK_VERSION_SIZE(1);
-    ASSERT_EVENTS_FRAMEWORK_VERSION(0, Project::Version::FRAMEWORK_VERSION);
-    ASSERT_EVENTS_PROJECT_VERSION_SIZE(1);
-    ASSERT_EVENTS_PROJECT_VERSION(0, Project::Version::FRAMEWORK_VERSION);
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/SystemResources/test/ut/SystemResourcesTester.hpp
+++ b/Svc/SystemResources/test/ut/SystemResourcesTester.hpp
@@ -45,10 +45,6 @@ class SystemResourcesTester : public SystemResourcesGTestBase {
     //!
     void test_disable_enable();
 
-    //! Test version EVR
-    //!
-    void test_version_evr();
-
   private:
     // ----------------------------------------------------------------------
     // Helper methods

--- a/Svc/Version/Version.cpp
+++ b/Svc/Version/Version.cpp
@@ -112,7 +112,7 @@ void Version ::VERSION_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, Svc::VersionT
 // ----------------------------------------------------------------------
 // implementations for internal functions
 // ----------------------------------------------------------------------
-// functions to log tlm on versions
+// Send both events and tlm for framework version
 void Version ::fwVersion_tlm() {
     Fw::LogStringArg fw_event = (Project::Version::FRAMEWORK_VERSION);
     this->log_ACTIVITY_LO_FrameworkVersion(fw_event);
@@ -120,6 +120,7 @@ void Version ::fwVersion_tlm() {
     this->tlmWrite_FrameworkVersion(fw_tlm);
 }
 
+// Send both events and tlm for project version
 void Version ::projectVersion_tlm() {
     Fw::LogStringArg proj_event = Project::Version::PROJECT_VERSION;
     this->log_ACTIVITY_LO_ProjectVersion(proj_event);
@@ -127,6 +128,7 @@ void Version ::projectVersion_tlm() {
     this->tlmWrite_ProjectVersion(proj_tlm);
 }
 
+// Send both events and tlm for library versions
 void Version ::libraryVersion_tlm() {
 
     // Process libraries array
@@ -173,6 +175,7 @@ void Version ::libraryVersion_tlm() {
     }
 }
 
+// Send all events and tlm (if versbosity is enabled) for custom versions
 void Version ::customVersion_tlm_all() {
     for (U8 i = 0; (m_enable == true) && (m_num_custom_elements != 0) && (i < Svc::VersionCfg::VersionEnum::NUM_CONSTANTS);
          i++) {
@@ -180,6 +183,7 @@ void Version ::customVersion_tlm_all() {
     }
 }
 
+// Send events and tlm (if versbosity is enabled) for custom versions
 void Version ::customVersion_tlm(VersionSlot custom_slot) {
     // Process custom version TLM only if verbosity is enabled and there are any valid writes to it;
     //  it doesn't necessarily have to be consecutive

--- a/Svc/Version/Version.cpp
+++ b/Svc/Version/Version.cpp
@@ -183,49 +183,51 @@ void Version ::customVersion_tlm_all() {
 void Version ::customVersion_tlm(VersionSlot custom_slot) {
     // Process custom version TLM only if verbosity is enabled and there are any valid writes to it;
     //  it doesn't necessarily have to be consecutive
-    if ((this->verId_db[custom_slot].getversion_value() != "no_ver") && m_enable == true &&
+    if ((this->verId_db[custom_slot].getversion_value() != "no_ver") && 
         (this->m_num_custom_elements > 0)) {  // Write TLM for valid writes
 
-        // Emit Events/TLM on library versions
+        // Emit Events/TLM on custom versions
         this->log_ACTIVITY_LO_CustomVersions(this->verId_db[custom_slot].getversion_enum(),
                                              this->verId_db[custom_slot].getversion_value());
 
+        if (m_enable == true) { //Send TLM only if verbosity is enabled
         // Write to TLM
-        switch (custom_slot) {
-            case VER_SLOT_00:
-                this->tlmWrite_CustomVersion01(verId_db[custom_slot]);
-                break;
-            case VER_SLOT_01:
-                this->tlmWrite_CustomVersion02(verId_db[custom_slot]);
-                break;
-            case VER_SLOT_02:
-                this->tlmWrite_CustomVersion03(verId_db[custom_slot]);
-                break;
-            case VER_SLOT_03:
-                this->tlmWrite_CustomVersion04(verId_db[custom_slot]);
-                break;
-            case VER_SLOT_04:
-                this->tlmWrite_CustomVersion05(verId_db[custom_slot]);
-                break;
-            case VER_SLOT_05:
-                this->tlmWrite_CustomVersion06(verId_db[custom_slot]);
-                break;
-            case VER_SLOT_06:
-                this->tlmWrite_CustomVersion07(verId_db[custom_slot]);
-                break;
-            case VER_SLOT_07:
-                this->tlmWrite_CustomVersion08(verId_db[custom_slot]);
-                break;
-            case VER_SLOT_08:
-                this->tlmWrite_CustomVersion09(verId_db[custom_slot]);
-                break;
-            case VER_SLOT_09:
-                this->tlmWrite_CustomVersion10(verId_db[custom_slot]);
-                break;
-            default:
-                // There are only 10 custom slots available
-                FW_ASSERT(0, custom_slot);
-                break;
+            switch (custom_slot) {
+                case VER_SLOT_00:
+                    this->tlmWrite_CustomVersion01(verId_db[custom_slot]);
+                    break;
+                case VER_SLOT_01:
+                    this->tlmWrite_CustomVersion02(verId_db[custom_slot]);
+                    break;
+                case VER_SLOT_02:
+                    this->tlmWrite_CustomVersion03(verId_db[custom_slot]);
+                    break;
+                case VER_SLOT_03:
+                    this->tlmWrite_CustomVersion04(verId_db[custom_slot]);
+                    break;
+                case VER_SLOT_04:
+                    this->tlmWrite_CustomVersion05(verId_db[custom_slot]);
+                    break;
+                case VER_SLOT_05:
+                    this->tlmWrite_CustomVersion06(verId_db[custom_slot]);
+                    break;
+                case VER_SLOT_06:
+                    this->tlmWrite_CustomVersion07(verId_db[custom_slot]);
+                    break;
+                case VER_SLOT_07:
+                    this->tlmWrite_CustomVersion08(verId_db[custom_slot]);
+                    break;
+                case VER_SLOT_08:
+                    this->tlmWrite_CustomVersion09(verId_db[custom_slot]);
+                    break;
+                case VER_SLOT_09:
+                    this->tlmWrite_CustomVersion10(verId_db[custom_slot]);
+                    break;
+                default:
+                    // There are only 10 custom slots available
+                    FW_ASSERT(0, custom_slot);
+                    break;
+            }
         }
     }
 }

--- a/Svc/Version/Version.cpp
+++ b/Svc/Version/Version.cpp
@@ -175,7 +175,7 @@ void Version ::libraryVersion_tlm() {
     }
 }
 
-// Send all events and tlm (if versbosity is enabled) for custom versions
+// Send all events and tlm (if verbosity is enabled) for custom versions
 void Version ::customVersion_tlm_all() {
     for (U8 i = 0; (m_enable == true) && (m_num_custom_elements != 0) && (i < Svc::VersionCfg::VersionEnum::NUM_CONSTANTS);
          i++) {
@@ -183,7 +183,7 @@ void Version ::customVersion_tlm_all() {
     }
 }
 
-// Send events and tlm (if versbosity is enabled) for custom versions
+// Send events and tlm (if verbosity is enabled) for custom versions
 void Version ::customVersion_tlm(VersionSlot custom_slot) {
     // Process custom version TLM only if verbosity is enabled and there are any valid writes to it;
     //  it doesn't necessarily have to be consecutive

--- a/Svc/Version/docs/sdd.md
+++ b/Svc/Version/docs/sdd.md
@@ -9,18 +9,18 @@ Tracks versions for framework,project, libraries and user defined project specif
 |SVC-VERSION-001|`Svc::Version` upon startup shall generate an event and a telemetry channel with version for framework.| This is to provide transparency on framework version being used|
 |SVC-VERSION-002|`Svc::Version` upon startup shall generate an event and a telemetry channel with version for project | This is to provide transparency on project version being used|
 |SVC-VERSION-003|`Svc::Version` upon startup shall generate events and telemetry channels (upto 10) with versions for library.| Transparency on different library versions|
-|SVC-VERSION-004|`Svc::Version` upon startup shall make verbosity on custom versions configurable.| Transparency on different library versions|
+|SVC-VERSION-004|`Svc::Version` upon startup shall make verbosity on custom versions configurable.| Verbosity will enable/disable the channel generation but will not effect the event generation|
 |SVC-VERSION-005|`Svc::Version` shall provide a ground command to request events and telemetry on framework version| Accessibility on demand|
 |SVC-VERSION-006|`Svc::Version` shall provide a ground command to request events and telemetry on project version| Accessibility on demand|
 |SVC-VERSION-007|`Svc::Version` shall provide a ground command to request events and telemetry channels (upto 10) on library versions| Accessibility on demand|
-|SVC-VERSION-008|`Svc::Version` shall provide a ground command to request events and telemetry channels (upto 10) on custom versions| Accessibility on demand|
+|SVC-VERSION-008|`Svc::Version` shall provide a ground command to request events and telemetry channels (upto 10) on custom versions| Accessibility on demand. Verbosity configuration will determine the channel generation|
 |SVC-VERSION-009|`Svc::Version` shall provide a ground command to enable/disable verbosity on custom versions| Accessibility on demand|
 |SVC-VERSION-010|`Svc::Version` shall provide a telemetry channel on framework version| Accessibility to versions being used|
 |SVC-VERSION-011|`Svc::Version` shall provide a telemetry channel on project version| Accessibility to versions being used|
 |SVC-VERSION-012|`Svc::Version` shall provide upto 10 telemetry channels on library versions| Accessibility to versions being used|
-|SVC-VERSION-013|`Svc::Version` shall provide upto 10 telemetry channels on custom versions| Accessibility to versions being used|
-|SVC-VERSION-014|`Svc::Version` shall provide an interface for other components to set custom versions.| Enables projects to set hardware and FPGA versions, say, as needed. Also generates Events/TLM|
-|SVC-VERSION-015|`Svc::Version` shall provide an interface for other components to get custom versions.| Also generates Events/TLM|
+|SVC-VERSION-013|`Svc::Version` shall provide upto 10 telemetry channels on custom versions| Accessibility to versions being used. Only accessible if verbosity is enabled|
+|SVC-VERSION-014|`Svc::Version` shall provide an interface for other components to set custom versions.| Enables projects to set hardware and FPGA versions, say, as needed. Also generates Events/TLM based on verbosity configuration|
+|SVC-VERSION-015|`Svc::Version` shall provide an interface for other components to get custom versions.| Also generates Events/TLM based on verbosity configuration|
 
 ## Emitting Versions on Start-Up
 

--- a/Svc/Version/test/ut/VersionTester.cpp
+++ b/Svc/Version/test/ut/VersionTester.cpp
@@ -85,13 +85,35 @@ void VersionTester ::test_enable() {
     this->sendCmd_ENABLE(0, cmd_seq, VersionEnabled::DISABLED);
     ASSERT_CMD_RESPONSE(0, 0, 9, Fw::CmdResponse::OK);
     VersionTester::test_setVer(false);
-    ASSERT_EVENTS_CustomVersions_SIZE(0);
+    //When verbosity is disabled, events are still generated but not EHAs
+    ASSERT_EVENTS_CustomVersions_SIZE(10);
+    ASSERT_TLM_CustomVersion01_SIZE(0);
+    ASSERT_TLM_CustomVersion02_SIZE(0);
+    ASSERT_TLM_CustomVersion03_SIZE(0);
+    ASSERT_TLM_CustomVersion04_SIZE(0);
+    ASSERT_TLM_CustomVersion05_SIZE(0);
+    ASSERT_TLM_CustomVersion06_SIZE(0);
+    ASSERT_TLM_CustomVersion07_SIZE(0);
+    ASSERT_TLM_CustomVersion08_SIZE(0);
+    ASSERT_TLM_CustomVersion09_SIZE(0);
+    ASSERT_TLM_CustomVersion10_SIZE(0);
 
     cmd_seq = 9;
     this->sendCmd_ENABLE(0, cmd_seq, VersionEnabled::ENABLED);
     ASSERT_CMD_RESPONSE(0, 0, 9, Fw::CmdResponse::OK);
     VersionTester::test_setVer(true);
+    //When verbosity is enabled, events and EHAs are generated
     ASSERT_EVENTS_CustomVersions_SIZE(10);
+    ASSERT_TLM_CustomVersion01_SIZE(1);
+    ASSERT_TLM_CustomVersion02_SIZE(1);
+    ASSERT_TLM_CustomVersion03_SIZE(1);
+    ASSERT_TLM_CustomVersion04_SIZE(1);
+    ASSERT_TLM_CustomVersion05_SIZE(1);
+    ASSERT_TLM_CustomVersion06_SIZE(1);
+    ASSERT_TLM_CustomVersion07_SIZE(1);
+    ASSERT_TLM_CustomVersion08_SIZE(1);
+    ASSERT_TLM_CustomVersion09_SIZE(1);
+    ASSERT_TLM_CustomVersion10_SIZE(1);
 }
 
 void VersionTester ::test_versions() {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  Y |
|**_Documentation Included (y/n)_**| Y |

---
## Change Description

This pull request is for ticket #2826 changes

## Rationale

1. Removes redundant version events and channels generated in SystemResources
2. Updated Versions component to produce events on custom versions when verbosity is disabled (channel generation still depends on verbosity configuration)

## Testing/Review Recommendations

Updated UTs to ensure events are generated regardless of verbosity configuration but channel depend upon it. 

## Future Work

Currently there is no future work identified related to this issue. 
