### PR TITLE
Fix CMake CI and update workflow triggers

### DIFF
--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -8,13 +8,12 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ devel, release/** ]
-    # Only run this test when CMake files and setup change
-    paths:
-      - 'cmake/**'
-      - '**/CMakeLists.txt'
-      - '**.cmake'
-      - 'requirements.txt'
-      - ".github/workflows/cmake-test.yml"
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/actions/spelling/**'
+      - '.github/ISSUE_TEMPLATE/**'
+
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/cmake/test/src/test_ref_shared.py
+++ b/cmake/test/src/test_ref_shared.py
@@ -141,6 +141,9 @@ def test_ref_module_info(REF_BUILD):
         "SignalSetArrayAc.hpp",
         "SignalTypeEnumAc.cpp",
         "SignalTypeEnumAc.hpp",
+        'SignalGen_DpReqTypeEnumAc.cpp',
+        'SignalGen_DpReqTypeEnumAc.hpp',
+        'SignalGen_DpReqTypeEnumAi.xml',
     ]
     actual_gen = [Path(source).name for source in generated]
     assert sorted(expected_gen) == sorted(

--- a/cmake/test/src/test_ref_shared.py
+++ b/cmake/test/src/test_ref_shared.py
@@ -141,9 +141,9 @@ def test_ref_module_info(REF_BUILD):
         "SignalSetArrayAc.hpp",
         "SignalTypeEnumAc.cpp",
         "SignalTypeEnumAc.hpp",
-        'SignalGen_DpReqTypeEnumAc.cpp',
-        'SignalGen_DpReqTypeEnumAc.hpp',
-        'SignalGen_DpReqTypeEnumAi.xml',
+        "SignalGen_DpReqTypeEnumAc.cpp",
+        "SignalGen_DpReqTypeEnumAc.hpp",
+        "SignalGen_DpReqTypeEnumAi.xml",
     ]
     actual_gen = [Path(source).name for source in generated]
     assert sorted(expected_gen) == sorted(

--- a/cmake/test/src/test_unittests.py
+++ b/cmake/test/src/test_unittests.py
@@ -167,6 +167,9 @@ def test_unittest_module_ut_info(UT_BUILD):
         "SignalGenTesterBase.cpp",
         "SignalGenTesterBase.hpp",
         "SignalGenTesterHelpers.cpp",
+        'SignalGen_DpReqTypeEnumAc.cpp',
+        'SignalGen_DpReqTypeEnumAc.hpp',
+        'SignalGen_DpReqTypeEnumAi.xml',
     ]
     actual_gen = [Path(source).name for source in generated]
     assert sorted(expected_gen) == sorted(

--- a/cmake/test/src/test_unittests.py
+++ b/cmake/test/src/test_unittests.py
@@ -167,9 +167,9 @@ def test_unittest_module_ut_info(UT_BUILD):
         "SignalGenTesterBase.cpp",
         "SignalGenTesterBase.hpp",
         "SignalGenTesterHelpers.cpp",
-        'SignalGen_DpReqTypeEnumAc.cpp',
-        'SignalGen_DpReqTypeEnumAc.hpp',
-        'SignalGen_DpReqTypeEnumAi.xml',
+        "SignalGen_DpReqTypeEnumAc.cpp",
+        "SignalGen_DpReqTypeEnumAc.hpp",
+        "SignalGen_DpReqTypeEnumAi.xml",
     ]
     actual_gen = [Path(source).name for source in generated]
     assert sorted(expected_gen) == sorted(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

https://github.com/nasa/fprime/pull/2713 made changes to SignalGen which broke the CMake CI checks. This went unnoticed because the workflow trigger events were not generic enough.

Fixing the CMake tests, and making the CMake CI run on our generic suite of "everything but doc changes"
