### PR TITLE
Add FW_PACKET_FILE descriptor to FileDownlink and FileUplink logic

### DIFF
--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -363,7 +363,7 @@ void FileDownlink ::sendCancelPacket() {
     Fw::SerializeStatus status = buffer.getSerializer().serialize(Fw::ComPacket::FW_PACKET_FILE);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType),
-                            buffer.getSize() - sizeof(FwPacketDescriptorType));
+                            buffer.getSize() - static_cast<Fw::Buffer::SizeType>(sizeof(FwPacketDescriptorType)));
     // Serialize the filePacket content into the buffer
     status = filePacket.toBuffer(offsetBuffer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
@@ -401,7 +401,9 @@ void FileDownlink ::sendFilePacket(const Fw::FilePacket& filePacket) {
     Fw::SerializeStatus status = this->m_buffer.getSerializer().serialize(Fw::ComPacket::FW_PACKET_FILE);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // Serialize the filePacket content into the buffer, offset by the size of the packet descriptor
-    Fw::Buffer offsetBuffer(this->m_buffer.getData() + sizeof(FwPacketDescriptorType), filePacket.bufferSize());
+    Fw::Buffer offsetBuffer(
+        this->m_buffer.getData() + sizeof(FwPacketDescriptorType),
+        this->m_buffer.getSize() - static_cast<Fw::Buffer::SizeType>(sizeof(FwPacketDescriptorType)));
     status = filePacket.toBuffer(offsetBuffer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // set the buffer size to the packet size

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -429,11 +429,17 @@ namespace Svc {
     Fw::FilePacket filePacket;
     filePacket.fromCancelPacket(cancelPacket);
     this->getBuffer(buffer, CANCEL_PACKET);
+    FW_ASSERT(
+      buffer.getSize() >= filePacket.bufferSize() + sizeof(FwPacketDescriptorType),
+      static_cast<FwAssertArgType>(buffer.getSize()),
+      static_cast<FwAssertArgType>(filePacket.bufferSize() + sizeof(FwPacketDescriptorType))
+    );
 
     // Serialize the packet descriptor FW_PACKET_FILE to the buffer
     Fw::SerializeStatus status = buffer.getSerializer().serialize(Fw::ComPacket::FW_PACKET_FILE);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
-    Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType), filePacket.bufferSize());
+    Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType),
+                            buffer.getSize() - sizeof(FwPacketDescriptorType));
     // Serialize the filePacket content into the buffer
     status = filePacket.toBuffer(offsetBuffer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -9,25 +9,22 @@
 // acknowledged.
 // ======================================================================
 
-#include <Svc/FileDownlink/FileDownlink.hpp>
 #include <Fw/Com/ComPacket.hpp>
-#include <Fw/Types/Assert.hpp>
 #include <Fw/FPrimeBasicTypes.hpp>
+#include <Fw/Types/Assert.hpp>
 #include <Fw/Types/StringUtils.hpp>
 #include <Os/QueueString.hpp>
+#include <Svc/FileDownlink/FileDownlink.hpp>
 #include <limits>
 
 namespace Svc {
 
-  // ----------------------------------------------------------------------
-  // Construction, initialization, and destruction
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Construction, initialization, and destruction
+// ----------------------------------------------------------------------
 
-  FileDownlink ::
-    FileDownlink(
-        const char *const name
-    ) :
-      FileDownlinkComponentBase(name),
+FileDownlink ::FileDownlink(const char* const name)
+    : FileDownlinkComponentBase(name),
       m_configured(false),
       m_filesSent(this),
       m_packetsSent(this),
@@ -40,113 +37,80 @@ namespace Svc {
       m_lastCompletedType(Fw::FilePacket::T_NONE),
       m_lastBufferId(0),
       m_curEntry(),
-      m_cntxId(0)
-  {
-  }
+      m_cntxId(0) {}
 
-  void FileDownlink ::
-    configure(
-        U32 timeout,
-        U32 cooldown,
-        U32 cycleTime,
-        U32 fileQueueDepth
-    )
-  {
+void FileDownlink ::configure(U32 timeout, U32 cooldown, U32 cycleTime, U32 fileQueueDepth) {
     this->m_timeout = timeout;
     this->m_cooldown = cooldown;
     this->m_cycleTime = cycleTime;
     this->m_configured = true;
 
-    Os::Queue::Status stat = m_fileQueue.create(
-      Os::QueueString("fileDownlinkQueue"),
-      static_cast<FwSizeType>(fileQueueDepth),
-      static_cast<FwSizeType>(sizeof(struct FileEntry))
-    );
+    Os::Queue::Status stat =
+        m_fileQueue.create(Os::QueueString("fileDownlinkQueue"), static_cast<FwSizeType>(fileQueueDepth),
+                           static_cast<FwSizeType>(sizeof(struct FileEntry)));
     FW_ASSERT(stat == Os::Queue::OP_OK, static_cast<FwAssertArgType>(stat));
-  }
+}
 
-  void FileDownlink ::
-    preamble()
-  {
+void FileDownlink ::preamble() {
     FW_ASSERT(this->m_configured == true);
-  }
+}
 
-  FileDownlink ::
-    ~FileDownlink()
-  {
+FileDownlink ::~FileDownlink() {}
 
-  }
+// ----------------------------------------------------------------------
+// Handler implementations for user-defined typed input ports
+// ----------------------------------------------------------------------
 
-  // ----------------------------------------------------------------------
-  // Handler implementations for user-defined typed input ports
-  // ----------------------------------------------------------------------
+void FileDownlink ::Run_handler(const FwIndexType portNum, U32 context) {
+    switch (this->m_mode.get()) {
+        case Mode::IDLE: {
+            FwSizeType real_size = 0;
+            FwQueuePriorityType prio = 0;
+            Os::Queue::Status stat = m_fileQueue.receive(reinterpret_cast<U8*>(&this->m_curEntry),
+                                                         static_cast<FwSizeType>(sizeof(this->m_curEntry)),
+                                                         Os::Queue::BlockingType::NONBLOCKING, real_size, prio);
 
-  void FileDownlink ::
-    Run_handler(
-        const FwIndexType portNum,
-        U32 context
-    )
-  {
-    switch(this->m_mode.get())
-    {
-      case Mode::IDLE: {
-        FwSizeType real_size = 0;
-        FwQueuePriorityType prio = 0;
-        Os::Queue::Status stat = m_fileQueue.receive(
-          reinterpret_cast<U8*>(&this->m_curEntry),
-          static_cast<FwSizeType>(sizeof(this->m_curEntry)),
-          Os::Queue::BlockingType::NONBLOCKING,
-          real_size,
-          prio
-        );
+            if (stat != Os::Queue::Status::OP_OK || sizeof(this->m_curEntry) != real_size) {
+                return;
+            }
 
-        if(stat != Os::Queue::Status::OP_OK || sizeof(this->m_curEntry) != real_size) {
-          return;
+            sendFile(this->m_curEntry.srcFilename, this->m_curEntry.destFilename, this->m_curEntry.offset,
+                     this->m_curEntry.length);
+            break;
         }
-
-        sendFile(
-          this->m_curEntry.srcFilename,
-          this->m_curEntry.destFilename,
-          this->m_curEntry.offset,
-          this->m_curEntry.length
-        );
-        break;
-      }
-      case Mode::COOLDOWN: {
-        if (this->m_curTimer >= this->m_cooldown) {
-          this->m_curTimer = 0;
-          this->m_mode.set(Mode::IDLE);
-        } else {
-          this->m_curTimer += m_cycleTime;
+        case Mode::COOLDOWN: {
+            if (this->m_curTimer >= this->m_cooldown) {
+                this->m_curTimer = 0;
+                this->m_mode.set(Mode::IDLE);
+            } else {
+                this->m_curTimer += m_cycleTime;
+            }
+            break;
         }
-        break;
-      }
-      case Mode::WAIT: {
-        //If current timeout is too-high and we are waiting for a packet, issue a timeout
-        if (this->m_curTimer >= this->m_timeout) {
-          this->m_curTimer = 0;
-          this->log_WARNING_HI_DownlinkTimeout(this->m_file.getSourceName(), this->m_file.getDestName());
-          this->enterCooldown();
-          this->sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR);
-        } else { //Otherwise update the current counter
-          this->m_curTimer += m_cycleTime;
+        case Mode::WAIT: {
+            // If current timeout is too-high and we are waiting for a packet, issue a timeout
+            if (this->m_curTimer >= this->m_timeout) {
+                this->m_curTimer = 0;
+                this->log_WARNING_HI_DownlinkTimeout(this->m_file.getSourceName(), this->m_file.getDestName());
+                this->enterCooldown();
+                this->sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK
+                                                                          : SendFileStatus::STATUS_ERROR);
+            } else {  // Otherwise update the current counter
+                this->m_curTimer += m_cycleTime;
+            }
+            break;
         }
-        break;
-      }
-      default:
-        break;
+        default:
+            break;
     }
-  }
+}
 
-  Svc::SendFileResponse FileDownlink ::
-    SendFile_handler(
-        const FwIndexType portNum,
-        const Fw::StringBase& sourceFilename, // lgtm[cpp/large-parameter] dictated by command architecture
-        const Fw::StringBase& destFilename, // lgtm[cpp/large-parameter] dictated by command architecture
-        U32 offset,
-        U32 length
-    )
-  {
+Svc::SendFileResponse FileDownlink ::SendFile_handler(
+    const FwIndexType portNum,
+    const Fw::StringBase& sourceFilename,  // lgtm[cpp/large-parameter] dictated by command architecture
+    const Fw::StringBase& destFilename,    // lgtm[cpp/large-parameter] dictated by command architecture
+    U32 offset,
+    U32 length) {
     struct FileEntry entry;
     entry.srcFilename[0] = 0;
     entry.destFilename[0] = 0;
@@ -159,67 +123,54 @@ namespace Svc {
 
     FW_ASSERT(sourceFilename.length() < sizeof(entry.srcFilename));
     FW_ASSERT(destFilename.length() < sizeof(entry.destFilename));
-    (void) Fw::StringUtils::string_copy(entry.srcFilename, sourceFilename.toChar(), static_cast<FwSizeType>(sizeof(entry.srcFilename)));
-    (void) Fw::StringUtils::string_copy(entry.destFilename, destFilename.toChar(), static_cast<FwSizeType>(sizeof(entry.destFilename)));
+    (void)Fw::StringUtils::string_copy(entry.srcFilename, sourceFilename.toChar(),
+                                       static_cast<FwSizeType>(sizeof(entry.srcFilename)));
+    (void)Fw::StringUtils::string_copy(entry.destFilename, destFilename.toChar(),
+                                       static_cast<FwSizeType>(sizeof(entry.destFilename)));
 
-    Os::Queue::Status status = m_fileQueue.send(reinterpret_cast<U8*>(&entry), static_cast<FwSizeType>(sizeof(entry)), 0, Os::Queue::BlockingType::NONBLOCKING);
+    Os::Queue::Status status = m_fileQueue.send(reinterpret_cast<U8*>(&entry), static_cast<FwSizeType>(sizeof(entry)),
+                                                0, Os::Queue::BlockingType::NONBLOCKING);
 
-    if(status != Os::Queue::Status::OP_OK) {
-      return SendFileResponse(SendFileStatus::STATUS_ERROR, std::numeric_limits<U32>::max());
+    if (status != Os::Queue::Status::OP_OK) {
+        return SendFileResponse(SendFileStatus::STATUS_ERROR, std::numeric_limits<U32>::max());
     }
     return SendFileResponse(SendFileStatus::STATUS_OK, entry.context);
-  }
+}
 
-  void FileDownlink ::
-    pingIn_handler(
-        const FwIndexType portNum,
-        U32 key
-    )
-  {
-      this->pingOut_out(0,key);
-  }
+void FileDownlink ::pingIn_handler(const FwIndexType portNum, U32 key) {
+    this->pingOut_out(0, key);
+}
 
-  void FileDownlink ::
-    bufferReturn_handler(
-        const FwIndexType portNum,
-        Fw::Buffer &fwBuffer
-    )
-  {
-	  //If this is a stale buffer (old, timed-out, or both), then ignore its return.
-	  //File downlink actions only respond to the return of the most-recently-sent buffer.
-	  if (this->m_lastBufferId != fwBuffer.getContext() + 1 ||
-	      this->m_mode.get() == Mode::IDLE) {
-		  return;
-	  }
-	  //Non-ignored buffers cannot be returned in "DOWNLINK" and "IDLE" state.  Only in "WAIT", "CANCEL" state.
-	  FW_ASSERT(this->m_mode.get() == Mode::WAIT || this->m_mode.get() == Mode::CANCEL,
-                    static_cast<FwAssertArgType>(this->m_mode.get()));
-      //If the last packet has been sent (and is returning now) then finish the file
-	  if (this->m_lastCompletedType == Fw::FilePacket::T_END ||
-          this->m_lastCompletedType == Fw::FilePacket::T_CANCEL) {
-          finishHelper(this->m_lastCompletedType == Fw::FilePacket::T_CANCEL);
-          return;
-      }
-      //If waiting and a buffer is in-bound, then switch to downlink mode
-      else if (this->m_mode.get() == Mode::WAIT) {
-          this->m_mode.set(Mode::DOWNLINK);
-      }
+void FileDownlink ::bufferReturn_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
+    // If this is a stale buffer (old, timed-out, or both), then ignore its return.
+    // File downlink actions only respond to the return of the most-recently-sent buffer.
+    if (this->m_lastBufferId != fwBuffer.getContext() + 1 || this->m_mode.get() == Mode::IDLE) {
+        return;
+    }
+    // Non-ignored buffers cannot be returned in "DOWNLINK" and "IDLE" state.  Only in "WAIT", "CANCEL" state.
+    FW_ASSERT(this->m_mode.get() == Mode::WAIT || this->m_mode.get() == Mode::CANCEL,
+              static_cast<FwAssertArgType>(this->m_mode.get()));
+    // If the last packet has been sent (and is returning now) then finish the file
+    if (this->m_lastCompletedType == Fw::FilePacket::T_END || this->m_lastCompletedType == Fw::FilePacket::T_CANCEL) {
+        finishHelper(this->m_lastCompletedType == Fw::FilePacket::T_CANCEL);
+        return;
+    }
+    // If waiting and a buffer is in-bound, then switch to downlink mode
+    else if (this->m_mode.get() == Mode::WAIT) {
+        this->m_mode.set(Mode::DOWNLINK);
+    }
 
-      this->downlinkPacket();
-  }
+    this->downlinkPacket();
+}
 
-  // ----------------------------------------------------------------------
-  // Command handler implementations
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Command handler implementations
+// ----------------------------------------------------------------------
 
-  void FileDownlink ::
-    SendFile_cmdHandler(
-        const FwOpcodeType opCode,
-        const U32 cmdSeq,
-        const Fw::CmdStringArg& sourceFilename,
-        const Fw::CmdStringArg& destFilename
-    )
-  {
+void FileDownlink ::SendFile_cmdHandler(const FwOpcodeType opCode,
+                                        const U32 cmdSeq,
+                                        const Fw::CmdStringArg& sourceFilename,
+                                        const Fw::CmdStringArg& destFilename) {
     struct FileEntry entry;
     entry.srcFilename[0] = 0;
     entry.destFilename[0] = 0;
@@ -230,29 +181,27 @@ namespace Svc {
     entry.cmdSeq = cmdSeq;
     entry.context = std::numeric_limits<U32>::max();
 
-
     FW_ASSERT(sourceFilename.length() < sizeof(entry.srcFilename));
     FW_ASSERT(destFilename.length() < sizeof(entry.destFilename));
-    (void) Fw::StringUtils::string_copy(entry.srcFilename, sourceFilename.toChar(), static_cast<FwSizeType>(sizeof(entry.srcFilename)));
-    (void) Fw::StringUtils::string_copy(entry.destFilename, destFilename.toChar(), static_cast<FwSizeType>(sizeof(entry.destFilename)));
+    (void)Fw::StringUtils::string_copy(entry.srcFilename, sourceFilename.toChar(),
+                                       static_cast<FwSizeType>(sizeof(entry.srcFilename)));
+    (void)Fw::StringUtils::string_copy(entry.destFilename, destFilename.toChar(),
+                                       static_cast<FwSizeType>(sizeof(entry.destFilename)));
 
-    Os::Queue::Status status = m_fileQueue.send(reinterpret_cast<U8*>(&entry), static_cast<FwSizeType>(sizeof(entry)), 0, Os::Queue::BlockingType::NONBLOCKING);
+    Os::Queue::Status status = m_fileQueue.send(reinterpret_cast<U8*>(&entry), static_cast<FwSizeType>(sizeof(entry)),
+                                                0, Os::Queue::BlockingType::NONBLOCKING);
 
-    if(status != Os::Queue::Status::OP_OK) {
-      this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+    if (status != Os::Queue::Status::OP_OK) {
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
     }
-  }
+}
 
-  void FileDownlink ::
-    SendPartial_cmdHandler(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdStringArg& sourceFilename,
-      const Fw::CmdStringArg& destFilename,
-      U32 startOffset,
-      U32 length
-   )
-  {
+void FileDownlink ::SendPartial_cmdHandler(FwOpcodeType opCode,
+                                           U32 cmdSeq,
+                                           const Fw::CmdStringArg& sourceFilename,
+                                           const Fw::CmdStringArg& destFilename,
+                                           U32 startOffset,
+                                           U32 length) {
     struct FileEntry entry;
     entry.srcFilename[0] = 0;
     entry.destFilename[0] = 0;
@@ -263,103 +212,88 @@ namespace Svc {
     entry.cmdSeq = cmdSeq;
     entry.context = std::numeric_limits<U32>::max();
 
-
     FW_ASSERT(sourceFilename.length() < sizeof(entry.srcFilename));
     FW_ASSERT(destFilename.length() < sizeof(entry.destFilename));
-    (void) Fw::StringUtils::string_copy(entry.srcFilename, sourceFilename.toChar(), static_cast<FwSizeType>(sizeof(entry.srcFilename)));
-    (void) Fw::StringUtils::string_copy(entry.destFilename, destFilename.toChar(), static_cast<FwSizeType>(sizeof(entry.destFilename)));
+    (void)Fw::StringUtils::string_copy(entry.srcFilename, sourceFilename.toChar(),
+                                       static_cast<FwSizeType>(sizeof(entry.srcFilename)));
+    (void)Fw::StringUtils::string_copy(entry.destFilename, destFilename.toChar(),
+                                       static_cast<FwSizeType>(sizeof(entry.destFilename)));
 
-    Os::Queue::Status status = m_fileQueue.send(reinterpret_cast<U8*>(&entry), static_cast<FwSizeType>(sizeof(entry)), 0, Os::Queue::BlockingType::NONBLOCKING);
+    Os::Queue::Status status = m_fileQueue.send(reinterpret_cast<U8*>(&entry), static_cast<FwSizeType>(sizeof(entry)),
+                                                0, Os::Queue::BlockingType::NONBLOCKING);
 
-    if(status != Os::Queue::Status::OP_OK) {
-      this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+    if (status != Os::Queue::Status::OP_OK) {
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
     }
-  }
+}
 
-  void FileDownlink ::
-    Cancel_cmdHandler(
-        const FwOpcodeType opCode,
-        const U32 cmdSeq
-    )
-  {
-      //Must be able to cancel in both downlink and waiting states
-      if (this->m_mode.get() == Mode::DOWNLINK || this->m_mode.get() == Mode::WAIT) {
-          this->m_mode.set(Mode::CANCEL);
-      }
-      this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
-  }
+void FileDownlink ::Cancel_cmdHandler(const FwOpcodeType opCode, const U32 cmdSeq) {
+    // Must be able to cancel in both downlink and waiting states
+    if (this->m_mode.get() == Mode::DOWNLINK || this->m_mode.get() == Mode::WAIT) {
+        this->m_mode.set(Mode::CANCEL);
+    }
+    this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
+}
 
-  // ----------------------------------------------------------------------
-  // Private helper methods
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Private helper methods
+// ----------------------------------------------------------------------
 
-  Fw::CmdResponse FileDownlink ::
-    statusToCmdResp(SendFileStatus status)
-  {
-    switch(status.e) {
-    case SendFileStatus::STATUS_OK:
-      return Fw::CmdResponse::OK;
-    case SendFileStatus::STATUS_ERROR:
-      return Fw::CmdResponse::EXECUTION_ERROR;
-    case SendFileStatus::STATUS_INVALID:
-      return Fw::CmdResponse::VALIDATION_ERROR;
-    case SendFileStatus::STATUS_BUSY:
-        return Fw::CmdResponse::BUSY;
-    default:
-        // Trigger assertion if given unknown status
-        FW_ASSERT(false);
+Fw::CmdResponse FileDownlink ::statusToCmdResp(SendFileStatus status) {
+    switch (status.e) {
+        case SendFileStatus::STATUS_OK:
+            return Fw::CmdResponse::OK;
+        case SendFileStatus::STATUS_ERROR:
+            return Fw::CmdResponse::EXECUTION_ERROR;
+        case SendFileStatus::STATUS_INVALID:
+            return Fw::CmdResponse::VALIDATION_ERROR;
+        case SendFileStatus::STATUS_BUSY:
+            return Fw::CmdResponse::BUSY;
+        default:
+            // Trigger assertion if given unknown status
+            FW_ASSERT(false);
     }
 
     // It's impossible to reach this, but added to suppress gcc missing return warning
     return Fw::CmdResponse::EXECUTION_ERROR;
-  }
+}
 
-  void FileDownlink ::
-    sendResponse(SendFileStatus resp)
-  {
-    if(this->m_curEntry.source == FileDownlink::COMMAND) {
-      this->cmdResponse_out(this->m_curEntry.opCode, this->m_curEntry.cmdSeq, statusToCmdResp(resp));
+void FileDownlink ::sendResponse(SendFileStatus resp) {
+    if (this->m_curEntry.source == FileDownlink::COMMAND) {
+        this->cmdResponse_out(this->m_curEntry.opCode, this->m_curEntry.cmdSeq, statusToCmdResp(resp));
     } else {
-      for(FwIndexType i = 0; i < this->getNum_FileComplete_OutputPorts(); i++) {
-        if(this->isConnected_FileComplete_OutputPort(i)) {
-          this->FileComplete_out(i, Svc::SendFileResponse(resp, this->m_curEntry.context));
+        for (FwIndexType i = 0; i < this->getNum_FileComplete_OutputPorts(); i++) {
+            if (this->isConnected_FileComplete_OutputPort(i)) {
+                this->FileComplete_out(i, Svc::SendFileResponse(resp, this->m_curEntry.context));
+            }
         }
-      }
     }
-  }
+}
 
-  void FileDownlink ::
-    sendFile(
-          const char* sourceFilename,
-          const char* destFilename,
-          U32 startOffset,
-          U32 length
-      )
-  {
+void FileDownlink ::sendFile(const char* sourceFilename, const char* destFilename, U32 startOffset, U32 length) {
     // Open file for downlink
-    Os::File::Status status = this->m_file.open(
-        sourceFilename,
-        destFilename
-    );
+    Os::File::Status status = this->m_file.open(sourceFilename, destFilename);
 
     // Reject command if error when opening file
     if (status != Os::File::OP_OK) {
-      this->m_mode.set(Mode::IDLE);
-      this->m_warnings.fileOpenError();
-      sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR);
-      return;
+        this->m_mode.set(Mode::IDLE);
+        this->m_warnings.fileOpenError();
+        sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR);
+        return;
     }
-
 
     if (startOffset >= this->m_file.getSize()) {
         this->enterCooldown();
-        this->log_WARNING_HI_DownlinkPartialFail(this->m_file.getSourceName(), this->m_file.getDestName(), startOffset, this->m_file.getSize());
-        sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_INVALID);
+        this->log_WARNING_HI_DownlinkPartialFail(this->m_file.getSourceName(), this->m_file.getDestName(), startOffset,
+                                                 this->m_file.getSize());
+        sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK
+                                                            : SendFileStatus::STATUS_INVALID);
         return;
     } else if (startOffset + length > this->m_file.getSize()) {
         // If the amount to downlink is greater than the file size, emit a Warning and then allow
         // the file to be downlinked anyway
-        this->log_WARNING_LO_DownlinkPartialWarning(startOffset, length, this->m_file.getSize(), this->m_file.getSourceName(), this->m_file.getDestName());
+        this->log_WARNING_LO_DownlinkPartialWarning(startOffset, length, this->m_file.getSize(),
+                                                    this->m_file.getSourceName(), this->m_file.getDestName());
         length = this->m_file.getSize() - startOffset;
     }
 
@@ -376,38 +310,33 @@ namespace Svc {
     if (length > 0) {
         this->log_ACTIVITY_HI_SendStarted(length, this->m_file.getSourceName(), this->m_file.getDestName());
         this->m_endOffset = startOffset + length;
-    }
-    else {
-        this->log_ACTIVITY_HI_SendStarted(this->m_file.getSize() - startOffset, this->m_file.getSourceName(), this->m_file.getDestName());
+    } else {
+        this->log_ACTIVITY_HI_SendStarted(this->m_file.getSize() - startOffset, this->m_file.getSourceName(),
+                                          this->m_file.getDestName());
         this->m_endOffset = this->m_file.getSize();
     }
-  }
+}
 
-  Os::File::Status FileDownlink ::
-    sendDataPacket(U32 &byteOffset)
-  {
+Os::File::Status FileDownlink ::sendDataPacket(U32& byteOffset) {
     FW_ASSERT(byteOffset < this->m_endOffset);
-    const U32 maxDataSize = FILEDOWNLINK_INTERNAL_BUFFER_SIZE - Fw::FilePacket::DataPacket::HEADERSIZE - sizeof(FwPacketDescriptorType);
-    const U32 dataSize = (byteOffset + maxDataSize > this->m_endOffset) ? (this->m_endOffset - byteOffset) : maxDataSize;
+    const U32 maxDataSize =
+        FILEDOWNLINK_INTERNAL_BUFFER_SIZE - Fw::FilePacket::DataPacket::HEADERSIZE - sizeof(FwPacketDescriptorType);
+    const U32 dataSize =
+        (byteOffset + maxDataSize > this->m_endOffset) ? (this->m_endOffset - byteOffset) : maxDataSize;
     U8 buffer[maxDataSize];
-    //This will be last data packet sent
+    // This will be last data packet sent
     if (dataSize + byteOffset == this->m_endOffset) {
         this->m_lastCompletedType = Fw::FilePacket::T_DATA;
     }
 
-    const Os::File::Status status =
-      this->m_file.read(buffer, byteOffset, dataSize);
+    const Os::File::Status status = this->m_file.read(buffer, byteOffset, dataSize);
     if (status != Os::File::OP_OK) {
-      this->m_warnings.fileRead(status);
-      return status;
+        this->m_warnings.fileRead(status);
+        return status;
     }
 
     Fw::FilePacket::DataPacket dataPacket;
-    dataPacket.initialize(
-      this->m_sequenceIndex,
-      byteOffset,
-      static_cast<U16>(dataSize),
-      buffer);
+    dataPacket.initialize(this->m_sequenceIndex, byteOffset, static_cast<U16>(dataSize), buffer);
     ++this->m_sequenceIndex;
     Fw::FilePacket filePacket;
     filePacket.fromDataPacket(dataPacket);
@@ -416,12 +345,9 @@ namespace Svc {
     byteOffset += dataSize;
 
     return Os::File::OP_OK;
+}
 
-  }
-
-  void FileDownlink ::
-    sendCancelPacket()
-  {
+void FileDownlink ::sendCancelPacket() {
     Fw::Buffer buffer;
     Fw::FilePacket::CancelPacket cancelPacket;
     cancelPacket.initialize(this->m_sequenceIndex);
@@ -429,11 +355,9 @@ namespace Svc {
     Fw::FilePacket filePacket;
     filePacket.fromCancelPacket(cancelPacket);
     this->getBuffer(buffer, CANCEL_PACKET);
-    FW_ASSERT(
-      buffer.getSize() >= filePacket.bufferSize() + sizeof(FwPacketDescriptorType),
-      static_cast<FwAssertArgType>(buffer.getSize()),
-      static_cast<FwAssertArgType>(filePacket.bufferSize() + sizeof(FwPacketDescriptorType))
-    );
+    FW_ASSERT(buffer.getSize() >= filePacket.bufferSize() + sizeof(FwPacketDescriptorType),
+              static_cast<FwAssertArgType>(buffer.getSize()),
+              static_cast<FwAssertArgType>(filePacket.bufferSize() + sizeof(FwPacketDescriptorType)));
 
     // Serialize the packet descriptor FW_PACKET_FILE to the buffer
     Fw::SerializeStatus status = buffer.getSerializer().serialize(Fw::ComPacket::FW_PACKET_FILE);
@@ -445,11 +369,9 @@ namespace Svc {
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     this->bufferSendOut_out(0, buffer);
     this->m_packetsSent.packetSent();
-  }
+}
 
-  void FileDownlink ::
-    sendEndPacket()
-  {
+void FileDownlink ::sendEndPacket() {
     CFDP::Checksum checksum;
     this->m_file.getChecksum(checksum);
 
@@ -459,32 +381,22 @@ namespace Svc {
     Fw::FilePacket filePacket;
     filePacket.fromEndPacket(endPacket);
     this->sendFilePacket(filePacket);
+}
 
-  }
-
-  void FileDownlink ::
-    sendStartPacket()
-  {
+void FileDownlink ::sendStartPacket() {
     Fw::FilePacket::StartPacket startPacket;
-    startPacket.initialize(
-        this->m_file.getSize(),
-        this->m_file.getSourceName().toChar(),
-        this->m_file.getDestName().toChar()
-    );
+    startPacket.initialize(this->m_file.getSize(), this->m_file.getSourceName().toChar(),
+                           this->m_file.getDestName().toChar());
     Fw::FilePacket filePacket;
     filePacket.fromStartPacket(startPacket);
     this->sendFilePacket(filePacket);
-  }
+}
 
-  void FileDownlink ::
-    sendFilePacket(const Fw::FilePacket& filePacket)
-  {
+void FileDownlink ::sendFilePacket(const Fw::FilePacket& filePacket) {
     const U32 bufferSize = filePacket.bufferSize() + sizeof(FwPacketDescriptorType);
     FW_ASSERT(this->m_buffer.getData() != nullptr);
-    FW_ASSERT(
-      this->m_buffer.getSize() >= bufferSize,
-      static_cast<FwAssertArgType>(bufferSize),
-      static_cast<FwAssertArgType>(this->m_buffer.getSize()));
+    FW_ASSERT(this->m_buffer.getSize() >= bufferSize, static_cast<FwAssertArgType>(bufferSize),
+              static_cast<FwAssertArgType>(this->m_buffer.getSize()));
     // Serialize packet descriptor FW_PACKET_FILE to the buffer
     Fw::SerializeStatus status = this->m_buffer.getSerializer().serialize(Fw::ComPacket::FW_PACKET_FILE);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
@@ -498,73 +410,67 @@ namespace Svc {
     // restore buffer size to max
     this->m_buffer.setSize(FILEDOWNLINK_INTERNAL_BUFFER_SIZE);
     this->m_packetsSent.packetSent();
-  }
+}
 
-  void FileDownlink ::
-    enterCooldown()
-  {
+void FileDownlink ::enterCooldown() {
     this->m_file.getOsFile().close();
     this->m_mode.set(Mode::COOLDOWN);
     this->m_lastCompletedType = Fw::FilePacket::T_NONE;
     this->m_curTimer = 0;
-  }
+}
 
-  void FileDownlink ::
-    downlinkPacket()
-  {
-      FW_ASSERT(this->m_lastCompletedType != Fw::FilePacket::T_NONE, static_cast<FwAssertArgType>(this->m_lastCompletedType));
-      FW_ASSERT(this->m_mode.get() == Mode::CANCEL || this->m_mode.get() == Mode::DOWNLINK,
-                static_cast<FwAssertArgType>(this->m_mode.get()));
-      //If canceled mode and currently downlinking data then send a cancel packet
-      if (this->m_mode.get() == Mode::CANCEL && this->m_lastCompletedType == Fw::FilePacket::T_START) {
-          this->sendCancelPacket();
-          this->m_lastCompletedType = Fw::FilePacket::T_CANCEL;
-      }
-      //If in downlink mode and currently downlinking data then continue with the next packer
-      else if (this->m_mode.get() == Mode::DOWNLINK && this->m_lastCompletedType == Fw::FilePacket::T_START) {
-          //Send the next packet, or fail doing so
-          const Os::File::Status status = this->sendDataPacket(this->m_byteOffset);
-          if (status != Os::File::OP_OK) {
-              this->log_WARNING_HI_SendDataFail(this->m_file.getSourceName(), this->m_byteOffset);
-              this->enterCooldown();
-              this->sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR);
-              //Don't go to wait state
-              return;
-          }
-      }
-      //If in downlink mode or cancel and finished downlinking data then send the last packet
-      else if (this->m_lastCompletedType == Fw::FilePacket::T_DATA) {
-          this->sendEndPacket();
-          this->m_lastCompletedType = Fw::FilePacket::T_END;
-      }
-      this->m_mode.set(Mode::WAIT);
-      this->m_curTimer = 0;
-  }
+void FileDownlink ::downlinkPacket() {
+    FW_ASSERT(this->m_lastCompletedType != Fw::FilePacket::T_NONE,
+              static_cast<FwAssertArgType>(this->m_lastCompletedType));
+    FW_ASSERT(this->m_mode.get() == Mode::CANCEL || this->m_mode.get() == Mode::DOWNLINK,
+              static_cast<FwAssertArgType>(this->m_mode.get()));
+    // If canceled mode and currently downlinking data then send a cancel packet
+    if (this->m_mode.get() == Mode::CANCEL && this->m_lastCompletedType == Fw::FilePacket::T_START) {
+        this->sendCancelPacket();
+        this->m_lastCompletedType = Fw::FilePacket::T_CANCEL;
+    }
+    // If in downlink mode and currently downlinking data then continue with the next packer
+    else if (this->m_mode.get() == Mode::DOWNLINK && this->m_lastCompletedType == Fw::FilePacket::T_START) {
+        // Send the next packet, or fail doing so
+        const Os::File::Status status = this->sendDataPacket(this->m_byteOffset);
+        if (status != Os::File::OP_OK) {
+            this->log_WARNING_HI_SendDataFail(this->m_file.getSourceName(), this->m_byteOffset);
+            this->enterCooldown();
+            this->sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK
+                                                                      : SendFileStatus::STATUS_ERROR);
+            // Don't go to wait state
+            return;
+        }
+    }
+    // If in downlink mode or cancel and finished downlinking data then send the last packet
+    else if (this->m_lastCompletedType == Fw::FilePacket::T_DATA) {
+        this->sendEndPacket();
+        this->m_lastCompletedType = Fw::FilePacket::T_END;
+    }
+    this->m_mode.set(Mode::WAIT);
+    this->m_curTimer = 0;
+}
 
-  void FileDownlink ::
-    finishHelper(bool cancel)
-  {
-      //Complete command and switch to IDLE
-      if (not cancel) {
-          this->m_filesSent.fileSent();
-          this->log_ACTIVITY_HI_FileSent(this->m_file.getSourceName(), this->m_file.getDestName());
-      } else {
-          this->log_ACTIVITY_HI_DownlinkCanceled(this->m_file.getSourceName(), this->m_file.getDestName());
-      }
-      this->enterCooldown();
-      sendResponse(SendFileStatus::STATUS_OK);
-  }
+void FileDownlink ::finishHelper(bool cancel) {
+    // Complete command and switch to IDLE
+    if (not cancel) {
+        this->m_filesSent.fileSent();
+        this->log_ACTIVITY_HI_FileSent(this->m_file.getSourceName(), this->m_file.getDestName());
+    } else {
+        this->log_ACTIVITY_HI_DownlinkCanceled(this->m_file.getSourceName(), this->m_file.getDestName());
+    }
+    this->enterCooldown();
+    sendResponse(SendFileStatus::STATUS_OK);
+}
 
-  void FileDownlink ::
-    getBuffer(Fw::Buffer& buffer, PacketType type)
-  {
-      //Check type is correct
-      FW_ASSERT(type < COUNT_PACKET_TYPE && type >= 0, static_cast<FwAssertArgType>(type));
-      // Wrap the buffer around our indexed memory.
-      buffer.setData(this->m_memoryStore[type]);
-      buffer.setSize(FILEDOWNLINK_INTERNAL_BUFFER_SIZE);
-      //Set a known ID to look for later
-      buffer.setContext(m_lastBufferId);
-      m_lastBufferId++;
-  }
-} // end namespace Svc
+void FileDownlink ::getBuffer(Fw::Buffer& buffer, PacketType type) {
+    // Check type is correct
+    FW_ASSERT(type < COUNT_PACKET_TYPE && type >= 0, static_cast<FwAssertArgType>(type));
+    // Wrap the buffer around our indexed memory.
+    buffer.setData(this->m_memoryStore[type]);
+    buffer.setSize(FILEDOWNLINK_INTERNAL_BUFFER_SIZE);
+    // Set a known ID to look for later
+    buffer.setContext(m_lastBufferId);
+    m_lastBufferId++;
+}
+}  // end namespace Svc

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -433,7 +433,7 @@ namespace Svc {
     // Serialize the packet descriptor FW_PACKET_FILE to the buffer
     Fw::SerializeStatus status = buffer.getSerializeRepr().serialize(Fw::ComPacket::FW_PACKET_FILE);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
-    Fw::Buffer offsetBuffer(this->m_buffer.getData() + sizeof(FwPacketDescriptorType), filePacket.bufferSize());
+    Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType), filePacket.bufferSize());
     // Serialize the filePacket content into the buffer
     status = filePacket.toBuffer(offsetBuffer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -10,6 +10,7 @@
 // ======================================================================
 
 #include <Svc/FileDownlink/FileDownlink.hpp>
+#include <Fw/Com/ComPacket.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <Fw/Types/StringUtils.hpp>
@@ -386,9 +387,9 @@ namespace Svc {
     sendDataPacket(U32 &byteOffset)
   {
     FW_ASSERT(byteOffset < this->m_endOffset);
-    const U32 maxDataSize = FILEDOWNLINK_INTERNAL_BUFFER_SIZE - Fw::FilePacket::DataPacket::HEADERSIZE;
+    const U32 maxDataSize = FILEDOWNLINK_INTERNAL_BUFFER_SIZE - Fw::FilePacket::DataPacket::HEADERSIZE - sizeof(FwPacketDescriptorType);
     const U32 dataSize = (byteOffset + maxDataSize > this->m_endOffset) ? (this->m_endOffset - byteOffset) : maxDataSize;
-    U8 buffer[FILEDOWNLINK_INTERNAL_BUFFER_SIZE - Fw::FilePacket::DataPacket::HEADERSIZE];
+    U8 buffer[maxDataSize];
     //This will be last data packet sent
     if (dataSize + byteOffset == this->m_endOffset) {
         this->m_lastCompletedType = Fw::FilePacket::T_DATA;
@@ -429,7 +430,12 @@ namespace Svc {
     filePacket.fromCancelPacket(cancelPacket);
     this->getBuffer(buffer, CANCEL_PACKET);
 
-    const Fw::SerializeStatus status = filePacket.toBuffer(buffer);
+    // Serialize the packet descriptor FW_PACKET_FILE to the buffer
+    Fw::SerializeStatus status = buffer.getSerializeRepr().serialize(Fw::ComPacket::FW_PACKET_FILE);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
+    Fw::Buffer offsetBuffer(this->m_buffer.getData() + sizeof(FwPacketDescriptorType), filePacket.bufferSize());
+    // Serialize the filePacket content into the buffer
+    status = filePacket.toBuffer(offsetBuffer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     this->bufferSendOut_out(0, buffer);
     this->m_packetsSent.packetSent();
@@ -467,13 +473,18 @@ namespace Svc {
   void FileDownlink ::
     sendFilePacket(const Fw::FilePacket& filePacket)
   {
-    const U32 bufferSize = filePacket.bufferSize();
+    const U32 bufferSize = filePacket.bufferSize() + sizeof(FwPacketDescriptorType);
     FW_ASSERT(this->m_buffer.getData() != nullptr);
     FW_ASSERT(
       this->m_buffer.getSize() >= bufferSize,
       static_cast<FwAssertArgType>(bufferSize),
       static_cast<FwAssertArgType>(this->m_buffer.getSize()));
-    const Fw::SerializeStatus status = filePacket.toBuffer(this->m_buffer);
+    // Serialize packet descriptor FW_PACKET_FILE to the buffer
+    Fw::SerializeStatus status = this->m_buffer.getSerializeRepr().serialize(Fw::ComPacket::FW_PACKET_FILE);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
+    // Serialize the filePacket content into the buffer, offset by the size of the packet descriptor
+    Fw::Buffer offsetBuffer(this->m_buffer.getData() + sizeof(FwPacketDescriptorType), filePacket.bufferSize());
+    status = filePacket.toBuffer(offsetBuffer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // set the buffer size to the packet size
     this->m_buffer.setSize(bufferSize);

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -431,7 +431,7 @@ namespace Svc {
     this->getBuffer(buffer, CANCEL_PACKET);
 
     // Serialize the packet descriptor FW_PACKET_FILE to the buffer
-    Fw::SerializeStatus status = buffer.getSerializeRepr().serialize(Fw::ComPacket::FW_PACKET_FILE);
+    Fw::SerializeStatus status = buffer.getSerializer().serialize(Fw::ComPacket::FW_PACKET_FILE);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType), filePacket.bufferSize());
     // Serialize the filePacket content into the buffer
@@ -480,7 +480,7 @@ namespace Svc {
       static_cast<FwAssertArgType>(bufferSize),
       static_cast<FwAssertArgType>(this->m_buffer.getSize()));
     // Serialize packet descriptor FW_PACKET_FILE to the buffer
-    Fw::SerializeStatus status = this->m_buffer.getSerializeRepr().serialize(Fw::ComPacket::FW_PACKET_FILE);
+    Fw::SerializeStatus status = this->m_buffer.getSerializer().serialize(Fw::ComPacket::FW_PACKET_FILE);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // Serialize the filePacket content into the buffer, offset by the size of the packet descriptor
     Fw::Buffer offsetBuffer(this->m_buffer.getData() + sizeof(FwPacketDescriptorType), filePacket.bufferSize());

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -669,7 +669,10 @@ namespace Svc {
         Fw::FilePacket& filePacket
     )
   {
-    const Fw::SerializeStatus status = filePacket.fromBuffer(buffer);
+    // buffer contains the FW_PACKET_FILE descriptor - we remove it before deserializing into the filePacket
+    Fw::Buffer packetDataBuffer(buffer.getData() + sizeof(FwPacketDescriptorType), 
+                                buffer.getSize() - sizeof(FwPacketDescriptorType));
+    const Fw::SerializeStatus status = filePacket.fromBuffer(packetDataBuffer);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, status);
   }
 

--- a/Svc/FileUplink/Events.fppi
+++ b/Svc/FileUplink/Events.fppi
@@ -85,3 +85,11 @@ event DecodeError(
   severity warning high \
   id 9 \
   format "Unable to decode file packet. Status: {}"
+
+@ Invalid packet received
+event InvalidPacketReceived(
+                   packetType: U32 @< The packet type received
+                 ) \
+  severity warning high \
+  id 10 \
+  format "Invalid packet received. Wrong packet type: {}"

--- a/Svc/FileUplink/FileUplink.cpp
+++ b/Svc/FileUplink/FileUplink.cpp
@@ -10,89 +10,95 @@
 //
 // ======================================================================
 
-#include <Svc/FileUplink/FileUplink.hpp>
-#include <Fw/Types/Assert.hpp>
+#include <Fw/Com/ComPacket.hpp>
 #include <Fw/FPrimeBasicTypes.hpp>
+#include <Fw/Types/Assert.hpp>
+#include <Svc/FileUplink/FileUplink.hpp>
 
 namespace Svc {
 
-  // ----------------------------------------------------------------------
-  // Construction, initialization, and destruction
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Construction, initialization, and destruction
+// ----------------------------------------------------------------------
 
-  FileUplink ::
-    FileUplink(const char *const name) :
-      FileUplinkComponentBase(name),
+FileUplink ::FileUplink(const char* const name)
+    : FileUplinkComponentBase(name),
       m_receiveMode(START),
       m_lastSequenceIndex(0),
       m_lastPacketWriteStatus(Os::File::MAX_STATUS),
       m_filesReceived(this),
       m_packetsReceived(this),
-      m_warnings(this)
-  {
+      m_warnings(this) {}
 
-  }
+FileUplink ::~FileUplink() {}
 
-  FileUplink ::
-    ~FileUplink()
-  {
+// ----------------------------------------------------------------------
+// Handler implementations for user-defined typed input ports
+// ----------------------------------------------------------------------
 
-  }
+void FileUplink ::bufferSendIn_handler(const FwIndexType portNum, Fw::Buffer& buffer) {
+    // If packet is too small to contain a packet type, log + deallocate and return
+    if (buffer.getSize() < sizeof(FwPacketDescriptorType)) {
+        this->log_WARNING_HI_InvalidPacketReceived(Fw::ComPacket::FW_PACKET_UNKNOWN);
+        this->bufferSendOut_out(0, buffer);
+        return;
+    }
 
-  // ----------------------------------------------------------------------
-  // Handler implementations for user-defined typed input ports
-  // ----------------------------------------------------------------------
+    // Read the packet type from the packet buffer
+    FwPacketDescriptorType packetType = Fw::ComPacket::FW_PACKET_UNKNOWN;
+    Fw::SerializeStatus status = Fw::FW_DESERIALIZE_FORMAT_ERROR;
+    Fw::SerializeBufferBase& serial = buffer.getSerializeRepr();
+    status = serial.setBuffLen(buffer.getSize());
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
+    status = serial.deserialize(packetType);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
-  void FileUplink ::
-    bufferSendIn_handler(
-        const FwIndexType portNum,
-        Fw::Buffer& buffer
-    )
-  {
+    // If packet type is not a file packet, log + deallocate and return
+    if (packetType != Fw::ComPacket::FW_PACKET_FILE) {
+        this->log_WARNING_HI_InvalidPacketReceived(packetType);
+        this->bufferSendOut_out(0, buffer);
+        return;
+    }
+
+    // Deserialize the file packet contents into Fw::FilePacket (remove packet type token)
+    Fw::Buffer packetContents(buffer.getData() + sizeof(packetType), buffer.getSize() - sizeof(packetType));
     Fw::FilePacket filePacket;
-    const Fw::SerializeStatus status = filePacket.fromBuffer(buffer);
+    status = filePacket.fromBuffer(packetContents);
     if (status != Fw::FW_SERIALIZE_OK) {
         this->log_WARNING_HI_DecodeError(status);
     } else {
         Fw::FilePacket::Type header_type = filePacket.asHeader().getType();
         switch (header_type) {
-          case Fw::FilePacket::T_START:
-            this->handleStartPacket(filePacket.asStartPacket());
-            break;
-          case Fw::FilePacket::T_DATA:
-            this->handleDataPacket(filePacket.asDataPacket());
-            break;
-          case Fw::FilePacket::T_END:
-            this->handleEndPacket(filePacket.asEndPacket());
-            break;
-          case Fw::FilePacket::T_CANCEL:
-            this->handleCancelPacket();
-            break;
-          default:
-            FW_ASSERT(0);
-            break;
+            case Fw::FilePacket::T_START:
+                this->handleStartPacket(filePacket.asStartPacket());
+                break;
+            case Fw::FilePacket::T_DATA:
+                this->handleDataPacket(filePacket.asDataPacket());
+                break;
+            case Fw::FilePacket::T_END:
+                this->handleEndPacket(filePacket.asEndPacket());
+                break;
+            case Fw::FilePacket::T_CANCEL:
+                this->handleCancelPacket();
+                break;
+            default:
+                FW_ASSERT(0);
+                break;
         }
     }
     this->bufferSendOut_out(0, buffer);
-  }
+}
 
-  void FileUplink ::
-    pingIn_handler(
-        const FwIndexType portNum,
-        U32 key
-    )
-  {
-      // return key
-      this->pingOut_out(0,key);
-  }
+void FileUplink ::pingIn_handler(const FwIndexType portNum, U32 key) {
+    // return key
+    this->pingOut_out(0, key);
+}
 
-  // ----------------------------------------------------------------------
-  // Private helper functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Private helper functions
+// ----------------------------------------------------------------------
 
-  void FileUplink ::
-    handleStartPacket(const Fw::FilePacket::StartPacket& startPacket)
-  {
+void FileUplink ::handleStartPacket(const Fw::FilePacket::StartPacket& startPacket) {
     // Clear all event throttles in preparation for new start packet
     this->log_WARNING_HI_FileWriteError_ThrottleClear();
     this->log_WARNING_HI_InvalidReceiveMode_ThrottleClear();
@@ -100,33 +106,29 @@ namespace Svc {
     this->log_WARNING_HI_PacketOutOfOrder_ThrottleClear();
     this->m_packetsReceived.packetReceived();
     if (this->m_receiveMode != START) {
-      this->m_file.osFile.close();
-      this->m_warnings.invalidReceiveMode(Fw::FilePacket::T_START);
+        this->m_file.osFile.close();
+        this->m_warnings.invalidReceiveMode(Fw::FilePacket::T_START);
     }
     const Os::File::Status status = this->m_file.open(startPacket);
     if (status == Os::File::OP_OK) {
-      this->goToDataMode();
+        this->goToDataMode();
+    } else {
+        this->m_warnings.fileOpen(this->m_file.name);
+        this->goToStartMode();
     }
-    else {
-      this->m_warnings.fileOpen(this->m_file.name);
-      this->goToStartMode();
-    }
-  }
+}
 
-  void FileUplink ::
-    handleDataPacket(const Fw::FilePacket::DataPacket& dataPacket)
-  {
+void FileUplink ::handleDataPacket(const Fw::FilePacket::DataPacket& dataPacket) {
     this->m_packetsReceived.packetReceived();
     if (this->m_receiveMode != DATA) {
-      this->m_warnings.invalidReceiveMode(Fw::FilePacket::T_DATA);
-      return;
+        this->m_warnings.invalidReceiveMode(Fw::FilePacket::T_DATA);
+        return;
     }
 
     const U32 sequenceIndex = dataPacket.asHeader().getSequenceIndex();
 
     // skip this packet if it is a duplicate and it has already been written
-    if (this->m_lastPacketWriteStatus == Os::File::OP_OK &&
-        this->checkDuplicatedPacket(sequenceIndex)) {
+    if (this->m_lastPacketWriteStatus == Os::File::OP_OK && this->checkDuplicatedPacket(sequenceIndex)) {
         return;
     }
 
@@ -134,98 +136,73 @@ namespace Svc {
     const U32 byteOffset = dataPacket.getByteOffset();
     const U32 dataSize = dataPacket.getDataSize();
     if (byteOffset + dataSize > this->m_file.size) {
-      this->m_warnings.packetOutOfBounds(sequenceIndex, this->m_file.name);
-      return;
+        this->m_warnings.packetOutOfBounds(sequenceIndex, this->m_file.name);
+        return;
     }
-    const Os::File::Status status = this->m_file.write(
-        dataPacket.getData(),
-        byteOffset,
-        dataSize
-    );
+    const Os::File::Status status = this->m_file.write(dataPacket.getData(), byteOffset, dataSize);
     if (status != Os::File::OP_OK) {
-      this->m_warnings.fileWrite(this->m_file.name);
+        this->m_warnings.fileWrite(this->m_file.name);
     }
 
     this->m_lastPacketWriteStatus = status;
-  }
+}
 
-  void FileUplink ::
-    handleEndPacket(const Fw::FilePacket::EndPacket& endPacket)
-  {
+void FileUplink ::handleEndPacket(const Fw::FilePacket::EndPacket& endPacket) {
     this->m_packetsReceived.packetReceived();
     if (this->m_receiveMode == DATA) {
-      this->m_filesReceived.fileReceived();
-      this->checkSequenceIndex(endPacket.asHeader().getSequenceIndex());
-      this->compareChecksums(endPacket);
-      this->log_ACTIVITY_HI_FileReceived(this->m_file.name);
-    }
-    else {
-      this->m_warnings.invalidReceiveMode(Fw::FilePacket::T_END);
+        this->m_filesReceived.fileReceived();
+        this->checkSequenceIndex(endPacket.asHeader().getSequenceIndex());
+        this->compareChecksums(endPacket);
+        this->log_ACTIVITY_HI_FileReceived(this->m_file.name);
+    } else {
+        this->m_warnings.invalidReceiveMode(Fw::FilePacket::T_END);
     }
     this->goToStartMode();
-  }
+}
 
-  void FileUplink ::
-    handleCancelPacket()
-  {
+void FileUplink ::handleCancelPacket() {
     this->m_packetsReceived.packetReceived();
     this->log_ACTIVITY_HI_UplinkCanceled();
     this->goToStartMode();
-  }
+}
 
-  void FileUplink ::
-    checkSequenceIndex(const U32 sequenceIndex)
-  {
+void FileUplink ::checkSequenceIndex(const U32 sequenceIndex) {
     if (sequenceIndex != this->m_lastSequenceIndex + 1) {
-      this->m_warnings.packetOutOfOrder(
-          sequenceIndex,
-          this->m_lastSequenceIndex
-      );
+        this->m_warnings.packetOutOfOrder(sequenceIndex, this->m_lastSequenceIndex);
     }
     this->m_lastSequenceIndex = sequenceIndex;
-  }
+}
 
-  bool FileUplink ::
-    checkDuplicatedPacket(const U32 sequenceIndex)
-  {
+bool FileUplink ::checkDuplicatedPacket(const U32 sequenceIndex) {
     // check for duplicate packet
     if (sequenceIndex == this->m_lastSequenceIndex) {
-      this->m_warnings.packetDuplicate(sequenceIndex);
-      return true;
+        this->m_warnings.packetDuplicate(sequenceIndex);
+        return true;
     }
 
     return false;
-  }
+}
 
-  void FileUplink ::
-    compareChecksums(const Fw::FilePacket::EndPacket& endPacket)
-  {
+void FileUplink ::compareChecksums(const Fw::FilePacket::EndPacket& endPacket) {
     CFDP::Checksum computed, stored;
     this->m_file.getChecksum(computed);
     endPacket.getChecksum(stored);
     if (computed != stored) {
-      this->m_warnings.badChecksum(
-          computed.getValue(),
-          stored.getValue()
-      );
+        this->m_warnings.badChecksum(computed.getValue(), stored.getValue());
     }
-  }
+}
 
-  void FileUplink ::
-    goToStartMode()
-  {
+void FileUplink ::goToStartMode() {
     this->m_file.osFile.close();
     this->m_receiveMode = START;
     this->m_lastSequenceIndex = 0;
     this->m_lastPacketWriteStatus = Os::File::MAX_STATUS;
-  }
+}
 
-  void FileUplink ::
-    goToDataMode()
-  {
+void FileUplink ::goToDataMode() {
     this->m_receiveMode = DATA;
     this->m_lastSequenceIndex = 0;
     this->m_lastPacketWriteStatus = Os::File::MAX_STATUS;
-  }
-
 }
+
+}  // namespace Svc

--- a/Svc/FileUplink/FileUplink.cpp
+++ b/Svc/FileUplink/FileUplink.cpp
@@ -45,12 +45,8 @@ void FileUplink ::bufferSendIn_handler(const FwIndexType portNum, Fw::Buffer& bu
     }
 
     // Read the packet type from the packet buffer
-    FwPacketDescriptorType packetType = Fw::ComPacket::FW_PACKET_UNKNOWN;
-    Fw::SerializeStatus status = Fw::FW_DESERIALIZE_FORMAT_ERROR;
-    Fw::SerializeBufferBase& serial = buffer.getSerializeRepr();
-    status = serial.setBuffLen(buffer.getSize());
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
-    status = serial.deserialize(packetType);
+    FwPacketDescriptorType packetType;
+    Fw::SerializeStatus status = buffer.getDeserializer().deserialize(packetType);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // If packet type is not a file packet, log + deallocate and return

--- a/Svc/FileUplink/FileUplink.cpp
+++ b/Svc/FileUplink/FileUplink.cpp
@@ -61,9 +61,10 @@ void FileUplink ::bufferSendIn_handler(const FwIndexType portNum, Fw::Buffer& bu
     }
 
     // Deserialize the file packet contents into Fw::FilePacket (remove packet type token)
-    Fw::Buffer packetContents(buffer.getData() + sizeof(packetType), buffer.getSize() - sizeof(packetType));
+    Fw::Buffer packetBuffer(buffer.getData() + sizeof(packetType),
+                            buffer.getSize() - static_cast<Fw::Buffer::SizeType>(sizeof(packetType)));
     Fw::FilePacket filePacket;
-    status = filePacket.fromBuffer(packetContents);
+    status = filePacket.fromBuffer(packetBuffer);
     if (status != Fw::FW_SERIALIZE_OK) {
         this->log_WARNING_HI_DecodeError(status);
     } else {

--- a/Svc/FileUplink/test/ut/FileUplinkTester.cpp
+++ b/Svc/FileUplink/test/ut/FileUplinkTester.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 
 #include "FileUplinkTester.hpp"
+#include "Fw/Com/ComPacket.hpp"
 
 #define INSTANCE 0
 #define MAX_HISTORY_SIZE 10
@@ -611,11 +612,17 @@ namespace Svc {
 
     this->clearHistory();
 
-    const size_t bufferSize = filePacket.bufferSize();
+    const size_t bufferSize = filePacket.bufferSize() + sizeof(FwPacketDescriptorType);
     U8 bufferData[bufferSize];
     Fw::Buffer buffer(bufferData, bufferSize);
 
-    const Fw::SerializeStatus status = filePacket.toBuffer(buffer);
+    // Serialize the packet descriptor FW_PACKET_FILE to the buffer
+    Fw::SerializeStatus status = buffer.getSerializeRepr().serialize(Fw::ComPacket::FW_PACKET_FILE);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
+    // Serialize the filePacket content into the buffer after the packet descriptor token
+    Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType),
+                            bufferSize - sizeof(FwPacketDescriptorType));
+    status = filePacket.toBuffer(offsetBuffer);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, status);
 
     this->invoke_to_bufferSendIn(0, buffer);

--- a/Svc/FileUplink/test/ut/FileUplinkTester.cpp
+++ b/Svc/FileUplink/test/ut/FileUplinkTester.cpp
@@ -617,7 +617,7 @@ namespace Svc {
     Fw::Buffer buffer(bufferData, bufferSize);
 
     // Serialize the packet descriptor FW_PACKET_FILE to the buffer
-    Fw::SerializeStatus status = buffer.getSerializeRepr().serialize(Fw::ComPacket::FW_PACKET_FILE);
+    Fw::SerializeStatus status = buffer.getSerializer().serialize(Fw::ComPacket::FW_PACKET_FILE);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // Serialize the filePacket content into the buffer after the packet descriptor token
     Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType),

--- a/Svc/FprimeRouter/FprimeRouter.cpp
+++ b/Svc/FprimeRouter/FprimeRouter.cpp
@@ -62,14 +62,6 @@ void FprimeRouter ::dataIn_handler(FwIndexType portNum, Fw::Buffer& packetBuffer
                 // If the file uplink output port is connected,
                 // send the file packet. Otherwise take no action.
                 if (this->isConnected_fileOut_OutputPort(0)) {
-                    // Make sure we can cast down to U32 without overflow
-                    FW_ASSERT((packetSize - sizeof(packetType)) < std::numeric_limits<U32>::max(),
-                              static_cast<FwAssertArgType>(packetSize - sizeof(packetType)));
-                    // Shift the packet buffer to skip the packet type
-                    // The FileUplink component does not expect the packet
-                    // type to be there.
-                    packetBuffer.setData(packetData + sizeof(packetType));
-                    packetBuffer.setSize(static_cast<U32>(packetSize - sizeof(packetType)));
                     // Send the packet buffer
                     this->fileOut_out(0, packetBuffer);
                     // Transfer ownership of the packetBuffer to the receiver

--- a/Svc/FramingProtocol/FprimeProtocol.cpp
+++ b/Svc/FramingProtocol/FprimeProtocol.cpp
@@ -20,41 +20,35 @@ FprimeFraming::FprimeFraming(): FramingProtocol() {}
 FprimeDeframing::FprimeDeframing(): DeframingProtocol() {}
 
 void FprimeFraming::frame(const U8* const data, const U32 size, Fw::ComPacket::ComPacketType packet_type) {
+    // NOTE: packet_type is not used in this implementation
+
     FW_ASSERT(data != nullptr);
     FW_ASSERT(m_interface != nullptr);
-    // Use of I32 size is explicit as ComPacketType will be specifically serialized as an I32
-    FpFrameHeader::TokenType real_data_size =
-        size + ((packet_type != Fw::ComPacket::FW_PACKET_UNKNOWN) ?
-        static_cast<Svc::FpFrameHeader::TokenType>(sizeof(I32)) :
-        0);
-    FpFrameHeader::TokenType total = real_data_size + FpFrameHeader::SIZE + HASH_DIGEST_LENGTH;
-    Fw::Buffer buffer = m_interface->allocate(total);
+
+    FpFrameHeader::TokenType totalSize = size + FpFrameHeader::SIZE + HASH_DIGEST_LENGTH;
+    Fw::Buffer buffer = m_interface->allocate(totalSize);
     Fw::SerializeBufferBase& serializer = buffer.getSerializeRepr();
     Utils::HashBuffer hash;
 
-    // Serialize data
+    // Serialize start word
     Fw::SerializeStatus status;
     status = serializer.serialize(FpFrameHeader::START_WORD);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
-    status = serializer.serialize(real_data_size);
+    // Serialize data size
+    status = serializer.serialize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
-    // Serialize packet type if supplied, otherwise it *must* be present in the data
-    if (packet_type != Fw::ComPacket::FW_PACKET_UNKNOWN) {
-        status = serializer.serialize(static_cast<I32>(packet_type)); // I32 used for enum storage
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    }
-
+    // Serialize data
     status = serializer.serialize(data, size, true);  // Serialize without length
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Calculate and add transmission hash
-    Utils::Hash::hash(buffer.getData(), static_cast<FwSizeType>(total - HASH_DIGEST_LENGTH), hash);
+    Utils::Hash::hash(buffer.getData(), static_cast<FwSizeType>(totalSize - HASH_DIGEST_LENGTH), hash);
     status = serializer.serialize(hash.getBuffAddr(), HASH_DIGEST_LENGTH, true);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
-    buffer.setSize(total);
+    buffer.setSize(totalSize);
 
     m_interface->send(buffer);
 }

--- a/Svc/FramingProtocol/test/ut/FramingTester.cpp
+++ b/Svc/FramingProtocol/test/ut/FramingTester.cpp
@@ -51,10 +51,6 @@ namespace Svc {
       // Check the packet size
       const U32 packetSize = this->getPacketSize();
       this->checkPacketSize(packetSize);
-      // Check the packet type
-      if (this->packetType != Fw::ComPacket::FW_PACKET_UNKNOWN) {
-        this->checkPacketType();
-      }
       // Check the data
       this->checkData();
       // Check the hash value
@@ -84,10 +80,6 @@ namespace Svc {
     checkPacketSize(FpFrameHeader::TokenType packetSize)
   {
     FwSizeType expectedPacketSize = this->dataSize;
-    if (this->packetType != Fw::ComPacket::FW_PACKET_UNKNOWN) {
-      // Packet type is stored in header
-      expectedPacketSize += sizeof(SerialPacketType);
-    }
     ASSERT_EQ(packetSize, expectedPacketSize);
   }
 
@@ -125,10 +117,6 @@ namespace Svc {
     checkData()
   {
     FwSizeType dataOffset = PACKET_TYPE_OFFSET;
-    if (this->packetType != Fw::ComPacket::FW_PACKET_UNKNOWN) {
-      // Packet type is stored in header
-      dataOffset += sizeof(SerialPacketType);
-    }
     const I32 result = memcmp(
         this->data,
         &this->bufferStorage[dataOffset],

--- a/config/FileDownlinkCfg.hpp
+++ b/config/FileDownlinkCfg.hpp
@@ -20,7 +20,7 @@ namespace Svc {
     static const bool FILEDOWNLINK_COMMAND_FAILURES_DISABLED = true;
     // Size of the internal file downlink buffer. This must now be static as
     // file down maintains its own internal buffer.
-    static const U32 FILEDOWNLINK_INTERNAL_BUFFER_SIZE = FW_COM_BUFFER_MAX_SIZE-sizeof(FwPacketDescriptorType);
+    static const U32 FILEDOWNLINK_INTERNAL_BUFFER_SIZE = FW_COM_BUFFER_MAX_SIZE;
 }
 
 #endif /* SVC_FILEDOWNLINK_FILEDOWNLINKCFG_HPP_ */


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/3467

Packet descriptor is now handled at reception/emission time within FileUplink/FileDownlink.

## Rationale

No custom code in routing / framing needed anymore, etc. File packets are stamped when created.
