### PR TITLE
Set assert size constant

### DIFF
--- a/Fw/Sm/CMakeLists.txt
+++ b/Fw/Sm/CMakeLists.txt
@@ -8,4 +8,5 @@
 set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/SmSignalBuffer.cpp"
 )
+set(MOD_DEPS config)
 register_fprime_module()

--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -83,7 +83,7 @@ void AssertHook::reportAssert(FILE_NAME_ARG file,
                               FwAssertArgType arg4,
                               FwAssertArgType arg5,
                               FwAssertArgType arg6) {
-    CHAR destBuffer[FW_ASSERT_DFL_MSG_LEN];
+    CHAR destBuffer[FW_ASSERT_TEXT_SIZE];
     defaultReportAssert(file, lineNo, numArgs, arg1, arg2, arg3, arg4, arg5, arg6, destBuffer, sizeof(destBuffer));
     // print message
     this->printAssert(destBuffer);
@@ -115,7 +115,7 @@ NATIVE_INT_TYPE defaultSwAssert(FILE_NAME_ARG file,
                                 FwAssertArgType arg5,
                                 FwAssertArgType arg6) {
     if (nullptr == s_assertHook) {
-        CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
+        CHAR assertMsg[FW_ASSERT_TEXT_SIZE];
         defaultReportAssert(file, lineNo, numArgs, arg1, arg2, arg3, arg4, arg5, arg6, assertMsg, sizeof(assertMsg));
         defaultPrintAssert(assertMsg);
         assert(0);
@@ -184,7 +184,7 @@ NATIVE_INT_TYPE CAssert0(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo);
 
 NATIVE_INT_TYPE CAssert0(FILE_NAME_ARG file, NATIVE_UINT_TYPE lineNo) {
     if (nullptr == Fw::s_assertHook) {
-        CHAR assertMsg[FW_ASSERT_DFL_MSG_LEN];
+        CHAR assertMsg[FW_ASSERT_TEXT_SIZE];
         Fw::defaultReportAssert(file, lineNo, 0, 0, 0, 0, 0, 0, 0, assertMsg, sizeof(assertMsg));
     } else {
         Fw::s_assertHook->reportAssert(file, lineNo, 0, 0, 0, 0, 0, 0, 0);

--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -3,8 +3,6 @@
 #include <cassert>
 #include <cstdio>
 
-#define FW_ASSERT_DFL_MSG_LEN 256
-
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
 #define fileIdFs "Assert: 0x%08" PRIx32 ":%" PRI_PlatformUIntType
 #else

--- a/Os/CMakeLists.txt
+++ b/Os/CMakeLists.txt
@@ -13,6 +13,7 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Generic")
 set(SOURCE_FILES
     "${CMAKE_CURRENT_LIST_DIR}/test/ut/file/SyntheticFileSystem.cpp"
 )
+set(MOD_DEPS config)
 register_fprime_module(Os_Test_File_SyntheticFileSystem)
 
 

--- a/Os/Posix/CMakeLists.txt
+++ b/Os/Posix/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCE_FILES
 set(HEADER_FILES
     "${CMAKE_CURRENT_LIST_DIR}/error.hpp"
 )
+set(MOD_DEPS config)
 register_fprime_module(Os_Posix_Shared)
 
 # -----------------------------------------
@@ -56,7 +57,7 @@ set(SOURCE_FILES
 set(HEADER_FILES
     "${CMAKE_CURRENT_LIST_DIR}/Console.hpp"
 )
-set(MOD_DEPS)
+set(MOD_DEPS config)
 register_fprime_module(Os_Console_Posix)
 register_fprime_implementation(Os/Console Os_Console_Posix "${CMAKE_CURRENT_LIST_DIR}/DefaultConsole.cpp")
 

--- a/Os/Stub/CMakeLists.txt
+++ b/Os/Stub/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCE_FILES
     "${CMAKE_CURRENT_LIST_DIR}/File.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/DefaultFile.cpp"
 )
+set(MOD_DEPS config)
 register_fprime_module(Os_File_Stub)
 register_fprime_implementation(Os/File Os_File_Stub)
 
@@ -30,7 +31,7 @@ set(SOURCE_FILES
 set(HEADER_FILES
         "${CMAKE_CURRENT_LIST_DIR}/Queue.hpp"
 )
-set(MOD_DEPS)
+set(MOD_DEPS config)
 register_fprime_module(Os_Queue_Stub)
 register_fprime_implementation(Os/Queue Os_Queue_Stub "${CMAKE_CURRENT_LIST_DIR}/DefaultQueue.cpp")
 
@@ -41,7 +42,7 @@ set(SOURCE_FILES
 set(HEADER_FILES
         "${CMAKE_CURRENT_LIST_DIR}/Task.hpp"
 )
-set(MOD_DEPS)
+set(MOD_DEPS config)
 register_fprime_module(Os_Task_Stub)
 register_fprime_implementation(Os/Task Os_Task_Stub "${CMAKE_CURRENT_LIST_DIR}/DefaultTask.cpp")
 
@@ -52,7 +53,7 @@ set(SOURCE_FILES
 set(HEADER_FILES
         "${CMAKE_CURRENT_LIST_DIR}/Console.hpp"
 )
-set(MOD_DEPS)
+set(MOD_DEPS config)
 register_fprime_module(Os_Console_Stub)
 register_fprime_implementation(Os/Console Os_Console_Stub "${CMAKE_CURRENT_LIST_DIR}/DefaultConsole.cpp")
 
@@ -60,7 +61,7 @@ register_fprime_implementation(Os/Console Os_Console_Stub "${CMAKE_CURRENT_LIST_
 set(SOURCE_FILES
         "${CMAKE_CURRENT_LIST_DIR}/FileSystem.cpp"
 )
-set(MOD_DEPS)
+set(MOD_DEPS config)
 register_fprime_module(Os_FileSystem_Stub)
 register_fprime_implementation(Os/FileSystem Os_FileSystem_Stub "${CMAKE_CURRENT_LIST_DIR}/DefaultFileSystem.cpp")
 
@@ -69,7 +70,7 @@ register_fprime_implementation(Os/FileSystem Os_FileSystem_Stub "${CMAKE_CURRENT
 set(SOURCE_FILES
         "${CMAKE_CURRENT_LIST_DIR}/Directory.cpp"
 )
-set(MOD_DEPS)
+set(MOD_DEPS config)
 register_fprime_module(Os_Directory_Stub)
 register_fprime_implementation(Os/Directory Os_Directory_Stub "${CMAKE_CURRENT_LIST_DIR}/DefaultDirectory.cpp")
 
@@ -104,7 +105,7 @@ register_fprime_ut(StubFileTest)
 set(SOURCE_FILES
         "${CMAKE_CURRENT_LIST_DIR}/test/Console.cpp"
 )
-set(MOD_DEPS)
+set(MOD_DEPS config)
 register_fprime_module(Os_Console_Test_Stub)
 register_fprime_implementation(Os/Console Os_Console_Test_Stub "${CMAKE_CURRENT_LIST_DIR}/test/DefaultConsole.cpp")
 

--- a/Os/Stub/ConditionVariable.hpp
+++ b/Os/Stub/ConditionVariable.hpp
@@ -38,6 +38,9 @@ class StubConditionVariable : public ConditionVariableInterface {
     //! \brief get handle
     ConditionVariableHandle* getHandle() override;
 
+    //! \brief assignment operator is forbidden
+    virtual ConditionVariableInterface& operator=(const ConditionVariableInterface& other) override = delete;
+
   private:
     //! Handle for PosixMutex
     StubConditionVariableHandle m_handle;

--- a/config/AcConstants.fpp
+++ b/config/AcConstants.fpp
@@ -51,6 +51,9 @@ constant DpWriterNumProcPorts = 5
 @ The size of a file name string
 constant FileNameStringSize = 200
 
+@ The size of an assert text string
+constant FwAssertTextSize = 256
+
 @ The size of a file name in an AssertFatalAdapter event
 @ Note: File names in assertion failures are also truncated by
 @ the constants FW_ASSERT_TEXT_SIZE and FW_LOG_STRING_MAX_SIZE, set

--- a/config/FpConfig.h
+++ b/config/FpConfig.h
@@ -231,12 +231,6 @@ typedef FwIndexType FwQueueSizeType;
 #define FW_ASSERT_LEVEL FW_FILENAME_ASSERT  //!< Defines the type of assert used
 #endif
 
-// Define max length of assert string
-// Note: This constant truncates file names in assertion failure event reports
-#ifndef FW_ASSERT_TEXT_SIZE
-#define FW_ASSERT_TEXT_SIZE 256  //!< Size of string used to store assert description
-#endif
-
 // Adjust various configuration parameters in the architecture. Some of the above enables may disable some of the values
 
 // The size of the object name stored in the object base class. Larger names will be truncated.

--- a/config/FpConfig.h
+++ b/config/FpConfig.h
@@ -226,7 +226,6 @@ typedef FwIndexType FwQueueSizeType;
 //   4. FW_RELATIVE_PATH_ASSERT: asserts report a relative path within F´ or F´ library and line number
 //
 // Note: users who want alternate asserts should set assert level to FW_NO_ASSERT and define FW_ASSERT in this header
-#define FW_ASSERT_DFL_MSG_LEN 256  //!< Maximum assert message length when using the default assert handler
 #ifndef FW_ASSERT_LEVEL
 #define FW_ASSERT_LEVEL FW_FILENAME_ASSERT  //!< Defines the type of assert used
 #endif

--- a/config/FpConfig.hpp
+++ b/config/FpConfig.hpp
@@ -9,6 +9,14 @@
  * acknowledged.
  */
 #include <Fw/Types/BasicTypes.hpp>
+#include <FppConstantsAc.hpp>
 extern "C" {
 #include <FpConfig.h>
+
+// Define max length of assert string
+// Note: This constant truncates file names in assertion failure event reports
+#ifndef FW_ASSERT_TEXT_SIZE
+#define FW_ASSERT_TEXT_SIZE FwAssertTextSize  //!< Size of string used to store assert description
+#endif
+
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #2891 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
Updated assert size constant to use an FPP constant.

- Added FPP constant `FwAssertTextSize`
- The `FW_ASSERT_TEXT_SIZE` is now defined in terms of the FPP constant `FwAssertTextSize`
- Replaced `FW_ASSERT_DFL_MSG_LEN` with `FW_ASSERT_TEXT_SIZE`
- Removed `FW_ASSERT_DFL_MSG_LEN`
- Added `config` to module dependencies to correct build errors
- Fixed a compile error caused by _unrelated_ code