### PR TITLE
Stop ignoring real buffers shrunk to 0 size

### DIFF
--- a/Svc/BufferManager/BufferManagerComponentImpl.cpp
+++ b/Svc/BufferManager/BufferManagerComponentImpl.cpp
@@ -82,9 +82,11 @@ namespace Svc {
       // make sure component has been set up
       FW_ASSERT(this->m_setup);
       FW_ASSERT(m_buffers);
-      // check for empty buffers - this is just a warning since this component returns
-      // empty buffers if it can't allocate one.
-      if (fwBuffer.getSize() == 0) {
+      // check for null, empty buffers - this is a warning because this component returns
+      // null, empty buffers if it can't allocate one.
+      // however, empty non-null buffers could potentially be previously allocated
+      // buffers with their size reduced. the user is allowed to make buffers smaller.
+      if (fwBuffer.getData() == nullptr && fwBuffer.getSize() == 0) {
           this->log_WARNING_HI_ZeroSizeBuffer();
           this->m_emptyBuffs++;
           return;

--- a/Svc/BufferManager/BufferManagerComponentImpl.cpp
+++ b/Svc/BufferManager/BufferManagerComponentImpl.cpp
@@ -87,7 +87,7 @@ namespace Svc {
       // however, empty non-null buffers could potentially be previously allocated
       // buffers with their size reduced. the user is allowed to make buffers smaller.
       if (fwBuffer.getData() == nullptr && fwBuffer.getSize() == 0) {
-          this->log_WARNING_HI_ZeroSizeBuffer();
+          this->log_WARNING_HI_NullEmptyBuffer();
           this->m_emptyBuffs++;
           return;
       }

--- a/Svc/BufferManager/Events.fppi
+++ b/Svc/BufferManager/Events.fppi
@@ -7,9 +7,9 @@ event NoBuffsAvailable(
   format "No available buffers of size {}" \
   throttle 10
 
-@ The buffer manager received a zero-sized buffer as a return. Probably undetected empty buffer allocation
-event ZeroSizeBuffer \
+@ The buffer manager received a null pointer and zero-sized buffer as a return. Probably undetected failed buffer allocation
+event NullEmptyBuffer \
   severity warning high \
   id 0x01 \
-  format "Received zero size buffer" \
+  format "Received null pointer and zero size buffer" \
   throttle 10


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

If BufferManager is asked to allocate a buffer when it has no more buffers, it will return a null, zero-size buffer. Therefore, if BufferManager receives a request to deallocate a zero-sized buffer, it discards the buffer, on the assumption that it resulted from a failed allocation.

However, if a user allocates a buffer from BufferManager, they are allowed to decrease the size before they deallocate it. Therefore, a zero size buffer passed to the deallocation function cannot _necessarily_ be discarded; it could be a real buffer that needs to be freed. Only discard deallocated buffers if they are empty _and null_.

## Rationale

Without this fix, trying to return allocated buffers to a BufferManager with sizes updated to 0 can result in a memory leak.

## Testing/Review Recommendations

No specific recommendations.

## Future Work

No future work.
