### PR TITLE
Replace FpConfig type aliases with FPP generated aliases

### DIFF
--- a/config/FpConfig.fpp
+++ b/config/FpConfig.fpp
@@ -1,16 +1,43 @@
-type FwChanIdType
-type FwDpIdType
-type FwDpPriorityType
-type FwEnumStoreType
-type FwEventIdType
-type FwIndexType
-type FwOpcodeType
-type FwPacketDescriptorType
-type FwPrmIdType
-type FwSignedSizeType
-type FwSizeStoreType
-type FwSizeType
-type FwTimeBaseStoreType
-type FwTimeContextStoreType
-type FwTlmPacketizeIdType
-type FwTraceIdType
+@ The type of a telemetry channel identifier
+type FwChanIdType = U32
+
+@ The type of a data product identifier
+type FwDpIdType = U32
+
+@ The type of a data product priority
+type FwDpPriorityType = U32
+
+@ The type of an event identifier
+type FwEventIdType = U32
+
+@ The type of a command opcode
+type FwOpcodeType = U32
+
+@ The type of a com packet descriptor
+type FwPacketDescriptorType = U32
+
+@ The type of a parameter identifier
+type FwPrmIdType = U32
+
+@ The type used to serialize a size value
+type FwSizeStoreType = U16
+
+@ The unsigned type of larger sizes internal to the software,
+@ e.g., memory buffer sizes, file sizes
+type FwSizeType = U32
+
+@ The type used to serialize a time base value
+type FwTimeBaseStoreType = U16
+
+@ The type used to serialize a time context value
+type FwTimeContextStoreType = U8
+
+@ The type of a telemetry packet identifier
+type FwTlmPacketizeIdType = U16
+
+@ The type of a trace identifier
+type FwTraceIdType = U32
+
+@ The type used to serialize a C++ enumeration constant
+@ FPP enumerations are serialized according to their representation types
+type FwEnumStoreType = I32

--- a/config/FpConfig.h
+++ b/config/FpConfig.h
@@ -18,6 +18,25 @@ extern "C" {
 #endif
 
 // ----------------------------------------------------------------------
+// Type aliases defined by FPP
+// ----------------------------------------------------------------------
+
+#include <FwChanIdTypeAliasAc.h>
+#include <FwDpIdTypeAliasAc.h>
+#include <FwDpPriorityTypeAliasAc.h>
+#include <FwEnumStoreTypeAliasAc.h>
+#include <FwEventIdTypeAliasAc.h>
+#include <FwOpcodeTypeAliasAc.h>
+#include <FwPacketDescriptorTypeAliasAc.h>
+#include <FwPrmIdTypeAliasAc.h>
+#include <FwSizeStoreTypeAliasAc.h>
+#include <FwSizeTypeAliasAc.h>
+#include <FwTimeBaseStoreTypeAliasAc.h>
+#include <FwTimeContextStoreTypeAliasAc.h>
+#include <FwTlmPacketizeIdTypeAliasAc.h>
+#include <FwTraceIdTypeAliasAc.h>
+
+// ----------------------------------------------------------------------
 // Type aliases
 // ----------------------------------------------------------------------
 
@@ -29,11 +48,6 @@ typedef PlatformIndexType FwIndexType;
 // file sizes
 typedef PlatformSignedSizeType FwSignedSizeType;
 #define PRI_FwSignedSizeType PRI_PlatformSignedSizeType
-
-// The unsigned type of larger sizes internal to the software, e.g., memory buffer sizes,
-// file sizes
-typedef PlatformSizeType FwSizeType;
-#define PRI_FwSizeType PRI_PlatformSizeType
 
 // The type of an assertion argument
 typedef PlatformAssertArgType FwAssertArgType;
@@ -55,15 +69,6 @@ typedef PlatformTaskPriorityType FwTaskPriorityType;
 typedef PlatformQueuePriorityType FwQueuePriorityType;
 #define PRI_FwQueuePriorityType PRI_PlatformQueuePriorityType
 
-// The type used to serialize a size value
-typedef U16 FwSizeStoreType;
-#define PRI_FwSizeStoreType PRIu16
-
-// The type used to serialize a C++ enumeration constant
-// FPP enumerations are serialized according to their representation types
-typedef I32 FwEnumStoreType;
-#define PRI_FwEnumStoreType PRId32
-
 // Define enumeration for Time base types
 // Note: maintaining C-style
 typedef enum {
@@ -74,50 +79,6 @@ typedef enum {
         0xFFFF  //!< Don't care value for sequences. If FwTimeBaseStoreType is changed, value should be changed
 } TimeBase;
 #define FW_CONTEXT_DONT_CARE 0xFF  //!< Don't care value for time contexts in sequences
-
-// The type used to serialize a time base value
-typedef U16 FwTimeBaseStoreType;
-#define PRI_FwTimeBaseStoreType PRIu16
-
-// The type used to serialize a time context value
-typedef U8 FwTimeContextStoreType;
-#define PRI_FwTimeContextStoreType PRIu8
-
-// The type of a com packet descriptor
-typedef U32 FwPacketDescriptorType;
-#define PRI_FwPacketDescriptorType PRIu32
-
-// The type of a command opcode
-typedef U32 FwOpcodeType;
-#define PRI_FwOpcodeType PRIu32
-
-// The type of a telemetry channel identifier
-typedef U32 FwChanIdType;
-#define PRI_FwChanIdType PRIu32
-
-// The type of a trace identifier
-typedef U32 FwTraceIdType;
-#define PRI_FwTraceIdType PRIu32
-
-// The type of an event identifier
-typedef U32 FwEventIdType;
-#define PRI_FwEventIdType PRIu32
-
-// The type of a parameter identifier
-typedef U32 FwPrmIdType;
-#define PRI_FwPrmIdType PRIu32
-
-// The type of a telemetry packet identifier
-typedef U16 FwTlmPacketizeIdType;
-#define PRI_FwTlmPacketizeIdType PRIu16
-
-// The type of a data product identifier
-typedef U32 FwDpIdType;
-#define PRI_FwDpIdType PRIu32
-
-// The type of a data product priority
-typedef U32 FwDpPriorityType;
-#define PRI_FwDpPriorityType PRIu32
 
 // ----------------------------------------------------------------------
 // Derived type aliases


### PR DESCRIPTION
This PR replaces typedefs created in `FpConfig.h` with FPP generated type definitions.  This is the diff I've been building https://github.com/nasa/fpp/pull/669 against. It depends on that PR for this to build successfully which is why I'm opening this as a draft until that is merged.