### PR TITLE
Do not ASSERT when notifying StubConditionVariable

### DIFF
--- a/Os/Stub/ConditionVariable.cpp
+++ b/Os/Stub/ConditionVariable.cpp
@@ -10,13 +10,17 @@ namespace Stub {
 namespace Mutex {
 
 void StubConditionVariable::wait(Os::Mutex& mutex) {
+    // This stub implementation can only be used in deployments that never need to wait on any ConditionVariable.
+    // Trigger an assertion if anyone ever tries to wait.
     FW_ASSERT(0);
 }
 void StubConditionVariable::notify() {
-    FW_ASSERT(0);
+    // Nobody is waiting, because we assert if anyone tries to wait.
+    // Therefore, we can notify all waiters by doing nothing.
 }
 void StubConditionVariable::notifyAll() {
-    FW_ASSERT(0);
+    // Nobody is waiting, because we assert if anyone tries to wait.
+    // Therefore, we can notify all waiters by doing nothing.
 }
 
 ConditionVariableHandle* StubConditionVariable::getHandle() {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| no |
|**_Documentation Included (y/n)_**| n/a |

---
## Change Description

This change modifies the existing StubConditionVariable to not assert if `notify` or `notifyAll` is called. It retains the assertion if `wait` is called.

## Rationale

**Background**: Linking any F Prime deployment requires an implementation of every OS interface, including OS interfaces never actually used in that deployment. Stub implementations of these interfaces, such as StubConditionVariable, are provided for platforms that do not have these OS features and do not need the associated functionality. StubConditionVariable asserts if any of its functions are called, which helps OS-free deployments "fail fast" if they unintentionally call functions that are not provided on the current platform.

**Why I propose this PR:** I have an OS-free deployment that solely uses passive and queued components. I have no need for condition variables, because nothing will ever wait on them. However, I want to use `Os/Generic/PriorityQueue`, which calls `ConditionVariable::notify` even if I only ever use it in NONBLOCKING mode. So I provide my own implementation of `ConditionVariable` that does nothing in the case of `notify` or `notifyAll`, but still asserts if `ConditionVariable::wait` is ever called.

**Proposal**: I suggest that the F Prime core could switch to my stub implementation instead of the current stub implementation without breaking any existing code. By doing so, it would simplify the implementation of OS-free deployments that solely use passive and queued components. This PR alters the default stub implementation to the implementation I use.

**Why this PR is OK:** This PR works because the `notify` and `notifyAll` calls on a condition variable are equivalent to a No-Op if there are no waiters. Since the `wait` function is never called (or else it would assert), there are never any waiters. This means that a safe implementation of `notify` and `notifyAll` is to do nothing.

1. This PR does not break any existing code, because any working existing codebase does not call `notify` or `notifyAll`. If it did call either of these functions, it would have asserted. So no working existing codebase will change behavior as a result of this PR.
2. This PR does introduce the possibility that future code that mistakenly calls `notify` or `notifyAll` would not be easily detected. However, if there is never any call to `wait`, using this implementation of `notify` or `notifyAll` will never matter. If there ever is any call to `wait`, it will still result in an assertion.

**Alternatives considered:** I can't simply use the ConditionVariable implementation provided by https://github.com/fprime-community/fprime-baremetal/, because it won't assert if `wait` is accidentally called.

Let me know your opinion on this proposed change in behavior for StubConditionVariable. I am filing the proposal directly as a PR instead of an issue because it is easier to explain the proposal with the real patch.

## Testing/Review Recommendations

No specific recommendations.

## Future Work

I may have further comments in the future on the stub `Mutex` implementation.
