### PR TITLE
Add OSAL singleton initialization to `Os::init()`

### DIFF
--- a/Os/Cpu.hpp
+++ b/Os/Cpu.hpp
@@ -79,7 +79,7 @@ class Cpu final : public CpuInterface {
     //-----------------------------------------------------------------------------
 
     //! \brief initialize the singleton
-    void init();
+    static void init();
 
     //! \brief return singleton
     static Cpu& getSingleton();

--- a/Os/Memory.hpp
+++ b/Os/Memory.hpp
@@ -67,7 +67,7 @@ class Memory final : public MemoryInterface {
   public:
 
     //! \brief initialize the singleton
-    void init();
+    static void init();
 
     //! \brief return singleton
     static Memory& getSingleton();

--- a/Os/Os.cpp
+++ b/Os/Os.cpp
@@ -13,10 +13,10 @@ namespace Os {
 
 void init() {
     // Initialize all OSAL singletons
-    (void)Os::Console::init();
-    (void)Os::FileSystem::init();
-    (void)Os::Cpu::init();
-    (void)Os::Memory::init();
+    Os::Console::init();
+    Os::FileSystem::init();
+    Os::Cpu::init();
+    Os::Memory::init();
 }
 
 }  // namespace Os

--- a/Os/Os.cpp
+++ b/Os/Os.cpp
@@ -5,14 +5,18 @@
 #include "Os/Os.hpp"
 #include "FpConfig.h"
 #include "Os/Console.hpp"
+#include "Os/Cpu.hpp"
 #include "Os/FileSystem.hpp"
+#include "Os/Memory.hpp"
 
 namespace Os {
 
 void init() {
-    // Console and FileSystem are singletons and must be initialized
+    // Initialize all OSAL singletons
     (void)Os::Console::init();
     (void)Os::FileSystem::init();
+    (void)Os::Cpu::init();
+    (void)Os::Memory::init();
 }
 
 }  // namespace Os

--- a/Os/Os.hpp
+++ b/Os/Os.hpp
@@ -35,7 +35,7 @@ struct UsedTotal {
 
 }
 
-//! \brief Initialization of the OSAL layer
+//! \brief Initialize the OSAL layer
 //!
 //! - Initialize all singletons for the OSAL modules that use the singleton pattern
 void init();

--- a/Os/Os.hpp
+++ b/Os/Os.hpp
@@ -35,7 +35,9 @@ struct UsedTotal {
 
 }
 
-//! \brief Initialization function for the OSAL layer
+//! \brief Initialization of the OSAL layer
+//!
+//! - Initialize all singletons for the OSAL modules that use the singleton pattern
 void init();
 
 }  // namespace Os

--- a/Os/Os.hpp
+++ b/Os/Os.hpp
@@ -35,7 +35,7 @@ struct UsedTotal {
 
 }
 
-//! \brief Initialize the OSAL layer
+//! \brief Initialize the OS Abstraction Layer (OSAL)
 //!
 //! - Initialize all singletons for the OSAL modules that use the singleton pattern
 void init();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds missing singletons in `Os::init()`

Implements first part of https://github.com/nasa/fprime/issues/2942
