### PR TITLE
Fix SignalGen commands in integration tests

### DIFF
--- a/Ref/SignalGen/SignalGen.hpp
+++ b/Ref/SignalGen/SignalGen.hpp
@@ -52,7 +52,7 @@ namespace Ref {
             U32 cmdSeq /*!< The command sequence number*/
         ) final;
 
-        //! Handler implementation for command SignalGen_Dp
+        //! Handler implementation for command Dp
         //!
         //! Signal Generator Settings
         void Dp_cmdHandler(

--- a/Ref/SignalGen/docs/sdd.md
+++ b/Ref/SignalGen/docs/sdd.md
@@ -26,7 +26,7 @@ The `Ref::SignalGen` component has the following component diagram:
 
 #### 3.1.2 Data Products
 
-The `Ref::SignalGen` component will generate data products using the `SignalGen_Dp` command.
+The `Ref::SignalGen` component will generate data products using the `Dp` command.
 It will demonstrate the two different ways to request data product buffers and will generate
 a data product based on storing a commanded number of 
 

--- a/Ref/test/int/ref_integration_test.py
+++ b/Ref/test/int/ref_integration_test.py
@@ -255,9 +255,7 @@ def test_active_logger_filter(fprime_test_api):
 
 def test_signal_generation(fprime_test_api):
     """Tests the behavior of signal gen component"""
-    fprime_test_api.send_and_assert_command(
-        "Ref.SG4.Settings", [1, 5, 0, "SQUARE"]
-    )
+    fprime_test_api.send_and_assert_command("Ref.SG4.Settings", [1, 5, 0, "SQUARE"])
     # First telemetry item should fill only the first slot of the history
     history = [0, 0, 0, 5]
     pair_history = [{"time": 0, "value": value} for value in history]

--- a/Ref/test/int/ref_integration_test.py
+++ b/Ref/test/int/ref_integration_test.py
@@ -256,17 +256,17 @@ def test_active_logger_filter(fprime_test_api):
 def test_signal_generation(fprime_test_api):
     """Tests the behavior of signal gen component"""
     fprime_test_api.send_and_assert_command(
-        "Ref.SG4.SignalGen_Settings", [1, 5, 0, "SQUARE"]
+        "Ref.SG4.Settings", [1, 5, 0, "SQUARE"]
     )
     # First telemetry item should fill only the first slot of the history
     history = [0, 0, 0, 5]
     pair_history = [{"time": 0, "value": value} for value in history]
     info = {"type": "SQUARE", "history": history, "pairHistory": pair_history}
-    fprime_test_api.send_and_assert_command("Ref.SG4.SignalGen_Toggle")
+    fprime_test_api.send_and_assert_command("Ref.SG4.Toggle")
     fprime_test_api.assert_telemetry("Ref.SG4.History", history, timeout=6)
     fprime_test_api.assert_telemetry("Ref.SG4.PairHistory", pair_history, timeout=1)
     fprime_test_api.assert_telemetry("Ref.SG4.Info", info, timeout=1)
-    fprime_test_api.send_and_assert_command("Ref.SG4.SignalGen_Toggle")
+    fprime_test_api.send_and_assert_command("Ref.SG4.Toggle")
 
 
 def test_seqgen(fprime_test_api):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

https://github.com/nasa/fprime/pull/2713 changed names of commands in SignalGen.
This fixes the integration test scripts that are testing these commands.