### PR TITLE
[Docs] Correct small typos

### DIFF
--- a/docs/user-manual/framework/ground-interface.md
+++ b/docs/user-manual/framework/ground-interface.md
@@ -38,7 +38,7 @@ constructs (e.g. radios, spacecraft buses). From the perspective of F´, the dri
 data and handle outgoing data.
 
 > [!NOTE]
-> typically projects use a single driver to handle both input and output, however; two drivers may be used to if differing behavior is needed for uplink and downlink.(e.g. UDP downlink for speed and  Tcp uplink reliability).
+> typically projects use a single driver to handle both input and output, however; two drivers may be used too if differing behavior is needed for uplink and downlink.(e.g. UDP downlink for speed and  Tcp uplink reliability).
 
 All drivers implement an input port receiving data from the framer. The driver should write input data to the hardware
 the driver manages. Drivers implement at least one of two methods to retrieve data from hardware: an input port

--- a/docs/user-manual/overview/enum-arr-ser.md
+++ b/docs/user-manual/overview/enum-arr-ser.md
@@ -1,17 +1,21 @@
 # Data Types and Data Structures: Primitive Types, Enums, Arrays, and Serializables
 
 This guide will describe the types available in F´.  F´ defines both useful short names for primitive types as well as
-a set of autocoded complex types.  The types describe here are available to both the flight software and the ground
+a set of autocoded complex types.  The types described here are available to both the flight software and the ground
 system unless otherwise noted. Included in this document:
 
-- [Primitive Types](#primitive-types)
-- [Polymorphic Type](#polymorphic-type)
-- [Complex Types](#complex-types)
+- [Data Types and Data Structures: Primitive Types, Enums, Arrays, and Serializables](#data-types-and-data-structures-primitive-types-enums-arrays-and-serializables)
+  - [Primitive Types](#primitive-types)
+  - [Polymorphic Type](#polymorphic-type)
+    - [Setting Polymorphic Values](#setting-polymorphic-values)
+    - [Getting Polymorphic Values](#getting-polymorphic-values)
+    - [Checking Polymorphic Values](#checking-polymorphic-values)
+  - [Complex Types](#complex-types)
     - [Enums](#enums)
     - [Arrays](#arrays)
     - [Serializables](#serializables)
     - [C++ Classes](#c-classes)
-- [Conclusion](#conclusion)
+  - [Conclusion](#conclusion)
 
 ## Primitive Types
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| None  |
|**_Has Unit Tests (y/n)_**| NA  |
|**_Documentation Included (y/n)_**| y  |

---
## Change Description

The documentation contained small typos:

| Original Text | Corrected text |
|-|-|
| The types describe here are... | The types **described** here are... |
| ...however; two drivers may be used to if differing behavior is needed for uplink and downlink. | ...however; two drivers may be used **too** if differing behavior is needed for uplink and downlink. |

The table of contents of the `Data Types and Data Structures` page keeps auto-updating, so I left it updated in this PR as well.

## Rationale

Who doesn't like correct grammar 🙂 

## Testing/Review Recommendations

1. Learn English
2. I won't waste your time with any more steps 🙂 

## Future Work

NA.
