### PR TITLE
NUM_PORTS -> FwIndexType

### DIFF
--- a/Fw/Port/InputPortBase.hpp
+++ b/Fw/Port/InputPortBase.hpp
@@ -24,7 +24,7 @@ namespace Fw {
             void init() override;
 
             PassiveComponentBase* m_comp; // !< pointer to containing component
-            NATIVE_INT_TYPE m_portNum; // !< port number in containing object
+            FwIndexType m_portNum; // !< port number in containing object
 #if FW_OBJECT_TO_STRING == 1
             const char* getToStringFormatString() override; //!< Get format string for toString call
 #endif

--- a/Svc/ActiveRateGroup/ActiveRateGroup.hpp
+++ b/Svc/ActiveRateGroup/ActiveRateGroup.hpp
@@ -30,7 +30,7 @@ namespace Svc {
 
     class ActiveRateGroup : public ActiveRateGroupComponentBase {
         public:
-            static constexpr NATIVE_INT_TYPE CONNECTION_COUNT_MAX = NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS;
+            static constexpr FwIndexType CONNECTION_COUNT_MAX = NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS;
 
             //!  \brief ActiveRateGroup constructor
             //!

--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -28,7 +28,7 @@ ComQueue ::ComQueue(const char* const compName)
       m_allocator(nullptr),
       m_allocation(nullptr) {
     // Initialize throttles to "off"
-    for (NATIVE_UINT_TYPE i = 0; i < TOTAL_PORT_COUNT; i++) {
+    for (FwIndexType i = 0; i < TOTAL_PORT_COUNT; i++) {
         this->m_throttle[i] = false;
     }
 }
@@ -131,7 +131,7 @@ void ComQueue::comQueueIn_handler(const FwIndexType portNum, Fw::ComBuffer& data
 }
 
 void ComQueue::buffQueueIn_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
-    const NATIVE_INT_TYPE queueNum = portNum + COM_PORT_COUNT;
+    const FwIndexType queueNum = portNum + COM_PORT_COUNT;
     // Ensure that the port number of buffQueueIn is consistent with the expectation
     FW_ASSERT(portNum >= 0 && portNum < BUFFER_PORT_COUNT, portNum);
     FW_ASSERT(queueNum < TOTAL_PORT_COUNT);

--- a/Svc/ComQueue/ComQueue.hpp
+++ b/Svc/ComQueue/ComQueue.hpp
@@ -13,6 +13,7 @@
 #include <Utils/Types/Queue.hpp>
 #include "Fw/Types/MemAllocator.hpp"
 #include "Os/Mutex.hpp"
+#include <limits>
 
 namespace Svc {
 
@@ -28,6 +29,8 @@ class ComQueue : public ComQueueComponentBase {
     //!< Count of Fw::Buffer input ports and thus Fw::Buffer queues
     static const FwIndexType BUFFER_PORT_COUNT = ComQueueComponentBase::NUM_BUFFQUEUEIN_INPUT_PORTS;
 
+    static_assert((COM_PORT_COUNT + BUFFER_PORT_COUNT) <= std::numeric_limits<FwIndexType>::max(),
+                  "FwIndexType not large enough to hold com and buffer ports");
     //!< Total count of input buffer ports and thus total queues
     static const FwIndexType TOTAL_PORT_COUNT = COM_PORT_COUNT + BUFFER_PORT_COUNT;
 

--- a/Svc/ComQueue/test/ut/ComQueueTester.cpp
+++ b/Svc/ComQueue/test/ut/ComQueueTester.cpp
@@ -34,7 +34,7 @@ void ComQueueTester ::dispatchAll() {
 
 void ComQueueTester ::configure() {
     ComQueue::QueueConfigurationTable configurationTable;
-    for (NATIVE_UINT_TYPE i = 0; i < ComQueue::TOTAL_PORT_COUNT; i++){
+    for (FwIndexType i = 0; i < ComQueue::TOTAL_PORT_COUNT; i++){
         configurationTable.entries[i].priority = i;
         configurationTable.entries[i].depth = 3;
     }
@@ -135,7 +135,7 @@ void ComQueueTester ::testPrioritySend() {
 
     ComQueue::QueueConfigurationTable configurationTable;
 
-    for (NATIVE_UINT_TYPE i = 0; i < ComQueue::TOTAL_PORT_COUNT; i++) {
+    for (FwIndexType i = 0; i < ComQueue::TOTAL_PORT_COUNT; i++) {
         configurationTable.entries[i].priority = ComQueue::TOTAL_PORT_COUNT - i - 1;
         configurationTable.entries[i].depth = 3;
         data[i][0] = ComQueue::TOTAL_PORT_COUNT - i - 1;
@@ -162,7 +162,7 @@ void ComQueueTester ::testPrioritySend() {
     ASSERT_from_buffQueueSend_SIZE(0);
     ASSERT_from_comQueueSend_SIZE(0);
 
-    for (NATIVE_INT_TYPE index = 0; index < ComQueue::TOTAL_PORT_COUNT; index++) {
+    for (FwIndexType index = 0; index < ComQueue::TOTAL_PORT_COUNT; index++) {
         U8 orderKey;
         U32 previousComSize = fromPortHistory_comQueueSend->size();
         U32 previousBufSize = fromPortHistory_buffQueueSend->size();
@@ -192,7 +192,7 @@ void ComQueueTester::testExternalQueueOverflow() {
     ComQueueDepth expectedComDepth;
     BuffQueueDepth expectedBuffDepth;
 
-    for (NATIVE_UINT_TYPE i = 0; i < ComQueue::TOTAL_PORT_COUNT; i++) {
+    for (FwIndexType i = 0; i < ComQueue::TOTAL_PORT_COUNT; i++) {
         configurationTable.entries[i].priority = i;
         configurationTable.entries[i].depth = 2;
 
@@ -209,7 +209,7 @@ void ComQueueTester::testExternalQueueOverflow() {
     U8 data[BUFFER_LENGTH] = {0xde, 0xad, 0xbe};
     Fw::Buffer buffer(&data[0], sizeof(data));
 
-    for (NATIVE_INT_TYPE queueNum = 0; queueNum < ComQueue::TOTAL_PORT_COUNT; queueNum++) {
+    for (FwIndexType queueNum = 0; queueNum < ComQueue::TOTAL_PORT_COUNT; queueNum++) {
         QueueType overflow_type;
         FwIndexType portNum;
         // queue[portNum].depth + 2 to deliberately cause overflow and check throttle of exactly 1
@@ -263,7 +263,7 @@ void ComQueueTester::testInternalQueueOverflow() {
     U8 data[BUFFER_LENGTH] = {0xde, 0xad, 0xbe};
     Fw::Buffer buffer(data, sizeof(data));
 
-    const NATIVE_INT_TYPE queueNum = ComQueue::COM_PORT_COUNT;
+    const FwIndexType queueNum = ComQueue::COM_PORT_COUNT;
     const FwSizeType msgCountMax = this->component.m_queue.getDepth();
     QueueType overflow_type;
     FwIndexType portNum;

--- a/Svc/Health/HealthComponentImpl.cpp
+++ b/Svc/Health/HealthComponentImpl.cpp
@@ -206,7 +206,7 @@ namespace Svc {
     NATIVE_INT_TYPE HealthImpl::findEntry(const Fw::CmdStringArg& entry) {
 
         // walk through entries
-        for (NATIVE_UINT_TYPE tableEntry = 0; tableEntry < NUM_PINGSEND_OUTPUT_PORTS; tableEntry++) {
+        for (FwIndexType tableEntry = 0; tableEntry < NUM_PINGSEND_OUTPUT_PORTS; tableEntry++) {
             if (entry == this->m_pingTrackerEntries[tableEntry].entry.entryName) {
                 return static_cast<NATIVE_INT_TYPE>(tableEntry);
             }

--- a/Svc/Health/test/ut/HealthTester.cpp
+++ b/Svc/Health/test/ut/HealthTester.cpp
@@ -168,7 +168,7 @@ namespace Svc {
         QUEUE_DEPTH, INSTANCE
     );
 
-    for (NATIVE_UINT_TYPE entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
+    for (FwIndexType entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
         this->pingEntries[entry].warnCycles = Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS+entry;
         this->pingEntries[entry].fatalCycles = Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS*2+entry+1;
         this->pingEntries[entry].entryName.format("task%d",entry);
@@ -209,14 +209,14 @@ namespace Svc {
 	  ASSERT_TLM_SIZE(0);
 	  ASSERT_CMD_RESPONSE_SIZE(0);
 
-	  for (NATIVE_UINT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
+	  for (FwIndexType port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
 	      this->keys[port] = port;
 	  }
 
 	  //invoke run handler same number as number of ports
 	  for (U32 i = 0; i < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; i++) {
 		  this->invoke_to_Run(0,0);
-	      for (NATIVE_UINT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
+	      for (FwIndexType port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
 	          this->keys[port] += Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS;
 	      }
 
@@ -248,7 +248,7 @@ namespace Svc {
       //invoke run handler enough times for warnings
       for (U32 i = 0; i < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS*2; i++) {
           this->invoke_to_Run(0,0);
-          for (NATIVE_UINT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
+          for (FwIndexType port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
               ASSERT_EQ(i+1,this->component.m_pingTrackerEntries[port].cycleCount);
           }
       }
@@ -258,7 +258,7 @@ namespace Svc {
       ASSERT_TLM_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
       ASSERT_EVENTS_HLTH_PING_WARN_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
 
-      for (NATIVE_UINT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
+      for (FwIndexType port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
           char name[80];
           snprintf(name, sizeof(name), "task%d",port);
           ASSERT_EVENTS_HLTH_PING_WARN(port,name);
@@ -282,7 +282,7 @@ namespace Svc {
       //invoke run handler enough times for warnings
       for (U32 i = 0; i < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS*2; i++) {
           this->invoke_to_Run(0,0);
-          for (NATIVE_UINT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
+          for (FwIndexType port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
               ASSERT_EQ(i+1,this->component.m_pingTrackerEntries[port].cycleCount);
           }
       }
@@ -292,7 +292,7 @@ namespace Svc {
       ASSERT_TLM_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
       ASSERT_EVENTS_HLTH_PING_WARN_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
 
-      for (NATIVE_UINT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
+      for (FwIndexType port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
           char name[80];
           snprintf(name, sizeof(name), "task%d",port);
           ASSERT_EVENTS_HLTH_PING_WARN(port,name);
@@ -304,7 +304,7 @@ namespace Svc {
       //invoke run handler enough times for FATALs
       for (U32 i = 0; i < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; i++) {
           this->invoke_to_Run(0,0);
-          for (NATIVE_UINT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
+          for (FwIndexType port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
               ASSERT_EQ(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS*2+i+1,this->component.m_pingTrackerEntries[port].cycleCount);
           }
       }
@@ -314,7 +314,7 @@ namespace Svc {
       ASSERT_EVENTS_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
       ASSERT_EVENTS_HLTH_PING_LATE_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
 
-      for (NATIVE_UINT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
+      for (FwIndexType port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
           char name[80];
           snprintf(name, sizeof(name), "task%d",port);
           ASSERT_EVENTS_HLTH_PING_LATE(port,name);
@@ -337,14 +337,14 @@ namespace Svc {
       //invoke run handler
       for (U32 i = 0; i < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS*2; i++) {
           this->invoke_to_Run(0,0);
-          for (NATIVE_INT_TYPE entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
+          for (FwIndexType entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
               ASSERT_EQ(i+1,this->component.m_pingTrackerEntries[entry].cycleCount);
           }
       }
 
       ASSERT_EVENTS_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
       ASSERT_EVENTS_HLTH_PING_WARN_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
-      for (NATIVE_INT_TYPE entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
+      for (FwIndexType entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
           char name[80];
           snprintf(name, sizeof(name), "task%d",entry);
           ASSERT_EVENTS_HLTH_PING_WARN(entry, name);
@@ -395,7 +395,7 @@ namespace Svc {
       // check that cycle counts increase again
       for (U32 i = 0; i < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; i++) {
           this->invoke_to_Run(0,0);
-          for (NATIVE_INT_TYPE entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
+          for (FwIndexType entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
               ASSERT_EQ(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS*2+1+i,this->component.m_pingTrackerEntries[entry].cycleCount);
           }
       }
@@ -404,7 +404,7 @@ namespace Svc {
       // Should be FATAL timeouts
       ASSERT_EVENTS_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
       ASSERT_EVENTS_HLTH_PING_LATE_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
-      for (NATIVE_INT_TYPE entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
+      for (FwIndexType entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
           char name[80];
           snprintf(name,sizeof(name), "task%d",entry);
           ASSERT_EVENTS_HLTH_PING_LATE(entry,name);
@@ -426,11 +426,11 @@ namespace Svc {
 
       // disable monitoring one at a time
 
-      for (NATIVE_INT_TYPE entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
+      for (FwIndexType entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
           this->clearEvents();
           this->clearHistory();
           // reset cycle count
-          for (NATIVE_INT_TYPE e2 = 0; e2 < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; e2++) {
+          for (FwIndexType e2 = 0; e2 < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; e2++) {
               this->component.m_pingTrackerEntries[e2].cycleCount = 0;
           }
           // disable entry
@@ -446,13 +446,13 @@ namespace Svc {
           ASSERT_EVENTS_HLTH_CHECK_PING(0,Fw::Enabled::DISABLED,name);
 
           // run a few cycles
-          for (NATIVE_INT_TYPE cycle = 0; cycle < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; cycle++) {
+          for (FwIndexType cycle = 0; cycle < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; cycle++) {
 
               // run a cycle
               this->invoke_to_Run(0,0);
 
               // verify only enable entries count up
-              for (NATIVE_INT_TYPE e3 = 0; e3 < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; e3++) {
+              for (FwIndexType e3 = 0; e3 < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; e3++) {
                   if (e3 == entry) {
                       // shouldn't be counting up
                       ASSERT_EQ(0u,this->component.m_pingTrackerEntries[e3].cycleCount);
@@ -488,7 +488,7 @@ namespace Svc {
       ASSERT_TLM_SIZE(0);
       ASSERT_CMD_RESPONSE_SIZE(0);
 
-      for (NATIVE_UINT_TYPE entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
+      for (FwIndexType entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
           this->clearEvents();
           this->clearHistory();
           // verify previous value
@@ -596,7 +596,7 @@ namespace Svc {
 	  ASSERT_EVENTS_SIZE(0);
 	  ASSERT_TLM_SIZE(0);
 
-	  for (NATIVE_INT_TYPE entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
+	  for (FwIndexType entry = 0; entry < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; entry++) {
 	      this->keys[entry] = entry;
 	  }
 
@@ -654,7 +654,7 @@ namespace Svc {
       //check for expected EVRs
       ASSERT_EVENTS_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
       ASSERT_EVENTS_HLTH_PING_WRONG_KEY_SIZE(Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS);
-      for (NATIVE_INT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
+      for (FwIndexType port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS; port++) {
           char name[80];
           snprintf(name, sizeof(name), "task%d",port);
           ASSERT_EVENTS_HLTH_PING_WRONG_KEY(port,name,FLAG_KEY_VALUE);
@@ -717,7 +717,7 @@ namespace Svc {
       ASSERT_EVENTS_SIZE(0);
 
       //set up the correct keys for all ports except last
-      for (NATIVE_INT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS - 1; port++) {
+      for (FwIndexType port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS - 1; port++) {
           this->keys[port] = port;
       }
       this->keys[Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS - 1] = 9999;
@@ -735,7 +735,7 @@ namespace Svc {
           //invoke schedIn
           this->invoke_to_Run(0,0);
 
-          for (NATIVE_INT_TYPE port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS - 1; port++) {
+          for (FwIndexType port = 0; port < Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS - 1; port++) {
               if (i == 0) {
                   this->keys[port] += Svc::HealthComponentBase::NUM_PINGSEND_OUTPUT_PORTS;
               } else {

--- a/Svc/RateGroupDriver/RateGroupDriver.hpp
+++ b/Svc/RateGroupDriver/RateGroupDriver.hpp
@@ -34,7 +34,7 @@ namespace Svc {
 
         public:
             //! Size of the divider table, provided as a constants to users passing the table in
-            static const NATIVE_UINT_TYPE DIVIDER_SIZE = NUM_CYCLEOUT_OUTPUT_PORTS;
+            static const FwIndexType DIVIDER_SIZE = NUM_CYCLEOUT_OUTPUT_PORTS;
 
             //! \class Divider
             //! \brief Struct describing a divider

--- a/Svc/StaticMemory/test/ut/StaticMemoryTester.cpp
+++ b/Svc/StaticMemory/test/ut/StaticMemoryTester.cpp
@@ -70,7 +70,7 @@ namespace Svc {
   {
 
     // bufferDeallocate
-    for (NATIVE_INT_TYPE i = 0; i < StaticMemoryComponentBase::NUM_BUFFERALLOCATE_INPUT_PORTS; ++i) {
+    for (FwIndexType i = 0; i < StaticMemoryComponentBase::NUM_BUFFERALLOCATE_INPUT_PORTS; ++i) {
       this->connect_to_bufferDeallocate(
           i,
           this->component.get_bufferDeallocate_InputPort(i)
@@ -78,7 +78,7 @@ namespace Svc {
     }
 
     // bufferAllocate
-    for (NATIVE_INT_TYPE i = 0; i < StaticMemoryComponentBase::NUM_BUFFERALLOCATE_INPUT_PORTS; ++i) {
+    for (FwIndexType i = 0; i < StaticMemoryComponentBase::NUM_BUFFERALLOCATE_INPUT_PORTS; ++i) {
       this->connect_to_bufferAllocate(
           i,
           this->component.get_bufferAllocate_InputPort(i)

--- a/Svc/UdpReceiver/test/ut/Tester.cpp
+++ b/Svc/UdpReceiver/test/ut/Tester.cpp
@@ -129,7 +129,7 @@ namespace Svc {
     );
 
     // Output serial ports
-    for (NATIVE_UINT_TYPE port = 0; port < UdpReceiverComponentImpl::NUM_PORTSOUT_OUTPUT_PORTS; port++) {
+    for (FwIndexType port = 0; port < UdpReceiverComponentImpl::NUM_PORTSOUT_OUTPUT_PORTS; port++) {
         this->component.set_PortsOut_OutputPort(port,this->get_from_PortsOut(port));
     }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This is an automated change to convert usages of NUM_PORTS and PORT_COUNT use FwIndexType.  

There are 2 manual fixes:

1. Input port `m_portNum` -> `FwIndexType`
2. Added static assert to ensure constant addition remains in-bounds for `FwIndexType`