### PR TITLE
Fix posix Task for cases where _SC_PAGESIZE is undefined

### DIFF
--- a/Os/Posix/Task.cpp
+++ b/Os/Posix/Task.cpp
@@ -32,8 +32,13 @@ namespace Task {
     PlatformIntType set_stack_size(pthread_attr_t& attributes, const Os::Task::Arguments& arguments) {
         PlatformIntType status = PosixTaskHandle::SUCCESS;
         FwSizeType stack = arguments.m_stackSize;
-        // Check for stack size multiple of page size
+// Check for stack size multiple of page size or skip when the function
+// is unavailable.
+#ifdef _SC_PAGESIZE
         long page_size = sysconf(_SC_PAGESIZE);
+#else
+        long page_size = -1; // Force skip and warning
+#endif
         if (page_size <= 0) {
             Fw::Logger::log(
                     "[WARNING] %s could not determine page size %s. Skipping stack-size check.\n",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

VxWorks posix implementation does not define `_SC_PAGESIZE` for a call to sysconf.  However, this is only used for an additional check on stack size.  This should not prevent the use of Posix::Tasks should it be undefined.