### PR TITLE
Fix format string specifiers for queue and task names

### DIFF
--- a/Fw/Comp/ActiveComponentBase.cpp
+++ b/Fw/Comp/ActiveComponentBase.cpp
@@ -60,7 +60,7 @@ namespace Fw {
         taskName = this->getObjName();
 #else
         char taskNameChar[FW_TASK_NAME_BUFFER_SIZE];
-        (void)snprintf(taskNameChar,sizeof(taskNameChar),"ActComp_%d",Os::Task::getNumTasks());
+        (void)snprintf(taskNameChar,sizeof(taskNameChar),"ActComp_%" PRI_FwSizeType,Os::Task::getNumTasks());
         taskName = taskNameChar;
 #endif
         // Cooperative threads tasks externalize the task loop, and as such use the state machine as their task function

--- a/Fw/Comp/QueuedComponentBase.cpp
+++ b/Fw/Comp/QueuedComponentBase.cpp
@@ -37,7 +37,7 @@ namespace Fw {
         queueName = this->m_objName;
 #else
         char queueNameChar[FW_QUEUE_NAME_BUFFER_SIZE];
-        (void)snprintf(queueNameChar,sizeof(queueNameChar),"CompQ_%d",Os::Queue::getNumQueues());
+        (void)snprintf(queueNameChar,sizeof(queueNameChar),"CompQ_%" PRI_FwSizeType,Os::Queue::getNumQueues());
         queueName = queueNameChar;
 #endif
     	return this->m_queue.create(queueName, depth, msgSize);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Replace format string specifier `%d` with `%PRI_FwSizeType` where it is used for `FwSizeType` values. This is needed in two cases gated behind `FW_OBJECT_NAMES == 0`.

## Rationale

The `%d` specifier for `FwSizeType` values does not work on platforms where `FwSizeType` is 64 bits. The replacement works correctly on all platforms. It appears that this was missed due to a lack of validation of `FW_OBJECT_NAMES == 0` code, or perhaps a lack of `-Werror` in the native toolchain.

## Testing/Review Recommendations

N/A

## Future Work

Implementing #3100 might help catch these kinds of bugs sooner.
