### PR TITLE
Remove ActiveLogger Priority

### DIFF
--- a/Svc/ActiveLogger/ActiveLogger.fpp
+++ b/Svc/ActiveLogger/ActiveLogger.fpp
@@ -37,7 +37,6 @@ module Svc {
                             $severity: Fw.LogSeverity @< The severity argument
                             args: Fw.LogBuffer @< Buffer containing serialized log entry
                           ) \
-      priority 1 \
       drop
 
     # ----------------------------------------------------------------------


### PR DESCRIPTION
removing priority for now in order to avoid incorrect message order when using pseudo-priority queues.

| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/3267 |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**| N|

---
## Change Description

Remove priority from ActiveLogger

## Rationale

Issues in event queue-message order being out of order

## Testing/Review Recommendations

Nominal CI

## Future Work

Better handle queue priorities.
