### PR TITLE
Fix LinuxGpioDriver build w/ disabled object names

### DIFF
--- a/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
@@ -139,7 +139,7 @@ Os::File::Status LinuxGpioDriver ::setupLineHandle(const PlatformIntType chip_de
     struct gpiohandle_request request;
     (void) ::memset(&request, 0, sizeof request);
     request.lineoffsets[0] = gpio;
-    Fw::StringUtils::string_copy(request.consumer_label, this->getObjName(),
+    Fw::StringUtils::string_copy(request.consumer_label, FW_OPTIONAL_NAME(this->getObjName()),
                                  static_cast<FwSizeType>(sizeof request.consumer_label));
     request.default_values[0] = (default_state == Fw::Logic::HIGH) ? 1 : 0;
     request.fd = -1;
@@ -165,7 +165,7 @@ Os::File::Status LinuxGpioDriver ::setupLineEvent(const PlatformIntType chip_des
     struct gpioevent_request event;
     (void) ::memset(&event, 0, sizeof event);
     event.lineoffset = gpio;
-    Fw::StringUtils::string_copy(event.consumer_label, this->getObjName(),
+    Fw::StringUtils::string_copy(event.consumer_label, FW_OPTIONAL_NAME(this->getObjName()),
                                  static_cast<FwSizeType>(sizeof event.consumer_label));
     event.fd = -1;
     event.handleflags = configuration_to_handler_flags(configuration);

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverCommon.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverCommon.cpp
@@ -34,7 +34,7 @@ Drv::GpioStatus LinuxGpioDriver ::start(const FwSizeType priority,
             this->m_running = true;
         }
         Fw::String name;
-        name.format("%s.interrupt", this->getObjName());
+        name.format("%s.interrupt", FW_OPTIONAL_NAME(this->getObjName()));
         Os::Task::Arguments arguments(name, &this->interruptFunction, this, priority, stackSize, cpuAffinity,
                                       identifier);
         this->m_poller.start(arguments);


### PR DESCRIPTION

| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

When F Prime is configured with FW_OBJECT_NAMES == 0, the getObjName() function is not available, which causes a failure to build. Use FW_OPTIONAL_NAME to allow LinuxGpioDriver to build.

## Rationale

Allows projects that set FW_OBJECT_NAMES to 0 to run `fprime-util build native` on their root directory without issue.

## Testing/Review Recommendations

There's an argument for using a better replacement than an empty string when object names are omitted, but I'm not sure it matters very much.

## Future Work

It would be nice to have a Linux platform with FW_OBJECT_NAMES == 0 be included in CI to avoid problems like this from cropping up in the future.
