### PR TITLE
Bugfix/empty seq

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -470,6 +470,7 @@ jdperez
 jenkins
 jenkinsci
 jishii
+Joaquim
 jobrestrictions
 joshuaa
 jpl
@@ -594,6 +595,7 @@ nogen
 noncomma
 NONINFRINGEMENT
 noparent
+norecords
 normalwidths
 NOSIZE
 NOSPEC
@@ -842,6 +844,7 @@ showinitializer
 sideeffect
 sighandler
 Signedness
+Silveira
 sinc
 Sinha
 sloc

--- a/Svc/CmdSequencer/CMakeLists.txt
+++ b/Svc/CmdSequencer/CMakeLists.txt
@@ -16,7 +16,8 @@ set(SOURCE_FILES
 )
 
 register_fprime_module()
-### UTs ###
+
+# ## UTs ###
 set(UT_SOURCE_FILES
   "${FPRIME_FRAMEWORK_PATH}/Svc/CmdSequencer/CmdSequencer.fpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/AMPCS.cpp"
@@ -30,12 +31,14 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/Mixed.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/MixedRelativeBase.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/NoFiles.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/NoRecords.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/Relative.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/AMPCS/CRCs.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/AMPCS/Headers.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/AMPCS/Records.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/BadCRCFile.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/BadDescriptorFile.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/NoRecordsFile.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/BadTimeBaseFile.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/BadTimeContextFile.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/SequenceFiles/Buffers.cpp"

--- a/Svc/CmdSequencer/CmdSequencerImpl.hpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.hpp
@@ -111,6 +111,9 @@ namespace Svc {
                   const FwTimeContextStoreType seqTimeContext //!< The sequence file time context
               );
 
+              // No Records 
+              void noRecords();
+
             PRIVATE:
 
               //! The enclosing component

--- a/Svc/CmdSequencer/Events.cpp
+++ b/Svc/CmdSequencer/Events.cpp
@@ -130,6 +130,17 @@ namespace Svc {
     );
     component.error();
   }
+  
+  void CmdSequencerComponentImpl::Sequence::Events ::
+    noRecords()
+  {
+    Fw::LogStringArg& logFileName = this->m_sequence.getLogFileName();
+    CmdSequencerComponentImpl& component = this->m_sequence.m_component;
+    component.log_WARNING_LO_CS_NoRecords(
+      logFileName
+    );
+    component.error();
+  }
 
 }
 

--- a/Svc/CmdSequencer/Events.fppi
+++ b/Svc/CmdSequencer/Events.fppi
@@ -214,3 +214,11 @@ event CS_JoinWaitingNotComplete() \
   severity warning high \
   id 24 \
   format "Still waiting for sequence file to complete"
+
+event CS_FileEmpty(
+                      #fileName: string size 60 @< The name of the sequence file
+                    ) \
+  severity warning high \
+  id 25 \
+  format "Sequence file is empty. Ignoring."
+  #format "Sequence file {} is empty. Ignoring."

--- a/Svc/CmdSequencer/Events.fppi
+++ b/Svc/CmdSequencer/Events.fppi
@@ -215,10 +215,9 @@ event CS_JoinWaitingNotComplete() \
   id 24 \
   format "Still waiting for sequence file to complete"
 
-event CS_FileEmpty(
-                      #fileName: string size 60 @< The name of the sequence file
+event CS_NoRecords(
+                      fileName: string size 60 @< The name of the sequence file
                     ) \
-  severity warning high \
+  severity warning low \
   id 25 \
-  format "Sequence file is empty. Ignoring."
-  #format "Sequence file {} is empty. Ignoring."
+  format "Sequence file {} has no records. Ignoring."

--- a/Svc/CmdSequencer/FPrimeSequence.cpp
+++ b/Svc/CmdSequencer/FPrimeSequence.cpp
@@ -91,9 +91,14 @@ namespace Svc {
   }
 
   void CmdSequencerComponentImpl::FPrimeSequence ::
-     nextRecord(Record& record)
+    nextRecord(Record& record)
   {
     Fw::SerializeStatus status = this->deserializeRecord(record);
+    if (status == Fw::SerializeStatus::FW_DESERIALIZE_BUFFER_EMPTY)
+    {
+      this->m_component.log_WARNING_HI_CS_FileEmpty();
+      return;
+    }
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
   }
 

--- a/Svc/CmdSequencer/FPrimeSequence.cpp
+++ b/Svc/CmdSequencer/FPrimeSequence.cpp
@@ -94,11 +94,6 @@ namespace Svc {
     nextRecord(Record& record)
   {
     Fw::SerializeStatus status = this->deserializeRecord(record);
-    if (status == Fw::SerializeStatus::FW_DESERIALIZE_BUFFER_EMPTY)
-    {
-      this->m_component.log_WARNING_HI_CS_FileEmpty();
-      return;
-    }
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
   }
 
@@ -427,6 +422,12 @@ namespace Svc {
     Fw::SerializeBufferBase& buffer = this->m_buffer;
     const U32 numRecords = this->m_header.m_numRecords;
     Sequence::Record record;
+
+    if (numRecords == 0)
+    {
+      this->m_events.noRecords();
+      return false;
+    }
 
     // Deserialize all records
     for (NATIVE_UINT_TYPE recordNumber = 0; recordNumber < numRecords; recordNumber++) {

--- a/Svc/CmdSequencer/test/ut/CmdSequencerMain.cpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerMain.cpp
@@ -13,6 +13,7 @@
 #include "Svc/CmdSequencer/test/ut/Immediate.hpp"
 #include "Svc/CmdSequencer/test/ut/ImmediateEOS.hpp"
 #include "Svc/CmdSequencer/test/ut/InvalidFiles.hpp"
+#include "Svc/CmdSequencer/test/ut/NoRecords.hpp"
 #include "Svc/CmdSequencer/test/ut/NoFiles.hpp"
 #include "Svc/CmdSequencer/test/ut/Relative.hpp"
 #include "Svc/CmdSequencer/test/ut/SequenceFiles/SequenceFiles.hpp"
@@ -316,6 +317,7 @@ TEST(InvalidFiles, USecFieldTooShort) {
   tester.USecFieldTooShort();
 }
 
+
 TEST(Mixed, AutoByCommand) {
   TEST_CASE(103.1.4,"Nominal Timed Relative Commands");
   Svc::Mixed::CmdSequencerTester tester;
@@ -390,6 +392,15 @@ TEST(JoinWait, JoinWaitWithActiveSeq) {
     tester.test_join_wait_with_active_seq();
 }
 
+TEST(InvalidFiles, RunNoRecords) {
+  Svc::NoRecords::CmdSequencerTester tester;
+  tester.RunNoRecords();
+}
+
+TEST(InvalidFiles, ValidateNoRecords) {
+  Svc::NoRecords::CmdSequencerTester tester;
+  tester.ValidateNoRecords();
+}
 
 int main(int argc, char **argv) {
   // Create ./bin directory for test files

--- a/Svc/CmdSequencer/test/ut/NoRecords.cpp
+++ b/Svc/CmdSequencer/test/ut/NoRecords.cpp
@@ -1,0 +1,99 @@
+// ======================================================================
+// \title  NoRecords.hpp
+// \author Joaquim Silveira
+// \brief  Test command sequence with no records
+//
+// ======================================================================
+
+#include "Svc/CmdSequencer/test/ut/CommandBuffers.hpp"
+#include "Svc/CmdSequencer/test/ut/NoRecords.hpp"
+#include "Svc/CmdSequencer/test/ut/SequenceFiles/NoRecordsFile.hpp"
+
+namespace Svc {
+
+    namespace NoRecords {
+
+        // ----------------------------------------------------------------------
+        // Constructors
+        // ----------------------------------------------------------------------
+
+        CmdSequencerTester ::
+            CmdSequencerTester(const SequenceFiles::File::Format::t format) :
+            Svc::CmdSequencerTester(format)
+        {
+
+        }
+
+        // ----------------------------------------------------------------------
+        // Tests
+        // ----------------------------------------------------------------------
+
+        void CmdSequencerTester ::
+            Init()
+        {
+            // Nothing to do
+        }
+
+        void CmdSequencerTester ::
+            ValidateNoRecords()
+        {
+            SequenceFiles::NoRecordsFile file(this->format);
+
+            // Set the time
+            Fw::Time testTime(TB_WORKSTATION_TIME, 0, 0);
+            this->setTestTime(testTime);
+
+            // Write the file
+            const char* const fileName = file.getName().toChar();
+            file.write();
+
+            // Validate the file
+            this->sendCmd_CS_VALIDATE(0, 0, Fw::CmdStringArg(fileName));
+            this->clearAndDispatch();
+
+            // Assert command response
+            ASSERT_CMD_RESPONSE_SIZE(1);
+            ASSERT_CMD_RESPONSE(
+                0,
+                CmdSequencerComponentBase::OPCODE_CS_VALIDATE,
+                0,
+                Fw::CmdResponse::EXECUTION_ERROR
+            );
+            // Assert events
+            ASSERT_EVENTS_SIZE(1);
+            ASSERT_EVENTS_CS_NoRecords(0, fileName);
+        }
+
+        void CmdSequencerTester ::
+            RunNoRecords()
+        {
+            SequenceFiles::NoRecordsFile file(this->format);
+            
+            // Set the time
+            Fw::Time testTime(TB_WORKSTATION_TIME, 0, 0);
+            this->setTestTime(testTime);
+
+            // Write the file
+            const char* const fileName = file.getName().toChar();
+            file.write();
+
+            // Send run command
+            this->sendCmd_CS_RUN(0, 0, Fw::CmdStringArg(fileName), Svc::CmdSequencer_BlockState::NO_BLOCK);
+            this->clearAndDispatch();
+            // Assert command response
+            ASSERT_CMD_RESPONSE_SIZE(1);
+            ASSERT_CMD_RESPONSE(
+                0,
+                CmdSequencerComponentBase::OPCODE_CS_RUN,
+                0,
+                Fw::CmdResponse::EXECUTION_ERROR
+            );
+            // Assert events
+            ASSERT_EVENTS_SIZE(1);
+            ASSERT_EVENTS_CS_NoRecords(0, fileName);
+
+        }
+
+    }
+
+}

--- a/Svc/CmdSequencer/test/ut/NoRecords.hpp
+++ b/Svc/CmdSequencer/test/ut/NoRecords.hpp
@@ -1,0 +1,54 @@
+// ======================================================================
+// \title  NoRecords.hpp
+// \author Joaquim Silveira
+// \brief  Test command sequence with no records
+//
+// ======================================================================
+
+#ifndef Svc_NoRecords_HPP
+#define Svc_NoRecords_HPP
+
+#include "CmdSequencerTester.hpp"
+
+namespace Svc {
+
+    namespace NoRecords {
+
+        //! Test sequencer behavior with no input files
+        class CmdSequencerTester :
+            public Svc::CmdSequencerTester
+        {
+
+        public:
+
+            // ----------------------------------------------------------------------
+            // Constructors
+            // ----------------------------------------------------------------------
+
+            //! Construct object CmdSequencerTester
+            CmdSequencerTester(
+                const SequenceFiles::File::Format::t format =
+                SequenceFiles::File::Format::F_PRIME //!< The file format to use
+            );
+
+        public:
+
+            // ----------------------------------------------------------------------
+            // Tests
+            // ----------------------------------------------------------------------
+
+            //! Initialization
+            void Init();
+
+            //! Issue a validate command on an empty sequence
+            void ValidateNoRecords();
+
+            //! Issue a run command on an empty sequence
+            void RunNoRecords();
+        };
+
+    }
+
+}
+
+#endif

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/NoRecordsFile.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/NoRecordsFile.cpp
@@ -1,0 +1,55 @@
+// ====================================================================== 
+// \title  NoRecordsFile.cpp
+// \author Rob Bocchino
+// \brief  NoRecordsFile implementation
+//
+// \copyright
+// Copyright (C) 2009-2018 California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+
+#include "Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/AMPCS.hpp"
+#include "Svc/CmdSequencer/test/ut/SequenceFiles/Buffers.hpp"
+#include "Svc/CmdSequencer/test/ut/SequenceFiles/FPrime/FPrime.hpp"
+#include "Svc/CmdSequencer/test/ut/SequenceFiles/NoRecordsFile.hpp"
+#include "gtest/gtest.h"
+
+namespace Svc {
+
+    namespace SequenceFiles {
+
+        NoRecordsFile ::
+            NoRecordsFile(const Format::t format) :
+            File("norecords", format)
+        {
+        }
+
+        void NoRecordsFile::serializeFPrime(Fw::SerializeBufferBase& buffer) {
+            // Header
+            const NATIVE_INT_TYPE numRecs = 0;
+            const U32 recordDataSize = numRecs * FPrime::Records::STANDARD_SIZE;
+            const U32 dataSize = recordDataSize + FPrime::CRCs::SIZE;
+            const TimeBase timeBase = TB_WORKSTATION_TIME;
+            const U32 timeContext = 0;
+            FPrime::Headers::serialize(dataSize, numRecs, timeBase, timeContext, buffer);
+
+            // No Records
+
+            // CRC
+            FPrime::CRCs::serialize(buffer);
+        }
+
+        void NoRecordsFile ::
+            serializeAMPCS(Fw::SerializeBufferBase& buffer)
+        {
+            // Header
+            AMPCS::Headers::serialize(buffer);
+            // No Records
+            
+            // CRC
+            AMPCS::CRCs::createFile(buffer, this->getName().toChar());
+        }
+
+    }
+
+}

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/NoRecordsFile.hpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/NoRecordsFile.hpp
@@ -1,0 +1,47 @@
+// ====================================================================== 
+// \title  NoRecordsFile.hpp
+// \author Joaquim Silveira
+// \brief  NoRecords interface
+
+
+#ifndef Svc_SequenceFiles_NoRecordsFile_HPP
+#define Svc_SequenceFiles_NoRecordsFile_HPP
+
+#include "Svc/CmdSequencer/test/ut/SequenceFiles/File.hpp"
+#include "Svc/CmdSequencer/CmdSequencerImpl.hpp"
+
+namespace Svc {
+
+    namespace SequenceFiles {
+
+        //! A file containing no records
+        class NoRecordsFile :
+            public File
+        {
+
+        public:
+
+            //! Construct a NoRecordsFile
+            NoRecordsFile(
+                const Format::t format //!< The file format
+            );
+
+        public:
+
+            //! Serialize the file in F Prime format
+            void serializeFPrime(
+                Fw::SerializeBufferBase& buffer //!< The buffer
+            );
+
+            //! Serialize the file in AMPCS format
+            void serializeAMPCS(
+                Fw::SerializeBufferBase& buffer //!< The buffer
+            );
+
+        };
+
+    }
+
+}
+
+#endif


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3005  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Implemented FileEmpty warning for the `Svc::CmdDispatcher` Component, which is called when deserializing the next record returns an empty buffer.

## Rationale
The Flight Software should raise a warning on empty command sequence files instead of crashing. 

## Testing/Review Recommendations


## Future Work

