### PR TITLE
Clarify dependency for FW_ENABLE_TEXT_LOGGING

### DIFF
--- a/config/FpConfig.h
+++ b/config/FpConfig.h
@@ -349,7 +349,8 @@ typedef FwIndexType FwQueueSizeType;
 #define FW_INTERNAL_INTERFACE_STRING_MAX_SIZE 256  //!< Max size of interface string parameter type
 #endif
 
-// enables text logging of events as well as data logging. Adds a second logging port for text output.
+// Enables text logging of events as well as data logging. Adds a second logging port for text output.
+// In order to set this to 0, FPRIME_ENABLE_TEXT_LOGGERS must be set to OFF.
 #ifndef FW_ENABLE_TEXT_LOGGING
 #define FW_ENABLE_TEXT_LOGGING 1  //!< Indicates whether text logging is turned on
 #endif


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

If I set FW_ENABLE_TEXT_LOGGING to 0, it results in a number of very confusing errors... unless I also set FPRIME_ENABLE_TEXT_LOGGERS to OFF. This wasn't apparent to me, because I found out about FW_ENABLE_TEXT_LOGGING from #ifdefs in broken code, not by reading documentation.

Add an extra comment to indicate the dependency. This would have kept me from getting confused.

## Rationale

See above.

## Testing/Review Recommendations

N/A

## Future Work

We could consider generating an explicit `#error` if FPRIME_ENABLE_TEXT_LOGGERS=ON and FW_ENABLE_TEXT_LOGGING=0.
