### PR TITLE
Remove accidental files from LinuxTimer

### DIFF
--- a/Svc/LinuxTimer/SDFLIGHT_ac_sloc.txt
+++ b/Svc/LinuxTimer/SDFLIGHT_ac_sloc.txt
@@ -1,4 +1,0 @@
-    sloc     ncsl comments       ;,   file
-     159       90       39       27   /home/tcanham/source/leonardo-fsw/Svc/LinuxTimer/LinuxTimerComponentAc.cpp
-     170       57       84       17   /home/tcanham/source/leonardo-fsw/Svc/LinuxTimer/LinuxTimerComponentAc.hpp
-     329      147      123       44  total 	[ncsl:sloc     44%]

--- a/Svc/LinuxTimer/SDFLIGHT_written_sloc.txt
+++ b/Svc/LinuxTimer/SDFLIGHT_written_sloc.txt
@@ -1,4 +1,0 @@
-    sloc     ncsl comments       ;,   file
-      62       30       22        3   /home/tcanham/source/leonardo-fsw/Svc/LinuxTimer/LinuxTimerComponentImplCommon.cpp
-      72       26       34        8   /home/tcanham/source/leonardo-fsw/Svc/LinuxTimer/LinuxTimerComponentImpl.hpp
-     134       56       56       11  total 	[ncsl:sloc     41%]

--- a/Svc/LinuxTimer/SDFLIGHT_xml_sloc.txt
+++ b/Svc/LinuxTimer/SDFLIGHT_xml_sloc.txt
@@ -1,3 +1,0 @@
-    sloc     ncsl comments       ;,   file
-      21       19        0        4   /home/tcanham/source/leonardo-fsw/Svc/LinuxTimer/LinuxTimerComponentAi.xml
-      21       19        0        4  total 	[ncsl:sloc     86%]


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3068  |


---
## Change Description
Removes 3 files that were accidentally added to the LinuxTimer directory 6 years ago.

Closes #3068 