### PR TITLE
Upgrade GitHub Actions ahead of NodeJS deprecation

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -35,7 +35,7 @@ jobs:
         JOBS: 2
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ci-framework-logs
@@ -58,7 +58,7 @@ jobs:
         JOBS: 2
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ci-ref-logs
@@ -83,7 +83,7 @@ jobs:
         JOBS: 2
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ci-int-logs

--- a/.github/workflows/build-test-rpi.yml
+++ b/.github/workflows/build-test-rpi.yml
@@ -37,14 +37,14 @@ jobs:
       run: mkdir -p artifact/RPI; cp -rp RPI/test RPI/build-artifacts artifact/RPI; cp -rp ci artifact
     # Build Artifacts
     - name: 'RPI Build Output'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rpi-build
         path: artifact
         retention-days: 5
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: rpi-logs
@@ -64,7 +64,7 @@ jobs:
         . venv/bin/activate
         pip install -r requirements.txt
     - name: RPI Build Download
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: rpi-build
     - name: RPI Integration Tests
@@ -74,7 +74,7 @@ jobs:
         /bin/bash ci/tests/RPI-Ints.bash
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: pi-int-logs

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,7 +31,7 @@ jobs:
       run: ./ci/tests/Framework.bash
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ci-framework-logs
@@ -51,7 +51,7 @@ jobs:
       run: ./ci/tests/Ref.bash
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ci-ref-logs
@@ -75,7 +75,7 @@ jobs:
       run: ./ci/tests/30-ints.bash
     # Archive the outputs
     - name: 'Archive Logs'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ci-int-logs

--- a/.github/workflows/codeql-jpl-standard.yml
+++ b/.github/workflows/codeql-jpl-standard.yml
@@ -32,11 +32,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # Run jobs in parallel for each config-file
@@ -52,4 +52,4 @@ jobs:
           fprime-util build --all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -31,11 +31,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/actions/codeql/security-pack.yml
@@ -50,6 +50,6 @@ jobs:
           fprime-util generate
           fprime-util build --all
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/cppcheck-scan.yml
+++ b/.github/workflows/cppcheck-scan.yml
@@ -55,13 +55,13 @@ jobs:
         run: xsltproc .github/scripts/cppcheck-xml2text.xslt cppcheck_err.xml | tee $GITHUB_STEP_SUMMARY cppcheck_err.txt
 
       - name: Upload SARIF file to GitHub Code Scanning Alerts
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ github.workspace }}/cppcheck_err.sarif
           category: "cppcheck"
 
       - name: Archive static analysis artifacts to download and view
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cppcheck-errors
           path: ./*cppcheck_err.*

--- a/.github/workflows/cpplint-scan.yml
+++ b/.github/workflows/cpplint-scan.yml
@@ -53,13 +53,13 @@ jobs:
           sed -i -e 's/\"name\": \"CppCheck\"/\"name\": \"CppLint\"/g' cpplint_cppcheck_result.sarif
 
       - name: Upload SARIF file to GitHub Code Scanning Alerts
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ github.workspace }}/cpplint_cppcheck_result.sarif
           category: "cpplint"
 
       - name: Archive static analysis artifacts to download and view
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cpplint-errors
           path: ./*cpplint_cppcheck_result.*

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -59,7 +59,7 @@ jobs:
           cp -r ./build-artifacts rpi-artifacts
           cp -r Components/Led/test/int rpi-artifacts
       - name: 'Archive Build Artifacts'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rpi-artifacts
           path: rpi-artifacts
@@ -80,7 +80,7 @@ jobs:
           . venv/bin/activate
           pip install -r requirements.txt
       - name: "Artifacts Download"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: rpi-artifacts
       - name: Run Integration Tests
@@ -92,7 +92,7 @@ jobs:
           sleep 10
           pytest --dictionary ./build-artifacts/raspberrypi/LedBlinker/dict/LedBlinkerTopologyDictionary.json ./int/led_integration_tests.py
       - name: 'Archive logs'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rpi-logs

--- a/.github/workflows/fpp-tests.yml
+++ b/.github/workflows/fpp-tests.yml
@@ -42,7 +42,7 @@ jobs:
           fprime-util check
         shell: bash
       - name: "Archive Logs"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: FppTest-Logs

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -12,9 +12,9 @@ jobs:
       name: Format
       runs-on: ubuntu-latest
       steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Check formatting


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Several Actions have been emitting warnings because of deprecation of NodeJS 16 - this change is to upgrade to the newer version, as per recommendation from GitHub.

e.g. see https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact
