### PR TITLE
Remove include of internal glibc header

### DIFF
--- a/STest/STest/Random/bsd_random.h
+++ b/STest/STest/Random/bsd_random.h
@@ -9,8 +9,6 @@
 // acknowledged.
 // ======================================================================
 
-
-#include <sys/cdefs.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

`sys/cdefs.h` does not exist on musl because it is not a standard header. Remove the include, which does not appear to be necessary.

## Rationale

See the musl FAQ: [Q: When compiling something against musl, I get error messages about sys/cdefs.h](https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-get-error-messages-about-%3Ccode%3Esys/cdefs.h%3C/code%3E)

## Testing/Review Recommendations

N/A

## Future Work

N/A
