### PR TITLE
Use mkdocs search boosting instructions for website pages

### DIFF
--- a/Ref/docs/sdd.md
+++ b/Ref/docs/sdd.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Reference Deployment
 
 ## 1. Description

--- a/docs/user-manual/overview/source-tree.md
+++ b/docs/user-manual/overview/source-tree.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.4
+---
+
 # A Tour of the Source Tree
 
 The following directories constitute the demonstration code. The


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Making use of [Search Boosting](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#usage) and [Search exclusion](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-exclusion) from mkdocs to try and fine tune search results a little.

- Boosting down the "A tour of the source tree page". Since this page lists out all major parts of the source tree, it tends to appear **a lot** for any search of concepts or components. For example, it shows up as first result for most search of a Component name (e.g search "Svc ActiveLogger" etc.)
- Excluding the Ref SDD which does not seem like a relevant page to expose on the website
