### PR TITLE
Update old site with new site link

### DIFF
--- a/docs/_includes/toc.md
+++ b/docs/_includes/toc.md
@@ -1,3 +1,7 @@
+<h4>A new website is available!</h4>
+<h4><a href="https://fprime.jpl.nasa.gov/">Switch to the new F´ website</a></h4>
+<br>
+<hr>
 <h4><a href="/fprime/GettingStarted/README.html">Getting Started</a></h4>
   <ul>
     <li><a href="/fprime/INSTALL.html">Installing F´</a></li>

--- a/docs/_includes/toc.md
+++ b/docs/_includes/toc.md
@@ -1,4 +1,4 @@
-<h4>A new website is available!</h4>
+<h4 style="color: #fff;">A new website is available!</h4>
 <h4><a href="https://fprime.jpl.nasa.gov/">Switch to the new F´ website</a></h4>
 <br>
 <hr>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,13 @@ title: "F´ A Flight Software and Embedded Systems Framework"
 layout: default
 ---
 
+## Announcement
+A new website is now available! Find the information on the latest F Prime versions here: [Switch to the new website](https://fprime.jpl.nasa.gov/)
+
+
+
+--- 
+
 F´ (or F Prime) is a software framework for the rapid development and deployment of embedded systems and spaceflight applications.
 Originally developed at NASA's Jet Propulsion Laboratory, F´ is open-source software that has been successfully deployed
 for several space applications. It has been used for but is not limited to, CubeSats, SmallSats, instruments, and


### PR DESCRIPTION
## Change Description

- Add a notice/link to the new F Prime website in the old website's Table of Contents (`toc.md`)
- Add description of new website announcement to home page of old website

## Rationale

Redirect users looking at the old website to the new website.


Fix https://github.com/nasa/fprime/issues/3014 (last item)