### PR TITLE
Fix Logger in baremetal FatalHandler component implementation

### DIFF
--- a/Svc/FatalHandler/FatalHandlerComponentBaremetalImpl.cpp
+++ b/Svc/FatalHandler/FatalHandlerComponentBaremetalImpl.cpp
@@ -19,7 +19,7 @@ namespace Svc {
             const NATIVE_INT_TYPE portNum,
             FwEventIdType Id) {
         // for **nix, delay then exit with error code
-        Os::Log::log("FATAL %d handled.\n",Id);
+        Fw::Logger::log("FATAL %d handled.\n",Id);
         while (true) {} // Returning might be bad
     }
 


### PR DESCRIPTION
---
## Change Description

`Os::Log::log` no longer exists after the OSAL changes. The baremetal `FatalHandler` still had `Os::Log::log`. I changed it to `Fw::Logger::log`

## Rationale

Critical bug for baremetal (Arduino) implementation. This causes a build error.
