### PR TITLE
Add CI check for fprime-examples repo

### DIFF
--- a/.github/workflows/codeql-jpl-standard.yml
+++ b/.github/workflows/codeql-jpl-standard.yml
@@ -1,7 +1,7 @@
 # Semantic code analysis with CodeQL 
 # see https://github.com/github/codeql-action
 
-name: "JPL Coding Standard Scan"
+name: "Code Scan: JPL Coding Standard"
 
 on:
   push:

--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -1,7 +1,7 @@
 # Semantic code analysis with CodeQL 
 # see https://github.com/github/codeql-action
 
-name: "CodeQL Security Scan"
+name: "Code Scan: CodeQL Security"
 
 on:
   push:

--- a/.github/workflows/cppcheck-scan.yml
+++ b/.github/workflows/cppcheck-scan.yml
@@ -1,5 +1,5 @@
 # Adapted from https://github.com/nasa/cFS/blob/c36aa2c1df0fb47a3838577908af3d0d0ab0ef54/.github/workflows/static-analysis.yml
-name: "Cppcheck Scan"
+name: "Code Scan: CppCheck"
 
 on:
   push:

--- a/.github/workflows/cpplint-scan.yml
+++ b/.github/workflows/cpplint-scan.yml
@@ -1,4 +1,4 @@
-name: "Cpplint Scan"
+name: "Code Scan: Cpplint"
 
 on:
   push:

--- a/.github/workflows/ext-build-examples-repo.yml
+++ b/.github/workflows/ext-build-examples-repo.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-examples
 
-name: "External repo: fprime-examples"
+name: "External Build: fprime-examples"
 
 on:
   push:
@@ -13,6 +13,7 @@ on:
       - '**.md'
       - '.github/actions/spelling/**'
       - '.github/ISSUE_TEMPLATE/**'
+      - '.gitignore'
 
 jobs:
   get-branch:

--- a/.github/workflows/ext-build-examples-repo.yml
+++ b/.github/workflows/ext-build-examples-repo.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-examples
 
-name: "External Build: fprime-examples"
+name: "External Repo: fprime-examples"
 
 on:
   push:

--- a/.github/workflows/ext-build-examples-repo.yml
+++ b/.github/workflows/ext-build-examples-repo.yml
@@ -30,3 +30,4 @@ jobs:
       build_location: FlightExamples
       run_unit_tests: true
       target_ref: ${{ needs.get-branch.outputs.target-branch }}
+      fprime_location: ./FlightExamples/lib/fprime

--- a/.github/workflows/ext-build-examples-repo.yml
+++ b/.github/workflows/ext-build-examples-repo.yml
@@ -1,0 +1,32 @@
+# Builds and runs UTs on https://github.com/fprime-community/fprime-examples
+
+name: "External repo: fprime-examples"
+
+on:
+  push:
+    branches: [ devel, release/**, ci/** ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ devel, release/** ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/actions/spelling/**'
+      - '.github/ISSUE_TEMPLATE/**'
+
+jobs:
+  get-branch:
+    name: "Get target branch"
+    uses: ./.github/workflows/reusable-get-pr-branch.yml
+    with:
+      target_repository: fprime-community/fprime-examples
+
+  run:
+    needs: get-branch
+    name: ""
+    uses: ./.github/workflows/reusable-project-builder.yml
+    with: 
+      target_repository: fprime-community/fprime-examples
+      build_location: FlightExamples
+      run_unit_tests: true
+      target_ref: ${{ needs.get-branch.outputs.target-branch }}

--- a/.github/workflows/ext-build-hello-world.yml
+++ b/.github/workflows/ext-build-hello-world.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-tutorial-hello-world
 
-name: "External Build: Tutorial: HelloWorld"
+name: "External Repo: Tutorial: HelloWorld"
 
 on:
   push:

--- a/.github/workflows/ext-build-hello-world.yml
+++ b/.github/workflows/ext-build-hello-world.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-tutorial-hello-world
 
-name: "Tutorial: HelloWorld"
+name: "External repo: Tutorial: HelloWorld"
 
 on:
   push:

--- a/.github/workflows/ext-build-hello-world.yml
+++ b/.github/workflows/ext-build-hello-world.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-tutorial-hello-world
 
-name: "External repo: Tutorial: HelloWorld"
+name: "External Build: Tutorial: HelloWorld"
 
 on:
   push:

--- a/.github/workflows/ext-build-led-blinker.yml
+++ b/.github/workflows/ext-build-led-blinker.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-workshop-led-blinker
 
-name: "External repo: Tutorial: LedBlinker"
+name: "External Build: Tutorial: LedBlinker"
 
 on:
   push:

--- a/.github/workflows/ext-build-led-blinker.yml
+++ b/.github/workflows/ext-build-led-blinker.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-workshop-led-blinker
 
-name: "External Build: Tutorial: LedBlinker"
+name: "External Repo: Tutorial: LedBlinker"
 
 on:
   push:

--- a/.github/workflows/ext-build-led-blinker.yml
+++ b/.github/workflows/ext-build-led-blinker.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-workshop-led-blinker
 
-name: "Tutorial: LedBlinker"
+name: "External repo: Tutorial: LedBlinker"
 
 on:
   push:

--- a/.github/workflows/ext-build-math-comp.yml
+++ b/.github/workflows/ext-build-math-comp.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-tutorial-math-component
 
-name: "Tutorial: MathComponent"
+name: "External repo: Tutorial: MathComponent"
 
 on:
   push:

--- a/.github/workflows/ext-build-math-comp.yml
+++ b/.github/workflows/ext-build-math-comp.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-tutorial-math-component
 
-name: "External repo: Tutorial: MathComponent"
+name: "External Build: Tutorial: MathComponent"
 
 on:
   push:

--- a/.github/workflows/ext-build-math-comp.yml
+++ b/.github/workflows/ext-build-math-comp.yml
@@ -1,6 +1,6 @@
 # Builds and runs UTs on https://github.com/fprime-community/fprime-tutorial-math-component
 
-name: "External Build: Tutorial: MathComponent"
+name: "External Repo: Tutorial: MathComponent"
 
 on:
   push:

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -1,7 +1,7 @@
 # Cross-compile https://github.com/fprime-community/fprime-workshop-led-blinker
 # Runs integration tests on RaspberryPi
 
-name: "RPI LedBlinker"
+name: "External repo: RPI LedBlinker"
 
 on:
   push:

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -1,7 +1,7 @@
 # Cross-compile https://github.com/fprime-community/fprime-workshop-led-blinker
 # Runs integration tests on RaspberryPi
 
-name: "External Build: RPI LedBlinker"
+name: "External Repo: RPI LedBlinker"
 
 on:
   push:

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -1,7 +1,7 @@
 # Cross-compile https://github.com/fprime-community/fprime-workshop-led-blinker
 # Runs integration tests on RaspberryPi
 
-name: "External repo: RPI LedBlinker"
+name: "External Build: RPI LedBlinker"
 
 on:
   push:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Partially implements https://github.com/nasa/fprime/issues/3108

Adds in the common set of "build and run UTs" tests for https://github.com/fprime-community/fprime-examples

My love of neatly arranged things also made me rename the other external CI workflows so that they're all nicely ordered in the GitHub PR UI (alphabetical order)

## Rationale

Keep fprime-examples up-to-date with latest `devel`

