### PR TITLE
Converting NATIVE_INT_TYPE in assert casts

### DIFF
--- a/Autocoders/Python/test/pass_by_attrib/Msg1Port.cpp
+++ b/Autocoders/Python/test/pass_by_attrib/Msg1Port.cpp
@@ -71,13 +71,13 @@ namespace Ports {
 
         U32 arg3;
         status = buffer.deserialize(arg3);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<FwAssertArgType>(status));
         U32 *arg2;
         status = buffer.deserialize(static_cast<void *>(arg2));
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<FwAssertArgType>(status));
         U32 arg1;
         status = buffer.deserialize(arg1);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<FwAssertArgType>(status));
 
         this->m_func(this->m_comp, this->m_portNum, arg1, arg2, arg3);
     }
@@ -114,13 +114,13 @@ void OutputMsg1Port::invoke(U32 arg1, U32 *arg2, U32 &arg3) {
         Fw::SerializeStatus status;
         Msg1PortBuffer _buffer;
         status = _buffer.serialize(arg1);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<FwAssertArgType>(status));
 
         status = _buffer.serialize(static_cast<void *>(arg2));
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<FwAssertArgType>(status));
 
         status = _buffer.serialize(arg3);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == status,static_cast<FwAssertArgType>(status));
 
         this->m_serPort->invokeSerial(_buffer);
 #endif

--- a/Drv/Ports/DataTypes/DataBuffer.cpp
+++ b/Drv/Ports/DataTypes/DataBuffer.cpp
@@ -5,7 +5,7 @@ namespace Drv {
 
     DataBuffer::DataBuffer(const U8 *args, NATIVE_UINT_TYPE size) {
         Fw::SerializeStatus stat = Fw::SerializeBufferBase::setBuff(args,size);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
     }
 
     DataBuffer::DataBuffer() {
@@ -16,7 +16,7 @@ namespace Drv {
 
     DataBuffer::DataBuffer(const DataBuffer& other) : Fw::SerializeBufferBase() {
         Fw::SerializeStatus stat = Fw::SerializeBufferBase::setBuff(other.m_data,other.getBuffLength());
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
     }
 
     DataBuffer& DataBuffer::operator=(const DataBuffer& other) {
@@ -25,7 +25,7 @@ namespace Drv {
         }
 
         Fw::SerializeStatus stat = Fw::SerializeBufferBase::setBuff(other.m_data,other.getBuffLength());
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
         return *this;
     }
 

--- a/Fw/Cmd/CmdArgBuffer.cpp
+++ b/Fw/Cmd/CmdArgBuffer.cpp
@@ -5,7 +5,7 @@ namespace Fw {
 
     CmdArgBuffer::CmdArgBuffer(const U8 *args, NATIVE_UINT_TYPE size) {
         SerializeStatus stat = this->setBuff(args,size);
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
     }
 
     CmdArgBuffer::CmdArgBuffer() {
@@ -16,7 +16,7 @@ namespace Fw {
 
     CmdArgBuffer::CmdArgBuffer(const CmdArgBuffer& other) : Fw::SerializeBufferBase() {
         SerializeStatus stat = this->setBuff(other.m_bufferData,other.getBuffLength());
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
     }
 
     CmdArgBuffer& CmdArgBuffer::operator=(const CmdArgBuffer& other) {
@@ -25,7 +25,7 @@ namespace Fw {
         }
 
         SerializeStatus stat = this->setBuff(other.m_bufferData,other.getBuffLength());
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
         return *this;
     }
 

--- a/Fw/Com/ComBuffer.cpp
+++ b/Fw/Com/ComBuffer.cpp
@@ -5,7 +5,7 @@ namespace Fw {
 
     ComBuffer::ComBuffer(const U8 *args, NATIVE_UINT_TYPE size) {
         SerializeStatus stat = SerializeBufferBase::setBuff(args,size);
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
     }
 
     ComBuffer::ComBuffer() {
@@ -16,7 +16,7 @@ namespace Fw {
 
     ComBuffer::ComBuffer(const ComBuffer& other) : Fw::SerializeBufferBase() {
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
     }
 
     ComBuffer& ComBuffer::operator=(const ComBuffer& other) {
@@ -25,7 +25,7 @@ namespace Fw {
         }
 
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
         return *this;
     }
 

--- a/Fw/Comp/ActiveComponentBase.cpp
+++ b/Fw/Comp/ActiveComponentBase.cpp
@@ -56,13 +56,13 @@ namespace Fw {
         Os::Task::taskRoutine routine = (m_task.isCooperative()) ? this->s_taskStateMachine : this->s_taskLoop;
         Os::Task::Arguments arguments(taskName, routine, this, priority, stackSize, cpuAffinity, static_cast<PlatformUIntType>(identifier));
         Os::Task::Status status = this->m_task.start(arguments);
-        FW_ASSERT(status == Os::Task::Status::OP_OK,static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(status == Os::Task::Status::OP_OK,static_cast<FwAssertArgType>(status));
     }
 
     void ActiveComponentBase::exit() {
         ActiveComponentExitSerializableBuffer exitBuff;
         SerializeStatus stat = exitBuff.serialize(static_cast<I32>(ACTIVE_COMPONENT_EXIT));
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
         (void)this->m_queue.send(exitBuff,0,Os::Queue::BlockingType::NONBLOCKING);
     }
 

--- a/Fw/Log/AmpcsEvrLogPacket.cpp
+++ b/Fw/Log/AmpcsEvrLogPacket.cpp
@@ -80,7 +80,7 @@ namespace Fw {
         if (stat == FW_SERIALIZE_OK) {
             // Shouldn't fail
             stat = this->m_logBuffer.setBuffLen(size);
-            FW_ASSERT(stat == FW_SERIALIZE_OK,static_cast<NATIVE_INT_TYPE>(stat));
+            FW_ASSERT(stat == FW_SERIALIZE_OK,static_cast<FwAssertArgType>(stat));
         }
         return stat;
     }

--- a/Fw/Log/LogPacket.cpp
+++ b/Fw/Log/LogPacket.cpp
@@ -61,7 +61,7 @@ namespace Fw {
         if (stat == FW_SERIALIZE_OK) {
             // Shouldn't fail
             stat = this->m_logBuffer.setBuffLen(size);
-            FW_ASSERT(stat == FW_SERIALIZE_OK,static_cast<NATIVE_INT_TYPE>(stat));
+            FW_ASSERT(stat == FW_SERIALIZE_OK,static_cast<FwAssertArgType>(stat));
         }
         return stat;
     }

--- a/Fw/Prm/PrmBuffer.cpp
+++ b/Fw/Prm/PrmBuffer.cpp
@@ -5,7 +5,7 @@ namespace Fw {
 
 	ParamBuffer::ParamBuffer(const U8 *args, NATIVE_UINT_TYPE size) {
 	    SerializeStatus stat = SerializeBufferBase::setBuff(args,size);
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
     }
 
 	ParamBuffer::ParamBuffer() {
@@ -16,7 +16,7 @@ namespace Fw {
 
     ParamBuffer::ParamBuffer(const ParamBuffer& other) : Fw::SerializeBufferBase() {
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
 	}
 
     ParamBuffer& ParamBuffer::operator=(const ParamBuffer& other) {
@@ -25,7 +25,7 @@ namespace Fw {
         }
 
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
         return *this;
     }
 

--- a/Fw/Sm/SmSignalBuffer.cpp
+++ b/Fw/Sm/SmSignalBuffer.cpp
@@ -7,7 +7,7 @@ namespace Fw {
         FW_ASSERT(args != nullptr);
         FW_ASSERT(size <= sizeof(this->m_bufferData));
         SerializeStatus stat = SerializeBufferBase::setBuff(args,static_cast<NATIVE_UINT_TYPE>(size));
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
     }
 
     SmSignalBuffer::SmSignalBuffer() : m_bufferData{} {
@@ -23,7 +23,7 @@ namespace Fw {
         FW_ASSERT(other.getBuffLength() <= sizeof(this->m_bufferData));
 
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
     }
 
     SmSignalBuffer& SmSignalBuffer::operator=(const SmSignalBuffer& other) {
@@ -35,7 +35,7 @@ namespace Fw {
         FW_ASSERT(other.getBuffLength() <= sizeof(this->m_bufferData));
 
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
         return *this;
     }
 

--- a/Fw/Tlm/TlmBuffer.cpp
+++ b/Fw/Tlm/TlmBuffer.cpp
@@ -5,7 +5,7 @@ namespace Fw {
 
     TlmBuffer::TlmBuffer(const U8 *args, NATIVE_UINT_TYPE size) {
         SerializeStatus stat = SerializeBufferBase::setBuff(args,size);
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
     }
 
     TlmBuffer::TlmBuffer() {
@@ -16,7 +16,7 @@ namespace Fw {
 
     TlmBuffer::TlmBuffer(const TlmBuffer& other) : Fw::SerializeBufferBase() {
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
     }
 
     TlmBuffer& TlmBuffer::operator=(const TlmBuffer& other) {
@@ -25,7 +25,7 @@ namespace Fw {
         }
 
         SerializeStatus stat = SerializeBufferBase::setBuff(other.m_bufferData,other.getBuffLength());
-        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
         return *this;
     }
 

--- a/Fw/Tlm/TlmPacket.cpp
+++ b/Fw/Tlm/TlmPacket.cpp
@@ -152,7 +152,7 @@ namespace Fw {
         if (stat == FW_SERIALIZE_OK) {
             // Shouldn't fail
             stat = this->m_tlmBuffer.setBuffLen(size);
-            FW_ASSERT(stat == FW_SERIALIZE_OK,static_cast<NATIVE_INT_TYPE>(stat));
+            FW_ASSERT(stat == FW_SERIALIZE_OK,static_cast<FwAssertArgType>(stat));
         }
         return stat;
     }

--- a/Os/Posix/test/ut/PosixMutexTests.cpp
+++ b/Os/Posix/test/ut/PosixMutexTests.cpp
@@ -47,7 +47,7 @@ TEST_F(FunctionalityTester, PosixMutexDataProtection) {
     Os::Task test_task;
     Os::Task::Arguments arguments(Fw::String("MutexTestLockTask"), testTaskRoutine, static_cast<void*>(tester.get()));
     Os::Task::Status stat = test_task.start(arguments);
-    FW_ASSERT(Os::Task::OP_OK == stat, static_cast<NATIVE_INT_TYPE>(stat));
+    FW_ASSERT(Os::Task::OP_OK == stat, static_cast<FwAssertArgType>(stat));
 
     Os::Test::Mutex::Tester::ProtectDataCheck protect_data_rule;
 

--- a/Ref/RecvBuffApp/RecvBuffComponentImpl.cpp
+++ b/Ref/RecvBuffApp/RecvBuffComponentImpl.cpp
@@ -31,16 +31,16 @@ namespace Ref {
         // deserialize packet ID
         U32 id = 0;
         Fw::SerializeStatus stat = buff.deserialize(id);
-        FW_ASSERT(stat == Fw::FW_SERIALIZE_OK,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(stat == Fw::FW_SERIALIZE_OK,static_cast<FwAssertArgType>(stat));
         // deserialize data
         U8 testData[24] = {0};
         NATIVE_UINT_TYPE size = sizeof(testData);
         stat = buff.deserialize(testData,size);
-        FW_ASSERT(stat == Fw::FW_SERIALIZE_OK,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(stat == Fw::FW_SERIALIZE_OK,static_cast<FwAssertArgType>(stat));
         // deserialize checksum
         U32 csum = 0;
         stat = buff.deserialize(csum);
-        FW_ASSERT(stat == Fw::FW_SERIALIZE_OK,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(stat == Fw::FW_SERIALIZE_OK,static_cast<FwAssertArgType>(stat));
         // if first packet, send event
         if (not this->m_firstBuffReceived) {
             this->log_ACTIVITY_LO_FirstPacketReceived(id);

--- a/Svc/ActiveLogger/ActiveLoggerImpl.cpp
+++ b/Svc/ActiveLogger/ActiveLoggerImpl.cpp
@@ -79,7 +79,7 @@ namespace Svc {
                 }
                 break;
             default:
-                FW_ASSERT(0,static_cast<NATIVE_INT_TYPE>(severity.e));
+                FW_ASSERT(0,static_cast<FwAssertArgType>(severity.e));
                 return;
         }
 
@@ -112,7 +112,7 @@ namespace Svc {
         this->m_logPacket.setLogBuffer(args);
         this->m_comBuffer.resetSer();
         Fw::SerializeStatus stat = this->m_logPacket.serialize(this->m_comBuffer);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<NATIVE_INT_TYPE>(stat));
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == stat,static_cast<FwAssertArgType>(stat));
 
         if (this->isConnected_PktSend_OutputPort(0)) {
             this->PktSend_out(0, this->m_comBuffer,0);

--- a/Svc/GenericHub/GenericHubComponentImpl.cpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.cpp
@@ -39,11 +39,11 @@ void GenericHubComponentImpl ::send_data(const HubType type,
     Fw::SerializeBufferBase& serialize = outgoing.getSerializeRepr();
     // Write data to our buffer
     status = serialize.serialize(static_cast<U32>(type));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = serialize.serialize(static_cast<U32>(port));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = serialize.serialize(data, size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     outgoing.setSize(serialize.getBuffLength());
     dataOut_out(0, outgoing);
 }
@@ -70,15 +70,15 @@ void GenericHubComponentImpl ::dataIn_handler(const FwIndexType portNum, Fw::Buf
 
     // Must inform buffer that there is *real* data in the buffer
     status = incoming.setBuffLen(fwBuffer.getSize());
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = incoming.deserialize(type_in);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     type = static_cast<HubType>(type_in);
     FW_ASSERT(type < HUB_TYPE_MAX, type);
     status = incoming.deserialize(port);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = incoming.deserialize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // invokeSerial deserializes arguments before calling a normal invoke, this will return ownership immediately
     U8* rawData = fwBuffer.getData() + sizeof(U32) + sizeof(U32) + sizeof(FwBuffSizeType);
@@ -88,7 +88,7 @@ void GenericHubComponentImpl ::dataIn_handler(const FwIndexType portNum, Fw::Buf
         // Com buffer representations should be copied before the call returns, so we need not "allocate" new data
         Fw::ExternalSerializeBuffer wrapper(rawData, rawSize);
         status = wrapper.setBuffLen(rawSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         portOut_out(static_cast<FwIndexType>(port), wrapper);
         // Deallocate the existing buffer
         dataInDeallocate_out(0, fwBuffer);
@@ -104,13 +104,13 @@ void GenericHubComponentImpl ::dataIn_handler(const FwIndexType portNum, Fw::Buf
 
         // Deserialize tokens for events
         status = incoming.deserialize(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         status = incoming.deserialize(timeTag);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         status = incoming.deserialize(severity);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         status = incoming.deserialize(args);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
         // Send it!
         this->LogSend_out(static_cast<FwIndexType>(port), id, timeTag, severity, args);
@@ -124,11 +124,11 @@ void GenericHubComponentImpl ::dataIn_handler(const FwIndexType portNum, Fw::Buf
 
         // Deserialize tokens for channels
         status = incoming.deserialize(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         status = incoming.deserialize(timeTag);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         status = incoming.deserialize(val);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<NATIVE_INT_TYPE>(status));
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
         // Send it!
         this->TlmSend_out(static_cast<FwIndexType>(port), id, timeTag, val);

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -170,7 +170,7 @@ namespace Svc {
                 buff.resetSer();
                 Fw::SerializeStatus serStat = buff.serialize(recordSize);
                 // should always work
-                FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat,static_cast<NATIVE_INT_TYPE>(serStat));
+                FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat,static_cast<FwAssertArgType>(serStat));
 
                 // write record size
                 writeSize = buff.getBuffLength();
@@ -198,7 +198,7 @@ namespace Svc {
 
                 serStat = buff.serialize(this->m_db[entry].id);
                 // should always work
-                FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat,static_cast<NATIVE_INT_TYPE>(serStat));
+                FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat,static_cast<FwAssertArgType>(serStat));
 
                 // write parameter ID
                 writeSize = buff.getBuffLength();
@@ -312,7 +312,7 @@ namespace Svc {
             // set serialized size to read size
             Fw::SerializeStatus desStat = buff.setBuffLen(static_cast<Fw::Serializable::SizeType>(readSize));
             // should never fail
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == desStat,static_cast<NATIVE_INT_TYPE>(desStat));
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == desStat,static_cast<FwAssertArgType>(desStat));
             // reset deserialization
             buff.resetDeser();
             // deserialize, since record size is serialized in file
@@ -343,7 +343,7 @@ namespace Svc {
             // set serialized size to read parameter ID
             desStat = buff.setBuffLen(static_cast<Fw::Serializable::SizeType>(readSize));
             // should never fail
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == desStat,static_cast<NATIVE_INT_TYPE>(desStat));
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == desStat,static_cast<FwAssertArgType>(desStat));
             // reset deserialization
             buff.resetDeser();
             // deserialize, since parameter ID is serialized in file
@@ -369,7 +369,7 @@ namespace Svc {
             // set serialized size to read size
             desStat = this->m_db[entry].val.setBuffLen(static_cast<Fw::Serializable::SizeType>(readSize));
             // should never fail
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == desStat,static_cast<NATIVE_INT_TYPE>(desStat));
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == desStat,static_cast<FwAssertArgType>(desStat));
             recordNum++;
 
         }

--- a/Svc/TlmChan/TlmChan.cpp
+++ b/Svc/TlmChan/TlmChan.cpp
@@ -162,12 +162,12 @@ void TlmChan::Run_handler(FwIndexType portNum, U32 context) {
                 stat = pkt.addValue(p_entry->id, p_entry->lastUpdate, p_entry->buffer);
                 // if this doesn't work, that means packet isn't big enough for
                 // even one channel, so assert
-                FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, static_cast<NATIVE_INT_TYPE>(stat));
+                FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, static_cast<FwAssertArgType>(stat));
             } else if (Fw::FW_SERIALIZE_OK == stat) {
                 // if there was still room, do nothing move on to the next channel in the packet
             } else  // any other status is an assert, since it shouldn't happen
             {
-                FW_ASSERT(0, static_cast<NATIVE_INT_TYPE>(stat));
+                FW_ASSERT(0, static_cast<FwAssertArgType>(stat));
             }
             // flag as updated
             p_entry->updated = false;

--- a/Utils/Hash/HashBufferCommon.cpp
+++ b/Utils/Hash/HashBufferCommon.cpp
@@ -11,14 +11,14 @@ HashBuffer::HashBuffer() {}
 
 HashBuffer::HashBuffer(const U8* args, NATIVE_UINT_TYPE size) : Fw::SerializeBufferBase() {
     Fw::SerializeStatus stat = Fw::SerializeBufferBase::setBuff(args, size);
-    FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, static_cast<NATIVE_INT_TYPE>(stat));
+    FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, static_cast<FwAssertArgType>(stat));
 }
 
 HashBuffer::~HashBuffer() {}
 
 HashBuffer::HashBuffer(const HashBuffer& other) : Fw::SerializeBufferBase() {
     Fw::SerializeStatus stat = Fw::SerializeBufferBase::setBuff(other.m_bufferData, other.getBuffLength());
-    FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, static_cast<NATIVE_INT_TYPE>(stat));
+    FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, static_cast<FwAssertArgType>(stat));
 }
 
 HashBuffer& HashBuffer::operator=(const HashBuffer& other) {
@@ -27,7 +27,7 @@ HashBuffer& HashBuffer::operator=(const HashBuffer& other) {
     }
 
     Fw::SerializeStatus stat = Fw::SerializeBufferBase::setBuff(other.m_bufferData, other.getBuffLength());
-    FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, static_cast<NATIVE_INT_TYPE>(stat));
+    FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, static_cast<FwAssertArgType>(stat));
     return *this;
 }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This is another automatic change. It changes NATIVE_INT_TYPE to be FwAssertArgType in FW_ASSERT calls.