### PR TITLE
Fix warnings in FppTest build

### DIFF
--- a/FppTest/CMakeLists.txt
+++ b/FppTest/CMakeLists.txt
@@ -11,24 +11,27 @@ project(FppTest C CXX)
 include("${CMAKE_CURRENT_LIST_DIR}/../cmake/FPrime.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/../cmake/FPrime-Code.cmake")
 
+add_compile_options(
+    -Wall
+    -Wdouble-promotion
+    -Wno-sign-compare
+    -Wno-zero-length-array
+    -Werror
+    -Wextra
+    -Wno-unused-parameter
+    -Wno-variadic-macro-arguments-omitted
+    -Wno-vla
+    -Wold-style-cast
+    -Wshadow
+    -pedantic
+)
+
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/array/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/component/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/dp/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/state_machine/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/enum/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/struct/")
-
-add_compile_options(
-    -Wall
-    -Wconversion
-    -Wdouble-promotion
-    -Werror
-    -Wextra
-    -Wno-unused-parameter
-    -Wold-style-cast
-    -Wshadow
-    -pedantic
-)
 
 set(SOURCE_FILES "source.cpp")
 set(MOD_DEPS

--- a/FppTest/CMakeLists.txt
+++ b/FppTest/CMakeLists.txt
@@ -17,12 +17,20 @@ add_compile_options(
     -Wdouble-promotion
     -Werror
     -Wextra
-    -Wno-unused-parameter
-    -Wno-variadic-macro-arguments-omitted
-    -Wno-vla
     -Wold-style-cast
     -Wshadow
     -pedantic
+)
+
+# Required by F Prime
+add_compile_options(
+    -Wno-unused-parameter
+    -Wno-vla
+)
+
+# Required by Google Test typed tests
+add_compile_options(
+    -Wno-variadic-macro-arguments-omitted
 )
 
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/array/")

--- a/FppTest/CMakeLists.txt
+++ b/FppTest/CMakeLists.txt
@@ -29,9 +29,11 @@ add_compile_options(
 )
 
 # Required by Google Test typed tests
-add_compile_options(
-    -Wno-variadic-macro-arguments-omitted
-)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(
+        -Wno-variadic-macro-arguments-omitted
+    )
+endif()
 
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/array/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/component/")

--- a/FppTest/CMakeLists.txt
+++ b/FppTest/CMakeLists.txt
@@ -14,7 +14,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/../cmake/FPrime-Code.cmake")
 add_compile_options(
     -Wall
     -Wdouble-promotion
-    -Wno-sign-compare
     -Wno-zero-length-array
     -Werror
     -Wextra

--- a/FppTest/CMakeLists.txt
+++ b/FppTest/CMakeLists.txt
@@ -13,6 +13,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/../cmake/FPrime-Code.cmake")
 
 add_compile_options(
     -Wall
+    -Wconversion
     -Wdouble-promotion
     -Wno-zero-length-array
     -Werror

--- a/FppTest/CMakeLists.txt
+++ b/FppTest/CMakeLists.txt
@@ -15,7 +15,6 @@ add_compile_options(
     -Wall
     -Wconversion
     -Wdouble-promotion
-    -Wno-zero-length-array
     -Werror
     -Wextra
     -Wno-unused-parameter

--- a/FppTest/array/FormatTest.cpp
+++ b/FppTest/array/FormatTest.cpp
@@ -63,7 +63,7 @@ TEST_F(FormatTest, U8) {
 
     buf1 << a;
     for (U32 i = 0; i < FormatU8::SIZE; i++) {
-        buf2 << "a " << (U16) testVals[i] << " b ";
+        buf2 << "a " << static_cast<U16>(testVals[i]) << " b ";
     }
     buf2 << "]";
 
@@ -129,7 +129,7 @@ TEST_F(FormatTest, I8) {
 
     buf1 << a;
     for (U32 i = 0; i < FormatI8::SIZE; i++) {
-        buf2 << "a " << (I16) testVals[i] << " b ";
+        buf2 << "a " << static_cast<I16>(testVals[i]) << " b ";
     }
     buf2 << "]";
 

--- a/FppTest/array/main.cpp
+++ b/FppTest/array/main.cpp
@@ -132,7 +132,7 @@ U32 FppTest::Array::getSerializedSize<::String>
     U32 serializedSize = 0;
 
     for (U32 i = 0; i < ::String::SIZE; i++) {
-        serializedSize += a[i].serializedSize();
+        serializedSize += static_cast<U32>(a[i].serializedSize());
     }
 
     return serializedSize;

--- a/FppTest/component/tests/AsyncTesterHelpers.cpp
+++ b/FppTest/component/tests/AsyncTesterHelpers.cpp
@@ -49,7 +49,7 @@ void Tester ::connectAsyncPorts() {
     }
 
     // serialAsync
-    for (FwSizeType i = 0; i < 3; ++i) {
+    for (FwIndexType i = 0; i < 3; ++i) {
         this->connect_to_serialAsync(i, this->component.get_serialAsync_InputPort(i));
     }
 

--- a/FppTest/component/tests/EventTests.cpp
+++ b/FppTest/component/tests/EventTests.cpp
@@ -32,9 +32,9 @@ void Tester ::testEventHelper(FwIndexType portNum, FppTest::Types::PrimitivePara
     component.log_ACTIVITY_LO_EventPrimitive(data.args.val1, data.args.val2, data.args.val3, data.args.val4,
                                              data.args.val5, data.args.val6);
 
-    ASSERT_EVENTS_SIZE(size);
-    ASSERT_EVENTS_EventPrimitive_SIZE(size);
-    ASSERT_EVENTS_EventPrimitive(portNum, data.args.val1, data.args.val2, data.args.val3, data.args.val4,
+    ASSERT_EVENTS_SIZE(static_cast<U32>(size));
+    ASSERT_EVENTS_EventPrimitive_SIZE(static_cast<U32>(size));
+    ASSERT_EVENTS_EventPrimitive(static_cast<U32>(portNum), data.args.val1, data.args.val2, data.args.val3, data.args.val4,
                                  data.args.val5, data.args.val6);
 }
 
@@ -63,7 +63,7 @@ void Tester ::testEvent(FwIndexType portNum, FppTest::Types::LogStringParams& da
     ASSERT_EVENTS_EventString_SIZE(1);
     Fw::StringTemplate<80> arg1(data.args.val1);
     Fw::StringTemplate<100> arg2(data.args.val2);
-    ASSERT_EVENTS_EventString(portNum, arg1.toChar(), arg2.toChar());
+    ASSERT_EVENTS_EventString(static_cast<U32>(portNum), arg1.toChar(), arg2.toChar());
 
     this->printTextLogHistory(stdout);
 }
@@ -76,7 +76,7 @@ void Tester ::testEvent(FwIndexType portNum, FppTest::Types::EnumParam& data) {
 
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_EventEnum_SIZE(1);
-    ASSERT_EVENTS_EventEnum(portNum, data.args.val);
+    ASSERT_EVENTS_EventEnum(static_cast<U32>(portNum), data.args.val);
 
     this->printTextLogHistory(stdout);
 }
@@ -87,9 +87,9 @@ void Tester ::testEventHelper(FwIndexType portNum, FppTest::Types::ArrayParam& d
 
     component.log_FATAL_EventArray(data.args.val);
 
-    ASSERT_EVENTS_SIZE(size);
-    ASSERT_EVENTS_EventArray_SIZE(size);
-    ASSERT_EVENTS_EventArray(portNum, data.args.val);
+    ASSERT_EVENTS_SIZE(static_cast<U32>(size));
+    ASSERT_EVENTS_EventArray_SIZE(static_cast<U32>(size));
+    ASSERT_EVENTS_EventArray(static_cast<U32>(portNum), data.args.val);
 }
 
 void Tester ::testEvent(FwIndexType portNum, FppTest::Types::ArrayParam& data) {
@@ -118,7 +118,7 @@ void Tester ::testEvent(FwIndexType portNum, FppTest::Types::StructParam& data) 
 
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_EventStruct_SIZE(1);
-    ASSERT_EVENTS_EventStruct(portNum, data.args.val);
+    ASSERT_EVENTS_EventStruct(static_cast<U32>(portNum), data.args.val);
 
     this->printTextLogHistory(stdout);
 }
@@ -129,9 +129,9 @@ void Tester ::testEventHelper(FwIndexType portNum, FppTest::Types::BoolParam& da
 
     component.log_WARNING_LO_EventBool(data.args.val);
 
-    ASSERT_EVENTS_SIZE(size);
-    ASSERT_EVENTS_EventBool_SIZE(size);
-    ASSERT_EVENTS_EventBool(portNum, data.args.val);
+    ASSERT_EVENTS_SIZE(static_cast<U32>(size));
+    ASSERT_EVENTS_EventBool_SIZE(static_cast<U32>(size));
+    ASSERT_EVENTS_EventBool(static_cast<U32>(portNum), data.args.val);
 }
 
 void Tester ::testEvent(FwIndexType portNum, FppTest::Types::BoolParam& data) {

--- a/FppTest/component/tests/PortTests.hpp
+++ b/FppTest/component/tests/PortTests.hpp
@@ -242,7 +242,7 @@
     void Tester ::test##PORT_KIND##PortInvokeSerial(FwIndexType portNum, FppTest::Types::NoParams& port) {         \
         ASSERT_TRUE(component.isConnected_serialOut_OutputPort(portNum));                                              \
                                                                                                                        \
-        U8 data[0];                                                                                                    \
+        U8 data[1];                                                                                                    \
         Fw::SerialBuffer buf(data, sizeof(data));                                                                      \
                                                                                                                        \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::NO_ARGS, buf);                                            \
@@ -254,7 +254,7 @@
         Fw::SerializeStatus status;                                                                                    \
                                                                                                                        \
         /* Check unsuccessful deserialization of first parameter */                                                    \
-        U8 invalidData1[0];                                                                                            \
+        U8 invalidData1[1];                                                                                            \
         Fw::SerialBuffer invalidBuf1(invalidData1, sizeof(invalidData1));                                              \
                                                                                                                        \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, invalidBuf1);                                  \
@@ -379,7 +379,7 @@
         Fw::SerializeStatus status;                                                                                    \
                                                                                                                        \
         /* Check unsuccessful deserialization of first parameter */                                                    \
-        U8 invalidData1[0];                                                                                            \
+        U8 invalidData1[1];                                                                                            \
         Fw::SerialBuffer invalidBuf1(invalidData1, sizeof(invalidData1));                                              \
                                                                                                                        \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRING, invalidBuf1);                                     \
@@ -455,7 +455,7 @@
         Fw::SerializeStatus status;                                                                                    \
                                                                                                                        \
         /* Check unsuccessful deserialization of first parameter */                                                    \
-        U8 invalidData1[0];                                                                                            \
+        U8 invalidData1[1];                                                                                            \
         Fw::SerialBuffer invalidBuf1(invalidData1, sizeof(invalidData1));                                              \
                                                                                                                        \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::ENUM, invalidBuf1);                                       \
@@ -494,7 +494,7 @@
         Fw::SerializeStatus status;                                                                                    \
                                                                                                                        \
         /* Check unsuccessful deserialization of first parameter */                                                    \
-        U8 invalidData1[0];                                                                                            \
+        U8 invalidData1[1];                                                                                            \
         Fw::SerialBuffer invalidBuf1(invalidData1, sizeof(invalidData1));                                              \
                                                                                                                        \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::ARRAY, invalidBuf1);                                      \
@@ -532,7 +532,7 @@
         Fw::SerializeStatus status;                                                                                    \
                                                                                                                        \
         /* Check unsuccessful deserialization of first parameter */                                                    \
-        U8 invalidData1[0];                                                                                            \
+        U8 invalidData1[1];                                                                                            \
         Fw::SerialBuffer invalidBuf1(invalidData1, sizeof(invalidData1));                                              \
                                                                                                                        \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRUCT, invalidBuf1);                                     \

--- a/FppTest/component/tests/TesterHelpers.cpp
+++ b/FppTest/component/tests/TesterHelpers.cpp
@@ -222,12 +222,12 @@ void Tester ::connectPorts() {
     // ----------------------------------------------------------------------
 
     // serialGuarded
-    for (FwSizeType i = 0; i < 6; ++i) {
+    for (FwIndexType i = 0; i < 6; ++i) {
         this->connect_to_serialGuarded(i, this->component.get_serialGuarded_InputPort(i));
     }
 
     // serialSync
-    for (FwSizeType i = 0; i < 6; ++i) {
+    for (FwIndexType i = 0; i < 6; ++i) {
         this->connect_to_serialSync(i, this->component.get_serialSync_InputPort(i));
     }
 }

--- a/FppTest/component/tests/TimeTests.cpp
+++ b/FppTest/component/tests/TimeTests.cpp
@@ -19,11 +19,11 @@
 // ----------------------------------------------------------------------
 
 void Tester ::testTime() {
-    Fw::Time time(STest::Pick::any(), STest::Pick::any());
+    Fw::Time random_time(STest::Pick::any(), STest::Pick::any());
     Fw::Time zero_time(TB_NONE, 0, 0);
     Fw::Time result;
 
-    this->setTestTime(time);
+    this->setTestTime(random_time);
 
     result = component.getTime();
     ASSERT_EQ(result, zero_time);
@@ -32,11 +32,11 @@ void Tester ::testTime() {
     ASSERT_TRUE(component.isConnected_timeGetOut_OutputPort(0));
 
     result = component.getTime();
-    ASSERT_EQ(result, time);
+    ASSERT_EQ(result, random_time);
 
     this->connectSpecialPortsSerial();
     ASSERT_TRUE(component.isConnected_timeGetOut_OutputPort(0));
 
     result = component.getTime();
-    ASSERT_EQ(result, time);
+    ASSERT_EQ(result, random_time);
 }

--- a/FppTest/component/tests/TlmTests.hpp
+++ b/FppTest/component/tests/TlmTests.hpp
@@ -38,8 +38,7 @@
         ASSERT_TLM_Channel##TYPE##_SIZE(1);                                                   \
         ASSERT_TLM_Channel##TYPE(0, data.args.val);                                           \
                                                                                               \
-        Fw::Time time = Fw::ZERO_TIME;                                                        \
-        component.tlmWrite_Channel##TYPE(data.args.val, time);                                \
+        component.tlmWrite_Channel##TYPE(data.args.val, Fw::ZERO_TIME);                       \
                                                                                               \
         ASSERT_TLM_SIZE(2);                                                                   \
         ASSERT_TLM_Channel##TYPE##_SIZE(2);                                                   \
@@ -70,8 +69,7 @@
             data2 = FppTest::Types::TlmStringParam();                                            \
         }                                                                                        \
                                                                                                  \
-        Fw::Time time = Fw::ZERO_TIME;                                                           \
-        component.tlmWrite_ChannelString(data2.args.val, time);                                  \
+        component.tlmWrite_ChannelString(data2.args.val, Fw::ZERO_TIME);                         \
                                                                                                  \
         ASSERT_TLM_SIZE(2);                                                                      \
         ASSERT_TLM_ChannelString_SIZE(2);                                                        \

--- a/FppTest/dp/DpTest.cpp
+++ b/FppTest/dp/DpTest.cpp
@@ -16,19 +16,19 @@ namespace FppTest {
 // ----------------------------------------------------------------------
 
 DpTest::DpTest(const char* const compName,
-               U32 u32RecordData,
-               U16 dataRecordData,
-               const U8ArrayRecordData& u8ArrayRecordData,
-               const U32ArrayRecordData& u32ArrayRecordData,
-               const DataArrayRecordData& dataArrayRecordData,
+               U32 a_u32RecordData,
+               U16 a_dataRecordData,
+               const U8ArrayRecordData& a_u8ArrayRecordData,
+               const U32ArrayRecordData& a_u32ArrayRecordData,
+               const DataArrayRecordData& a_dataArrayRecordData,
                const Fw::StringBase& a_stringRecordData)
     : DpTestComponentBase(compName),
       m_container(),
-      u32RecordData(u32RecordData),
-      dataRecordData(dataRecordData),
-      u8ArrayRecordData(u8ArrayRecordData),
-      u32ArrayRecordData(u32ArrayRecordData),
-      dataArrayRecordData(dataArrayRecordData),
+      u32RecordData(a_u32RecordData),
+      dataRecordData(a_dataRecordData),
+      u8ArrayRecordData(a_u8ArrayRecordData),
+      u32ArrayRecordData(a_u32ArrayRecordData),
+      dataArrayRecordData(a_dataArrayRecordData),
       stringRecordData(a_stringRecordData),
       sendTime(Fw::ZERO_TIME) {
     for (auto& elt : this->stringArrayRecordData) {

--- a/FppTest/dp/DpTest.cpp
+++ b/FppTest/dp/DpTest.cpp
@@ -58,7 +58,7 @@ void DpTest::schedIn_handler(const FwIndexType portNum, U32 context) {
     // Get a buffer for Container 1
     {
         Fw::Success status = this->dpGet_Container1(CONTAINER_1_DATA_SIZE, this->m_container);
-        FW_ASSERT(status == Fw::Success::SUCCESS, status);
+        FW_ASSERT(status == Fw::Success::SUCCESS, static_cast<FwAssertArgType>(status));
         // Check the container
         this->checkContainer(this->m_container, ContainerId::Container1, CONTAINER_1_PACKET_SIZE,
                              DpTest::ContainerPriority::Container1);
@@ -110,7 +110,7 @@ void DpTest ::dpRecv_Container1_handler(DpContainer& container, Fw::Success::T s
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
-            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
+            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         }
         // Use the time stamp from the time get port
         this->dpSend(this->m_container);
@@ -131,7 +131,7 @@ void DpTest ::dpRecv_Container2_handler(DpContainer& container, Fw::Success::T s
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
-            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
+            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         }
         // Provide an explicit time stamp
         this->dpSend(this->m_container, this->sendTime);
@@ -152,7 +152,7 @@ void DpTest ::dpRecv_Container3_handler(DpContainer& container, Fw::Success::T s
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
-            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
+            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         }
         // Use the time stamp from the time get port
         this->dpSend(this->m_container);
@@ -173,7 +173,7 @@ void DpTest ::dpRecv_Container4_handler(DpContainer& container, Fw::Success::T s
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
-            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
+            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         }
         // Use the time stamp from the time get port
         this->dpSend(this->m_container);
@@ -194,7 +194,7 @@ void DpTest ::dpRecv_Container5_handler(DpContainer& container, Fw::Success::T s
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
-            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
+            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         }
         // Use the time stamp from the time get port
         this->dpSend(this->m_container);
@@ -214,7 +214,7 @@ void DpTest ::dpRecv_Container6_handler(DpContainer& container, Fw::Success::T s
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
-            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
+            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         }
         // Use the time stamp from the time get port
         this->dpSend(this->m_container);
@@ -235,7 +235,7 @@ void DpTest ::dpRecv_Container7_handler(DpContainer& container, Fw::Success::T s
             if (serializeStatus == Fw::FW_SERIALIZE_NO_ROOM_LEFT) {
                 break;
             }
-            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, status);
+            FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         }
         // Use the time stamp from the time get port
         this->dpSend(this->m_container);
@@ -263,11 +263,15 @@ void DpTest::checkContainer(const DpContainer& container,
                             FwSizeType size,
                             FwDpPriorityType priority) const {
     this->checkContainerEmpty(container);
-    FW_ASSERT(container.getBaseId() == this->getIdBase(), container.getBaseId(), this->getIdBase());
-    FW_ASSERT(container.getId() == container.getBaseId() + localId, container.getId(), container.getBaseId(),
-              ContainerId::Container1);
-    FW_ASSERT(container.getBuffer().getSize() == size, container.getBuffer().getSize(), size);
-    FW_ASSERT(container.getPriority() == priority, container.getPriority(), priority);
+    FW_ASSERT(container.getBaseId() == this->getIdBase(), static_cast<FwAssertArgType>(container.getBaseId()),
+              static_cast<FwAssertArgType>(this->getIdBase()));
+    FW_ASSERT(container.getId() == container.getBaseId() + localId, static_cast<FwAssertArgType>(container.getId()),
+              static_cast<FwAssertArgType>(container.getBaseId()),
+              static_cast<FwAssertArgType>(ContainerId::Container1));
+    FW_ASSERT(container.getBuffer().getSize() == size, static_cast<FwAssertArgType>(container.getBuffer().getSize()),
+              static_cast<FwAssertArgType>(size));
+    FW_ASSERT(container.getPriority() == priority, static_cast<FwAssertArgType>(container.getPriority()),
+              static_cast<FwAssertArgType>(priority));
 }
 
 }  // end namespace FppTest

--- a/FppTest/dp/test/ut/Tester.cpp
+++ b/FppTest/dp/test/ut/Tester.cpp
@@ -35,7 +35,7 @@ Tester::Tester()
       container7Buffer(this->container7Data, sizeof this->container7Data),
       component("DpTest",
                 STest::Pick::any(),
-                STest::Pick::any(),
+                static_cast<U16>(STest::Pick::any()),
                 this->u8ArrayRecordData,
                 this->u32ArrayRecordData,
                 this->dataArrayRecordData,
@@ -436,7 +436,7 @@ void Tester::productRecvIn_CheckFailure(FwDpIdType id, Fw::Buffer buffer) {
 Fw::Success::T Tester::productGet_handler(FwDpIdType id, FwSizeType size, Fw::Buffer& buffer) {
     this->pushProductGetEntry(id, size);
     Fw::Success status = Fw::Success::FAILURE;
-    FW_ASSERT(id >= ID_BASE, id, ID_BASE);
+    FW_ASSERT(id >= ID_BASE, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(ID_BASE));
     const FwDpIdType localId = id - ID_BASE;
     switch (localId) {
         case DpTest::ContainerId::Container1:

--- a/FppTest/dp/test/ut/Tester.cpp
+++ b/FppTest/dp/test/ut/Tester.cpp
@@ -176,7 +176,6 @@ void Tester::productRecvIn_Container3_SUCCESS() {
         status = serialRepr.deserializeSize(size);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         ASSERT_EQ(size, this->u8ArrayRecordData.size());
-        const U8* const buffAddr = serialRepr.getBuffAddr();
         for (FwSizeType j = 0; j < size; ++j) {
             U8 byte;
             status = serialRepr.deserialize(byte);
@@ -220,7 +219,6 @@ void Tester::productRecvIn_Container4_SUCCESS() {
         status = serialRepr.deserializeSize(size);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         ASSERT_EQ(size, this->u32ArrayRecordData.size());
-        const U8* const buffAddr = serialRepr.getBuffAddr();
         for (FwSizeType j = 0; j < size; ++j) {
             U32 elt;
             status = serialRepr.deserialize(elt);
@@ -264,7 +262,6 @@ void Tester::productRecvIn_Container5_SUCCESS() {
         status = serialRepr.deserializeSize(size);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         ASSERT_EQ(size, this->dataArrayRecordData.size());
-        const U8* const buffAddr = serialRepr.getBuffAddr();
         for (FwSizeType j = 0; j < size; ++j) {
             DpTest_Data elt;
             status = serialRepr.deserialize(elt);
@@ -347,7 +344,6 @@ void Tester::productRecvIn_Container7_SUCCESS() {
         status = serialRepr.deserializeSize(size);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         ASSERT_EQ(size, arraySize);
-        const U8* const buffAddr = serialRepr.getBuffAddr();
         for (FwSizeType j = 0; j < size; ++j) {
             Fw::String elt;
             status = serialRepr.deserialize(elt);

--- a/FppTest/enum/main.cpp
+++ b/FppTest/enum/main.cpp
@@ -85,10 +85,14 @@ Explicit::T FppTest::Enum::getInvalidValue<Explicit>() {
                 std::numeric_limits<Explicit::SerialType>::max()
             ));
         default:
-            return static_cast<Explicit::T>(STest::Pick::lowerUpper(
-                (Explicit::A - 1) * (-1),
-                std::numeric_limits<Explicit::SerialType>::max()
-            ) * (-1));
+            return static_cast<Explicit::T>(
+                static_cast<I32>(
+                    STest::Pick::lowerUpper(
+                        (Explicit::A - 1) * (-1),
+                        std::numeric_limits<Explicit::SerialType>::max()
+                    )
+                ) * (-1)
+            );
     }
 }
 

--- a/FppTest/state_machine/external_instance/DeviceSm.hpp
+++ b/FppTest/state_machine/external_instance/DeviceSm.hpp
@@ -54,7 +54,7 @@ class DeviceSm {
                                  
   public:
                                  
-    DeviceSm(DeviceSm_Interface* parent) : parent(parent) {}
+    DeviceSm(DeviceSm_Interface* a_parent) : parent(a_parent) {}
   
     enum DeviceSm_States {
       OFF,

--- a/FppTest/state_machine/external_instance/HackSm.hpp
+++ b/FppTest/state_machine/external_instance/HackSm.hpp
@@ -40,7 +40,7 @@ class HackSm {
                                  
   public:
                                  
-    HackSm(HackSm_Interface* parent) : parent(parent) {}
+    HackSm(HackSm_Interface* a_parent) : parent(a_parent) {}
   
     enum HackSm_States {
       OFF,

--- a/FppTest/state_machine/internal/harness/History.hpp
+++ b/FppTest/state_machine/internal/harness/History.hpp
@@ -62,7 +62,7 @@ class History {
     //! Get the history item at an index
     const T& getItemAt(FwIndexType index  //!< The index
     ) const {
-        FW_ASSERT(index < this->m_size);
+        FW_ASSERT(static_cast<FwSizeType>(index) < this->m_size);
         return this->m_items[index];
     }
 

--- a/FppTest/state_machine/internal/harness/History.hpp
+++ b/FppTest/state_machine/internal/harness/History.hpp
@@ -16,6 +16,7 @@
 
 #include <FpConfig.hpp>
 #include <array>
+#include <cstdlib>
 
 #include "Fw/Types/Assert.hpp"
 

--- a/FppTest/state_machine/internal/harness/History.hpp
+++ b/FppTest/state_machine/internal/harness/History.hpp
@@ -63,7 +63,7 @@ class History {
     const T& getItemAt(FwIndexType index  //!< The index
     ) const {
         FW_ASSERT(static_cast<FwSizeType>(index) < this->m_size);
-        return this->m_items[index];
+        return this->m_items[static_cast<size_t>(index)];
     }
 
   private:

--- a/FppTest/state_machine/internal/harness/Pick.hpp
+++ b/FppTest/state_machine/internal/harness/Pick.hpp
@@ -47,7 +47,7 @@ static inline TestAbsType testAbsType() {
 static inline TestArray testArray() {
     TestArray result;
     for (FwIndexType i = 0; i < TestArray::SIZE; i++) {
-        result[i] = STest::Pick::any();
+        result[static_cast<U32>(i)] = STest::Pick::any();
     }
     return result;
 }
@@ -69,7 +69,7 @@ static inline TestStruct testStruct() {
 static inline void string(Fw::StringBase& s,                           //!< The string value (output)
                           FwSizeType maxLen = Fw::String::STRING_SIZE  //!< The max string length
 ) {
-    const U32 size = STest::Pick::lowerUpper(0, maxLen);
+    const U32 size = STest::Pick::lowerUpper(0, static_cast<U32>(maxLen));
     s = "";
     for (U32 i = 0; i < size; i++) {
         char c = static_cast<char>(STest::Pick::lowerUpper(32, 126));

--- a/FppTest/state_machine/internal/initial/Basic.cpp
+++ b/FppTest/state_machine/internal/initial/Basic.cpp
@@ -32,9 +32,9 @@ void Basic::test() {
     this->initBase(id);
     ASSERT_EQ(this->m_id, id);
     ASSERT_EQ(this->getState(), State::S);
-    const FwSizeType expectedSize = 3;
+    const FwIndexType expectedSize = 3;
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedSize);
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::__FPRIME_AC_INITIAL_TRANSITION);
     }
 }

--- a/FppTest/state_machine/internal/initial/Choice.cpp
+++ b/FppTest/state_machine/internal/initial/Choice.cpp
@@ -56,13 +56,13 @@ void Choice::testTrue() {
     this->checkActionsAndGuards(expectedActionSize, expectedGuardSize);
 }
 
-void Choice::checkActionsAndGuards(FwSizeType expectedActionSize, FwSizeType expectedGuardSize) {
+void Choice::checkActionsAndGuards(FwIndexType expectedActionSize, FwIndexType expectedGuardSize) {
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedActionSize);
-    for (FwSizeType i = 0; i < expectedActionSize; i++) {
+    for (FwIndexType i = 0; i < expectedActionSize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::__FPRIME_AC_INITIAL_TRANSITION);
     }
     ASSERT_EQ(this->m_guard_g.getCallHistory().getSize(), expectedGuardSize);
-    for (FwSizeType i = 0; i < expectedGuardSize; i++) {
+    for (FwIndexType i = 0; i < expectedGuardSize; i++) {
         ASSERT_EQ(this->m_guard_g.getCallHistory().getItemAt(i), Signal::__FPRIME_AC_INITIAL_TRANSITION);
     }
 }

--- a/FppTest/state_machine/internal/initial/Choice.hpp
+++ b/FppTest/state_machine/internal/initial/Choice.hpp
@@ -48,8 +48,8 @@ class Choice final : public ChoiceStateMachineBase {
 
   private:
     //! Helper function for checking actions and guards
-    void checkActionsAndGuards(FwSizeType expectedActionSize,  //!< The expected action size
-                               FwSizeType expectedGuardSize    //!< The expected guard size
+    void checkActionsAndGuards(FwIndexType expectedActionSize,  //!< The expected action size
+                               FwIndexType expectedGuardSize    //!< The expected guard size
     );
 
   private:

--- a/FppTest/state_machine/internal/initial/Nested.cpp
+++ b/FppTest/state_machine/internal/initial/Nested.cpp
@@ -33,9 +33,9 @@ void Nested::test() {
     this->initBase(id);
     ASSERT_EQ(this->m_id, id);
     ASSERT_EQ(this->getState(), State::S_T);
-    const FwSizeType expectedActionSize = 6;
+    const FwIndexType expectedActionSize = 6;
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedActionSize);
-    for (FwSizeType i = 0; i < expectedActionSize; i++) {
+    for (FwIndexType i = 0; i < expectedActionSize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::__FPRIME_AC_INITIAL_TRANSITION);
     }
 }

--- a/FppTest/state_machine/internal/state/Basic.cpp
+++ b/FppTest/state_machine/internal/state/Basic.cpp
@@ -37,9 +37,9 @@ void Basic::test() {
     ASSERT_EQ(this->getState(), State::T);
     this->sendSignal_s();
     ASSERT_EQ(this->getState(), State::T);
-    const FwSizeType expectedSize = 6;
+    const FwIndexType expectedSize = 6;
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedSize);
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::s);
     }
 }

--- a/FppTest/state_machine/internal/state/BasicGuard.cpp
+++ b/FppTest/state_machine/internal/state/BasicGuard.cpp
@@ -59,13 +59,13 @@ void BasicGuard::testTrue() {
     this->checkActionsAndGuards(6, 1);
 }
 
-void BasicGuard::checkActionsAndGuards(FwSizeType expectedActionSize, FwSizeType expectedGuardSize) {
+void BasicGuard::checkActionsAndGuards(FwIndexType expectedActionSize, FwIndexType expectedGuardSize) {
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedActionSize);
-    for (FwSizeType i = 0; i < expectedActionSize; i++) {
+    for (FwIndexType i = 0; i < expectedActionSize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::s);
     }
     ASSERT_EQ(this->m_guard_g.getCallHistory().getSize(), expectedGuardSize);
-    for (FwSizeType i = 0; i < expectedGuardSize; i++) {
+    for (FwIndexType i = 0; i < expectedGuardSize; i++) {
         ASSERT_EQ(this->m_guard_g.getCallHistory().getItemAt(i), Signal::s);
     }
 }

--- a/FppTest/state_machine/internal/state/BasicGuard.hpp
+++ b/FppTest/state_machine/internal/state/BasicGuard.hpp
@@ -49,8 +49,8 @@ class BasicGuard final : public BasicGuardStateMachineBase {
 
   private:
     //! Helper function for checking actions and guards
-    void checkActionsAndGuards(FwSizeType expectedActionSize,  //!< The expected action size
-                               FwSizeType expectedGuardSize    //!< The expected guard size
+    void checkActionsAndGuards(FwIndexType expectedActionSize,  //!< The expected action size
+                               FwIndexType expectedGuardSize    //!< The expected guard size
     );
 
   private:

--- a/FppTest/state_machine/internal/state/BasicSelf.cpp
+++ b/FppTest/state_machine/internal/state/BasicSelf.cpp
@@ -37,9 +37,9 @@ void BasicSelf::test() {
     this->m_action_a_history.clear();
     this->sendSignal_s();
     ASSERT_EQ(this->getState(), State::S);
-    const FwSizeType expectedSize = 6;
+    const FwIndexType expectedSize = 6;
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedSize);
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::s);
     }
 }

--- a/FppTest/state_machine/internal/state/BasicString.cpp
+++ b/FppTest/state_machine/internal/state/BasicString.cpp
@@ -43,9 +43,9 @@ void BasicString::test() {
     ASSERT_EQ(this->getState(), State::T);
     this->sendSignal_s(value);
     ASSERT_EQ(this->getState(), State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::s);
     }
     ASSERT_EQ(this->m_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal/state/BasicTestAbsType.cpp
+++ b/FppTest/state_machine/internal/state/BasicTestAbsType.cpp
@@ -42,9 +42,9 @@ void BasicTestAbsType::test() {
     ASSERT_EQ(this->getState(), State::T);
     this->sendSignal_s(value);
     ASSERT_EQ(this->getState(), State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::s);
     }
     ASSERT_EQ(this->m_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal/state/BasicTestArray.cpp
+++ b/FppTest/state_machine/internal/state/BasicTestArray.cpp
@@ -42,9 +42,9 @@ void BasicTestArray::test() {
     ASSERT_EQ(this->getState(), State::T);
     this->sendSignal_s(value);
     ASSERT_EQ(this->getState(), State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::s);
     }
     ASSERT_EQ(this->m_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal/state/BasicTestEnum.cpp
+++ b/FppTest/state_machine/internal/state/BasicTestEnum.cpp
@@ -42,9 +42,9 @@ void BasicTestEnum::test() {
     ASSERT_EQ(this->getState(), State::T);
     this->sendSignal_s(value);
     ASSERT_EQ(this->getState(), State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::s);
     }
     ASSERT_EQ(this->m_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal/state/BasicTestStruct.cpp
+++ b/FppTest/state_machine/internal/state/BasicTestStruct.cpp
@@ -42,9 +42,9 @@ void BasicTestStruct::test() {
     ASSERT_EQ(this->getState(), State::T);
     this->sendSignal_s(value);
     ASSERT_EQ(this->getState(), State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::s);
     }
     ASSERT_EQ(this->m_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal/state/BasicU32.cpp
+++ b/FppTest/state_machine/internal/state/BasicU32.cpp
@@ -42,9 +42,9 @@ void BasicU32::test() {
     ASSERT_EQ(this->getState(), State::T);
     this->sendSignal_s(value);
     ASSERT_EQ(this->getState(), State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_action_a_history.getItemAt(i), Signal::s);
     }
     ASSERT_EQ(this->m_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal/state/StateToChild.cpp
+++ b/FppTest/state_machine/internal/state/StateToChild.cpp
@@ -62,11 +62,11 @@ void StateToChild::testS2_to_S2() {
     this->m_actionHistory.clear();
     this->sendSignal_S1_to_S2();
     ASSERT_EQ(this->getState(), State::S1_S2);
-    const FwSizeType expectedSize = 3;
+    const FwIndexType expectedSize = 3;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_S2);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -82,11 +82,11 @@ void StateToChild::testS2_to_S3() {
     this->sendSignal_S2_to_S3();
     this->sendSignal_S2_to_S3();
     ASSERT_EQ(this->getState(), State::S1_S3);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S2_to_S3);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -102,11 +102,11 @@ void StateToChild::testS3_to_S2() {
     ASSERT_EQ(this->getState(), State::S1_S3);
     this->sendSignal_S1_to_S2();
     ASSERT_EQ(this->getState(), State::S1_S2);
-    const FwSizeType expectedSize = 3;
+    const FwIndexType expectedSize = 3;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_S2);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);

--- a/FppTest/state_machine/internal/state/StateToChoice.cpp
+++ b/FppTest/state_machine/internal/state/StateToChoice.cpp
@@ -64,11 +64,11 @@ void StateToChoice::testInit() {
     this->initBase(id);
     ASSERT_EQ(this->m_id, id);
     ASSERT_EQ(this->getState(), State::S1_S2);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::__FPRIME_AC_INITIAL_TRANSITION);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::ENTER_S1);
@@ -86,11 +86,11 @@ void StateToChoice::testS2_to_C() {
     this->sendSignal_S1_to_C();
     this->sendSignal_S2_to_S3();
     ASSERT_EQ(this->getState(), State::S4_S5);
-    const FwSizeType expectedSize = 4;
+    const FwIndexType expectedSize = 4;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_C);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -107,11 +107,11 @@ void StateToChoice::testS2_to_S3() {
     this->sendSignal_S2_to_S3();
     this->sendSignal_S2_to_S3();
     ASSERT_EQ(this->getState(), State::S1_S3);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S2_to_S3);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -128,11 +128,11 @@ void StateToChoice::testS2_to_S4() {
     this->sendSignal_S1_to_S4();
     this->sendSignal_S1_to_S4();
     ASSERT_EQ(this->getState(), State::S4_S5);
-    const FwSizeType expectedSize = 4;
+    const FwIndexType expectedSize = 4;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_S4);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -152,11 +152,11 @@ void StateToChoice::testS3_to_C() {
     this->sendSignal_S1_to_C();
     this->sendSignal_S2_to_S3();
     ASSERT_EQ(this->getState(), State::S4_S6);
-    const FwSizeType expectedSize = 4;
+    const FwIndexType expectedSize = 4;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_C);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);
@@ -175,11 +175,11 @@ void StateToChoice::testS3_to_S4() {
     this->sendSignal_S1_to_S4();
     this->sendSignal_S1_to_S4();
     ASSERT_EQ(this->getState(), State::S4_S6);
-    const FwSizeType expectedSize = 4;
+    const FwIndexType expectedSize = 4;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_S4);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);

--- a/FppTest/state_machine/internal/state/StateToSelf.cpp
+++ b/FppTest/state_machine/internal/state/StateToSelf.cpp
@@ -56,11 +56,11 @@ void StateToSelf::testInit() {
     this->initBase(id);
     ASSERT_EQ(this->m_id, id);
     ASSERT_EQ(this->getState(), State::S1_S2);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::__FPRIME_AC_INITIAL_TRANSITION);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::ENTER_S1);
@@ -74,11 +74,11 @@ void StateToSelf::testS2_to_S1() {
     this->m_actionHistory.clear();
     this->sendSignal_S1_to_S1();
     ASSERT_EQ(this->getState(), State::S1_S2);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_S1);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -96,11 +96,11 @@ void StateToSelf::testS2_to_S3() {
     this->sendSignal_S2_to_S3();
     this->sendSignal_S2_to_S3();
     ASSERT_EQ(this->getState(), State::S1_S3);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S2_to_S3);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -115,11 +115,11 @@ void StateToSelf::testS3_to_S1() {
     this->m_actionHistory.clear();
     this->sendSignal_S1_to_S1();
     ASSERT_EQ(this->getState(), State::S1_S2);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_S1);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);

--- a/FppTest/state_machine/internal/state/StateToState.cpp
+++ b/FppTest/state_machine/internal/state/StateToState.cpp
@@ -64,11 +64,11 @@ void StateToState::testInit() {
     this->initBase(id);
     ASSERT_EQ(this->m_id, id);
     ASSERT_EQ(this->getState(), State::S1_S2);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::__FPRIME_AC_INITIAL_TRANSITION);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::ENTER_S1);
@@ -83,11 +83,11 @@ void StateToState::testS2_to_S3() {
     this->sendSignal_S2_to_S3();
     this->sendSignal_S2_to_S3();
     ASSERT_EQ(this->getState(), State::S1_S3);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S2_to_S3);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -102,11 +102,11 @@ void StateToState::testS2_to_S4() {
     this->sendSignal_S1_to_S4();
     this->sendSignal_S1_to_S4();
     ASSERT_EQ(this->getState(), State::S4_S5);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_S4);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -124,11 +124,11 @@ void StateToState::testS2_to_S5() {
     this->sendSignal_S1_to_S5();
     this->sendSignal_S1_to_S5();
     ASSERT_EQ(this->getState(), State::S4_S5);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_S5);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -147,11 +147,11 @@ void StateToState::testS3_to_S4() {
     this->sendSignal_S1_to_S4();
     this->sendSignal_S2_to_S3();
     ASSERT_EQ(this->getState(), State::S4_S5);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_S4);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);
@@ -169,11 +169,11 @@ void StateToState::testS3_to_S5() {
     this->m_actionHistory.clear();
     this->sendSignal_S1_to_S5();
     ASSERT_EQ(this->getState(), State::S4_S5);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_actionHistory.getSignals();
     const auto& actions = this->m_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), Signal::S1_to_S5);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);

--- a/FppTest/state_machine/internal_instance/initial/Basic.cpp
+++ b/FppTest/state_machine/internal_instance/initial/Basic.cpp
@@ -64,12 +64,12 @@ void Basic::test() {
     this->init(queueDepth, instanceId);
     ASSERT_EQ(this->basic1_getState(), Basic_Basic::State::S);
     ASSERT_EQ(this->smInitialBasic1_getState(), SmInitial_Basic::State::S);
-    const FwSizeType expectedSize = 3;
+    const FwIndexType expectedSize = 3;
     ASSERT_EQ(this->m_basic1_action_a_history.getSize(), expectedSize);
     ASSERT_EQ(this->m_basic2_action_a_history.getSize(), expectedSize);
     ASSERT_EQ(this->m_smInitialBasic1_action_a_history.getSize(), expectedSize);
     ASSERT_EQ(this->m_smInitialBasic2_action_a_history.getSize(), expectedSize);
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(this->m_basic1_action_a_history.getItemAt(i), Basic_Basic::Signal::__FPRIME_AC_INITIAL_TRANSITION);
         ASSERT_EQ(this->m_basic2_action_a_history.getItemAt(i), Basic_Basic::Signal::__FPRIME_AC_INITIAL_TRANSITION);
         ASSERT_EQ(this->m_smInitialBasic1_action_a_history.getItemAt(i),

--- a/FppTest/state_machine/internal_instance/initial/Choice.cpp
+++ b/FppTest/state_machine/internal_instance/initial/Choice.cpp
@@ -69,8 +69,8 @@ void Choice::testFalse() {
     this->init(queueDepth, instanceId);
     ASSERT_EQ(this->choice_getState(), Choice_Choice::State::T);
     ASSERT_EQ(this->smInitialChoice_getState(), SmInitial_Choice::State::T);
-    const FwSizeType expectedActionSize = 5;
-    const FwSizeType expectedGuardSize = 1;
+    const FwIndexType expectedActionSize = 5;
+    const FwIndexType expectedGuardSize = 1;
     this->checkActionsAndGuards(expectedActionSize, expectedGuardSize);
 }
 
@@ -84,8 +84,8 @@ void Choice::testTrue() {
     this->init(queueDepth, instanceId);
     ASSERT_EQ(this->choice_getState(), Choice_Choice::State::S);
     ASSERT_EQ(this->smInitialChoice_getState(), SmInitial_Choice::State::S);
-    const FwSizeType expectedActionSize = 3;
-    const FwSizeType expectedGuardSize = 1;
+    const FwIndexType expectedActionSize = 3;
+    const FwIndexType expectedGuardSize = 1;
     this->checkActionsAndGuards(expectedActionSize, expectedGuardSize);
 }
 
@@ -93,17 +93,17 @@ void Choice::testTrue() {
 // Helper functions
 // ----------------------------------------------------------------------
 
-void Choice::checkActionsAndGuards(FwSizeType expectedActionSize, FwSizeType expectedGuardSize) {
+void Choice::checkActionsAndGuards(FwIndexType expectedActionSize, FwIndexType expectedGuardSize) {
     ASSERT_EQ(this->m_choice_action_a_history.getSize(), expectedActionSize);
     ASSERT_EQ(this->m_smInitialChoice_action_a_history.getSize(), expectedActionSize);
-    for (FwSizeType i = 0; i < expectedActionSize; i++) {
+    for (FwIndexType i = 0; i < expectedActionSize; i++) {
         ASSERT_EQ(this->m_choice_action_a_history.getItemAt(i), Choice_Choice::Signal::__FPRIME_AC_INITIAL_TRANSITION);
         ASSERT_EQ(this->m_smInitialChoice_action_a_history.getItemAt(i),
                   SmInitial_Choice::Signal::__FPRIME_AC_INITIAL_TRANSITION);
     }
     ASSERT_EQ(this->m_choice_guard_g.getCallHistory().getSize(), expectedGuardSize);
     ASSERT_EQ(this->m_smInitialChoice_guard_g.getCallHistory().getSize(), expectedGuardSize);
-    for (FwSizeType i = 0; i < expectedGuardSize; i++) {
+    for (FwIndexType i = 0; i < expectedGuardSize; i++) {
         ASSERT_EQ(this->m_choice_guard_g.getCallHistory().getItemAt(i),
                   Choice_Choice::Signal::__FPRIME_AC_INITIAL_TRANSITION);
         ASSERT_EQ(this->m_smInitialChoice_guard_g.getCallHistory().getItemAt(i),

--- a/FppTest/state_machine/internal_instance/initial/Choice.hpp
+++ b/FppTest/state_machine/internal_instance/initial/Choice.hpp
@@ -109,8 +109,8 @@ class Choice : public ChoiceComponentBase {
     // ----------------------------------------------------------------------
 
     //! Helper function for checking actions and guards
-    void checkActionsAndGuards(FwSizeType expectedActionSize,  //!< The expected action size
-                               FwSizeType expectedGuardSize    //!< The expected guard size
+    void checkActionsAndGuards(FwIndexType expectedActionSize,  //!< The expected action size
+                               FwIndexType expectedGuardSize    //!< The expected guard size
     );
 
   private:

--- a/FppTest/state_machine/internal_instance/initial/Nested.cpp
+++ b/FppTest/state_machine/internal_instance/initial/Nested.cpp
@@ -56,10 +56,10 @@ void Nested::test() {
     this->init(queueDepth, instanceId);
     ASSERT_EQ(this->nested_getState(), Nested_Nested::State::S_T);
     ASSERT_EQ(this->smInitialNested_getState(), SmInitial_Nested::State::S_T);
-    const FwSizeType expectedActionSize = 6;
+    const FwIndexType expectedActionSize = 6;
     ASSERT_EQ(this->m_nested_action_a_history.getSize(), expectedActionSize);
     ASSERT_EQ(this->m_smInitialNested_action_a_history.getSize(), expectedActionSize);
-    for (FwSizeType i = 0; i < expectedActionSize; i++) {
+    for (FwIndexType i = 0; i < expectedActionSize; i++) {
         ASSERT_EQ(this->m_nested_action_a_history.getItemAt(i), Nested_Nested::Signal::__FPRIME_AC_INITIAL_TRANSITION);
         ASSERT_EQ(this->m_smInitialNested_action_a_history.getItemAt(i),
                   SmInitial_Nested::Signal::__FPRIME_AC_INITIAL_TRANSITION);

--- a/FppTest/state_machine/internal_instance/state/Basic.cpp
+++ b/FppTest/state_machine/internal_instance/state/Basic.cpp
@@ -71,9 +71,9 @@ void Basic::test() {
         const auto status = this->doDispatch();
         ASSERT_EQ(status, MSG_DISPATCH_OK);
         ASSERT_EQ(this->basic1_getState(), Basic_Basic::State::T);
-        const FwSizeType expectedSize = 6;
+        const FwIndexType expectedSize = 6;
         ASSERT_EQ(this->m_basic1_action_a_history.getSize(), expectedSize);
-        for (FwSizeType i = 0; i < expectedSize; i++) {
+        for (FwIndexType i = 0; i < expectedSize; i++) {
             ASSERT_EQ(this->m_basic1_action_a_history.getItemAt(i), Basic_Basic::Signal::s);
         }
     }
@@ -83,9 +83,9 @@ void Basic::test() {
         const auto status = this->doDispatch();
         ASSERT_EQ(status, MSG_DISPATCH_OK);
         ASSERT_EQ(this->basic2_getState(), Basic_Basic::State::T);
-        const FwSizeType expectedSize = 6;
+        const FwIndexType expectedSize = 6;
         ASSERT_EQ(this->m_basic2_action_a_history.getSize(), expectedSize);
-        for (FwSizeType i = 0; i < expectedSize; i++) {
+        for (FwIndexType i = 0; i < expectedSize; i++) {
             ASSERT_EQ(this->m_basic2_action_a_history.getItemAt(i), Basic_Basic::Signal::s);
         }
     }
@@ -95,9 +95,9 @@ void Basic::test() {
         const auto status = this->doDispatch();
         ASSERT_EQ(status, MSG_DISPATCH_OK);
         ASSERT_EQ(this->smStateBasic1_getState(), SmState_Basic::State::T);
-        const FwSizeType expectedSize = 6;
+        const FwIndexType expectedSize = 6;
         ASSERT_EQ(this->m_smStateBasic1_action_a_history.getSize(), expectedSize);
-        for (FwSizeType i = 0; i < expectedSize; i++) {
+        for (FwIndexType i = 0; i < expectedSize; i++) {
             ASSERT_EQ(this->m_smStateBasic1_action_a_history.getItemAt(i), SmState_Basic::Signal::s);
         }
     }
@@ -107,9 +107,9 @@ void Basic::test() {
         const auto status = this->doDispatch();
         ASSERT_EQ(status, MSG_DISPATCH_OK);
         ASSERT_EQ(this->smStateBasic2_getState(), SmState_Basic::State::T);
-        const FwSizeType expectedSize = 6;
+        const FwIndexType expectedSize = 6;
         ASSERT_EQ(this->m_smStateBasic2_action_a_history.getSize(), expectedSize);
-        for (FwSizeType i = 0; i < expectedSize; i++) {
+        for (FwIndexType i = 0; i < expectedSize; i++) {
             ASSERT_EQ(this->m_smStateBasic2_action_a_history.getItemAt(i), SmState_Basic::Signal::s);
         }
     }

--- a/FppTest/state_machine/internal_instance/state/BasicGuard.cpp
+++ b/FppTest/state_machine/internal_instance/state/BasicGuard.cpp
@@ -77,13 +77,13 @@ void BasicGuard::testTrue() {
 // Helper functions
 // ----------------------------------------------------------------------
 
-void BasicGuard::checkActionsAndGuards(FwSizeType expectedActionSize, FwSizeType expectedGuardSize) {
+void BasicGuard::checkActionsAndGuards(FwIndexType expectedActionSize, FwIndexType expectedGuardSize) {
     ASSERT_EQ(this->m_smStateBasicGuard_action_a_history.getSize(), expectedActionSize);
-    for (FwSizeType i = 0; i < expectedActionSize; i++) {
+    for (FwIndexType i = 0; i < expectedActionSize; i++) {
         ASSERT_EQ(this->m_smStateBasicGuard_action_a_history.getItemAt(i), SmState_BasicGuard::Signal::s);
     }
     ASSERT_EQ(this->m_smStateBasicGuard_guard_g.getCallHistory().getSize(), expectedGuardSize);
-    for (FwSizeType i = 0; i < expectedGuardSize; i++) {
+    for (FwIndexType i = 0; i < expectedGuardSize; i++) {
         ASSERT_EQ(this->m_smStateBasicGuard_guard_g.getCallHistory().getItemAt(i), SmState_BasicGuard::Signal::s);
     }
 }

--- a/FppTest/state_machine/internal_instance/state/BasicGuard.hpp
+++ b/FppTest/state_machine/internal_instance/state/BasicGuard.hpp
@@ -90,8 +90,8 @@ class BasicGuard : public BasicGuardComponentBase {
     // ----------------------------------------------------------------------
 
     //! Helper function for checking actions and guards
-    void checkActionsAndGuards(FwSizeType expectedActionSize,  //!< The expected action size
-                               FwSizeType expectedGuardSize    //!< The expected guard size
+    void checkActionsAndGuards(FwIndexType expectedActionSize,  //!< The expected action size
+                               FwIndexType expectedGuardSize    //!< The expected guard size
     );
 
   private:

--- a/FppTest/state_machine/internal_instance/state/BasicSelf.cpp
+++ b/FppTest/state_machine/internal_instance/state/BasicSelf.cpp
@@ -46,9 +46,9 @@ void BasicSelf::test() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateBasicSelf_getState(), SmState_BasicSelf::State::S);
-    const FwSizeType expectedSize = 6;
+    const FwIndexType expectedSize = 6;
     ASSERT_EQ(this->m_smStateBasicSelf_action_a_history.getSize(), expectedSize);
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(this->m_smStateBasicSelf_action_a_history.getItemAt(i), SmState_BasicSelf::Signal::s);
     }
 }

--- a/FppTest/state_machine/internal_instance/state/BasicString.cpp
+++ b/FppTest/state_machine/internal_instance/state/BasicString.cpp
@@ -54,9 +54,9 @@ void BasicString::test() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateBasicString_getState(), SmState_BasicString::State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_smStateBasicString_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_smStateBasicString_action_a_history.getItemAt(i), SmState_BasicString::Signal::s);
     }
     ASSERT_EQ(this->m_smStateBasicString_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal_instance/state/BasicTestAbsType.cpp
+++ b/FppTest/state_machine/internal_instance/state/BasicTestAbsType.cpp
@@ -53,9 +53,9 @@ void BasicTestAbsType::test() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateBasicTestAbsType_getState(), SmState_BasicTestAbsType::State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_smStateBasicTestAbsType_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_smStateBasicTestAbsType_action_a_history.getItemAt(i), SmState_BasicTestAbsType::Signal::s);
     }
     ASSERT_EQ(this->m_smStateBasicTestAbsType_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal_instance/state/BasicTestArray.cpp
+++ b/FppTest/state_machine/internal_instance/state/BasicTestArray.cpp
@@ -52,9 +52,9 @@ void BasicTestArray::test() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateBasicTestArray_getState(), SmState_BasicTestArray::State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_smStateBasicTestArray_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_smStateBasicTestArray_action_a_history.getItemAt(i), SmState_BasicTestArray::Signal::s);
     }
     ASSERT_EQ(this->m_smStateBasicTestArray_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal_instance/state/BasicTestEnum.cpp
+++ b/FppTest/state_machine/internal_instance/state/BasicTestEnum.cpp
@@ -52,9 +52,9 @@ void BasicTestEnum::test() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateBasicTestEnum_getState(), SmState_BasicTestEnum::State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_smStateBasicTestEnum_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_smStateBasicTestEnum_action_a_history.getItemAt(i), SmState_BasicTestEnum::Signal::s);
     }
     ASSERT_EQ(this->m_smStateBasicTestEnum_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal_instance/state/BasicTestStruct.cpp
+++ b/FppTest/state_machine/internal_instance/state/BasicTestStruct.cpp
@@ -53,9 +53,9 @@ void BasicTestStruct::test() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateBasicTestStruct_getState(), SmState_BasicTestStruct::State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_smStateBasicTestStruct_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_smStateBasicTestStruct_action_a_history.getItemAt(i), SmState_BasicTestStruct::Signal::s);
     }
     ASSERT_EQ(this->m_smStateBasicTestStruct_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal_instance/state/BasicU32.cpp
+++ b/FppTest/state_machine/internal_instance/state/BasicU32.cpp
@@ -48,9 +48,9 @@ void BasicU32::test() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateBasicU32_getState(), SmState_BasicU32::State::T);
-    const FwSizeType expectedASize = 5;
+    const FwIndexType expectedASize = 5;
     ASSERT_EQ(this->m_smStateBasicU32_action_a_history.getSize(), expectedASize);
-    for (FwSizeType i = 0; i < expectedASize; i++) {
+    for (FwIndexType i = 0; i < expectedASize; i++) {
         ASSERT_EQ(this->m_smStateBasicU32_action_a_history.getItemAt(i), SmState_BasicU32::Signal::s);
     }
     ASSERT_EQ(this->m_smStateBasicU32_action_b_history.getSize(), 1);

--- a/FppTest/state_machine/internal_instance/state/StateToChild.cpp
+++ b/FppTest/state_machine/internal_instance/state/StateToChild.cpp
@@ -73,11 +73,11 @@ void StateToChild::testS2_to_S2() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateStateToChild_getState(), SmState_StateToChild::State::S1_S2);
-    const FwSizeType expectedSize = 3;
+    const FwIndexType expectedSize = 3;
     ASSERT_EQ(this->m_smStateStateToChild_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToChild_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToChild_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToChild::Signal::S1_to_S2);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -93,11 +93,11 @@ void StateToChild::testS2_to_S3() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateStateToChild_getState(), SmState_StateToChild::State::S1_S3);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_smStateStateToChild_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToChild_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToChild_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToChild::Signal::S2_to_S3);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -121,11 +121,11 @@ void StateToChild::testS3_to_S2() {
         ASSERT_EQ(status, MSG_DISPATCH_OK);
         ASSERT_EQ(this->smStateStateToChild_getState(), SmState_StateToChild::State::S1_S2);
     }
-    const FwSizeType expectedSize = 3;
+    const FwIndexType expectedSize = 3;
     ASSERT_EQ(this->m_smStateStateToChild_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToChild_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToChild_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToChild::Signal::S1_to_S2);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);

--- a/FppTest/state_machine/internal_instance/state/StateToChoice.cpp
+++ b/FppTest/state_machine/internal_instance/state/StateToChoice.cpp
@@ -91,11 +91,11 @@ void StateToChoice::testInit() {
     this->m_smStateStateToChoice_actionHistory.clear();
     this->init(queueDepth, instanceId);
     ASSERT_EQ(this->smStateStateToChoice_getState(), SmState_StateToChoice::State::S1_S2);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_smStateStateToChoice_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToChoice_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToChoice_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToChoice::Signal::__FPRIME_AC_INITIAL_TRANSITION);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::ENTER_S1);
@@ -112,11 +112,11 @@ void StateToChoice::testS2_to_C() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateStateToChoice_getState(), SmState_StateToChoice::State::S4_S5);
-    const FwSizeType expectedSize = 4;
+    const FwIndexType expectedSize = 4;
     ASSERT_EQ(this->m_smStateStateToChoice_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToChoice_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToChoice_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToChoice::Signal::S1_to_C);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -133,11 +133,11 @@ void StateToChoice::testS2_to_S3() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateStateToChoice_getState(), SmState_StateToChoice::State::S1_S3);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_smStateStateToChoice_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToChoice_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToChoice_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToChoice::Signal::S2_to_S3);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -154,11 +154,11 @@ void StateToChoice::testS2_to_S4() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateStateToChoice_getState(), SmState_StateToChoice::State::S4_S5);
-    const FwSizeType expectedSize = 4;
+    const FwIndexType expectedSize = 4;
     ASSERT_EQ(this->m_smStateStateToChoice_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToChoice_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToChoice_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToChoice::Signal::S1_to_S4);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -184,11 +184,11 @@ void StateToChoice::testS3_to_C() {
         ASSERT_EQ(status, MSG_DISPATCH_OK);
     }
     ASSERT_EQ(this->smStateStateToChoice_getState(), SmState_StateToChoice::State::S4_S6);
-    const FwSizeType expectedSize = 4;
+    const FwIndexType expectedSize = 4;
     ASSERT_EQ(this->m_smStateStateToChoice_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToChoice_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToChoice_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToChoice::Signal::S1_to_C);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);
@@ -214,11 +214,11 @@ void StateToChoice::testS3_to_S4() {
         ASSERT_EQ(status, MSG_DISPATCH_OK);
     }
     ASSERT_EQ(this->smStateStateToChoice_getState(), SmState_StateToChoice::State::S4_S6);
-    const FwSizeType expectedSize = 4;
+    const FwIndexType expectedSize = 4;
     ASSERT_EQ(this->m_smStateStateToChoice_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToChoice_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToChoice_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToChoice::Signal::S1_to_S4);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);

--- a/FppTest/state_machine/internal_instance/state/StateToSelf.cpp
+++ b/FppTest/state_machine/internal_instance/state/StateToSelf.cpp
@@ -68,11 +68,11 @@ void StateToSelf::testInit() {
     this->m_smStateStateToSelf_actionHistory.clear();
     this->init(queueDepth, instanceId);
     ASSERT_EQ(this->smStateStateToSelf_getState(), SmState_StateToSelf::State::S1_S2);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_smStateStateToSelf_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToSelf_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToSelf_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToSelf::Signal::__FPRIME_AC_INITIAL_TRANSITION);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::ENTER_S1);
@@ -87,11 +87,11 @@ void StateToSelf::testS2_to_S1() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateStateToSelf_getState(), SmState_StateToSelf::State::S1_S2);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_smStateStateToSelf_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToSelf_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToSelf_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToSelf::Signal::S1_to_S1);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -109,11 +109,11 @@ void StateToSelf::testS2_to_S3() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateStateToSelf_getState(), SmState_StateToSelf::State::S1_S3);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_smStateStateToSelf_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToSelf_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToSelf_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToSelf::Signal::S2_to_S3);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -136,11 +136,11 @@ void StateToSelf::testS3_to_S1() {
         ASSERT_EQ(status, MSG_DISPATCH_OK);
     }
     ASSERT_EQ(this->smStateStateToSelf_getState(), SmState_StateToSelf::State::S1_S2);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_smStateStateToSelf_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToSelf_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToSelf_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToSelf::Signal::S1_to_S1);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);

--- a/FppTest/state_machine/internal_instance/state/StateToState.cpp
+++ b/FppTest/state_machine/internal_instance/state/StateToState.cpp
@@ -78,11 +78,11 @@ void StateToState::testInit() {
     this->m_smStateStateToState_actionHistory.clear();
     this->init(queueDepth, instanceId);
     ASSERT_EQ(this->smStateStateToState_getState(), SmState_StateToState::State::S1_S2);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_smStateStateToState_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToState_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToState_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToState::Signal::__FPRIME_AC_INITIAL_TRANSITION);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::ENTER_S1);
@@ -97,11 +97,11 @@ void StateToState::testS2_to_S3() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateStateToState_getState(), SmState_StateToState::State::S1_S3);
-    const FwSizeType expectedSize = 2;
+    const FwIndexType expectedSize = 2;
     ASSERT_EQ(this->m_smStateStateToState_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToState_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToState_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToState::Signal::S2_to_S3);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -116,11 +116,11 @@ void StateToState::testS2_to_S4() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateStateToState_getState(), SmState_StateToState::State::S4_S5);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_smStateStateToState_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToState_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToState_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToState::Signal::S1_to_S4);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -138,11 +138,11 @@ void StateToState::testS2_to_S5() {
     const auto status = this->doDispatch();
     ASSERT_EQ(status, MSG_DISPATCH_OK);
     ASSERT_EQ(this->smStateStateToState_getState(), SmState_StateToState::State::S4_S5);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_smStateStateToState_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToState_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToState_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToState::Signal::S1_to_S5);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S2);
@@ -168,11 +168,11 @@ void StateToState::testS3_to_S4() {
         ASSERT_EQ(status, MSG_DISPATCH_OK);
     }
     ASSERT_EQ(this->smStateStateToState_getState(), SmState_StateToState::State::S4_S5);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_smStateStateToState_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToState_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToState_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToState::Signal::S1_to_S4);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);
@@ -198,11 +198,11 @@ void StateToState::testS3_to_S5() {
         ASSERT_EQ(status, MSG_DISPATCH_OK);
     }
     ASSERT_EQ(this->smStateStateToState_getState(), SmState_StateToState::State::S4_S5);
-    const FwSizeType expectedSize = 5;
+    const FwIndexType expectedSize = 5;
     ASSERT_EQ(this->m_smStateStateToState_actionHistory.getSize(), expectedSize);
     const auto& signals = this->m_smStateStateToState_actionHistory.getSignals();
     const auto& actions = this->m_smStateStateToState_actionHistory.getValues();
-    for (FwSizeType i = 0; i < expectedSize; i++) {
+    for (FwIndexType i = 0; i < expectedSize; i++) {
         ASSERT_EQ(signals.getItemAt(i), SmState_StateToState::Signal::S1_to_S5);
     }
     ASSERT_EQ(actions.getItemAt(0), ActionId::EXIT_S3);

--- a/FppTest/struct/NonPrimitiveStructTest.cpp
+++ b/FppTest/struct/NonPrimitiveStructTest.cpp
@@ -265,7 +265,7 @@ TEST_F(NonPrimitiveStructTest, Serialization) {
                    testStruct, testU32Arr, testStructArr);
     NonPrimitive sCopy;
 
-    U32 stringSerializedSize = testString.length() + sizeof(FwBuffSizeType);
+    U32 stringSerializedSize = static_cast<U32>(testString.length() + sizeof(FwBuffSizeType));
     U32 serializedSize = NonPrimitive::SERIALIZED_SIZE
                          - Fw::StringBase::STATIC_SERIALIZED_SIZE(80)
                          + stringSerializedSize;

--- a/FppTest/struct/NonPrimitiveStructTest.cpp
+++ b/FppTest/struct/NonPrimitiveStructTest.cpp
@@ -75,7 +75,7 @@ protected:
         }
     }
 
-    void assertUnsuccessfulSerialization(NonPrimitive& s, U32 bufSize) {
+    void assertUnsuccessfulSerialization(NonPrimitive& s, FwSizeType bufSize) {
         U8 data[bufSize];
         Fw::SerialBuffer buf(data, sizeof(data));
         Fw::SerializeStatus status;
@@ -266,9 +266,11 @@ TEST_F(NonPrimitiveStructTest, Serialization) {
     NonPrimitive sCopy;
 
     U32 stringSerializedSize = static_cast<U32>(testString.length() + sizeof(FwBuffSizeType));
-    U32 serializedSize = NonPrimitive::SERIALIZED_SIZE
-                         - Fw::StringBase::STATIC_SERIALIZED_SIZE(80)
-                         + stringSerializedSize;
+    U32 serializedSize = static_cast<U32>(
+			    NonPrimitive::SERIALIZED_SIZE
+                            - Fw::StringBase::STATIC_SERIALIZED_SIZE(80)
+                            + stringSerializedSize
+                         );
     Fw::SerializeStatus status;
 
     // Test successful serialization

--- a/FppTest/typed_tests/EnumTest.hpp
+++ b/FppTest/typed_tests/EnumTest.hpp
@@ -46,7 +46,7 @@ namespace FppTest {
         typename EnumType::T getInvalidValue() {
             U8 sign = 0;
             if (std::numeric_limits<typename EnumType::SerialType>::min() < 0) {
-                sign = STest::Pick::lowerUpper(0, 1);
+                sign = static_cast<U8>(STest::Pick::lowerUpper(0, 1));
             }
 
             switch (sign) {
@@ -58,12 +58,16 @@ namespace FppTest {
                         )
                     ));
                 default:
-                    return static_cast<typename EnumType::T>(STest::Pick::lowerUpper(
-                        1,
-                        static_cast<U32>((-1) *
-                            (std::numeric_limits<typename EnumType::SerialType>::min() + 1)
-                        )
-                    ) * (-1));
+                    return static_cast<typename EnumType::T>(
+                        static_cast<I32>(
+                          STest::Pick::lowerUpper(
+                            1,
+                            static_cast<U32>((-1) *
+                                static_cast<I32>(std::numeric_limits<typename EnumType::SerialType>::min() + 1)
+                            )
+                          )
+                      ) * (-1)
+                    );
             }
         }
 

--- a/FppTest/utils/Utils.cpp
+++ b/FppTest/utils/Utils.cpp
@@ -45,7 +45,7 @@ namespace FppTest {
             FW_ASSERT(capacity > 0);
             // min length must fit within capacity
             FW_ASSERT(minLength < capacity);
-            U32 length = STest::Pick::lowerUpper(minLength, capacity - 1);
+            U32 length = STest::Pick::lowerUpper(static_cast<U32>(minLength), static_cast<U32>(capacity - 1));
 
             for (U32 i = 0; i < length; i++) {
                 FW_ASSERT(i < capacity);

--- a/TestUtils/Option.hpp
+++ b/TestUtils/Option.hpp
@@ -35,7 +35,7 @@ class Option {
         this->m_state = State::VALUE;
         this->m_value = value;
     }
-    void clear() { this->state = State::NO_VALUE; }
+    void clear() { this->m_state = State::NO_VALUE; }
     T get() const {
         FW_ASSERT(this->hasValue());
         return this->m_value;


### PR DESCRIPTION
* Revise CMakeLists.txt so the warnings listed in the file are applied to the build, instead of ignored
* Update the code to fix the resulting compiler warnings
* Fix a coding issue in TestUtils/Option.hpp that was caught by the latest version of clang

Closes #3432.

## Future Work

Make the build system more robust for specifying compiler warnings. The current situation invites errors like this because (1) CMake silently accepts configurations that look like they are checking for warnings XYZ, when in fact they are checking for none; and (2) the output for "we checked for warnings XYZ and all the checks passed" is indistinguishable from the output for "we did not do any checks at all."

Perhaps we could have the build print out the warning flags used in the build? Or have F Prime apply a set of standard warning flags by default that a project could turn off? In the second case, if you made a mistake like this you would see it, because the warnings would still be on.