### PR TITLE
Integrating SBOM generation into CMake

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -806,6 +806,7 @@ saveop
 sbb
 SBF
 SBINDIR
+sbom
 Scatterometer
 scc
 schematron
@@ -866,6 +867,7 @@ sourceforge
 Sourcetrail
 sourcing
 spacetech
+spdx
 SPHINXBUILD
 SPHINXOPTS
 spi

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -907,6 +907,7 @@ suseconds
 SVCLOGFILE
 SVCLOGFILEL
 swcaegitadmin
+syft
 synchronicity
 synopsys
 sysconf

--- a/cmake/FPrime.cmake
+++ b/cmake/FPrime.cmake
@@ -125,6 +125,7 @@ macro(fprime_setup_standard_targets)
         register_fprime_target(target/version)
         register_fprime_target(target/install)
         register_fprime_ut_target(target/ut)
+        register_fprime_target(target/sbom)
 
         if (FPRIME_ENABLE_UTIL_TARGETS)
             register_fprime_target(target/refresh_cache)

--- a/cmake/target/sbom.cmake
+++ b/cmake/target/sbom.cmake
@@ -1,0 +1,49 @@
+####
+# cmake/target/sbom.cmake:
+#
+# A target used to add SBOM generation to the build. Will be invoked when running the "all" target
+# and installed into the build_artifacts directory underneath the platform folder.
+####
+set(REDIRECTOR "${CMAKE_CURRENT_LIST_DIR}/tools/redirector.py")
+
+####
+# sbom_add_global_target:
+# 
+# Used to register a global target that will build with "all" and generates the SBOM.
+#
+# TODO: will this install correctly, or do I need an install global target?
+#####
+function(sbom_add_global_target TARGET)
+    find_program(SYFT NAMES syft)
+    # Check if syft is available before running
+    if (SYFT)
+        add_custom_target("${TARGET}" ALL
+            COMMAND
+            # Redirector to cleanly capture standard out
+            ${PYTHON} ${REDIRECTOR} "${CMAKE_BINARY_DIR}/${PROJECT_NAME}_sbom.json"
+            # syft arguments
+            "${SYFT}" "dir:${FPRIME_PROJECT_ROOT}" -o spdx-json
+            # Excludes .github paths not in the root of the project as those should not be activated by the project
+            --exclude '*/**/.github'
+            DEPENDS $<TARGET_PROPERTY:${TARGET},SBOM_DEPENDENCIES>
+        )
+        # Install the SBOM file
+        install(FILES "${CMAKE_BINARY_DIR}/${PROJECT_NAME}_sbom.json" DESTINATION ${TOOLCHAIN_NAME} COMPONENT ${TARGET})
+        add_custom_command(TARGET "${TARGET}" POST_BUILD COMMAND "${CMAKE_COMMAND}"
+                          -DCMAKE_INSTALL_COMPONENT=${TARGET} -P ${CMAKE_BINARY_DIR}/cmake_install.cmake)
+    else()
+        message(STATUS "[INFO] to find 'syft' on PATH, please install to generate software bill-of-materials")
+    endif()
+endfunction()
+
+# For deployments
+function(sbom_add_deployment_target MODULE TARGET SOURCES DEPENDENCIES FULL_DEPENDENCIES)
+    append_list_property("${MODULE}" TARGET "${TARGET}" PROPERTY SBOM_DEPENDENCIES)
+    get_property(VAR1 TARGET "${TARGET}" PROPERTY SBOM_DEPENDENCIES)
+endfunction()
+
+# Used to register all modules
+function(sbom_add_module_target MODULE TARGET SOURCE_FILES DEPENDENCIES)
+    append_list_property("${MODULE}" TARGET "${TARGET}" PROPERTY SBOM_DEPENDENCIES)
+    get_property(VAR1 TARGET "${TARGET}" PROPERTY SBOM_DEPENDENCIES)
+endfunction()

--- a/cmake/target/sbom.cmake
+++ b/cmake/target/sbom.cmake
@@ -11,7 +11,6 @@ set(REDIRECTOR "${CMAKE_CURRENT_LIST_DIR}/tools/redirector.py")
 # 
 # Used to register a global target that will build with "all" and generates the SBOM.
 #
-# TODO: will this install correctly, or do I need an install global target?
 #####
 function(sbom_add_global_target TARGET)
     find_program(SYFT NAMES syft)
@@ -19,7 +18,7 @@ function(sbom_add_global_target TARGET)
     if (SYFT)
         add_custom_target("${TARGET}" ALL
             COMMAND
-            # Redirector to cleanly capture standard out
+            # Redirect to cleanly capture standard out
             ${PYTHON} ${REDIRECTOR} "${CMAKE_BINARY_DIR}/${PROJECT_NAME}_sbom.json"
             # syft arguments
             "${SYFT}" "dir:${FPRIME_PROJECT_ROOT}" -o spdx-json
@@ -38,12 +37,14 @@ endfunction()
 
 # For deployments
 function(sbom_add_deployment_target MODULE TARGET SOURCES DEPENDENCIES FULL_DEPENDENCIES)
-    append_list_property("${MODULE}" TARGET "${TARGET}" PROPERTY SBOM_DEPENDENCIES)
-    get_property(VAR1 TARGET "${TARGET}" PROPERTY SBOM_DEPENDENCIES)
+    if (TARGET "${TARGET}")
+        append_list_property("${MODULE}" TARGET "${TARGET}" PROPERTY SBOM_DEPENDENCIES)
+    endif()
 endfunction()
 
 # Used to register all modules
 function(sbom_add_module_target MODULE TARGET SOURCE_FILES DEPENDENCIES)
-    append_list_property("${MODULE}" TARGET "${TARGET}" PROPERTY SBOM_DEPENDENCIES)
-    get_property(VAR1 TARGET "${TARGET}" PROPERTY SBOM_DEPENDENCIES)
+    if (TARGET "${TARGET}")
+        append_list_property("${MODULE}" TARGET "${TARGET}" PROPERTY SBOM_DEPENDENCIES)
+    endif()
 endfunction()

--- a/docs/documentation/user-manual/index.md
+++ b/docs/documentation/user-manual/index.md
@@ -19,5 +19,8 @@ In-depth user guide and language specification for FPP
 ## __Ground Data System (GDS)__
 Dive into the F´ GDS and its testing framework
 
+## __Security__
+Security documentation spanning the F Prime ecosystem
+
 ## __Design__
 Explanation of the F Prime architecture and design philosophies

--- a/docs/documentation/user-manual/security/software-bill-of-materials.md
+++ b/docs/documentation/user-manual/security/software-bill-of-materials.md
@@ -1,0 +1,31 @@
+# Software Bill Of Materials Generation
+
+A software bill of materials is a record of the software that constitutes a product. F Prime will automatically generate a Bill of Materials for a your project as part of the build system. Generation requires the `syft` tool to be installed.
+
+## Running Software Bill of Materials
+
+To generate the software bill of material you must first install [`syft`](https://github.com/anchore/syft). Follow the instruction in the README to install `syft` and ensure that it is on the PATH.
+
+Once `syft` is installed the path, your software bill of materials will be installed in the `build-artifacts/` folder.
+
+## Details and Idiosyncrasies
+
+F Prime uses the `spdx-json` format for the bill of materials using the `syft` tool. It will capture software tools installed in the filesystem rooted at the project root. This will include python installations, `requirements.txt` packages, and various other tools detectable by `syft`.
+
+To see the full catalog run `syft cataloger list`.
+
+>[!WARNING]
+> `cmake` and your C++ compiler are not likely installed within the project file system. To generate a bill of materials including these external tools, you will need to build a container to build your product and scan that container.
+
+## Scanning for Vulnerabilities
+
+To scan for vulnerabilities in the bill of materials, you must first install [`grype`](https://github.com/anchore/grype). Follow the instructions in the README to install `grype` and ensure it is on the PATH.
+
+Once `grype` is installed, you can scan the bill of materials using the following command.
+
+```
+grype ./build-artifacts/*_sbom.json
+```
+
+![WARNING]
+! `grype` is just one tool to look for vulnerabilities in your project. Vulnerabilities may be found by other means.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -303,6 +303,8 @@ nav:
         - 'GDS Dashboard Reference': documentation/user-manual/gds/gds-dashboard-reference.md
         - 'Integration Test API': documentation/user-manual/gds/gds-test-api-guide.md
         - 'Sequencing in F´': documentation/user-manual/gds/seqgen.md
+      - Security:
+        - 'Software Bill of Materials Generation': documentation/user-manual/security/software-bill-of-materials.md
       - Design:
         - 'F´ Software Architecture': documentation/user-manual/design/fprime-architecture.md
         - 'Numerical Types Design': documentation/user-manual/design/numerical-types.md


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds in automatic SBOM generation to the F Prime build when syft is installed!

Since `cmake` and `c++` are outside of the fprime package, it cannot detect those two dependencies.  If this is needed on a project, then it would be advisable to build a standard build container for the product and run SBOM against that container, then merge it with the results here.