### PR TITLE
Add minor improvements for handling external libraries

### DIFF
--- a/Fw/SerializableFile/CMakeLists.txt
+++ b/Fw/SerializableFile/CMakeLists.txt
@@ -22,10 +22,10 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/Test.cpp"
 )
 set(UT_MOD_DEPS
-  "${FPRIME_FRAMEWORK_PATH}/Fw/SerializableFile"
-  "${FPRIME_FRAMEWORK_PATH}/Fw/SerializableFile/test/TestSerializable"
-  "${FPRIME_FRAMEWORK_PATH}/Fw/Types"
-  "${FPRIME_FRAMEWORK_PATH}/Utils/Hash"
-  "${FPRIME_FRAMEWORK_PATH}/Os"
+  Fw/SerializableFile
+  Fw/SerializableFile/test/TestSerializable
+  Fw/Types
+  Utils/Hash
+  Os
 )
 register_fprime_ut()

--- a/Fw/Types/CMakeLists.txt
+++ b/Fw/Types/CMakeLists.txt
@@ -30,7 +30,7 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/TypesTest.cpp"
 )
 set(UT_MOD_DEPS
-  "${FPRIME_FRAMEWORK_PATH}/Os"
+  Os
 )
 register_fprime_ut()
 set (UT_TARGET_NAME "${FPRIME_CURRENT_MODULE}_ut_exe")

--- a/cmake/FPrime.cmake
+++ b/cmake/FPrime.cmake
@@ -62,6 +62,7 @@ function(fprime_setup_global_includes)
     include_directories("${FPRIME_FRAMEWORK_PATH}")
     include_directories("${FPRIME_CONFIG_DIR}")
     include_directories("${FPRIME_PROJECT_ROOT}")
+    include_directories("${FPRIME_PROJECT_ROOT}/lib/include")
 
     # Setup the include directories that exist within the build-cache
     include_directories("${CMAKE_BINARY_DIR}")

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -280,6 +280,7 @@ endfunction()
 #
 # 1. Linker flags: starts with -l
 # 2. Existing Files: accounts for preexisting libraries shared and otherwise
+# 3. Absolute paths starting with / : accounts for libraries that are built at project build-time
 #
 # OUTPUT_VAR: variable to set in PARENT_SCOPE to TRUE/FALSE
 # TOKEN: token to check if "linker only"
@@ -287,7 +288,8 @@ endfunction()
 function(linker_only OUTPUT_VAR TOKEN)
     set("${OUTPUT_VAR}" FALSE PARENT_SCOPE)
     starts_with(IS_LINKER_FLAG "${TOKEN}" "-l")
-    if (IS_LINKER_FLAG OR (EXISTS "${TOKEN}" AND NOT IS_DIRECTORY "${TOKEN}"))
+    starts_with(IS_ABSOLUTE_PATH "${TOKEN}" "/")
+    if (IS_LINKER_FLAG OR IS_ABSOLUTE_PATH OR (EXISTS "${TOKEN}" AND NOT IS_DIRECTORY "${TOKEN}"))
         set("${OUTPUT_VAR}" TRUE PARENT_SCOPE)
     endif()
 endfunction()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Incremental step in addressing https://github.com/nasa/fprime/issues/3056

**Proposed change:** If a `MOD_DEPS` entry is an absolute path, it should be recognized as a linker_only flag.

## Rationale 

When building a non-CMake-based library from source as part of the CMake build (e.g. with `ExternalProject_Add`), it can be useful to reference in the `MOD_DEPS` the path to a soon-to-be-built `lib<libName>.a` file.

However the current handling would not recognize this as a library file, since it only checks for the existence of the file. This addresses it by adding a check "is this an absolute path?". If yes, consider it a linker-only dependency.
