### PR TITLE
Fix error printing during Ninja sub-build

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -562,7 +562,7 @@ endfunction(introspect)
 # - **ERROR_MESSAGE**: message to output should an error occurs
 ####
 function(execute_process_or_fail ERROR_MESSAGE)
-    # Quiet standard output unless we are doing verbose output generate
+    # Quiet standard output unless we are doing verbose output (handled below)
     set(OUTPUT_ARGS OUTPUT_QUIET)
     # Print the invocation if debug output is set
     if (CMAKE_DEBUG_OUTPUT)
@@ -571,19 +571,28 @@ function(execute_process_or_fail ERROR_MESSAGE)
         foreach(ARG IN LISTS ARGN)
             set(COMMAND_AS_STRING "${COMMAND_AS_STRING}\"${ARG}\" ")
         endforeach()
-        
-        #string(REPLACE ";" "\" \"" COMMAND_AS_STRING "${ARGN}")
         message(STATUS "[cli] ${COMMAND_AS_STRING}")
+    endif()
+    # Ninja pipes stderr to stdout so remove quiet output to see errors
+    if (CMAKE_GENERATOR MATCHES "Ninja")
+        set(OUTPUT_ARGS)
     endif()
     execute_process(
         COMMAND ${ARGN}
         RESULT_VARIABLE RETURN_CODE
+        OUTPUT_VARIABLE STANDARD_OUTPUT
         ERROR_VARIABLE STANDARD_ERROR
         ERROR_STRIP_TRAILING_WHITESPACE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
         ${OUTPUT_ARGS}
     )
     if (NOT RETURN_CODE EQUAL 0)
-        message(FATAL_ERROR "${ERROR_MESSAGE}:\n${STANDARD_ERROR}")
+        set(MESSAGE "${ERROR_MESSAGE}:\n${STANDARD_ERROR}")
+        # Ninja pipes stderr to stdout so we have to print stdout to see errors
+        if (CMAKE_GENERATOR MATCHES "Ninja")
+            string(APPEND MESSAGE "\n${STANDARD_OUTPUT}")
+        endif()
+        message(FATAL_ERROR "${MESSAGE}")
     endif()
 endfunction()
 

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -587,12 +587,12 @@ function(execute_process_or_fail ERROR_MESSAGE)
         ${OUTPUT_ARGS}
     )
     if (NOT RETURN_CODE EQUAL 0)
-        set(MESSAGE "${ERROR_MESSAGE}:\n${STANDARD_ERROR}")
+        set(FATAL_MESSAGE "${ERROR_MESSAGE}:\n${STANDARD_ERROR}")
         # Ninja pipes stderr to stdout so we have to print stdout to see errors
         if (CMAKE_GENERATOR MATCHES "Ninja")
-            string(APPEND MESSAGE "\n${STANDARD_OUTPUT}")
+            string(APPEND FATAL_MESSAGE "\n${STANDARD_OUTPUT}")
         endif()
-        message(FATAL_ERROR "${MESSAGE}")
+        message(FATAL_ERROR "${FATAL_MESSAGE}")
     endif()
 endfunction()
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix #2994 

Ninja pipes `execute_process()` stderr to stdout, so the errors were getting silenced by the build system at generate time.
This fixes it by printing stdout when Ninja is selected as the generator.
