### PR TITLE
LinuxGpioDriver: fix static_assert's for FwSizeType. Possible fix for #3030

### DIFF
--- a/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
@@ -20,6 +20,7 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <cerrno>
+#include <type_traits>
 
 namespace Drv {
 
@@ -287,9 +288,13 @@ Drv::GpioStatus LinuxGpioDriver ::gpioWrite_handler(const NATIVE_INT_TYPE portNu
 }
 
 void LinuxGpioDriver ::pollLoop() {
-    static_assert(GPIO_POLL_TIMEOUT < std::numeric_limits<int>::max(), "Poll timeout would overflow");
+    // Ensure size of FwSizeType is large enough to fit the necessary ranges
+    // NOTE: casts to unsigned types for int and ssize_t are made to avoid sign-compare warning;
+    //       in both cases the cast is safe because max() returns nonnegative value.
+    static_assert(GPIO_POLL_TIMEOUT < static_cast<unsigned int>(std::numeric_limits<int>::max()), "Poll timeout would overflow");
     static_assert(sizeof(struct gpioevent_data) < std::numeric_limits<FwSizeType>::max(), "FwSizeType too small");
-    static_assert(std::numeric_limits<ssize_t>::max() <= std::numeric_limits<FwSizeType>::max(), "FwSizeType too small");
+    typedef std::make_unsigned<ssize_t>::type unsigned_ssize;
+    static_assert(static_cast<unsigned_ssize>(std::numeric_limits<ssize_t>::max()) <= std::numeric_limits<FwSizeType>::max(), "FwSizeType too small");
     // Setup poll information
     pollfd file_descriptors[1];
     // Loop forever

--- a/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
@@ -293,8 +293,8 @@ void LinuxGpioDriver ::pollLoop() {
     //       in both cases the cast is safe because max() returns nonnegative value.
     static_assert(GPIO_POLL_TIMEOUT < static_cast<unsigned int>(std::numeric_limits<int>::max()), "Poll timeout would overflow");
     static_assert(sizeof(struct gpioevent_data) < std::numeric_limits<FwSizeType>::max(), "FwSizeType too small");
-    typedef std::make_unsigned<ssize_t>::type unsigned_ssize;
-    static_assert(static_cast<unsigned_ssize>(std::numeric_limits<ssize_t>::max()) <= std::numeric_limits<FwSizeType>::max(), "FwSizeType too small");
+    typedef std::make_unsigned<ssize_t>::type unsigned_ssize_t;
+    static_assert(static_cast<unsigned_ssize_t>(std::numeric_limits<ssize_t>::max()) <= std::numeric_limits<FwSizeType>::max(), "FwSizeType too small");
     // Setup poll information
     pollfd file_descriptors[1];
     // Loop forever

--- a/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
@@ -293,7 +293,7 @@ void LinuxGpioDriver ::pollLoop() {
     //       in both cases the cast is safe because max() returns nonnegative value.
     static_assert(GPIO_POLL_TIMEOUT < static_cast<unsigned int>(std::numeric_limits<int>::max()), "Poll timeout would overflow");
     static_assert(sizeof(struct gpioevent_data) < std::numeric_limits<FwSizeType>::max(), "FwSizeType too small");
-    typedef std::make_unsigned<ssize_t>::type unsigned_ssize_t;
+    using unsigned_ssize_t = std::make_unsigned<ssize_t>::type;
     static_assert(static_cast<unsigned_ssize_t>(std::numeric_limits<ssize_t>::max()) <= std::numeric_limits<FwSizeType>::max(), "FwSizeType too small");
     // Setup poll information
     pollfd file_descriptors[1];


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#3030 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

A possible fix to avoid warning for signed/unsigned comparison in LinuxGpioDriver.
The signed max() values are cast to corresponding unsigned types. The cast is safe because max() returns nonnegative value which shall fit to unsigned type.

## Rationale

Possible fix for issue nasa/fprime#3030.

## Testing/Review Recommendations

Steps to reproduce and test:
1. cd to the top level directory of the fprime repo
2. fprime-util generate -f
3. fprime-util build

There should be no build errors.

## Future Work

N/A.
