### PR TITLE
Restoring HAS_F64 functionality

### DIFF
--- a/Fw/Types/StringToNumber.cpp
+++ b/Fw/Types/StringToNumber.cpp
@@ -103,6 +103,7 @@ Fw::StringUtils::StringToNumberStatus Fw::StringUtils::string_to_number(const CH
 Fw::StringUtils::StringToNumberStatus Fw::StringUtils::string_to_number(const CHAR* input, FwSizeType buffer_size, I8& output, char** next, U8 base) {
     return string_to_number_as_template<I8, long long, strtoll>(input, buffer_size, output, next, base);
 }
+#if FW_HAS_F64
 Fw::StringUtils::StringToNumberStatus Fw::StringUtils::string_to_number(const CHAR* input, FwSizeType buffer_size, F64& output, char** next) {
     char* output_next = nullptr;
     Fw::StringUtils::StringToNumberStatus status = string_to_helper_input_check(input, buffer_size, 0);
@@ -112,6 +113,7 @@ Fw::StringUtils::StringToNumberStatus Fw::StringUtils::string_to_number(const CH
     status = string_to_helper_output_check(status, input, output_next, next);
     return status;
 }
+#endif
 
 Fw::StringUtils::StringToNumberStatus Fw::StringUtils::string_to_number(const CHAR* input, FwSizeType buffer_size, F32& output, char** next) {
     char* output_next = nullptr;

--- a/Fw/Types/StringUtils.hpp
+++ b/Fw/Types/StringUtils.hpp
@@ -195,7 +195,7 @@ StringToNumberStatus string_to_number(const CHAR* input, FwSizeType buffer_size,
  * \return SUCCESSFUL_CONVERSION when output is valid, something else on error.
  */
 StringToNumberStatus string_to_number(const CHAR* input, FwSizeType buffer_size, F32& output, char** next);
-
+#if FW_HAS_F64
 /**
  * \brief converts a string to a F64
  *
@@ -209,7 +209,7 @@ StringToNumberStatus string_to_number(const CHAR* input, FwSizeType buffer_size,
  * \return SUCCESSFUL_CONVERSION when output is valid, something else on error.
  */
 StringToNumberStatus string_to_number(const CHAR* input, FwSizeType buffer_size, F64& output, char** next);
-
+#endif
 
 
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes `HAS_f64` regression in string utils.