### PR TITLE
#2074 Parameterize buffer size in UDP and TCP Server.

### DIFF
--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -10,6 +10,7 @@
 //
 // ======================================================================
 
+#include <limits>
 #include <Drv/TcpServer/TcpServerComponentImpl.hpp>
 #include <FpConfig.hpp>
 #include "Fw/Types/Assert.hpp"
@@ -27,7 +28,14 @@ TcpServerComponentImpl::TcpServerComponentImpl(const char* const compName)
 SocketIpStatus TcpServerComponentImpl::configure(const char* hostname,
                                                  const U16 port,
                                                  const U32 send_timeout_seconds,
-                                                 const U32 send_timeout_microseconds) {
+                                                 const U32 send_timeout_microseconds,
+	                                         FwSizeType buffer_size) {
+
+    // Check that ensures the configured buffer size fits within the limits fixed-width type, U32
+
+    FW_ASSERT(buffer_size <= std::numeric_limits<U32>::max(), static_cast<FwAssertArgType>(buffer_size));
+    m_allocation_size = buffer_size; // Store the buffer size
+				     //
     (void)m_socket.configure(hostname, port, send_timeout_seconds, send_timeout_microseconds);
     return startup();
 }

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -55,7 +55,7 @@ IpSocket& TcpServerComponentImpl::getSocketHandler() {
 }
 
 Fw::Buffer TcpServerComponentImpl::getBuffer() {
-    return allocate_out(0, 1024);
+    return allocate_out(0, m_allocation_size);
 }
 
 void TcpServerComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status) {

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -55,7 +55,7 @@ IpSocket& TcpServerComponentImpl::getSocketHandler() {
 }
 
 Fw::Buffer TcpServerComponentImpl::getBuffer() {
-    return allocate_out(0, m_allocation_size);
+    return allocate_out(0, static_cast<U32>(m_allocation_size));
 }
 
 void TcpServerComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status) {

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -55,12 +55,14 @@ class TcpServerComponentImpl : public TcpServerComponentBase, public SocketCompo
      * \param send_timeout_seconds: send timeout seconds component. Defaults to: SOCKET_TIMEOUT_SECONDS
      * \param send_timeout_microseconds: send timeout microseconds component. Must be less than 1000000. Defaults to:
      * SOCKET_TIMEOUT_MICROSECONDS
+     * \param buffer_size: size of the buffer to be allocated. Defaults to 1024.
      * \return status of the configure
      */
     SocketIpStatus configure(const char* hostname,
                              const U16 port,
                              const U32 send_timeout_seconds = SOCKET_SEND_TIMEOUT_SECONDS,
-                             const U32 send_timeout_microseconds = SOCKET_SEND_TIMEOUT_MICROSECONDS);
+                             const U32 send_timeout_microseconds = SOCKET_SEND_TIMEOUT_MICROSECONDS,
+			     FwSizeType buffer_size = 1024);
 
     /**
      * \brief is started
@@ -161,6 +163,8 @@ class TcpServerComponentImpl : public TcpServerComponentBase, public SocketCompo
     Drv::SendStatus send_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) override;
 
     Drv::TcpServerSocket m_socket; //!< Socket implementation
+
+    FwSizeType m_allocation_size; //!< Member variable to store the buffer size
 };
 
 }  // end namespace Drv

--- a/Drv/Udp/UdpComponentImpl.cpp
+++ b/Drv/Udp/UdpComponentImpl.cpp
@@ -10,6 +10,7 @@
 //
 // ======================================================================
 
+#include <limits>
 #include <Drv/Udp/UdpComponentImpl.hpp>
 #include <IpCfg.hpp>
 #include <FpConfig.hpp>
@@ -32,7 +33,10 @@ SocketIpStatus UdpComponentImpl::configureSend(const char* hostname,
     return m_socket.configureSend(hostname, port, send_timeout_seconds, send_timeout_microseconds);
 }
 
-SocketIpStatus UdpComponentImpl::configureRecv(const char* hostname, const U16 port) {
+SocketIpStatus UdpComponentImpl::configureRecv(const char* hostname, const U16 port, FwSizeType buffer_size) {
+    FW_ASSERT(buffer_size <= std::numeric_limits<U32>::max(), static_cast<FwAssertArgType>(buffer_size));
+    m_allocation_size = buffer_size; // Store the buffer size
+
     return m_socket.configureRecv(hostname, port);
 }
 
@@ -51,7 +55,7 @@ IpSocket& UdpComponentImpl::getSocketHandler() {
 }
 
 Fw::Buffer UdpComponentImpl::getBuffer() {
-    return allocate_out(0, 1024);
+    return allocate_out(0, static_cast<U32>(m_allocation_size));
 }
 
 void UdpComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status) {

--- a/Drv/Udp/UdpComponentImpl.hpp
+++ b/Drv/Udp/UdpComponentImpl.hpp
@@ -70,9 +70,10 @@ class UdpComponentImpl : public UdpComponentBase, public SocketComponentHelper {
      *
      * \param hostname: ip address of remote tcp server in the form x.x.x.x
      * \param port: port of remote tcp server
+     * \param buffer_size: size of the buffer to be allocated. Defaults to 1024.
      *  \return status of the configure
      */
-    SocketIpStatus configureRecv(const char* hostname, const U16 port);
+    SocketIpStatus configureRecv(const char* hostname, const U16 port, FwSizeType buffer_size = 1024);
 
     /**
      * \brief get the port being received on
@@ -147,7 +148,10 @@ PROTECTED:
      * \return SEND_OK on success, SEND_RETRY when critical data should be retried and SEND_ERROR upon error
      */
     Drv::SendStatus send_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer);
+
     Drv::UdpSocket m_socket; //!< Socket implementation
+
+    FwSizeType m_allocation_size; //!< Member variable to store the buffer size
 };
 
 }  // end namespace Drv


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| 2759|
|**_Has Unit Tests (y/n)_**|n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Git ticket #2759 parameterized buffer size in Drv/TcpCllient.
This Git ticket added similar parameterization for Drv/TcpServer and Drv/Udp.

## Rationale

This improvement allows the user to customize buffer size. Default is 1024 bytes.

## Testing/Review Recommendations

The updates are minor and identical to the ones previously implemented in Drv/TcpClient.
Code logic is not affected. Therefore, no additional unit testing is needed.

## Future Work

None.
