### PR TITLE
Return cmd repsonse for LOG_STATUS in SeqDispatcher

### DIFF
--- a/Svc/SeqDispatcher/SeqDispatcher.cpp
+++ b/Svc/SeqDispatcher/SeqDispatcher.cpp
@@ -182,5 +182,6 @@ void SeqDispatcher::LOG_STATUS_cmdHandler(
   for(FwIndexType idx = 0; idx < SeqDispatcherSequencerPorts; idx++) {
     this->log_ACTIVITY_LO_LogSequencerStatus(static_cast<U16>(idx), this->m_entryTable[idx].state, Fw::LogStringArg(this->m_entryTable[idx].sequenceRunning));
   }
+  this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }
 }  // end namespace components

--- a/Svc/SeqDispatcher/test/ut/SeqDispatcherTester.cpp
+++ b/Svc/SeqDispatcher/test/ut/SeqDispatcherTester.cpp
@@ -76,10 +76,13 @@ void SeqDispatcherTester ::testDispatch() {
 void SeqDispatcherTester::testLogStatus() {
   this->sendCmd_RUN(0,0, Fw::String("test"), Fw::Wait::WAIT);
   this->component.doDispatch();
+  this->clearHistory();
   this->sendCmd_LOG_STATUS(0,0);
   this->component.doDispatch();
   ASSERT_EVENTS_SIZE(SeqDispatcherSequencerPorts);
   ASSERT_EVENTS_LogSequencerStatus(0, 0, SeqDispatcher_CmdSequencerState::RUNNING_SEQUENCE_BLOCK, "test");
+  ASSERT_CMD_RESPONSE_SIZE(1);
+  ASSERT_CMD_RESPONSE(0, SeqDispatcher::OPCODE_LOG_STATUS, 0, Fw::CmdResponse::OK);
 }
 
 void SeqDispatcherTester::seqRunOut_handler(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#3437 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description
Adds a UT and a cmd response to the LOG_STATUS command.
