### PR TITLE
Add F Prime terminology translation guide

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -213,6 +213,7 @@ nav:
       - 'Porting F´ To a New Platform': docs/how-to/porting-guide.md
     - Reference:
       - docs/reference/index.md
+      - 'Software Engineering Terminology to F´ Nomenclature': docs/reference/fprime-translations.md
       - 'C++ Documentation': docs/reference/api/cpp/html/index.html
       - 'F´ Components SDDs': docs/reference/sdd.md
       - 'FPP Language Specification': https://nasa.github.io/fpp/fpp-spec.html

--- a/docs/reference/fprime-translations.md
+++ b/docs/reference/fprime-translations.md
@@ -1,4 +1,4 @@
-# F PRime Translation Guide: Software Engineering Terminology to F Prime Nomenclature
+# F Prime Translation Guide: Software Engineering Terminology to F Prime Nomenclature
 
 This guide provides a mapping between common software engineering concepts and their equivalent implementations in the F´ framework. It serves as a reference for developers new to F´ development.
 
@@ -7,7 +7,7 @@ This guide provides a mapping between common software engineering concepts and t
 | Software Concept | F Prime Equivalent | Notes |
 |-----------------|-------------------|--------|
 | String | Fw::String | Safe string implementation with size limits |
-| Buffer | Fw::Buffer | Memory buffer with size tracking |
+| Buffer | [Fw::Buffer](../../Fw/Buffer/docs/sdd.md) | Memory buffer with size tracking |
 | Queue | Os::Queue | Thread-safe queue implementation |
 
 > [!NOTE]
@@ -33,8 +33,8 @@ This guide provides a mapping between common software engineering concepts and t
 |-----------------|-------------------|--------|
 | Stack Allocation | Local variables | Standard stack allocation |
 | Heap Allocation | Fw::MemAllocator | Managed heap allocation |
-| Memory Pooling | Svc::BufferManager | Fixed-size buffer management |
-| Smart Pointer | Fw::Buffer | Buffer containing pointer, size, and context |
+| Memory Pooling | [Svc::BufferManager](../../Svc/BufferManager/docs/sdd.md) | Fixed-size buffer management |
+| Smart Pointer | [Fw::Buffer](../../Fw/Buffer/docs/sdd.md) | Buffer containing pointer, size, and context |
 
 ## System Architecture
 

--- a/docs/reference/fprime-translations.md
+++ b/docs/reference/fprime-translations.md
@@ -1,4 +1,4 @@
-# F´ Translation Guide: Software Engineering to F Prime Nomenclature
+# F PRime Translation Guide: Software Engineering Terminology to F Prime Nomenclature
 
 This guide provides a mapping between common software engineering concepts and their equivalent implementations in the F´ framework. It serves as a reference for developers new to F´ development.
 
@@ -6,20 +6,26 @@ This guide provides a mapping between common software engineering concepts and t
 
 | Software Concept | F Prime Equivalent | Notes |
 |-----------------|-------------------|--------|
-| Queue | Os::Queue | Thread-safe queue implementation |
 | String | Fw::String | Safe string implementation with size limits |
 | Buffer | Fw::Buffer | Memory buffer with size tracking |
+| Queue | Os::Queue | Thread-safe queue implementation |
+
+> [!NOTE]
+> `Os::Queue` is rarely used directly but rather is used via `async` port calls.
 
 ## Communication & Synchronization
 
 | Software Concept | F Prime Equivalent | Notes |
 |-----------------|-------------------|--------|
 | Function Call | Synchronous Port | Direct component-to-component calls |
-| Callback | Port Registration | Components register ports for callbacks |
-| Event Loop | Active Component | Components with their own execution thread |
 | Message Queue | Async Port | Asynchronous component communication supported by a queue |
+| Event Loop | Active Component | Components with their own execution thread |
 | Mutex | Os::Mutex | Thread synchronization primitive |
 | Thread | Os::Task | OS task abstraction |
+
+
+> [!NOTE]
+> `Os::Task` is rarely used directly but rather is contained  within `active` components.
 
 ## Memory Management
 
@@ -27,7 +33,7 @@ This guide provides a mapping between common software engineering concepts and t
 |-----------------|-------------------|--------|
 | Stack Allocation | Local variables | Standard stack allocation |
 | Heap Allocation | Fw::MemAllocator | Managed heap allocation |
-| Memory Pool | Svc::BufferManager | Fixed-size buffer management |
+| Memory Pooling | Svc::BufferManager | Fixed-size buffer management |
 | Smart Pointer | Fw::Buffer | Buffer containing pointer, size, and context |
 
 ## System Architecture
@@ -35,10 +41,10 @@ This guide provides a mapping between common software engineering concepts and t
 | Software Concept | F Prime Equivalent | Notes |
 |-----------------|-------------------|--------|
 | Module | Component | Basic unit of functionality |
-| Interface | Port | Component communication interface |
-| Service | Service Component | Components providing system services |
+| Interface | Port(s) | Component communication interface |
+| System Service | Service Component | Components providing system services |
 | Driver | Driver Component | Hardware abstraction components |
-| Configuration | Parameters | Component configuration management via ground-commanded parameters |
+| Runtime Configuration | Parameters | Component configuration management via ground-commanded parameters |
 
 ## Error Handling
 

--- a/docs/user-guide/framework/fprime-translations.md
+++ b/docs/user-guide/framework/fprime-translations.md
@@ -1,0 +1,84 @@
+# F´ Translation Guide: Software Engineering to F Prime Nomenclature
+
+This guide provides a mapping between common software engineering concepts and their equivalent implementations in the F´ framework. It serves as a reference for developers transitioning to F´ development.
+
+## Data Structures & Containers
+
+| Software Concept | F Prime Equivalent | Notes |
+|-----------------|-------------------|--------|
+| Queue | Os::Queue | Thread-safe queue implementation for RTOS |
+| Array | Fw::Array<T> | Fixed-size array with bounds checking |
+| String | Fw::String | Safe string implementation with size limits |
+| Buffer | Fw::Buffer | Memory buffer with size tracking |
+| Vector | Fw::Array<T> | F Prime uses fixed arrays instead of dynamic vectors |
+| Map/Dictionary | Table + for loop | Implement lookup tables with arrays and linear search |
+| Set | Bit array/mask | Use bit fields for efficient set operations |
+
+## Communication & Synchronization
+
+| Software Concept | F Prime Equivalent | Notes |
+|-----------------|-------------------|--------|
+| Function Call | Synchronous Port | Direct component-to-component calls |
+| Callback | Port Registration | Components register ports for callbacks |
+| Event Loop | Active Component | Components with their own execution thread |
+| Message Queue | Async Port | Asynchronous component communication |
+| Publish/Subscribe | Event Port | Multi-cast port connections |
+| Mutex | Os::Mutex | Thread synchronization primitive |
+| Semaphore | Os::Semaphore | Resource management between threads |
+| Thread | Os::Task | RTOS task abstraction |
+| Timer | Rate Group | Time-based execution scheduling |
+
+## Memory Management
+
+| Software Concept | F Prime Equivalent | Notes |
+|-----------------|-------------------|--------|
+| Heap Allocation | Fw::MemAllocator | Managed heap allocation |
+| Stack Allocation | Local variables | Standard stack allocation |
+| Memory Pool | Svc::BufferManager | Fixed-size buffer management |
+| Smart Pointer | Object ownership | Components own their objects |
+| Reference Counting | Port references | Managed by component framework |
+| Memory Mapping | Drv::BlockDriver | Hardware memory management |
+
+## System Architecture
+
+| Software Concept | F Prime Equivalent | Notes |
+|-----------------|-------------------|--------|
+| Module | Component | Basic unit of functionality |
+| Interface | Port | Component communication interface |
+| Service | Service Component | Components providing system services |
+| Driver | Driver Component | Hardware abstraction components |
+| Configuration | Parameters | Component configuration management |
+| Plugin | Component Library | Reusable component implementations |
+| State Machine | Component States | Internal component state management |
+
+## Error Handling
+
+| Software Concept | F Prime Equivalent | Notes |
+|-----------------|-------------------|--------|
+| Exception | Assert + Event | Assertion and event logging |
+| Error Code | Status Type | Enumerated status returns |
+| Try/Catch | Command Handler | Command execution with status return |
+| Logging | Events | System event logging framework |
+| Debug Print | Fw::Logger | Debug output facility |
+
+## Testing
+
+| Software Concept | F Prime Equivalent | Notes |
+|-----------------|-------------------|--------|
+| Unit Test | GTest Component | Google Test integration |
+| Mock Object | Test Component | Component test implementations |
+| Test Fixture | Test Harness | Component test setup |
+| Integration Test | Integration Test | System-level test scenarios |
+| Test Coverage | gcov + STest | Code coverage analysis |
+
+## Common Design Patterns
+
+| Pattern | F Prime Implementation | Notes |
+|---------|----------------------|--------|
+| Observer | Event Ports | Components subscribe to events |
+| Command | Command Ports | Component command handling |
+| Factory | Component Constructor | Component instantiation |
+| Singleton | System Components | Single-instance components |
+| Facade | Port Arrays | Multiple interface aggregation |
+| Strategy | Component Implementation | Swappable component behavior |
+| Proxy | Port Connection | Inter-component communication |

--- a/docs/user-guide/framework/fprime-translations.md
+++ b/docs/user-guide/framework/fprime-translations.md
@@ -1,18 +1,14 @@
 # F´ Translation Guide: Software Engineering to F Prime Nomenclature
 
-This guide provides a mapping between common software engineering concepts and their equivalent implementations in the F´ framework. It serves as a reference for developers transitioning to F´ development.
+This guide provides a mapping between common software engineering concepts and their equivalent implementations in the F´ framework. It serves as a reference for developers new to F´ development.
 
 ## Data Structures & Containers
 
 | Software Concept | F Prime Equivalent | Notes |
 |-----------------|-------------------|--------|
-| Queue | Os::Queue | Thread-safe queue implementation for RTOS |
-| Array | Fw::Array<T> | Fixed-size array with bounds checking |
+| Queue | Os::Queue | Thread-safe queue implementation |
 | String | Fw::String | Safe string implementation with size limits |
 | Buffer | Fw::Buffer | Memory buffer with size tracking |
-| Vector | Fw::Array<T> | F Prime uses fixed arrays instead of dynamic vectors |
-| Map/Dictionary | Table + for loop | Implement lookup tables with arrays and linear search |
-| Set | Bit array/mask | Use bit fields for efficient set operations |
 
 ## Communication & Synchronization
 
@@ -21,23 +17,18 @@ This guide provides a mapping between common software engineering concepts and t
 | Function Call | Synchronous Port | Direct component-to-component calls |
 | Callback | Port Registration | Components register ports for callbacks |
 | Event Loop | Active Component | Components with their own execution thread |
-| Message Queue | Async Port | Asynchronous component communication |
-| Publish/Subscribe | Event Port | Multi-cast port connections |
+| Message Queue | Async Port | Asynchronous component communication supported by a queue |
 | Mutex | Os::Mutex | Thread synchronization primitive |
-| Semaphore | Os::Semaphore | Resource management between threads |
-| Thread | Os::Task | RTOS task abstraction |
-| Timer | Rate Group | Time-based execution scheduling |
+| Thread | Os::Task | OS task abstraction |
 
 ## Memory Management
 
 | Software Concept | F Prime Equivalent | Notes |
 |-----------------|-------------------|--------|
-| Heap Allocation | Fw::MemAllocator | Managed heap allocation |
 | Stack Allocation | Local variables | Standard stack allocation |
+| Heap Allocation | Fw::MemAllocator | Managed heap allocation |
 | Memory Pool | Svc::BufferManager | Fixed-size buffer management |
-| Smart Pointer | Object ownership | Components own their objects |
-| Reference Counting | Port references | Managed by component framework |
-| Memory Mapping | Drv::BlockDriver | Hardware memory management |
+| Smart Pointer | Fw::Buffer | Buffer containing pointer, size, and context |
 
 ## System Architecture
 
@@ -47,9 +38,7 @@ This guide provides a mapping between common software engineering concepts and t
 | Interface | Port | Component communication interface |
 | Service | Service Component | Components providing system services |
 | Driver | Driver Component | Hardware abstraction components |
-| Configuration | Parameters | Component configuration management |
-| Plugin | Component Library | Reusable component implementations |
-| State Machine | Component States | Internal component state management |
+| Configuration | Parameters | Component configuration management via ground-commanded parameters |
 
 ## Error Handling
 
@@ -57,28 +46,6 @@ This guide provides a mapping between common software engineering concepts and t
 |-----------------|-------------------|--------|
 | Exception | Assert + Event | Assertion and event logging |
 | Error Code | Status Type | Enumerated status returns |
-| Try/Catch | Command Handler | Command execution with status return |
 | Logging | Events | System event logging framework |
 | Debug Print | Fw::Logger | Debug output facility |
 
-## Testing
-
-| Software Concept | F Prime Equivalent | Notes |
-|-----------------|-------------------|--------|
-| Unit Test | GTest Component | Google Test integration |
-| Mock Object | Test Component | Component test implementations |
-| Test Fixture | Test Harness | Component test setup |
-| Integration Test | Integration Test | System-level test scenarios |
-| Test Coverage | gcov + STest | Code coverage analysis |
-
-## Common Design Patterns
-
-| Pattern | F Prime Implementation | Notes |
-|---------|----------------------|--------|
-| Observer | Event Ports | Components subscribe to events |
-| Command | Command Ports | Component command handling |
-| Factory | Component Constructor | Component instantiation |
-| Singleton | System Components | Single-instance components |
-| Facade | Port Arrays | Multiple interface aggregation |
-| Strategy | Component Implementation | Swappable component behavior |
-| Proxy | Port Connection | Inter-component communication |


### PR DESCRIPTION
"Resolves #1251 - Creates documentation to translate software engineering concepts to F´ nomenclature"
LeStarch on Feb 13, 2025
@matt392code these tables you posted are exactly what we need for this issue. Do you want to pull those tables into a PR? Create:
docs/user-guide/framework/fprime-translations.md
Add all of the tables you put at the top (everything up to "Example Translations"). I will need to go through and edit some of the data, but want to let you get credit for the initial work.
| | |
|:---|:---|
|**_Related Issue(s)_**| #1251 |
|**_Has Unit Tests (y/n)_**| Not Applicable - tech documentation only | 
|**_Documentation Included (y/n)_**| y |

---
## Change Description
Adds a new documentation file that translates common software engineering concepts to F´ terminology. The guide includes mappings for:
- Data Structures & Containers
- Communication & Synchronization
- Memory Management
- System Architecture
- Error Handling
- Testing
- Common Design Patterns

## Rationale
This documentation helps developers transition to F´ by providing clear mappings between familiar software concepts and their F´ equivalents, as requested in issue #1251.

## Testing/Review Recommendations
Please review the terminology mappings for accuracy and completeness. The documentation is based on the tables previously posted in issue #1251.

## Future Work
- Additional examples could be added after initial review
- Terminology could be expanded based on community feedback
