### PR TITLE
UDP does not bind on send only port. Fixes: #3127

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -259,6 +259,7 @@ dps
 DPWRITER
 DRAINBUFFERS
 drv
+drvtcpserversocket
 dsdl
 dspal
 Dstate

--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -75,8 +75,8 @@ class IpSocket {
      * \param send_timeout_microseconds: send timeout microseconds portion. Must be less than 1000000
      * \return status of configure
      */
-    SocketIpStatus configure(const char* hostname, const U16 port, const U32 send_timeout_seconds,
-                             const U32 send_timeout_microseconds);
+    virtual SocketIpStatus configure(const char* hostname, const U16 port, const U32 send_timeout_seconds,
+                                     const U32 send_timeout_microseconds);
 
     /**
      * \brief open the IP socket for communications

--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -44,7 +44,8 @@ enum SocketIpStatus {
     SOCK_FAILED_TO_READ_BACK_PORT = -15,     //!< Failed to read back port from connection
     SOCK_NO_DATA_AVAILABLE = -16,            //!< No data available or read operation would block
     SOCK_ANOTHER_THREAD_OPENING = -17,       //!< Another thread is opening
-    SOCK_AUTO_CONNECT_DISABLED = -18          //!< Automatic connections are disabled
+    SOCK_AUTO_CONNECT_DISABLED = -18,        //!< Automatic connections are disabled
+    SOCK_INVALID_CALL = -19                  //!< Operation is invalid
 };
 
 /**

--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -43,7 +43,8 @@ enum SocketIpStatus {
     SOCK_NOT_STARTED = -14,                  //!< Socket has not been started
     SOCK_FAILED_TO_READ_BACK_PORT = -15,     //!< Failed to read back port from connection
     SOCK_NO_DATA_AVAILABLE = -16,            //!< No data available or read operation would block
-    SOCK_ANOTHER_THREAD_OPENING = -17        //!< Another thread is opening
+    SOCK_ANOTHER_THREAD_OPENING = -17,       //!< Another thread is opening
+    SOCK_AUTOCONNECT_DISABLED = -18          //!< Automatic connections are disabled
 };
 
 /**

--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -44,7 +44,7 @@ enum SocketIpStatus {
     SOCK_FAILED_TO_READ_BACK_PORT = -15,     //!< Failed to read back port from connection
     SOCK_NO_DATA_AVAILABLE = -16,            //!< No data available or read operation would block
     SOCK_ANOTHER_THREAD_OPENING = -17,       //!< Another thread is opening
-    SOCK_AUTOCONNECT_DISABLED = -18          //!< Automatic connections are disabled
+    SOCK_AUTO_CONNECT_DISABLED = -18          //!< Automatic connections are disabled
 };
 
 /**

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -28,7 +28,7 @@ void SocketComponentHelper::start(const Fw::StringBase &name,
                                      const Os::Task::ParamType cpuAffinity) {
     FW_ASSERT(m_task.getState() == Os::Task::State::NOT_STARTED);  // It is a coding error to start this task multiple times
     this->m_stop = false;
-    m_reconnect = reconnect;
+    this->setAutoconnect(reconnect);
     // Note: the first step is for the IP socket to open the port
     Os::Task::Arguments arguments(name, SocketComponentHelper::readTask, this, priority, stack, cpuAffinity);
     Os::Task::Status stat = m_task.start(arguments);
@@ -77,13 +77,28 @@ bool SocketComponentHelper::isOpened() {
     return is_open;
 }
 
+void SocketComponentHelper::setAutoConnect(bool auto_connect) {
+    Os::ScopeLock scopedLock(this->m_lock);
+    this->m_reconnect = auto_connect;
+}
+
 SocketIpStatus SocketComponentHelper::reconnect() {
     SocketIpStatus status = SOCK_SUCCESS;
-    // Open a network connection if it has not already been open
     if (not this->isOpened()) {
-        status = this->open();
-        if (status == SocketIpStatus::SOCK_ANOTHER_THREAD_OPENING) {
-            status = SocketIpStatus::SOCK_SUCCESS;
+        // Check for autoconnect before attempting to reconnect
+        bool reconnect = false;
+        {
+            Os::ScopeLock scopedLock(this->m_lock);
+            reconnect = this->m_reconnect;
+        }
+        // Open a network connection if it has not already been open
+        if (not reconnect) {
+            status = SOCK_AUTOCONNECT_DISABLED;
+        } else {
+            status = this->open();
+            if (status == SocketIpStatus::SOCK_ANOTHER_THREAD_OPENING) {
+                status = SocketIpStatus::SOCK_SUCCESS;
+            }
         }
     }
     return status;

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -85,7 +85,7 @@ void SocketComponentHelper::setAutoConnect(bool auto_connect) {
 SocketIpStatus SocketComponentHelper::reconnect() {
     SocketIpStatus status = SOCK_SUCCESS;
     if (not this->isOpened()) {
-        // Check for autoconnect before attempting to reconnect
+        // Check for auto-connect before attempting to reconnect
         bool reconnect = false;
         {
             Os::ScopeLock scopedLock(this->m_lock);
@@ -213,7 +213,7 @@ void SocketComponentHelper::readLoop() {
             this->sendBuffer(buffer, status);
         }
     }
-    // This will loop until stopped. If autoconnect is disabled, this will break at the moment of reconnect
+    // This will loop until stopped. If auto-connect is disabled, this will break at the moment of reconnect
     while (this->running());
     // Close the socket
     this->close(); // Close the port entirely

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -93,7 +93,7 @@ SocketIpStatus SocketComponentHelper::reconnect() {
         }
         // Open a network connection if it has not already been open
         if (not reconnect) {
-            status = SOCK_AUTOCONNECT_DISABLED;
+            status = SOCK_AUTO_CONNECT_DISABLED;
         } else {
             status = this->open();
             if (status == SocketIpStatus::SOCK_ANOTHER_THREAD_OPENING) {
@@ -182,7 +182,7 @@ void SocketComponentHelper::readLoop() {
         if ((not this->isOpened()) and this->running()) {
             status = this->reconnect();
             // When reconnect is disabled, just break as this is a exit condition for the loop
-            if (status == SOCK_AUTOCONNECT_DISABLED) {
+            if (status == SOCK_AUTO_CONNECT_DISABLED) {
                 break;
             }
             // If the reconnection failed in any other way, warn, wait, and retry

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -22,13 +22,11 @@ SocketComponentHelper::SocketComponentHelper() {}
 SocketComponentHelper::~SocketComponentHelper() {}
 
 void SocketComponentHelper::start(const Fw::StringBase &name,
-                                     const bool reconnect,
-                                     const Os::Task::ParamType priority,
-                                     const Os::Task::ParamType stack,
-                                     const Os::Task::ParamType cpuAffinity) {
+                                  const Os::Task::ParamType priority,
+                                  const Os::Task::ParamType stack,
+                                  const Os::Task::ParamType cpuAffinity) {
     FW_ASSERT(m_task.getState() == Os::Task::State::NOT_STARTED);  // It is a coding error to start this task multiple times
     this->m_stop = false;
-    this->setAutoConnect(reconnect);
     // Note: the first step is for the IP socket to open the port
     Os::Task::Arguments arguments(name, SocketComponentHelper::readTask, this, priority, stack, cpuAffinity);
     Os::Task::Status stat = m_task.start(arguments);
@@ -77,22 +75,22 @@ bool SocketComponentHelper::isOpened() {
     return is_open;
 }
 
-void SocketComponentHelper::setAutoConnect(bool auto_connect) {
+void SocketComponentHelper::setAutomaticOpen(bool auto_open) {
     Os::ScopeLock scopedLock(this->m_lock);
-    this->m_reconnect = auto_connect;
+    this->m_reopen = auto_open;
 }
 
-SocketIpStatus SocketComponentHelper::reconnect() {
+SocketIpStatus SocketComponentHelper::reopen() {
     SocketIpStatus status = SOCK_SUCCESS;
     if (not this->isOpened()) {
-        // Check for auto-connect before attempting to reconnect
-        bool reconnect = false;
+        // Check for auto-open before attempting to reopen
+        bool reopen = false;
         {
             Os::ScopeLock scopedLock(this->m_lock);
-            reconnect = this->m_reconnect;
+            reopen = this->m_reopen;
         }
         // Open a network connection if it has not already been open
-        if (not reconnect) {
+        if (not reopen) {
             status = SOCK_AUTO_CONNECT_DISABLED;
         } else {
             status = this->open();
@@ -111,12 +109,12 @@ SocketIpStatus SocketComponentHelper::send(const U8* const data, const U32 size)
     this->m_lock.unlock();
     // Prevent transmission before connection, or after a disconnect
     if (descriptor.fd == -1) {
-        status = this->reconnect();
-        // if reconnect wasn't successful, pass the that up to the caller
+        status = this->reopen();
+        // if reopen wasn't successful, pass the that up to the caller
         if(status != SOCK_SUCCESS) {
             return status;
         }
-        // Refresh local copy after reconnect
+        // Refresh local copy after reopen
         this->m_lock.lock();
         descriptor = this->m_descriptor;
         this->m_lock.unlock();
@@ -180,8 +178,8 @@ void SocketComponentHelper::readLoop() {
     do {
         // Prevent transmission before connection, or after a disconnect
         if ((not this->isOpened()) and this->running()) {
-            status = this->reconnect();
-            // When reconnect is disabled, just break as this is a exit condition for the loop
+            status = this->reopen();
+            // When reopen is disabled, just break as this is a exit condition for the loop
             if (status == SOCK_AUTO_CONNECT_DISABLED) {
                 break;
             }
@@ -213,7 +211,7 @@ void SocketComponentHelper::readLoop() {
             this->sendBuffer(buffer, status);
         }
     }
-    // This will loop until stopped. If auto-connect is disabled, this will break at the moment of reconnect
+    // This will loop until stopped. If auto-open is disabled, this will break when reopen returns disabled status
     while (this->running());
     // Close the socket
     this->close(); // Close the port entirely

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -28,7 +28,7 @@ void SocketComponentHelper::start(const Fw::StringBase &name,
                                      const Os::Task::ParamType cpuAffinity) {
     FW_ASSERT(m_task.getState() == Os::Task::State::NOT_STARTED);  // It is a coding error to start this task multiple times
     this->m_stop = false;
-    this->setAutoconnect(reconnect);
+    this->setAutoConnect(reconnect);
     // Note: the first step is for the IP socket to open the port
     Os::Task::Arguments arguments(name, SocketComponentHelper::readTask, this, priority, stack, cpuAffinity);
     Os::Task::Status stat = m_task.start(arguments);

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -181,7 +181,12 @@ void SocketComponentHelper::readLoop() {
         // Prevent transmission before connection, or after a disconnect
         if ((not this->isOpened()) and this->running()) {
             status = this->reconnect();
-            if (status != SOCK_SUCCESS) {
+            // When reconnect is disabled, just break as this is a exit condition for the loop
+            if (status == SOCK_AUTOCONNECT_DISABLED) {
+                break;
+            }
+            // If the reconnection failed in any other way, warn, wait, and retry
+            else if (status != SOCK_SUCCESS) {
                 Fw::Logger::log("[WARNING] Failed to open port with status %d and errno %d\n", status, errno);
                 (void)Os::Task::delay(SOCKET_RETRY_INTERVAL);
                 continue;
@@ -208,9 +213,8 @@ void SocketComponentHelper::readLoop() {
             this->sendBuffer(buffer, status);
         }
     }
-    // As long as not told to stop, and we are successful interrupted or ordered to retry, keep receiving
-    while (this->running() &&
-           (status == SOCK_SUCCESS || (status == SOCK_NO_DATA_AVAILABLE) || status == SOCK_INTERRUPTED_TRY_AGAIN || this->m_reconnect));
+    // This will loop until stopped. If autoconnect is disabled, this will break at the moment of reconnect
+    while (this->running());
     // Close the socket
     this->close(); // Close the port entirely
 }

--- a/Drv/Ip/SocketComponentHelper.hpp
+++ b/Drv/Ip/SocketComponentHelper.hpp
@@ -51,7 +51,7 @@ class SocketComponentHelper {
      * to the Os::Task::start call.
      *
      * \param name: name of the task
-     * \param reconnect: automatically reconnect socket when closed. Default: true.
+     * \param reconnect: automatically (re)connect socket when closed. Default: true.
      * \param priority: priority of the started task. See: Os::Task::start. Default: TASK_DEFAULT, not prioritized
      * \param stack: stack size provided to the task. See: Os::Task::start. Default: TASK_DEFAULT, posix threads default
      * \param cpuAffinity: cpu affinity provided to task. See: Os::Task::start. Default: TASK_DEFAULT, don't care
@@ -84,6 +84,16 @@ class SocketComponentHelper {
      * \return true if socket is open, false otherwise
      */
     bool isOpened();
+
+    /**
+     * \brief set the socket to automatically connect or reconnect
+     *
+     * Set the autoconnect flag to automatically connect or reconnect the socket when it is closed. This is useful for
+     * allowing the socket to reconnect when a disconnection event happens
+     * 
+     * \param auto_connect: true to automatically connect, false otherwise
+     */
+    void setAutoConnect(bool auto_connect);
 
      /**
      * \brief Re-open port if it has been disconnected
@@ -212,7 +222,7 @@ class SocketComponentHelper {
     Os::Task m_task;
     Os::Mutex m_lock;
     SocketDescriptor m_descriptor;
-    bool m_reconnect = false; //!< Force reconnection
+    bool m_reconnect = true; //!< Force reconnection
     bool m_stop = true; //!< Stops the task when set to true
     OpenState m_open = OpenState::NOT_OPEN; //!< Have we successfully opened
 };

--- a/Drv/Ip/SocketComponentHelper.hpp
+++ b/Drv/Ip/SocketComponentHelper.hpp
@@ -46,27 +46,26 @@ class SocketComponentHelper {
     /**
      * \brief start the socket read task to start producing data
      *
-     * Starts up the socket reading task and opens socket. This should be called before send calls are expected to
-     * work. Will connect to the previously configured port and host. priority, stack, and cpuAffinity are provided
-     * to the Os::Task::start call.
+     * Starts up the socket reading task and when reopen was configured, will open up the socket. 
+     * 
+     * \note: users must now use `setAutomaticOpen` to configure the socket to automatically open connections. The
+     *        default behavior is to automatically open connections.
      *
      * \param name: name of the task
-     * \param reconnect: automatically (re)connect socket when closed. Default: true.
      * \param priority: priority of the started task. See: Os::Task::start. Default: TASK_DEFAULT, not prioritized
      * \param stack: stack size provided to the task. See: Os::Task::start. Default: TASK_DEFAULT, posix threads default
      * \param cpuAffinity: cpu affinity provided to task. See: Os::Task::start. Default: TASK_DEFAULT, don't care
      */
     void start(const Fw::StringBase &name,
-                         const bool reconnect = true,
-                         const Os::Task::ParamType priority = Os::Task::TASK_DEFAULT,
-                         const Os::Task::ParamType stack = Os::Task::TASK_DEFAULT,
-                         const Os::Task::ParamType cpuAffinity = Os::Task::TASK_DEFAULT);
+               const Os::Task::ParamType priority = Os::Task::TASK_DEFAULT,
+               const Os::Task::ParamType stack = Os::Task::TASK_DEFAULT,
+               const Os::Task::ParamType cpuAffinity = Os::Task::TASK_DEFAULT);
 
     /**
      * \brief open the socket for communications
      *
-     * Typically the socket read task will open the connection and keep it open. However, in cases where the read task
-     * will not be started, this function may be used to open the socket.
+     * Typically the socket read task will open the connection and keep it open. However, in cases where the socket is
+     * not automatically opening, this call will open the socket. This will block until the socket is opened.
      *
      * Note: this just delegates to the handler
      *
@@ -86,14 +85,14 @@ class SocketComponentHelper {
     bool isOpened();
 
     /**
-     * \brief set the socket to automatically connect or reconnect
+     * \brief set socket to automatically open connections when true, or not when false
      *
-     * Set the auto-connect flag to automatically connect or reconnect the socket when it is closed. This is useful for
-     * allowing the socket to reconnect when a disconnection event happens
+     * When passed `true`, this instructs the socket to automatically open a socket and reopen socket failed connections. When passed `false`
+     * the user must explicitly call the `open` method to open the socket initially and when a socket fails.  
      * 
-     * \param auto_connect: true to automatically connect, false otherwise
+     * \param auto_open: true to automatically open and reopen sockets, false otherwise
      */
-    void setAutoConnect(bool auto_connect);
+    void setAutomaticOpen(bool auto_open);
 
     /**
      * \brief send data to the IP socket from the given buffer
@@ -215,19 +214,19 @@ class SocketComponentHelper {
     /**
      * \brief Re-open port if it has been disconnected
      *
-     * This function is a helper to handle the situations where this code needs to safely call reconnect. User code should
-     * connect using the `open` call. This is for connecting/reconnecting in situations where automatic reconnect is performed
-     * by framework code.
+     * This function is a helper to handle the situations where this code needs to safely reopen a socket. User code should
+     * connect using the `open` call. This is for opening/reopening in situations where automatic open is performed
+     * within this socket helper.
      *
      * \return status of reconnect, SOCK_SUCCESS for success, something else on error
      */
-    SocketIpStatus reconnect();
+    SocketIpStatus reopen();
 
   PROTECTED:
     Os::Task m_task;
     Os::Mutex m_lock;
     SocketDescriptor m_descriptor;
-    bool m_reconnect = true; //!< Force reconnection
+    bool m_reopen = true; //!< Force reopen on disconnect
     bool m_stop = true; //!< Stops the task when set to true
     OpenState m_open = OpenState::NOT_OPEN; //!< Have we successfully opened
 };

--- a/Drv/Ip/SocketComponentHelper.hpp
+++ b/Drv/Ip/SocketComponentHelper.hpp
@@ -95,14 +95,6 @@ class SocketComponentHelper {
      */
     void setAutoConnect(bool auto_connect);
 
-     /**
-     * \brief Re-open port if it has been disconnected
-     *
-     *
-     * \return status of reconnect, SOCK_SUCCESS for success, something else on error
-     */
-    SocketIpStatus reconnect();
-
     /**
      * \brief send data to the IP socket from the given buffer
      *
@@ -219,6 +211,19 @@ class SocketComponentHelper {
      */
     static void readTask(void* pointer);
 
+  PRIVATE:
+    /**
+     * \brief Re-open port if it has been disconnected
+     *
+     * This function is a helper to handle the situations where this code needs to safely call reconnect. User code should
+     * connect using the `open` call. This is for connecting/reconnecting in situations where automatic reconnect is performed
+     * by framework code.
+     *
+     * \return status of reconnect, SOCK_SUCCESS for success, something else on error
+     */
+    SocketIpStatus reconnect();
+
+  PROTECTED:
     Os::Task m_task;
     Os::Mutex m_lock;
     SocketDescriptor m_descriptor;

--- a/Drv/Ip/SocketComponentHelper.hpp
+++ b/Drv/Ip/SocketComponentHelper.hpp
@@ -88,7 +88,7 @@ class SocketComponentHelper {
     /**
      * \brief set the socket to automatically connect or reconnect
      *
-     * Set the autoconnect flag to automatically connect or reconnect the socket when it is closed. This is useful for
+     * Set the auto-connect flag to automatically connect or reconnect the socket when it is closed. This is useful for
      * allowing the socket to reconnect when a disconnection event happens
      * 
      * \param auto_connect: true to automatically connect, false otherwise

--- a/Drv/Ip/UdpSocket.cpp
+++ b/Drv/Ip/UdpSocket.cpp
@@ -151,22 +151,33 @@ SocketIpStatus UdpSocket::openProtocol(SocketDescriptor& socketDescriptor) {
         memcpy(&this->m_state->m_addr_send, &address, sizeof(this->m_state->m_addr_send));
     }
 
-    // When we are setting up for receiving as well, then we must bind to a port
-    if ((status = this->bind(socketFd)) != SOCK_SUCCESS) {
-        ::close(socketFd);
-        return status; // Not closing FD as it is still a valid send FD
-    }
+    // Receive port set up only done when configure receive was called
     U16 recv_port = this->m_recv_port;
+    if (recv_port != 0) {
+        // When we are setting up for receiving as well, then we must bind to a port
+        if ((status = this->bind(socketFd)) != SOCK_SUCCESS) {
+            ::close(socketFd); // Closing FD as a retry will reopen send side
+            return status;
+        }
+    }
+
     // Log message for UDP
-    if (port == 0) {
-        Fw::Logger::log("Setup to receive udp at %s:%hu\n", m_recv_hostname,
+    if ((port == 0) && (recv_port > 0)) {
+        Fw::Logger::log("Setup to only receive udp at %s:%hu\n", m_recv_hostname,
                            recv_port);
-    } else {
+    } else if ((port > 0) && (recv_port == 0))  {
+        Fw::Logger::log("Setup to only send udp at %s:%hu\n", m_hostname,
+                           port);
+    } else if ((port > 0) && (recv_port > 0))  {
         Fw::Logger::log("Setup to receive udp at %s:%hu and send to %s:%hu\n",
                            m_recv_hostname,
                            recv_port,
                            m_hostname,
                            port);
+    }
+    // Neither configuration method was called
+    else {
+        FW_ASSERT(port > 0 || recv_port > 0, port, recv_port);
     }
     FW_ASSERT(status == SOCK_SUCCESS, status);
     socketDescriptor.fd = socketFd;

--- a/Drv/Ip/UdpSocket.cpp
+++ b/Drv/Ip/UdpSocket.cpp
@@ -154,9 +154,10 @@ SocketIpStatus UdpSocket::openProtocol(SocketDescriptor& socketDescriptor) {
     // Receive port set up only done when configure receive was called
     U16 recv_port = this->m_recv_port;
     if (recv_port != 0) {
+        status = this->bind(socketFd);
         // When we are setting up for receiving as well, then we must bind to a port
-        if ((status = this->bind(socketFd)) != SOCK_SUCCESS) {
-            ::close(socketFd); // Closing FD as a retry will reopen send side
+        if (status != SOCK_SUCCESS) {
+            (void) ::close(socketFd); // Closing FD as a retry will reopen send side
             return status;
         }
     }

--- a/Drv/Ip/UdpSocket.cpp
+++ b/Drv/Ip/UdpSocket.cpp
@@ -59,6 +59,11 @@ UdpSocket::~UdpSocket() {
     delete m_state;
 }
 
+SocketIpStatus UdpSocket::configure(const char* const hostname, const U16 port, const U32 timeout_seconds, const U32 timeout_microseconds) {
+    FW_ASSERT(0); // Must use configureSend and/or configureRecv
+}
+
+
 SocketIpStatus UdpSocket::configureSend(const char* const hostname, const U16 port, const U32 timeout_seconds, const U32 timeout_microseconds) {
     //Timeout is for the send, so configure send will work with the base class
     FW_ASSERT(port != 0, port); // Send cannot be on port 0

--- a/Drv/Ip/UdpSocket.cpp
+++ b/Drv/Ip/UdpSocket.cpp
@@ -61,6 +61,7 @@ UdpSocket::~UdpSocket() {
 
 SocketIpStatus UdpSocket::configure(const char* const hostname, const U16 port, const U32 timeout_seconds, const U32 timeout_microseconds) {
     FW_ASSERT(0); // Must use configureSend and/or configureRecv
+    return SocketIpStatus::SOCK_INVALID_CALL;
 }
 
 

--- a/Drv/Ip/UdpSocket.hpp
+++ b/Drv/Ip/UdpSocket.hpp
@@ -43,7 +43,7 @@ class UdpSocket : public IpSocket {
      * \warning configure is disabled for UdpSocket. Use configureSend and configureRecv instead.
      */
     SocketIpStatus configure(const char* hostname, const U16 port, const U32 send_timeout_seconds,
-                             const U32 send_timeout_microseconds);
+                             const U32 send_timeout_microseconds) override;
 
     /**
      * \brief configure the udp socket for outgoing transmissions

--- a/Drv/Ip/UdpSocket.hpp
+++ b/Drv/Ip/UdpSocket.hpp
@@ -38,6 +38,14 @@ class UdpSocket : public IpSocket {
     virtual ~UdpSocket();
 
     /**
+     * \brief configure is disabled
+     * 
+     * \warning configure is disabled for UdpSocket. Use configureSend and configureRecv instead.
+     */
+    SocketIpStatus configure(const char* hostname, const U16 port, const U32 send_timeout_seconds,
+                             const U32 send_timeout_microseconds);
+
+    /**
      * \brief configure the udp socket for outgoing transmissions
      *
      * Configures the UDP handler to use the given hostname and port for outgoing transmissions. Incoming hostname

--- a/Drv/TcpClient/docs/sdd.md
+++ b/Drv/TcpClient/docs/sdd.md
@@ -36,30 +36,32 @@ This status is an enumeration whose values are described in the following table:
 
 ## Usage
 
-The Drv::TcpClientComponentImpl must be configured with the address of the remote connection, and the socket must be
-open to begin. Usually, the user runs the Drv::TcpClientComponentImpl engaging its read thread, which will automatically
-open the  connection. The component is passive and has no commands meaning users should `init`, `configure`, and
-`startSocketTask`. Upon shutdown, the `stopSocketThread` and `joinSocketThread` methods should be called to ensure
-proper resource deallocation. This typical usage is shown in the C++ snippet below.
+
+The Drv::TcpClientComponentImpl must be configured with the address of the remote connection using the `configure` method.
+The sockets must also be opened to send and receive data using `open`. When the component is set to automatically connect,
+`open` is called via the frist send or receive. Users declining to use automatic connection or who wish to control when open
+initially happens should call `open` before any send or receive. 
+
+Users desiring to receive via TCP should start the receive thread using `start`, may stop the thread using `stop` and may
+wait for the thread to exit using `join`.
 
 ```c++
 Drv::TcpClientComponentImpl comm = Drv::TcpClientComponentImpl("TCP Client");
 
 bool constructApp(bool dump, U32 port_number, char* hostname) {
     ...
-    comm.init(0);
+    comm.configure(hostname, port_number);
     ...
     if (hostname != nullptr && port_number != 0) {
         Os::TaskString name("ReceiveTask");
-        comm.configure(hostname, port_number);
-        comm.startSocketTask(name);
+        comm.start(name);
     }
 }
 
 void exitTasks() {
     ...
-    comm.stopSocketTask();
-    (void) comm.joinSocketTask(nullptr);
+    comm.stop();
+    (void) comm.join();
 }
 ```
 ## Class Diagram
@@ -73,9 +75,3 @@ void exitTasks() {
 | TCP-CLIENT-COMP-002 | The tcp client component shall provide a read thread | unit test |
 | TCP-CLIENT-COMP-003 | The tcp client component shall provide bidirectional communication with a tcp server | unit test |
 
-## Change Log
-
-| Date | Description |
-|---|---|
-| 2020-12-17 | Initial Draft |
-| 2021-01-28 | Updated |

--- a/Drv/TcpClient/docs/sdd.md
+++ b/Drv/TcpClient/docs/sdd.md
@@ -38,9 +38,11 @@ This status is an enumeration whose values are described in the following table:
 
 
 The Drv::TcpClientComponentImpl must be configured with the address of the remote connection using the `configure` method.
-The sockets must also be opened to send and receive data using `open`. When the component is set to automatically connect,
-`open` is called via the frist send or receive. Users declining to use automatic connection or who wish to control when open
+The sockets must also be opened to send and receive data using `open`. When the component is set to automatically open,
+`open` is called via the first send or receive. Users declining to use automatic opening or who wish to control when open
 initially happens should call `open` before any send or receive. 
+
+Automatic opening is the default.  Call `setAutomaticOpen(false);` to disable this behavior.
 
 Users desiring to receive via TCP should start the receive thread using `start`, may stop the thread using `stop` and may
 wait for the thread to exit using `join`.

--- a/Drv/TcpClient/test/ut/TcpClientTestMain.cpp
+++ b/Drv/TcpClient/test/ut/TcpClientTestMain.cpp
@@ -25,6 +25,16 @@ TEST(Reconnect, TcpClientReceiveThreadReconnect) {
     tester.test_advanced_reconnect();
 }
 
+TEST(AutoConnect, AutoConnectOnSendOff) {
+    Drv::TcpClientTester tester;
+    tester.test_no_automatic_send_connection();
+}
+
+TEST(AutoConnect, AutoConnectOnRecvOff) {
+    Drv::TcpClientTester tester;
+    tester.test_no_automatic_recv_connection();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Drv/TcpClient/test/ut/TcpClientTester.cpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.cpp
@@ -39,7 +39,8 @@ void TcpClientTester ::setup_helper(Drv::TcpServerSocket& server, Drv::SocketDes
     // Start up a receive thread
     if (recv_thread) {
         Os::TaskString name("receiver thread");
-        this->component.start(name, reconnect, Os::Task::TASK_DEFAULT, Os::Task::TASK_DEFAULT);
+        this->component.setAutomaticOpen(reconnect);
+        this->component.start(name, Os::Task::TASK_DEFAULT, Os::Task::TASK_DEFAULT);
     }
 }
 
@@ -156,7 +157,7 @@ void TcpClientTester ::test_no_automatic_send_connection() {
     Drv::TcpServerSocket server;
     Drv::SocketDescriptor server_fd;
     this->setup_helper(server, server_fd, false, false);
-    this->component.setAutoConnect(false);
+    this->component.setAutomaticOpen(false);
     ASSERT_EQ(this->component.send(reinterpret_cast<const U8*>("a"), 1), Drv::SOCK_AUTO_CONNECT_DISABLED);
     ASSERT_FALSE(this->component.isOpened());
     // Clean-up even if the send worked

--- a/Drv/TcpClient/test/ut/TcpClientTester.cpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.cpp
@@ -23,17 +23,11 @@ namespace Drv {
 // Construction and destruction
 // ----------------------------------------------------------------------
 
-void TcpClientTester ::test_with_loop(U32 iterations, bool recv_thread) {
-    U8 buffer[sizeof(m_data_storage)] = {};
-    Drv::SocketIpStatus status1 = Drv::SOCK_SUCCESS;
-    Drv::SocketIpStatus status2 = Drv::SOCK_SUCCESS;
+void TcpClientTester ::setup_helper(Drv::TcpServerSocket& server, Drv::SocketDescriptor& server_fd, bool recv_thread, bool reconnect) {
     Drv::SocketIpStatus serverStat = Drv::SOCK_SUCCESS;
 
     U16 port =  0;
-
-    Drv::TcpServerSocket server;
     server.configure("127.0.0.1", port, 0, 100);
-    Drv::SocketDescriptor server_fd;
 
     serverStat = server.startup(server_fd);
     this->component.configure("127.0.0.1", server.getListenPort(), 0, 100);
@@ -45,8 +39,19 @@ void TcpClientTester ::test_with_loop(U32 iterations, bool recv_thread) {
     // Start up a receive thread
     if (recv_thread) {
         Os::TaskString name("receiver thread");
-        this->component.start(name, true, Os::Task::TASK_DEFAULT, Os::Task::TASK_DEFAULT);
+        this->component.start(name, reconnect, Os::Task::TASK_DEFAULT, Os::Task::TASK_DEFAULT);
     }
+}
+
+
+void TcpClientTester ::test_with_loop(U32 iterations, bool recv_thread) {
+    U8 buffer[sizeof(m_data_storage)] = {};
+    Drv::SocketIpStatus status1 = Drv::SOCK_SUCCESS;
+    Drv::SocketIpStatus status2 = Drv::SOCK_SUCCESS;
+
+    Drv::TcpServerSocket server;
+    Drv::SocketDescriptor server_fd;
+    setup_helper(server, server_fd, recv_thread, true);
 
     // Loop through a bunch of client disconnects
     for (U32 i = 0; i < iterations; i++) {
@@ -145,6 +150,32 @@ void TcpClientTester ::test_receive_thread() {
 
 void TcpClientTester ::test_advanced_reconnect() {
     test_with_loop(10, true); // Up to 10 * RECONNECT_MS
+}
+
+void TcpClientTester ::test_no_automatic_send_connection() {
+    Drv::TcpServerSocket server;
+    Drv::SocketDescriptor server_fd;
+    this->setup_helper(server, server_fd, false, false);
+    this->component.setAutoConnect(false);
+    ASSERT_EQ(this->component.send(reinterpret_cast<const U8*>("a"), 1), Drv::SOCK_AUTO_CONNECT_DISABLED);
+    ASSERT_FALSE(this->component.isOpened());
+    // Clean-up even if the send worked
+    Drv::Test::drain(server, server_fd);
+    server.terminate(server_fd);
+}
+
+void TcpClientTester ::test_no_automatic_recv_connection() {
+    Drv::TcpServerSocket server;
+    Drv::SocketDescriptor server_fd;
+    this->setup_helper(server, server_fd, true, false);
+    // Wait for connection to not start
+    EXPECT_FALSE(this->wait_on_change(this->component.getSocketHandler(), true, Drv::Test::get_configured_delay_ms()/10 + 1));
+    ASSERT_FALSE(this->component.isOpened());
+    // Clean-up even if the thread (incorrectly) started
+    this->component.stop();
+    this->component.join();
+    Drv::Test::drain(server, server_fd);
+    server.terminate(server_fd);
 }
 
 // ----------------------------------------------------------------------

--- a/Drv/TcpClient/test/ut/TcpClientTester.hpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.hpp
@@ -51,6 +51,8 @@ namespace Drv {
       // Tests
       // ----------------------------------------------------------------------
 
+      void setup_helper(Drv::TcpServerSocket& server, Drv::SocketDescriptor& server_fd, bool recv_thread, bool reconnect);
+
       void test_basic_messaging();
 
       void test_multiple_messaging();
@@ -58,6 +60,10 @@ namespace Drv {
       void test_receive_thread();
 
       void test_advanced_reconnect();
+
+      void test_no_automatic_send_connection();
+
+      void test_no_automatic_recv_connection();
 
       void test_with_loop(U32 iterations, bool recv_thread=false);
 

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -115,9 +115,9 @@ void TcpServerComponentImpl::readLoop() {
     if (this->running() && status == SOCK_SUCCESS) {
         // Perform the nominal read loop
         SocketComponentHelper::readLoop();
-        // Terminate the server
-        this->terminate();
     }
+    // Terminate the server
+    this->terminate();
 }
 
 // ----------------------------------------------------------------------

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -110,7 +110,7 @@ void TcpServerComponentImpl::readLoop() {
              continue;
          }
     }
-    while (this->running() && status != SOCK_SUCCESS && this->m_reconnect);
+    while (this->running() && status != SOCK_SUCCESS && this->m_reopen);
     // If start up was successful then perform normal operations
     if (this->running() && status == SOCK_SUCCESS) {
         // Perform the nominal read loop

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -62,7 +62,7 @@ class TcpServerComponentImpl : public TcpServerComponentBase, public SocketCompo
                              const U16 port,
                              const U32 send_timeout_seconds = SOCKET_SEND_TIMEOUT_SECONDS,
                              const U32 send_timeout_microseconds = SOCKET_SEND_TIMEOUT_MICROSECONDS,
-			     FwSizeType buffer_size = 1024);
+                             FwSizeType buffer_size = 1024);
 
     /**
      * \brief is started

--- a/Drv/TcpServer/docs/sdd.md
+++ b/Drv/TcpServer/docs/sdd.md
@@ -5,7 +5,7 @@ connects and sends/receives bytes. It implements the callback formation (shown b
 and producing the callback port call. Since it is a server, it must startup and listen for client connections. Designed
 for single client communication, it does not permit a queue of connecting clients.
 
-For more information on the supporting TCP implementation see: Drv::TcpServerSocket.
+For more information on the supporting TCP implementation see: [Drv::TcpServerSocket]().
 For more information on the ByteStreamModelDriver see: Drv::ByteStreamDriverModel.
 
 ## Design
@@ -37,36 +37,45 @@ This status is an enumeration whose values are described in the following table:
 
 ## Usage
 
+The Drv::TcpClientComponentImpl must be configured with the address of the remote connection using the `configure` method.
+The `configure` method will also start the TCP server listening for remote connections. However, clients will not be accepted
+until the connection is opened. Sockets are opened using `open`. When the component is set to automatically connect
+this `open` is called done via the frist send or receive. Users declining to use automatic connection or who wish to control when
+open initially happens should call `open` before any send or receive.  
+
+Users desiring to receive via TCP should start the receive thread using `start`, may stop the thread using `stop` and may
+wait for the thread to exit using `join`.
+
 The Drv::TcpServerComponentImpl must be configured with the address of the remote connection, and the socket must be
-open to begin. Usually, the user runs the Drv::TcpServerComponentImpl engaging its read thread, which will automatically
-open the  connection. The component is passive and has no commands meaning users should `init`, `configure`, and
-`startSocketTask`. In addition to these methods shared with the Drv::TcpClientComponentImpl, the server provides
-`startup` and `shutdown` methods to start and stop the listening socket. It `startup` must be run before the read task
-is started and `shutdown` should be called before the task is stopped.
+open to begin. When the user calls `configure` the listening port of the TCP server is automatically connected and begins
+listening for incoming connections.
 
-Upon shutdown, the `stopSocketThread` and `joinSocketThread` methods should be called to ensure
-proper resource deallocation. This typical usage is shown in the C++ snippet below.
+When configured to automatically connect as is the default, the single queued client will be accepted on the first send
+data call, or when the receive thread is started. Usually, the user runs the Drv::TcpServerComponentImpl's read thread
+with automatic connection enabled, which will automatically accept the client connection.
 
+`configure` must be called before any data is sent or received. `start` must be called for the component to receive data.
+
+
+Users should call `stop` to stop the receive task and `join` to wait for it to exit.
+
+Users turning off automatic connection must call `open` to open the connection.
 
 ```c++
 Drv::TcpServerComponentImpl comm = Drv::TcpServerComponentImpl("TCP Server");
 
 bool constructApp(bool dump, U32 port_number, char* hostname) {
+    ... configure 
+    comm.configure(hostname, port_number);
     ...
-    comm.init(0);
-    ...
-    if (hostname != nullptr && port_number != 0) {
-        Os::TaskString name("ReceiveTask");
-        comm.configure(hostname, port_number);
-        comm.startSocketTask(name);
-    }
+    Os::TaskString name("ReceiveTask");
+    comm.start(name);
 }
 
 void exitTasks() {
     ...
-    comm.shutdown();
-    comm.stopSocketTask();
-    (void) comm.joinSocketTask(nullptr);
+    comm.stop();
+    (void) comm.join();
 }
 ```
 ## Class Diagram
@@ -79,10 +88,3 @@ void exitTasks() {
 | TCP-SERVER-COMP-001 | The tcp server component shall implement the ByteStreamDriverModel  | inspection |
 | TCP-SERVER-COMP-002 | The tcp server component shall provide a read thread | unit test |
 | TCP-SERVER-COMP-003 | The tcp server component shall provide bidirectional communication with a tcp client | unit test |
-
-## Change Log
-
-| Date | Description |
-|---|---|
-| 2020-12-21 | Initial Draft |
-| 2021-01-28 | Updated |

--- a/Drv/TcpServer/docs/sdd.md
+++ b/Drv/TcpServer/docs/sdd.md
@@ -5,8 +5,8 @@ connects and sends/receives bytes. It implements the callback formation (shown b
 and producing the callback port call. Since it is a server, it must startup and listen for client connections. Designed
 for single client communication, it does not permit a queue of connecting clients.
 
-For more information on the supporting TCP implementation see: [Drv::TcpServerSocket]().
-For more information on the ByteStreamModelDriver see: Drv::ByteStreamDriverModel.
+For more information on the supporting TCP implementation see: [Drv::TcpServerSocket](../../Ip/docs/sdd.md#drvtcpserversocket-class).
+For more information on the ByteStreamModelDriver see: [Drv::ByteStreamDriverModel](../..//ByteStreamDriverModel/docs/sdd.md).
 
 ## Design
 

--- a/Drv/TcpServer/docs/sdd.md
+++ b/Drv/TcpServer/docs/sdd.md
@@ -39,9 +39,11 @@ This status is an enumeration whose values are described in the following table:
 
 The Drv::TcpClientComponentImpl must be configured with the address of the remote connection using the `configure` method.
 The `configure` method will also start the TCP server listening for remote connections. However, clients will not be accepted
-until the connection is opened. Sockets are opened using `open`. When the component is set to automatically connect
-this `open` is called done via the frist send or receive. Users declining to use automatic connection or who wish to control when
+until the connection is opened. Sockets are opened using `open`. When the component is set to automatically open,
+`open` is called done via the first send or receive. Users declining to use automatic opening or who wish to control when
 open initially happens should call `open` before any send or receive.  
+
+Automatic opening is the default.  Call `setAutomaticOpen(false);` to disable this behavior.
 
 Users desiring to receive via TCP should start the receive thread using `start`, may stop the thread using `stop` and may
 wait for the thread to exit using `join`.

--- a/Drv/TcpServer/test/ut/TcpServerTestMain.cpp
+++ b/Drv/TcpServer/test/ut/TcpServerTestMain.cpp
@@ -24,6 +24,17 @@ TEST(Reconnect, TcpServerReceiveThreadReconnect) {
     tester.test_advanced_reconnect();
 }
 
+TEST(AutoConnect, AutoConnectOnSendOff) {
+    Drv::TcpServerTester tester;
+    tester.test_no_automatic_send_connection();
+}
+
+TEST(AutoConnect, AutoConnectOnRecvOff) {
+    Drv::TcpServerTester tester;
+    tester.test_no_automatic_recv_connection();
+}
+
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Drv/TcpServer/test/ut/TcpServerTester.cpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.cpp
@@ -23,23 +23,31 @@ namespace Drv {
 // Construction and destruction
 // ----------------------------------------------------------------------
 
+void TcpServerTester ::setup_helper(bool recv_thread, bool reconnect) {
+    Drv::SocketIpStatus status1 = Drv::SOCK_SUCCESS;
+    U16 port =  0;
+    EXPECT_FALSE(component.isStarted());
+    status1 = this->component.configure("127.0.0.1", port, 0, 100);
+    EXPECT_EQ(status1, Drv::SOCK_SUCCESS);
+    // Start up a receive thread
+    if (recv_thread) {
+        Os::TaskString name("receiver thread");
+        this->component.start(name, reconnect, Os::Task::TASK_DEFAULT, Os::Task::TASK_DEFAULT);
+    }
+    // Component should always launch the listening server on configure
+    // The thread will retry if the configure fails
+    EXPECT_TRUE(this->wait_on_started(true, Drv::Test::get_configured_delay_ms()/10 + 1));
+    EXPECT_TRUE(component.isStarted());
+}
+
 void TcpServerTester ::test_with_loop(U32 iterations, bool recv_thread) {
     U8 buffer[sizeof(m_data_storage)] = {};
     Drv::SocketIpStatus status1 = Drv::SOCK_SUCCESS;
     Drv::SocketIpStatus status2 = Drv::SOCK_SUCCESS;
-
-    U16 port =  0;
     Drv::SocketDescriptor client_fd;
-    status1 = this->component.configure("127.0.0.1", port, 0, 100);
-    EXPECT_EQ(status1, Drv::SOCK_SUCCESS);
 
-    // Start up a receive thread
-    if (recv_thread) {
-        Os::TaskString name("receiver thread");
-        this->component.start(name, true, Os::Task::TASK_DEFAULT, Os::Task::TASK_DEFAULT);
-        EXPECT_TRUE(this->wait_on_started(true, Drv::Test::get_configured_delay_ms()/10 + 1));
-    }
-    EXPECT_TRUE(component.isStarted());
+    this->setup_helper(recv_thread, recv_thread);
+
     // Loop through a bunch of client disconnects
     for (U32 i = 0; i < iterations && status1 == SOCK_SUCCESS; i++) {
         Drv::TcpClientSocket client;
@@ -163,6 +171,46 @@ void TcpServerTester ::test_receive_thread() {
 
 void TcpServerTester ::test_advanced_reconnect() {
     test_with_loop(10, true); // Up to 10 * RECONNECT_MS
+}
+
+void TcpServerTester ::test_no_automatic_send_connection() {
+    Drv::TcpClientSocket client;
+    Drv::SocketDescriptor client_fd;
+    
+    // Set up the server without automatic connection
+    this->setup_helper(false, true);
+    this->component.setAutoConnect(false);
+    Drv::Test::force_recv_timeout(client_fd.fd, client);
+
+    // Connect a client to the server so it is waiting in the "listen" queue
+    client.configure("127.0.0.1", this->component.getListenPort(), 0, 100);
+    ASSERT_EQ(client.open(client_fd), Drv::SOCK_SUCCESS);
+
+    // Send a message from the server and ensure that the server is not opened
+    ASSERT_EQ(this->component.send(reinterpret_cast<const U8*>("a"), 1), Drv::SOCK_AUTO_CONNECT_DISABLED);
+    ASSERT_FALSE(this->component.isOpened());
+
+    // Clean-up even if the send worked
+    client.close(client_fd);
+    this->component.terminate();
+}
+
+void TcpServerTester ::test_no_automatic_recv_connection() {
+    Drv::TcpClientSocket client;
+    Drv::SocketDescriptor client_fd;
+
+    // Set up the server without automatic connection
+    this->setup_helper(true, false);
+
+    // Connect a client to the server so it is waiting in the "listen" queue
+    // The read thread should not automatically connect and will thus exit with a failure
+    client.configure("127.0.0.1", this->component.getListenPort(), 0, 100);
+    ASSERT_EQ(client.open(client_fd), Drv::SOCK_FAILED_TO_CONNECT);
+    ASSERT_FALSE(this->component.isOpened());
+
+    // Clean-up even if the receive worked
+    client.close(client_fd);
+    this->component.terminate();
 }
 
 // ----------------------------------------------------------------------

--- a/Drv/TcpServer/test/ut/TcpServerTester.cpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.cpp
@@ -32,7 +32,8 @@ void TcpServerTester ::setup_helper(bool recv_thread, bool reconnect) {
     // Start up a receive thread
     if (recv_thread) {
         Os::TaskString name("receiver thread");
-        this->component.start(name, reconnect, Os::Task::TASK_DEFAULT, Os::Task::TASK_DEFAULT);
+        this->component.setAutomaticOpen(reconnect);
+        this->component.start(name, Os::Task::TASK_DEFAULT, Os::Task::TASK_DEFAULT);
     }
     // Component should always launch the listening server on configure
     // The thread will retry if the configure fails
@@ -179,7 +180,7 @@ void TcpServerTester ::test_no_automatic_send_connection() {
     
     // Set up the server without automatic connection
     this->setup_helper(false, true);
-    this->component.setAutoConnect(false);
+    this->component.setAutomaticOpen(false);
     Drv::Test::force_recv_timeout(client_fd.fd, client);
 
     // Connect a client to the server so it is waiting in the "listen" queue

--- a/Drv/TcpServer/test/ut/TcpServerTester.hpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.hpp
@@ -51,6 +51,7 @@ namespace Drv {
       // Tests
       // ----------------------------------------------------------------------
 
+      void setup_helper(bool recv_thread, bool reconnect);
 
       //! Test basic messaging
       //!
@@ -70,6 +71,10 @@ namespace Drv {
 
       // Helpers
       void test_with_loop(U32 iterations, bool recv_thread=false);
+ 
+      void test_no_automatic_send_connection();
+
+      void test_no_automatic_recv_connection();
 
       bool wait_on_change(bool open, U32 iterations);
       bool wait_on_started(bool open, U32 iterations);

--- a/Drv/Udp/docs/sdd.md
+++ b/Drv/Udp/docs/sdd.md
@@ -38,9 +38,11 @@ This status is an enumeration whose values are described in the following table:
 
 The Drv::UdpComponentImpl must be configured with the address(es) of the remote entity. Users can configure send and
 receive independently using `configureSend` and `configureRecv`.  The sockets must also be opened to send and receive
-data using the `open` call. When the component is set to automatically connect `open` is called via the first send or
-receive call. Users declining to use automatic connection or who wish to control when open initially happens should call
-`open` before sending or receiving. 
+data using the `open` call. When the component is set to automatically open, `open` is called via the first send or
+receive call. Users declining to use automatic opening or who wish to control when open initially happens should call
+`open` before sending or receiving.
+
+Automatic opening is the default.  Call `setAutomaticOpen(false);` to disable this behavior.
 
 Users desiring to receive via UDP should start the receive thread using `start`, may stop the thread using `stop` and may
 wait for the thread to exit using `join`.

--- a/Drv/Udp/docs/sdd.md
+++ b/Drv/Udp/docs/sdd.md
@@ -36,26 +36,28 @@ This status is an enumeration whose values are described in the following table:
 
 ## Usage
 
-The Drv::UdpComponentImpl must be configured with the address of the remote connection, and the socket must be
-open to begin. Usually, the user runs the Drv::UdpComponentImpl engaging its read thread, which will automatically
-open the  connection. The component is passive and has no commands meaning users should `init`,
-`configureSend`/`configureRecv`, and `startSocketTask`. Upon shutdown, the `stopSocketThread` and `joinSocketThread`
-methods should be called to ensure proper resource deallocation. This typical usage is shown in the C++ snippet below.
+The Drv::UdpComponentImpl must be configured with the address(es) of the remote entity. Users can configure send and
+receive independently using `configureSend` and `configureRecv`.  The sockets must also be opened to send and receive
+data using the `open` call. When the component is set to automatically connect `open` is called via the first send or
+receive call. Users declining to use automatic connection or who wish to control when open initially happens should call
+`open` before sending or receiving. 
 
-Since UDP support single or bidirectional communication, configuring each direction is cone separately using the two
-methods `configureSend` and `configureRecv`. The user is not required to call both.
+Users desiring to receive via UDP should start the receive thread using `start`, may stop the thread using `stop` and may
+wait for the thread to exit using `join`.
+
+Since UDP support single or bidirectional communication, configuring each direction is done separately using the two
+methods `configureSend` and `configureRecv`. The user must call at least one of the configure methods and may call both.
 
 ```c++
 Drv::UdpComponentImpl comm = Drv::UdpComponentImpl("UDP Client");
 
 bool constructApp(bool dump, U32 port_number, char* hostname) {
     ...
-    comm.init(0);
+    comm.configureSend(hostname, port_number);
+    comm.configureRecv(hostname, port_number);
     ...
     if (hostname != nullptr && port_number != 0) {
         Os::TaskString name("ReceiveTask");
-        comm.configureSend(hostname, port_number);
-        comm.configureRecv(hostname, port_number);
         // Needed for receiving only, remove if not configuring to receive
         comm.startSocketTask(name);
     }
@@ -63,8 +65,8 @@ bool constructApp(bool dump, U32 port_number, char* hostname) {
 
 void exitTasks() {
     ...
-    comm.stopSocketTask();
-    (void) comm.joinSocketTask(nullptr);
+    comm.stop();
+    (void) comm.join();
 }
 ```
 ## Class Diagram
@@ -79,9 +81,3 @@ void exitTasks() {
 | UDP-COMP-002 | The udp component shall provide a read thread | unit test |
 | UDP-COMP-003 | The udp component shall provide single and bidirectional communication across udp | unit test |
 
-## Change Log
-
-| Date | Description |
-|---|---|
-| 2020-12-21 | Initial Draft |
-| 2021-01-28 | Updated |

--- a/RPI/Top/instances.fpp
+++ b/RPI/Top/instances.fpp
@@ -252,12 +252,18 @@ module RPI {
     };
     """
 
+    phase Fpp.ToCpp.Phases.configComponents """
+    // Configure socket server if and only if there is a valid specification
+    if (state.hostName != nullptr && state.portNumber != 0) {
+        RPI::comm.configure(state.hostName, state.portNumber);
+    }
+    """
+
     phase Fpp.ToCpp.Phases.startTasks """
     // Initialize socket server if and only if there is a valid specification
     if (state.hostName != nullptr && state.portNumber != 0) {
-        Os::TaskString name("ReceiveTask");
         // Uplink is configured for receive so a socket task is started
-        RPI::comm.configure(state.hostName, state.portNumber);
+        Os::TaskString name("ReceiveTask");
         RPI::comm.start(
             name,
             ConfigConstants::RPI_comm::PRIORITY,

--- a/Ref/Top/RefTopology.cpp
+++ b/Ref/Top/RefTopology.cpp
@@ -136,6 +136,9 @@ void setupTopology(const TopologyState& state) {
     regCommands();
     // Autocoded configuration. Function provided by autocoder.
     configComponents(state);
+    if (state.hostname != nullptr && state.port != 0) {
+        comm.configure(state.hostname, state.port);
+    }
     // Project-specific component configuration. Function provided above. May be inlined, if desired.
     configureTopology();
     // Autocoded parameter loading. Function provided by autocoder.
@@ -148,8 +151,7 @@ void setupTopology(const TopologyState& state) {
     if (state.hostname != nullptr && state.port != 0) {
         Os::TaskString name("ReceiveTask");
         // Uplink is configured for receive so a socket task is started
-        comm.configure(state.hostname, state.port);
-        comm.start(name, true, COMM_PRIORITY, Default::STACK_SIZE);
+        comm.start(name, COMM_PRIORITY, Default::STACK_SIZE);
     }
 }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Removes the attempt to bind on UDP ports where only `send` was configured.

I also fixed the reconnect handling now that `send` can also attempt to reconnect.

UTs to check the following would be nice:

- [x] UDP (send only)
- [x]  UDP (recv only)
- [x] Disabled autoconnect properly results in autoconnect disabled.
   - [x] In thread
   - [x] In send
   - [x] Via thread start method
   - [x] Via `setAutoConnect` method 
- [x] Update SDDs for this behavior
  - [x] UDP in send/recv only mode
  - [x] Autoconnect enabled
  - [x] Autoconnect disabled
  - [x] Implication on client recv loop
  - [x] Implication on server recv loop

## Rationale

UDP may send, receive, or both depending.  When a send only UDP calls `bind` it fails because the receive port is invalid.

Fixed: #3127 #3133.



## Testing/Review Recommendations

Tested with UDP in the downlink chain of Ref (only downlink) works as expected with the following caveat:

`configureSend` must be called before starting threads.

## Future Work

Decided to do the future work!
