### PR TITLE
Add fix for xml entities not working

### DIFF
--- a/Autocoders/Python/bin/tlm_packet_gen.py
+++ b/Autocoders/Python/bin/tlm_packet_gen.py
@@ -260,7 +260,7 @@ class TlmPacketParser(object):
             raise TlmPacketParseIOError("File %s does not exist!" % xml_filename)
 
         fd = open(xml_filename, "r")
-        xml_parser = etree.XMLParser(remove_comments=True)
+        xml_parser = etree.XMLParser(remove_comments=True, load_dtd=True, resolve_entities=True, no_network=True)
         element_tree = etree.parse(fd, parser=xml_parser)
         channel_size_dict = None
 

--- a/Autocoders/Python/bin/tlm_packet_gen.py
+++ b/Autocoders/Python/bin/tlm_packet_gen.py
@@ -260,7 +260,9 @@ class TlmPacketParser(object):
             raise TlmPacketParseIOError("File %s does not exist!" % xml_filename)
 
         fd = open(xml_filename, "r")
-        xml_parser = etree.XMLParser(remove_comments=True, load_dtd=True, resolve_entities=True, no_network=True)
+        xml_parser = etree.XMLParser(
+            remove_comments=True, load_dtd=True, resolve_entities=True, no_network=True
+        )
         element_tree = etree.parse(fd, parser=xml_parser)
         channel_size_dict = None
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3111 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
See #3111 
Tested locally. Would be ideal if someone can replicate the issue briefly and test this single line fix.
Instructions:
1. Create a packets.xml as defined in the above issue
2. Make sure lxml version is 5.3.0
3. Try to build
4. See that it fails without this fix, and works with it