### PR TITLE
Switch bootstrap tests to project lib structure

### DIFF
--- a/.github/workflows/cookiecutters-test.yml
+++ b/.github/workflows/cookiecutters-test.yml
@@ -53,14 +53,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-          path: ./MyProject/fprime
+          path: ./MyProject/lib/fprime
           fetch-depth: 0
 
       - name: "Update dependencies and install fprime-tools@devel"
         run: |
              cd MyProject
              . fprime-venv/bin/activate
-             pip install -U -r ./fprime/requirements.txt
+             pip install -U -r ./lib/fprime/requirements.txt
              pip install git+https://github.com/nasa/fprime-tools@devel
 
       - name: "Version Check"

--- a/.github/workflows/cookiecutters-test.yml
+++ b/.github/workflows/cookiecutters-test.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
              cd MyProject
              . fprime-venv/bin/activate
-             expect ./fprime/.github/actions/cookiecutter-check/deployment.expect
+             expect ./lib/fprime/.github/actions/cookiecutter-check/deployment.expect
              cd MyDeployment
              fprime-util build -j4
 
@@ -88,6 +88,6 @@ jobs:
         run: |
              cd MyProject
              . fprime-venv/bin/activate
-             expect ./fprime/.github/actions/cookiecutter-check/component.expect
+             expect ./lib/fprime/.github/actions/cookiecutter-check/component.expect
              cd MyComponent
              fprime-util build -j4


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

https://github.com/fprime-community/fprime-bootstrap/pull/14 switches `fprime-bootstrap` to the preferred `./lib/fprime/` structure (`fprime` submodule is within `lib/` folder rather than at top level of project).

This PR adapts the bootstrap test so that it functions correctly with regards to the above change.
