### PR TITLE
Dup to fcntl

### DIFF
--- a/Os/Posix/File.cpp
+++ b/Os/Posix/File.cpp
@@ -45,21 +45,17 @@ static_assert(std::numeric_limits<FwSignedSizeType>::min() <= std::numeric_limit
               "Minimum value of FwSizeType larger than the minimum value of ssize_t. Configure a larger type.");
 
 //!\brief default copy constructor
-#ifndef TGT_OS_TYPE_VXWORKS
 PosixFile::PosixFile(const PosixFile& other) {
     // Must properly duplicate the file handle
-    this->m_handle.m_file_descriptor = ::dup(other.m_handle.m_file_descriptor);
+    this->m_handle.m_file_descriptor = fcntl(other.m_handle.m_file_descriptor, F_DUPFD, 0);
 }
-#endif
 
-#ifndef TGT_OS_TYPE_VXWORKS
 PosixFile& PosixFile::operator=(const PosixFile& other) {
     if (this != &other) {
-        this->m_handle.m_file_descriptor = ::dup(other.m_handle.m_file_descriptor);
+        this->m_handle.m_file_descriptor = fcntl(other.m_handle.m_file_descriptor, F_DUPFD, 0);
     }
     return *this;
 }
-#endif
 
 PosixFile::Status PosixFile::open(const char* filepath,
                                   PosixFile::Mode requested_mode,

--- a/Os/Posix/File.hpp
+++ b/Os/Posix/File.hpp
@@ -33,24 +33,10 @@ class PosixFile : public FileInterface {
     PosixFile() = default;
 
     //! \brief copy constructor
-#ifdef TGT_OS_TYPE_VXWORKS
-    // Adding this pound-if-define code to allow building VxWorks for POSIX.
-    // Better than the alternative of copying this entire file to the VxWorks repo
-    // and removing this line.
-    PosixFile(const PosixFile& other) = delete;
-#else
     PosixFile(const PosixFile& other);
-#endif
 
-//! \brief assignment operator that copies the internal representation
-#ifdef TGT_OS_TYPE_VXWORKS
-    // Adding this pound-if-define code to allow building VxWorks for POSIX.
-    // Better than the alternative of copying this entire file to the VxWorks repo
-    // and removing this line.
-    PosixFile& operator=(const PosixFile& other) = delete;
-#else
+    //! \brief assignment operator that copies the internal representation
     PosixFile& operator=(const PosixFile& other);
-#endif
 
     //! \brief destructor
     //!

--- a/Svc/PosixTime/CMakeLists.txt
+++ b/Svc/PosixTime/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 # Note: using PROJECT_NAME as EXECUTABLE_NAME
 ####
-restrict_platforms(Posix)
+#restrict_platforms(Posix)
 
 set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/PosixTime.fpp"

--- a/Svc/PosixTime/CMakeLists.txt
+++ b/Svc/PosixTime/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 # Note: using PROJECT_NAME as EXECUTABLE_NAME
 ####
-#restrict_platforms(Posix)
+restrict_platforms(Posix)
 
 set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/PosixTime.fpp"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Change dup to fcntl. How fcntl is used here, it should be equivalent to dup.

## Rationale

Needed for VxWorks when compiling with Posix File.

## Testing/Review Recommendations

CI

## Future Work

Note any additional work that will be done relating to this issue.
