### PR TITLE
Fix typo in markdown warning in SBOM docs

### DIFF
--- a/docs/user-manual/security/software-bill-of-materials.md
+++ b/docs/user-manual/security/software-bill-of-materials.md
@@ -27,5 +27,5 @@ Once `grype` is installed, you can scan the bill of materials using the followin
 grype ./build-artifacts/*_sbom.json
 ```
 
-![WARNING]
-! `grype` is just one tool to look for vulnerabilities in your project. Vulnerabilities may be found by other means.
+>[!WARNING]
+> `grype` is just one tool to look for vulnerabilities in your project. Vulnerabilities may be found by other means.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix typo in a markdown file. Purpose of this PR is also to validate in real conditions that the CI in functioning properly with the new website.
