### PR TITLE
Place `SyntheticFileSystem` under `BUILD_TESTING` condition

### DIFF
--- a/Os/CMakeLists.txt
+++ b/Os/CMakeLists.txt
@@ -89,12 +89,6 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Generic")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Linux")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Darwin")
 
-set(SOURCE_FILES
-    "${CMAKE_CURRENT_LIST_DIR}/test/ut/file/SyntheticFileSystem.cpp"
-)
-set(MOD_DEPS config)
-register_fprime_module(Os_Test_File_SyntheticFileSystem)
-
 # Basic source files used in every OSAL layer.  Contains common code and helpers.
 set(SOURCE_FILES
     "${CMAKE_CURRENT_LIST_DIR}/ValidateFileCommon.cpp"
@@ -127,3 +121,11 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/OsMutexBasicLockableTest.cpp"
 )
 register_fprime_ut()
+
+if (BUILD_TESTING)
+    set(SOURCE_FILES
+        "${CMAKE_CURRENT_LIST_DIR}/test/ut/file/SyntheticFileSystem.cpp"
+    )
+    set(MOD_DEPS config)
+    register_fprime_module(Os_Test_File_SyntheticFileSystem)
+endif()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Places `Os::Test::File::SyntheticFileSystem` under `BUILD_TESTING` condition.

## Rationale

This allows F Prime to be compiled using a WindRiver compiler (ex: RISC-V cross compiler).