### PR TITLE
Reworking prevent_prescan in subbuild context

### DIFF
--- a/Svc/FatalHandler/FatalHandlerComponentBaremetalImpl.cpp
+++ b/Svc/FatalHandler/FatalHandlerComponentBaremetalImpl.cpp
@@ -5,7 +5,7 @@
 // ======================================================================
 
 #include <cstdlib>
-#include <Os/Console.hpp>
+#include <Fw/Logger/Logger.hpp>
 #include <Svc/FatalHandler/FatalHandlerComponentImpl.hpp>
 #include <FpConfig.hpp>
 
@@ -19,7 +19,7 @@ namespace Svc {
             const NATIVE_INT_TYPE portNum,
             FwEventIdType Id) {
         // for **nix, delay then exit with error code
-        Os::Log::log("FATAL %d handled.\n",Id);
+        Fw::Logger::log("FATAL %" PRI_FwEventIdType "handled.\n",Id);
         while (true) {} // Returning might be bad
     }
 

--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -18,6 +18,19 @@ set(FPRIME_UT_TARGET_LIST "" CACHE INTERNAL "FPRIME_UT_TARGET_LIST: custom fprim
 set(FPRIME_AUTOCODER_TARGET_LIST "" CACHE INTERNAL "FPRIME_AUTOCODER_TARGET_LIST: custom fprime targets" FORCE)
 
 ####
+# Macro `skip_on_sub_build`:
+#
+# Skip this remaining code in the current function or file when executing in the context of a sub build. Sub builds
+# execute utility and setup functions in fprime. However, certain CMake functions are not appropriate in this context
+# and should be skipped.
+####
+macro(skip_on_sub_build)
+    if (DEFINED FPRIME_SUB_BUILD_TARGETS)
+        return()
+    endif()
+endmacro()
+
+####
 # Macro `restrict_platforms`:
 #
 # Restricts a CMakeLists.txt file to a given list of platforms. This prevents usage on platforms for which the module


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Refurbish `prevent_prescan` to handle generic subbuilds