### PR TITLE
NATIVE_INT_TYPE portNum to FwIndexType portNum

### DIFF
--- a/Autocoders/Python/templates/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/templates/ExampleComponentImpl.cpp
@@ -20,7 +20,7 @@ namespace ExampleComponents {
         ExampleComponentBase::init(queueDepth,instance);
     }
 
-    void ExampleComponentImpl::exampleInput_handler(NATIVE_INT_TYPE portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5) {
+    void ExampleComponentImpl::exampleInput_handler(FwIndexType portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5) {
         Fw::TlmString arg = "A string arg";
         // write some telemetry
         this->tlmWrite_stringchan(arg);
@@ -33,7 +33,7 @@ namespace ExampleComponents {
 
     }
 
-    SomeOtherNamespace::AnotherEnum ExampleComponentImpl::anotherInput_handler(NATIVE_INT_TYPE portNum, I32 arg1, F64 arg2, SomeOtherNamespace::SomeEnum arg3) {
+    SomeOtherNamespace::AnotherEnum ExampleComponentImpl::anotherInput_handler(FwIndexType portNum, I32 arg1, F64 arg2, SomeOtherNamespace::SomeEnum arg3) {
 
     	return SomeOtherNamespace::MEMB1;
     }

--- a/Autocoders/Python/templates/ExampleComponentImpl.hpp
+++ b/Autocoders/Python/templates/ExampleComponentImpl.hpp
@@ -19,8 +19,8 @@ namespace ExampleComponents {
             virtual ~ExampleComponentImpl();
         protected:
         private:
-            void exampleInput_handler(NATIVE_INT_TYPE portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5);
-            SomeOtherNamespace::AnotherEnum anotherInput_handler(NATIVE_INT_TYPE portNum, I32 arg1, F64 arg2, SomeOtherNamespace::SomeEnum arg3);
+            void exampleInput_handler(FwIndexType portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5);
+            SomeOtherNamespace::AnotherEnum anotherInput_handler(FwIndexType portNum, I32 arg1, F64 arg2, SomeOtherNamespace::SomeEnum arg3);
             void TEST_CMD_1_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, ExampleComponentBase::CmdEnum arg2, const Fw::CmdStringArg& arg3);
             void TEST_CMD_2_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, F32 arg2);
 

--- a/Autocoders/Python/templates/test/ut/main.cpp
+++ b/Autocoders/Python/templates/test/ut/main.cpp
@@ -10,7 +10,7 @@ public:
     ATester() : ExampleComponents::ExampleGTestBase("comp",10) {}
 
         void from_exampleOutput_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             I32 arg1, //!< A built-in type argument
             const ANameSpace::mytype &arg2, //!< A user-defined type argument
             U8 arg3, //!< The third argument

--- a/Autocoders/Python/test/array_xml/ExampleArrayImpl.cpp
+++ b/Autocoders/Python/test/array_xml/ExampleArrayImpl.cpp
@@ -19,7 +19,7 @@ namespace Example {
         Component1ComponentBase::init(queueDepth);
     }
 
-    void ExampleArrayImpl::ExArrayIn_handler(NATIVE_INT_TYPE portNum, const Example::SubNameSpace::ArrayType& array1, const Example::ArrSerial& serial1) {
+    void ExampleArrayImpl::ExArrayIn_handler(FwIndexType portNum, const Example::SubNameSpace::ArrayType& array1, const Example::ArrSerial& serial1) {
         Fw::String s;
         array1.toString(s);
 
@@ -27,7 +27,7 @@ namespace Example {
         this->ArrayOut_out(0, array1, serial1);
     }
 
-    void ExampleArrayImpl::ArrayIn_handler(NATIVE_INT_TYPE portNum, const Example::SubNameSpace::ArrayType& array1, const Example::ArrSerial& serial1) {
+    void ExampleArrayImpl::ArrayIn_handler(FwIndexType portNum, const Example::SubNameSpace::ArrayType& array1, const Example::ArrSerial& serial1) {
         Fw::String s;
         array1.toString(s);
 

--- a/Autocoders/Python/test/array_xml/ExampleArrayImpl.hpp
+++ b/Autocoders/Python/test/array_xml/ExampleArrayImpl.hpp
@@ -14,8 +14,8 @@ namespace Example {
 		void init(NATIVE_INT_TYPE queueDepth);
 
     private:
-        void ExArrayIn_handler(NATIVE_INT_TYPE portNum, const Example::SubNameSpace::ArrayType& array1, const Example::ArrSerial& serial1);
-        void ArrayIn_handler(NATIVE_INT_TYPE portNum, const Example::SubNameSpace::ArrayType& array1, const Example::ArrSerial& serial1);
+        void ExArrayIn_handler(FwIndexType portNum, const Example::SubNameSpace::ArrayType& array1, const Example::ArrSerial& serial1);
+        void ArrayIn_handler(FwIndexType portNum, const Example::SubNameSpace::ArrayType& array1, const Example::ArrSerial& serial1);
 	};
 
 };

--- a/Autocoders/Python/test/command1/TestCommand1Impl.cpp
+++ b/Autocoders/Python/test/command1/TestCommand1Impl.cpp
@@ -22,7 +22,7 @@ void TestCommand1Impl::init() {
     Test1ComponentBase::init();
 }
 
-void TestCommand1Impl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestCommand1Impl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 }
 
 void TestCommand1Impl::TEST_CMD_1_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, F32 arg2, U8 arg3) {

--- a/Autocoders/Python/test/command1/TestCommand1Impl.hpp
+++ b/Autocoders/Python/test/command1/TestCommand1Impl.hpp
@@ -16,7 +16,7 @@ class TestCommand1Impl: public Cmd::Test1ComponentBase {
         virtual ~TestCommand1Impl();
         void init();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
         void TEST_CMD_1_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, F32 arg2, U8 arg3);
 };
 

--- a/Autocoders/Python/test/command1/TestCommandSourceImpl.cpp
+++ b/Autocoders/Python/test/command1/TestCommandSourceImpl.cpp
@@ -19,12 +19,12 @@ TestCommandSourceImpl::~TestCommandSourceImpl() {
 }
 
 void TestCommandSourceImpl::cmdStatusPort_handler(
-        NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq,
+        FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq,
         const Fw::CmdResponse& response) {
     this->printStatus(response);
 }
 
-void TestCommandSourceImpl::cmdRegPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode) {
+void TestCommandSourceImpl::cmdRegPort_handler(FwIndexType portNum, FwOpcodeType opCode) {
     printf("Received registration for opcode %d\n",opCode);
 }
 

--- a/Autocoders/Python/test/command1/TestCommandSourceImpl.hpp
+++ b/Autocoders/Python/test/command1/TestCommandSourceImpl.hpp
@@ -17,8 +17,8 @@ class TestCommandSourceImpl: public Cmd::CommandTesterComponentBase {
         void init();
         void test_TEST_CMD_1(I32 arg1, F32 arg2, U8 arg3);
     protected:
-        void cmdStatusPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse& response);
-        void cmdRegPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode);
+        void cmdStatusPort_handler(FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse& response);
+        void cmdRegPort_handler(FwIndexType portNum, FwOpcodeType opCode);
     private:
         void printStatus(Fw::CmdResponse response);
 };

--- a/Autocoders/Python/test/command2/TestCommandComponentImpl.cpp
+++ b/Autocoders/Python/test/command2/TestCommandComponentImpl.cpp
@@ -50,7 +50,7 @@ namespace AcTest {
 
   void TestCommandComponentImpl ::
     aport_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         I32 arg4,
         F32 arg5,
         U8 arg6

--- a/Autocoders/Python/test/command2/TestCommandComponentImpl.hpp
+++ b/Autocoders/Python/test/command2/TestCommandComponentImpl.hpp
@@ -53,7 +53,7 @@ namespace AcTest {
       //! Handler implementation for aport
       //!
       void aport_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           I32 arg4, /*!< The first argument*/
           F32 arg5, /*!< The second argument*/
           U8 arg6 /*!< The third argument*/

--- a/Autocoders/Python/test/command_multi_inst/TestCommand1Impl.cpp
+++ b/Autocoders/Python/test/command_multi_inst/TestCommand1Impl.cpp
@@ -23,7 +23,7 @@ void TestCommand1Impl::init(NATIVE_INT_TYPE queueDepth, //!< The queue depth
     Test1ComponentBase::init(queueDepth,instance);
 }
 
-void TestCommand1Impl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestCommand1Impl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 }
 
 void TestCommand1Impl::TEST_CMD_1_cmdHandler(

--- a/Autocoders/Python/test/command_multi_inst/TestCommand1Impl.hpp
+++ b/Autocoders/Python/test/command_multi_inst/TestCommand1Impl.hpp
@@ -17,7 +17,7 @@ class TestCommand1Impl: public Cmd::Test1ComponentBase {
         void init(NATIVE_INT_TYPE queueDepth, //!< The queue depth
                 NATIVE_INT_TYPE instance = 0);
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
         void TEST_CMD_1_cmdHandler(
                 FwOpcodeType opCode, /*!< The opcode*/
                 U32 cmdSeq, /*!< The command sequence number*/

--- a/Autocoders/Python/test/command_multi_inst/TestCommandSourceImpl.cpp
+++ b/Autocoders/Python/test/command_multi_inst/TestCommandSourceImpl.cpp
@@ -19,12 +19,12 @@ TestCommandSourceImpl::~TestCommandSourceImpl() {
 }
 
 void TestCommandSourceImpl::cmdStatusPort_handler(
-        NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq,
+        FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq,
         const Fw::CmdResponse& response) {
     this->printStatus(response);
 }
 
-void TestCommandSourceImpl::cmdRegPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode) {
+void TestCommandSourceImpl::cmdRegPort_handler(FwIndexType portNum, FwOpcodeType opCode) {
     printf("Received registration for opcode %d\n",opCode);
 }
 

--- a/Autocoders/Python/test/command_multi_inst/TestCommandSourceImpl.hpp
+++ b/Autocoders/Python/test/command_multi_inst/TestCommandSourceImpl.hpp
@@ -17,8 +17,8 @@ class TestCommandSourceImpl: public Cmd::CommandTesterComponentBase {
         void init();
         void test_TEST_CMD_1(I32 arg1, F32 arg2, U8 arg3);
     protected:
-        void cmdStatusPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse& response);
-        void cmdRegPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode);
+        void cmdStatusPort_handler(FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse& response);
+        void cmdRegPort_handler(FwIndexType portNum, FwOpcodeType opCode);
     private:
         void printStatus(Fw::CmdResponse response);
 };

--- a/Autocoders/Python/test/command_res/Test1ComponentImpl.cpp
+++ b/Autocoders/Python/test/command_res/Test1ComponentImpl.cpp
@@ -50,7 +50,7 @@ namespace Cmd {
 
   void Test1ComponentImpl ::
     aport_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         I32 arg4,
         F32 arg5,
         U8 arg6

--- a/Autocoders/Python/test/command_res/Test1ComponentImpl.hpp
+++ b/Autocoders/Python/test/command_res/Test1ComponentImpl.hpp
@@ -53,7 +53,7 @@ namespace Cmd {
       //! Handler implementation for aport
       //!
       void aport_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           I32 arg4, /*!< The first argument*/
           F32 arg5, /*!< The second argument*/
           U8 arg6 /*!< The third argument*/

--- a/Autocoders/Python/test/command_string/TestCommandImpl.cpp
+++ b/Autocoders/Python/test/command_string/TestCommandImpl.cpp
@@ -19,7 +19,7 @@ void TestCommand1Impl::init(NATIVE_INT_TYPE queueDepth) {
 TestCommand1Impl::~TestCommand1Impl() {
 }
 
-void TestCommand1Impl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestCommand1Impl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }
 

--- a/Autocoders/Python/test/command_string/TestCommandImpl.hpp
+++ b/Autocoders/Python/test/command_string/TestCommandImpl.hpp
@@ -15,7 +15,7 @@ class TestCommand1Impl: public AcTest::TestCommandComponentBase {
         TestCommand1Impl(const char* compName);
         void init(NATIVE_INT_TYPE queueDepth);
         virtual ~TestCommand1Impl();
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
         void TEST_CMD_1_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, const Fw::CmdStringArg& arg2, SomeEnum arg3);
 };
 

--- a/Autocoders/Python/test/command_string/TestCommandSourceImpl.cpp
+++ b/Autocoders/Python/test/command_string/TestCommandSourceImpl.cpp
@@ -17,12 +17,12 @@ TestCommandSourceImpl::~TestCommandSourceImpl() {
 }
 
 void TestCommandSourceImpl::cmdStatusPort_handler(
-        NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq,
+        FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq,
         const Fw::CmdResponse& response) {
     this->printStatus(response);
 }
 
-void TestCommandSourceImpl::cmdRegPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode) {
+void TestCommandSourceImpl::cmdRegPort_handler(FwIndexType portNum, FwOpcodeType opCode) {
     printf("Received registration for opcode %d\n",opCode);
 }
 

--- a/Autocoders/Python/test/command_string/TestCommandSourceImpl.hpp
+++ b/Autocoders/Python/test/command_string/TestCommandSourceImpl.hpp
@@ -18,8 +18,8 @@ class TestCommandSourceImpl: public Cmd::CommandTesterComponentBase {
         void init();
         void test_TEST_CMD_1(I32 arg1, const Fw::CmdStringArg& arg2, I32 arg3);
     protected:
-        void cmdStatusPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse& response);
-        void cmdRegPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode);
+        void cmdStatusPort_handler(FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse& response);
+        void cmdRegPort_handler(FwIndexType portNum, FwOpcodeType opCode);
     private:
         void printStatus(const Fw::CmdResponse& response);
 };

--- a/Autocoders/Python/test/command_tester/test/ut/main.cpp
+++ b/Autocoders/Python/test/command_tester/test/ut/main.cpp
@@ -14,7 +14,7 @@ class ATester : public Cmd::CommandTesterGTestBase {
     }
 
     void from_cmdSendPort_handler(
-              const NATIVE_INT_TYPE portNum, //!< The port number
+              const FwIndexType portNum, //!< The port number
               FwOpcodeType opCode, //!< Command Op Code
               U32 cmdSeq, //!< Command Sequence
               Fw::CmdArgBuffer &args //!< Buffer containing arguments

--- a/Autocoders/Python/test/enum1port/DrvTimingSignalPort.hpp
+++ b/Autocoders/Python/test/enum1port/DrvTimingSignalPort.hpp
@@ -14,7 +14,7 @@ namespace Drv {
 
     class InputTimingSignalPort : public Fw::InputPortBase {
       public:
-        typedef void (*CompFuncPtr)(Fw::ComponentBase* callComp, NATIVE_INT_TYPE portNum, TimingSignal signal);
+        typedef void (*CompFuncPtr)(Fw::ComponentBase* callComp, FwIndexType portNum, TimingSignal signal);
 
         InputTimingSignalPort();
         void init();

--- a/Autocoders/Python/test/enum_xml/Component1Impl.cpp
+++ b/Autocoders/Python/test/enum_xml/Component1Impl.cpp
@@ -18,12 +18,12 @@ namespace Example {
         Component1ComponentBase::init(queueDepth);
     }
 
-    void ExampleEnumImpl::ExEnumIn_handler(NATIVE_INT_TYPE portNum, const Example::SubNamespace::Enum1& enum1, const Example::Serial1& serial1) {
+    void ExampleEnumImpl::ExEnumIn_handler(FwIndexType portNum, const Example::SubNamespace::Enum1& enum1, const Example::Serial1& serial1) {
         printf("%s Invoked ExEnumIn_handler(%d, %d, %d, %d, %d);\n", FW_OPTIONAL_NAME(this->getObjName()), portNum, static_cast<FwEnumStoreType>(enum1.e), serial1.getMember1(), serial1.getMember2(), static_cast<FwEnumStoreType>(serial1.getMember3().e));
         this->EnumOut_out(0, enum1, serial1);
     }
 
-    void ExampleEnumImpl::EnumIn_handler(NATIVE_INT_TYPE portNum, const Example::SubNamespace::Enum1& enum1, const Example::Serial1& serial1) {
+    void ExampleEnumImpl::EnumIn_handler(FwIndexType portNum, const Example::SubNamespace::Enum1& enum1, const Example::Serial1& serial1) {
         printf("%s Invoked EnumIn_handler(%d, %d, %d, %d, %d);\n", FW_OPTIONAL_NAME(this->getObjName()), portNum, static_cast<FwEnumStoreType>(enum1.e), serial1.getMember1(), serial1.getMember2(), static_cast<FwEnumStoreType>(serial1.getMember3().e));
     }
 };

--- a/Autocoders/Python/test/enum_xml/Component1Impl.hpp
+++ b/Autocoders/Python/test/enum_xml/Component1Impl.hpp
@@ -14,8 +14,8 @@ namespace Example {
 		void init(NATIVE_INT_TYPE queueDepth);
 
     private:
-        void ExEnumIn_handler(NATIVE_INT_TYPE portNum, const Example::SubNamespace::Enum1& enum1, const Example::Serial1& serial1);
-        void EnumIn_handler(NATIVE_INT_TYPE portNum, const Example::SubNamespace::Enum1& enum1, const Example::Serial1& serial1);
+        void ExEnumIn_handler(FwIndexType portNum, const Example::SubNamespace::Enum1& enum1, const Example::Serial1& serial1);
+        void EnumIn_handler(FwIndexType portNum, const Example::SubNamespace::Enum1& enum1, const Example::Serial1& serial1);
 	};
 
 };

--- a/Autocoders/Python/test/event1/TestLogImpl.cpp
+++ b/Autocoders/Python/test/event1/TestLogImpl.cpp
@@ -20,7 +20,7 @@ void TestLogImpl::init() {
 }
 
 
-void TestLogImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestLogImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }
 

--- a/Autocoders/Python/test/event1/TestLogImpl.hpp
+++ b/Autocoders/Python/test/event1/TestLogImpl.hpp
@@ -17,7 +17,7 @@ class TestLogImpl: public Somewhere::TestLogComponentBase {
         void init();
         void sendEvent(I32 arg1, F32 arg2, U8 arg3);
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/event1/TestLogRecvImpl.cpp
+++ b/Autocoders/Python/test/event1/TestLogRecvImpl.cpp
@@ -15,7 +15,7 @@ TestLogRecvImpl::TestLogRecvImpl(const char* name) : LogTextImpl(name)
 TestLogRecvImpl::~TestLogRecvImpl() {
 }
 
-void TestLogRecvImpl::logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
+void TestLogRecvImpl::logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
     printf("Received log %d, Time (%d,%d:%d) severity %d\n",id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severity.e);
     I32 arg1;
     F32 arg2;

--- a/Autocoders/Python/test/event1/TestLogRecvImpl.hpp
+++ b/Autocoders/Python/test/event1/TestLogRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestLogRecvImpl: public LogTextImpl {
         virtual ~TestLogRecvImpl();
         void init();
     protected:
-        void logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
+        void logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
     private:
 };
 

--- a/Autocoders/Python/test/event_enum/TestLogImpl.cpp
+++ b/Autocoders/Python/test/event_enum/TestLogImpl.cpp
@@ -20,7 +20,7 @@ void TestLogImpl::init() {
 }
 
 
-void TestLogImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestLogImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }
 

--- a/Autocoders/Python/test/event_enum/TestLogImpl.hpp
+++ b/Autocoders/Python/test/event_enum/TestLogImpl.hpp
@@ -17,7 +17,7 @@ class TestLogImpl: public Somewhere::TestLogComponentBase {
         void init();
         void sendEvent(I32 arg1, I32 arg2, U8 arg3);
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/event_enum/TestLogRecvImpl.cpp
+++ b/Autocoders/Python/test/event_enum/TestLogRecvImpl.cpp
@@ -15,7 +15,7 @@ TestLogRecvImpl::TestLogRecvImpl(const char* name) : LogTextImpl(name)
 TestLogRecvImpl::~TestLogRecvImpl() {
 }
 
-void TestLogRecvImpl::logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
+void TestLogRecvImpl::logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
     printf("Received log %d, Time (%d,%d:%d) severity %d\n",id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severity.e);
     I32 arg1;
     I32 arg2;

--- a/Autocoders/Python/test/event_enum/TestLogRecvImpl.hpp
+++ b/Autocoders/Python/test/event_enum/TestLogRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestLogRecvImpl: public LogTextImpl {
         virtual ~TestLogRecvImpl();
         void init();
     protected:
-        void logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
+        void logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
     private:
 };
 

--- a/Autocoders/Python/test/event_multi_inst/TestLogImpl.cpp
+++ b/Autocoders/Python/test/event_multi_inst/TestLogImpl.cpp
@@ -20,7 +20,7 @@ void TestLogImpl::init() {
 }
 
 
-void TestLogImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestLogImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }
 

--- a/Autocoders/Python/test/event_multi_inst/TestLogImpl.hpp
+++ b/Autocoders/Python/test/event_multi_inst/TestLogImpl.hpp
@@ -17,7 +17,7 @@ class TestLogImpl: public Somewhere::TestLogComponentBase {
         void init();
         void sendEvent(I32 arg1, F32 arg2, U8 arg3);
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/event_multi_inst/TestLogRecvImpl.cpp
+++ b/Autocoders/Python/test/event_multi_inst/TestLogRecvImpl.cpp
@@ -15,7 +15,7 @@ TestLogRecvImpl::TestLogRecvImpl(const char* name) : LogTextImpl(name)
 TestLogRecvImpl::~TestLogRecvImpl() {
 }
 
-void TestLogRecvImpl::logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
+void TestLogRecvImpl::logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
     printf("Received log %d, Time (%d,%d:%d) severity %d\n",id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severity.e);
     I32 arg1;
     F32 arg2;

--- a/Autocoders/Python/test/event_multi_inst/TestLogRecvImpl.hpp
+++ b/Autocoders/Python/test/event_multi_inst/TestLogRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestLogRecvImpl: public LogTextImpl {
         virtual ~TestLogRecvImpl();
         void init();
     protected:
-        void logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
+        void logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
     private:
 };
 

--- a/Autocoders/Python/test/event_string/TestLogImpl.cpp
+++ b/Autocoders/Python/test/event_string/TestLogImpl.cpp
@@ -20,7 +20,7 @@ void TestLogImpl::init() {
 }
 
 
-void TestLogImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestLogImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }
 

--- a/Autocoders/Python/test/event_string/TestLogImpl.hpp
+++ b/Autocoders/Python/test/event_string/TestLogImpl.hpp
@@ -17,7 +17,7 @@ class TestLogImpl: public Somewhere::TestLogComponentBase {
         void init();
         void sendEvent(I32 arg1, Fw::LogStringArg& arg2, U8 arg3);
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/event_string/TestLogRecvImpl.cpp
+++ b/Autocoders/Python/test/event_string/TestLogRecvImpl.cpp
@@ -16,7 +16,7 @@ TestLogRecvImpl::TestLogRecvImpl(const char* name) : LogTextImpl(name)
 TestLogRecvImpl::~TestLogRecvImpl() {
 }
 
-void TestLogRecvImpl::logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
+void TestLogRecvImpl::logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
     printf("Received log %d, Time (%d,%d:%d) severity %d\n",id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severity.e);
     I32 arg1;
     Fw::LogStringArg arg2;

--- a/Autocoders/Python/test/event_string/TestLogRecvImpl.hpp
+++ b/Autocoders/Python/test/event_string/TestLogRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestLogRecvImpl: public LogTextImpl {
         virtual ~TestLogRecvImpl();
         void init();
     protected:
-        void logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
+        void logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
     private:
 };
 

--- a/Autocoders/Python/test/event_throttle/TestLogImpl.cpp
+++ b/Autocoders/Python/test/event_throttle/TestLogImpl.cpp
@@ -20,7 +20,7 @@ void TestLogImpl::init(NATIVE_INT_TYPE instance) {
 }
 
 
-void TestLogImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestLogImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }
 

--- a/Autocoders/Python/test/event_throttle/TestLogImpl.hpp
+++ b/Autocoders/Python/test/event_throttle/TestLogImpl.hpp
@@ -18,7 +18,7 @@ class TestLogImpl: public Somewhere::TestLogComponentBase {
         void sendEvent(I32 arg1, F32 arg2, U8 arg3);
         void resetEvent();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/event_throttle/TestLogRecvImpl.cpp
+++ b/Autocoders/Python/test/event_throttle/TestLogRecvImpl.cpp
@@ -15,7 +15,7 @@ TestLogRecvImpl::TestLogRecvImpl(const char* name) : LogTextImpl(name)
 TestLogRecvImpl::~TestLogRecvImpl() {
 }
 
-void TestLogRecvImpl::logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, Fw::LogSeverity severity, Fw::LogBuffer &args) {
+void TestLogRecvImpl::logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, Fw::LogSeverity severity, Fw::LogBuffer &args) {
     printf("Received log %d, Time (%d,%d:%d) severity %d\n",id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severity);
     I32 arg1;
     F32 arg2;

--- a/Autocoders/Python/test/event_throttle/TestLogRecvImpl.hpp
+++ b/Autocoders/Python/test/event_throttle/TestLogRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestLogRecvImpl: public LogTextImpl {
         virtual ~TestLogRecvImpl();
         void init();
     protected:
-        void logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, Fw::LogSeverity severity, Fw::LogBuffer &args);
+        void logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, Fw::LogSeverity severity, Fw::LogBuffer &args);
     private:
 };
 

--- a/Autocoders/Python/test/ext_dict/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/test/ext_dict/ExampleComponentImpl.cpp
@@ -20,7 +20,7 @@ namespace ExampleComponents {
         ExampleComponentBase::init(queueDepth,instance);
     }
 
-    void ExampleComponentImpl::exampleInput_handler(NATIVE_INT_TYPE portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5) {
+    void ExampleComponentImpl::exampleInput_handler(FwIndexType portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5) {
         //Fw::TlmString arg = "A string arg";
         // write some telemetry
         U32 chan = 0;

--- a/Autocoders/Python/test/ext_dict/ExampleComponentImpl.hpp
+++ b/Autocoders/Python/test/ext_dict/ExampleComponentImpl.hpp
@@ -19,7 +19,7 @@ namespace ExampleComponents {
             virtual ~ExampleComponentImpl();
         protected:
         private:
-            void exampleInput_handler(NATIVE_INT_TYPE portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5);
+            void exampleInput_handler(FwIndexType portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5);
             void TEST_CMD_1_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, ExampleComponentBase::CmdEnum arg2, const Fw::CmdStringArg& arg3);
             void TEST_CMD_2_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, F32 arg2);
 

--- a/Autocoders/Python/test/ext_dict/test/ut/main.cpp
+++ b/Autocoders/Python/test/ext_dict/test/ut/main.cpp
@@ -11,7 +11,7 @@ class ATester : public ExampleComponents::ExampleGTestBase {
         ATester() : ExampleComponents::ExampleGTestBase("comp",10) {
     }
     void from_exampleOutput_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             I32 arg1, //!< A built-in type argument
             const ANameSpace::mytype& arg2, //!< A user-defined type argument
             U8 arg3, //!< The third argument
@@ -21,7 +21,7 @@ class ATester : public ExampleComponents::ExampleGTestBase {
 };
 
         void ATester::from_exampleOutput_handler(
-                const NATIVE_INT_TYPE portNum, //!< The port number
+                const FwIndexType portNum, //!< The port number
                 I32 arg1, //!< A built-in type argument
                 const ANameSpace::mytype& arg2, //!< A user-defined type argument
                 U8 arg3, //!< The third argument

--- a/Autocoders/Python/test/log_tester/TestTextLogImpl.cpp
+++ b/Autocoders/Python/test/log_tester/TestTextLogImpl.cpp
@@ -19,7 +19,7 @@ void LogTextImpl::init() {
     Log::LogTesterComponentBase::init();
 }
 
-void LogTextImpl::textLogRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity &severity, Fw::TextLogString &text) {
+void LogTextImpl::textLogRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity &severity, Fw::TextLogString &text) {
     printf("Log id %d, time (%d,%d:%d), severity %d, text \"%s\"",id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severity.e,text.toChar());
 }
 

--- a/Autocoders/Python/test/log_tester/TestTextLogImpl.hpp
+++ b/Autocoders/Python/test/log_tester/TestTextLogImpl.hpp
@@ -17,7 +17,7 @@ class LogTextImpl: public Log::LogTesterComponentBase {
         void init();
         void setTime(Fw::Time time);
     protected:
-        void textLogRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity &severity, Fw::TextLogString &text);
+        void textLogRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity &severity, Fw::TextLogString &text);
     private:
 };
 

--- a/Autocoders/Python/test/log_tester/test/ut/main.cpp
+++ b/Autocoders/Python/test/log_tester/test/ut/main.cpp
@@ -14,7 +14,7 @@ class ATester : public Log::LogTesterGTestBase {
     }
 
   void from_Time_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Time &time
     )
   {

--- a/Autocoders/Python/test/noargport/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/test/noargport/ExampleComponentImpl.cpp
@@ -49,7 +49,7 @@ namespace ExampleComponents {
 
   void ExampleComponentImpl ::
     noArgPort_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     // TODO
@@ -57,7 +57,7 @@ namespace ExampleComponents {
 
   void ExampleComponentImpl ::
     asyncNoArgPort_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     // TODO
@@ -65,7 +65,7 @@ namespace ExampleComponents {
 
   void ExampleComponentImpl ::
     guardedNoArgPort_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     // TODO
@@ -73,7 +73,7 @@ namespace ExampleComponents {
 
   U32 ExampleComponentImpl ::
     exampleInput_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     return 0;

--- a/Autocoders/Python/test/noargport/ExampleComponentImpl.hpp
+++ b/Autocoders/Python/test/noargport/ExampleComponentImpl.hpp
@@ -53,25 +53,25 @@ namespace ExampleComponents {
       //! Handler implementation for noArgPort
       //!
       void noArgPort_handler(
-          const NATIVE_INT_TYPE portNum /*!< The port number*/
+          const FwIndexType portNum /*!< The port number*/
       );
 
       //! Handler implementation for asyncNoArgPort
       //!
       void asyncNoArgPort_handler(
-          const NATIVE_INT_TYPE portNum /*!< The port number*/
+          const FwIndexType portNum /*!< The port number*/
       );
 
       //! Handler implementation for guardedNoArgPort
       //!
       void guardedNoArgPort_handler(
-          const NATIVE_INT_TYPE portNum /*!< The port number*/
+          const FwIndexType portNum /*!< The port number*/
       );
 
       //! Handler implementation for exampleInput
       //!
       U32 exampleInput_handler(
-          const NATIVE_INT_TYPE portNum /*!< The port number*/
+          const FwIndexType portNum /*!< The port number*/
       );
 
 

--- a/Autocoders/Python/test/param1/TestPrmImpl.cpp
+++ b/Autocoders/Python/test/param1/TestPrmImpl.cpp
@@ -19,7 +19,7 @@ void TestPrmImpl::init() {
     Prm::TestPrmComponentBase::init();
 }
 
-void TestPrmImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestPrmImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }
 

--- a/Autocoders/Python/test/param1/TestPrmImpl.hpp
+++ b/Autocoders/Python/test/param1/TestPrmImpl.hpp
@@ -18,7 +18,7 @@ class TestPrmImpl: public Prm::TestPrmComponentBase {
         void init();
         void printParam();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTPARAMIMPL_HPP_ */

--- a/Autocoders/Python/test/param1/TestPrmSourceImpl.cpp
+++ b/Autocoders/Python/test/param1/TestPrmSourceImpl.cpp
@@ -15,13 +15,13 @@ TestParamSourceImpl::TestParamSourceImpl(const char* name) : Prm::ParamTesterCom
 TestParamSourceImpl::~TestParamSourceImpl() {
 }
 
-Fw::ParamValid TestParamSourceImpl::paramGetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+Fw::ParamValid TestParamSourceImpl::paramGetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
 
     val = this->m_prm;
     return Fw::ParamValid::VALID;
 }
 
-void TestParamSourceImpl::paramSetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+void TestParamSourceImpl::paramSetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
 
 }
 

--- a/Autocoders/Python/test/param1/TestPrmSourceImpl.hpp
+++ b/Autocoders/Python/test/param1/TestPrmSourceImpl.hpp
@@ -17,8 +17,8 @@ class TestParamSourceImpl: public Prm::ParamTesterComponentBase {
         void init();
         void setPrm(U32 val);
     protected:
-        Fw::ParamValid paramGetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
-        void paramSetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+        Fw::ParamValid paramGetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+        void paramSetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
         Fw::ParamBuffer m_prm;
 };
 

--- a/Autocoders/Python/test/param_enum/TestPrmImpl.cpp
+++ b/Autocoders/Python/test/param_enum/TestPrmImpl.cpp
@@ -19,7 +19,7 @@ void TestPrmImpl::init() {
     Prm::TestPrmComponentBase::init();
 }
 
-void TestPrmImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestPrmImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }
 

--- a/Autocoders/Python/test/param_enum/TestPrmImpl.hpp
+++ b/Autocoders/Python/test/param_enum/TestPrmImpl.hpp
@@ -18,7 +18,7 @@ class TestPrmImpl: public Prm::TestPrmComponentBase {
         void init();
         void printParam();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTPARAMIMPL_HPP_ */

--- a/Autocoders/Python/test/param_enum/TestPrmSourceImpl.cpp
+++ b/Autocoders/Python/test/param_enum/TestPrmSourceImpl.cpp
@@ -15,13 +15,13 @@ TestParamSourceImpl::TestParamSourceImpl(const char* name) : Prm::ParamTesterCom
 TestParamSourceImpl::~TestParamSourceImpl() {
 }
 
-Fw::ParamValid TestParamSourceImpl::paramGetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+Fw::ParamValid TestParamSourceImpl::paramGetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
 
     val = this->m_prm;
     return Fw::ParamValid::VALID;
 }
 
-void TestParamSourceImpl::paramSetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+void TestParamSourceImpl::paramSetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
 
 }
 

--- a/Autocoders/Python/test/param_enum/TestPrmSourceImpl.hpp
+++ b/Autocoders/Python/test/param_enum/TestPrmSourceImpl.hpp
@@ -17,8 +17,8 @@ class TestParamSourceImpl: public Prm::ParamTesterComponentBase {
         void init();
         void setPrm(I32 val);
     protected:
-        Fw::ParamValid paramGetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
-        void paramSetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+        Fw::ParamValid paramGetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+        void paramSetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
     private:
         Fw::ParamBuffer m_prm;
 };

--- a/Autocoders/Python/test/param_multi_inst/TestPrmImpl.cpp
+++ b/Autocoders/Python/test/param_multi_inst/TestPrmImpl.cpp
@@ -19,7 +19,7 @@ void TestPrmImpl::init() {
     Prm::TestPrmComponentBase::init();
 }
 
-void TestPrmImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestPrmImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }
 

--- a/Autocoders/Python/test/param_multi_inst/TestPrmImpl.hpp
+++ b/Autocoders/Python/test/param_multi_inst/TestPrmImpl.hpp
@@ -18,7 +18,7 @@ class TestPrmImpl: public Prm::TestPrmComponentBase {
         void init();
         void printParam();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
         void parameterUpdated(FwPrmIdType id);
 };
 

--- a/Autocoders/Python/test/param_multi_inst/TestPrmSourceImpl.cpp
+++ b/Autocoders/Python/test/param_multi_inst/TestPrmSourceImpl.cpp
@@ -15,13 +15,13 @@ TestParamSourceImpl::TestParamSourceImpl(const char* name) : Prm::ParamTesterCom
 TestParamSourceImpl::~TestParamSourceImpl() {
 }
 
-Fw::ParamValid TestParamSourceImpl::paramGetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+Fw::ParamValid TestParamSourceImpl::paramGetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
 
     val = this->m_prm;
     return Fw::ParamValid::VALID;
 }
 
-void TestParamSourceImpl::paramSetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+void TestParamSourceImpl::paramSetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
 
 }
 

--- a/Autocoders/Python/test/param_multi_inst/TestPrmSourceImpl.hpp
+++ b/Autocoders/Python/test/param_multi_inst/TestPrmSourceImpl.hpp
@@ -17,8 +17,8 @@ class TestParamSourceImpl: public Prm::ParamTesterComponentBase {
         void init();
         void setPrm(U32 val);
     protected:
-        Fw::ParamValid paramGetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
-        void paramSetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+        Fw::ParamValid paramGetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+        void paramSetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
         Fw::ParamBuffer m_prm;
 };
 

--- a/Autocoders/Python/test/param_string/TestPrmImpl.cpp
+++ b/Autocoders/Python/test/param_string/TestPrmImpl.cpp
@@ -19,7 +19,7 @@ void TestPrmImpl::init() {
     Prm::TestPrmComponentBase::init();
 }
 
-void TestPrmImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestPrmImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }
 

--- a/Autocoders/Python/test/param_string/TestPrmImpl.hpp
+++ b/Autocoders/Python/test/param_string/TestPrmImpl.hpp
@@ -19,7 +19,7 @@ class TestPrmImpl: public Prm::TestPrmComponentBase {
         void init();
         void printParam();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTPARAMIMPL_HPP_ */

--- a/Autocoders/Python/test/param_string/TestPrmSourceImpl.cpp
+++ b/Autocoders/Python/test/param_string/TestPrmSourceImpl.cpp
@@ -15,13 +15,13 @@ TestParamSourceImpl::TestParamSourceImpl(const char* name) : Prm::ParamTesterCom
 TestParamSourceImpl::~TestParamSourceImpl() {
 }
 
-Fw::ParamValid TestParamSourceImpl::paramGetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+Fw::ParamValid TestParamSourceImpl::paramGetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
 
     val = this->m_prm;
     return Fw::ParamValid::VALID;
 }
 
-void TestParamSourceImpl::paramSetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+void TestParamSourceImpl::paramSetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
 
 }
 

--- a/Autocoders/Python/test/param_string/TestPrmSourceImpl.hpp
+++ b/Autocoders/Python/test/param_string/TestPrmSourceImpl.hpp
@@ -18,8 +18,8 @@ class TestParamSourceImpl: public Prm::ParamTesterComponentBase {
         void init();
         void setPrm(Fw::ParamString& val);
     protected:
-        Fw::ParamValid paramGetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
-        void paramSetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+        Fw::ParamValid paramGetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+        void paramSetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
     private:
         Fw::ParamBuffer m_prm;
 };

--- a/Autocoders/Python/test/pass_by_attrib/Msg1Port.hpp
+++ b/Autocoders/Python/test/pass_by_attrib/Msg1Port.hpp
@@ -25,7 +25,7 @@ namespace Ports {
         enum {
             SERIALIZED_SIZE = sizeof(U32) + sizeof(U32 *) + sizeof(U32)
         };
-        typedef void (*CompFuncPtr)(Fw::ComponentBase* callComp, NATIVE_INT_TYPE portNum, U32 arg1, U32 *arg2, U32 &arg3);
+        typedef void (*CompFuncPtr)(Fw::ComponentBase* callComp, FwIndexType portNum, U32 arg1, U32 *arg2, U32 &arg3);
 
         InputMsg1Port();
         void init();

--- a/Autocoders/Python/test/pass_by_kind/Component1.cpp
+++ b/Autocoders/Python/test/pass_by_kind/Component1.cpp
@@ -20,7 +20,7 @@ namespace Example {
         Component1ComponentBase::init(queueDepth);
     }
 
-    void Component1::AsyncPort_handler(NATIVE_INT_TYPE portNum,U32 *arg1, U32 &arg2, U32 arg3,
+    void Component1::AsyncPort_handler(FwIndexType portNum,U32 *arg1, U32 &arg2, U32 arg3,
         ExampleType *arg4, ExampleType &arg5, const ExampleType &arg6,
         Arg7String *arg7, Arg8String &arg8, const Arg9String &arg9) {
         *arg1 = 1;
@@ -34,7 +34,7 @@ namespace Example {
         // arg9 is a const ref -- compiler won't let us modify through it
     }
 
-    void Component1::SyncPort_handler(NATIVE_INT_TYPE portNum,U32 *arg1, U32 &arg2, U32 arg3,
+    void Component1::SyncPort_handler(FwIndexType portNum,U32 *arg1, U32 &arg2, U32 arg3,
         ExampleType *arg4, ExampleType &arg5, const ExampleType &arg6,
         Arg7String *arg7, Arg8String &arg8, const Arg9String &arg9) {
         *arg1 = 1;

--- a/Autocoders/Python/test/pass_by_kind/Component1.hpp
+++ b/Autocoders/Python/test/pass_by_kind/Component1.hpp
@@ -14,11 +14,11 @@ namespace Example {
         void init(NATIVE_INT_TYPE queueDepth);
 
     private:
-        void AsyncPort_handler(NATIVE_INT_TYPE portNum,U32 *arg1, U32 &arg2, U32 arg3,
+        void AsyncPort_handler(FwIndexType portNum,U32 *arg1, U32 &arg2, U32 arg3,
         ExampleType *arg4, ExampleType &arg5, const ExampleType &arg6,
         Arg7String *arg7, Arg8String &arg8, const Arg9String &arg9);
 
-        void SyncPort_handler(NATIVE_INT_TYPE portNum,U32 *arg1, U32 &arg2, U32 arg3,
+        void SyncPort_handler(FwIndexType portNum,U32 *arg1, U32 &arg2, U32 arg3,
         ExampleType *arg4, ExampleType &arg5, const ExampleType &arg6,
         Arg7String *arg7, Arg8String &arg8, const Arg9String &arg9);
     };

--- a/Autocoders/Python/test/port_loopback/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/test/port_loopback/ExampleComponentImpl.cpp
@@ -50,7 +50,7 @@ namespace ExampleComponents {
 
   void ExampleComponentImpl ::
     exampleInput_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         I32 arg1,
         AnotherExample::SomeEnum arg2,
         const AnotherExample::arg6String& arg6

--- a/Autocoders/Python/test/port_loopback/ExampleComponentImpl.hpp
+++ b/Autocoders/Python/test/port_loopback/ExampleComponentImpl.hpp
@@ -54,7 +54,7 @@ namespace ExampleComponents {
       //! Handler implementation for exampleInput
       //!
       void exampleInput_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           I32 arg1, //!< A built-in type argument
           AnotherExample::SomeEnum arg2, //!< The ENUM argument
           const AnotherExample::arg6String& arg6

--- a/Autocoders/Python/test/port_loopback/test/ut/main.cpp
+++ b/Autocoders/Python/test/port_loopback/test/ut/main.cpp
@@ -12,7 +12,7 @@ public:
         }
 
         void from_exampleOutput_handler(
-                const NATIVE_INT_TYPE portNum, //!< The port number
+                const FwIndexType portNum, //!< The port number
                 I32 arg1, //!< A built-in type argument
                 AnotherExample::SomeEnum arg2, //!< The ENUM argument
                 const AnotherExample::arg6String& arg6
@@ -20,7 +20,7 @@ public:
     };
 
     void ATester::from_exampleOutput_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             I32 arg1, //!< A built-in type argument
             AnotherExample::SomeEnum arg2, //!< The ENUM argument
             const AnotherExample::arg6String& arg6

--- a/Autocoders/Python/test/port_nogen/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/test/port_nogen/ExampleComponentImpl.cpp
@@ -20,7 +20,7 @@ namespace ExampleComponents {
         ExampleComponentBase::init(queueDepth,instance);
     }
 
-    void ExampleComponentImpl::exampleInput_handler(NATIVE_INT_TYPE portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5) {
+    void ExampleComponentImpl::exampleInput_handler(FwIndexType portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5) {
         Fw::TlmString arg = "A string arg";
         // write some telemetry
         U32 tlmval = 0;

--- a/Autocoders/Python/test/port_nogen/ExampleComponentImpl.hpp
+++ b/Autocoders/Python/test/port_nogen/ExampleComponentImpl.hpp
@@ -19,7 +19,7 @@ namespace ExampleComponents {
             virtual ~ExampleComponentImpl();
         protected:
         private:
-            void exampleInput_handler(NATIVE_INT_TYPE portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5);
+            void exampleInput_handler(FwIndexType portNum, I32 arg1, const ANameSpace::mytype& arg2, U8 arg3, const Example3::ExampleSerializable& arg4, AnotherExample::SomeEnum arg5);
             void TEST_CMD_1_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, ExampleComponentBase::CmdEnum arg2, const Fw::CmdStringArg& arg3);
             void TEST_CMD_2_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, F32 arg2);
 

--- a/Autocoders/Python/test/port_nogen/test/ut/main.cpp
+++ b/Autocoders/Python/test/port_nogen/test/ut/main.cpp
@@ -12,7 +12,7 @@ class ATester : public ExampleComponents::ExampleGTestBase {
     }
 
 		void from_exampleOutput_handler(
-			const NATIVE_INT_TYPE portNum, //!< The port number
+			const FwIndexType portNum, //!< The port number
 			I32 arg1, //!< A built-in type argument
 			const ANameSpace::mytype& arg2, //!< A user-defined type argument
 			U8 arg3, //!< The third argument
@@ -24,7 +24,7 @@ class ATester : public ExampleComponents::ExampleGTestBase {
 
 
 		void ATester::from_exampleOutput_handler(
-			const NATIVE_INT_TYPE portNum, //!< The port number
+			const FwIndexType portNum, //!< The port number
 			I32 arg1, //!< A built-in type argument
 			const ANameSpace::mytype& arg2, //!< A user-defined type argument
 			U8 arg3, //!< The third argument

--- a/Autocoders/Python/test/queued1/TestComponentImpl.cpp
+++ b/Autocoders/Python/test/queued1/TestComponentImpl.cpp
@@ -17,14 +17,14 @@ namespace SvcTest {
     TestComponentImpl::~TestComponentImpl() {
     }
 
-    void TestComponentImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+    void TestComponentImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
         printf("aport_handler called with %d, %f, %d,\n",arg4,arg5,arg6);
         // call dispatcher
         MsgDispatchStatus stat = this->doDispatch();
         printf("Dispatch status: %d\n",stat);
     }
 
-    void TestComponentImpl::aport2_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, bool arg6) {
+    void TestComponentImpl::aport2_handler(FwIndexType portNum, I32 arg4, F32 arg5, bool arg6) {
         printf("aport2_handler called with %d, %f, %s.\n",arg4,arg5,arg6?"TRUE":"FALSE");
     }
 

--- a/Autocoders/Python/test/queued1/TestComponentImpl.hpp
+++ b/Autocoders/Python/test/queued1/TestComponentImpl.hpp
@@ -17,8 +17,8 @@ namespace SvcTest {
             TestComponentImpl(const char* compName);
             virtual ~TestComponentImpl();
         private:
-            void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
-            void aport2_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, bool arg6);
+            void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
+            void aport2_handler(FwIndexType portNum, I32 arg4, F32 arg5, bool arg6);
 
     };
 

--- a/Autocoders/Python/test/serial_passive/TestSerialImpl.cpp
+++ b/Autocoders/Python/test/serial_passive/TestSerialImpl.cpp
@@ -51,7 +51,7 @@ namespace TestComponents {
 
   void TestSerialImpl ::
     SerialInSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase &Buffer //!< The serialization buffer
     )
   {
@@ -60,7 +60,7 @@ namespace TestComponents {
 
   void TestSerialImpl ::
     SerialInGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase &Buffer //!< The serialization buffer
     )
   {
@@ -69,7 +69,7 @@ namespace TestComponents {
 
   void TestSerialImpl ::
     SerialInAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase &Buffer //!< The serialization buffer
     )
   {

--- a/Autocoders/Python/test/serial_passive/TestSerialImpl.hpp
+++ b/Autocoders/Python/test/serial_passive/TestSerialImpl.hpp
@@ -54,21 +54,21 @@ namespace TestComponents {
       //! Handler implementation for SerialInSync
       //!
       void SerialInSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase &Buffer //!< The serialization buffer
       );
 
       //! Handler implementation for SerialInGuarded
       //!
       void SerialInGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase &Buffer //!< The serialization buffer
       );
 
       //! Handler implementation for SerialInAsync
       //!
       void SerialInAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase &Buffer //!< The serialization buffer
       );
 

--- a/Autocoders/Python/test/serial_passive/test/ut/serial_passiveTester.cpp
+++ b/Autocoders/Python/test/serial_passive/test/ut/serial_passiveTester.cpp
@@ -53,7 +53,7 @@ namespace TestComponents {
 
   void serial_passiveTester ::
     from_SerialOut_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase &Buffer //!< The serialization buffer
     )
   {

--- a/Autocoders/Python/test/serial_passive/test/ut/serial_passiveTester.hpp
+++ b/Autocoders/Python/test/serial_passive/test/ut/serial_passiveTester.hpp
@@ -55,7 +55,7 @@ namespace TestComponents {
       //! Handler for from_SerialOut
       //!
       void from_SerialOut_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase &Buffer //!< The serialization buffer
       );
 

--- a/Autocoders/Python/test/serialize_user/ExampleComponentImpl.cpp
+++ b/Autocoders/Python/test/serialize_user/ExampleComponentImpl.cpp
@@ -20,7 +20,7 @@ void ExampleComponentImpl::init(NATIVE_INT_TYPE queueDepth) {
 ExampleComponentImpl::~ExampleComponentImpl() {
 }
 
-void ExampleComponentImpl::exampleInput_handler(NATIVE_INT_TYPE portNum, I32 arg1, const ANameSpace::UserSerializer& arg2) {
+void ExampleComponentImpl::exampleInput_handler(FwIndexType portNum, I32 arg1, const ANameSpace::UserSerializer& arg2) {
 
     Fw::String str;
     arg2.toString(str);

--- a/Autocoders/Python/test/serialize_user/ExampleComponentImpl.hpp
+++ b/Autocoders/Python/test/serialize_user/ExampleComponentImpl.hpp
@@ -16,7 +16,7 @@ class ExampleComponentImpl: public ExampleComponents::ExampleComponentComponentB
         void init(NATIVE_INT_TYPE queueDepth);
         virtual ~ExampleComponentImpl();
     private:
-        void exampleInput_handler(NATIVE_INT_TYPE portNum, I32 arg1, const ANameSpace::UserSerializer& arg2);
+        void exampleInput_handler(FwIndexType portNum, I32 arg1, const ANameSpace::UserSerializer& arg2);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/serialize_user/test/ut/main.cpp
+++ b/Autocoders/Python/test/serialize_user/test/ut/main.cpp
@@ -13,7 +13,7 @@ class ATester : public ExampleComponents::ExampleComponentGTestBase {
 
 
    void from_exampleOutput_handler(
-		const NATIVE_INT_TYPE portNum, //!< The port number
+		const FwIndexType portNum, //!< The port number
 		I32 arg1, //!< A built-in type argument
 		const ANameSpace::UserSerializer& arg2 //!< A user-defined type argument
 	);
@@ -22,7 +22,7 @@ class ATester : public ExampleComponents::ExampleComponentGTestBase {
 
 
 void ATester::from_exampleOutput_handler(
-	const NATIVE_INT_TYPE portNum, //!< The port number
+	const FwIndexType portNum, //!< The port number
 	I32 arg1, //!< A built-in type argument
 	const ANameSpace::UserSerializer& arg2 //!< A user-defined type argument
 ) {

--- a/Autocoders/Python/test/stress/TestCommandImpl.cpp
+++ b/Autocoders/Python/test/stress/TestCommandImpl.cpp
@@ -20,11 +20,11 @@ void TestCommand1Impl::init(NATIVE_INT_TYPE queueDepth) {
 TestCommand1Impl::~TestCommand1Impl() {
 }
 
-void TestCommand1Impl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestCommand1Impl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
     printf("Received aport_Test_handler call with %i %f %d\n",arg4,arg5,arg6);
 }
 
-void TestCommand1Impl::aport2_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, const Ref::Gnc::Quaternion& arg6) {
+void TestCommand1Impl::aport2_handler(FwIndexType portNum, I32 arg4, F32 arg5, const Ref::Gnc::Quaternion& arg6) {
     Fw::String str;
     arg6.toString(str);
     printf("Received aport2_Test2_handler call with %i %f %s\n",arg4,arg5,str.toChar());

--- a/Autocoders/Python/test/stress/TestCommandImpl.hpp
+++ b/Autocoders/Python/test/stress/TestCommandImpl.hpp
@@ -19,8 +19,8 @@ class TestCommand1Impl: public StressTest::TestCommandComponentBase {
         void genTlm(Ref::Gnc::Quaternion val);
         void sendEvent(I32 arg1, F32 arg2, U8 arg3);
     private:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
-        void aport2_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, const Ref::Gnc::Quaternion& arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport2_handler(FwIndexType portNum, I32 arg4, F32 arg5, const Ref::Gnc::Quaternion& arg6);
         void TEST_CMD_1_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, StressTest::TestCommandComponentBase::SomeEnum arg2);
         void TEST_CMD_2_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, I32 arg1, F32 arg2);
 };

--- a/Autocoders/Python/test/stress/TestCommandSourceImpl.cpp
+++ b/Autocoders/Python/test/stress/TestCommandSourceImpl.cpp
@@ -16,12 +16,12 @@ TestCommandSourceImpl::~TestCommandSourceImpl() {
 }
 
 void TestCommandSourceImpl::cmdStatusPort_handler(
-        NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq,
+        FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq,
         const Fw::CmdResponse& response) {
     this->printStatus(response);
 }
 
-void TestCommandSourceImpl::cmdRegPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode) {
+void TestCommandSourceImpl::cmdRegPort_handler(FwIndexType portNum, FwOpcodeType opCode) {
     printf("Received registration for opcode %d\n",opCode);
 }
 

--- a/Autocoders/Python/test/stress/TestCommandSourceImpl.hpp
+++ b/Autocoders/Python/test/stress/TestCommandSourceImpl.hpp
@@ -18,8 +18,8 @@ class TestCommandSourceImpl: public Cmd::CommandTesterComponentBase {
         void init();
         void test_TEST_CMD_1(I32 arg1, I32 arg2);
     protected:
-        void cmdStatusPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse& response);
-        void cmdRegPort_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode);
+        void cmdStatusPort_handler(FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse& response);
+        void cmdRegPort_handler(FwIndexType portNum, FwOpcodeType opCode);
     private:
         void printStatus(const Fw::CmdResponse& response);
 };

--- a/Autocoders/Python/test/stress/TestLogRecvImpl.cpp
+++ b/Autocoders/Python/test/stress/TestLogRecvImpl.cpp
@@ -15,7 +15,7 @@ TestLogRecvImpl::TestLogRecvImpl(const char* name) : LogTextImpl(name)
 TestLogRecvImpl::~TestLogRecvImpl() {
 }
 
-void TestLogRecvImpl::logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
+void TestLogRecvImpl::logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
     printf("Received log %d, Time (%d,%d:%d) severity %d\n",id,timeTag.getTimeBase(),timeTag.getSeconds(),timeTag.getUSeconds(),severity.e);
     I32 arg1;
     F32 arg2;

--- a/Autocoders/Python/test/stress/TestLogRecvImpl.hpp
+++ b/Autocoders/Python/test/stress/TestLogRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestLogRecvImpl: public LogTextImpl {
         virtual ~TestLogRecvImpl();
         void init();
     protected:
-        void logRecvPort_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
+        void logRecvPort_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
     private:
 };
 

--- a/Autocoders/Python/test/stress/TestPrmSourceImpl.cpp
+++ b/Autocoders/Python/test/stress/TestPrmSourceImpl.cpp
@@ -25,12 +25,12 @@ void TestParamSourceImpl::setPrm(U32 val) {
     this->m_prm.serialize(val);
 }
 
-Fw::ParamValid TestParamSourceImpl::paramGetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+Fw::ParamValid TestParamSourceImpl::paramGetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
     val = this->m_prm;
     return Fw::ParamValid::VALID;
 }
 
-void TestParamSourceImpl::paramSetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+void TestParamSourceImpl::paramSetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
 
 }
 

--- a/Autocoders/Python/test/stress/TestPrmSourceImpl.hpp
+++ b/Autocoders/Python/test/stress/TestPrmSourceImpl.hpp
@@ -18,8 +18,8 @@ class TestParamSourceImpl: public Prm::ParamTesterComponentBase {
         void setPrm(U32 val);
     protected:
     private:
-        Fw::ParamValid paramGetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
-        void paramSetPort_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+        Fw::ParamValid paramGetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+        void paramSetPort_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
         Fw::ParamBuffer m_prm;
 };
 

--- a/Autocoders/Python/test/stress/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/stress/TestTelemRecvImpl.cpp
@@ -17,7 +17,7 @@ TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterCompone
 TestTelemRecvImpl::~TestTelemRecvImpl() {
 }
 
-void TestTelemRecvImpl::tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
+void TestTelemRecvImpl::tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
     Ref::Gnc::Quaternion tlmVal;
     val.deserialize(tlmVal);
     Fw::String str;

--- a/Autocoders/Python/test/stress/TestTelemRecvImpl.hpp
+++ b/Autocoders/Python/test/stress/TestTelemRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestTelemRecvImpl: public Tlm::TelemTesterComponentBase {
         virtual ~TestTelemRecvImpl();
         void init();
     protected:
-        void tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
+        void tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
     private:
 };
 

--- a/Autocoders/Python/test/stress/test/ut/main.cpp
+++ b/Autocoders/Python/test/stress/test/ut/main.cpp
@@ -12,14 +12,14 @@ public:
         }
 
         void from_aport_handler(
-                const NATIVE_INT_TYPE portNum, //!< The port number
+                const FwIndexType portNum, //!< The port number
                 I32 arg4, //!< The first argument
                 F32 arg5, //!< The second argument
                 U8 arg6 //!< The third argument
         );
 
         void from_aport2_handler(
-                const NATIVE_INT_TYPE portNum, //!< The port number
+                const FwIndexType portNum, //!< The port number
                 I32 arg4, //!< The first argument
                 F32 arg5, //!< The second argument
                 const Ref::Gnc::Quaternion& arg6 //!< The third argument
@@ -28,7 +28,7 @@ public:
 
 
     void ATester::from_aport_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             I32 arg4, //!< The first argument
             F32 arg5, //!< The second argument
             U8 arg6 //!< The third argument
@@ -37,7 +37,7 @@ public:
     }
 
     void ATester::from_aport2_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             I32 arg4, //!< The first argument
             F32 arg5, //!< The second argument
             const Ref::Gnc::Quaternion& arg6 //!< The third argument

--- a/Autocoders/Python/test/string_port/test/ut/main.cpp
+++ b/Autocoders/Python/test/string_port/test/ut/main.cpp
@@ -12,7 +12,7 @@ public:
         }
 
         void from_testOut_handler(
-                const NATIVE_INT_TYPE portNum, //!< The port number
+                const FwIndexType portNum, //!< The port number
                 I32 arg1, //!< A built-in type argument
                 AnotherExample::arg2String &arg2, //!< A string argument
                 const AnotherExample::arg3Buffer &arg3 //!< A buffer argument
@@ -21,7 +21,7 @@ public:
 
 
     void ATester::from_testOut_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             I32 arg1, //!< A built-in type argument
             AnotherExample::arg2String &arg2, //!< A string argument
             const AnotherExample::arg3Buffer &arg3 //!< A buffer argument

--- a/Autocoders/Python/test/testgen/MathSenderComponentImpl.cpp
+++ b/Autocoders/Python/test/testgen/MathSenderComponentImpl.cpp
@@ -49,7 +49,7 @@ namespace Ref {
 
   void MathSenderComponentImpl ::
     mathIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         F32 result
     )
   {

--- a/Autocoders/Python/test/testgen/MathSenderComponentImpl.hpp
+++ b/Autocoders/Python/test/testgen/MathSenderComponentImpl.hpp
@@ -53,7 +53,7 @@ namespace Ref {
       //! Handler implementation for mathIn
       //!
       void mathIn_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           F32 result /*!< the result of the operation*/
       );
 

--- a/Autocoders/Python/test/testgen/test/ut/testgenTester.cpp
+++ b/Autocoders/Python/test/testgen/test/ut/testgenTester.cpp
@@ -255,7 +255,7 @@ namespace Ref {
 
   void testgenTester ::
     from_mathOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         F32 val1,
         F32 val2,
         MathOperation operation

--- a/Autocoders/Python/test/testgen/test/ut/testgenTester.hpp
+++ b/Autocoders/Python/test/testgen/test/ut/testgenTester.hpp
@@ -49,7 +49,7 @@ namespace Ref {
       //! Handler for from_mathOut
       //!
       void from_mathOut_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           F32 val1,
           F32 val2,
           MathOperation operation /*!< operation argument*/

--- a/Autocoders/Python/test/time_tester/TestTimeImpl.cpp
+++ b/Autocoders/Python/test/time_tester/TestTimeImpl.cpp
@@ -16,7 +16,7 @@ TestTimeImpl::~TestTimeImpl() {
 }
 
 void TestTimeImpl::timeGetPort_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::Time &time /*!< The U32 cmd argument*/
     ) {
     time = this->m_time;

--- a/Autocoders/Python/test/time_tester/TestTimeImpl.hpp
+++ b/Autocoders/Python/test/time_tester/TestTimeImpl.hpp
@@ -18,7 +18,7 @@ class TestTimeImpl: public Time::TimeTesterComponentBase {
         void setTime(Fw::Time time);
     protected:
         void timeGetPort_handler(
-                NATIVE_INT_TYPE portNum, /*!< The port number*/
+                FwIndexType portNum, /*!< The port number*/
                 Fw::Time &time /*!< The U32 cmd argument*/
             );
     private:

--- a/Autocoders/Python/test/tlm1/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm1/TestTelemImpl.cpp
@@ -24,6 +24,6 @@ void TestTlmImpl::genTlm(U32 val) {
     this->tlmWrite_somechan(val);
 }
 
-void TestTlmImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestTlmImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }

--- a/Autocoders/Python/test/tlm1/TestTelemImpl.hpp
+++ b/Autocoders/Python/test/tlm1/TestTelemImpl.hpp
@@ -17,7 +17,7 @@ class TestTlmImpl: public Tlm::TestTlmComponentBase {
         virtual ~TestTlmImpl();
         void init();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/tlm1/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm1/TestTelemRecvImpl.cpp
@@ -15,7 +15,7 @@ TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterCompone
 TestTelemRecvImpl::~TestTelemRecvImpl() {
 }
 
-void TestTelemRecvImpl::tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
+void TestTelemRecvImpl::tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
     U32 tlmVal;
     val.deserialize(tlmVal);
     printf("ID: %d TLM value is %d. Time is %d:%d base: %d\n",id,tlmVal,timeTag.getSeconds(),timeTag.getUSeconds(),timeTag.getTimeBase());

--- a/Autocoders/Python/test/tlm1/TestTelemRecvImpl.hpp
+++ b/Autocoders/Python/test/tlm1/TestTelemRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestTelemRecvImpl: public Tlm::TelemTesterComponentBase {
         virtual ~TestTelemRecvImpl();
         void init();
     protected:
-        void tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
+        void tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
     private:
 };
 

--- a/Autocoders/Python/test/tlm2/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm2/TestTelemImpl.cpp
@@ -23,6 +23,6 @@ void TestTlmImpl::genTlm(Ref::Gnc::Quaternion val) {
     this->tlmWrite_AQuat(val);
 }
 
-void TestTlmImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestTlmImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }

--- a/Autocoders/Python/test/tlm2/TestTelemImpl.hpp
+++ b/Autocoders/Python/test/tlm2/TestTelemImpl.hpp
@@ -17,7 +17,7 @@ class TestTlmImpl: public Tlm::TestTlmComponentBase {
         virtual ~TestTlmImpl();
         void init();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/tlm2/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm2/TestTelemRecvImpl.cpp
@@ -17,7 +17,7 @@ TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterCompone
 TestTelemRecvImpl::~TestTelemRecvImpl() {
 }
 
-void TestTelemRecvImpl::tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
+void TestTelemRecvImpl::tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
     Ref::Gnc::Quaternion tlmVal;
     val.deserialize(tlmVal);
     Fw::String str;

--- a/Autocoders/Python/test/tlm2/TestTelemRecvImpl.hpp
+++ b/Autocoders/Python/test/tlm2/TestTelemRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestTelemRecvImpl: public Tlm::TelemTesterComponentBase {
         virtual ~TestTelemRecvImpl();
         void init();
     protected:
-        void tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
+        void tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
     private:
 };
 

--- a/Autocoders/Python/test/tlm_enum/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm_enum/TestTelemImpl.cpp
@@ -25,6 +25,6 @@ void TestTlmImpl::genTlm(I32 val) {
     this->tlmWrite_somechan(argVal);
 }
 
-void TestTlmImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestTlmImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }

--- a/Autocoders/Python/test/tlm_enum/TestTelemImpl.hpp
+++ b/Autocoders/Python/test/tlm_enum/TestTelemImpl.hpp
@@ -17,7 +17,7 @@ class TestTlmImpl: public Tlm::TestTlmComponentBase {
         virtual ~TestTlmImpl();
         void init();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/tlm_enum/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm_enum/TestTelemRecvImpl.cpp
@@ -16,7 +16,7 @@ TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterCompone
 TestTelemRecvImpl::~TestTelemRecvImpl() {
 }
 
-void TestTelemRecvImpl::tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
+void TestTelemRecvImpl::tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
     U32 tlmVal;
     val.deserialize(tlmVal);
     printf("ID: %d TLM value is %d. Time is %d:%d base: %d\n",id,tlmVal,timeTag.getSeconds(),timeTag.getUSeconds(),timeTag.getTimeBase());

--- a/Autocoders/Python/test/tlm_enum/TestTelemRecvImpl.hpp
+++ b/Autocoders/Python/test/tlm_enum/TestTelemRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestTelemRecvImpl: public Tlm::TelemTesterComponentBase {
         virtual ~TestTelemRecvImpl();
         void init();
     protected:
-        void tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
+        void tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
     private:
 };
 

--- a/Autocoders/Python/test/tlm_multi_inst/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm_multi_inst/TestTelemImpl.cpp
@@ -24,6 +24,6 @@ void TestTlmImpl::genTlm(U32 val) {
     this->tlmWrite_somechan(val);
 }
 
-void TestTlmImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestTlmImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }

--- a/Autocoders/Python/test/tlm_multi_inst/TestTelemImpl.hpp
+++ b/Autocoders/Python/test/tlm_multi_inst/TestTelemImpl.hpp
@@ -17,7 +17,7 @@ class TestTlmImpl: public Tlm::TestTlmComponentBase {
         virtual ~TestTlmImpl();
         void init();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/tlm_multi_inst/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm_multi_inst/TestTelemRecvImpl.cpp
@@ -15,7 +15,7 @@ TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterCompone
 TestTelemRecvImpl::~TestTelemRecvImpl() {
 }
 
-void TestTelemRecvImpl::tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
+void TestTelemRecvImpl::tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
     U32 tlmVal;
     val.deserialize(tlmVal);
     printf("ID: %d TLM value is %d. Time is %d:%d base: %d\n",id,tlmVal,timeTag.getSeconds(),timeTag.getUSeconds(),timeTag.getTimeBase());

--- a/Autocoders/Python/test/tlm_multi_inst/TestTelemRecvImpl.hpp
+++ b/Autocoders/Python/test/tlm_multi_inst/TestTelemRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestTelemRecvImpl: public Tlm::TelemTesterComponentBase {
         virtual ~TestTelemRecvImpl();
         void init();
     protected:
-        void tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
+        void tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
     private:
 };
 

--- a/Autocoders/Python/test/tlm_onchange/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm_onchange/TestTelemImpl.cpp
@@ -24,6 +24,6 @@ void TestTlmImpl::genTlm(U32 val) {
     this->tlmWrite_somechan(val);
 }
 
-void TestTlmImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestTlmImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }

--- a/Autocoders/Python/test/tlm_onchange/TestTelemImpl.hpp
+++ b/Autocoders/Python/test/tlm_onchange/TestTelemImpl.hpp
@@ -17,7 +17,7 @@ class TestTlmImpl: public Tlm::TestTlmComponentBase {
         virtual ~TestTlmImpl();
         void init();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/tlm_onchange/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm_onchange/TestTelemRecvImpl.cpp
@@ -15,7 +15,7 @@ TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterCompone
 TestTelemRecvImpl::~TestTelemRecvImpl() {
 }
 
-void TestTelemRecvImpl::tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
+void TestTelemRecvImpl::tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
     U32 tlmVal;
     val.deserialize(tlmVal);
     printf("ID: %d TLM value is %d. Time is %d:%d base: %d\n",id,tlmVal,timeTag.getSeconds(),timeTag.getUSeconds(),timeTag.getTimeBase());

--- a/Autocoders/Python/test/tlm_onchange/TestTelemRecvImpl.hpp
+++ b/Autocoders/Python/test/tlm_onchange/TestTelemRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestTelemRecvImpl: public Tlm::TelemTesterComponentBase {
         virtual ~TestTelemRecvImpl();
         void init();
     protected:
-        void tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
+        void tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
     private:
 };
 

--- a/Autocoders/Python/test/tlm_string/TestTelemImpl.cpp
+++ b/Autocoders/Python/test/tlm_string/TestTelemImpl.cpp
@@ -24,6 +24,6 @@ void TestTlmImpl::genTlm(Fw::TlmString& val) {
     this->tlmWrite_stringchan(val);
 }
 
-void TestTlmImpl::aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6) {
+void TestTlmImpl::aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6) {
 
 }

--- a/Autocoders/Python/test/tlm_string/TestTelemImpl.hpp
+++ b/Autocoders/Python/test/tlm_string/TestTelemImpl.hpp
@@ -17,7 +17,7 @@ class TestTlmImpl: public Tlm::TestTlmComponentBase {
         virtual ~TestTlmImpl();
         void init();
     protected:
-        void aport_handler(NATIVE_INT_TYPE portNum, I32 arg4, F32 arg5, U8 arg6);
+        void aport_handler(FwIndexType portNum, I32 arg4, F32 arg5, U8 arg6);
 };
 
 #endif /* TESTCOMMAND1IMPL_HPP_ */

--- a/Autocoders/Python/test/tlm_string/TestTelemRecvImpl.cpp
+++ b/Autocoders/Python/test/tlm_string/TestTelemRecvImpl.cpp
@@ -16,7 +16,7 @@ TestTelemRecvImpl::TestTelemRecvImpl(const char* name) : Tlm::TelemTesterCompone
 TestTelemRecvImpl::~TestTelemRecvImpl() {
 }
 
-void TestTelemRecvImpl::tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
+void TestTelemRecvImpl::tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val) {
     Fw::TlmString tlmVal;
 
     Fw::SerializeStatus stat = val.deserialize(tlmVal);;

--- a/Autocoders/Python/test/tlm_string/TestTelemRecvImpl.hpp
+++ b/Autocoders/Python/test/tlm_string/TestTelemRecvImpl.hpp
@@ -16,7 +16,7 @@ class TestTelemRecvImpl: public Tlm::TelemTesterComponentBase {
         virtual ~TestTelemRecvImpl();
         void init();
     protected:
-        void tlmRecvPort_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
+        void tlmRecvPort_handler(FwIndexType portNum, FwChanIdType id, Fw::Time &timeTag, Fw::TlmBuffer &val);
     private:
 };
 

--- a/Drv/BlockDriver/BlockDriverImpl.cpp
+++ b/Drv/BlockDriver/BlockDriverImpl.cpp
@@ -25,12 +25,12 @@ namespace Drv {
         this->m_cycles++;
     }
 
-    void BlockDriverImpl::BufferIn_handler(NATIVE_INT_TYPE portNum, Drv::DataBuffer& buffer) {
+    void BlockDriverImpl::BufferIn_handler(FwIndexType portNum, Drv::DataBuffer& buffer) {
         // just a pass-through
         this->BufferOut_out(0,buffer);
     }
 
-    void BlockDriverImpl::Sched_handler(NATIVE_INT_TYPE portNum, U32 context) {
+    void BlockDriverImpl::Sched_handler(FwIndexType portNum, U32 context) {
     }
 
     void BlockDriverImpl::callIsr() {
@@ -45,7 +45,7 @@ namespace Drv {
     }
 
     void BlockDriverImpl::PingIn_handler(
-            const NATIVE_INT_TYPE portNum,
+            const FwIndexType portNum,
             U32 key
         )
       {

--- a/Drv/BlockDriver/BlockDriverImpl.hpp
+++ b/Drv/BlockDriver/BlockDriverImpl.hpp
@@ -20,12 +20,12 @@ namespace Drv {
 
         // downcalls for input ports
         void InterruptReport_internalInterfaceHandler(U32 ip);
-        void BufferIn_handler(NATIVE_INT_TYPE portNum, Drv::DataBuffer& buffer);
-        void Sched_handler(NATIVE_INT_TYPE portNum, U32 context);
+        void BufferIn_handler(FwIndexType portNum, Drv::DataBuffer& buffer);
+        void Sched_handler(FwIndexType portNum, U32 context);
         //! Handler implementation for PingIn
         //!
         void PingIn_handler(
-            const NATIVE_INT_TYPE portNum, /*!< The port number*/
+            const FwIndexType portNum, /*!< The port number*/
             U32 key /*!< Value to return to pinger*/
         );
 

--- a/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
@@ -255,7 +255,7 @@ Os::File::Status LinuxGpioDriver ::open(const char* device,
     return status;
 }
 
-Drv::GpioStatus LinuxGpioDriver ::gpioRead_handler(const NATIVE_INT_TYPE portNum, Fw::Logic& state) {
+Drv::GpioStatus LinuxGpioDriver ::gpioRead_handler(const FwIndexType portNum, Fw::Logic& state) {
     Drv::GpioStatus status = Drv::GpioStatus::INVALID_MODE;
     if (this->m_configuration == GpioConfiguration::GPIO_INPUT) {
         struct gpiohandle_data values;
@@ -271,7 +271,7 @@ Drv::GpioStatus LinuxGpioDriver ::gpioRead_handler(const NATIVE_INT_TYPE portNum
     return status;
 }
 
-Drv::GpioStatus LinuxGpioDriver ::gpioWrite_handler(const NATIVE_INT_TYPE portNum, const Fw::Logic& state) {
+Drv::GpioStatus LinuxGpioDriver ::gpioWrite_handler(const FwIndexType portNum, const Fw::Logic& state) {
     Drv::GpioStatus status = Drv::GpioStatus::INVALID_MODE;
     if (this->m_configuration == GpioConfiguration::GPIO_OUTPUT) {
         struct gpiohandle_data values;

--- a/Drv/LinuxGpioDriver/LinuxGpioDriver.hpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriver.hpp
@@ -112,12 +112,12 @@ class LinuxGpioDriver : public LinuxGpioDriverComponentBase {
 
     //! Handler implementation for gpioRead
     //!
-    Drv::GpioStatus gpioRead_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Drv::GpioStatus gpioRead_handler(const FwIndexType portNum, /*!< The port number*/
                                      Fw::Logic& state);
 
     //! Handler implementation for gpioWrite
     //!
-    Drv::GpioStatus gpioWrite_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Drv::GpioStatus gpioWrite_handler(const FwIndexType portNum, /*!< The port number*/
                                       const Fw::Logic& state);
     //! Task to run interrupt polling
     Os::Task m_poller;

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverStub.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverStub.cpp
@@ -44,11 +44,11 @@ Os::File::Status LinuxGpioDriver ::open(const char* device,
     return Os::File::Status::NOT_SUPPORTED;
 }
 
-Drv::GpioStatus LinuxGpioDriver ::gpioRead_handler(const NATIVE_INT_TYPE portNum, Fw::Logic& state) {
+Drv::GpioStatus LinuxGpioDriver ::gpioRead_handler(const FwIndexType portNum, Fw::Logic& state) {
     return Drv::GpioStatus::UNKNOWN_ERROR;
 }
 
-Drv::GpioStatus LinuxGpioDriver ::gpioWrite_handler(const NATIVE_INT_TYPE portNum, const Fw::Logic& state) {
+Drv::GpioStatus LinuxGpioDriver ::gpioWrite_handler(const FwIndexType portNum, const Fw::Logic& state) {
     return Drv::GpioStatus::UNKNOWN_ERROR;
 }
 

--- a/Drv/LinuxI2cDriver/LinuxI2cDriver.cpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriver.cpp
@@ -61,7 +61,7 @@ namespace Drv {
 
   Drv::I2cStatus LinuxI2cDriver ::
     write_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 addr,
         Fw::Buffer &serBuffer
     )
@@ -88,7 +88,7 @@ namespace Drv {
 
   Drv::I2cStatus LinuxI2cDriver ::
     read_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 addr,
         Fw::Buffer &serBuffer
     )
@@ -115,7 +115,7 @@ namespace Drv {
 
   Drv::I2cStatus LinuxI2cDriver ::
     writeRead_handler(
-      const NATIVE_INT_TYPE portNum, /*!< The port number*/
+      const FwIndexType portNum, /*!< The port number*/
       U32 addr,
       Fw::Buffer &writeBuffer,
       Fw::Buffer &readBuffer

--- a/Drv/LinuxI2cDriver/LinuxI2cDriver.hpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriver.hpp
@@ -45,7 +45,7 @@ namespace Drv {
       //! Handler implementation for write
       //!
       I2cStatus write_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 addr,
           Fw::Buffer &serBuffer
       );
@@ -53,7 +53,7 @@ namespace Drv {
       //! Handler implementation for read
       //!
       I2cStatus read_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 addr,
           Fw::Buffer &serBuffer
       );
@@ -61,7 +61,7 @@ namespace Drv {
       //! Handler implementation for writeRead
       //!
       I2cStatus  writeRead_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 addr,
           Fw::Buffer &writeBuffer,
           Fw::Buffer &readBuffer

--- a/Drv/LinuxI2cDriver/LinuxI2cDriverStub.cpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriverStub.cpp
@@ -46,7 +46,7 @@ LinuxI2cDriver ::LinuxI2cDriver(
 
   I2cStatus LinuxI2cDriver ::
     write_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 addr,
         Fw::Buffer &serBuffer
     )
@@ -56,7 +56,7 @@ LinuxI2cDriver ::LinuxI2cDriver(
 
   Drv::I2cStatus LinuxI2cDriver ::
     read_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 addr,
         Fw::Buffer &serBuffer
     )
@@ -66,7 +66,7 @@ LinuxI2cDriver ::LinuxI2cDriver(
 
   Drv::I2cStatus LinuxI2cDriver ::
     writeRead_handler(
-      const NATIVE_INT_TYPE portNum, /*!< The port number*/
+      const FwIndexType portNum, /*!< The port number*/
       U32 addr,
       Fw::Buffer &writeBuffer,
       Fw::Buffer &readBuffer

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -33,7 +33,7 @@ namespace Drv {
     // ----------------------------------------------------------------------
 
     void LinuxSpiDriverComponentImpl::SpiReadWrite_handler(
-            const NATIVE_INT_TYPE portNum, Fw::Buffer &writeBuffer,
+            const FwIndexType portNum, Fw::Buffer &writeBuffer,
             Fw::Buffer &readBuffer) {
 
         if (this->m_fd == -1) {

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
@@ -84,7 +84,7 @@ namespace Drv {
 
             //! Handler implementation for SpiReadWrite
             //!
-            void SpiReadWrite_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+            void SpiReadWrite_handler(const FwIndexType portNum, /*!< The port number*/
             Fw::Buffer &WriteBuffer, Fw::Buffer &readBuffer);
 
             NATIVE_INT_TYPE m_fd;

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImplStub.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImplStub.cpp
@@ -28,7 +28,7 @@ namespace Drv {
     // ----------------------------------------------------------------------
 
     void LinuxSpiDriverComponentImpl::SpiReadWrite_handler(
-            const NATIVE_INT_TYPE portNum, Fw::Buffer &WriteBuffer,
+            const FwIndexType portNum, Fw::Buffer &WriteBuffer,
             Fw::Buffer &readBuffer) {
         // TODO
     }

--- a/Drv/LinuxUartDriver/LinuxUartDriver.cpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.cpp
@@ -292,7 +292,7 @@ LinuxUartDriver ::~LinuxUartDriver() {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-Drv::SendStatus LinuxUartDriver ::send_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& serBuffer) {
+Drv::SendStatus LinuxUartDriver ::send_handler(const FwIndexType portNum, Fw::Buffer& serBuffer) {
     Drv::SendStatus status = Drv::SendStatus::SEND_OK;
     if (this->m_fd == -1 || serBuffer.getData() == nullptr || serBuffer.getSize() == 0) {
         status = Drv::SendStatus::SEND_ERROR;

--- a/Drv/LinuxUartDriver/LinuxUartDriver.hpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.hpp
@@ -93,7 +93,7 @@ class LinuxUartDriver : public LinuxUartDriverComponentBase {
 
     //! Handler implementation for serialSend
     //!
-    Drv::SendStatus send_handler(NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Drv::SendStatus send_handler(FwIndexType portNum, /*!< The port number*/
                                  Fw::Buffer& serBuffer);
 
 

--- a/Drv/StreamCrossover/StreamCrossover.cpp
+++ b/Drv/StreamCrossover/StreamCrossover.cpp
@@ -34,7 +34,7 @@ namespace Drv {
 
   void StreamCrossover ::
     streamIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer &recvBuffer,
         const Drv::RecvStatus &recvStatus
     )

--- a/Drv/StreamCrossover/StreamCrossover.hpp
+++ b/Drv/StreamCrossover/StreamCrossover.hpp
@@ -40,7 +40,7 @@ namespace Drv {
       //! Handler implementation for streamIn
       //!
       void streamIn_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::Buffer &recvBuffer, 
           const Drv::RecvStatus &recvStatus 
       );

--- a/Drv/StreamCrossover/test/ut/StreamCrossoverTester.cpp
+++ b/Drv/StreamCrossover/test/ut/StreamCrossoverTester.cpp
@@ -71,7 +71,7 @@ namespace Drv {
 
   Drv::SendStatus StreamCrossoverTester ::
     from_streamOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer &sendBuffer
     )
   {
@@ -90,7 +90,7 @@ namespace Drv {
 
   void StreamCrossoverTester ::
     from_errorDeallocate_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer &fwBuffer
     )
   {

--- a/Drv/StreamCrossover/test/ut/StreamCrossoverTester.hpp
+++ b/Drv/StreamCrossover/test/ut/StreamCrossoverTester.hpp
@@ -57,14 +57,14 @@ namespace Drv {
       //! Handler for from_streamOut
       //!
       Drv::SendStatus from_streamOut_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::Buffer &sendBuffer 
       );
 
       //! Handler for from_deallocate
       //!
       void from_errorDeallocate_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::Buffer &fwBuffer 
       );
 

--- a/Drv/TcpClient/TcpClientComponentImpl.cpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.cpp
@@ -76,7 +76,7 @@ void TcpClientComponentImpl::connected() {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-Drv::SendStatus TcpClientComponentImpl::send_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+Drv::SendStatus TcpClientComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     Drv::SocketIpStatus status = send(fwBuffer.getData(), fwBuffer.getSize());
     // Only deallocate buffer when the caller is not asked to retry
     if (status == SOCK_INTERRUPTED_TRY_AGAIN) {

--- a/Drv/TcpClient/TcpClientComponentImpl.hpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.hpp
@@ -125,7 +125,7 @@ class TcpClientComponentImpl : public TcpClientComponentBase, public SocketCompo
      * \param fwBuffer: buffer containing data to be sent
      * \return SEND_OK on success, SEND_RETRY when critical data should be retried and SEND_ERROR upon error
      */
-    Drv::SendStatus send_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer);
+    Drv::SendStatus send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer);
 
     Drv::TcpClientSocket m_socket; //!< Socket implementation
 

--- a/Drv/TcpClient/test/ut/TcpClientTester.cpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.cpp
@@ -185,7 +185,7 @@ void TcpClientTester ::test_no_automatic_recv_connection() {
 
   void TcpClientTester ::
     from_recv_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer &recvBuffer,
         const RecvStatus &recvStatus
     )
@@ -201,13 +201,13 @@ void TcpClientTester ::test_no_automatic_recv_connection() {
     delete[] recvBuffer.getData();
 }
 
-void TcpClientTester ::from_ready_handler(const NATIVE_INT_TYPE portNum) {
+void TcpClientTester ::from_ready_handler(const FwIndexType portNum) {
     this->pushFromPortEntry_ready();
 }
 
 Fw::Buffer TcpClientTester ::
     from_allocate_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 size
     )
   {
@@ -219,7 +219,7 @@ Fw::Buffer TcpClientTester ::
 
   void TcpClientTester ::
     from_deallocate_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer &fwBuffer
     )
   {

--- a/Drv/TcpClient/test/ut/TcpClientTester.hpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.hpp
@@ -76,7 +76,7 @@ namespace Drv {
       //! Handler for from_recv
       //!
       void from_recv_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::Buffer &recvBuffer,
           const RecvStatus &recvStatus
       );
@@ -84,20 +84,20 @@ namespace Drv {
       //! Handler for from_ready
       //!
       void from_ready_handler(
-          const NATIVE_INT_TYPE portNum /*!< The port number*/
+          const FwIndexType portNum /*!< The port number*/
       );
 
       //! Handler for from_allocate
       //!
       Fw::Buffer from_allocate_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 size
       );
 
       //! Handler for from_deallocate
       //!
       void from_deallocate_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::Buffer &fwBuffer
       );
 

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -124,7 +124,7 @@ void TcpServerComponentImpl::readLoop() {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-Drv::SendStatus TcpServerComponentImpl::send_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+Drv::SendStatus TcpServerComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     Drv::SocketIpStatus status = this->send(fwBuffer.getData(), fwBuffer.getSize());
     // Only deallocate buffer when the caller is not asked to retry
     if (status == SOCK_INTERRUPTED_TRY_AGAIN) {

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -160,7 +160,7 @@ class TcpServerComponentImpl : public TcpServerComponentBase, public SocketCompo
      * \param fwBuffer: buffer containing data to be sent
      * \return SEND_OK on success, SEND_RETRY when critical data should be retried and SEND_ERROR upon error
      */
-    Drv::SendStatus send_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) override;
+    Drv::SendStatus send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) override;
 
     Drv::TcpServerSocket m_socket; //!< Socket implementation
 

--- a/Drv/TcpServer/test/ut/TcpServerTester.cpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.cpp
@@ -218,7 +218,7 @@ void TcpServerTester ::test_no_automatic_recv_connection() {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void TcpServerTester ::from_recv_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& recvBuffer, const RecvStatus& recvStatus) {
+void TcpServerTester ::from_recv_handler(const FwIndexType portNum, Fw::Buffer& recvBuffer, const RecvStatus& recvStatus) {
     // this function will still receive a status of error because the recv port is always called
     this->pushFromPortEntry_recv(recvBuffer, recvStatus);
     if (recvStatus == RecvStatus::RECV_OK) {
@@ -230,13 +230,13 @@ void TcpServerTester ::from_recv_handler(const NATIVE_INT_TYPE portNum, Fw::Buff
     delete[] recvBuffer.getData();
 }
 
-void TcpServerTester ::from_ready_handler(const NATIVE_INT_TYPE portNum) {
+void TcpServerTester ::from_ready_handler(const FwIndexType portNum) {
     this->pushFromPortEntry_ready();
 }
 
 Fw::Buffer TcpServerTester ::
     from_allocate_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 size
     )
   {
@@ -247,7 +247,7 @@ Fw::Buffer TcpServerTester ::
 
   void TcpServerTester ::
     from_deallocate_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer &fwBuffer
     )
   {

--- a/Drv/TcpServer/test/ut/TcpServerTester.hpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.hpp
@@ -88,7 +88,7 @@ namespace Drv {
       //! Handler for from_recv
       //!
       void from_recv_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::Buffer &recvBuffer,
           const RecvStatus &recvStatus
       );
@@ -96,20 +96,20 @@ namespace Drv {
       //! Handler for from_ready
       //!
       void from_ready_handler(
-          const NATIVE_INT_TYPE portNum /*!< The port number*/
+          const FwIndexType portNum /*!< The port number*/
       );
 
       //! Handler for from_allocate
       //!
       Fw::Buffer from_allocate_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 size
       );
 
       //! Handler for from_deallocate
       //!
       void from_deallocate_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::Buffer &fwBuffer
       );
 

--- a/Drv/Udp/UdpComponentImpl.cpp
+++ b/Drv/Udp/UdpComponentImpl.cpp
@@ -82,7 +82,7 @@ void UdpComponentImpl::connected() {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-Drv::SendStatus UdpComponentImpl::send_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+Drv::SendStatus UdpComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     Drv::SocketIpStatus status = send(fwBuffer.getData(), fwBuffer.getSize());
     // Always return the buffer
     deallocate_out(0, fwBuffer);

--- a/Drv/Udp/UdpComponentImpl.hpp
+++ b/Drv/Udp/UdpComponentImpl.hpp
@@ -147,7 +147,7 @@ PROTECTED:
      * \param fwBuffer: buffer containing data to be sent
      * \return SEND_OK on success, SEND_RETRY when critical data should be retried and SEND_ERROR upon error
      */
-    Drv::SendStatus send_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer);
+    Drv::SendStatus send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer);
 
     Drv::UdpSocket m_socket; //!< Socket implementation
 

--- a/Drv/Udp/test/ut/UdpTester.cpp
+++ b/Drv/Udp/test/ut/UdpTester.cpp
@@ -160,7 +160,7 @@ void UdpTester ::test_advanced_reconnect() {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void UdpTester ::from_recv_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& recvBuffer, const RecvStatus& recvStatus) {
+void UdpTester ::from_recv_handler(const FwIndexType portNum, Fw::Buffer& recvBuffer, const RecvStatus& recvStatus) {
     this->pushFromPortEntry_recv(recvBuffer, recvStatus);
     // Make sure we can get to unblocking the spinner
     if (recvStatus == RecvStatus::RECV_OK){
@@ -171,13 +171,13 @@ void UdpTester ::from_recv_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& re
     delete[] recvBuffer.getData();
 }
 
-void UdpTester ::from_ready_handler(const NATIVE_INT_TYPE portNum) {
+void UdpTester ::from_ready_handler(const FwIndexType portNum) {
     this->pushFromPortEntry_ready();
 }
 
 Fw::Buffer UdpTester ::
     from_allocate_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 size
     )
   {
@@ -189,7 +189,7 @@ Fw::Buffer UdpTester ::
 
   void UdpTester ::
     from_deallocate_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer &fwBuffer
     )
   {

--- a/Drv/Udp/test/ut/UdpTester.hpp
+++ b/Drv/Udp/test/ut/UdpTester.hpp
@@ -83,7 +83,7 @@ namespace Drv {
       //! Handler for from_recv
       //!
       void from_recv_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::Buffer &recvBuffer,
           const RecvStatus &recvStatus
       );
@@ -91,20 +91,20 @@ namespace Drv {
       //! Handler for from_ready
       //!
       void from_ready_handler(
-          const NATIVE_INT_TYPE portNum /*!< The port number*/
+          const FwIndexType portNum /*!< The port number*/
       );
 
       //! Handler for from_allocate
       //!
       Fw::Buffer from_allocate_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 size
       );
 
       //! Handler for from_deallocate
       //!
       void from_deallocate_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::Buffer &fwBuffer
       );
 

--- a/FppTest/component/active/ActiveTest.cpp
+++ b/FppTest/component/active/ActiveTest.cpp
@@ -34,7 +34,7 @@
 
   void ActiveTest ::
     arrayArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -44,7 +44,7 @@
 
   void ActiveTest ::
     enumArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -54,7 +54,7 @@
 
   void ActiveTest ::
     noArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     this->noArgsOut_out(portNum);
@@ -62,7 +62,7 @@
 
   void ActiveTest ::
     primitiveArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -84,7 +84,7 @@
 
   void ActiveTest ::
     structArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -93,7 +93,7 @@
   }
   void ActiveTest ::
     stringArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const Fw::StringBase &str80,
         Fw::StringBase &str80Ref,
         const Fw::StringBase &str100,
@@ -111,7 +111,7 @@
 
   void ActiveTest ::
     arrayArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -121,7 +121,7 @@
 
   void ActiveTest ::
     arrayArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -131,7 +131,7 @@
 
   FormalParamArray ActiveTest ::
     arrayReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -141,7 +141,7 @@
 
   FormalParamArray ActiveTest ::
     arrayReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -151,7 +151,7 @@
 
   void ActiveTest :: 
     cmdOut_handler(
-        NATIVE_INT_TYPE portNum,
+        FwIndexType portNum,
         FwOpcodeType opCode,
         U32 cmdSeq,
         Fw::CmdArgBuffer& args
@@ -161,7 +161,7 @@
 
   void ActiveTest ::
     enumArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -171,7 +171,7 @@
 
   void ActiveTest ::
     enumArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -181,7 +181,7 @@
 
   FormalParamEnum ActiveTest ::
     enumReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -191,7 +191,7 @@
 
   FormalParamEnum ActiveTest ::
     enumReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -201,7 +201,7 @@
 
   void ActiveTest ::
     noArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     this->noArgsOut_out(portNum);
@@ -209,7 +209,7 @@
 
   bool ActiveTest ::
     noArgsReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     return this->noArgsReturnOut_out(portNum);
@@ -217,7 +217,7 @@
 
   bool ActiveTest ::
     noArgsReturnSync_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     return this->noArgsReturnOut_out(portNum);
@@ -225,7 +225,7 @@
 
   void ActiveTest ::
     noArgsSync_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     this->noArgsOut_out(portNum);
@@ -233,7 +233,7 @@
 
   void ActiveTest ::
     primitiveArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -255,7 +255,7 @@
 
   void ActiveTest ::
     primitiveArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -277,7 +277,7 @@
 
   U32 ActiveTest ::
     primitiveReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -299,7 +299,7 @@
 
   U32 ActiveTest ::
     primitiveReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -321,7 +321,7 @@
 
   void ActiveTest ::
     stringArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const Fw::StringBase &str80,
         Fw::StringBase &str80Ref,
         const Fw::StringBase &str100,
@@ -339,7 +339,7 @@
 
   void ActiveTest ::
     stringArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const Fw::StringBase &str80,
         Fw::StringBase &str80Ref,
         const Fw::StringBase &str100,
@@ -357,7 +357,7 @@
 
   void ActiveTest ::
     structArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -367,7 +367,7 @@
 
   void ActiveTest ::
     structArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -377,7 +377,7 @@
 
   FormalParamStruct ActiveTest ::
     structReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -387,7 +387,7 @@
 
   FormalParamStruct ActiveTest ::
     structReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -397,7 +397,7 @@
 
   void ActiveTest ::
       enumArgsHook_handler(
-          const NATIVE_INT_TYPE portNum,
+          const FwIndexType portNum,
           const FormalParamEnum &en,
           FormalParamEnum &enRef
       ) {}
@@ -408,7 +408,7 @@
 
   void ActiveTest ::
     serialAsync_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -417,7 +417,7 @@
 
   void ActiveTest ::
     serialAsyncAssert_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -426,7 +426,7 @@
 
   void ActiveTest ::
     serialAsyncBlockPriority_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -435,7 +435,7 @@
 
   void ActiveTest ::
     serialAsyncDropPriority_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -444,7 +444,7 @@
 
   void ActiveTest ::
     serialGuarded_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -453,7 +453,7 @@
 
   void ActiveTest ::
     serialSync_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -699,7 +699,7 @@
 
   void ActiveTest ::
       enumArgsHook_overflowHook(
-          const NATIVE_INT_TYPE portNum,
+          const FwIndexType portNum,
           const FormalParamEnum &en,
           FormalParamEnum &enRef
   )

--- a/FppTest/component/active/ActiveTest.hpp
+++ b/FppTest/component/active/ActiveTest.hpp
@@ -37,42 +37,42 @@ class ActiveTest :
 
     //! Handler implementation for arrayArgsAsync
     void arrayArgsAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for arrayArgsGuarded
     void arrayArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for arrayArgsSync
     void arrayArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for arrayReturnGuarded
     FormalParamArray arrayReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for arrayReturnSync
     FormalParamArray arrayReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for cmdOut
     void cmdOut_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         FwOpcodeType opCode, //!< Command Op Code
         U32 cmdSeq, //!< Command Sequence
         Fw::CmdArgBuffer& args //!< Buffer containing arguments
@@ -80,67 +80,67 @@ class ActiveTest :
 
     //! Handler implementation for enumArgsAsync
     void enumArgsAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for enumArgsGuarded
     void enumArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for enumArgsSync
     void enumArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for enumReturnGuarded
     FormalParamEnum enumReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for enumReturnSync
     FormalParamEnum enumReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for noArgsAsync
     void noArgsAsync_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for noArgsGuarded
     void noArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for noArgsReturnGuarded
     bool noArgsReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for noArgsReturnSync
     bool noArgsReturnSync_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for noArgsSync
     void noArgsSync_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for primitiveArgsAsync
     void primitiveArgsAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -151,7 +151,7 @@ class ActiveTest :
 
     //! Handler implementation for primitiveArgsGuarded
     void primitiveArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -162,7 +162,7 @@ class ActiveTest :
 
     //! Handler implementation for primitiveArgsSync
     void primitiveArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -173,7 +173,7 @@ class ActiveTest :
 
     //! Handler implementation for primitiveReturnGuarded
     U32 primitiveReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -184,7 +184,7 @@ class ActiveTest :
 
     //! Handler implementation for primitiveReturnSync
     U32 primitiveReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -195,7 +195,7 @@ class ActiveTest :
 
     //! Handler implementation for stringArgsAsync
     void stringArgsAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const Fw::StringBase& str80, //!< A string of size 80
         Fw::StringBase& str80Ref,
         const Fw::StringBase& str100, //!< A string of size 100
@@ -204,7 +204,7 @@ class ActiveTest :
 
     //! Handler implementation for stringArgsGuarded
     void stringArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const Fw::StringBase& str80, //!< A string of size 80
         Fw::StringBase& str80Ref,
         const Fw::StringBase& str100, //!< A string of size 100
@@ -213,7 +213,7 @@ class ActiveTest :
 
     //! Handler implementation for stringArgsSync
     void stringArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const Fw::StringBase& str80, //!< A string of size 80
         Fw::StringBase& str80Ref,
         const Fw::StringBase& str100, //!< A string of size 100
@@ -222,42 +222,42 @@ class ActiveTest :
 
     //! Handler implementation for structArgsAsync
     void structArgsAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for structArgsGuarded
     void structArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for structArgsSync
     void structArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for structReturnGuarded
     FormalParamStruct structReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for structReturnSync
     FormalParamStruct structReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for enumArgsOverflow
     void enumArgsHook_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
@@ -270,37 +270,37 @@ class ActiveTest :
 
     //! Handler implementation for serialAsync
     void serialAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
     //! Handler implementation for serialAsyncAssert
     void serialAsyncAssert_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
     //! Handler implementation for serialAsyncBlockPriority
     void serialAsyncBlockPriority_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
     //! Handler implementation for serialAsyncDropPriority
     void serialAsyncDropPriority_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
     //! Handler implementation for serialGuarded
     void serialGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
     //! Handler implementation for serialSync
     void serialSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
@@ -452,7 +452,7 @@ class ActiveTest :
 
     //! Overflow hook implementation for enumArgsOverflow
     void enumArgsHook_overflowHook(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );

--- a/FppTest/component/active/test/ut/Tester.cpp
+++ b/FppTest/component/active/test/ut/Tester.cpp
@@ -34,7 +34,7 @@ void Tester ::initComponents() {
     this->component.init(Tester::TEST_INSTANCE_QUEUE_DEPTH, Tester::TEST_INSTANCE_ID);
 }
 
-Fw::ParamValid Tester ::from_prmGetIn_handler(const NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
+Fw::ParamValid Tester ::from_prmGetIn_handler(const FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
     val.resetSer();
 
     Fw::SerializeStatus status;
@@ -79,7 +79,7 @@ Fw::ParamValid Tester ::from_prmGetIn_handler(const NATIVE_INT_TYPE portNum, FwP
     return prmValid;
 }
 
-void Tester ::from_prmSetIn_handler(const NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
+void Tester ::from_prmSetIn_handler(const FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
     Fw::SerializeStatus status;
     U32 id_base = component.getIdBase();
 

--- a/FppTest/component/active/test/ut/Tester.hpp
+++ b/FppTest/component/active/test/ut/Tester.hpp
@@ -76,7 +76,7 @@ class Tester : public ActiveTestGTestBase {
 
     //! Handler for from_arrayArgsOut
     //!
-    void from_arrayArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_arrayArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                    const FormalParamArray& a,     /*!<
                                    An array
                                    */
@@ -87,7 +87,7 @@ class Tester : public ActiveTestGTestBase {
 
     //! Handler for from_arrayReturnOut
     //!
-    FormalParamArray from_arrayReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    FormalParamArray from_arrayReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                                  const FormalParamArray& a,     /*!<
                                                  An array
                                                  */
@@ -98,7 +98,7 @@ class Tester : public ActiveTestGTestBase {
 
     //! Handler for from_enumArgsOut
     //!
-    void from_enumArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_enumArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                   const FormalParamEnum& en,     /*!<
                                   An enum
                                   */
@@ -109,7 +109,7 @@ class Tester : public ActiveTestGTestBase {
 
     //! Handler for from_enumReturnOut
     //!
-    FormalParamEnum from_enumReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    FormalParamEnum from_enumReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                                const FormalParamEnum& en,     /*!<
                                                An enum
                                                */
@@ -120,17 +120,17 @@ class Tester : public ActiveTestGTestBase {
 
     //! Handler for from_noArgsOut
     //!
-    void from_noArgsOut_handler(const NATIVE_INT_TYPE portNum /*!< The port number*/
+    void from_noArgsOut_handler(const FwIndexType portNum /*!< The port number*/
     ) final;
 
     //! Handler for from_noArgsReturnOut
     //!
-    bool from_noArgsReturnOut_handler(const NATIVE_INT_TYPE portNum /*!< The port number*/
+    bool from_noArgsReturnOut_handler(const FwIndexType portNum /*!< The port number*/
     ) final;
 
     //! Handler for from_primitiveArgsOut
     //!
-    void from_primitiveArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_primitiveArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                        U32 u32,
                                        U32& u32Ref,
                                        F32 f32,
@@ -140,7 +140,7 @@ class Tester : public ActiveTestGTestBase {
 
     //! Handler for from_primitiveReturnOut
     //!
-    U32 from_primitiveReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    U32 from_primitiveReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                         U32 u32,
                                         U32& u32Ref,
                                         F32 f32,
@@ -150,7 +150,7 @@ class Tester : public ActiveTestGTestBase {
 
     //! Handler for from_prmGetIn
     //!
-    Fw::ParamValid from_prmGetIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Fw::ParamValid from_prmGetIn_handler(const FwIndexType portNum, /*!< The port number*/
                                          FwPrmIdType id,                /*!<
                                                     Parameter ID
                                                     */
@@ -161,7 +161,7 @@ class Tester : public ActiveTestGTestBase {
 
     //! Handler for from_prmGetIn
     //!
-    void from_prmSetIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_prmSetIn_handler(const FwIndexType portNum, /*!< The port number*/
                                FwPrmIdType id,                /*!<
                                           Parameter ID
                                           */
@@ -172,7 +172,7 @@ class Tester : public ActiveTestGTestBase {
 
     //! Handler for from_structArgsOut
     //!
-    void from_structArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_structArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                     const FormalParamStruct& s,    /*!<
                                    A struct
                                    */
@@ -183,7 +183,7 @@ class Tester : public ActiveTestGTestBase {
 
     //! Handler for from_structReturnOut
     //!
-    FormalParamStruct from_structReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    FormalParamStruct from_structReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                                    const FormalParamStruct& s,    /*!<
                                                   A struct
                                                   */
@@ -192,7 +192,7 @@ class Tester : public ActiveTestGTestBase {
                                                       */
     ) final;
 
-    void from_enumArgsHookOverflowed_handler(const NATIVE_INT_TYPE portNum,
+    void from_enumArgsHookOverflowed_handler(const FwIndexType portNum,
                                              const FormalParamEnum& en,
                                              FormalParamEnum& enRef);
 
@@ -203,7 +203,7 @@ class Tester : public ActiveTestGTestBase {
 
     //! Handler for from_serialOut
     //!
-    void from_serialOut_handler(NATIVE_INT_TYPE portNum,        /*!< The port number*/
+    void from_serialOut_handler(FwIndexType portNum,        /*!< The port number*/
                                 Fw::SerializeBufferBase& Buffer /*!< The serialization buffer*/
     ) final;
 

--- a/FppTest/component/passive/PassiveTest.cpp
+++ b/FppTest/component/passive/PassiveTest.cpp
@@ -33,7 +33,7 @@
 
   void PassiveTest ::
     arrayArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -43,7 +43,7 @@
 
   void PassiveTest ::
     arrayArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -53,7 +53,7 @@
 
   FormalParamArray PassiveTest ::
     arrayReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -63,7 +63,7 @@
 
   FormalParamArray PassiveTest ::
     arrayReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -73,7 +73,7 @@
 
   void PassiveTest :: 
     cmdOut_handler(
-        NATIVE_INT_TYPE portNum,
+        FwIndexType portNum,
         FwOpcodeType opCode,
         U32 cmdSeq,
         Fw::CmdArgBuffer& args
@@ -83,7 +83,7 @@
 
   void PassiveTest ::
     enumArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -93,7 +93,7 @@
 
   void PassiveTest ::
     enumArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -103,7 +103,7 @@
 
   FormalParamEnum PassiveTest ::
     enumReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -113,7 +113,7 @@
 
   FormalParamEnum PassiveTest ::
     enumReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -123,7 +123,7 @@
 
   void PassiveTest ::
     noArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     this->noArgsOut_out(portNum);
@@ -131,7 +131,7 @@
 
   bool PassiveTest ::
     noArgsReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     return this->noArgsReturnOut_out(portNum);
@@ -139,7 +139,7 @@
 
   bool PassiveTest ::
     noArgsReturnSync_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     return this->noArgsReturnOut_out(portNum);
@@ -147,7 +147,7 @@
 
   void PassiveTest ::
     noArgsSync_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     this->noArgsOut_out(portNum);
@@ -155,7 +155,7 @@
 
   void PassiveTest ::
     primitiveArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -177,7 +177,7 @@
 
   void PassiveTest ::
     primitiveArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -199,7 +199,7 @@
 
   U32 PassiveTest ::
     primitiveReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -221,7 +221,7 @@
 
   U32 PassiveTest ::
     primitiveReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -243,7 +243,7 @@
 
   void PassiveTest ::
     stringArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const Fw::StringBase &str80,
         Fw::StringBase &str80Ref,
         const Fw::StringBase &str100,
@@ -261,7 +261,7 @@
 
   void PassiveTest ::
     stringArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const Fw::StringBase &str80,
         Fw::StringBase &str80Ref,
         const Fw::StringBase &str100,
@@ -279,7 +279,7 @@
 
   void PassiveTest ::
     structArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -289,7 +289,7 @@
 
   void PassiveTest ::
     structArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -299,7 +299,7 @@
 
   FormalParamStruct PassiveTest ::
     structReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -309,7 +309,7 @@
 
   FormalParamStruct PassiveTest ::
     structReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -323,7 +323,7 @@
 
   void PassiveTest ::
     serialGuarded_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -332,7 +332,7 @@
 
   void PassiveTest ::
     serialSync_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {

--- a/FppTest/component/passive/PassiveTest.hpp
+++ b/FppTest/component/passive/PassiveTest.hpp
@@ -37,35 +37,35 @@ class PassiveTest :
 
     //! Handler implementation for arrayArgsGuarded
     void arrayArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for arrayArgsSync
     void arrayArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for arrayReturnGuarded
     FormalParamArray arrayReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for arrayReturnSync
     FormalParamArray arrayReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for cmdOut
     void cmdOut_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         FwOpcodeType opCode, //!< Command Op Code
         U32 cmdSeq, //!< Command Sequence
         Fw::CmdArgBuffer& args //!< Buffer containing arguments
@@ -73,55 +73,55 @@ class PassiveTest :
 
     //! Handler implementation for enumArgsGuarded
     void enumArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for enumArgsSync
     void enumArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for enumReturnGuarded
     FormalParamEnum enumReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for enumReturnSync
     FormalParamEnum enumReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for noArgsGuarded
     void noArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for noArgsReturnGuarded
     bool noArgsReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for noArgsReturnSync
     bool noArgsReturnSync_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for noArgsSync
     void noArgsSync_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for primitiveArgsGuarded
     void primitiveArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -132,7 +132,7 @@ class PassiveTest :
 
     //! Handler implementation for primitiveArgsSync
     void primitiveArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -143,7 +143,7 @@ class PassiveTest :
 
     //! Handler implementation for primitiveReturnGuarded
     U32 primitiveReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -154,7 +154,7 @@ class PassiveTest :
 
     //! Handler implementation for primitiveReturnSync
     U32 primitiveReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -165,7 +165,7 @@ class PassiveTest :
 
     //! Handler implementation for stringArgsGuarded
     void stringArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const Fw::StringBase& str80, //!< A string of size 80
         Fw::StringBase& str80Ref,
         const Fw::StringBase& str100, //!< A string of size 100
@@ -174,7 +174,7 @@ class PassiveTest :
 
     //! Handler implementation for stringArgsSync
     void stringArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const Fw::StringBase& str80, //!< A string of size 80
         Fw::StringBase& str80Ref,
         const Fw::StringBase& str100, //!< A string of size 100
@@ -183,28 +183,28 @@ class PassiveTest :
 
     //! Handler implementation for structArgsGuarded
     void structArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for structArgsSync
     void structArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for structReturnGuarded
     FormalParamStruct structReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for structReturnSync
     FormalParamStruct structReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
@@ -217,13 +217,13 @@ class PassiveTest :
 
     //! Handler implementation for serialGuarded
     void serialGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
     //! Handler implementation for serialSync
     void serialSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 

--- a/FppTest/component/passive/test/ut/Tester.cpp
+++ b/FppTest/component/passive/test/ut/Tester.cpp
@@ -32,7 +32,7 @@ void Tester ::initComponents() {
     this->component.init(Tester::TEST_INSTANCE_ID);
 }
 
-Fw::ParamValid Tester ::from_prmGetIn_handler(const NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
+Fw::ParamValid Tester ::from_prmGetIn_handler(const FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
     val.resetSer();
 
     Fw::SerializeStatus status;
@@ -77,7 +77,7 @@ Fw::ParamValid Tester ::from_prmGetIn_handler(const NATIVE_INT_TYPE portNum, FwP
     return prmValid;
 }
 
-void Tester ::from_prmSetIn_handler(const NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
+void Tester ::from_prmSetIn_handler(const FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
     Fw::SerializeStatus status;
     U32 id_base = component.getIdBase();
 

--- a/FppTest/component/passive/test/ut/Tester.hpp
+++ b/FppTest/component/passive/test/ut/Tester.hpp
@@ -65,7 +65,7 @@ class Tester : public PassiveTestGTestBase {
 
     //! Handler for from_arrayArgsOut
     //!
-    void from_arrayArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_arrayArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                    const FormalParamArray& a,     /*!<
                                    An array
                                    */
@@ -76,7 +76,7 @@ class Tester : public PassiveTestGTestBase {
 
     //! Handler for from_arrayReturnOut
     //!
-    FormalParamArray from_arrayReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    FormalParamArray from_arrayReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                                  const FormalParamArray& a,     /*!<
                                                  An array
                                                  */
@@ -87,7 +87,7 @@ class Tester : public PassiveTestGTestBase {
 
     //! Handler for from_enumArgsOut
     //!
-    void from_enumArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_enumArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                   const FormalParamEnum& en,     /*!<
                                   An enum
                                   */
@@ -98,7 +98,7 @@ class Tester : public PassiveTestGTestBase {
 
     //! Handler for from_enumReturnOut
     //!
-    FormalParamEnum from_enumReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    FormalParamEnum from_enumReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                                const FormalParamEnum& en,     /*!<
                                                An enum
                                                */
@@ -109,17 +109,17 @@ class Tester : public PassiveTestGTestBase {
 
     //! Handler for from_noArgsOut
     //!
-    void from_noArgsOut_handler(const NATIVE_INT_TYPE portNum /*!< The port number*/
+    void from_noArgsOut_handler(const FwIndexType portNum /*!< The port number*/
     );
 
     //! Handler for from_noArgsReturnOut
     //!
-    bool from_noArgsReturnOut_handler(const NATIVE_INT_TYPE portNum /*!< The port number*/
+    bool from_noArgsReturnOut_handler(const FwIndexType portNum /*!< The port number*/
     );
 
     //! Handler for from_primitiveArgsOut
     //!
-    void from_primitiveArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_primitiveArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                        U32 u32,
                                        U32& u32Ref,
                                        F32 f32,
@@ -129,7 +129,7 @@ class Tester : public PassiveTestGTestBase {
 
     //! Handler for from_primitiveReturnOut
     //!
-    U32 from_primitiveReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    U32 from_primitiveReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                         U32 u32,
                                         U32& u32Ref,
                                         F32 f32,
@@ -139,7 +139,7 @@ class Tester : public PassiveTestGTestBase {
 
     //! Handler for from_prmGetIn
     //!
-    Fw::ParamValid from_prmGetIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Fw::ParamValid from_prmGetIn_handler(const FwIndexType portNum, /*!< The port number*/
                                          FwPrmIdType id,                /*!<
                                                     Parameter ID
                                                     */
@@ -150,7 +150,7 @@ class Tester : public PassiveTestGTestBase {
 
     //! Handler for from_prmGetIn
     //!
-    void from_prmSetIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_prmSetIn_handler(const FwIndexType portNum, /*!< The port number*/
                                FwPrmIdType id,                /*!<
                                           Parameter ID
                                           */
@@ -161,7 +161,7 @@ class Tester : public PassiveTestGTestBase {
 
     //! Handler for from_structArgsOut
     //!
-    void from_structArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_structArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                     const FormalParamStruct& s,    /*!<
                                    A struct
                                    */
@@ -172,7 +172,7 @@ class Tester : public PassiveTestGTestBase {
 
     //! Handler for from_structReturnOut
     //!
-    FormalParamStruct from_structReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    FormalParamStruct from_structReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                                    const FormalParamStruct& s,    /*!<
                                                   A struct
                                                   */
@@ -188,7 +188,7 @@ class Tester : public PassiveTestGTestBase {
 
     //! Handler for from_serialOut
     //!
-    void from_serialOut_handler(NATIVE_INT_TYPE portNum,        /*!< The port number*/
+    void from_serialOut_handler(FwIndexType portNum,        /*!< The port number*/
                                 Fw::SerializeBufferBase& Buffer /*!< The serialization buffer*/
     );
 

--- a/FppTest/component/queued/QueuedTest.cpp
+++ b/FppTest/component/queued/QueuedTest.cpp
@@ -34,7 +34,7 @@
 
   void QueuedTest ::
     arrayArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -44,7 +44,7 @@
 
   void QueuedTest ::
     enumArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -54,7 +54,7 @@
 
   void QueuedTest ::
     noArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     this->noArgsOut_out(portNum);
@@ -62,7 +62,7 @@
 
   void QueuedTest ::
     primitiveArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -84,7 +84,7 @@
 
   void QueuedTest ::
     structArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -93,7 +93,7 @@
   }
   void QueuedTest ::
     stringArgsAsync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const Fw::StringBase &str80,
         Fw::StringBase &str80Ref,
         const Fw::StringBase &str100,
@@ -111,7 +111,7 @@
 
   void QueuedTest ::
     arrayArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -121,7 +121,7 @@
 
   void QueuedTest ::
     arrayArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -131,7 +131,7 @@
 
   FormalParamArray QueuedTest ::
     arrayReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -141,7 +141,7 @@
 
   FormalParamArray QueuedTest ::
     arrayReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamArray &a,
         FormalParamArray &aRef
     )
@@ -151,7 +151,7 @@
 
   void QueuedTest :: 
     cmdOut_handler(
-        NATIVE_INT_TYPE portNum,
+        FwIndexType portNum,
         FwOpcodeType opCode,
         U32 cmdSeq,
         Fw::CmdArgBuffer& args
@@ -161,7 +161,7 @@
 
   void QueuedTest ::
     enumArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -171,7 +171,7 @@
 
   void QueuedTest ::
     enumArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -181,7 +181,7 @@
 
   FormalParamEnum QueuedTest ::
     enumReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -191,7 +191,7 @@
 
   FormalParamEnum QueuedTest ::
     enumReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamEnum &en,
         FormalParamEnum &enRef
     )
@@ -201,7 +201,7 @@
 
   void QueuedTest ::
     noArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     this->noArgsOut_out(portNum);
@@ -209,7 +209,7 @@
 
   bool QueuedTest ::
     noArgsReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     return this->noArgsReturnOut_out(portNum);
@@ -217,7 +217,7 @@
 
   bool QueuedTest ::
     noArgsReturnSync_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     return this->noArgsReturnOut_out(portNum);
@@ -225,7 +225,7 @@
 
   void QueuedTest ::
     noArgsSync_handler(
-        const NATIVE_INT_TYPE portNum
+        const FwIndexType portNum
     )
   {
     this->noArgsOut_out(portNum);
@@ -233,7 +233,7 @@
 
   void QueuedTest ::
     primitiveArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -255,7 +255,7 @@
 
   void QueuedTest ::
     primitiveArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -277,7 +277,7 @@
 
   U32 QueuedTest ::
     primitiveReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -299,7 +299,7 @@
 
   U32 QueuedTest ::
     primitiveReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 u32,
         U32 &u32Ref,
         F32 f32,
@@ -321,7 +321,7 @@
 
   void QueuedTest ::
     stringArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const Fw::StringBase &str80,
         Fw::StringBase &str80Ref,
         const Fw::StringBase &str100,
@@ -339,7 +339,7 @@
 
   void QueuedTest ::
     stringArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const Fw::StringBase &str80,
         Fw::StringBase &str80Ref,
         const Fw::StringBase &str100,
@@ -357,7 +357,7 @@
 
   void QueuedTest ::
     structArgsGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -367,7 +367,7 @@
 
   void QueuedTest ::
     structArgsSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -377,7 +377,7 @@
 
   FormalParamStruct QueuedTest ::
     structReturnGuarded_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -387,7 +387,7 @@
 
   FormalParamStruct QueuedTest ::
     structReturnSync_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const FormalParamStruct &s,
         FormalParamStruct &sRef
     )
@@ -398,7 +398,7 @@
 
   void QueuedTest ::
       enumArgsHook_handler(
-          const NATIVE_INT_TYPE portNum,
+          const FwIndexType portNum,
           const FormalParamEnum &en,
           FormalParamEnum &enRef
       )
@@ -410,7 +410,7 @@
 
   void QueuedTest ::
     serialAsync_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -419,7 +419,7 @@
 
   void QueuedTest ::
     serialAsyncAssert_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -428,7 +428,7 @@
 
   void QueuedTest ::
     serialAsyncBlockPriority_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -437,7 +437,7 @@
 
   void QueuedTest ::
     serialAsyncDropPriority_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -446,7 +446,7 @@
 
   void QueuedTest ::
     serialGuarded_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -455,7 +455,7 @@
 
   void QueuedTest ::
     serialSync_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {
@@ -702,7 +702,7 @@
 
   void QueuedTest ::
       enumArgsHook_overflowHook(
-          const NATIVE_INT_TYPE portNum,
+          const FwIndexType portNum,
           const FormalParamEnum &en,
           FormalParamEnum &enRef
       )

--- a/FppTest/component/queued/QueuedTest.hpp
+++ b/FppTest/component/queued/QueuedTest.hpp
@@ -37,42 +37,42 @@ class QueuedTest :
 
     //! Handler implementation for arrayArgsAsync
     void arrayArgsAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for arrayArgsGuarded
     void arrayArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for arrayArgsSync
     void arrayArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for arrayReturnGuarded
     FormalParamArray arrayReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for arrayReturnSync
     FormalParamArray arrayReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamArray& a, //!< An array
         FormalParamArray& aRef //!< An array ref
     );
 
     //! Handler implementation for cmdOut
     void cmdOut_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         FwOpcodeType opCode, //!< Command Op Code
         U32 cmdSeq, //!< Command Sequence
         Fw::CmdArgBuffer& args //!< Buffer containing arguments
@@ -80,67 +80,67 @@ class QueuedTest :
 
     //! Handler implementation for enumArgsAsync
     void enumArgsAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for enumArgsGuarded
     void enumArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for enumArgsSync
     void enumArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for enumReturnGuarded
     FormalParamEnum enumReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for enumReturnSync
     FormalParamEnum enumReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
 
     //! Handler implementation for noArgsAsync
     void noArgsAsync_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for noArgsGuarded
     void noArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for noArgsReturnGuarded
     bool noArgsReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for noArgsReturnSync
     bool noArgsReturnSync_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for noArgsSync
     void noArgsSync_handler(
-        NATIVE_INT_TYPE portNum //!< The port number
+        FwIndexType portNum //!< The port number
     );
 
     //! Handler implementation for primitiveArgsAsync
     void primitiveArgsAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -151,7 +151,7 @@ class QueuedTest :
 
     //! Handler implementation for primitiveArgsGuarded
     void primitiveArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -162,7 +162,7 @@ class QueuedTest :
 
     //! Handler implementation for primitiveArgsSync
     void primitiveArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -173,7 +173,7 @@ class QueuedTest :
 
     //! Handler implementation for primitiveReturnGuarded
     U32 primitiveReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -184,7 +184,7 @@ class QueuedTest :
 
     //! Handler implementation for primitiveReturnSync
     U32 primitiveReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         U32 u32,
         U32& u32Ref,
         F32 f32,
@@ -195,7 +195,7 @@ class QueuedTest :
 
     //! Handler implementation for stringArgsAsync
     void stringArgsAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const Fw::StringBase& str80, //!< A string of size 80
         Fw::StringBase& str80Ref,
         const Fw::StringBase& str100, //!< A string of size 100
@@ -204,7 +204,7 @@ class QueuedTest :
 
     //! Handler implementation for stringArgsGuarded
     void stringArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const Fw::StringBase& str80, //!< A string of size 80
         Fw::StringBase& str80Ref,
         const Fw::StringBase& str100, //!< A string of size 100
@@ -213,7 +213,7 @@ class QueuedTest :
 
     //! Handler implementation for stringArgsSync
     void stringArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const Fw::StringBase& str80, //!< A string of size 80
         Fw::StringBase& str80Ref,
         const Fw::StringBase& str100, //!< A string of size 100
@@ -222,42 +222,42 @@ class QueuedTest :
 
     //! Handler implementation for structArgsAsync
     void structArgsAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for structArgsGuarded
     void structArgsGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for structArgsSync
     void structArgsSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for structReturnGuarded
     FormalParamStruct structReturnGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for structReturnSync
     FormalParamStruct structReturnSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamStruct& s, //!< A struct
         FormalParamStruct& sRef //!< A struct ref
     );
 
     //! Handler implementation for enumArgsOverflow
     void enumArgsHook_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );
@@ -270,37 +270,37 @@ class QueuedTest :
 
     //! Handler implementation for serialAsync
     void serialAsync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
     //! Handler implementation for serialAsyncAssert
     void serialAsyncAssert_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
     //! Handler implementation for serialAsyncBlockPriority
     void serialAsyncBlockPriority_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
     //! Handler implementation for serialAsyncDropPriority
     void serialAsyncDropPriority_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
     //! Handler implementation for serialGuarded
     void serialGuarded_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
     //! Handler implementation for serialSync
     void serialSync_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         Fw::SerializeBufferBase& buffer //!< The serialization buffer
     );
 
@@ -452,7 +452,7 @@ class QueuedTest :
 
     //! Overflow hook implementation for enumArgsOverflow
     void enumArgsHook_overflowHook(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         const FormalParamEnum& en, //!< An enum
         FormalParamEnum& enRef //!< An enum ref
     );

--- a/FppTest/component/queued/test/ut/Tester.cpp
+++ b/FppTest/component/queued/test/ut/Tester.cpp
@@ -33,7 +33,7 @@ void Tester ::initComponents() {
     this->component.init(Tester::TEST_INSTANCE_QUEUE_DEPTH, Tester::TEST_INSTANCE_ID);
 }
 
-Fw::ParamValid Tester ::from_prmGetIn_handler(const NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
+Fw::ParamValid Tester ::from_prmGetIn_handler(const FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
     val.resetSer();
 
     Fw::SerializeStatus status;
@@ -78,7 +78,7 @@ Fw::ParamValid Tester ::from_prmGetIn_handler(const NATIVE_INT_TYPE portNum, FwP
     return prmValid;
 }
 
-void Tester ::from_prmSetIn_handler(const NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
+void Tester ::from_prmSetIn_handler(const FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
     Fw::SerializeStatus status;
     U32 id_base = component.getIdBase();
 

--- a/FppTest/component/queued/test/ut/Tester.hpp
+++ b/FppTest/component/queued/test/ut/Tester.hpp
@@ -76,7 +76,7 @@ class Tester : public QueuedTestGTestBase {
 
     //! Handler for from_arrayArgsOut
     //!
-    void from_arrayArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_arrayArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                    const FormalParamArray& a,     /*!<
                                    An array
                                    */
@@ -87,7 +87,7 @@ class Tester : public QueuedTestGTestBase {
 
     //! Handler for from_arrayReturnOut
     //!
-    FormalParamArray from_arrayReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    FormalParamArray from_arrayReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                                  const FormalParamArray& a,     /*!<
                                                  An array
                                                  */
@@ -98,7 +98,7 @@ class Tester : public QueuedTestGTestBase {
 
     //! Handler for from_enumArgsOut
     //!
-    void from_enumArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_enumArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                   const FormalParamEnum& en,     /*!<
                                   An enum
                                   */
@@ -109,7 +109,7 @@ class Tester : public QueuedTestGTestBase {
 
     //! Handler for from_enumReturnOut
     //!
-    FormalParamEnum from_enumReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    FormalParamEnum from_enumReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                                const FormalParamEnum& en,     /*!<
                                                An enum
                                                */
@@ -120,17 +120,17 @@ class Tester : public QueuedTestGTestBase {
 
     //! Handler for from_noArgsOut
     //!
-    void from_noArgsOut_handler(const NATIVE_INT_TYPE portNum /*!< The port number*/
+    void from_noArgsOut_handler(const FwIndexType portNum /*!< The port number*/
     );
 
     //! Handler for from_noArgsReturnOut
     //!
-    bool from_noArgsReturnOut_handler(const NATIVE_INT_TYPE portNum /*!< The port number*/
+    bool from_noArgsReturnOut_handler(const FwIndexType portNum /*!< The port number*/
     );
 
     //! Handler for from_primitiveArgsOut
     //!
-    void from_primitiveArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_primitiveArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                        U32 u32,
                                        U32& u32Ref,
                                        F32 f32,
@@ -140,7 +140,7 @@ class Tester : public QueuedTestGTestBase {
 
     //! Handler for from_primitiveReturnOut
     //!
-    U32 from_primitiveReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    U32 from_primitiveReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                         U32 u32,
                                         U32& u32Ref,
                                         F32 f32,
@@ -150,7 +150,7 @@ class Tester : public QueuedTestGTestBase {
 
     //! Handler for from_prmGetIn
     //!
-    Fw::ParamValid from_prmGetIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Fw::ParamValid from_prmGetIn_handler(const FwIndexType portNum, /*!< The port number*/
                                          FwPrmIdType id,                /*!<
                                                     Parameter ID
                                                     */
@@ -161,7 +161,7 @@ class Tester : public QueuedTestGTestBase {
 
     //! Handler for from_prmGetIn
     //!
-    void from_prmSetIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_prmSetIn_handler(const FwIndexType portNum, /*!< The port number*/
                                FwPrmIdType id,                /*!<
                                           Parameter ID
                                           */
@@ -172,7 +172,7 @@ class Tester : public QueuedTestGTestBase {
 
     //! Handler for from_structArgsOut
     //!
-    void from_structArgsOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_structArgsOut_handler(const FwIndexType portNum, /*!< The port number*/
                                     const FormalParamStruct& s,    /*!<
                                    A struct
                                    */
@@ -183,7 +183,7 @@ class Tester : public QueuedTestGTestBase {
 
     //! Handler for from_structReturnOut
     //!
-    FormalParamStruct from_structReturnOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    FormalParamStruct from_structReturnOut_handler(const FwIndexType portNum, /*!< The port number*/
                                                    const FormalParamStruct& s,    /*!<
                                                   A struct
                                                   */
@@ -192,7 +192,7 @@ class Tester : public QueuedTestGTestBase {
                                                       */
     );
 
-    void from_enumArgsHookOverflowed_handler(const NATIVE_INT_TYPE portNum,
+    void from_enumArgsHookOverflowed_handler(const FwIndexType portNum,
                                              const FormalParamEnum& en,
                                              FormalParamEnum& enRef);
 
@@ -203,7 +203,7 @@ class Tester : public QueuedTestGTestBase {
 
     //! Handler for from_serialOut
     //!
-    void from_serialOut_handler(NATIVE_INT_TYPE portNum,        /*!< The port number*/
+    void from_serialOut_handler(FwIndexType portNum,        /*!< The port number*/
                                 Fw::SerializeBufferBase& Buffer /*!< The serialization buffer*/
     );
 

--- a/FppTest/component/tests/CmdTests.hpp
+++ b/FppTest/component/tests/CmdTests.hpp
@@ -36,7 +36,7 @@
     CMD_TEST_INVOKE_DECL(ArrayParam, Async)                              \
     CMD_TEST_INVOKE_DECL(StructParam, Async)
 
-#define CMD_TEST_DECL(TYPE, ASYNC) void test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::TYPE& data);
+#define CMD_TEST_DECL(TYPE, ASYNC) void test##ASYNC##Command(FwIndexType portNum, FppTest::Types::TYPE& data);
 
 #define CMD_TEST_DECLS               \
     CMD_TEST_INVOKE_DECLS            \
@@ -156,7 +156,7 @@
     }
 
 #define CMD_TEST_DEFS(ASYNC, _ASYNC)                                                                        \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& data) {           \
+    void Tester ::test##ASYNC##Command(FwIndexType portNum, FppTest::Types::NoParams& data) {           \
         ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
@@ -177,7 +177,7 @@
         ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_NO_ARGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
     }                                                                                                       \
                                                                                                             \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& data) {    \
+    void Tester ::test##ASYNC##Command(FwIndexType portNum, FppTest::Types::PrimitiveParams& data) {    \
         ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
@@ -241,7 +241,7 @@
         ASSERT_CMD_RESPONSE(7, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
     }                                                                                                       \
                                                                                                             \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::CmdStringParams& data) {    \
+    void Tester ::test##ASYNC##Command(FwIndexType portNum, FppTest::Types::CmdStringParams& data) {    \
         ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
@@ -277,7 +277,7 @@
         ASSERT_CMD_RESPONSE(3, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
     }                                                                                                       \
                                                                                                             \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParam& data) {          \
+    void Tester ::test##ASYNC##Command(FwIndexType portNum, FppTest::Types::EnumParam& data) {          \
         ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
@@ -306,7 +306,7 @@
         ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::FORMAT_ERROR);      \
     }                                                                                                       \
                                                                                                             \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& data) {         \
+    void Tester ::test##ASYNC##Command(FwIndexType portNum, FppTest::Types::ArrayParam& data) {         \
         ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \
@@ -335,7 +335,7 @@
         ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::FORMAT_ERROR);     \
     }                                                                                                       \
                                                                                                             \
-    void Tester ::test##ASYNC##Command(NATIVE_INT_TYPE portNum, FppTest::Types::StructParam& data) {        \
+    void Tester ::test##ASYNC##Command(FwIndexType portNum, FppTest::Types::StructParam& data) {        \
         ASSERT_TRUE(this->isConnected_to_cmdIn(portNum));                                                   \
         ASSERT_TRUE(component.isConnected_cmdRegOut_OutputPort(portNum));                                   \
         ASSERT_TRUE(component.isConnected_cmdResponseOut_OutputPort(portNum));                              \

--- a/FppTest/component/tests/EventTests.cpp
+++ b/FppTest/component/tests/EventTests.cpp
@@ -16,7 +16,7 @@
 // Event tests
 // ----------------------------------------------------------------------
 
-void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& data) {
+void Tester ::testEvent(FwIndexType portNum, FppTest::Types::NoParams& data) {
     ASSERT_TRUE(component.isConnected_eventOut_OutputPort(portNum));
     ASSERT_TRUE(component.isConnected_textEventOut_OutputPort(portNum));
 
@@ -28,7 +28,7 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& data)
     this->printTextLogHistory(stdout);
 }
 
-void Tester ::testEventHelper(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& data, NATIVE_UINT_TYPE size) {
+void Tester ::testEventHelper(FwIndexType portNum, FppTest::Types::PrimitiveParams& data, NATIVE_UINT_TYPE size) {
     component.log_ACTIVITY_LO_EventPrimitive(data.args.val1, data.args.val2, data.args.val3, data.args.val4,
                                              data.args.val5, data.args.val6);
 
@@ -38,7 +38,7 @@ void Tester ::testEventHelper(NATIVE_INT_TYPE portNum, FppTest::Types::Primitive
                                  data.args.val5, data.args.val6);
 }
 
-void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& data) {
+void Tester ::testEvent(FwIndexType portNum, FppTest::Types::PrimitiveParams& data) {
     ASSERT_TRUE(component.isConnected_eventOut_OutputPort(portNum));
     ASSERT_TRUE(component.isConnected_textEventOut_OutputPort(portNum));
 
@@ -56,7 +56,7 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams
     this->printTextLogHistory(stdout);
 }
 
-void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::LogStringParams& data) {
+void Tester ::testEvent(FwIndexType portNum, FppTest::Types::LogStringParams& data) {
     component.log_COMMAND_EventString(data.args.val1, data.args.val2);
 
     ASSERT_EVENTS_SIZE(1);
@@ -68,7 +68,7 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::LogStringParams
     this->printTextLogHistory(stdout);
 }
 
-void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParam& data) {
+void Tester ::testEvent(FwIndexType portNum, FppTest::Types::EnumParam& data) {
     ASSERT_TRUE(component.isConnected_eventOut_OutputPort(portNum));
     ASSERT_TRUE(component.isConnected_textEventOut_OutputPort(portNum));
 
@@ -81,7 +81,7 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParam& data
     this->printTextLogHistory(stdout);
 }
 
-void Tester ::testEventHelper(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& data, NATIVE_UINT_TYPE size) {
+void Tester ::testEventHelper(FwIndexType portNum, FppTest::Types::ArrayParam& data, NATIVE_UINT_TYPE size) {
     ASSERT_TRUE(component.isConnected_eventOut_OutputPort(portNum));
     ASSERT_TRUE(component.isConnected_textEventOut_OutputPort(portNum));
 
@@ -92,7 +92,7 @@ void Tester ::testEventHelper(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayPara
     ASSERT_EVENTS_EventArray(portNum, data.args.val);
 }
 
-void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& data) {
+void Tester ::testEvent(FwIndexType portNum, FppTest::Types::ArrayParam& data) {
     ASSERT_TRUE(component.isConnected_eventOut_OutputPort(portNum));
     ASSERT_TRUE(component.isConnected_textEventOut_OutputPort(portNum));
 
@@ -110,7 +110,7 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& dat
     this->printTextLogHistory(stdout);
 }
 
-void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::StructParam& data) {
+void Tester ::testEvent(FwIndexType portNum, FppTest::Types::StructParam& data) {
     ASSERT_TRUE(component.isConnected_eventOut_OutputPort(portNum));
     ASSERT_TRUE(component.isConnected_textEventOut_OutputPort(portNum));
 
@@ -123,7 +123,7 @@ void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::StructParam& da
     this->printTextLogHistory(stdout);
 }
 
-void Tester ::testEventHelper(NATIVE_INT_TYPE portNum, FppTest::Types::BoolParam& data, NATIVE_UINT_TYPE size) {
+void Tester ::testEventHelper(FwIndexType portNum, FppTest::Types::BoolParam& data, NATIVE_UINT_TYPE size) {
     ASSERT_TRUE(component.isConnected_eventOut_OutputPort(portNum));
     ASSERT_TRUE(component.isConnected_textEventOut_OutputPort(portNum));
 
@@ -134,7 +134,7 @@ void Tester ::testEventHelper(NATIVE_INT_TYPE portNum, FppTest::Types::BoolParam
     ASSERT_EVENTS_EventBool(portNum, data.args.val);
 }
 
-void Tester ::testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::BoolParam& data) {
+void Tester ::testEvent(FwIndexType portNum, FppTest::Types::BoolParam& data) {
     ASSERT_TRUE(component.isConnected_eventOut_OutputPort(portNum));
     ASSERT_TRUE(component.isConnected_textEventOut_OutputPort(portNum));
 

--- a/FppTest/component/tests/EventTests.hpp
+++ b/FppTest/component/tests/EventTests.hpp
@@ -14,10 +14,10 @@
 // Event test declarations
 // ----------------------------------------------------------------------
 
-#define EVENT_TEST_DECL(TYPE) void testEvent(NATIVE_INT_TYPE portNum, FppTest::Types::TYPE& data);
+#define EVENT_TEST_DECL(TYPE) void testEvent(FwIndexType portNum, FppTest::Types::TYPE& data);
 
 #define EVENT_TEST_HELPER_DECL(TYPE) \
-    void testEventHelper(NATIVE_INT_TYPE portNum, FppTest::Types::TYPE& data, NATIVE_UINT_TYPE size);
+    void testEventHelper(FwIndexType portNum, FppTest::Types::TYPE& data, NATIVE_UINT_TYPE size);
 
 #define EVENT_TEST_DECLS                    \
     EVENT_TEST_DECL(NoParams)               \

--- a/FppTest/component/tests/OverflowTests.cpp
+++ b/FppTest/component/tests/OverflowTests.cpp
@@ -68,7 +68,7 @@ void Tester ::testOverflowHook() {
 // Handler to support overflow hook test
 // ----------------------------------------------------------------------
 
-void Tester ::from_enumArgsHookOverflowed_handler(const NATIVE_INT_TYPE portNum,
+void Tester ::from_enumArgsHookOverflowed_handler(const FwIndexType portNum,
                                                   const FormalParamEnum& en,
                                                   FormalParamEnum& enRef) {
     this->pushFromPortEntry_enumArgsHookOverflowed(en, enRef);

--- a/FppTest/component/tests/ParamTests.cpp
+++ b/FppTest/component/tests/ParamTests.cpp
@@ -61,7 +61,7 @@ void Tester ::testParam() {
     }
 }
 
-void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::BoolParam& data) {
+void Tester ::testParamCommand(FwIndexType portNum, FppTest::Types::BoolParam& data) {
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param
@@ -94,7 +94,7 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::BoolPara
     ASSERT_EQ(boolPrm.args.val, data.args.val);
 }
 
-void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::U32Param& data) {
+void Tester ::testParamCommand(FwIndexType portNum, FppTest::Types::U32Param& data) {
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param
@@ -127,7 +127,7 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::U32Param
     ASSERT_EQ(u32Prm.args.val, data.args.val);
 }
 
-void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::PrmStringParam& data) {
+void Tester ::testParamCommand(FwIndexType portNum, FppTest::Types::PrmStringParam& data) {
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param
@@ -160,7 +160,7 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::PrmStrin
     ASSERT_EQ(stringPrm.args.val, data.args.val);
 }
 
-void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParam& data) {
+void Tester ::testParamCommand(FwIndexType portNum, FppTest::Types::EnumParam& data) {
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param
@@ -193,7 +193,7 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::EnumPara
     ASSERT_EQ(enumPrm.args.val, data.args.val);
 }
 
-void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParam& data) {
+void Tester ::testParamCommand(FwIndexType portNum, FppTest::Types::ArrayParam& data) {
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param
@@ -226,7 +226,7 @@ void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayPar
     ASSERT_EQ(arrayPrm.args.val, data.args.val);
 }
 
-void Tester ::testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::StructParam& data) {
+void Tester ::testParamCommand(FwIndexType portNum, FppTest::Types::StructParam& data) {
     Fw::CmdArgBuffer buf;
 
     // Test unsuccessful saving of param

--- a/FppTest/component/tests/ParamTests.hpp
+++ b/FppTest/component/tests/ParamTests.hpp
@@ -14,7 +14,7 @@
 // Parameter test declarations
 // ----------------------------------------------------------------------
 
-#define PARAM_CMD_TEST_DECL(TYPE) void testParamCommand(NATIVE_INT_TYPE portNum, FppTest::Types::TYPE& data);
+#define PARAM_CMD_TEST_DECL(TYPE) void testParamCommand(FwIndexType portNum, FppTest::Types::TYPE& data);
 
 #define PARAM_CMD_TEST_DECLS            \
     PARAM_CMD_TEST_DECL(BoolParam)      \

--- a/FppTest/component/tests/PortTests.hpp
+++ b/FppTest/component/tests/PortTests.hpp
@@ -19,7 +19,7 @@
 // ----------------------------------------------------------------------
 
 #define PORT_TEST_INVOKE_DECL(PORT_KIND, TYPE) \
-    void test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::TYPE& port);
+    void test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::TYPE& port);
 
 #define PORT_TEST_INVOKE_DECLS(PORT_KIND)              \
     PORT_TEST_INVOKE_DECL(PORT_KIND, NoParams)         \
@@ -35,10 +35,10 @@
     PORT_TEST_INVOKE_DECL(PORT_KIND, StructReturn)
 
 #define PORT_TEST_INVOKE_SERIAL_HELPER_DECL(PORT_KIND) \
-    void invoke##PORT_KIND##SerialPort(NATIVE_INT_TYPE portNum, Fw::SerialBuffer& buf);
+    void invoke##PORT_KIND##SerialPort(FwIndexType portNum, Fw::SerialBuffer& buf);
 
 #define PORT_TEST_INVOKE_SERIAL_DECL(PORT_KIND, TYPE) \
-    void test##PORT_KIND##PortInvokeSerial(NATIVE_INT_TYPE portNum, FppTest::Types::TYPE& port);
+    void test##PORT_KIND##PortInvokeSerial(FwIndexType portNum, FppTest::Types::TYPE& port);
 
 #define PORT_TEST_INVOKE_SERIAL_DECLS(PORT_KIND)              \
     PORT_TEST_INVOKE_SERIAL_DECL(PORT_KIND, NoParams)         \
@@ -91,14 +91,14 @@
 // ----------------------------------------------------------------------
 
 #define PORT_TEST_INVOKE_DEFS(PORT_KIND)                                                                         \
-    void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& port) {         \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::NoParams& port) {         \
         ASSERT_TRUE(component.isConnected_noArgsOut_OutputPort(portNum));                                        \
         ASSERT_TRUE(this->isConnected_to_noArgs##PORT_KIND(portNum));                                            \
                                                                                                                  \
         this->invoke_to_noArgs##PORT_KIND(portNum);                                                              \
     }                                                                                                            \
                                                                                                                  \
-    void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& port) {  \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::PrimitiveParams& port) {  \
         ASSERT_TRUE(component.isConnected_primitiveArgsOut_OutputPort(portNum));                                 \
         ASSERT_TRUE(this->isConnected_to_primitiveArgs##PORT_KIND(portNum));                                     \
                                                                                                                  \
@@ -106,7 +106,7 @@
                                                  port.args.val4, port.args.val5, port.args.val6);                \
     }                                                                                                            \
                                                                                                                  \
-    void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::PortStringParams& port) { \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::PortStringParams& port) { \
         ASSERT_TRUE(component.isConnected_stringArgsOut_OutputPort(portNum));                                    \
         ASSERT_TRUE(this->isConnected_to_stringArgs##PORT_KIND(portNum));                                        \
                                                                                                                  \
@@ -114,21 +114,21 @@
                                               port.args.val4);                                                   \
     }                                                                                                            \
                                                                                                                  \
-    void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParams& port) {       \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::EnumParams& port) {       \
         ASSERT_TRUE(component.isConnected_enumArgsOut_OutputPort(portNum));                                      \
         ASSERT_TRUE(this->isConnected_to_enumArgs##PORT_KIND(portNum));                                          \
                                                                                                                  \
         this->invoke_to_enumArgs##PORT_KIND(portNum, port.args.val1, port.args.val2);                            \
     }                                                                                                            \
                                                                                                                  \
-    void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParams& port) {      \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::ArrayParams& port) {      \
         ASSERT_TRUE(component.isConnected_arrayArgsOut_OutputPort(portNum));                                     \
         ASSERT_TRUE(this->isConnected_to_arrayArgs##PORT_KIND(portNum));                                         \
                                                                                                                  \
         this->invoke_to_arrayArgs##PORT_KIND(portNum, port.args.val1, port.args.val2);                           \
     }                                                                                                            \
                                                                                                                  \
-    void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::StructParams& port) {     \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::StructParams& port) {     \
         ASSERT_TRUE(component.isConnected_structArgsOut_OutputPort(portNum));                                    \
         ASSERT_TRUE(this->isConnected_to_structArgs##PORT_KIND(portNum));                                        \
                                                                                                                  \
@@ -136,7 +136,7 @@
     }
 
 #define PORT_TEST_INVOKE_RETURN_DEFS(PORT_KIND)                                                                       \
-    void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::NoParamReturn& port) {         \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::NoParamReturn& port) {         \
         ASSERT_TRUE(component.isConnected_noArgsReturnOut_OutputPort(portNum));                                       \
         ASSERT_TRUE(this->isConnected_to_noArgsReturn##PORT_KIND(portNum));                                           \
                                                                                                                       \
@@ -145,7 +145,7 @@
         ASSERT_EQ(returnVal, this->noParamReturnVal.val);                                                             \
     }                                                                                                                 \
                                                                                                                       \
-    void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveReturn& port) {       \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::PrimitiveReturn& port) {       \
         ASSERT_TRUE(component.isConnected_primitiveReturnOut_OutputPort(portNum));                                    \
         ASSERT_TRUE(this->isConnected_to_primitiveReturn##PORT_KIND(portNum));                                        \
                                                                                                                       \
@@ -155,7 +155,7 @@
         ASSERT_EQ(returnVal, this->primitiveReturnVal.val);                                                           \
     }                                                                                                                 \
                                                                                                                       \
-    void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::EnumReturn& port) {            \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::EnumReturn& port) {            \
         ASSERT_TRUE(component.isConnected_enumReturnOut_OutputPort(portNum));                                         \
         ASSERT_TRUE(this->isConnected_to_enumReturn##PORT_KIND(portNum));                                             \
                                                                                                                       \
@@ -164,7 +164,7 @@
         ASSERT_EQ(returnVal, this->enumReturnVal.val);                                                                \
     }                                                                                                                 \
                                                                                                                       \
-    void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayReturn& port) {           \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::ArrayReturn& port) {           \
         ASSERT_TRUE(component.isConnected_arrayReturnOut_OutputPort(portNum));                                        \
         ASSERT_TRUE(this->isConnected_to_arrayReturn##PORT_KIND(portNum));                                            \
                                                                                                                       \
@@ -173,7 +173,7 @@
         ASSERT_EQ(returnVal, this->arrayReturnVal.val);                                                               \
     }                                                                                                                 \
                                                                                                                       \
-    void Tester ::test##PORT_KIND##PortInvoke(NATIVE_INT_TYPE portNum, FppTest::Types::StructReturn& port) {          \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::StructReturn& port) {          \
         ASSERT_TRUE(component.isConnected_structReturnOut_OutputPort(portNum));                                       \
         ASSERT_TRUE(this->isConnected_to_structReturn##PORT_KIND(portNum));                                           \
                                                                                                                       \
@@ -188,13 +188,13 @@
 // ----------------------------------------------------------------------
 
 #define PORT_TEST_INVOKE_SERIAL_HELPER_DEF(PORT_KIND)                                             \
-    void Tester ::invoke##PORT_KIND##SerialPort(NATIVE_INT_TYPE portNum, Fw::SerialBuffer& buf) { \
+    void Tester ::invoke##PORT_KIND##SerialPort(FwIndexType portNum, Fw::SerialBuffer& buf) { \
         ASSERT_TRUE(this->isConnected_to_serial##PORT_KIND(portNum));                             \
         this->invoke_to_serial##PORT_KIND(portNum, buf);                                          \
     }
 
 #define PORT_TEST_INVOKE_SERIAL_HELPER_DEF_ASYNC                                          \
-    void Tester ::invokeAsyncSerialPort(NATIVE_INT_TYPE portNum, Fw::SerialBuffer& buf) { \
+    void Tester ::invokeAsyncSerialPort(FwIndexType portNum, Fw::SerialBuffer& buf) { \
         Fw::QueuedComponentBase::MsgDispatchStatus status;                                \
                                                                                           \
         switch (portNum) {                                                                \
@@ -227,7 +227,7 @@
     }
 
 #define PORT_TEST_INVOKE_SERIAL_DEFS(PORT_KIND)                                                                        \
-    void Tester ::test##PORT_KIND##PortInvokeSerial(NATIVE_INT_TYPE portNum, FppTest::Types::NoParams& port) {         \
+    void Tester ::test##PORT_KIND##PortInvokeSerial(FwIndexType portNum, FppTest::Types::NoParams& port) {         \
         ASSERT_TRUE(component.isConnected_serialOut_OutputPort(portNum));                                              \
                                                                                                                        \
         U8 data[0];                                                                                                    \
@@ -236,7 +236,7 @@
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::NO_ARGS, buf);                                            \
     }                                                                                                                  \
                                                                                                                        \
-    void Tester ::test##PORT_KIND##PortInvokeSerial(NATIVE_INT_TYPE portNum, FppTest::Types::PrimitiveParams& port) {  \
+    void Tester ::test##PORT_KIND##PortInvokeSerial(FwIndexType portNum, FppTest::Types::PrimitiveParams& port) {  \
         ASSERT_TRUE(component.isConnected_serialOut_OutputPort(portNum));                                              \
                                                                                                                        \
         Fw::SerializeStatus status;                                                                                    \
@@ -361,7 +361,7 @@
         this->checkSerializeStatusSuccess();                                                                           \
     }                                                                                                                  \
                                                                                                                        \
-    void Tester ::test##PORT_KIND##PortInvokeSerial(NATIVE_INT_TYPE portNum, FppTest::Types::PortStringParams& port) { \
+    void Tester ::test##PORT_KIND##PortInvokeSerial(FwIndexType portNum, FppTest::Types::PortStringParams& port) { \
         ASSERT_TRUE(component.isConnected_serialOut_OutputPort(portNum));                                              \
                                                                                                                        \
         Fw::SerializeStatus status;                                                                                    \
@@ -437,7 +437,7 @@
         this->checkSerializeStatusSuccess();                                                                           \
     }                                                                                                                  \
                                                                                                                        \
-    void Tester ::test##PORT_KIND##PortInvokeSerial(NATIVE_INT_TYPE portNum, FppTest::Types::EnumParams& port) {       \
+    void Tester ::test##PORT_KIND##PortInvokeSerial(FwIndexType portNum, FppTest::Types::EnumParams& port) {       \
         ASSERT_TRUE(component.isConnected_serialOut_OutputPort(portNum));                                              \
                                                                                                                        \
         Fw::SerializeStatus status;                                                                                    \
@@ -476,7 +476,7 @@
         this->checkSerializeStatusSuccess();                                                                           \
     }                                                                                                                  \
                                                                                                                        \
-    void Tester ::test##PORT_KIND##PortInvokeSerial(NATIVE_INT_TYPE portNum, FppTest::Types::ArrayParams& port) {      \
+    void Tester ::test##PORT_KIND##PortInvokeSerial(FwIndexType portNum, FppTest::Types::ArrayParams& port) {      \
         ASSERT_TRUE(component.isConnected_serialOut_OutputPort(portNum));                                              \
                                                                                                                        \
         Fw::SerializeStatus status;                                                                                    \
@@ -514,7 +514,7 @@
         this->checkSerializeStatusSuccess();                                                                           \
     }                                                                                                                  \
                                                                                                                        \
-    void Tester ::test##PORT_KIND##PortInvokeSerial(NATIVE_INT_TYPE portNum, FppTest::Types::StructParams& port) {     \
+    void Tester ::test##PORT_KIND##PortInvokeSerial(FwIndexType portNum, FppTest::Types::StructParams& port) {     \
         ASSERT_TRUE(component.isConnected_serialOut_OutputPort(portNum));                                              \
                                                                                                                        \
         Fw::SerializeStatus status;                                                                                    \

--- a/FppTest/component/tests/TesterHandlers.cpp
+++ b/FppTest/component/tests/TesterHandlers.cpp
@@ -16,42 +16,42 @@
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void Tester ::from_arrayArgsOut_handler(const NATIVE_INT_TYPE portNum,
+void Tester ::from_arrayArgsOut_handler(const FwIndexType portNum,
                                         const FormalParamArray& a,
                                         FormalParamArray& aRef) {
     this->pushFromPortEntry_arrayArgsOut(a, aRef);
 }
 
-FormalParamArray Tester ::from_arrayReturnOut_handler(const NATIVE_INT_TYPE portNum,
+FormalParamArray Tester ::from_arrayReturnOut_handler(const FwIndexType portNum,
                                                       const FormalParamArray& a,
                                                       FormalParamArray& aRef) {
     this->pushFromPortEntry_arrayReturnOut(a, aRef);
     return arrayReturnVal.val;
 }
 
-void Tester ::from_enumArgsOut_handler(const NATIVE_INT_TYPE portNum,
+void Tester ::from_enumArgsOut_handler(const FwIndexType portNum,
                                        const FormalParamEnum& en,
                                        FormalParamEnum& enRef) {
     this->pushFromPortEntry_enumArgsOut(en, enRef);
 }
 
-FormalParamEnum Tester ::from_enumReturnOut_handler(const NATIVE_INT_TYPE portNum,
+FormalParamEnum Tester ::from_enumReturnOut_handler(const FwIndexType portNum,
                                                     const FormalParamEnum& en,
                                                     FormalParamEnum& enRef) {
     this->pushFromPortEntry_enumReturnOut(en, enRef);
     return enumReturnVal.val;
 }
 
-void Tester ::from_noArgsOut_handler(const NATIVE_INT_TYPE portNum) {
+void Tester ::from_noArgsOut_handler(const FwIndexType portNum) {
     this->pushFromPortEntry_noArgsOut();
 }
 
-bool Tester ::from_noArgsReturnOut_handler(const NATIVE_INT_TYPE portNum) {
+bool Tester ::from_noArgsReturnOut_handler(const FwIndexType portNum) {
     this->pushFromPortEntry_noArgsReturnOut();
     return noParamReturnVal.val;
 }
 
-void Tester ::from_primitiveArgsOut_handler(const NATIVE_INT_TYPE portNum,
+void Tester ::from_primitiveArgsOut_handler(const FwIndexType portNum,
                                             U32 u32,
                                             U32& u32Ref,
                                             F32 f32,
@@ -61,7 +61,7 @@ void Tester ::from_primitiveArgsOut_handler(const NATIVE_INT_TYPE portNum,
     this->pushFromPortEntry_primitiveArgsOut(u32, u32Ref, f32, f32Ref, b, bRef);
 }
 
-U32 Tester ::from_primitiveReturnOut_handler(const NATIVE_INT_TYPE portNum,
+U32 Tester ::from_primitiveReturnOut_handler(const FwIndexType portNum,
                                              U32 u32,
                                              U32& u32Ref,
                                              F32 f32,
@@ -72,13 +72,13 @@ U32 Tester ::from_primitiveReturnOut_handler(const NATIVE_INT_TYPE portNum,
     return primitiveReturnVal.val;
 }
 
-void Tester ::from_structArgsOut_handler(const NATIVE_INT_TYPE portNum,
+void Tester ::from_structArgsOut_handler(const FwIndexType portNum,
                                          const FormalParamStruct& s,
                                          FormalParamStruct& sRef) {
     this->pushFromPortEntry_structArgsOut(s, sRef);
 }
 
-FormalParamStruct Tester ::from_structReturnOut_handler(const NATIVE_INT_TYPE portNum,
+FormalParamStruct Tester ::from_structReturnOut_handler(const FwIndexType portNum,
                                                         const FormalParamStruct& s,
                                                         FormalParamStruct& sRef) {
     this->pushFromPortEntry_structReturnOut(s, sRef);
@@ -89,7 +89,7 @@ FormalParamStruct Tester ::from_structReturnOut_handler(const NATIVE_INT_TYPE po
 // Handlers for serial from ports
 // ----------------------------------------------------------------------
 
-void Tester ::from_serialOut_handler(NATIVE_INT_TYPE portNum,        /*!< The port number*/
+void Tester ::from_serialOut_handler(FwIndexType portNum,        /*!< The port number*/
                                      Fw::SerializeBufferBase& Buffer /*!< The serialization buffer*/
 ) {
     Fw::SerializeStatus status;

--- a/FppTest/component/tests/TlmTests.hpp
+++ b/FppTest/component/tests/TlmTests.hpp
@@ -14,7 +14,7 @@
 // Telemetry test declarations
 // ----------------------------------------------------------------------
 
-#define TLM_TEST_DECL(TYPE) void testTelemetry(NATIVE_INT_TYPE portNum, FppTest::Types::TYPE##Param& data);
+#define TLM_TEST_DECL(TYPE) void testTelemetry(FwIndexType portNum, FppTest::Types::TYPE##Param& data);
 
 #define TLM_TEST_DECLS       \
     TLM_TEST_DECL(U32)       \
@@ -29,7 +29,7 @@
 // ----------------------------------------------------------------------
 
 #define TLM_TEST_DEF(TYPE)                                                                    \
-    void Tester ::testTelemetry(NATIVE_INT_TYPE portNum, FppTest::Types::TYPE##Param& data) { \
+    void Tester ::testTelemetry(FwIndexType portNum, FppTest::Types::TYPE##Param& data) { \
         ASSERT_TRUE(component.isConnected_tlmOut_OutputPort(portNum));                        \
                                                                                               \
         component.tlmWrite_Channel##TYPE(data.args.val);                                      \
@@ -50,7 +50,7 @@
     TLM_TEST_DEF(U32)                                                                            \
     TLM_TEST_DEF(F32)                                                                            \
                                                                                                  \
-    void Tester ::testTelemetry(NATIVE_INT_TYPE portNum, FppTest::Types::TlmStringParam& data) { \
+    void Tester ::testTelemetry(FwIndexType portNum, FppTest::Types::TlmStringParam& data) { \
         ASSERT_TRUE(component.isConnected_tlmOut_OutputPort(portNum));                           \
                                                                                                  \
         component.tlmWrite_ChannelString(data.args.val);                                         \

--- a/FppTest/dp/DpTest.cpp
+++ b/FppTest/dp/DpTest.cpp
@@ -42,7 +42,7 @@ DpTest ::~DpTest() {}
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void DpTest::schedIn_handler(const NATIVE_INT_TYPE portNum, U32 context) {
+void DpTest::schedIn_handler(const FwIndexType portNum, U32 context) {
     // Request a buffer for Container 1
     this->dpRequest_Container1(CONTAINER_1_DATA_SIZE);
     // Request a buffer for Container 2

--- a/FppTest/dp/DpTest.hpp
+++ b/FppTest/dp/DpTest.hpp
@@ -82,7 +82,7 @@ class DpTest : public DpTestComponentBase {
     // ----------------------------------------------------------------------
 
     //! Handler implementation for schedIn
-    void schedIn_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+    void schedIn_handler(const FwIndexType portNum,  //!< The port number
                          U32 context                     //!< The call order
                          ) final;
 

--- a/FppTest/state_machine/external_instance/SmTest.cpp
+++ b/FppTest/state_machine/external_instance/SmTest.cpp
@@ -24,7 +24,7 @@ SmTest ::~SmTest() {}
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void SmTest::schedIn_handler(const NATIVE_INT_TYPE portNum, U32 context) {
+void SmTest::schedIn_handler(const FwIndexType portNum, U32 context) {
     Fw::SmSignalBuffer data;
 
     device1_stateMachineInvoke(DeviceSm_Interface::DeviceSm_Signals::RTI_SIG, data);

--- a/FppTest/state_machine/external_instance/SmTest.hpp
+++ b/FppTest/state_machine/external_instance/SmTest.hpp
@@ -58,7 +58,7 @@ class SmTest :
     // ----------------------------------------------------------------------
 
     //! Handler implementation for schedIn
-    void schedIn_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+    void schedIn_handler(const FwIndexType portNum,  //!< The port number
                          U32 context                     //!< The call order
                          ) final;
 

--- a/Fw/Port/InputPortBase.cpp
+++ b/Fw/Port/InputPortBase.cpp
@@ -20,7 +20,7 @@ namespace Fw {
 
     }
 
-    void InputPortBase::setPortNum(NATIVE_INT_TYPE portNum) {
+    void InputPortBase::setPortNum(FwIndexType portNum) {
         FW_ASSERT(portNum >= 0,portNum);
         this->m_portNum = portNum;
     }

--- a/Fw/Port/InputPortBase.hpp
+++ b/Fw/Port/InputPortBase.hpp
@@ -11,7 +11,7 @@ namespace Fw {
 
     class InputPortBase : public PortBase {
         public:
-            void setPortNum(NATIVE_INT_TYPE portNum); // !< set the port number
+            void setPortNum(FwIndexType portNum); // !< set the port number
 
 #if FW_PORT_SERIALIZATION
             virtual SerializeStatus invokeSerial(SerializeBufferBase &buffer) = 0; // !< invoke the port with a serialized version of the call

--- a/Fw/Port/InputSerializePort.hpp
+++ b/Fw/Port/InputSerializePort.hpp
@@ -18,7 +18,7 @@ namespace Fw {
 
             SerializeStatus invokeSerial(SerializeBufferBase &buffer) override; // !< invoke the port with a serialized version of the call
 
-            typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp, NATIVE_INT_TYPE portNum, SerializeBufferBase &arg); //!< port callback definition
+            typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp, FwIndexType portNum, SerializeBufferBase &arg); //!< port callback definition
             void addCallComp(Fw::PassiveComponentBase* callComp, CompFuncPtr funcPtr); //!< call to register a component
 
         protected:

--- a/RPI/RpiDemo/RpiDemoComponentImpl.cpp
+++ b/RPI/RpiDemo/RpiDemoComponentImpl.cpp
@@ -71,7 +71,7 @@ namespace RPI {
 
   void RpiDemoComponentImpl ::
     Run_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 context
     )
   {
@@ -104,7 +104,7 @@ namespace RPI {
 
   void RpiDemoComponentImpl ::
     UartRead_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer &serBuffer,
         const Drv::RecvStatus &status
     )

--- a/RPI/RpiDemo/RpiDemoComponentImpl.hpp
+++ b/RPI/RpiDemo/RpiDemoComponentImpl.hpp
@@ -59,14 +59,14 @@ namespace RPI {
       //! Handler implementation for Run
       //!
       void Run_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 context /*!< The call order*/
       ) override;
 
       //! Handler implementation for UartRead
       //!
       void UartRead_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::Buffer &serBuffer, /*!< Buffer containing data*/
           const Drv::RecvStatus &status /*!< Status of read*/
       ) override;

--- a/Ref/PingReceiver/PingReceiverComponentImpl.cpp
+++ b/Ref/PingReceiver/PingReceiverComponentImpl.cpp
@@ -40,7 +40,7 @@ namespace Ref {
 
   void PingReceiverComponentImpl ::
     PingIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 key
     )
   {

--- a/Ref/PingReceiver/PingReceiverComponentImpl.hpp
+++ b/Ref/PingReceiver/PingReceiverComponentImpl.hpp
@@ -46,7 +46,7 @@ namespace Ref {
       //! Handler implementation for PingIn
       //!
       void PingIn_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 key /*!< Value to return to pinger*/
       );
 

--- a/Ref/RecvBuffApp/RecvBuffComponentImpl.cpp
+++ b/Ref/RecvBuffApp/RecvBuffComponentImpl.cpp
@@ -23,7 +23,7 @@ namespace Ref {
 
     }
 
-    void RecvBuffImpl::Data_handler(NATIVE_INT_TYPE portNum, Drv::DataBuffer &buff) {
+    void RecvBuffImpl::Data_handler(FwIndexType portNum, Drv::DataBuffer &buff) {
 
         this->m_stats.setBuffRecv(++this->m_buffsReceived);
         // reset deserialization of buffer

--- a/Ref/RecvBuffApp/RecvBuffComponentImpl.hpp
+++ b/Ref/RecvBuffApp/RecvBuffComponentImpl.hpp
@@ -16,7 +16,7 @@ namespace Ref {
         private:
 
             // downcall for input port
-            void Data_handler(NATIVE_INT_TYPE portNum, Drv::DataBuffer &buff);
+            void Data_handler(FwIndexType portNum, Drv::DataBuffer &buff);
             Ref::PacketStat m_stats;
             U32 m_buffsReceived; // !< number of buffers received
             bool m_firstBuffReceived; // !< first buffer received or not

--- a/Ref/SendBuffApp/SendBuffComponentImpl.cpp
+++ b/Ref/SendBuffApp/SendBuffComponentImpl.cpp
@@ -27,7 +27,7 @@ namespace Ref {
 
     }
 
-    void SendBuffImpl::SchedIn_handler(NATIVE_INT_TYPE portNum, U32 context) {
+    void SendBuffImpl::SchedIn_handler(FwIndexType portNum, U32 context) {
 
         // first, dequeue any messages
 

--- a/Ref/SendBuffApp/SendBuffComponentImpl.hpp
+++ b/Ref/SendBuffApp/SendBuffComponentImpl.hpp
@@ -16,7 +16,7 @@ namespace Ref {
 
         private:
 
-            void SchedIn_handler(NATIVE_INT_TYPE portNum, U32 context); //!< downcall for input port
+            void SchedIn_handler(FwIndexType portNum, U32 context); //!< downcall for input port
             void SB_START_PKTS_cmdHandler(FwOpcodeType opcode, U32 cmdSeq); //!< START_PKTS command handler
             void SB_INJECT_PKT_ERROR_cmdHandler(FwOpcodeType opcode, U32 cmdSeq); //!< START_PKTS command handler
             void SB_GEN_FATAL_cmdHandler(

--- a/Ref/SignalGen/SignalGen.cpp
+++ b/Ref/SignalGen/SignalGen.cpp
@@ -92,7 +92,7 @@ namespace Ref {
     }
 
     void SignalGen::schedIn_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         U32 context /*!< The call order*/
     )
     {

--- a/Ref/SignalGen/SignalGen.hpp
+++ b/Ref/SignalGen/SignalGen.hpp
@@ -29,7 +29,7 @@ namespace Ref {
     private:
 
         void schedIn_handler(
-            NATIVE_INT_TYPE portNum, /*!< The port number*/
+            FwIndexType portNum, /*!< The port number*/
             U32 context /*!< The call order*/
         ) final;
 

--- a/Svc/ActiveLogger/ActiveLoggerImpl.cpp
+++ b/Svc/ActiveLogger/ActiveLoggerImpl.cpp
@@ -40,7 +40,7 @@ namespace Svc {
     ActiveLoggerImpl::~ActiveLoggerImpl() {
     }
 
-    void ActiveLoggerImpl::LogRecv_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
+    void ActiveLoggerImpl::LogRecv_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args) {
 
         // make sure ID is not zero. Zero is reserved for ID filter.
         FW_ASSERT(id != 0);
@@ -194,7 +194,7 @@ namespace Svc {
     }
 
     void ActiveLoggerImpl::pingIn_handler(
-          const NATIVE_INT_TYPE portNum,
+          const FwIndexType portNum,
           U32 key
       )
     {

--- a/Svc/ActiveLogger/ActiveLoggerImpl.hpp
+++ b/Svc/ActiveLogger/ActiveLoggerImpl.hpp
@@ -20,7 +20,7 @@ namespace Svc {
             virtual ~ActiveLoggerImpl(); //!< destructor
         PROTECTED:
         PRIVATE:
-            void LogRecv_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
+            void LogRecv_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::LogBuffer &args);
             void loqQueue_internalInterfaceHandler(FwEventIdType id, const Fw::Time &timeTag, const Fw::LogSeverity& severity, const Fw::LogBuffer &args);
 
             void SET_EVENT_FILTER_cmdHandler(
@@ -44,7 +44,7 @@ namespace Svc {
             //! Handler implementation for pingIn
             //!
             void pingIn_handler(
-                const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                const FwIndexType portNum, /*!< The port number*/
                 U32 key /*!< Value to return to pinger*/
             );
 

--- a/Svc/ActiveLogger/test/ut/ActiveLoggerImplTester.cpp
+++ b/Svc/ActiveLogger/test/ut/ActiveLoggerImplTester.cpp
@@ -34,7 +34,7 @@ namespace Svc {
     }
 
     void ActiveLoggerImplTester::from_PktSend_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             Fw::ComBuffer &data, //!< Buffer containing packet data
             U32 context //!< context; not used
         ) {
@@ -43,7 +43,7 @@ namespace Svc {
     }
 
     void ActiveLoggerImplTester::from_FatalAnnounce_handler(
-                          const NATIVE_INT_TYPE portNum, //!< The port number
+                          const FwIndexType portNum, //!< The port number
                           FwEventIdType Id //!< The ID of the FATAL event
                       ) {
         this->m_receivedFatalEvent = true;
@@ -620,7 +620,7 @@ namespace Svc {
     }
     void ActiveLoggerImplTester ::
       from_pingOut_handler(
-          const NATIVE_INT_TYPE portNum,
+          const FwIndexType portNum,
           U32 key
       )
     {

--- a/Svc/ActiveLogger/test/ut/ActiveLoggerImplTester.hpp
+++ b/Svc/ActiveLogger/test/ut/ActiveLoggerImplTester.hpp
@@ -33,12 +33,12 @@ namespace Svc {
         private:
 
             void from_PktSend_handler(
-                    const NATIVE_INT_TYPE portNum, //!< The port number
+                    const FwIndexType portNum, //!< The port number
                     Fw::ComBuffer &data, //!< Buffer containing packet data
                     U32 context //!< context (not used)
                 ) override;
             void from_FatalAnnounce_handler(
-                      const NATIVE_INT_TYPE portNum, //!< The port number
+                      const FwIndexType portNum, //!< The port number
                       FwEventIdType Id //!< The ID of the FATAL event
                   ) override;
 
@@ -83,7 +83,7 @@ namespace Svc {
             //! Handler for from_pingOut
             //!
             void from_pingOut_handler(
-                const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                const FwIndexType portNum, /*!< The port number*/
                 U32 key /*!< Value to return to pinger*/
             ) override;
     };

--- a/Svc/ActiveRateGroup/ActiveRateGroup.cpp
+++ b/Svc/ActiveRateGroup/ActiveRateGroup.cpp
@@ -52,7 +52,7 @@ namespace Svc {
         this->log_DIAGNOSTIC_RateGroupStarted();
     }
 
-    void ActiveRateGroup::CycleIn_handler(NATIVE_INT_TYPE portNum, Os::RawTime& cycleStart) {
+    void ActiveRateGroup::CycleIn_handler(FwIndexType portNum, Os::RawTime& cycleStart) {
 
         // Make sure it's been configured
         FW_ASSERT(this->m_numContexts);
@@ -106,12 +106,12 @@ namespace Svc {
 
     }
 
-    void ActiveRateGroup::CycleIn_preMsgHook(NATIVE_INT_TYPE portNum, Os::RawTime& cycleStart) {
+    void ActiveRateGroup::CycleIn_preMsgHook(FwIndexType portNum, Os::RawTime& cycleStart) {
         // set flag to indicate cycle has started. Check in thread for overflow.
         this->m_cycleStarted = true;
     }
 
-    void ActiveRateGroup::PingIn_handler(NATIVE_INT_TYPE portNum, U32 key) {
+    void ActiveRateGroup::PingIn_handler(FwIndexType portNum, U32 key) {
         // return the key to health
         this->PingOut_out(0,key);
     }

--- a/Svc/ActiveRateGroup/ActiveRateGroup.hpp
+++ b/Svc/ActiveRateGroup/ActiveRateGroup.hpp
@@ -69,7 +69,7 @@ namespace Svc {
             //!  \param portNum incoming port call. For this class, should always be zero
             //!  \param cycleStart value stored by the cycle driver, used to compute execution time.
 
-            void CycleIn_handler(NATIVE_INT_TYPE portNum, Os::RawTime& cycleStart);
+            void CycleIn_handler(FwIndexType portNum, Os::RawTime& cycleStart);
 
             //!  \brief Input cycle port pre message hook
             //!
@@ -79,7 +79,7 @@ namespace Svc {
             //!  \param portNum incoming port call. For this class, should always be zero
             //!  \param cycleStart value stored by the cycle driver, used to compute execution time.
 
-            void CycleIn_preMsgHook(NATIVE_INT_TYPE portNum, Os::RawTime& cycleStart); //!< CycleIn pre-message hook
+            void CycleIn_preMsgHook(FwIndexType portNum, Os::RawTime& cycleStart); //!< CycleIn pre-message hook
 
             //!  \brief Input ping port handler
             //!
@@ -88,7 +88,7 @@ namespace Svc {
             //!  \param portNum incoming port call. For this class, should always be zero
             //!  \param key value returned to health task to verify round trip
 
-            void PingIn_handler(NATIVE_INT_TYPE portNum, U32 key);
+            void PingIn_handler(FwIndexType portNum, U32 key);
 
             //!  \brief Task preamble
             //!

--- a/Svc/ActiveRateGroup/test/ut/ActiveRateGroupImplTester.cpp
+++ b/Svc/ActiveRateGroup/test/ut/ActiveRateGroupImplTester.cpp
@@ -42,7 +42,7 @@ namespace Svc {
     ActiveRateGroupImplTester::~ActiveRateGroupImplTester() {
     }
 
-    void ActiveRateGroupImplTester::from_RateGroupMemberOut_handler(NATIVE_INT_TYPE portNum, U32 context) {
+    void ActiveRateGroupImplTester::from_RateGroupMemberOut_handler(FwIndexType portNum, U32 context) {
         ASSERT_TRUE(portNum < static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(m_impl.m_RateGroupMemberOut_OutputPort)));
         this->m_callLog[portNum].portCalled = true;
         this->m_callLog[portNum].contextVal = context;
@@ -58,7 +58,7 @@ namespace Svc {
 
     void ActiveRateGroupImplTester ::
       from_PingOut_handler(
-          const NATIVE_INT_TYPE portNum,
+          const FwIndexType portNum,
           U32 key
       )
     {

--- a/Svc/ActiveRateGroup/test/ut/ActiveRateGroupImplTester.hpp
+++ b/Svc/ActiveRateGroup/test/ut/ActiveRateGroupImplTester.hpp
@@ -34,12 +34,12 @@ namespace Svc {
 
         private:
 
-            void from_RateGroupMemberOut_handler(NATIVE_INT_TYPE portNum, U32 context);
+            void from_RateGroupMemberOut_handler(FwIndexType portNum, U32 context);
 
             //! Handler for from_PingOut
             //!
             void from_PingOut_handler(
-              const NATIVE_INT_TYPE portNum, /*!< The port number*/
+              const FwIndexType portNum, /*!< The port number*/
               U32 key /*!< Value to return to pinger*/
             );
 

--- a/Svc/ActiveTextLogger/ActiveTextLogger.cpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.cpp
@@ -30,7 +30,7 @@ namespace Svc {
     // Handlers to implement for typed input ports
     // ----------------------------------------------------------------------
 
-    void ActiveTextLogger::TextLogger_handler(NATIVE_INT_TYPE portNum,
+    void ActiveTextLogger::TextLogger_handler(FwIndexType portNum,
                                                   FwEventIdType id,
                                                   Fw::Time &timeTag,
                                                   const Fw::LogSeverity& severity,

--- a/Svc/ActiveTextLogger/ActiveTextLogger.hpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.hpp
@@ -83,7 +83,7 @@ namespace Svc {
         //! Handler for input port TextLogger
         //
         virtual void TextLogger_handler(
-            NATIVE_INT_TYPE portNum, /*!< The port number*/
+            FwIndexType portNum, /*!< The port number*/
             FwEventIdType id, /*!< Log ID*/
             Fw::Time &timeTag, /*!< Time Tag*/
             const Fw::LogSeverity& severity, /*!< The severity argument*/

--- a/Svc/BufferAccumulator/BufferAccumulator.cpp
+++ b/Svc/BufferAccumulator/BufferAccumulator.cpp
@@ -67,7 +67,7 @@ void BufferAccumulator ::deallocateQueue(Fw::MemAllocator& allocator) {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void BufferAccumulator ::bufferSendInFill_handler(const NATIVE_INT_TYPE portNum,
+void BufferAccumulator ::bufferSendInFill_handler(const FwIndexType portNum,
                                                   Fw::Buffer& buffer) {
 
   const bool status = this->m_bufferQueue.enqueue(buffer);
@@ -90,7 +90,7 @@ void BufferAccumulator ::bufferSendInFill_handler(const NATIVE_INT_TYPE portNum,
 }
 
 void BufferAccumulator ::bufferSendInReturn_handler(
-    const NATIVE_INT_TYPE portNum, Fw::Buffer& buffer) {
+    const FwIndexType portNum, Fw::Buffer& buffer) {
 
   this->bufferSendOutReturn_out(0, buffer);
   this->m_waitForBuffer = false;
@@ -102,7 +102,7 @@ void BufferAccumulator ::bufferSendInReturn_handler(
   }
 }
 
-void BufferAccumulator ::pingIn_handler(const NATIVE_INT_TYPE portNum,
+void BufferAccumulator ::pingIn_handler(const FwIndexType portNum,
                                         U32 key) {
   this->pingOut_out(0, key);
 }

--- a/Svc/BufferAccumulator/BufferAccumulator.hpp
+++ b/Svc/BufferAccumulator/BufferAccumulator.hpp
@@ -120,18 +120,18 @@ namespace Svc {
         //!
         void
             bufferSendInFill_handler(
-                    const NATIVE_INT_TYPE portNum,  //!< The port number
+                    const FwIndexType portNum,  //!< The port number
                     Fw::Buffer& buffer);
 
         //! Handler implementation for bufferSendInReturn
         //!
         void bufferSendInReturn_handler(
-                const NATIVE_INT_TYPE portNum,  //!< The port number
+                const FwIndexType portNum,  //!< The port number
                 Fw::Buffer& buffer);
 
         //! Handler implementation for pingIn
         //!
-        void pingIn_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+        void pingIn_handler(const FwIndexType portNum,  //!< The port number
                             U32 key  //!< Value to return to pinger
                             );
 

--- a/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.cpp
+++ b/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.cpp
@@ -61,17 +61,17 @@ BufferAccumulatorTester ::~BufferAccumulatorTester() {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void BufferAccumulatorTester ::from_bufferSendOutDrain_handler(const NATIVE_INT_TYPE portNum,
+void BufferAccumulatorTester ::from_bufferSendOutDrain_handler(const FwIndexType portNum,
                                               Fw::Buffer& fwBuffer) {
   this->pushFromPortEntry_bufferSendOutDrain(fwBuffer);
 }
 
-void BufferAccumulatorTester ::from_bufferSendOutReturn_handler(const NATIVE_INT_TYPE portNum,
+void BufferAccumulatorTester ::from_bufferSendOutReturn_handler(const FwIndexType portNum,
                                                Fw::Buffer& fwBuffer) {
   this->pushFromPortEntry_bufferSendOutReturn(fwBuffer);
 }
 
-void BufferAccumulatorTester ::from_pingOut_handler(const NATIVE_INT_TYPE portNum, U32 key) {
+void BufferAccumulatorTester ::from_pingOut_handler(const FwIndexType portNum, U32 key) {
   this->pushFromPortEntry_pingOut(key);
 }
 

--- a/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.hpp
+++ b/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.hpp
@@ -42,18 +42,18 @@ class BufferAccumulatorTester : public BufferAccumulatorGTestBase {
   //! Handler for from_bufferSendOutDrain
   //!
   void from_bufferSendOutDrain_handler(
-      const NATIVE_INT_TYPE portNum,  //!< The port number
+      const FwIndexType portNum,  //!< The port number
       Fw::Buffer& fwBuffer);
 
   //! Handler for from_bufferSendOutReturn
   //!
   void from_bufferSendOutReturn_handler(
-      const NATIVE_INT_TYPE portNum,  //!< The port number
+      const FwIndexType portNum,  //!< The port number
       Fw::Buffer& fwBuffer);
 
   //! Handler for from_pingOut
   //!
-  void from_pingOut_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+  void from_pingOut_handler(const FwIndexType portNum,  //!< The port number
                             U32 key  //!< Value to return to pinger
   );
 

--- a/Svc/BufferLogger/BufferLogger.cpp
+++ b/Svc/BufferLogger/BufferLogger.cpp
@@ -50,7 +50,7 @@ namespace Svc {
 
   void BufferLogger ::
     bufferSendIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer& fwBuffer
     )
   {
@@ -64,7 +64,7 @@ namespace Svc {
 
   void BufferLogger ::
     comIn_handler(
-        NATIVE_INT_TYPE portNum,
+        FwIndexType portNum,
         Fw::ComBuffer &data,
         U32 context
     )
@@ -77,14 +77,14 @@ namespace Svc {
   }
 
   void BufferLogger ::
-    pingIn_handler(NATIVE_INT_TYPE portNum, U32 key)
+    pingIn_handler(FwIndexType portNum, U32 key)
   {
     this->pingOut_out(0, key);
   }
 
   void BufferLogger ::
     schedIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 context
     )
   {

--- a/Svc/BufferLogger/BufferLogger.hpp
+++ b/Svc/BufferLogger/BufferLogger.hpp
@@ -183,14 +183,14 @@ namespace Svc {
       //! Handler implementation for bufferSendIn
       //!
       void bufferSendIn_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           Fw::Buffer& fwBuffer
       );
 
       //! Handler implementation for comIn
       //!
       void comIn_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           Fw::ComBuffer &data, //!< Buffer containing packet data
           U32 context //!< Call context value; meaning chosen by user
       );
@@ -198,14 +198,14 @@ namespace Svc {
       //! Handler implementation for pingIn
       //!
       void pingIn_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           U32 key //!< Value to return to pinger
       );
 
       //! Handler implementation for schedIn
       //!
       void schedIn_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 context /*!< The call order*/
       );
 

--- a/Svc/BufferLogger/test/ut/BufferLoggerTester.cpp
+++ b/Svc/BufferLogger/test/ut/BufferLoggerTester.cpp
@@ -78,7 +78,7 @@ namespace Svc {
 
   void BufferLoggerTester ::
     from_bufferSendOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer& fwBuffer
     )
   {
@@ -87,7 +87,7 @@ namespace Svc {
 
   void BufferLoggerTester ::
     from_pingOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 key
     )
   {

--- a/Svc/BufferLogger/test/ut/BufferLoggerTester.hpp
+++ b/Svc/BufferLogger/test/ut/BufferLoggerTester.hpp
@@ -62,14 +62,14 @@ namespace Svc {
       //! Handler for from_bufferSendOut
       //!
       void from_bufferSendOut_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::Buffer& fwBuffer
       );
 
       //! Handler for from_pingOut
       //!
       void from_pingOut_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 key /*!< Value to return to pinger*/
       );
 

--- a/Svc/BufferManager/BufferManagerComponentImpl.cpp
+++ b/Svc/BufferManager/BufferManagerComponentImpl.cpp
@@ -75,7 +75,7 @@ namespace Svc {
 
   void BufferManagerComponentImpl ::
     bufferSendIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer &fwBuffer
     )
   {
@@ -129,7 +129,7 @@ namespace Svc {
 
   Fw::Buffer BufferManagerComponentImpl ::
     bufferGetCallee_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 size
     )
   {
@@ -238,7 +238,7 @@ namespace Svc {
 
   void BufferManagerComponentImpl ::
     schedIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 context
     )
   {

--- a/Svc/BufferManager/BufferManagerComponentImpl.hpp
+++ b/Svc/BufferManager/BufferManagerComponentImpl.hpp
@@ -108,19 +108,19 @@ namespace Svc
         //!
         void
         bufferSendIn_handler(
-            const NATIVE_INT_TYPE portNum, /*!< The port number*/
+            const FwIndexType portNum, /*!< The port number*/
             Fw::Buffer &fwBuffer);
 
         //! Handler implementation for bufferGetCallee
         //!
         Fw::Buffer bufferGetCallee_handler(
-            const NATIVE_INT_TYPE portNum, /*!< The port number*/
+            const FwIndexType portNum, /*!< The port number*/
             U32 size);
 
         //! Handler implementation for schedIn
         //!
         void schedIn_handler(
-            const NATIVE_INT_TYPE portNum, /*!< The port number*/
+            const FwIndexType portNum, /*!< The port number*/
             U32 context /*!< The call order*/
         );
 

--- a/Svc/BufferRepeater/BufferRepeater.cpp
+++ b/Svc/BufferRepeater/BufferRepeater.cpp
@@ -59,7 +59,7 @@ bool BufferRepeater ::check_allocation(FwIndexType index,
 // Handler implementations for user-defined serial input ports
 // ----------------------------------------------------------------------
 
-void BufferRepeater ::portIn_handler(NATIVE_INT_TYPE portNum, /*!< The port number*/
+void BufferRepeater ::portIn_handler(FwIndexType portNum, /*!< The port number*/
                                      Fw::Buffer& buffer       /*!< The serialization buffer*/
 ) {
     FW_ASSERT(this->m_allocation_failure_response < NUM_BUFFER_REPEATER_FAILURE_OPTIONS);

--- a/Svc/BufferRepeater/BufferRepeater.hpp
+++ b/Svc/BufferRepeater/BufferRepeater.hpp
@@ -68,7 +68,7 @@ class BufferRepeater : public BufferRepeaterComponentBase {
 
     //! Handler implementation for portIn
     //!
-    void portIn_handler(NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void portIn_handler(FwIndexType portNum, /*!< The port number*/
                         Fw::Buffer& Buffer       /*!< The serialization buffer*/
     );
 

--- a/Svc/BufferRepeater/test/ut/BufferRepeaterTester.cpp
+++ b/Svc/BufferRepeater/test/ut/BufferRepeaterTester.cpp
@@ -104,7 +104,7 @@ void BufferRepeaterTester ::testFailure(BufferRepeater::BufferRepeaterFailureOpt
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-Fw::Buffer BufferRepeaterTester ::from_allocate_handler(const NATIVE_INT_TYPE portNum, U32 size) {
+Fw::Buffer BufferRepeaterTester ::from_allocate_handler(const FwIndexType portNum, U32 size) {
     this->pushFromPortEntry_allocate(size);
     Fw::Buffer new_buffer;
 
@@ -118,12 +118,12 @@ Fw::Buffer BufferRepeaterTester ::from_allocate_handler(const NATIVE_INT_TYPE po
     return new_buffer;
 }
 
-void BufferRepeaterTester ::from_deallocate_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void BufferRepeaterTester ::from_deallocate_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     this->pushFromPortEntry_deallocate(fwBuffer);
     EXPECT_EQ(fwBuffer.getData(), m_initial_buffer.getData()) << "Deallocated non-initial buffer";
 }
 
-void BufferRepeaterTester ::from_portOut_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void BufferRepeaterTester ::from_portOut_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     this->m_port_index_history.push_back(portNum);
     this->pushFromPortEntry_portOut(fwBuffer);
     EXPECT_NE(fwBuffer.getData(), nullptr) << "Passed invalid buffer out port";

--- a/Svc/BufferRepeater/test/ut/BufferRepeaterTester.hpp
+++ b/Svc/BufferRepeater/test/ut/BufferRepeaterTester.hpp
@@ -52,17 +52,17 @@ class BufferRepeaterTester : public BufferRepeaterGTestBase {
 
     //! Handler for from_allocate
     //!
-    Fw::Buffer from_allocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Fw::Buffer from_allocate_handler(const FwIndexType portNum, /*!< The port number*/
                                      U32 size);
 
     //! Handler for from_deallocate
     //!
-    void from_deallocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_deallocate_handler(const FwIndexType portNum, /*!< The port number*/
                                  Fw::Buffer& fwBuffer);
 
     //! Handler for from_portOut
     //!
-    void from_portOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_portOut_handler(const FwIndexType portNum, /*!< The port number*/
                               Fw::Buffer& fwBuffer);
 
   private:

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
@@ -24,7 +24,7 @@ namespace Svc {
     CommandDispatcherImpl::~CommandDispatcherImpl() {
     }
 
-    void CommandDispatcherImpl::compCmdReg_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode) {
+    void CommandDispatcherImpl::compCmdReg_handler(FwIndexType portNum, FwOpcodeType opCode) {
         // search for an empty slot
         bool slotFound = false;
         for (U32 slot = 0; slot < FW_NUM_ARRAY_ELEMENTS(this->m_entryTable); slot++) {
@@ -47,7 +47,7 @@ namespace Svc {
         FW_ASSERT(slotFound,static_cast<FwAssertArgType>(opCode));
     }
 
-    void CommandDispatcherImpl::compCmdStat_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse &response) {
+    void CommandDispatcherImpl::compCmdStat_handler(FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse &response) {
         // check response and log
         if (Fw::CmdResponse::OK == response.e) {
             this->log_COMMAND_OpCodeCompleted(opCode);
@@ -82,7 +82,7 @@ namespace Svc {
         }
     }
 
-    void CommandDispatcherImpl::seqCmdBuff_handler(NATIVE_INT_TYPE portNum, Fw::ComBuffer &data, U32 context) {
+    void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffer &data, U32 context) {
 
         Fw::CmdPacket cmdPkt;
         Fw::SerializeStatus stat = cmdPkt.deserialize(data);
@@ -186,7 +186,7 @@ namespace Svc {
         this->cmdResponse_out(opCode,cmdSeq,Fw::CmdResponse::OK);
     }
 
-    void CommandDispatcherImpl::pingIn_handler(NATIVE_INT_TYPE portNum, U32 key) {
+    void CommandDispatcherImpl::pingIn_handler(FwIndexType portNum, U32 key) {
         // respond to ping
         this->pingOut_out(0,key);
     }

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
@@ -54,7 +54,7 @@ namespace Svc {
             //!  \param opCode the opcode of the completed command.
             //!  \param cmdSeq the sequence number assigned to the command when it was dispatched
             //!  \param response the completion status of the command
-            void compCmdStat_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse &response);
+            void compCmdStat_handler(FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse &response);
             //!  \brief component command buffer handler
             //!
             //!  The command buffer handler is called to submit a new
@@ -63,7 +63,7 @@ namespace Svc {
             //!  \param portNum the number of the incoming port.
             //!  \param data the buffer containing the command.
             //!  \param context a user value returned with the status
-            void seqCmdBuff_handler(NATIVE_INT_TYPE portNum, Fw::ComBuffer &data, U32 context);
+            void seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffer &data, U32 context);
             //!  \brief component command registration handler
             //!
             //!  The command registration handler is called to register
@@ -72,7 +72,7 @@ namespace Svc {
             //!
             //!  \param portNum the number of the incoming port.
             //!  \param opCode the opcode being registered.
-            void compCmdReg_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode);
+            void compCmdReg_handler(FwIndexType portNum, FwOpcodeType opCode);
             //!  \brief component ping handler
             //!
             //!  The ping handler responds to messages to verify that the task
@@ -81,7 +81,7 @@ namespace Svc {
             //!  \param portNum the number of the incoming port.
             //!  \param opCode the opcode being registered.
             //!  \param key the key value that is returned with the ping response
-            void pingIn_handler(NATIVE_INT_TYPE portNum, U32 key);
+            void pingIn_handler(FwIndexType portNum, U32 key);
             //!  \brief NO_OP command handler
             //!
             //!  A test command that does nothing

--- a/Svc/CmdDispatcher/test/ut/CommandDispatcherImplTester.cpp
+++ b/Svc/CmdDispatcher/test/ut/CommandDispatcherImplTester.cpp
@@ -30,14 +30,14 @@ namespace Svc {
     CommandDispatcherImplTester::~CommandDispatcherImplTester() {
     }
 
-    void CommandDispatcherImplTester::from_compCmdSend_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer &args) {
+    void CommandDispatcherImplTester::from_compCmdSend_handler(FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer &args) {
         this->m_cmdSendOpCode = opCode;
         this->m_cmdSendCmdSeq = cmdSeq;
         this->m_cmdSendArgs = args;
         this->m_cmdSendRcvd = true;
     }
 
-    void CommandDispatcherImplTester::from_seqCmdStatus_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse &response) {
+    void CommandDispatcherImplTester::from_seqCmdStatus_handler(FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse &response) {
         this->m_seqStatusRcvd = true;
         this->m_seqStatusOpCode = opCode;
         this->m_seqStatusCmdSeq = cmdSeq;
@@ -882,7 +882,7 @@ namespace Svc {
     }
 
     void CommandDispatcherImplTester::from_pingOut_handler(
-              const NATIVE_INT_TYPE portNum, /*!< The port number*/
+              const FwIndexType portNum, /*!< The port number*/
               U32 key /*!< Value to return to pinger*/
           ) {
 

--- a/Svc/CmdDispatcher/test/ut/CommandDispatcherImplTester.hpp
+++ b/Svc/CmdDispatcher/test/ut/CommandDispatcherImplTester.hpp
@@ -32,10 +32,10 @@ namespace Svc {
         private:
             Svc::CommandDispatcherImpl& m_impl;
 
-            void from_compCmdSend_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer &args);
+            void from_compCmdSend_handler(FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer &args);
 
             void from_pingOut_handler(
-                      const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                      const FwIndexType portNum, /*!< The port number*/
                       U32 key /*!< Value to return to pinger*/
                   );            // store port call
             bool m_cmdSendRcvd;
@@ -43,7 +43,7 @@ namespace Svc {
             U32 m_cmdSendCmdSeq;
             Fw::CmdArgBuffer m_cmdSendArgs;
 
-            void from_seqCmdStatus_handler(NATIVE_INT_TYPE portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse &response);
+            void from_seqCmdStatus_handler(FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdResponse &response);
 
             bool m_seqStatusRcvd;
             FwOpcodeType m_seqStatusOpCode;

--- a/Svc/CmdSequencer/CmdSequencerImpl.cpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.cpp
@@ -156,7 +156,7 @@ namespace Svc {
 
     //! Handler for input port seqRunIn
     void CmdSequencerComponentImpl::seqRunIn_handler(
-           NATIVE_INT_TYPE portNum,
+           FwIndexType portNum,
            const Fw::StringBase& filename
        ) {
 
@@ -199,7 +199,7 @@ namespace Svc {
 
     void CmdSequencerComponentImpl ::
       seqCancelIn_handler(
-          const NATIVE_INT_TYPE portNum
+          const FwIndexType portNum
       ) {
         if (RUNNING == this->m_runMode) {
             this->performCmd_Cancel();
@@ -285,7 +285,7 @@ namespace Svc {
 
     void CmdSequencerComponentImpl ::
       cmdResponseIn_handler(
-          NATIVE_INT_TYPE portNum,
+          FwIndexType portNum,
           FwOpcodeType opcode,
           U32 cmdSeq,
           const Fw::CmdResponse& response
@@ -322,7 +322,7 @@ namespace Svc {
     }
 
     void CmdSequencerComponentImpl ::
-      schedIn_handler(NATIVE_INT_TYPE portNum, NATIVE_UINT_TYPE order)
+      schedIn_handler(FwIndexType portNum, NATIVE_UINT_TYPE order)
     {
 
         Fw::Time currTime = this->getTime();
@@ -514,7 +514,7 @@ namespace Svc {
 
     void CmdSequencerComponentImpl ::
       pingIn_handler(
-          NATIVE_INT_TYPE portNum, /*!< The port number*/
+          FwIndexType portNum, /*!< The port number*/
           U32 key /*!< Value to return to pinger*/
       )
     {

--- a/Svc/CmdSequencer/CmdSequencerImpl.hpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.hpp
@@ -571,7 +571,7 @@ namespace Svc {
 
       //! Handler for input port cmdResponseIn
       void cmdResponseIn_handler(
-          NATIVE_INT_TYPE portNum, //!< The port number
+          FwIndexType portNum, //!< The port number
           FwOpcodeType opcode, //!< The command opcode
           U32 cmdSeq, //!< The command sequence number
           const Fw::CmdResponse& response //!< The command response
@@ -579,26 +579,26 @@ namespace Svc {
 
       //! Handler for input port schedIn
       void schedIn_handler(
-          NATIVE_INT_TYPE portNum, //!< The port number
+          FwIndexType portNum, //!< The port number
           NATIVE_UINT_TYPE order //!< The call order
       );
 
       //! Handler for input port seqRunIn
       void seqRunIn_handler(
-          NATIVE_INT_TYPE portNum, //!< The port number
+          FwIndexType portNum, //!< The port number
           const Fw::StringBase& filename //!< The sequence file
       );
 
       //! Handler for ping port
       void pingIn_handler(
-          NATIVE_INT_TYPE portNum, //!< The port number
+          FwIndexType portNum, //!< The port number
           U32 key //!< Value to return to pinger
       );
 
       //! Handler implementation for seqCancelIn
       //!
       void seqCancelIn_handler(
-          const NATIVE_INT_TYPE portNum /*!< The port number*/
+          const FwIndexType portNum /*!< The port number*/
       );
 
     PRIVATE:

--- a/Svc/CmdSequencer/test/ut/CmdSequencerTester.cpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerTester.cpp
@@ -54,7 +54,7 @@ namespace Svc {
 
   void CmdSequencerTester ::
     from_seqDone_handler(
-      const NATIVE_INT_TYPE portNum,
+      const FwIndexType portNum,
       FwOpcodeType opCode,
       U32 cmdSeq,
       const Fw::CmdResponse& response
@@ -65,7 +65,7 @@ namespace Svc {
 
   void CmdSequencerTester ::
     from_comCmdOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::ComBuffer &data,
         U32 context
     )
@@ -75,7 +75,7 @@ namespace Svc {
 
   void CmdSequencerTester ::
     from_pingOut_handler(
-      const NATIVE_INT_TYPE portNum,
+      const FwIndexType portNum,
       U32 key
     )
   {

--- a/Svc/CmdSequencer/test/ut/CmdSequencerTester.hpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerTester.hpp
@@ -188,7 +188,7 @@ namespace Svc {
       //! Handler for from_seqDone
       //!
       void from_seqDone_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           FwOpcodeType opCode, //!< Command Op Code
           U32 cmdSeq, //!< Command Sequence
           const Fw::CmdResponse& response //!< The command response argument
@@ -197,7 +197,7 @@ namespace Svc {
       //! Handler for from_comCmdOut
       //!
       void from_comCmdOut_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           Fw::ComBuffer &data, //!< Buffer containing packet data
           U32 context //!< Call context value; meaning chosen by user
       );
@@ -205,7 +205,7 @@ namespace Svc {
       //! Handler for from_pingOut
       //!
       void from_pingOut_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           U32 key //!< Value to return to pinger
       );
 

--- a/Svc/CmdSplitter/CmdSplitter.cpp
+++ b/Svc/CmdSplitter/CmdSplitter.cpp
@@ -28,7 +28,7 @@ void CmdSplitter ::configure(const FwOpcodeType remoteBaseOpcode) {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void CmdSplitter ::CmdBuff_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer& data, U32 context) {
+void CmdSplitter ::CmdBuff_handler(const FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
     Fw::CmdPacket cmdPkt;
     Fw::SerializeStatus stat = cmdPkt.deserialize(data);
 
@@ -46,7 +46,7 @@ void CmdSplitter ::CmdBuff_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer&
     }
 }
 
-void CmdSplitter ::seqCmdStatus_handler(const NATIVE_INT_TYPE portNum,
+void CmdSplitter ::seqCmdStatus_handler(const FwIndexType portNum,
                                         FwOpcodeType opCode,
                                         U32 cmdSeq,
                                         const Fw::CmdResponse& response) {

--- a/Svc/CmdSplitter/CmdSplitter.hpp
+++ b/Svc/CmdSplitter/CmdSplitter.hpp
@@ -39,14 +39,14 @@ class CmdSplitter : public CmdSplitterComponentBase {
 
     //! Handler implementation for CmdBuff
     //!
-    void CmdBuff_handler(const NATIVE_INT_TYPE portNum, /*!< The port number */
+    void CmdBuff_handler(const FwIndexType portNum, /*!< The port number */
                          Fw::ComBuffer& data,           /*!< Buffer containing packet data */
                          U32 context                    /*!< Call context value; meaning chosen by user */
     );
 
     //! Handler implementation for seqCmdStatus
     //!
-    void seqCmdStatus_handler(const NATIVE_INT_TYPE portNum,  /*!< The port number */
+    void seqCmdStatus_handler(const FwIndexType portNum,  /*!< The port number */
                               FwOpcodeType opCode,            /*!< Command Op Code */
                               U32 cmdSeq,                     /*!< Command Sequence */
                               const Fw::CmdResponse& response /*!< The command response argument */

--- a/Svc/CmdSplitter/test/ut/CmdSplitterTester.cpp
+++ b/Svc/CmdSplitter/test/ut/CmdSplitterTester.cpp
@@ -128,17 +128,17 @@ void CmdSplitterTester ::test_response_forwarding() {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void CmdSplitterTester ::from_LocalCmd_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer& data, U32 context) {
+void CmdSplitterTester ::from_LocalCmd_handler(const FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
     EXPECT_EQ(this->active_command_source, portNum) << "Command source not respected";
     this->pushFromPortEntry_LocalCmd(data, context);
 }
 
-void CmdSplitterTester ::from_RemoteCmd_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer& data, U32 context) {
+void CmdSplitterTester ::from_RemoteCmd_handler(const FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
     EXPECT_EQ(this->active_command_source, portNum) << "Command source not respected";
     this->pushFromPortEntry_RemoteCmd(data, context);
 }
 
-void CmdSplitterTester ::from_forwardSeqCmdStatus_handler(const NATIVE_INT_TYPE portNum,
+void CmdSplitterTester ::from_forwardSeqCmdStatus_handler(const FwIndexType portNum,
                                                FwOpcodeType opCode,
                                                U32 cmdSeq,
                                                const Fw::CmdResponse& response) {

--- a/Svc/CmdSplitter/test/ut/CmdSplitterTester.hpp
+++ b/Svc/CmdSplitter/test/ut/CmdSplitterTester.hpp
@@ -67,21 +67,21 @@ class CmdSplitterTester : public CmdSplitterGTestBase {
 
     //! Handler for from_LocalCmd
     //!
-    void from_LocalCmd_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_LocalCmd_handler(const FwIndexType portNum, /*!< The port number*/
                                Fw::ComBuffer& data,           /*!< Buffer containing packet data */
                                U32 context                    /*!< Call context value; meaning chosen by user */
     );
 
     //! Handler for from_RemoteCmd
     //!
-    void from_RemoteCmd_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_RemoteCmd_handler(const FwIndexType portNum, /*!< The port number*/
                                 Fw::ComBuffer& data,           /*!< Buffer containing packet data */
                                 U32 context                    /*!< Call context value; meaning chosen by user */
     );
 
     //! Handler for from_forwardSeqCmdStatus
     //!
-    void from_forwardSeqCmdStatus_handler(const NATIVE_INT_TYPE portNum,  /*!< The port number*/
+    void from_forwardSeqCmdStatus_handler(const FwIndexType portNum,  /*!< The port number*/
                                           FwOpcodeType opCode,            /*!< Command Op Code */
                                           U32 cmdSeq,                     /*!< Command Sequence */
                                           const Fw::CmdResponse& response /*!< The command response argument */

--- a/Svc/ComLogger/ComLogger.cpp
+++ b/Svc/ComLogger/ComLogger.cpp
@@ -94,7 +94,7 @@ namespace Svc {
 
   void ComLogger ::
     comIn_handler(
-        NATIVE_INT_TYPE portNum,
+        FwIndexType portNum,
         Fw::ComBuffer &data,
         U32 context
     )
@@ -142,7 +142,7 @@ namespace Svc {
 
   void ComLogger ::
     pingIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 key
     )
   {

--- a/Svc/ComLogger/ComLogger.hpp
+++ b/Svc/ComLogger/ComLogger.hpp
@@ -59,7 +59,7 @@ namespace Svc {
     PRIVATE:
 
       void comIn_handler(
-          NATIVE_INT_TYPE portNum,
+          FwIndexType portNum,
           Fw::ComBuffer &data,
           U32 context
       );
@@ -72,7 +72,7 @@ namespace Svc {
       //! Handler implementation for pingIn
       //!
       void pingIn_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 key /*!< Value to return to pinger*/
       );
 

--- a/Svc/ComLogger/test/ut/ComLoggerTester.cpp
+++ b/Svc/ComLogger/test/ut/ComLoggerTester.cpp
@@ -709,7 +709,7 @@ namespace Svc {
 
   void ComLoggerTester ::
     from_pingOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 key
     )
   {

--- a/Svc/ComLogger/test/ut/ComLoggerTester.hpp
+++ b/Svc/ComLogger/test/ut/ComLoggerTester.hpp
@@ -45,7 +45,7 @@ namespace Svc {
       //! Handler for from_pingOut
       //!
       void from_pingOut_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 key /*!< Value to return to pinger*/
       );
 

--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -124,13 +124,13 @@ void ComQueue::configure(QueueConfigurationTable queueConfig,
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void ComQueue::comQueueIn_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer& data, U32 context) {
+void ComQueue::comQueueIn_handler(const FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
     // Ensure that the port number of comQueueIn is consistent with the expectation
     FW_ASSERT(portNum >= 0 && portNum < COM_PORT_COUNT, portNum);
     (void)this->enqueue(portNum, QueueType::COM_QUEUE, reinterpret_cast<const U8*>(&data), sizeof(Fw::ComBuffer));
 }
 
-void ComQueue::buffQueueIn_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void ComQueue::buffQueueIn_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     const NATIVE_INT_TYPE queueNum = portNum + COM_PORT_COUNT;
     // Ensure that the port number of buffQueueIn is consistent with the expectation
     FW_ASSERT(portNum >= 0 && portNum < BUFFER_PORT_COUNT, portNum);
@@ -142,7 +142,7 @@ void ComQueue::buffQueueIn_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fw
     }
 }
 
-void ComQueue::comStatusIn_handler(const NATIVE_INT_TYPE portNum, Fw::Success& condition) {
+void ComQueue::comStatusIn_handler(const FwIndexType portNum, Fw::Success& condition) {
     switch (this->m_state) {
         // On success, the queue should be processed. On failure, the component should still wait.
         case WAITING:
@@ -163,7 +163,7 @@ void ComQueue::comStatusIn_handler(const NATIVE_INT_TYPE portNum, Fw::Success& c
     }
 }
 
-void ComQueue::run_handler(const NATIVE_INT_TYPE portNum, U32 context) {
+void ComQueue::run_handler(const FwIndexType portNum, U32 context) {
     // Downlink the high-water marks for the Fw::ComBuffer array types
     ComQueueDepth comQueueDepth;
     for (U32 i = 0; i < comQueueDepth.SIZE; i++) {

--- a/Svc/ComQueue/ComQueue.hpp
+++ b/Svc/ComQueue/ComQueue.hpp
@@ -123,25 +123,25 @@ class ComQueue : public ComQueueComponentBase {
 
     //! Receive and queue a Fw::Buffer
     //!
-    void buffQueueIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void buffQueueIn_handler(const FwIndexType portNum, /*!< The port number*/
                              Fw::Buffer& fwBuffer /*!< Buffer containing packet data*/);
 
     //! Receive and queue a Fw::ComBuffer
     //!
-    void comQueueIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void comQueueIn_handler(const FwIndexType portNum, /*!< The port number*/
                             Fw::ComBuffer& data,           /*!< Buffer containing packet data*/
                             U32 context                    /*!< Call context value; meaning chosen by user*/
     );
 
     //! Handle the status of the last sent message
     //!
-    void comStatusIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void comStatusIn_handler(const FwIndexType portNum, /*!< The port number*/
                              Fw::Success& condition         /*!<Status of communication state*/
     );
 
     //! Schedules the transmission of telemetry
     //!
-    void run_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void run_handler(const FwIndexType portNum, /*!< The port number*/
                      U32 context                    /*!<The call order*/
     );
 

--- a/Svc/ComQueue/test/ut/ComQueueTester.cpp
+++ b/Svc/ComQueue/test/ut/ComQueueTester.cpp
@@ -86,13 +86,13 @@ void ComQueueTester ::testQueueSend() {
     Fw::Buffer buffer(&data[0], sizeof(data));
     configure();
 
-    for(NATIVE_INT_TYPE portNum = 0; portNum < ComQueue::COM_PORT_COUNT; portNum++){
+    for(FwIndexType portNum = 0; portNum < ComQueue::COM_PORT_COUNT; portNum++){
         invoke_to_comQueueIn(portNum, comBuffer, 0);
         emitOneAndCheck(portNum, QueueType::COM_QUEUE, comBuffer, buffer);
     }
     clearFromPortHistory();
 
-    for(NATIVE_INT_TYPE portNum = 0; portNum < ComQueue::BUFFER_PORT_COUNT; portNum++){
+    for(FwIndexType portNum = 0; portNum < ComQueue::BUFFER_PORT_COUNT; portNum++){
         invoke_to_buffQueueIn(portNum, buffer);
         emitOneAndCheck(portNum, QueueType::BUFFER_QUEUE, comBuffer, buffer);
     }
@@ -106,7 +106,7 @@ void ComQueueTester ::testQueuePause() {
     Fw::Buffer buffer(&data[0], sizeof(data));
     configure();
 
-    for(NATIVE_INT_TYPE portNum = 0; portNum < ComQueue::COM_PORT_COUNT; portNum++){
+    for(FwIndexType portNum = 0; portNum < ComQueue::COM_PORT_COUNT; portNum++){
         invoke_to_comQueueIn(portNum, comBuffer, 0);
         // Send a bunch of failures
         Fw::Success state = Fw::Success::FAILURE;
@@ -117,7 +117,7 @@ void ComQueueTester ::testQueuePause() {
     }
     clearFromPortHistory();
 
-    for(NATIVE_INT_TYPE portNum = 0; portNum < ComQueue::BUFFER_PORT_COUNT; portNum++){
+    for(FwIndexType portNum = 0; portNum < ComQueue::BUFFER_PORT_COUNT; portNum++){
         invoke_to_buffQueueIn(portNum, buffer);
         // Send a bunch of failures
         Fw::Success state = Fw::Success::FAILURE;
@@ -148,12 +148,12 @@ void ComQueueTester ::testPrioritySend() {
 
     component.configure(configurationTable, 0, mallocAllocator);
 
-    for(NATIVE_INT_TYPE portNum = 0; portNum < ComQueue::COM_PORT_COUNT; portNum++){
+    for(FwIndexType portNum = 0; portNum < ComQueue::COM_PORT_COUNT; portNum++){
         Fw::ComBuffer comBuffer(&data[portNum][0], BUFFER_LENGTH);
         invoke_to_comQueueIn(portNum, comBuffer, 0);
     }
 
-    for (NATIVE_INT_TYPE portNum = 0; portNum < ComQueue::BUFFER_PORT_COUNT; portNum++) {
+    for (FwIndexType portNum = 0; portNum < ComQueue::BUFFER_PORT_COUNT; portNum++) {
         Fw::Buffer buffer(&data[portNum + ComQueue::COM_PORT_COUNT][0], BUFFER_LENGTH);
         invoke_to_buffQueueIn(portNum, buffer);
     }
@@ -211,7 +211,7 @@ void ComQueueTester::testExternalQueueOverflow() {
 
     for (NATIVE_INT_TYPE queueNum = 0; queueNum < ComQueue::TOTAL_PORT_COUNT; queueNum++) {
         QueueType overflow_type;
-        NATIVE_INT_TYPE portNum;
+        FwIndexType portNum;
         // queue[portNum].depth + 2 to deliberately cause overflow and check throttle of exactly 1
         for (NATIVE_UINT_TYPE msgCount = 0; msgCount < configurationTable.entries[queueNum].depth + 2; msgCount++) {
             sendByQueueNumber(buffer, queueNum, portNum, overflow_type);
@@ -266,7 +266,7 @@ void ComQueueTester::testInternalQueueOverflow() {
     const NATIVE_INT_TYPE queueNum = ComQueue::COM_PORT_COUNT;
     const FwSizeType msgCountMax = this->component.m_queue.getDepth();
     QueueType overflow_type;
-    NATIVE_INT_TYPE portNum;
+    FwIndexType portNum;
 
     // fill the queue
     for (FwSizeType msgCount = 0; msgCount < msgCountMax; msgCount++) {
@@ -296,7 +296,7 @@ void ComQueueTester ::testReadyFirst() {
     Fw::Buffer buffer(&data[0], sizeof(data));
     configure();
 
-    for(NATIVE_INT_TYPE portNum = 0; portNum < ComQueue::COM_PORT_COUNT; portNum++){
+    for(FwIndexType portNum = 0; portNum < ComQueue::COM_PORT_COUNT; portNum++){
         emitOne();
         invoke_to_comQueueIn(portNum, comBuffer, 0);
         dispatchAll();
@@ -304,7 +304,7 @@ void ComQueueTester ::testReadyFirst() {
     }
     clearFromPortHistory();
 
-    for(NATIVE_INT_TYPE portNum = 0; portNum < ComQueue::BUFFER_PORT_COUNT; portNum++){
+    for(FwIndexType portNum = 0; portNum < ComQueue::BUFFER_PORT_COUNT; portNum++){
         emitOne();
         invoke_to_buffQueueIn(portNum, buffer);
         dispatchAll();
@@ -318,11 +318,11 @@ void ComQueueTester ::testReadyFirst() {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void ComQueueTester ::from_buffQueueSend_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void ComQueueTester ::from_buffQueueSend_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     this->pushFromPortEntry_buffQueueSend(fwBuffer);
 }
 
-void ComQueueTester ::from_comQueueSend_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer& data, U32 context) {
+void ComQueueTester ::from_comQueueSend_handler(const FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
     this->pushFromPortEntry_comQueueSend(data, context);
 }
 

--- a/Svc/ComQueue/test/ut/ComQueueTester.hpp
+++ b/Svc/ComQueue/test/ut/ComQueueTester.hpp
@@ -86,12 +86,12 @@ class ComQueueTester : public ComQueueGTestBase {
 
     //! Handler for from_buffQueueSend
     //!
-    void from_buffQueueSend_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_buffQueueSend_handler(const FwIndexType portNum, /*!< The port number*/
                                     Fw::Buffer& fwBuffer);
 
     //! Handler for from_comQueueSend
     //!
-    void from_comQueueSend_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_comQueueSend_handler(const FwIndexType portNum, /*!< The port number*/
                                    Fw::ComBuffer& data,           /*!< Buffer containing packet data*/
                                    U32 context                    /*!< Call context value; meaning chosen by user*/
     );

--- a/Svc/ComSplitter/ComSplitter.cpp
+++ b/Svc/ComSplitter/ComSplitter.cpp
@@ -32,7 +32,7 @@ namespace Svc {
 
   void ComSplitter ::
     comIn_handler(
-        NATIVE_INT_TYPE portNum,
+        FwIndexType portNum,
         Fw::ComBuffer &data,
         U32 context
     )

--- a/Svc/ComSplitter/ComSplitter.hpp
+++ b/Svc/ComSplitter/ComSplitter.hpp
@@ -39,7 +39,7 @@ namespace Svc {
     private:
 
       void comIn_handler(
-          NATIVE_INT_TYPE portNum,
+          FwIndexType portNum,
           Fw::ComBuffer &data,
           U32 context
       );

--- a/Svc/ComSplitter/test/ut/ComSplitterTester.cpp
+++ b/Svc/ComSplitter/test/ut/ComSplitterTester.cpp
@@ -82,7 +82,7 @@ namespace Svc {
 
   void ComSplitterTester ::
     from_comOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::ComBuffer &data,
         U32 context
     )

--- a/Svc/ComSplitter/test/ut/ComSplitterTester.hpp
+++ b/Svc/ComSplitter/test/ut/ComSplitterTester.hpp
@@ -53,7 +53,7 @@ namespace Svc {
       //! Handler for from_comOut
       //!
       void from_comOut_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Fw::ComBuffer &data, /*!< Buffer containing packet data*/
           U32 context /*!< Call context value; meaning chosen by user*/
       );

--- a/Svc/ComStub/ComStub.cpp
+++ b/Svc/ComStub/ComStub.cpp
@@ -22,7 +22,7 @@ ComStub::~ComStub() {}
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-Drv::SendStatus ComStub::comDataIn_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& sendBuffer) {
+Drv::SendStatus ComStub::comDataIn_handler(const FwIndexType portNum, Fw::Buffer& sendBuffer) {
     FW_ASSERT(!this->m_reinitialize || !this->isConnected_comStatus_OutputPort(0));  // A message should never get here if we need to reinitialize is needed
     Drv::SendStatus driverStatus = Drv::SendStatus::SEND_RETRY;
     for (NATIVE_UINT_TYPE i = 0; driverStatus == Drv::SendStatus::SEND_RETRY && i < RETRY_LIMIT; i++) {
@@ -37,7 +37,7 @@ Drv::SendStatus ComStub::comDataIn_handler(const NATIVE_INT_TYPE portNum, Fw::Bu
     return Drv::SendStatus::SEND_OK;  // Always send ok to deframer as it does not handle this anyway
 }
 
-void ComStub::drvConnected_handler(const NATIVE_INT_TYPE portNum) {
+void ComStub::drvConnected_handler(const FwIndexType portNum) {
     Fw::Success radioSuccess = Fw::Success::SUCCESS;
     if (this->isConnected_comStatus_OutputPort(0) && m_reinitialize) {
         this->m_reinitialize = false;
@@ -45,7 +45,7 @@ void ComStub::drvConnected_handler(const NATIVE_INT_TYPE portNum) {
     }
 }
 
-void ComStub::drvDataIn_handler(const NATIVE_INT_TYPE portNum,
+void ComStub::drvDataIn_handler(const FwIndexType portNum,
                                 Fw::Buffer& recvBuffer,
                                 const Drv::RecvStatus& recvStatus) {
     this->comDataOut_out(0, recvBuffer, recvStatus);

--- a/Svc/ComStub/ComStub.hpp
+++ b/Svc/ComStub/ComStub.hpp
@@ -34,16 +34,16 @@ class ComStub : public ComStubComponentBase {
 
     //! Handler implementation for comDataIn
     //!
-    Drv::SendStatus comDataIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Drv::SendStatus comDataIn_handler(const FwIndexType portNum, /*!< The port number*/
                                       Fw::Buffer& sendBuffer) override;
 
     //! Handler implementation for drvConnected
     //!
-    void drvConnected_handler(const NATIVE_INT_TYPE portNum) override;
+    void drvConnected_handler(const FwIndexType portNum) override;
 
     //! Handler implementation for drvDataIn
     //!
-    void drvDataIn_handler(const NATIVE_INT_TYPE portNum,
+    void drvDataIn_handler(const FwIndexType portNum,
                            /*!< The port number*/ Fw::Buffer& recvBuffer,
                            const Drv::RecvStatus& recvStatus) override;
 

--- a/Svc/ComStub/test/ut/ComStubTester.cpp
+++ b/Svc/ComStub/test/ut/ComStubTester.cpp
@@ -121,17 +121,17 @@ void ComStubTester ::test_retry() {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void ComStubTester ::from_comDataOut_handler(const NATIVE_INT_TYPE portNum,
+void ComStubTester ::from_comDataOut_handler(const FwIndexType portNum,
                                       Fw::Buffer& recvBuffer,
                                       const Drv::RecvStatus& recvStatus) {
     this->pushFromPortEntry_comDataOut(recvBuffer, recvStatus);
 }
 
-void ComStubTester ::from_comStatus_handler(const NATIVE_INT_TYPE portNum, Fw::Success& condition) {
+void ComStubTester ::from_comStatus_handler(const FwIndexType portNum, Fw::Success& condition) {
     this->pushFromPortEntry_comStatus(condition);
 }
 
-Drv::SendStatus ComStubTester ::from_drvDataOut_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& sendBuffer) {
+Drv::SendStatus ComStubTester ::from_drvDataOut_handler(const FwIndexType portNum, Fw::Buffer& sendBuffer) {
     this->pushFromPortEntry_drvDataOut(sendBuffer);
     m_retries = (m_send_mode == Drv::SendStatus::SEND_RETRY) ? (m_retries + 1) : m_retries;
     if (m_retries < RETRIES) {

--- a/Svc/ComStub/test/ut/ComStubTester.hpp
+++ b/Svc/ComStub/test/ut/ComStubTester.hpp
@@ -57,19 +57,19 @@ class ComStubTester : public ComStubGTestBase {
 
     //! Handler for from_comDataOut
     //!
-    void from_comDataOut_handler(const NATIVE_INT_TYPE portNum, //!< The port number
+    void from_comDataOut_handler(const FwIndexType portNum, //!< The port number
                                  Fw::Buffer& recvBuffer,
                                  const Drv::RecvStatus& recvStatus);
 
     //! Handler for from_comStatus
     //!
-    void from_comStatus_handler(const NATIVE_INT_TYPE portNum, //!< The port number
+    void from_comStatus_handler(const FwIndexType portNum, //!< The port number
                                 Fw::Success& condition         //!< Status of communication state
     );
 
     //! Handler for from_drvDataOut
     //!
-    Drv::SendStatus from_drvDataOut_handler(const NATIVE_INT_TYPE portNum, //!< The port number
+    Drv::SendStatus from_drvDataOut_handler(const FwIndexType portNum, //!< The port number
                                             Fw::Buffer& sendBuffer);
 
   private:

--- a/Svc/Deframer/Deframer.cpp
+++ b/Svc/Deframer/Deframer.cpp
@@ -62,7 +62,7 @@ void Deframer ::setup(DeframingProtocol& protocol) {
 // ----------------------------------------------------------------------
 
 void Deframer ::cmdResponseIn_handler(
-    NATIVE_INT_TYPE portNum,
+    FwIndexType portNum,
     FwOpcodeType opcode,
     U32 cmdSeq,
     const Fw::CmdResponse& response
@@ -71,7 +71,7 @@ void Deframer ::cmdResponseIn_handler(
 }
 
 void Deframer ::framedIn_handler(
-    const NATIVE_INT_TYPE portNum,
+    const FwIndexType portNum,
     Fw::Buffer& recvBuffer,
     const Drv::RecvStatus& recvStatus
 ) {
@@ -85,7 +85,7 @@ void Deframer ::framedIn_handler(
 }
 
 void Deframer ::schedIn_handler(
-    const NATIVE_INT_TYPE portNum,
+    const FwIndexType portNum,
     U32 context
 ) {
     // Check for data

--- a/Svc/Deframer/Deframer.hpp
+++ b/Svc/Deframer/Deframer.hpp
@@ -66,7 +66,7 @@ class Deframer :
 
     //! Handler for input port cmdResponseIn
     void cmdResponseIn_handler(
-        NATIVE_INT_TYPE portNum, //!< The port number
+        FwIndexType portNum, //!< The port number
         FwOpcodeType opcode, //!< The command opcode
         U32 cmdSeq, //!< The command sequence number
         const Fw::CmdResponse& response //!< The command response
@@ -74,14 +74,14 @@ class Deframer :
 
     //! Handler implementation for framedIn
     void framedIn_handler(
-        const NATIVE_INT_TYPE portNum, //!< The port number
+        const FwIndexType portNum, //!< The port number
         Fw::Buffer& recvBuffer, //!< Buffer containing framed data
         const Drv::RecvStatus& recvStatus //!< Status of the bytes
     );
 
     //! Handler implementation for schedIn
     void schedIn_handler(
-        const NATIVE_INT_TYPE portNum, //!< The port number
+        const FwIndexType portNum, //!< The port number
         U32 context //!< The call order
     );
 

--- a/Svc/Deframer/test/ut-fprime-protocol/DeframerTester.cpp
+++ b/Svc/Deframer/test/ut-fprime-protocol/DeframerTester.cpp
@@ -96,7 +96,7 @@ namespace Svc {
     // ----------------------------------------------------------------------
 
     void DeframerTester ::from_comOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::ComBuffer& data,
         U32 context
     ) {
@@ -120,7 +120,7 @@ namespace Svc {
     }
 
     void DeframerTester ::from_bufferOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer& fwBuffer
     ) {
         // Check that a received frame is expected
@@ -151,7 +151,7 @@ namespace Svc {
     }
 
     Fw::Buffer DeframerTester ::from_bufferAllocate_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 size
     ) {
         this->pushFromPortEntry_bufferAllocate(size);
@@ -162,7 +162,7 @@ namespace Svc {
     }
 
     void DeframerTester ::from_bufferDeallocate_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer& fwBuffer
     ) {
         delete[] fwBuffer.getData();
@@ -170,14 +170,14 @@ namespace Svc {
     }
 
     void DeframerTester ::from_framedDeallocate_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer& fwBuffer
     ) {
         this->pushFromPortEntry_framedDeallocate(fwBuffer);
     }
 
     Drv::PollStatus DeframerTester ::from_framedPoll_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer& pollBuffer
     ) {
         this->pushFromPortEntry_framedPoll(pollBuffer);

--- a/Svc/Deframer/test/ut-fprime-protocol/DeframerTester.hpp
+++ b/Svc/Deframer/test/ut-fprime-protocol/DeframerTester.hpp
@@ -237,39 +237,39 @@ namespace Svc {
 
         //! Handler for from_comOut
         void from_comOut_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             Fw::ComBuffer& data, //!< Buffer containing packet data
             U32 context //!< Call context value; meaning chosen by user
         );
 
         //! Handler for from_bufferOut
         void from_bufferOut_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             Fw::Buffer& fwBuffer //!< The buffer
         );
 
         //! Handler for from_bufferAllocate
         Fw::Buffer from_bufferAllocate_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             U32 size //!< The size
         );
 
         //! Handler for from_bufferDeallocate
         void from_bufferDeallocate_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             Fw::Buffer& fwBuffer //!< The buffer
         );
 
         //! Handler for from_framedDeallocate
         //!
         void from_framedDeallocate_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             Fw::Buffer& fwBuffer //!< The buffer
         );
 
         //! Handler for from_framedPoll
         Drv::PollStatus from_framedPoll_handler(
-            const NATIVE_INT_TYPE portNum, //!< The port number
+            const FwIndexType portNum, //!< The port number
             Fw::Buffer& pollBuffer //!< The poll buffer
         );
 

--- a/Svc/Deframer/test/ut/DeframerTester.cpp
+++ b/Svc/Deframer/test/ut/DeframerTester.cpp
@@ -168,29 +168,29 @@ void DeframerTester ::testBufferOutUnconnected() {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void DeframerTester ::from_comOut_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer& data, U32 context) {
+void DeframerTester ::from_comOut_handler(const FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
     this->pushFromPortEntry_comOut(data, context);
 }
 
-void DeframerTester ::from_bufferOut_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void DeframerTester ::from_bufferOut_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     this->pushFromPortEntry_bufferOut(fwBuffer);
 }
 
-Fw::Buffer DeframerTester ::from_bufferAllocate_handler(const NATIVE_INT_TYPE portNum, U32 size) {
+Fw::Buffer DeframerTester ::from_bufferAllocate_handler(const FwIndexType portNum, U32 size) {
     this->pushFromPortEntry_bufferAllocate(size);
     Fw::Buffer buffer(nullptr, size);
     return buffer;
 }
 
-void DeframerTester ::from_bufferDeallocate_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void DeframerTester ::from_bufferDeallocate_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     this->pushFromPortEntry_bufferDeallocate(fwBuffer);
 }
 
-void DeframerTester ::from_framedDeallocate_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void DeframerTester ::from_framedDeallocate_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     this->pushFromPortEntry_framedDeallocate(fwBuffer);
 }
 
-Drv::PollStatus DeframerTester ::from_framedPoll_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& pollBuffer) {
+Drv::PollStatus DeframerTester ::from_framedPoll_handler(const FwIndexType portNum, Fw::Buffer& pollBuffer) {
     this->pushFromPortEntry_framedPoll(pollBuffer);
     return Drv::PollStatus::POLL_OK;
 }

--- a/Svc/Deframer/test/ut/DeframerTester.hpp
+++ b/Svc/Deframer/test/ut/DeframerTester.hpp
@@ -92,34 +92,34 @@ class DeframerTester : public DeframerGTestBase {
 
     //! Handler for from_comOut
     //!
-    void from_comOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_comOut_handler(const FwIndexType portNum, /*!< The port number*/
                              Fw::ComBuffer& data,           /*!< Buffer containing packet data*/
                              U32 context                    /*!< Call context value; meaning chosen by user*/
     );
 
     //! Handler for from_bufferOut
     //!
-    void from_bufferOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_bufferOut_handler(const FwIndexType portNum, /*!< The port number*/
                                 Fw::Buffer& fwBuffer);
 
     //! Handler for from_bufferAllocate
     //!
-    Fw::Buffer from_bufferAllocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Fw::Buffer from_bufferAllocate_handler(const FwIndexType portNum, /*!< The port number*/
                                            U32 size);
 
     //! Handler for from_bufferDeallocate
     //!
-    void from_bufferDeallocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_bufferDeallocate_handler(const FwIndexType portNum, /*!< The port number*/
                                        Fw::Buffer& fwBuffer);
 
     //! Handler for from_framedDeallocate
     //!
-    void from_framedDeallocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_framedDeallocate_handler(const FwIndexType portNum, /*!< The port number*/
                                        Fw::Buffer& fwBuffer);
 
     //! Handler for from_framedPoll
     //!
-    Drv::PollStatus from_framedPoll_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Drv::PollStatus from_framedPoll_handler(const FwIndexType portNum, /*!< The port number*/
                                             Fw::Buffer& pollBuffer);
 
   private:

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -827,7 +827,7 @@ namespace Svc {
 
     void DpCatalog ::
         fileDone_handler(
-            NATIVE_INT_TYPE portNum,
+            FwIndexType portNum,
             const Svc::SendFileResponse& resp
         )
     {
@@ -856,7 +856,7 @@ namespace Svc {
 
     void DpCatalog ::
         pingIn_handler(
-            NATIVE_INT_TYPE portNum,
+            FwIndexType portNum,
             U32 key
         )
     {

--- a/Svc/DpCatalog/DpCatalog.hpp
+++ b/Svc/DpCatalog/DpCatalog.hpp
@@ -67,7 +67,7 @@ namespace Svc {
         //!
         //! File Downlink send complete port
         void fileDone_handler(
-            NATIVE_INT_TYPE portNum, //!< The port number
+            FwIndexType portNum, //!< The port number
             const Svc::SendFileResponse& resp
         ) override;
 
@@ -75,7 +75,7 @@ namespace Svc {
         //!
         //! Ping input port
         void pingIn_handler(
-            NATIVE_INT_TYPE portNum, //!< The port number
+            FwIndexType portNum, //!< The port number
             U32 key //!< Value to return to pinger
         ) override;
 

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
@@ -257,7 +257,7 @@ namespace Svc {
 
     Svc::SendFileResponse DpCatalogTester ::
         from_fileOut_handler(
-            NATIVE_INT_TYPE portNum,
+            FwIndexType portNum,
             const Fw::StringBase& sourceFileName,
             const Fw::StringBase& destFileName,
             U32 offset,
@@ -271,7 +271,7 @@ namespace Svc {
 
     void DpCatalogTester ::
         from_pingOut_handler(
-            NATIVE_INT_TYPE portNum,
+            FwIndexType portNum,
             U32 key
         )
     {

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.hpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.hpp
@@ -105,7 +105,7 @@ namespace Svc {
 
         //! Handler implementation for fileOut
         Svc::SendFileResponse from_fileOut_handler(
-            NATIVE_INT_TYPE portNum, //!< The port number
+            FwIndexType portNum, //!< The port number
             const Fw::StringBase& sourceFileName, //!< Path of file to downlink
             const Fw::StringBase& destFileName, //!< Path to store downlinked file at
             U32 offset, //!< Amount of data in bytes to downlink from file. 0 to read until end of file
@@ -114,7 +114,7 @@ namespace Svc {
 
         //! Handler implementation for pingOut
         void from_pingOut_handler(
-            NATIVE_INT_TYPE portNum, //!< The port number
+            FwIndexType portNum, //!< The port number
             U32 key //!< Value to return to pinger
         ) override;
 

--- a/Svc/DpManager/DpManager.cpp
+++ b/Svc/DpManager/DpManager.cpp
@@ -26,14 +26,14 @@ DpManager::~DpManager() {}
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-Fw::Success DpManager::productGetIn_handler(const NATIVE_INT_TYPE portNum,
+Fw::Success DpManager::productGetIn_handler(const FwIndexType portNum,
                                             FwDpIdType id,
                                             FwSizeType size,
                                             Fw::Buffer& buffer) {
     return this->getBuffer(portNum, id, size, buffer);
 }
 
-void DpManager::productRequestIn_handler(const NATIVE_INT_TYPE portNum, FwDpIdType id, FwSizeType size) {
+void DpManager::productRequestIn_handler(const FwIndexType portNum, FwDpIdType id, FwSizeType size) {
     // Get a buffer
     Fw::Buffer buffer;
     const Fw::Success status = this->getBuffer(portNum, id, size, buffer);
@@ -41,7 +41,7 @@ void DpManager::productRequestIn_handler(const NATIVE_INT_TYPE portNum, FwDpIdTy
     this->productResponseOut_out(portNum, id, buffer, status);
 }
 
-void DpManager::productSendIn_handler(const NATIVE_INT_TYPE portNum, FwDpIdType id, const Fw::Buffer& buffer) {
+void DpManager::productSendIn_handler(const FwIndexType portNum, FwDpIdType id, const Fw::Buffer& buffer) {
     // id is unused
     (void)id;
     // Update state variables
@@ -52,7 +52,7 @@ void DpManager::productSendIn_handler(const NATIVE_INT_TYPE portNum, FwDpIdType 
     this->productSendOut_out(portNum, sendBuffer);
 }
 
-void DpManager::schedIn_handler(const NATIVE_INT_TYPE portNum, U32 context) {
+void DpManager::schedIn_handler(const FwIndexType portNum, U32 context) {
     // Emit telemetry
     this->tlmWrite_NumSuccessfulAllocations(this->numSuccessfulAllocations);
     this->tlmWrite_NumFailedAllocations(this->numFailedAllocations);

--- a/Svc/DpManager/DpManager.hpp
+++ b/Svc/DpManager/DpManager.hpp
@@ -63,26 +63,26 @@ class DpManager : public DpManagerComponentBase {
     // ----------------------------------------------------------------------
 
     //! Handler implementation for productGetIn
-    Fw::Success productGetIn_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+    Fw::Success productGetIn_handler(const FwIndexType portNum,  //!< The port number
                                      FwDpIdType id,                  //!< The container ID
                                      FwSizeType size,                //!< The size of the requested buffer
                                      Fw::Buffer& buffer              //!< The buffer
                                      ) final;
 
     //! Handler implementation for productRequestIn
-    void productRequestIn_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+    void productRequestIn_handler(const FwIndexType portNum,  //!< The port number
                                   FwDpIdType id,                  //!< The container ID
                                   FwSizeType size                 //!< The size of the requested buffer
                                   ) final;
 
     //! Handler implementation for productSendIn
-    void productSendIn_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+    void productSendIn_handler(const FwIndexType portNum,  //!< The port number
                                FwDpIdType id,                  //!< The container ID
                                const Fw::Buffer& buffer        //!< The buffer
                                ) final;
 
     //! Handler implementation for schedIn
-    void schedIn_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+    void schedIn_handler(const FwIndexType portNum,  //!< The port number
                          U32 context                     //!< The call order
                          ) final;
 

--- a/Svc/DpManager/test/ut/DpManagerTester.cpp
+++ b/Svc/DpManager/test/ut/DpManagerTester.cpp
@@ -24,7 +24,7 @@ DpManagerTester ::~DpManagerTester() {}
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-Fw::Buffer DpManagerTester::from_bufferGetOut_handler(const NATIVE_INT_TYPE portNum, U32 size) {
+Fw::Buffer DpManagerTester::from_bufferGetOut_handler(const FwIndexType portNum, U32 size) {
     this->abstractState.bufferGetOutPortNumOpt = TestUtils::Option<FwIndexType>::some(portNum);
     this->pushFromPortEntry_bufferGetOut(size);
     Fw::Buffer buffer;
@@ -45,7 +45,7 @@ Fw::Buffer DpManagerTester::from_bufferGetOut_handler(const NATIVE_INT_TYPE port
     return buffer;
 }
 
-void DpManagerTester::from_productResponseOut_handler(const NATIVE_INT_TYPE portNum,
+void DpManagerTester::from_productResponseOut_handler(const FwIndexType portNum,
                                                       FwDpIdType id,
                                                       const Fw::Buffer& buffer,
                                                       const Fw::Success& status) {
@@ -53,7 +53,7 @@ void DpManagerTester::from_productResponseOut_handler(const NATIVE_INT_TYPE port
     this->pushFromPortEntry_productResponseOut(id, buffer, status);
 }
 
-void DpManagerTester::from_productSendOut_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void DpManagerTester::from_productSendOut_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     this->abstractState.productSendOutPortNumOpt = TestUtils::Option<FwIndexType>::some(portNum);
     this->pushFromPortEntry_productSendOut(fwBuffer);
 }

--- a/Svc/DpManager/test/ut/DpManagerTester.hpp
+++ b/Svc/DpManager/test/ut/DpManagerTester.hpp
@@ -38,19 +38,19 @@ class DpManagerTester : public DpManagerGTestBase {
     // ----------------------------------------------------------------------
 
     //! Handler for from_bufferGetOut
-    Fw::Buffer from_bufferGetOut_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+    Fw::Buffer from_bufferGetOut_handler(const FwIndexType portNum,  //!< The port number
                                          U32 size                        //!< The size
     );
 
     //! Handler for from_productResponseOut
-    void from_productResponseOut_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+    void from_productResponseOut_handler(const FwIndexType portNum,  //!< The port number
                                          FwDpIdType id,                  //!< The container ID
                                          const Fw::Buffer& buffer,       //!< The buffer
                                          const Fw::Success& status       //!< The status
     );
 
     //! Handler for from_productSendOut
-    void from_productSendOut_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+    void from_productSendOut_handler(const FwIndexType portNum,  //!< The port number
                                      Fw::Buffer& fwBuffer            //!< The buffer
     );
 

--- a/Svc/DpWriter/DpWriter.cpp
+++ b/Svc/DpWriter/DpWriter.cpp
@@ -31,7 +31,7 @@ void DpWriter::configure(const Fw::StringBase& dpFileNamePrefix) {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void DpWriter::bufferSendIn_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& buffer) {
+void DpWriter::bufferSendIn_handler(const FwIndexType portNum, Fw::Buffer& buffer) {
     Fw::Success::T status = Fw::Success::SUCCESS;
     // portNum is unused
     (void)portNum;
@@ -112,7 +112,7 @@ void DpWriter::bufferSendIn_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& b
     }
 }
 
-void DpWriter::schedIn_handler(const NATIVE_INT_TYPE portNum, U32 context) {
+void DpWriter::schedIn_handler(const FwIndexType portNum, U32 context) {
     // portNum and context are not used
     (void)portNum;
     (void)context;

--- a/Svc/DpWriter/DpWriter.hpp
+++ b/Svc/DpWriter/DpWriter.hpp
@@ -43,13 +43,13 @@ class DpWriter : public DpWriterComponentBase {
 
     //! Handler implementation for bufferSendIn
     //!
-    void bufferSendIn_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+    void bufferSendIn_handler(const FwIndexType portNum,  //!< The port number
                               Fw::Buffer& fwBuffer            //!< The buffer
                               ) final;
 
     //! Handler implementation for schedIn
     //!
-    void schedIn_handler(const NATIVE_INT_TYPE portNum,  //!< The port number
+    void schedIn_handler(const FwIndexType portNum,  //!< The port number
                          U32 context                     //!< The call order
                          ) final;
 

--- a/Svc/DpWriter/test/ut/DpWriterTester.cpp
+++ b/Svc/DpWriter/test/ut/DpWriterTester.cpp
@@ -29,7 +29,7 @@ DpWriterTester ::~DpWriterTester() {}
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void DpWriterTester::from_procBufferSendOut_handler(NATIVE_INT_TYPE portNum, Fw::Buffer& buffer) {
+void DpWriterTester::from_procBufferSendOut_handler(FwIndexType portNum, Fw::Buffer& buffer) {
     this->pushFromPortEntry_procBufferSendOut(buffer);
     this->abstractState.m_procTypes |= (1 << portNum);
 }

--- a/Svc/DpWriter/test/ut/DpWriterTester.hpp
+++ b/Svc/DpWriter/test/ut/DpWriterTester.hpp
@@ -45,7 +45,7 @@ class DpWriterTester : public DpWriterGTestBase {
     // ----------------------------------------------------------------------
 
     //! Handler implementation for procBufferSendOut
-    void from_procBufferSendOut_handler(NATIVE_INT_TYPE portNum,  //!< The port number
+    void from_procBufferSendOut_handler(FwIndexType portNum,  //!< The port number
                                         Fw::Buffer& fwBuffer      //!< The buffer
     ) final;
 

--- a/Svc/FatalHandler/FatalHandlerComponentBaremetalImpl.cpp
+++ b/Svc/FatalHandler/FatalHandlerComponentBaremetalImpl.cpp
@@ -16,7 +16,7 @@ namespace Svc {
     // ----------------------------------------------------------------------
 
     void FatalHandlerComponentImpl::FatalReceive_handler(
-            const NATIVE_INT_TYPE portNum,
+            const FwIndexType portNum,
             FwEventIdType Id) {
         Fw::Logger::log("FATAL %" PRI_FwEventIdType "handled.\n",Id);
         while (true) {} // Returning might be bad

--- a/Svc/FatalHandler/FatalHandlerComponentImpl.hpp
+++ b/Svc/FatalHandler/FatalHandlerComponentImpl.hpp
@@ -46,7 +46,7 @@ namespace Svc {
       //! Handler implementation for FatalReceive
       //!
       void FatalReceive_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           FwEventIdType Id /*!< The ID of the FATAL event*/
       );
 

--- a/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
+++ b/Svc/FatalHandler/FatalHandlerComponentLinuxImpl.cpp
@@ -24,7 +24,7 @@ namespace Svc {
     // ----------------------------------------------------------------------
 
     void FatalHandlerComponentImpl::FatalReceive_handler(
-            const NATIVE_INT_TYPE portNum,
+            const FwIndexType portNum,
             FwEventIdType Id) {
         // for **nix, delay then exit with error code
         Fw::Logger::log("FATAL %d handled.\n",Id);

--- a/Svc/FatalHandler/FatalHandlerComponentVxWorksImpl.cpp
+++ b/Svc/FatalHandler/FatalHandlerComponentVxWorksImpl.cpp
@@ -18,7 +18,7 @@
 namespace Svc {
 
     void FatalHandlerComponentImpl::FatalReceive_handler(
-            const NATIVE_INT_TYPE portNum,
+            const FwIndexType portNum,
             FwEventIdType Id) {
         Fw::Logger::log("FATAL %d handled.\n",Id,0,0,0,0,0);
         taskSuspend(0);

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -82,7 +82,7 @@ namespace Svc {
 
   void FileDownlink ::
     Run_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 context
     )
   {
@@ -139,7 +139,7 @@ namespace Svc {
 
   Svc::SendFileResponse FileDownlink ::
     SendFile_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         const Fw::StringBase& sourceFilename, // lgtm[cpp/large-parameter] dictated by command architecture
         const Fw::StringBase& destFilename, // lgtm[cpp/large-parameter] dictated by command architecture
         U32 offset,
@@ -171,7 +171,7 @@ namespace Svc {
 
   void FileDownlink ::
     pingIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 key
     )
   {
@@ -180,7 +180,7 @@ namespace Svc {
 
   void FileDownlink ::
     bufferReturn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer &fwBuffer
     )
   {

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -296,7 +296,7 @@ namespace Svc {
       //! Handler implementation for Run
       //!
       void Run_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           U32 context //!< The call order
       );
 
@@ -304,7 +304,7 @@ namespace Svc {
       //! Handler implementation for SendFile
       //!
       Svc::SendFileResponse SendFile_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           const Fw::StringBase& sourceFilename, /*!< Path of file to downlink*/
           const Fw::StringBase& destFilename, /*!< Path to store downlinked file at*/
           U32 offset, /*!< Amount of data in bytes to downlink from file. 0 to read until end of file*/
@@ -314,14 +314,14 @@ namespace Svc {
       //! Handler implementation for bufferReturn
       //!
       void bufferReturn_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           Fw::Buffer &fwBuffer
       );
 
       //! Handler implementation for pingIn
       //!
       void pingIn_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 key /*!< Value to return to pinger*/
       );
 

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -395,7 +395,7 @@ namespace Svc {
 
    void FileDownlinkTester ::
     from_bufferSendOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer& buffer
     )
   {
@@ -413,7 +413,7 @@ namespace Svc {
 
    void FileDownlinkTester ::
      from_pingOut_handler(
-         const NATIVE_INT_TYPE portNum,
+         const FwIndexType portNum,
          U32 key
     )
     {
@@ -422,7 +422,7 @@ namespace Svc {
 
     void FileDownlinkTester ::
       from_FileComplete_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           const Svc::SendFileResponse& response
       )
     {

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
@@ -144,21 +144,21 @@ namespace Svc {
       //! Handler for from_bufferSendOut
       //!
       void from_bufferSendOut_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           Fw::Buffer& buffer
       );
 
       //! Handler for from_bufferSendOut
       //!
       void from_pingOut_handler(
-          const NATIVE_INT_TYPE portNum,
+          const FwIndexType portNum,
           U32 key
       );
 
       //! Handler for from_FileComplete
       //!
       void from_FileComplete_handler(
-          const NATIVE_INT_TYPE portNum,
+          const FwIndexType portNum,
           const Svc::SendFileResponse& resp
       );
 

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -245,7 +245,7 @@ namespace Svc {
 
   void FileManager ::
     pingIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 key
     )
   {

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -107,7 +107,7 @@ namespace Svc {
       //! Handler implementation for pingIn
       //!
       void pingIn_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 key /*!< Value to return to pinger*/
       );
 

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -677,7 +677,7 @@ namespace Svc {
   }
   void FileManagerTester ::
     from_pingOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 key
     )
   {

--- a/Svc/FileManager/test/ut/FileManagerTester.hpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.hpp
@@ -172,7 +172,7 @@ namespace Svc {
       //! Handler for from_pingOut
       //!
       void from_pingOut_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 key /*!< Value to return to pinger*/
       );
     private:

--- a/Svc/FileUplink/FileUplink.cpp
+++ b/Svc/FileUplink/FileUplink.cpp
@@ -45,7 +45,7 @@ namespace Svc {
 
   void FileUplink ::
     bufferSendIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer& buffer
     )
   {
@@ -78,7 +78,7 @@ namespace Svc {
 
   void FileUplink ::
     pingIn_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 key
     )
   {

--- a/Svc/FileUplink/FileUplink.hpp
+++ b/Svc/FileUplink/FileUplink.hpp
@@ -218,14 +218,14 @@ namespace Svc {
       //! Handler implementation for bufferSendIn
       //!
       void bufferSendIn_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           Fw::Buffer& buffer //!< Buffer wrapping data
       );
 
       //! Handler implementation for pingIn
       //!
       void pingIn_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 key /*!< Value to return to pinger*/
       );
 

--- a/Svc/FileUplink/test/ut/FileUplinkTester.cpp
+++ b/Svc/FileUplink/test/ut/FileUplinkTester.cpp
@@ -524,7 +524,7 @@ namespace Svc {
 
   void FileUplinkTester ::
     from_bufferSendOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Fw::Buffer& buffer
     )
   {
@@ -533,7 +533,7 @@ namespace Svc {
 
   void FileUplinkTester ::
     from_pingOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 key
     )
   {

--- a/Svc/FileUplink/test/ut/FileUplinkTester.hpp
+++ b/Svc/FileUplink/test/ut/FileUplinkTester.hpp
@@ -101,14 +101,14 @@ namespace Svc {
       //! Handler for from_bufferSendOut
       //!
       void from_bufferSendOut_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           Fw::Buffer& buffer
       );
 
       //! Handler for from_pingOut
       //!
       void from_pingOut_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 key /*!< Value to return to pinger*/
       );
 

--- a/Svc/Framer/Framer.cpp
+++ b/Svc/Framer/Framer.cpp
@@ -47,17 +47,17 @@ void Framer ::handle_framing(const U8* const data, const U32 size, Fw::ComPacket
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void Framer ::comIn_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer& data, U32 context) {
+void Framer ::comIn_handler(const FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
     this->handle_framing(data.getBuffAddr(), data.getBuffLength(), Fw::ComPacket::FW_PACKET_UNKNOWN);
 }
 
-void Framer ::bufferIn_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void Framer ::bufferIn_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     this->handle_framing(fwBuffer.getData(), fwBuffer.getSize(), Fw::ComPacket::FW_PACKET_FILE);
     // Deallocate the buffer after it was processed by the framing protocol
     this->bufferDeallocate_out(0, fwBuffer);
 }
 
-void Framer ::comStatusIn_handler(const NATIVE_INT_TYPE portNum, Fw::Success& condition) {
+void Framer ::comStatusIn_handler(const FwIndexType portNum, Fw::Success& condition) {
     if (this->isConnected_comStatusOut_OutputPort(portNum)) {
         this->comStatusOut_out(portNum, condition);
     }

--- a/Svc/Framer/Framer.hpp
+++ b/Svc/Framer/Framer.hpp
@@ -54,20 +54,20 @@ class Framer : public FramerComponentBase, public FramingProtocolInterface {
 
     //! Handler implementation for comIn
     //!
-    void comIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void comIn_handler(const FwIndexType portNum, /*!< The port number*/
                        Fw::ComBuffer& data,           /*!< Buffer containing packet data*/
                        U32 context                    /*!< Call context value; meaning chosen by user*/
     );
 
     //! Handler implementation for bufferIn
     //!
-    void bufferIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void bufferIn_handler(const FwIndexType portNum, /*!< The port number*/
                           Fw::Buffer& fwBuffer           /*!< The buffer*/
     );
 
     //! Handler implementation for comStatusIn
     //!
-    void comStatusIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void comStatusIn_handler(const FwIndexType portNum, /*!< The port number*/
                              Fw::Success& condition /*!< The condition*/);
 
     // ----------------------------------------------------------------------

--- a/Svc/Framer/test/ut/FramerTester.cpp
+++ b/Svc/Framer/test/ut/FramerTester.cpp
@@ -129,20 +129,20 @@ void FramerTester ::check_last_buffer(Fw::Buffer buffer) {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void FramerTester ::from_bufferDeallocate_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void FramerTester ::from_bufferDeallocate_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     this->pushFromPortEntry_bufferDeallocate(fwBuffer);
     m_returned = true;
     delete[] fwBuffer.getData();
 }
 
-Fw::Buffer FramerTester ::from_framedAllocate_handler(const NATIVE_INT_TYPE portNum, U32 size) {
+Fw::Buffer FramerTester ::from_framedAllocate_handler(const FwIndexType portNum, U32 size) {
     this->pushFromPortEntry_framedAllocate(size);
     Fw::Buffer buffer(new U8[size], size);
     m_buffer = buffer;
     return buffer;
 }
 
-Drv::SendStatus FramerTester ::from_framedOut_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& sendBuffer) {
+Drv::SendStatus FramerTester ::from_framedOut_handler(const FwIndexType portNum, Fw::Buffer& sendBuffer) {
     this->pushFromPortEntry_framedOut(sendBuffer);
     this->check_last_buffer(sendBuffer);
     delete[] sendBuffer.getData();
@@ -153,7 +153,7 @@ Drv::SendStatus FramerTester ::from_framedOut_handler(const NATIVE_INT_TYPE port
     return m_sendStatus;
 }
 
-void FramerTester ::from_comStatusOut_handler(const NATIVE_INT_TYPE portNum, Fw::Success& condition) {
+void FramerTester ::from_comStatusOut_handler(const FwIndexType portNum, Fw::Success& condition) {
     this->pushFromPortEntry_comStatusOut(condition);
 }
 

--- a/Svc/Framer/test/ut/FramerTester.hpp
+++ b/Svc/Framer/test/ut/FramerTester.hpp
@@ -80,26 +80,26 @@ class FramerTester : public FramerGTestBase {
 
     //! Handler for from_bufferDeallocate
     void from_bufferDeallocate_handler(
-        const NATIVE_INT_TYPE portNum, //!< The port number
+        const FwIndexType portNum, //!< The port number
         Fw::Buffer& fwBuffer //!< The buffer
     );
 
     //! Handler for from_framedAllocate
     Fw::Buffer from_framedAllocate_handler(
-        const NATIVE_INT_TYPE portNum, //!< The port number
+        const FwIndexType portNum, //!< The port number
         U32 size //!< The size
     );
 
     //! Handler for from_framedOut
     Drv::SendStatus from_framedOut_handler(
-        const NATIVE_INT_TYPE portNum, //!< The port number
+        const FwIndexType portNum, //!< The port number
         Fw::Buffer& sendBuffer //!< The buffer containing framed data
     );
 
     //! Handler for from_comStatusOut
     //!
     void from_comStatusOut_handler(
-        const NATIVE_INT_TYPE portNum, /*!< The port number*/
+        const FwIndexType portNum, /*!< The port number*/
         Fw::Success &condition /*!< Condition success/failure */
     );
 

--- a/Svc/GenericHub/GenericHubComponentImpl.cpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.cpp
@@ -52,12 +52,12 @@ void GenericHubComponentImpl ::send_data(const HubType type,
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void GenericHubComponentImpl ::buffersIn_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void GenericHubComponentImpl ::buffersIn_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     send_data(HUB_TYPE_BUFFER, portNum, fwBuffer.getData(), fwBuffer.getSize());
     bufferDeallocate_out(0, fwBuffer);
 }
 
-void GenericHubComponentImpl ::dataIn_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void GenericHubComponentImpl ::dataIn_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     HubType type = HUB_TYPE_MAX;
     U32 type_in = 0;
     U32 port = 0;
@@ -138,7 +138,7 @@ void GenericHubComponentImpl ::dataIn_handler(const NATIVE_INT_TYPE portNum, Fw:
     }
 }
 
-void GenericHubComponentImpl ::LogRecv_handler(const NATIVE_INT_TYPE portNum,
+void GenericHubComponentImpl ::LogRecv_handler(const FwIndexType portNum,
                                   FwEventIdType id,
                                   Fw::Time& timeTag,
                                   const Fw::LogSeverity& severity,
@@ -160,7 +160,7 @@ void GenericHubComponentImpl ::LogRecv_handler(const NATIVE_INT_TYPE portNum,
 
 }
 
-void GenericHubComponentImpl ::TlmRecv_handler(const NATIVE_INT_TYPE portNum,
+void GenericHubComponentImpl ::TlmRecv_handler(const FwIndexType portNum,
                                   FwChanIdType id,
                                   Fw::Time& timeTag,
                                   Fw::TlmBuffer& val) {
@@ -182,7 +182,7 @@ void GenericHubComponentImpl ::TlmRecv_handler(const NATIVE_INT_TYPE portNum,
 // Handler implementations for user-defined serial input ports
 // ----------------------------------------------------------------------
 
-void GenericHubComponentImpl ::portIn_handler(NATIVE_INT_TYPE portNum,        /*!< The port number*/
+void GenericHubComponentImpl ::portIn_handler(FwIndexType portNum,        /*!< The port number*/
                                               Fw::SerializeBufferBase& Buffer /*!< The serialization buffer*/
 ) {
     send_data(HUB_TYPE_PORT, portNum, Buffer.getBuffAddr(), Buffer.getBuffLength());

--- a/Svc/GenericHub/GenericHubComponentImpl.hpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.hpp
@@ -53,17 +53,17 @@ class GenericHubComponentImpl : public GenericHubComponentBase {
 
     //! Handler implementation for buffersIn
     //!
-    void buffersIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void buffersIn_handler(const FwIndexType portNum, /*!< The port number*/
                            Fw::Buffer& fwBuffer);
 
     //! Handler implementation for dataIn
     //!
-    void dataIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void dataIn_handler(const FwIndexType portNum, /*!< The port number*/
                         Fw::Buffer& fwBuffer);
 
     //! Handler implementation for LogRecv
     //!
-    void LogRecv_handler(const NATIVE_INT_TYPE portNum,   /*!< The port number*/
+    void LogRecv_handler(const FwIndexType portNum,   /*!< The port number*/
                          FwEventIdType id,                /*!< Log ID */
                          Fw::Time& timeTag,               /*!< Time Tag */
                          const Fw::LogSeverity& severity, /*!< The severity argument */
@@ -72,7 +72,7 @@ class GenericHubComponentImpl : public GenericHubComponentBase {
 
     //! Handler implementation for TlmRecv
     //!
-    void TlmRecv_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void TlmRecv_handler(const FwIndexType portNum, /*!< The port number*/
                          FwChanIdType id,               /*!< Telemetry Channel ID */
                          Fw::Time& timeTag,             /*!< Time Tag */
                          Fw::TlmBuffer& val             /*!< Buffer containing serialized telemetry value */
@@ -84,7 +84,7 @@ class GenericHubComponentImpl : public GenericHubComponentBase {
 
     //! Handler implementation for portIn
     //!
-    void portIn_handler(NATIVE_INT_TYPE portNum,        /*!< The port number*/
+    void portIn_handler(FwIndexType portNum,        /*!< The port number*/
                         Fw::SerializeBufferBase& Buffer /*!< The serialization buffer*/
     );
 

--- a/Svc/GenericHub/test/ut/GenericHubTester.cpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.cpp
@@ -149,7 +149,7 @@ void GenericHubTester ::send_random_buffer(U32 port) {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void GenericHubTester ::from_LogSend_handler(const NATIVE_INT_TYPE portNum,
+void GenericHubTester ::from_LogSend_handler(const FwIndexType portNum,
                                    FwEventIdType id,
                                    Fw::Time& timeTag,
                                    const Fw::LogSeverity& severity,
@@ -157,14 +157,14 @@ void GenericHubTester ::from_LogSend_handler(const NATIVE_INT_TYPE portNum,
     this->pushFromPortEntry_LogSend(id, timeTag, severity, args);
 }
 
-void GenericHubTester ::from_TlmSend_handler(const NATIVE_INT_TYPE portNum,
+void GenericHubTester ::from_TlmSend_handler(const FwIndexType portNum,
                                    FwChanIdType id,
                                    Fw::Time& timeTag,
                                    Fw::TlmBuffer& val) {
     this->pushFromPortEntry_TlmSend(id, timeTag, val);
 }
 
-void GenericHubTester ::from_dataOut_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void GenericHubTester ::from_dataOut_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     ASSERT_NE(fwBuffer.getData(), nullptr) << "Empty buffer to deallocate";
     ASSERT_GE(fwBuffer.getData(), m_data_for_allocation) << "Incorrect data pointer deallocated";
     ASSERT_LT(fwBuffer.getData(), m_data_for_allocation + sizeof(m_data_for_allocation))
@@ -178,7 +178,7 @@ void GenericHubTester ::from_dataOut_handler(const NATIVE_INT_TYPE portNum, Fw::
 // Handlers for serial from ports
 // ----------------------------------------------------------------------
 
-void GenericHubTester ::from_buffersOut_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void GenericHubTester ::from_buffersOut_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     m_buffer_out++;
     // Assert the buffer came through exactly on the right port
     ASSERT_EQ(portNum, m_current_port);
@@ -192,7 +192,7 @@ void GenericHubTester ::from_buffersOut_handler(const NATIVE_INT_TYPE portNum, F
     this->from_dataInDeallocate_handler(0, fwBuffer);
 }
 
-void GenericHubTester ::from_portOut_handler(NATIVE_INT_TYPE portNum,        /*!< The port number*/
+void GenericHubTester ::from_portOut_handler(FwIndexType portNum,        /*!< The port number*/
                                    Fw::SerializeBufferBase& Buffer /*!< The serialization buffer*/
 ) {
     m_comm_out++;
@@ -205,21 +205,21 @@ void GenericHubTester ::from_portOut_handler(NATIVE_INT_TYPE portNum,        /*!
     ASSERT_from_buffersOut_SIZE(0);
 }
 
-Fw::Buffer GenericHubTester ::from_dataOutAllocate_handler(const NATIVE_INT_TYPE portNum, const U32 size) {
+Fw::Buffer GenericHubTester ::from_dataOutAllocate_handler(const FwIndexType portNum, const U32 size) {
     EXPECT_EQ(m_allocate.getData(), nullptr) << "Allocation buffer is still in use";
     EXPECT_LE(size, sizeof(m_data_for_allocation)) << "Allocation buffer is still in use";
     m_allocate.set(m_data_for_allocation, size);
     return m_allocate;
 }
 
-void GenericHubTester ::from_bufferDeallocate_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void GenericHubTester ::from_bufferDeallocate_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     // Check buffer deallocations here
     ASSERT_EQ(fwBuffer.getData(), m_buffer.getData()) << "Ensure that the buffer was deallocated";
     ASSERT_EQ(fwBuffer.getSize(), m_buffer.getSize()) << "Ensure that the buffer was deallocated";
     this->pushFromPortEntry_bufferDeallocate(fwBuffer);
 }
 
-void GenericHubTester ::from_dataInDeallocate_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void GenericHubTester ::from_dataInDeallocate_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     ASSERT_NE(fwBuffer.getData(), nullptr) << "Empty buffer to deallocate";
     ASSERT_GE(fwBuffer.getData(), m_data_for_allocation) << "Incorrect data pointer deallocated";
     ASSERT_LT(fwBuffer.getData(), m_data_for_allocation + sizeof(m_data_for_allocation))

--- a/Svc/GenericHub/test/ut/GenericHubTester.hpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.hpp
@@ -69,7 +69,7 @@ class GenericHubTester : public GenericHubGTestBase {
 
     //! Handler for from_LogSend
     //!
-    void from_LogSend_handler(const NATIVE_INT_TYPE portNum,   /*!< The port number*/
+    void from_LogSend_handler(const FwIndexType portNum,   /*!< The port number*/
                               FwEventIdType id,                /*!< Log ID */
                               Fw::Time& timeTag,               /*!< Time Tag  */
                               const Fw::LogSeverity& severity, /*!< The severity argument */
@@ -79,7 +79,7 @@ class GenericHubTester : public GenericHubGTestBase {
     //! Handler for from_TlmSend
     //!
     void from_TlmSend_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           FwChanIdType id, /*!< Telemetry Channel ID */
           Fw::Time &timeTag, /*!< Time Tag */
           Fw::TlmBuffer &val /*!< Buffer containing serialized telemetry value */
@@ -87,27 +87,27 @@ class GenericHubTester : public GenericHubGTestBase {
 
     //! Handler for from_buffersOut
     //!
-    void from_buffersOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_buffersOut_handler(const FwIndexType portNum, /*!< The port number*/
                                  Fw::Buffer& fwBuffer);
 
     //! Handler for from_bufferDeallocate
     //!
-    void from_bufferDeallocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_bufferDeallocate_handler(const FwIndexType portNum, /*!< The port number*/
                                        Fw::Buffer& fwBuffer);
 
     //! Handler for from_dataOutAllocate
     //!
-    Fw::Buffer from_dataOutAllocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Fw::Buffer from_dataOutAllocate_handler(const FwIndexType portNum, /*!< The port number*/
                                             U32 size);
 
     //! Handler for from_dataOut
     //!
-    void from_dataOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_dataOut_handler(const FwIndexType portNum, /*!< The port number*/
                               Fw::Buffer& fwBuffer);
 
     //! Handler for from_dataDeallocate
     //!
-    void from_dataInDeallocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_dataInDeallocate_handler(const FwIndexType portNum, /*!< The port number*/
                                      Fw::Buffer& fwBuffer);
 
   private:
@@ -117,7 +117,7 @@ class GenericHubTester : public GenericHubGTestBase {
 
     //! Handler for from_portOut
     //!
-    void from_portOut_handler(NATIVE_INT_TYPE portNum,        /*!< The port number*/
+    void from_portOut_handler(FwIndexType portNum,        /*!< The port number*/
                               Fw::SerializeBufferBase& Buffer /*!< The serialization buffer*/
     );
 

--- a/Svc/Health/HealthComponentImpl.cpp
+++ b/Svc/Health/HealthComponentImpl.cpp
@@ -72,7 +72,7 @@ namespace Svc {
     // Handler implementations for user-defined typed input ports
     // ----------------------------------------------------------------------
 
-    void HealthImpl::PingReturn_handler(const NATIVE_INT_TYPE portNum, U32 key) {
+    void HealthImpl::PingReturn_handler(const FwIndexType portNum, U32 key) {
         // verify the key value
         if (key != this->m_pingTrackerEntries[portNum].key) {
             Fw::LogStringArg _arg = this->m_pingTrackerEntries[portNum].entry.entryName;
@@ -85,7 +85,7 @@ namespace Svc {
 
     }
 
-    void HealthImpl::Run_handler(const NATIVE_INT_TYPE portNum, U32 context) {
+    void HealthImpl::Run_handler(const FwIndexType portNum, U32 context) {
         //dispatch messages
         for (NATIVE_UINT_TYPE i = 0; i < this->queue_depth; i++) {
             MsgDispatchStatus stat = this->doDispatch();

--- a/Svc/Health/HealthComponentImpl.hpp
+++ b/Svc/Health/HealthComponentImpl.hpp
@@ -92,7 +92,7 @@ namespace Svc {
             //!
             //!  \param portNum Port number
             //!  \param key Key value
-            void PingReturn_handler(const NATIVE_INT_TYPE portNum, U32 key);
+            void PingReturn_handler(const FwIndexType portNum, U32 key);
 
             //!  \brief run handler
             //!
@@ -100,7 +100,7 @@ namespace Svc {
             //!
             //!  \param portNum Port number
             //!  \param context Port Context
-            void Run_handler(const NATIVE_INT_TYPE portNum, U32 context);
+            void Run_handler(const FwIndexType portNum, U32 context);
 
             //!  \brief HLTH_ENABLE handler
             //!

--- a/Svc/Health/test/ut/HealthTester.cpp
+++ b/Svc/Health/test/ut/HealthTester.cpp
@@ -47,7 +47,7 @@ namespace Svc {
 
   void HealthTester ::
     from_PingSend_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 key
     )
   {
@@ -68,7 +68,7 @@ namespace Svc {
 
   void HealthTester ::
     from_WdogStroke_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 code
     )
   {

--- a/Svc/Health/test/ut/HealthTester.hpp
+++ b/Svc/Health/test/ut/HealthTester.hpp
@@ -62,14 +62,14 @@ namespace Svc {
       //! Handler for from_PingSend
       //!
       void from_PingSend_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           U32 key //!< Value to return to pinger
       ) override;
 
       //! Handler for from_WdogStroke
       //!
       void from_WdogStroke_handler(
-          const NATIVE_INT_TYPE portNum, //!< The port number
+          const FwIndexType portNum, //!< The port number
           U32 code //!< Watchdog stroke code
       ) override;
 

--- a/Svc/LinuxTimer/test/ut/LinuxTimerTester.cpp
+++ b/Svc/LinuxTimer/test/ut/LinuxTimerTester.cpp
@@ -54,7 +54,7 @@ namespace Svc {
 
   void LinuxTimerTester ::
     from_CycleOut_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         Os::RawTime &cycleStart
     )
   {

--- a/Svc/LinuxTimer/test/ut/LinuxTimerTester.hpp
+++ b/Svc/LinuxTimer/test/ut/LinuxTimerTester.hpp
@@ -55,7 +55,7 @@ namespace Svc {
       //! Handler for from_CycleOut
       //!
       void from_CycleOut_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           Os::RawTime &cycleStart /*!< Cycle start timer value*/
       );
 

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
@@ -16,7 +16,7 @@ namespace Svc {
 	private:
 
 		// downcalls for input ports
-		void TextLogger_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::TextLogString &text);
+		void TextLogger_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::TextLogString &text);
 	};
 
 }

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
@@ -11,7 +11,7 @@ namespace Svc {
 
     ConsoleTextLoggerImpl::~ConsoleTextLoggerImpl() {}
 
-    void ConsoleTextLoggerImpl::TextLogger_handler(NATIVE_INT_TYPE portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::TextLogString &text) {
+    void ConsoleTextLoggerImpl::TextLogger_handler(FwIndexType portNum, FwEventIdType id, Fw::Time &timeTag, const Fw::LogSeverity& severity, Fw::TextLogString &text) {
         const char *severityString = "UNKNOWN";
         switch (severity.e) {
             case Fw::LogSeverity::FATAL:

--- a/Svc/PassiveRateGroup/PassiveRateGroup.cpp
+++ b/Svc/PassiveRateGroup/PassiveRateGroup.cpp
@@ -38,7 +38,7 @@ void PassiveRateGroup::configure(NATIVE_INT_TYPE contexts[], NATIVE_INT_TYPE num
 }
 
 
-void PassiveRateGroup::CycleIn_handler(NATIVE_INT_TYPE portNum, Os::RawTime& cycleStart) {
+void PassiveRateGroup::CycleIn_handler(FwIndexType portNum, Os::RawTime& cycleStart) {
     Os::RawTime endTime;
     FW_ASSERT(this->m_numContexts);
 

--- a/Svc/PassiveRateGroup/PassiveRateGroup.hpp
+++ b/Svc/PassiveRateGroup/PassiveRateGroup.hpp
@@ -62,7 +62,7 @@ class PassiveRateGroup : public PassiveRateGroupComponentBase {
     //!
     //!  \param portNum incoming port call. For this class, should always be zero
     //!  \param cycleStart value stored by the cycle driver, used to compute execution time.
-    void CycleIn_handler(NATIVE_INT_TYPE portNum, Os::RawTime& cycleStart);
+    void CycleIn_handler(FwIndexType portNum, Os::RawTime& cycleStart);
 
     U32 m_cycles;                                                     //!< cycles executed
     U32 m_maxTime;                                                    //!< maximum execution time in microseconds

--- a/Svc/PassiveRateGroup/test/ut/PassiveRateGroupImplTester.cpp
+++ b/Svc/PassiveRateGroup/test/ut/PassiveRateGroupImplTester.cpp
@@ -38,7 +38,7 @@ void PassiveRateGroupTester::clearPortCalls() {
 
 PassiveRateGroupTester::~PassiveRateGroupTester() {}
 
-void PassiveRateGroupTester::from_RateGroupMemberOut_handler(NATIVE_INT_TYPE portNum, U32 context) {
+void PassiveRateGroupTester::from_RateGroupMemberOut_handler(FwIndexType portNum, U32 context) {
     ASSERT_TRUE(portNum < static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(m_impl.m_RateGroupMemberOut_OutputPort)));
     this->m_callLog[portNum].portCalled = true;
     this->m_callLog[portNum].contextVal = context;

--- a/Svc/PassiveRateGroup/test/ut/PassiveRateGroupImplTester.hpp
+++ b/Svc/PassiveRateGroup/test/ut/PassiveRateGroupImplTester.hpp
@@ -31,7 +31,7 @@ namespace Svc {
 
         private:
 
-            void from_RateGroupMemberOut_handler(NATIVE_INT_TYPE portNum, U32 context);
+            void from_RateGroupMemberOut_handler(FwIndexType portNum, U32 context);
 
             Svc::PassiveRateGroup& m_impl;
 

--- a/Svc/PassiveRateGroup/test/ut/PassiveRateGroupTester.cpp
+++ b/Svc/PassiveRateGroup/test/ut/PassiveRateGroupTester.cpp
@@ -22,7 +22,7 @@
 void connectPorts(Svc::PassiveRateGroup& impl, Svc::PassiveRateGroupTester& tester) {
     tester.connect_to_CycleIn(0, impl.get_CycleIn_InputPort(0));
 
-    for (NATIVE_INT_TYPE portNum = 0;
+    for (FwIndexType portNum = 0;
          portNum < static_cast<NATIVE_INT_TYPE>(FW_NUM_ARRAY_ELEMENTS(impl.m_RateGroupMemberOut_OutputPort)); portNum++) {
         impl.set_RateGroupMemberOut_OutputPort(portNum, tester.get_from_RateGroupMemberOut(portNum));
     }

--- a/Svc/PassiveRateGroup/test/ut/PassiveRateGroupTester.hpp
+++ b/Svc/PassiveRateGroup/test/ut/PassiveRateGroupTester.hpp
@@ -31,7 +31,7 @@ namespace Svc {
 
         private:
 
-            void from_RateGroupMemberOut_handler(NATIVE_INT_TYPE portNum, U32 context);
+            void from_RateGroupMemberOut_handler(FwIndexType portNum, U32 context);
 
             Svc::PassiveRateGroup& m_impl;
 

--- a/Svc/PolyDb/PolyDb.cpp
+++ b/Svc/PolyDb/PolyDb.cpp
@@ -19,7 +19,7 @@ namespace Svc {
 
     void PolyDb ::
         getValue_handler(
-            NATIVE_INT_TYPE portNum,
+            FwIndexType portNum,
             const Svc::PolyDbCfg::PolyDbEntry& entry,
             Svc::MeasurementStatus& status,
             Fw::Time& time,
@@ -33,7 +33,7 @@ namespace Svc {
 
     void PolyDb ::
         setValue_handler(
-            NATIVE_INT_TYPE portNum,
+            FwIndexType portNum,
             const Svc::PolyDbCfg::PolyDbEntry& entry,
             Svc::MeasurementStatus& status,
             Fw::Time& time,

--- a/Svc/PolyDb/PolyDb.hpp
+++ b/Svc/PolyDb/PolyDb.hpp
@@ -60,7 +60,7 @@ namespace Svc {
         //!  \param val value of latest measurement
 
         void getValue_handler(
-            NATIVE_INT_TYPE portNum, //!< The port number
+            FwIndexType portNum, //!< The port number
             const Svc::PolyDbCfg::PolyDbEntry& entry, //!< The entry to access
             Svc::MeasurementStatus& status, //!< The command response argument
             Fw::Time& time, //!< The time of the measurement
@@ -79,7 +79,7 @@ namespace Svc {
         //!  \param val value of new measurement
 
         void setValue_handler(
-            NATIVE_INT_TYPE portNum, //!< The port number
+            FwIndexType portNum, //!< The port number
             const Svc::PolyDbCfg::PolyDbEntry& entry, //!< The entry to access
             Svc::MeasurementStatus& status, //!< The command response argument
             Fw::Time& time, //!< The time of the measurement

--- a/Svc/PosixTime/PosixTime.cpp
+++ b/Svc/PosixTime/PosixTime.cpp
@@ -19,7 +19,7 @@ namespace Svc {
     }
 
     void PosixTime::timeGetPort_handler(
-            NATIVE_INT_TYPE portNum, /*!< The port number*/
+            FwIndexType portNum, /*!< The port number*/
             Fw::Time &time /*!< The U32 cmd argument*/
         ) {
         timespec stime;

--- a/Svc/PosixTime/PosixTime.hpp
+++ b/Svc/PosixTime/PosixTime.hpp
@@ -18,7 +18,7 @@ class PosixTime: public PosixTimeComponentBase {
         virtual ~PosixTime();
     protected:
         void timeGetPort_handler(
-                NATIVE_INT_TYPE portNum, /*!< The port number*/
+                FwIndexType portNum, /*!< The port number*/
                 Fw::Time &time /*!< The U32 cmd argument*/
             );
     private:

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -60,7 +60,7 @@ namespace Svc {
     // If ports are no longer guarded, these accesses need to be protected from each other
     // If there are a lot of accesses, perhaps an interrupt lock could be used instead of guarded ports
 
-    Fw::ParamValid PrmDbImpl::getPrm_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+    Fw::ParamValid PrmDbImpl::getPrm_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
         // search for entry
         Fw::ParamValid stat = Fw::ParamValid::INVALID;
 
@@ -82,7 +82,7 @@ namespace Svc {
         return stat;
     }
 
-    void PrmDbImpl::setPrm_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
+    void PrmDbImpl::setPrm_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val) {
 
         this->lock();
 
@@ -377,7 +377,7 @@ namespace Svc {
         this->log_ACTIVITY_HI_PrmFileLoadComplete(recordNum);
     }
 
-    void PrmDbImpl::pingIn_handler(NATIVE_INT_TYPE portNum, U32 key) {
+    void PrmDbImpl::pingIn_handler(FwIndexType portNum, U32 key) {
         // respond to ping
         this->pingOut_out(0,key);
     }

--- a/Svc/PrmDb/PrmDbImpl.hpp
+++ b/Svc/PrmDb/PrmDbImpl.hpp
@@ -69,7 +69,7 @@ namespace Svc {
             //!  \param id identifier for parameter being used.
             //!  \param val buffer where value is placed.
             //!  \return status of retrieval. PARAM_VALID = successful read, PARAM_INVALID = unsuccessful read
-            Fw::ParamValid getPrm_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+            Fw::ParamValid getPrm_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
             //!  \brief PrmDb parameter set handler
             //!
             //!  This function updates the value of the parameter stored in RAM. The PRM_SAVE_FILE
@@ -78,7 +78,7 @@ namespace Svc {
             //!  \param portNum input port number. Should always be zero
             //!  \param id identifier for parameter being used.
             //!  \param val buffer where value to be saved is stored.
-            void setPrm_handler(NATIVE_INT_TYPE portNum, FwPrmIdType id, Fw::ParamBuffer &val);
+            void setPrm_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer &val);
 
             //!  \brief component ping handler
             //!
@@ -89,7 +89,7 @@ namespace Svc {
             //!  \param opCode the opcode being registered.
             //!  \param key the key value that is returned with the ping response
 
-            void pingIn_handler(NATIVE_INT_TYPE portNum, U32 key);
+            void pingIn_handler(FwIndexType portNum, U32 key);
             //!  \brief PrmDb PRM_SAVE_FILE command handler
             //!
             //!  This function saves the parameter values stored in RAM to the file

--- a/Svc/PrmDb/test/ut/PrmDbImplTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbImplTester.cpp
@@ -624,7 +624,7 @@ namespace Svc {
 
     void PrmDbImplTester ::
       from_pingOut_handler(
-          const NATIVE_INT_TYPE portNum,
+          const FwIndexType portNum,
           U32 key
       )
     {

--- a/Svc/PrmDb/test/ut/PrmDbImplTester.hpp
+++ b/Svc/PrmDb/test/ut/PrmDbImplTester.hpp
@@ -35,7 +35,7 @@ namespace Svc {
             //! Handler for from_pingOut
             //!
             void from_pingOut_handler(
-                const NATIVE_INT_TYPE portNum, /*!< The port number*/
+                const FwIndexType portNum, /*!< The port number*/
                 U32 key /*!< Value to return to pinger*/
             );
             Svc::PrmDbImpl& m_impl;

--- a/Svc/RateGroupDriver/RateGroupDriver.cpp
+++ b/Svc/RateGroupDriver/RateGroupDriver.cpp
@@ -41,7 +41,7 @@ namespace Svc {
 
     }
 
-    void RateGroupDriver::CycleIn_handler(NATIVE_INT_TYPE portNum, Os::RawTime& cycleStart) {
+    void RateGroupDriver::CycleIn_handler(FwIndexType portNum, Os::RawTime& cycleStart) {
 
         // Make sure that the dividers have been configured:
         // If this asserts, add the configure() call to initialization.

--- a/Svc/RateGroupDriver/RateGroupDriver.hpp
+++ b/Svc/RateGroupDriver/RateGroupDriver.hpp
@@ -81,7 +81,7 @@ namespace Svc {
 
             //! downcall for input port
             //! NOTE: This port can execute in ISR context.
-            void CycleIn_handler(NATIVE_INT_TYPE portNum, Os::RawTime& cycleStart);
+            void CycleIn_handler(FwIndexType portNum, Os::RawTime& cycleStart);
 
             //! divider array
             Divider m_dividers[NUM_CYCLEOUT_OUTPUT_PORTS];

--- a/Svc/RateGroupDriver/test/ut/RateGroupDriverImplTester.cpp
+++ b/Svc/RateGroupDriver/test/ut/RateGroupDriverImplTester.cpp
@@ -33,7 +33,7 @@ namespace Svc {
     RateGroupDriverImplTester::~RateGroupDriverImplTester() {
     }
 
-    void RateGroupDriverImplTester::from_CycleOut_handler(NATIVE_INT_TYPE portNum, Os::RawTime& cycleStart) {
+    void RateGroupDriverImplTester::from_CycleOut_handler(FwIndexType portNum, Os::RawTime& cycleStart) {
         this->m_portCalls[portNum] = true;
     }
 

--- a/Svc/RateGroupDriver/test/ut/RateGroupDriverImplTester.hpp
+++ b/Svc/RateGroupDriver/test/ut/RateGroupDriverImplTester.hpp
@@ -24,7 +24,7 @@ namespace Svc {
 
         private:
 
-            void from_CycleOut_handler(NATIVE_INT_TYPE portNum, Os::RawTime& cycleStart);
+            void from_CycleOut_handler(FwIndexType portNum, Os::RawTime& cycleStart);
 
             Svc::RateGroupDriver& m_impl;
 

--- a/Svc/SeqDispatcher/SeqDispatcher.cpp
+++ b/Svc/SeqDispatcher/SeqDispatcher.cpp
@@ -58,7 +58,7 @@ void SeqDispatcher::runSequence(FwIndexType sequencerIdx,
 }
 
 void SeqDispatcher::seqStartIn_handler(
-    NATIVE_INT_TYPE portNum, //!< The port number
+    FwIndexType portNum, //!< The port number
     const Fw::StringBase& fileName //!< The sequence file name
 ) {
   FW_ASSERT(portNum >= 0 && portNum < SeqDispatcherSequencerPorts, portNum);
@@ -91,7 +91,7 @@ void SeqDispatcher::seqStartIn_handler(
 }
 
 void SeqDispatcher::seqDoneIn_handler(
-    NATIVE_INT_TYPE portNum,         //!< The port number
+    FwIndexType portNum,         //!< The port number
     FwOpcodeType opCode,             //!< Command Op Code
     U32 cmdSeq,                      //!< Command Sequence
     const Fw::CmdResponse& response  //!< The command response argument
@@ -136,7 +136,7 @@ void SeqDispatcher::seqDoneIn_handler(
 }
 
 //! Handler for input port seqRunIn
-void SeqDispatcher::seqRunIn_handler(NATIVE_INT_TYPE portNum,
+void SeqDispatcher::seqRunIn_handler(FwIndexType portNum,
                                      const Fw::StringBase& fileName) {
   FwIndexType idx = this->getNextAvailableSequencerIdx();
   // no available sequencers

--- a/Svc/SeqDispatcher/SeqDispatcher.hpp
+++ b/Svc/SeqDispatcher/SeqDispatcher.hpp
@@ -34,19 +34,19 @@ class SeqDispatcher : public SeqDispatcherComponentBase {
 
     //! Handler for input port seqDoneIn
     void
-    seqDoneIn_handler(NATIVE_INT_TYPE portNum,         //!< The port number
+    seqDoneIn_handler(FwIndexType portNum,         //!< The port number
                       FwOpcodeType opCode,             //!< Command Op Code
                       U32 cmdSeq,                      //!< Command Sequence
                       const Fw::CmdResponse& response  //!< The command response argument
     );
 
     //! Handler for input port seqStartIn
-    void seqStartIn_handler(NATIVE_INT_TYPE portNum, //!< The port number
+    void seqStartIn_handler(FwIndexType portNum, //!< The port number
                             const Fw::StringBase& fileName //!< The sequence file
     );
 
     //! Handler for input port seqRunIn
-    void seqRunIn_handler(NATIVE_INT_TYPE portNum, //!< The port number
+    void seqRunIn_handler(FwIndexType portNum, //!< The port number
                           const Fw::StringBase& fileName //!< The sequence file
     );
 

--- a/Svc/StaticMemory/StaticMemoryComponentImpl.cpp
+++ b/Svc/StaticMemory/StaticMemoryComponentImpl.cpp
@@ -33,7 +33,7 @@ StaticMemoryComponentImpl ::~StaticMemoryComponentImpl() {}
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void StaticMemoryComponentImpl ::bufferDeallocate_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& fwBuffer) {
+void StaticMemoryComponentImpl ::bufferDeallocate_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     FW_ASSERT(static_cast<NATIVE_UINT_TYPE>(portNum) < FW_NUM_ARRAY_ELEMENTS(m_static_memory));
     FW_ASSERT(m_allocated[portNum], portNum); // It is also an error to deallocate before returning
     // Check the memory returned is within the region
@@ -45,7 +45,7 @@ void StaticMemoryComponentImpl ::bufferDeallocate_handler(const NATIVE_INT_TYPE 
     m_allocated[portNum] = false;
 }
 
-Fw::Buffer StaticMemoryComponentImpl ::bufferAllocate_handler(const NATIVE_INT_TYPE portNum, U32 size) {
+Fw::Buffer StaticMemoryComponentImpl ::bufferAllocate_handler(const FwIndexType portNum, U32 size) {
     FW_ASSERT(static_cast<NATIVE_UINT_TYPE>(portNum) < FW_NUM_ARRAY_ELEMENTS(m_static_memory));
     FW_ASSERT(size <= sizeof(m_static_memory[portNum])); // It is a topology error to ask for too much from this component
     FW_ASSERT(not m_allocated[portNum], portNum); // It is also an error to allocate again before returning

--- a/Svc/StaticMemory/StaticMemoryComponentImpl.hpp
+++ b/Svc/StaticMemory/StaticMemoryComponentImpl.hpp
@@ -41,12 +41,12 @@ class StaticMemoryComponentImpl : public StaticMemoryComponentBase {
 
     //! Handler implementation for bufferDeallocate
     //!
-    void bufferDeallocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void bufferDeallocate_handler(const FwIndexType portNum, /*!< The port number*/
                                   Fw::Buffer& fwBuffer);
 
     //! Handler implementation for bufferAllocate
     //!
-    Fw::Buffer bufferAllocate_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    Fw::Buffer bufferAllocate_handler(const FwIndexType portNum, /*!< The port number*/
                                       U32 size);
 
     bool m_allocated[NUM_BUFFERALLOCATE_INPUT_PORTS];

--- a/Svc/SystemResources/SystemResources.cpp
+++ b/Svc/SystemResources/SystemResources.cpp
@@ -63,7 +63,7 @@ SystemResources ::~SystemResources() {}
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void SystemResources ::run_handler(const NATIVE_INT_TYPE portNum, U32 tick_time_hz) {
+void SystemResources ::run_handler(const FwIndexType portNum, U32 tick_time_hz) {
     if (m_enable) {
         Cpu();
         Mem();

--- a/Svc/SystemResources/SystemResources.hpp
+++ b/Svc/SystemResources/SystemResources.hpp
@@ -46,7 +46,7 @@ class SystemResources : public SystemResourcesComponentBase {
         //! Handler implementation for run
         //!
         void
-        run_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+        run_handler(const FwIndexType portNum, /*!< The port number*/
                     U32 context                    /*!< The call order*/
         );
 

--- a/Svc/TlmChan/TlmChan.cpp
+++ b/Svc/TlmChan/TlmChan.cpp
@@ -46,12 +46,12 @@ NATIVE_UINT_TYPE TlmChan::doHash(FwChanIdType id) {
     return (id % TLMCHAN_HASH_MOD_VALUE) % TLMCHAN_NUM_TLM_HASH_SLOTS;
 }
 
-void TlmChan::pingIn_handler(const NATIVE_INT_TYPE portNum, U32 key) {
+void TlmChan::pingIn_handler(const FwIndexType portNum, U32 key) {
     // return key
     this->pingOut_out(0, key);
 }
 
-void TlmChan::TlmGet_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val) {
+void TlmChan::TlmGet_handler(FwIndexType portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val) {
     // Compute index for entry
 
     NATIVE_UINT_TYPE index = this->doHash(id);
@@ -78,7 +78,7 @@ void TlmChan::TlmGet_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time&
     }
 }
 
-void TlmChan::TlmRecv_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val) {
+void TlmChan::TlmRecv_handler(FwIndexType portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val) {
     // Compute index for entry
 
     NATIVE_UINT_TYPE index = this->doHash(id);
@@ -128,7 +128,7 @@ void TlmChan::TlmRecv_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time
     entryToUse->buffer = val;
 }
 
-void TlmChan::Run_handler(NATIVE_INT_TYPE portNum, U32 context) {
+void TlmChan::Run_handler(FwIndexType portNum, U32 context) {
     // Only write packets if connected
     if (not this->isConnected_PktSend_OutputPort(0)) {
         return;

--- a/Svc/TlmChan/TlmChan.hpp
+++ b/Svc/TlmChan/TlmChan.hpp
@@ -30,12 +30,12 @@ class TlmChan : public TlmChanComponentBase {
 
   PRIVATE:
     // Port functions
-    void TlmRecv_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val);
-    void TlmGet_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val);
-    void Run_handler(NATIVE_INT_TYPE portNum, U32 context);
+    void TlmRecv_handler(FwIndexType portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val);
+    void TlmGet_handler(FwIndexType portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val);
+    void Run_handler(FwIndexType portNum, U32 context);
     //! Handler implementation for pingIn
     //!
-    void pingIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void pingIn_handler(const FwIndexType portNum, /*!< The port number*/
                         U32 key                        /*!< Value to return to pinger*/
     );
 

--- a/Svc/TlmChan/test/ut/TlmChanTester.cpp
+++ b/Svc/TlmChan/test/ut/TlmChanTester.cpp
@@ -136,14 +136,14 @@ void TlmChanTester::runOffNominal() {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void TlmChanTester ::from_PktSend_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer& data, U32 context) {
+void TlmChanTester ::from_PktSend_handler(const FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
     this->pushFromPortEntry_PktSend(data, context);
     this->m_bufferRecv = true;
     this->m_rcvdBuffer[this->m_numBuffs] = data;
     this->m_numBuffs++;
 }
 
-void TlmChanTester ::from_pingOut_handler(const NATIVE_INT_TYPE portNum, U32 key) {
+void TlmChanTester ::from_pingOut_handler(const FwIndexType portNum, U32 key) {
     this->pushFromPortEntry_pingOut(key);
 }
 

--- a/Svc/TlmChan/test/ut/TlmChanTester.hpp
+++ b/Svc/TlmChan/test/ut/TlmChanTester.hpp
@@ -42,14 +42,14 @@ class TlmChanTester : public TlmChanGTestBase {
 
     //! Handler for from_PktSend
     //!
-    void from_PktSend_handler(const NATIVE_INT_TYPE portNum, //!< The port number
+    void from_PktSend_handler(const FwIndexType portNum, //!< The port number
                               Fw::ComBuffer& data,           //!< Buffer containing packet data
                               U32 context                    //!< Call context value; meaning chosen by user
     );
 
     //! Handler for from_pingOut
     //!
-    void from_pingOut_handler(const NATIVE_INT_TYPE portNum, //!< The port number
+    void from_pingOut_handler(const FwIndexType portNum, //!< The port number
                               U32 key                        //!< Value to return to pinger
     );
 

--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -180,7 +180,7 @@ TlmPacketizer::TlmEntry* TlmPacketizer::findBucket(FwChanIdType id) {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void TlmPacketizer ::TlmRecv_handler(const NATIVE_INT_TYPE portNum,
+void TlmPacketizer ::TlmRecv_handler(const FwIndexType portNum,
                                      FwChanIdType id,
                                      Fw::Time& timeTag,
                                      Fw::TlmBuffer& val) {
@@ -231,7 +231,7 @@ void TlmPacketizer ::TlmRecv_handler(const NATIVE_INT_TYPE portNum,
     }
 }
 
-void TlmPacketizer ::Run_handler(const NATIVE_INT_TYPE portNum, U32 context) {
+void TlmPacketizer ::Run_handler(const FwIndexType portNum, U32 context) {
     FW_ASSERT(this->m_configured);
 
     // Only write packets if connected
@@ -278,7 +278,7 @@ void TlmPacketizer ::Run_handler(const NATIVE_INT_TYPE portNum, U32 context) {
     }
 }
 
-void TlmPacketizer ::pingIn_handler(const NATIVE_INT_TYPE portNum, U32 key) {
+void TlmPacketizer ::pingIn_handler(const FwIndexType portNum, U32 key) {
     // return key
     this->pingOut_out(0, key);
 }

--- a/Svc/TlmPacketizer/TlmPacketizer.hpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.hpp
@@ -45,7 +45,7 @@ class TlmPacketizer : public TlmPacketizerComponentBase {
 
     //! Handler implementation for TlmRecv
     //!
-    void TlmRecv_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void TlmRecv_handler(const FwIndexType portNum, /*!< The port number*/
                          FwChanIdType id,               /*!< Telemetry Channel ID*/
                          Fw::Time& timeTag,             /*!< Time Tag*/
                          Fw::TlmBuffer& val             /*!< Buffer containing serialized telemetry value*/
@@ -53,13 +53,13 @@ class TlmPacketizer : public TlmPacketizerComponentBase {
 
     //! Handler implementation for Run
     //!
-    void Run_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void Run_handler(const FwIndexType portNum, /*!< The port number*/
                      U32 context                    /*!< The call order*/
     );
 
     //! Handler implementation for pingIn
     //!
-    void pingIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void pingIn_handler(const FwIndexType portNum, /*!< The port number*/
                         U32 key                        /*!< Value to return to pinger*/
     );
 

--- a/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
+++ b/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
@@ -904,11 +904,11 @@ void TlmPacketizerTester ::pingTest() {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void TlmPacketizerTester ::from_PktSend_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer& data, U32 context) {
+void TlmPacketizerTester ::from_PktSend_handler(const FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
     this->pushFromPortEntry_PktSend(data, context);
 }
 
-void TlmPacketizerTester ::from_pingOut_handler(const NATIVE_INT_TYPE portNum, U32 key) {
+void TlmPacketizerTester ::from_pingOut_handler(const FwIndexType portNum, U32 key) {
     this->pushFromPortEntry_pingOut(key);
 }
 

--- a/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.hpp
+++ b/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.hpp
@@ -82,14 +82,14 @@ class TlmPacketizerTester : public TlmPacketizerGTestBase {
 
     //! Handler for from_PktSend
     //!
-    void from_PktSend_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_PktSend_handler(const FwIndexType portNum, /*!< The port number*/
                               Fw::ComBuffer& data,           /*!< Buffer containing packet data*/
                               U32 context                    /*!< Call context value; meaning chosen by user*/
     ) override;
 
     //! Handler for from_pingOut
     //!
-    void from_pingOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_pingOut_handler(const FwIndexType portNum, /*!< The port number*/
                               U32 key                        /*!< Value to return to pinger*/
     ) override;
 

--- a/Svc/UdpReceiver/UdpReceiverComponentImpl.cpp
+++ b/Svc/UdpReceiver/UdpReceiverComponentImpl.cpp
@@ -106,7 +106,7 @@ namespace Svc {
 
   void UdpReceiverComponentImpl ::
     Sched_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 context
     )
   {

--- a/Svc/UdpReceiver/UdpReceiverComponentImpl.hpp
+++ b/Svc/UdpReceiver/UdpReceiverComponentImpl.hpp
@@ -60,7 +60,7 @@ namespace Svc {
       //! Handler implementation for Sched
       //!
       void Sched_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 context /*!< The call order*/
       );
 

--- a/Svc/UdpReceiver/test/ut/Tester.cpp
+++ b/Svc/UdpReceiver/test/ut/Tester.cpp
@@ -81,7 +81,7 @@ namespace Svc {
 
   void Tester ::
     from_PortsOut_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {

--- a/Svc/UdpReceiver/test/ut/Tester.hpp
+++ b/Svc/UdpReceiver/test/ut/Tester.hpp
@@ -59,7 +59,7 @@ namespace Svc {
       //! Handler for from_PortsOut
       //!
       void from_PortsOut_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
       );
 

--- a/Svc/UdpSender/UdpSenderComponentImpl.cpp
+++ b/Svc/UdpSender/UdpSenderComponentImpl.cpp
@@ -79,7 +79,7 @@ namespace Svc {
 
   void UdpSenderComponentImpl ::
     Sched_handler(
-        const NATIVE_INT_TYPE portNum,
+        const FwIndexType portNum,
         U32 context
     )
   {
@@ -93,7 +93,7 @@ namespace Svc {
 
   void UdpSenderComponentImpl ::
     PortsIn_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
     )
   {

--- a/Svc/UdpSender/UdpSenderComponentImpl.hpp
+++ b/Svc/UdpSender/UdpSenderComponentImpl.hpp
@@ -57,7 +57,7 @@ namespace Svc {
       //! Handler implementation for Sched
       //!
       void Sched_handler(
-          const NATIVE_INT_TYPE portNum, /*!< The port number*/
+          const FwIndexType portNum, /*!< The port number*/
           U32 context /*!< The call order*/
       );
 
@@ -70,7 +70,7 @@ namespace Svc {
       //! Handler implementation for PortsIn
       //!
       void PortsIn_handler(
-        NATIVE_INT_TYPE portNum, /*!< The port number*/
+        FwIndexType portNum, /*!< The port number*/
         Fw::SerializeBufferBase &Buffer /*!< The serialization buffer*/
       );
 

--- a/cmake/test/data/test-fprime-library/TestLibrary/TestComponent/TestComponent.cpp
+++ b/cmake/test/data/test-fprime-library/TestLibrary/TestComponent/TestComponent.cpp
@@ -12,5 +12,5 @@ void TestComponent ::init(const NATIVE_INT_TYPE instance) {
 
 TestComponent ::~TestComponent() {}
 
-void TestComponent ::schedIn_handler(NATIVE_INT_TYPE portNum, U32 context) {}
+void TestComponent ::schedIn_handler(FwIndexType portNum, U32 context) {}
 };

--- a/cmake/test/data/test-fprime-library/TestLibrary/TestComponent/TestComponent.hpp
+++ b/cmake/test/data/test-fprime-library/TestLibrary/TestComponent/TestComponent.hpp
@@ -12,7 +12,7 @@ class TestComponent : public TestComponentComponentBase
     void init(const NATIVE_INT_TYPE instance);
     ~TestComponent();
   private:
-    void schedIn_handler(NATIVE_INT_TYPE portNum, U32 context);
+    void schedIn_handler(FwIndexType portNum, U32 context);
 };
 
 };

--- a/cmake/test/data/test-fprime-library2/TestLibrary2/TestComponent/TestComponent.cpp
+++ b/cmake/test/data/test-fprime-library2/TestLibrary2/TestComponent/TestComponent.cpp
@@ -12,5 +12,5 @@ void TestComponent ::init(const NATIVE_INT_TYPE instance) {
 
 TestComponent ::~TestComponent() {}
 
-void TestComponent ::schedIn_handler(NATIVE_INT_TYPE portNum, U32 context) {}
+void TestComponent ::schedIn_handler(FwIndexType portNum, U32 context) {}
 };

--- a/cmake/test/data/test-fprime-library2/TestLibrary2/TestComponent/TestComponent.hpp
+++ b/cmake/test/data/test-fprime-library2/TestLibrary2/TestComponent/TestComponent.hpp
@@ -12,7 +12,7 @@ class TestComponent : public TestComponentComponentBase
     void init(const NATIVE_INT_TYPE instance);
     ~TestComponent();
   private:
-    void schedIn_handler(NATIVE_INT_TYPE portNum, U32 context);
+    void schedIn_handler(FwIndexType portNum, U32 context);
 };
 
 };


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This is an automatic replacement of `NATIVE_INT_TYPE portNum` to `FwIndexType portNum` to match the output of the FPP autocoder. 