### PR TITLE
Add `final` to component implementation classes

### DIFF
--- a/Drv/BlockDriver/BlockDriverImpl.hpp
+++ b/Drv/BlockDriver/BlockDriverImpl.hpp
@@ -5,7 +5,7 @@
 
 namespace Drv {
 
-    class BlockDriverImpl : public BlockDriverComponentBase  {
+    class BlockDriverImpl final : public BlockDriverComponentBase  {
 
     public:
 

--- a/Drv/LinuxGpioDriver/LinuxGpioDriver.hpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriver.hpp
@@ -20,7 +20,7 @@
 
 namespace Drv {
 
-class LinuxGpioDriver : public LinuxGpioDriverComponentBase {
+class LinuxGpioDriver final : public LinuxGpioDriverComponentBase {
   public:
     static constexpr FwSizeType GPIO_POLL_TIMEOUT = 500;  // Timeout looking for interrupts to check for shutdown
     // ----------------------------------------------------------------------

--- a/Drv/LinuxI2cDriver/LinuxI2cDriver.hpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriver.hpp
@@ -17,7 +17,7 @@
 
 namespace Drv {
 
-  class LinuxI2cDriver :
+  class LinuxI2cDriver final :
     public LinuxI2cDriverComponentBase
   {
 

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
@@ -52,7 +52,7 @@ namespace Drv {
         SPI_MODE_CPOL_HIGH_CPHA_HIGH,///< (CPOL = 1, CPHA = 1)
     };
 
-    class LinuxSpiDriverComponentImpl: public LinuxSpiDriverComponentBase {
+    class LinuxSpiDriverComponentImpl final : public LinuxSpiDriverComponentBase {
 
         public:
 

--- a/Drv/LinuxUartDriver/LinuxUartDriver.hpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.hpp
@@ -21,7 +21,7 @@
 
 namespace Drv {
 
-class LinuxUartDriver : public LinuxUartDriverComponentBase {
+class LinuxUartDriver final : public LinuxUartDriverComponentBase {
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Drv/StreamCrossover/StreamCrossover.hpp
+++ b/Drv/StreamCrossover/StreamCrossover.hpp
@@ -11,7 +11,7 @@
 
 namespace Drv {
 
-  class StreamCrossover :
+  class StreamCrossover final :
     public StreamCrossoverComponentBase
   {
 

--- a/Drv/TcpClient/TcpClientComponentImpl.hpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.hpp
@@ -20,7 +20,7 @@
 
 namespace Drv {
 
-class TcpClientComponentImpl : public TcpClientComponentBase, public SocketComponentHelper {
+class TcpClientComponentImpl final : public TcpClientComponentBase, public SocketComponentHelper {
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -21,7 +21,7 @@
 
 namespace Drv {
 
-class TcpServerComponentImpl : public TcpServerComponentBase, public SocketComponentHelper {
+class TcpServerComponentImpl final : public TcpServerComponentBase, public SocketComponentHelper {
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Fw/Cmd/CmdArgBuffer.hpp
+++ b/Fw/Cmd/CmdArgBuffer.hpp
@@ -18,7 +18,7 @@
 
 namespace Fw {
 
-    class CmdArgBuffer : public SerializeBufferBase {
+    class CmdArgBuffer final : public SerializeBufferBase {
         public:
 
             enum {

--- a/Fw/Com/ComBuffer.hpp
+++ b/Fw/Com/ComBuffer.hpp
@@ -17,7 +17,7 @@
 
 namespace Fw {
 
-    class ComBuffer : public SerializeBufferBase {
+    class ComBuffer final : public SerializeBufferBase {
         public:
 
             enum {

--- a/Fw/Log/LogBuffer.hpp
+++ b/Fw/Log/LogBuffer.hpp
@@ -18,7 +18,7 @@
 
 namespace Fw {
 
-    class LogBuffer : public SerializeBufferBase {
+    class LogBuffer final : public SerializeBufferBase {
         public:
 
             enum {

--- a/Fw/Port/InputSerializePort.hpp
+++ b/Fw/Port/InputSerializePort.hpp
@@ -9,7 +9,7 @@
 
 namespace Fw {
 
-    class InputSerializePort : public InputPortBase {
+    class InputSerializePort final : public InputPortBase {
         public:
             InputSerializePort();
             virtual ~InputSerializePort();

--- a/Fw/Port/OutputSerializePort.hpp
+++ b/Fw/Port/OutputSerializePort.hpp
@@ -9,7 +9,7 @@
 
 namespace Fw {
 
-    class OutputSerializePort : public OutputPortBase {
+    class OutputSerializePort final : public OutputPortBase {
         public:
             OutputSerializePort();
             virtual ~OutputSerializePort();

--- a/Fw/Prm/PrmBuffer.hpp
+++ b/Fw/Prm/PrmBuffer.hpp
@@ -24,7 +24,7 @@ namespace Fw {
     static_assert(FW_PARAM_BUFFER_MAX_SIZE >= StringBase::BUFFER_SIZE(FW_PARAM_STRING_MAX_SIZE),
                   "param string must fit into param buffer");
 
-    class ParamBuffer : public SerializeBufferBase {
+    class ParamBuffer final : public SerializeBufferBase {
         public:
 
             enum {

--- a/Fw/Prm/PrmString.hpp
+++ b/Fw/Prm/PrmString.hpp
@@ -14,7 +14,7 @@
 
 namespace Fw {
 
-class ParamString : public StringBase {
+class ParamString final : public StringBase {
   public:
     enum {
         SERIALIZED_TYPE_ID = FW_TYPEID_PRM_STR,

--- a/Fw/Sm/SmSignalBuffer.hpp
+++ b/Fw/Sm/SmSignalBuffer.hpp
@@ -15,7 +15,7 @@
 
 namespace Fw {
 
-    class SmSignalBuffer : public SerializeBufferBase {
+    class SmSignalBuffer final : public SerializeBufferBase {
         public:
 
             enum {

--- a/Fw/Tlm/TlmBuffer.hpp
+++ b/Fw/Tlm/TlmBuffer.hpp
@@ -17,7 +17,7 @@
 
 namespace Fw {
 
-    class TlmBuffer : public SerializeBufferBase {
+    class TlmBuffer final : public SerializeBufferBase {
         public:
 
             enum {

--- a/Fw/Types/SerialBuffer.hpp
+++ b/Fw/Types/SerialBuffer.hpp
@@ -21,7 +21,7 @@ namespace Fw {
 //! \class SerialBuffer
 //! \brief A variable-length serializable buffer
 //!
-class SerialBuffer : public SerializeBufferBase {
+class SerialBuffer final : public SerializeBufferBase {
   public:
     // ----------------------------------------------------------------------
     // Construction

--- a/RPI/RpiDemo/RpiDemoComponentImpl.hpp
+++ b/RPI/RpiDemo/RpiDemoComponentImpl.hpp
@@ -18,7 +18,7 @@
 
 namespace RPI {
 
-  class RpiDemoComponentImpl :
+  class RpiDemoComponentImpl final :
     public RpiDemoComponentBase
   {
 

--- a/Ref/PingReceiver/PingReceiverComponentImpl.hpp
+++ b/Ref/PingReceiver/PingReceiverComponentImpl.hpp
@@ -17,7 +17,7 @@
 
 namespace Ref {
 
-  class PingReceiverComponentImpl :
+  class PingReceiverComponentImpl final :
     public PingReceiverComponentBase
   {
 

--- a/Ref/RecvBuffApp/RecvBuffComponentImpl.hpp
+++ b/Ref/RecvBuffApp/RecvBuffComponentImpl.hpp
@@ -5,7 +5,7 @@
 
 namespace Ref {
 
-    class RecvBuffImpl : public RecvBuffComponentBase {
+    class RecvBuffImpl final : public RecvBuffComponentBase {
         public:
 
             // Only called by derived class

--- a/Ref/SendBuffApp/SendBuffComponentImpl.hpp
+++ b/Ref/SendBuffApp/SendBuffComponentImpl.hpp
@@ -7,7 +7,7 @@ namespace Ref {
 
     /// This component sends a data buffer to a driver each time it is invoked by a scheduler
 
-    class SendBuffImpl : public SendBuffComponentBase {
+    class SendBuffImpl final : public SendBuffComponentBase {
         public:
 
             // Only called by derived class

--- a/Ref/SignalGen/SignalGen.hpp
+++ b/Ref/SignalGen/SignalGen.hpp
@@ -22,7 +22,7 @@
 
 namespace Ref {
 
-    class SignalGen :
+    class SignalGen final :
         public SignalGenComponentBase
     {
 

--- a/Svc/ActiveLogger/ActiveLoggerImpl.hpp
+++ b/Svc/ActiveLogger/ActiveLoggerImpl.hpp
@@ -14,7 +14,7 @@
 
 namespace Svc {
 
-    class ActiveLoggerImpl: public ActiveLoggerComponentBase {
+    class ActiveLoggerImpl final : public ActiveLoggerComponentBase {
         public:
             ActiveLoggerImpl(const char* compName); //!< constructor
             virtual ~ActiveLoggerImpl(); //!< destructor

--- a/Svc/ActiveRateGroup/ActiveRateGroup.hpp
+++ b/Svc/ActiveRateGroup/ActiveRateGroup.hpp
@@ -28,7 +28,7 @@ namespace Svc {
     //! time of the rate group and detects overruns.
     //!
 
-    class ActiveRateGroup : public ActiveRateGroupComponentBase {
+    class ActiveRateGroup final : public ActiveRateGroupComponentBase {
         public:
             static constexpr FwIndexType CONNECTION_COUNT_MAX = NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS;
 

--- a/Svc/ActiveTextLogger/ActiveTextLogger.hpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.hpp
@@ -21,7 +21,7 @@ namespace Svc {
     //! consistent ordering.  It also provides the option to write the text
     //! to a file as well.
 
-    class ActiveTextLogger: public ActiveTextLoggerComponentBase {
+    class ActiveTextLogger final : public ActiveTextLoggerComponentBase {
 
         public:
 

--- a/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.hpp
+++ b/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.hpp
@@ -17,7 +17,7 @@
 
 namespace Svc {
 
-  class AssertFatalAdapterComponentImpl :
+  class AssertFatalAdapterComponentImpl final :
     public AssertFatalAdapterComponentBase
   {
 

--- a/Svc/BufferAccumulator/BufferAccumulator.hpp
+++ b/Svc/BufferAccumulator/BufferAccumulator.hpp
@@ -20,7 +20,7 @@
 
 namespace Svc {
 
-    class BufferAccumulator : public BufferAccumulatorComponentBase {
+    class BufferAccumulator final : public BufferAccumulatorComponentBase {
       PRIVATE:
 
         // ----------------------------------------------------------------------

--- a/Svc/BufferLogger/BufferLogger.hpp
+++ b/Svc/BufferLogger/BufferLogger.hpp
@@ -22,7 +22,7 @@
 
 namespace Svc {
 
-  class BufferLogger :
+  class BufferLogger final :
     public BufferLoggerComponentBase
   {
 

--- a/Svc/BufferManager/BufferManagerComponentImpl.hpp
+++ b/Svc/BufferManager/BufferManagerComponentImpl.hpp
@@ -53,7 +53,7 @@ namespace Svc
     // destructor of BufferManager if cleanup() is not called. If a project-specific manual memory
     // allocator is not needed, Fw::MallocAllocator can be used.
 
-    class BufferManagerComponentImpl : public BufferManagerComponentBase
+    class BufferManagerComponentImpl final : public BufferManagerComponentBase
     {
 
     public:

--- a/Svc/BufferRepeater/BufferRepeater.hpp
+++ b/Svc/BufferRepeater/BufferRepeater.hpp
@@ -17,7 +17,7 @@
 
 namespace Svc {
 
-class BufferRepeater : public BufferRepeaterComponentBase {
+class BufferRepeater final : public BufferRepeaterComponentBase {
   public:
     /**
      * Set of responses to failures to allocate a buffer when requested

--- a/Svc/ChronoTime/ChronoTime.hpp
+++ b/Svc/ChronoTime/ChronoTime.hpp
@@ -11,7 +11,7 @@
 
 namespace Svc {
 
-class ChronoTime : public ChronoTimeComponentBase {
+class ChronoTime final : public ChronoTimeComponentBase {
   public:
     // ----------------------------------------------------------------------
     // Component construction and destruction

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
@@ -29,7 +29,7 @@ namespace Svc {
     //! is connected to the seqCmdStatus port with the same number
     //! as the port that submitted the command, the command status will be returned.
 
-    class CommandDispatcherImpl : public CommandDispatcherComponentBase {
+    class CommandDispatcherImpl final : public CommandDispatcherComponentBase {
         public:
             //!  \brief Command Dispatcher constructor
             //!

--- a/Svc/CmdSequencer/CmdSequencerImpl.hpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.hpp
@@ -19,7 +19,7 @@
 
 namespace Svc {
 
-  class CmdSequencerComponentImpl :
+  class CmdSequencerComponentImpl final :
     public CmdSequencerComponentBase
   {
 

--- a/Svc/CmdSplitter/CmdSplitter.hpp
+++ b/Svc/CmdSplitter/CmdSplitter.hpp
@@ -12,7 +12,7 @@
 
 namespace Svc {
 
-class CmdSplitter : public CmdSplitterComponentBase {
+class CmdSplitter final : public CmdSplitterComponentBase {
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Svc/ComLogger/ComLogger.hpp
+++ b/Svc/ComLogger/ComLogger.hpp
@@ -19,7 +19,7 @@
 
 namespace Svc {
 
-  class ComLogger :
+  class ComLogger final :
     public ComLoggerComponentBase
   {
       // ----------------------------------------------------------------------

--- a/Svc/ComQueue/ComQueue.hpp
+++ b/Svc/ComQueue/ComQueue.hpp
@@ -21,7 +21,7 @@ namespace Svc {
 // Types
 // ----------------------------------------------------------------------
 
-class ComQueue : public ComQueueComponentBase {
+class ComQueue final : public ComQueueComponentBase {
   public:
     //!< Count of Fw::Com input ports and thus Fw::Com queues
     static const FwIndexType COM_PORT_COUNT = ComQueueComponentBase::NUM_COMQUEUEIN_INPUT_PORTS;

--- a/Svc/ComSplitter/ComSplitter.hpp
+++ b/Svc/ComSplitter/ComSplitter.hpp
@@ -12,7 +12,7 @@
 
 namespace Svc {
 
-  class ComSplitter :
+  class ComSplitter final :
     public ComSplitterComponentBase
   {
 

--- a/Svc/ComStub/ComStub.hpp
+++ b/Svc/ComStub/ComStub.hpp
@@ -11,7 +11,7 @@
 
 namespace Svc {
 
-class ComStub : public ComStubComponentBase {
+class ComStub final : public ComStubComponentBase {
   public:
     const NATIVE_UINT_TYPE RETRY_LIMIT = 10;
     // ----------------------------------------------------------------------

--- a/Svc/Deframer/Deframer.hpp
+++ b/Svc/Deframer/Deframer.hpp
@@ -35,7 +35,7 @@ namespace Svc {
  * Implementation uses a circular buffer to store incoming data, which is drained one framed packet
  * at a time into buffers dispatched to the rest of the system.
  */
-class Deframer :
+class Deframer final :
   public DeframerComponentBase,
   public DeframingProtocolInterface
 {

--- a/Svc/DpCatalog/DpCatalog.hpp
+++ b/Svc/DpCatalog/DpCatalog.hpp
@@ -18,7 +18,7 @@
 
 namespace Svc {
 
-    class DpCatalog :
+    class DpCatalog final :
         public DpCatalogComponentBase
     {
 

--- a/Svc/DpManager/DpManager.hpp
+++ b/Svc/DpManager/DpManager.hpp
@@ -14,7 +14,7 @@
 
 namespace Svc {
 
-class DpManager : public DpManagerComponentBase {
+class DpManager final : public DpManagerComponentBase {
   private:
     // ----------------------------------------------------------------------
     // Static assertions against the assumptions about the model

--- a/Svc/DpWriter/DpWriter.hpp
+++ b/Svc/DpWriter/DpWriter.hpp
@@ -17,7 +17,7 @@
 
 namespace Svc {
 
-class DpWriter : public DpWriterComponentBase {
+class DpWriter final : public DpWriterComponentBase {
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Svc/FatalHandler/FatalHandlerComponentImpl.hpp
+++ b/Svc/FatalHandler/FatalHandlerComponentImpl.hpp
@@ -17,7 +17,7 @@
 
 namespace Svc {
 
-  class FatalHandlerComponentImpl :
+  class FatalHandlerComponentImpl final :
     public FatalHandlerComponentBase
   {
 

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -22,7 +22,7 @@
 
 namespace Svc {
 
-  class FileDownlink :
+  class FileDownlink final :
     public FileDownlinkComponentBase
   {
 

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -18,7 +18,7 @@
 
 namespace Svc {
 
-  class FileManager :
+  class FileManager final :
     public FileManagerComponentBase
   {
 

--- a/Svc/FileUplink/FileUplink.hpp
+++ b/Svc/FileUplink/FileUplink.hpp
@@ -19,7 +19,7 @@
 
 namespace Svc {
 
-  class FileUplink :
+  class FileUplink final :
     public FileUplinkComponentBase
   {
 

--- a/Svc/Framer/Framer.hpp
+++ b/Svc/Framer/Framer.hpp
@@ -28,7 +28,7 @@ namespace Svc {
  * Using this component, projects can implement and supply a fresh FramingProtocol implementation
  * without changing the reference topology.
  */
-class Framer : public FramerComponentBase, public FramingProtocolInterface {
+class Framer final : public FramerComponentBase, public FramingProtocolInterface {
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Svc/GenericHub/GenericHubComponentImpl.hpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.hpp
@@ -17,7 +17,7 @@
 
 namespace Svc {
 
-class GenericHubComponentImpl : public GenericHubComponentBase {
+class GenericHubComponentImpl final : public GenericHubComponentBase {
   public:
     /**
      * HubType:

--- a/Svc/Health/HealthComponentImpl.hpp
+++ b/Svc/Health/HealthComponentImpl.hpp
@@ -29,7 +29,7 @@ namespace Svc {
     //!  against warning and fault thresholds. A watchdog is
     //!  always stroked in the run handler.
 
-    class HealthImpl: public HealthComponentBase {
+    class HealthImpl final : public HealthComponentBase {
 
         public:
             //!  \brief struct for ping entry

--- a/Svc/LinuxTimer/LinuxTimerComponentImpl.hpp
+++ b/Svc/LinuxTimer/LinuxTimerComponentImpl.hpp
@@ -18,7 +18,7 @@
 
 namespace Svc {
 
-  class LinuxTimerComponentImpl :
+  class LinuxTimerComponentImpl final :
     public LinuxTimerComponentBase
   {
 

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
@@ -5,7 +5,7 @@
 
 namespace Svc {
 
-	class ConsoleTextLoggerImpl : public PassiveTextLoggerComponentBase  {
+	class ConsoleTextLoggerImpl final : public PassiveTextLoggerComponentBase  {
 
 	public:
 

--- a/Svc/PassiveRateGroup/PassiveRateGroup.hpp
+++ b/Svc/PassiveRateGroup/PassiveRateGroup.hpp
@@ -27,7 +27,7 @@ namespace Svc {
 //! time of the rate group and detects overruns.
 //!
 
-class PassiveRateGroup : public PassiveRateGroupComponentBase {
+class PassiveRateGroup final : public PassiveRateGroupComponentBase {
   public:
     //!  \brief PassiveRateGroupImpl constructor
     //!

--- a/Svc/PolyDb/PolyDb.hpp
+++ b/Svc/PolyDb/PolyDb.hpp
@@ -27,7 +27,7 @@ namespace Svc {
     //! to ENs (Engineering Numbers) to decouple the conversion as well.
     //!
 
-    class PolyDb : public PolyDbComponentBase {
+    class PolyDb final : public PolyDbComponentBase {
     public:
         //!  \brief PolyDbImpl constructor
         //!

--- a/Svc/PosixTime/PosixTime.hpp
+++ b/Svc/PosixTime/PosixTime.hpp
@@ -12,7 +12,7 @@
 
 namespace Svc {
 
-class PosixTime: public PosixTimeComponentBase {
+class PosixTime final : public PosixTimeComponentBase {
     public:
         explicit PosixTime(const char* compName);
         virtual ~PosixTime();

--- a/Svc/PrmDb/PrmDbImpl.hpp
+++ b/Svc/PrmDb/PrmDbImpl.hpp
@@ -27,7 +27,7 @@ namespace Svc {
     //! for components.
     //!
 
-    class PrmDbImpl : public PrmDbComponentBase {
+    class PrmDbImpl final : public PrmDbComponentBase {
         public:
 
             friend class PrmDbImplTester;

--- a/Svc/RateGroupDriver/RateGroupDriver.hpp
+++ b/Svc/RateGroupDriver/RateGroupDriver.hpp
@@ -30,7 +30,7 @@ namespace Svc {
     //! Output rate is CycleIn rate/divider[port]
     //!
 
-    class RateGroupDriver : public RateGroupDriverComponentBase {
+    class RateGroupDriver final : public RateGroupDriverComponentBase {
 
         public:
             //! Size of the divider table, provided as a constants to users passing the table in

--- a/Svc/SeqDispatcher/SeqDispatcher.hpp
+++ b/Svc/SeqDispatcher/SeqDispatcher.hpp
@@ -15,7 +15,7 @@
 
 namespace Svc {
 
-class SeqDispatcher : public SeqDispatcherComponentBase {
+class SeqDispatcher final : public SeqDispatcherComponentBase {
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Svc/StaticMemory/StaticMemoryComponentImpl.hpp
+++ b/Svc/StaticMemory/StaticMemoryComponentImpl.hpp
@@ -18,7 +18,7 @@
 
 namespace Svc {
 
-class StaticMemoryComponentImpl : public StaticMemoryComponentBase {
+class StaticMemoryComponentImpl final : public StaticMemoryComponentBase {
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Svc/SystemResources/SystemResources.hpp
+++ b/Svc/SystemResources/SystemResources.hpp
@@ -20,7 +20,7 @@
 
 namespace Svc {
 
-class SystemResources : public SystemResourcesComponentBase {
+class SystemResources final : public SystemResourcesComponentBase {
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Svc/TlmChan/TlmChan.hpp
+++ b/Svc/TlmChan/TlmChan.hpp
@@ -19,7 +19,7 @@
 
 namespace Svc {
 
-class TlmChan : public TlmChanComponentBase {
+class TlmChan final : public TlmChanComponentBase {
   public:
     TlmChan(const char* compName);
     virtual ~TlmChan();

--- a/Svc/TlmPacketizer/TlmPacketizer.hpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.hpp
@@ -18,7 +18,7 @@
 
 namespace Svc {
 
-class TlmPacketizer : public TlmPacketizerComponentBase {
+class TlmPacketizer final : public TlmPacketizerComponentBase {
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Svc/UdpReceiver/UdpReceiverComponentImpl.hpp
+++ b/Svc/UdpReceiver/UdpReceiverComponentImpl.hpp
@@ -18,7 +18,7 @@
 
 namespace Svc {
 
-  class UdpReceiverComponentImpl :
+  class UdpReceiverComponentImpl final :
     public UdpReceiverComponentBase
   {
 

--- a/Svc/UdpSender/UdpSenderComponentImpl.hpp
+++ b/Svc/UdpSender/UdpSenderComponentImpl.hpp
@@ -21,7 +21,7 @@
 
 namespace Svc {
 
-  class UdpSenderComponentImpl :
+  class UdpSenderComponentImpl final :
     public UdpSenderComponentBase
   {
 

--- a/Svc/Version/Version.hpp
+++ b/Svc/Version/Version.hpp
@@ -11,7 +11,7 @@
 
 namespace Svc {
 
-class Version : public VersionComponentBase {
+class Version final : public VersionComponentBase {
   public:
     // ----------------------------------------------------------------------
     // Component construction and destruction


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  #3038  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description
Makes all component implementation classes final to address #3038.
For reference, updates to FPP codegen are in https://github.com/nasa/fpp/pull/623.
