### PR TITLE
Fix Os::Console singleton to be heapless

### DIFF
--- a/Os/Console.cpp
+++ b/Os/Console.cpp
@@ -4,6 +4,7 @@
 // ======================================================================
 #include <Os/Console.hpp>
 #include <Fw/Types/Assert.hpp>
+#include <new>
 
 alignas(Os::Console) U8 _singleton_store[sizeof Os::Console];
 

--- a/Os/Console.cpp
+++ b/Os/Console.cpp
@@ -5,6 +5,8 @@
 #include <Os/Console.hpp>
 #include <Fw/Types/Assert.hpp>
 
+alignas(Os::Console) U8 _singleton_store[sizeof Os::Console];
+
 namespace Os {
     Console* Console::s_singleton;
 
@@ -60,7 +62,7 @@ namespace Os {
     Console& Console::getSingleton() {
         // On the fly construction of singleton
         if (s_singleton == nullptr) {
-            s_singleton = new Console();
+            s_singleton = new (_singleton_store) Console;
             Fw::Logger::registerLogger(s_singleton);
         }
         return *s_singleton;

--- a/Os/Console.cpp
+++ b/Os/Console.cpp
@@ -6,17 +6,6 @@
 #include <Fw/Types/Assert.hpp>
 #include <new>
 
-// While we desire the singleton to be in global space to avoid placing
-// such object on the heap, the singleton must be constructed at first
-// request due to C++'s undefined ordering of constructors between
-// compilation units.
-//
-// To meet both requirements, we place an aligned and sized block of
-// memory on the in global space as seen here, and then placement-new
-// the singleton into that region. Thus constructing on the fly while
-// avoiding heap usage.
-alignas(Os::Console) U8 _singleton_store[sizeof(Os::Console)];
-
 namespace Os {
     Console* Console::s_singleton;
 
@@ -70,12 +59,8 @@ namespace Os {
     }
 
     Console& Console::getSingleton() {
-        // On the fly construction of singleton
-        if (s_singleton == nullptr) {
-            s_singleton = new (_singleton_store) Console;
-            Fw::Logger::registerLogger(s_singleton);
-        }
-        return *s_singleton;
+        static Console& singleton;
+        return singleton;
     }
 }
 

--- a/Os/Console.cpp
+++ b/Os/Console.cpp
@@ -59,7 +59,7 @@ namespace Os {
 
     Console& Console::getSingleton() {
         static Console s_singleton;
-        Fw::Logger::registerLogger(s_singleton);
+        Fw::Logger::registerLogger(&s_singleton);
         return s_singleton;
     }
 }

--- a/Os/Console.cpp
+++ b/Os/Console.cpp
@@ -4,7 +4,6 @@
 // ======================================================================
 #include <Os/Console.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <new>
 
 namespace Os {
     Console* Console::s_singleton;
@@ -59,8 +58,9 @@ namespace Os {
     }
 
     Console& Console::getSingleton() {
-        static Console& singleton;
-        return singleton;
+        static Console s_singleton;
+        Fw::Logger::registerLogger(s_singleton);
+        return s_singleton;
     }
 }
 

--- a/Os/Console.cpp
+++ b/Os/Console.cpp
@@ -6,7 +6,16 @@
 #include <Fw/Types/Assert.hpp>
 #include <new>
 
-alignas(Os::Console) U8 _singleton_store[sizeof Os::Console];
+// While we desire the singleton to be in global space to avoid placing
+// such object on the heap, the singleton must be constructed at first
+// request due to C++'s undefined ordering of constructors between
+// compilation units.
+//
+// To meet both requirements, we place an aligned and sized block of
+// memory on the in global space as seen here, and then placement-new
+// the singleton into that region. Thus constructing on the fly while
+// avoiding heap usage.
+alignas(Os::Console) U8 _singleton_store[sizeof(Os::Console)];
 
 namespace Os {
     Console* Console::s_singleton;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Os::Console singleton -> heap free placement new singleton.