### PR TITLE
Add apt-get update call to all workflows using apt-get

### DIFF
--- a/.github/workflows/cookiecutters-test.yml
+++ b/.github/workflows/cookiecutters-test.yml
@@ -55,6 +55,7 @@ jobs:
 
       - name: "Install expect and fprime-bootstrap"
         run: |
+             sudo apt-get update
              sudo apt-get install expect
              pip install git+https://github.com/fprime-community/fprime-bootstrap@${{ needs.get-bootstrap-branch.outputs.target-branch }}
 

--- a/.github/workflows/cppcheck-scan.yml
+++ b/.github/workflows/cppcheck-scan.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Install cppcheck
-        run: sudo apt-get install cppcheck xsltproc -y
+        run: sudo apt-get update && sudo apt-get install cppcheck xsltproc -y
 
       - name: Install sarif tool
         run: npm i -g @microsoft/sarif-multitool

--- a/.github/workflows/cpplint-scan.yml
+++ b/.github/workflows/cpplint-scan.yml
@@ -33,7 +33,7 @@ jobs:
         run: pip install cpplint
 
       - name: Install xsltproc
-        run: sudo apt-get install xsltproc -y
+        run: sudo apt-get update && sudo apt-get install xsltproc -y
 
       - name: Install sarif tool
         run: npm i -g @microsoft/sarif-multitool

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -16,6 +16,7 @@ jobs:
 
     - name: 'Generate Doxygen and CMake docs'
       run: |
+        sudo apt-get update
         sudo apt-get install -y doxygen
         ./docs/doxygen/generate_docs.bash
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds `apt-get update` prior to all `apt-get install` commands in our workflow suite.

Per [GitHub instructions](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners):
> Always run sudo apt-get update before installing a package.

## Rationale

Some workflows have been failing on some `apt-get install` commands (see https://github.com/nasa/fprime/actions/runs/14012794656/job/39472654879)