### PR TITLE
Remove old RTEMS5 link from docs

### DIFF
--- a/docs/UsersGuide/cmake/cmake-api.md
+++ b/docs/UsersGuide/cmake/cmake-api.md
@@ -26,7 +26,6 @@ define types and headers needed for F´ for any embedded system they desire.
 [Platform Template](../api/cmake/platform/platform-template.md): Platform file template documentation  
 [Linux](../api/cmake/platform/Linux.md): Linux platform support  
 [Darwin](../api/cmake/platform/Darwin.md): Darwin (macOS) platform support  
-[rtems5](../api/cmake/platform/rtems5.md): RTEMS 5 initial support  
 
 ## Target Documentation
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Remove dead link making MD Link Check fail: https://github.com/nasa/fprime/actions/runs/11979830114/job/33402820812
