### PR TITLE
Clarify buffer ownership for ByteStreamDriverModel

### DIFF
--- a/Drv/ByteStreamDriverModel/docs/sdd.md
+++ b/Drv/ByteStreamDriverModel/docs/sdd.md
@@ -11,11 +11,11 @@ The manager component (typically the ground interface) initiates the transfer of
 The caller will provide a `Fw::Buffer` containing the data to send and the port call will return a status of that send.
 These responses are an enumeration whose values are described in the following table:
 
-| Value | Description |
-|---|---|
-| Drv::SEND_OK    | Send functioned normally. |
-| Drv::SEND_RETRY | Send should be retried, but a subsequent send should return SEND_OK. |
-| Drv::SEND_ERROR | Send produced an error, future sends likely to fail. |
+| Value | Description | Buffer Ownership |
+|---|---|---|
+| Drv::SEND_OK    | Send functioned normally. | Ownership of the `Fw::Buffer` passes to the byte stream driver. |
+| Drv::SEND_RETRY | Send should be retried, but a subsequent send should return SEND_OK. | The caller retains ownership of the `Fw::Buffer`. |
+| Drv::SEND_ERROR | Send produced an error, future sends likely to fail. | Ownership of the `Fw::Buffer` passes to the byte stream driver. |
 
 **Note:** in either formation described below, send will operate as described here.
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Documentation Included (y/n)_**| yes |

---
## Change Description

`TcpClientComponentImpl::send_handler` and `TcpServerComponentImpl::send_handler` deallocate the provided `Fw::Buffer` if (and only if) they return SEND_OK or SEND_ERROR. If they return SEND_RETRY, they do not deallocate the buffer.

## Rationale

To make sure that users of the ByteStreamDriverInterface can implement the correct buffer handling logic, it's important to define what happens with ownership of the buffer.

## Testing/Review Recommendations

N/A

## Future Work

`UdpComponentImpl::send_handler` does not implement the interface in the same way: notably, it also deallocates the buffer when it returns SEND_RETRY. I believe this is incorrect and has not been noticed because SEND_RETRY is unlikely (or maybe impossible) for UDP connections. Some revision to that code may be necessary.
