### PR TITLE
Fixing string_utils types to FwSizeType

### DIFF
--- a/Fw/Types/StringBase.cpp
+++ b/Fw/Types/StringBase.cpp
@@ -24,7 +24,7 @@ StringBase::StringBase() {}
 StringBase::~StringBase() {}
 
 const CHAR* StringBase::operator+=(const CHAR* src) {
-    this->appendBuff(src, StringUtils::string_length(src, this->getCapacity()));
+    this->appendBuff(src, static_cast<SizeType>(StringUtils::string_length(src, this->getCapacity())));
     return this->toChar();
 }
 

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -3,22 +3,6 @@
 #include <cstring>
 #include <limits>
 
-char* Fw::StringUtils::string_copy(char* destination, const char* source, U32 num) {
-    // Check for size support
-    FW_ASSERT(std::numeric_limits<U32>::max() <= std::numeric_limits<FwSizeType>::max());
-    char* returned = Fw::StringUtils::string_copy(destination, source, static_cast<FwSizeType>(num));
-    return returned;
-}
-
-U32 Fw::StringUtils::string_length(const CHAR* source, U32 max_len) {
-    // Check for size support
-    FW_ASSERT(std::numeric_limits<U32>::max() <= std::numeric_limits<FwSizeType>::max());
-    FwSizeType returned = Fw::StringUtils::string_length(source, static_cast<FwSizeType>(max_len));
-    // Range checking for type remapping
-    FW_ASSERT(returned <= static_cast<FwSizeType>(std::numeric_limits<U32>::max()));
-    return static_cast<U32>(returned);
-}
-
 char* Fw::StringUtils::string_copy(char* destination, const char* source, FwSizeType num) {
     // Handle self-copy and 0 bytes copy
     if (destination == source || num == 0) {
@@ -37,7 +21,7 @@ char* Fw::StringUtils::string_copy(char* destination, const char* source, FwSize
 }
 
 FwSizeType Fw::StringUtils::string_length(const CHAR* source, FwSizeType max_len) {
-    U32 length = 0;
+    FwSizeType length = 0;
     FW_ASSERT(source != nullptr);
     for (length = 0; length < max_len; length++) {
         if (source[length] == '\0') {

--- a/Fw/Types/StringUtils.hpp
+++ b/Fw/Types/StringUtils.hpp
@@ -4,34 +4,6 @@
 
 namespace Fw {
 namespace StringUtils {
-
-/**
- * \brief copy string with null-termination guaranteed
- *
- * Standard implementations of strncpy fail to guarantee the termination of a
- * string with the null terminator. This implementation guarantees the string is
- * properly null-terminated at the possible expense of the last character of the
- * copied string being lost. The user is responsible for providing a destination
- * large enough for the content and a null-character. Other behavior retains the
- * behavior of strncpy.
- *
- * \param destination: destination buffer to hold copied contents
- * \param source: source buffer to read content to copy
- * \param num: length of destination buffer
- * \return destination buffer
- */
-char* string_copy(char* destination, const char* source, U32 num);
-
-/**
- * \brief get the length of the source string or max_len if the string is
- * longer than max_len.
- *
- * \param source: string to calculate the length
- * \param max_len: the maximum length of the source string
- * \return length of the source string or max_len
- */
-U32 string_length(const CHAR* source, U32 max_len);
-
 /**
  * \brief copy string with null-termination guaranteed
  *


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Removing ambiguous U32 functions from StringUtils.