### PR TITLE
Default website theme to light and minor format updates

### DIFF
--- a/docs/documentation/user-manual/index.md
+++ b/docs/documentation/user-manual/index.md
@@ -7,17 +7,17 @@ hide:
 
 The User Manual dives into F Prime design philosophy and architectural principles, providing a deep understanding of how the framework operates. Below are the different topics you can find under the User Manual. 
 
-## __F´ Overview__
+## Overview
 Technical overview of F Prime
 
-## __F´ Framework__
+## Framework
 Dive into the mechanics and design philosophies of the F Prime framework
 
-## __FPP (F Prime Prime)__
+## FPP (F Prime Prime)
 In-depth user guide and language specification for FPP
 
-## __F´ Ground Data System (GDS)__
+## Ground Data System (GDS)
 Dive into the F´ GDS and its testing framework
 
-## __F´ Design__
+## Design
 Explanation of the F Prime architecture and design philosophies

--- a/docs/documentation/user-manual/index.md
+++ b/docs/documentation/user-manual/index.md
@@ -7,17 +7,17 @@ hide:
 
 The User Manual dives into F Prime design philosophy and architectural principles, providing a deep understanding of how the framework operates. Below are the different topics you can find under the User Manual. 
 
-## Overview
+## __Overview__
 Technical overview of F Prime
 
-## Framework
+## __Framework__
 Dive into the mechanics and design philosophies of the F Prime framework
 
-## FPP (F Prime Prime)
+## __FPP (F Prime Prime)__
 In-depth user guide and language specification for FPP
 
-## Ground Data System (GDS)
+## __Ground Data System (GDS)__
 Dive into the F´ GDS and its testing framework
 
-## Design
+## __Design__
 Explanation of the F Prime architecture and design philosophies

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -23,5 +23,7 @@ New users should start with the [Hello World tutorial](../tutorials-hello-world/
 ## Further References
 
 Here are some additional references to continue learning about F´:
+
 - [More tutorials](../documentation/tutorials/)
 - [F´ User Manual](../documentation/user-manual/)
+- [Installation and Troubleshooting](./installing-fprime.md)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -29,8 +29,7 @@ theme:
   palette:
 
     # Palette toggle for light mode
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
+    - scheme: default
       primary: custom
       accent: custom
       toggle:
@@ -38,8 +37,7 @@ theme:
         name: Switch to dark mode
 
     # Palette toggle for dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
+    - scheme: slate
       primary: custom
       toggle:
         icon: material/lightbulb-off


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Per https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#system-preference

```
"(prefers-color-scheme: light)"
```

This pattern automatically picks up the user's system theme to display the according theme on the website. 

Discussed with @ashleynilo : it seems better to hard default to light theme. This provides more consistency in the behavior of the website, and light theme is more pleasing to the eye at first glance.

Also adding some minor format/spelling updates