### PR TITLE
Os file vxworks

### DIFF
--- a/Os/Posix/Directory.cpp
+++ b/Os/Posix/Directory.cpp
@@ -2,7 +2,7 @@
 // \title Os/Posix/Directory.cpp
 // \brief Posix implementation for Os::Directory
 // ======================================================================
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/stat.h>
 #include <cstring>
 

--- a/Os/Posix/Directory.cpp
+++ b/Os/Posix/Directory.cpp
@@ -2,8 +2,8 @@
 // \title Os/Posix/Directory.cpp
 // \brief Posix implementation for Os::Directory
 // ======================================================================
-#include <errno.h>
 #include <sys/stat.h>
+#include <cerrno>
 #include <cstring>
 
 #include <Fw/Types/Assert.hpp>

--- a/Os/Posix/File.cpp
+++ b/Os/Posix/File.cpp
@@ -45,28 +45,21 @@ static_assert(std::numeric_limits<FwSignedSizeType>::min() <= std::numeric_limit
               "Minimum value of FwSizeType larger than the minimum value of ssize_t. Configure a larger type.");
 
 //!\brief default copy constructor
+#ifndef TGT_OS_TYPE_VXWORKS
 PosixFile::PosixFile(const PosixFile& other) {
-#ifdef TGT_OS_TYPE_VXWORKS
-    // dup is not supported in VxWorks
-    FW_ASSERT(0);
-#else
     // Must properly duplicate the file handle
     this->m_handle.m_file_descriptor = ::dup(other.m_handle.m_file_descriptor);
-#endif
 }
+#endif
 
+#ifndef TGT_OS_TYPE_VXWORKS
 PosixFile& PosixFile::operator=(const PosixFile& other) {
-#ifdef TGT_OS_TYPE_VXWORKS
-    // dup is not supported in VxWorks
-    FW_ASSERT(0);
-    return *this;
-#else
     if (this != &other) {
         this->m_handle.m_file_descriptor = ::dup(other.m_handle.m_file_descriptor);
     }
     return *this;
-#endif
 }
+#endif
 
 PosixFile::Status PosixFile::open(const char* filepath,
                                   PosixFile::Mode requested_mode,

--- a/Os/Posix/File.cpp
+++ b/Os/Posix/File.cpp
@@ -2,14 +2,14 @@
 // \title Os/Posix/File.cpp
 // \brief posix implementation for Os::File
 // ======================================================================
-#include <cerrno>
 #include <fcntl.h>
 #include <unistd.h>
+#include <cerrno>
 #include <limits>
 
+#include <Fw/Types/Assert.hpp>
 #include <Os/File.hpp>
 #include <Os/Posix/File.hpp>
-#include <Fw/Types/Assert.hpp>
 #include <Os/Posix/error.hpp>
 
 namespace Os {
@@ -29,8 +29,10 @@ namespace File {
 #endif
 
 // Ensure size of FwSizeType is large enough to fit eh necessary range
-static_assert(sizeof(FwSignedSizeType) >= sizeof(off_t), "FwSizeType is not large enough to store values of type off_t");
-static_assert(sizeof(FwSignedSizeType) >= sizeof(ssize_t), "FwSizeType is not large enough to store values of type ssize_t");
+static_assert(sizeof(FwSignedSizeType) >= sizeof(off_t),
+              "FwSizeType is not large enough to store values of type off_t");
+static_assert(sizeof(FwSignedSizeType) >= sizeof(ssize_t),
+              "FwSizeType is not large enough to store values of type ssize_t");
 
 // Now check ranges of FwSizeType
 static_assert(std::numeric_limits<FwSignedSizeType>::max() >= std::numeric_limits<off_t>::max(),
@@ -66,7 +68,9 @@ PosixFile& PosixFile::operator=(const PosixFile& other) {
 #endif
 }
 
-PosixFile::Status PosixFile::open(const char* filepath, PosixFile::Mode requested_mode, PosixFile::OverwriteType overwrite) {
+PosixFile::Status PosixFile::open(const char* filepath,
+                                  PosixFile::Mode requested_mode,
+                                  PosixFile::OverwriteType overwrite) {
     PlatformIntType mode_flags = 0;
     Status status = OP_OK;
     switch (requested_mode) {
@@ -80,7 +84,8 @@ PosixFile::Status PosixFile::open(const char* filepath, PosixFile::Mode requeste
             mode_flags = O_WRONLY | O_CREAT | O_SYNC;
             break;
         case OPEN_CREATE:
-            mode_flags = O_WRONLY | O_CREAT | O_TRUNC | ((overwrite == PosixFile::OverwriteType::OVERWRITE) ? 0 : O_EXCL);
+            mode_flags =
+                O_WRONLY | O_CREAT | O_TRUNC | ((overwrite == PosixFile::OverwriteType::OVERWRITE) ? 0 : O_EXCL);
             break;
         case OPEN_APPEND:
             mode_flags = O_WRONLY | O_CREAT | O_APPEND;
@@ -106,7 +111,7 @@ void PosixFile::close() {
     }
 }
 
-PosixFile::Status  PosixFile::size(FwSignedSizeType& size_result) {
+PosixFile::Status PosixFile::size(FwSignedSizeType& size_result) {
     FwSignedSizeType current_position = 0;
     Status status = this->position(current_position);
     size_result = 0;
@@ -129,7 +134,7 @@ PosixFile::Status  PosixFile::size(FwSignedSizeType& size_result) {
     return status;
 }
 
-PosixFile::Status  PosixFile::position(FwSignedSizeType &position_result) {
+PosixFile::Status PosixFile::position(FwSignedSizeType& position_result) {
     Status status = OP_OK;
     position_result = 0;
     off_t actual = ::lseek(this->m_handle.m_file_descriptor, 0, SEEK_CUR);
@@ -171,7 +176,8 @@ PosixFile::Status PosixFile::preallocate(FwSignedSizeType offset, FwSignedSizeTy
                         // Fill in zeros past size of file to ensure compatibility with fallocate
                         for (FwSignedSizeType i = 0; i < write_length; i++) {
                             FwSignedSizeType write_size = 1;
-                            status = this->write(reinterpret_cast<const U8*>("\0"), write_size, PosixFile::WaitType::NO_WAIT);
+                            status = this->write(reinterpret_cast<const U8*>("\0"), write_size,
+                                                 PosixFile::WaitType::NO_WAIT);
                             if (Status::OP_OK != status || write_size != 1) {
                                 break;
                             }
@@ -190,7 +196,8 @@ PosixFile::Status PosixFile::preallocate(FwSignedSizeType offset, FwSignedSizeTy
 
 PosixFile::Status PosixFile::seek(FwSignedSizeType offset, PosixFile::SeekType seekType) {
     Status status = OP_OK;
-    off_t actual = ::lseek(this->m_handle.m_file_descriptor, offset, (seekType == SeekType::ABSOLUTE) ? SEEK_SET : SEEK_CUR);
+    off_t actual =
+        ::lseek(this->m_handle.m_file_descriptor, offset, (seekType == SeekType::ABSOLUTE) ? SEEK_SET : SEEK_CUR);
     PlatformIntType errno_store = errno;
     if (actual == PosixFileHandle::ERROR_RETURN_VALUE) {
         status = Os::Posix::errno_to_file_status(errno_store);
@@ -209,18 +216,18 @@ PosixFile::Status PosixFile::flush() {
     return status;
 }
 
-PosixFile::Status PosixFile::read(U8* buffer, FwSignedSizeType &size, PosixFile::WaitType wait) {
+PosixFile::Status PosixFile::read(U8* buffer, FwSignedSizeType& size, PosixFile::WaitType wait) {
     Status status = OP_OK;
     FwSignedSizeType accumulated = 0;
     // Loop up to 2 times for each by, bounded to prevent overflow
-    const FwSignedSizeType maximum = (size > (std::numeric_limits<FwSignedSizeType>::max()/2)) ? std::numeric_limits<FwSignedSizeType>::max() : size * 2;
+    const FwSignedSizeType maximum = (size > (std::numeric_limits<FwSignedSizeType>::max() / 2))
+                                         ? std::numeric_limits<FwSignedSizeType>::max()
+                                         : size * 2;
 
     for (FwSignedSizeType i = 0; i < maximum && accumulated < size; i++) {
         // char* for some posix implementations
-        ssize_t read_size = ::read(
-            this->m_handle.m_file_descriptor,
-            reinterpret_cast<CHAR*>(&buffer[accumulated]),
-            static_cast<size_t>(size - accumulated));
+        ssize_t read_size = ::read(this->m_handle.m_file_descriptor, reinterpret_cast<CHAR*>(&buffer[accumulated]),
+                                   static_cast<size_t>(size - accumulated));
         // Non-interrupt error
         if (PosixFileHandle::ERROR_RETURN_VALUE == read_size) {
             PlatformIntType errno_store = errno;
@@ -245,15 +252,19 @@ PosixFile::Status PosixFile::read(U8* buffer, FwSignedSizeType &size, PosixFile:
     return status;
 }
 
-PosixFile::Status PosixFile::write(const U8* buffer, FwSignedSizeType &size, PosixFile::WaitType wait) {
+PosixFile::Status PosixFile::write(const U8* buffer, FwSignedSizeType& size, PosixFile::WaitType wait) {
     Status status = OP_OK;
     FwSignedSizeType accumulated = 0;
     // Loop up to 2 times for each by, bounded to prevent overflow
-    const FwSignedSizeType maximum = (size > (std::numeric_limits<FwSignedSizeType>::max()/2)) ? std::numeric_limits<FwSignedSizeType>::max() : size * 2;
+    const FwSignedSizeType maximum = (size > (std::numeric_limits<FwSignedSizeType>::max() / 2))
+                                         ? std::numeric_limits<FwSignedSizeType>::max()
+                                         : size * 2;
 
     for (FwSignedSizeType i = 0; i < maximum && accumulated < size; i++) {
         // char* for some posix implementations
-        ssize_t write_size = ::write(this->m_handle.m_file_descriptor, reinterpret_cast<const CHAR*>(&buffer[accumulated]), static_cast<size_t>(size - accumulated));
+        ssize_t write_size =
+            ::write(this->m_handle.m_file_descriptor, reinterpret_cast<const CHAR*>(&buffer[accumulated]),
+                    static_cast<size_t>(size - accumulated));
         // Non-interrupt error
         if (PosixFileHandle::ERROR_RETURN_VALUE == write_size) {
             PlatformIntType errno_store = errno;
@@ -269,11 +280,11 @@ PosixFile::Status PosixFile::write(const U8* buffer, FwSignedSizeType &size, Pos
     size = accumulated;
     // When waiting, sync to disk
     if (wait) {
-       PlatformIntType fsync_return = ::fsync(this->m_handle.m_file_descriptor);
-       if (PosixFileHandle::ERROR_RETURN_VALUE == fsync_return) {
+        PlatformIntType fsync_return = ::fsync(this->m_handle.m_file_descriptor);
+        if (PosixFileHandle::ERROR_RETURN_VALUE == fsync_return) {
             PlatformIntType errno_store = errno;
             status = Os::Posix::errno_to_file_status(errno_store);
-       }
+        }
     }
     return status;
 }
@@ -282,7 +293,6 @@ FileHandle* PosixFile::getHandle() {
     return &this->m_handle;
 }
 
-} // namespace File
-} // namespace Posix
-} // namespace Os
-
+}  // namespace File
+}  // namespace Posix
+}  // namespace Os

--- a/Os/Posix/File.cpp
+++ b/Os/Posix/File.cpp
@@ -44,15 +44,26 @@ static_assert(std::numeric_limits<FwSignedSizeType>::min() <= std::numeric_limit
 
 //!\brief default copy constructor
 PosixFile::PosixFile(const PosixFile& other) {
+#ifdef TGT_OS_TYPE_VXWORKS
+    // dup is not supported in VxWorks
+    FW_ASSERT(0);
+#else
     // Must properly duplicate the file handle
     this->m_handle.m_file_descriptor = ::dup(other.m_handle.m_file_descriptor);
+#endif
 }
 
 PosixFile& PosixFile::operator=(const PosixFile& other) {
+#ifdef TGT_OS_TYPE_VXWORKS
+    // dup is not supported in VxWorks
+    FW_ASSERT(0);
+    return *this;
+#else
     if (this != &other) {
         this->m_handle.m_file_descriptor = ::dup(other.m_handle.m_file_descriptor);
     }
     return *this;
+#endif
 }
 
 PosixFile::Status PosixFile::open(const char* filepath, PosixFile::Mode requested_mode, PosixFile::OverwriteType overwrite) {

--- a/Os/Posix/File.hpp
+++ b/Os/Posix/File.hpp
@@ -33,10 +33,18 @@ class PosixFile : public FileInterface {
     PosixFile() = default;
 
     //! \brief copy constructor
+#ifdef TGT_OS_TYPE_VXWORKS
+    PosixFile(const PosixFile& other) = delete;
+#else
     PosixFile(const PosixFile& other);
+#endif
 
-    //! \brief assignment operator that copies the internal representation
+//! \brief assignment operator that copies the internal representation
+#ifdef TGT_OS_TYPE_VXWORKS
+    PosixFile& operator=(const PosixFile& other) = delete;
+#else
     PosixFile& operator=(const PosixFile& other);
+#endif
 
     //! \brief destructor
     //!
@@ -62,7 +70,7 @@ class PosixFile : public FileInterface {
     //! \param overwrite: overwrite existing file on create
     //! \return: status of the open
     //!
-    Os::FileInterface::Status open(const char *path, Mode mode, OverwriteType overwrite) override;
+    Os::FileInterface::Status open(const char* path, Mode mode, OverwriteType overwrite) override;
 
     //! \brief close the file, if not opened then do nothing
     //!
@@ -77,7 +85,7 @@ class PosixFile : public FileInterface {
     //! \param size: output parameter for size.
     //! \return OP_OK on success otherwise error status
     //!
-    Status size(FwSignedSizeType &size_result) override;
+    Status size(FwSignedSizeType& size_result) override;
 
     //! \brief get file pointer position of the currently open file
     //!
@@ -85,7 +93,7 @@ class PosixFile : public FileInterface {
     //! \param position: output parameter for size.
     //! \return OP_OK on success otherwise error status
     //!
-    Status position(FwSignedSizeType &position_result) override;
+    Status position(FwSignedSizeType& position_result) override;
 
     //! \brief pre-allocate file storage
     //!
@@ -139,7 +147,7 @@ class PosixFile : public FileInterface {
     //! \param wait: `WAIT` to wait for data, `NO_WAIT` to return what is currently available
     //! \return OP_OK on success otherwise error status
     //!
-    Status read(U8 *buffer, FwSignedSizeType &size, WaitType wait) override;
+    Status read(U8* buffer, FwSignedSizeType& size, WaitType wait) override;
 
     //! \brief read data from this file into supplied buffer bounded by size
     //!
@@ -159,7 +167,7 @@ class PosixFile : public FileInterface {
     //! \param wait: `WAIT` to wait for data to write to disk, `NO_WAIT` to return what is currently available
     //! \return OP_OK on success otherwise error status
     //!
-    Status write(const U8 *buffer, FwSignedSizeType &size, WaitType wait) override;
+    Status write(const U8* buffer, FwSignedSizeType& size, WaitType wait) override;
 
     //! \brief returns the raw file handle
     //!
@@ -168,15 +176,14 @@ class PosixFile : public FileInterface {
     //!
     //! \return raw file handle
     //!
-    FileHandle *getHandle() override;
-
+    FileHandle* getHandle() override;
 
   private:
     //! File handle for PosixFile
     PosixFileHandle m_handle;
 };
-} // namespace File
-} // namespace Posix
-} // namespace Os
+}  // namespace File
+}  // namespace Posix
+}  // namespace Os
 
-#endif // OS_POSIX_FILE_HPP
+#endif  // OS_POSIX_FILE_HPP

--- a/Os/Posix/File.hpp
+++ b/Os/Posix/File.hpp
@@ -34,6 +34,9 @@ class PosixFile : public FileInterface {
 
     //! \brief copy constructor
 #ifdef TGT_OS_TYPE_VXWORKS
+    // Adding this pound-if-define code to allow building VxWorks for POSIX.
+    // Better than the alternative of copying this entire file to the VxWorks repo
+    // and removing this line.
     PosixFile(const PosixFile& other) = delete;
 #else
     PosixFile(const PosixFile& other);
@@ -41,6 +44,9 @@ class PosixFile : public FileInterface {
 
 //! \brief assignment operator that copies the internal representation
 #ifdef TGT_OS_TYPE_VXWORKS
+    // Adding this pound-if-define code to allow building VxWorks for POSIX.
+    // Better than the alternative of copying this entire file to the VxWorks repo
+    // and removing this line.
     PosixFile& operator=(const PosixFile& other) = delete;
 #else
     PosixFile& operator=(const PosixFile& other);

--- a/Os/Posix/FileSystem.cpp
+++ b/Os/Posix/FileSystem.cpp
@@ -6,7 +6,9 @@
 #include "Os/Posix/error.hpp"
 
 #include <dirent.h>
+#ifndef TGT_OS_TYPE_VXWORKS
 #include <sys/statvfs.h>
+#endif
 #include <sys/stat.h>
 #include <unistd.h>
 #include <cstdio>
@@ -16,7 +18,6 @@
 namespace Os {
 namespace Posix {
 namespace FileSystem {
-
 
 PosixFileSystem::Status PosixFileSystem::_removeDirectory(const char* path) {
     Status status = OP_OK;
@@ -58,11 +59,19 @@ PosixFileSystem::Status PosixFileSystem::_changeWorkingDirectory(const char* pat
     return status;
 }
 
-PosixFileSystem::Status PosixFileSystem::_getFreeSpace(const char* path, FwSizeType& totalBytes, FwSizeType& freeBytes) {
+PosixFileSystem::Status PosixFileSystem::_getFreeSpace(const char* path,
+                                                       FwSizeType& totalBytes,
+                                                       FwSizeType& freeBytes) {
+#ifdef TGT_OS_TYPE_VXWORKS
+    return Status::NOT_SUPPORTED;
+#else
     Status stat = OP_OK;
-    static_assert(std::numeric_limits<FwSizeType>::max() >= std::numeric_limits<fsblkcnt_t>::max(), "FwSizeType must be able to hold fsblkcnt_t");
-    static_assert(std::numeric_limits<FwSizeType>::min() <= std::numeric_limits<fsblkcnt_t>::min(), "FwSizeType must be able to hold fsblkcnt_t");
-    static_assert(std::numeric_limits<FwSizeType>::max() >= std::numeric_limits<unsigned long>::max(), "FwSizeType must be able to hold unsigned long");
+    static_assert(std::numeric_limits<FwSizeType>::max() >= std::numeric_limits<fsblkcnt_t>::max(),
+                  "FwSizeType must be able to hold fsblkcnt_t");
+    static_assert(std::numeric_limits<FwSizeType>::min() <= std::numeric_limits<fsblkcnt_t>::min(),
+                  "FwSizeType must be able to hold fsblkcnt_t");
+    static_assert(std::numeric_limits<FwSizeType>::max() >= std::numeric_limits<unsigned long>::max(),
+                  "FwSizeType must be able to hold unsigned long");
     struct statvfs fsStat;
     int ret = statvfs(path, &fsStat);
     if (ret) {
@@ -81,12 +90,13 @@ PosixFileSystem::Status PosixFileSystem::_getFreeSpace(const char* path, FwSizeT
     freeBytes = free_blocks * block_size;
     totalBytes = total_blocks * block_size;
     return stat;
+#endif
 }
 
 FileSystemHandle* PosixFileSystem::getHandle() {
     return &this->m_handle;
 }
 
-} // namespace File
-} // namespace Posix
-} // namespace Os
+}  // namespace FileSystem
+}  // namespace Posix
+}  // namespace Os


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adding macros to include/exclude code when compiling for VxWorks. 

## Rationale

This allows VxWorks to build with the Posix file implementation. 

## Testing/Review Recommendations

I ran a simple hello world program in the VxSim. The hello world program opened a file and wrote some bytes to the file.

## Future Work

Note any additional work that will be done relating to this issue.
