### PR TITLE
Add os supplied cmake wrapper

### DIFF
--- a/Os/CMakeLists.txt
+++ b/Os/CMakeLists.txt
@@ -48,6 +48,22 @@ endfunction()
 function(add_fprime_supplied_os_module NAMES SUFFIX)
     # Get first element of list
     list(GET NAMES 0 FIRST_ITEM)
+
+    # Ensure expected files with expected filenames exist
+    if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/Default${FIRST_ITEM}.cpp")
+        message(FATAL_ERROR "${CMAKE_CURRENT_LIST_DIR}/Default${FIRST_ITEM}.cpp does not exist.")
+    endif()
+
+    foreach (NAME IN LISTS NAMES)
+        if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/${NAME}.cpp")
+            message(FATAL_ERROR "${CMAKE_CURRENT_LIST_DIR}/${NAME}.cpp does not exist.")
+        endif()
+        if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/${NAME}.hpp")
+            message(FATAL_ERROR "${CMAKE_CURRENT_LIST_DIR}/${NAME}.hpp does not exist.")
+        endif()
+    endforeach()
+
+    # Setup variables
     set(OS_MODULE_NAME "Os_${FIRST_ITEM}_${SUFFIX}")
     # Clear variables
     set(SOURCE_FILES)

--- a/Os/Darwin/CMakeLists.txt
+++ b/Os/Darwin/CMakeLists.txt
@@ -8,8 +8,8 @@
 restrict_platforms(Darwin)
 add_custom_target("${FPRIME_CURRENT_MODULE}")
 
-add_fprime_supplied_os_module(Cpu Darwin)
-add_fprime_supplied_os_module(Memory Darwin)
+register_os_implementation(Cpu Darwin)
+register_os_implementation(Memory Darwin)
 
 # -----------------------------------------
 ### Os/Darwin/Cpu Section

--- a/Os/Linux/CMakeLists.txt
+++ b/Os/Linux/CMakeLists.txt
@@ -8,8 +8,8 @@
 restrict_platforms(Linux)
 add_custom_target("${FPRIME_CURRENT_MODULE}")
 
-add_fprime_supplied_os_module(Cpu Linux)
-add_fprime_supplied_os_module(Memory Linux)
+register_os_implementation(Cpu Linux)
+register_os_implementation(Memory Linux)
 
 # -----------------------------------------
 ### Os/Linux/Cpu Section

--- a/Os/Posix/CMakeLists.txt
+++ b/Os/Posix/CMakeLists.txt
@@ -22,11 +22,11 @@ set(MOD_DEPS config)
 register_fprime_module(Os_Posix_Shared)
 
 # Set up Posix implementations
-add_fprime_supplied_os_module("File;FileSystem;Directory" Posix Os_Posix_Shared)
-add_fprime_supplied_os_module("Console" Posix)
-add_fprime_supplied_os_module("Task" Posix Os_Posix_Shared Fw_Time)
-add_fprime_supplied_os_module("Mutex;ConditionVariable" Posix Os_Posix_Shared)
-add_fprime_supplied_os_module("RawTime" Posix Os_Posix_Shared)
+register_os_implementation("File;FileSystem;Directory" Posix Os_Posix_Shared)
+register_os_implementation("Console" Posix)
+register_os_implementation("Task" Posix Os_Posix_Shared Fw_Time)
+register_os_implementation("Mutex;ConditionVariable" Posix Os_Posix_Shared)
+register_os_implementation("RawTime" Posix Os_Posix_Shared)
 
 # -----------------------------------------
 ### Os/File/Posix Test Section

--- a/Os/Stub/CMakeLists.txt
+++ b/Os/Stub/CMakeLists.txt
@@ -7,14 +7,14 @@
 ####
 add_custom_target("${FPRIME_CURRENT_MODULE}")
 
-add_fprime_supplied_os_module("File;FileSystem;Directory" Stub)
-add_fprime_supplied_os_module(Console Stub)
-add_fprime_supplied_os_module(Task Stub)
-add_fprime_supplied_os_module("Mutex;ConditionVariable" Stub)
-add_fprime_supplied_os_module(Cpu Stub)
-add_fprime_supplied_os_module(Memory Stub)
-add_fprime_supplied_os_module(Queue Stub)
-add_fprime_supplied_os_module(RawTime Stub)
+register_os_implementation("File;FileSystem;Directory" Stub)
+register_os_implementation(Console Stub)
+register_os_implementation(Task Stub)
+register_os_implementation("Mutex;ConditionVariable" Stub)
+register_os_implementation(Cpu Stub)
+register_os_implementation(Memory Stub)
+register_os_implementation(Queue Stub)
+register_os_implementation(RawTime Stub)
 
 # Remainder of file is specific to UTs
 if (NOT BUILD_TESTING)

--- a/Os/Stub/test/CMakeLists.txt
+++ b/Os/Stub/test/CMakeLists.txt
@@ -10,14 +10,14 @@ if (NOT BUILD_TESTING)
 endif ()
 add_custom_target("${FPRIME_CURRENT_MODULE}")
 
-add_fprime_supplied_os_module("File;FileSystem;Directory" Test_Stub)
-add_fprime_supplied_os_module(Console Test_Stub)
-add_fprime_supplied_os_module(Task Test_Stub)
-add_fprime_supplied_os_module("Mutex;ConditionVariable" Test_Stub)
-add_fprime_supplied_os_module(Cpu Test_Stub)
-add_fprime_supplied_os_module(Memory Test_Stub)
-add_fprime_supplied_os_module(Queue Test_Stub)
-add_fprime_supplied_os_module(RawTime Test_Stub) # add Fw_Buffer here?
+register_os_implementation("File;FileSystem;Directory" Test_Stub)
+register_os_implementation(Console Test_Stub)
+register_os_implementation(Task Test_Stub)
+register_os_implementation("Mutex;ConditionVariable" Test_Stub)
+register_os_implementation(Cpu Test_Stub)
+register_os_implementation(Memory Test_Stub)
+register_os_implementation(Queue Test_Stub)
+register_os_implementation(RawTime Test_Stub) # add Fw_Buffer here?
 
 #### File Stub Testing ####
 set(UT_SOURCE_FILES

--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -645,6 +645,25 @@ function(register_fprime_implementation IMPLEMENTATION IMPLEMENTOR)
 endfunction()
 
 ####
+# Adds a named os implementation.
+#
+# Assumptions:
+#   1. NAMES is a list of 1 or more named files separated by ;
+#   2. There exists a file named Default${FIRST_ITEM}, where FIRST_ITEM is the first element in NAME, in the same
+#       directory where this cmake function was called
+#   3. For each item e listed in NAMES, there exists a file called ${e}.hpp and ${e}.cpp in the same directory
+#       where this cmake function was called
+#
+# NAMES: list of named files to add to this module.  The first will be treated as the name of the module.
+#        i.e. File;Directory;FileSystem will contain the file, directory, and filesystem files in a module called File.
+# SUFFIX: suffix to implementation (e.g. Posix)
+# ARGN: extra MOD_DEPS to add (e.g. Fw_Time)
+####
+function(register_os_implementation NAMES SUFFIX)
+    add_fprime_supplied_os_module("${NAMES}" "${SUFFIX}" "${ARGN}")
+endfunction()
+
+####
 # Function `choose_fprime_implementation`:
 #
 # Designates that the given implementor is the selected implementor for the needed implementation. Platforms must call


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Added wrapper to an internal cmake function.

## Rationale

This wrapper function simplifies cmake files within external OSAL's cmakelist files.

## Testing/Review Recommendations

Make sure CI passes.

## Future Work

Note any additional work that will be done relating to this issue.
