### PR TITLE
Fix Jekyll docs build error from curly braces interpretation

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -268,6 +268,7 @@ endcond
 endfunction
 endloc
 endmacro
+endraw
 enduml
 ENQUEUEX
 enumchan

--- a/docs/HowTo/develop-subtopologies.md
+++ b/docs/HowTo/develop-subtopologies.md
@@ -264,6 +264,7 @@ topology MainDeployment {
 
 At this point, we want to now call our subtopology's configure/start/teardown functions within the corresponding functions of our `MainDeployment` topology. So, in `MainDeploymentTopology.cpp`:
 
+<!-- {% raw %} -->
 ```cpp
 // at the top, include our topology.hpp
 #include <MySubtopology/MySubtopologyTopology.hpp>
@@ -293,6 +294,7 @@ void teardownTopology(const TopologyState& state){
     MySubtopology::teardownTopology({})
 }
 ```
+<!-- {% endraw %} -->
 
 Lastly, since our RNG component has some telemetry, we need to include (or ignore) these channels within the `Packets.xml` file in this folder. As with any other component that is added to a deployment, you use the same syntax with the name of the instance followed by the name of the telemetry channel. For example:
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Jekyll build has been failing due to it interpreting curly braces in the MD file.
Reference for the fix: https://stackoverflow.com/questions/24102498/escaping-double-curly-braces-inside-a-markdown-code-block-in-jekyll