### PR TITLE
Fix FileDownlink conversion warning

### DIFF
--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -393,7 +393,7 @@ void FileDownlink ::sendStartPacket() {
 }
 
 void FileDownlink ::sendFilePacket(const Fw::FilePacket& filePacket) {
-    const U32 bufferSize = filePacket.bufferSize() + sizeof(FwPacketDescriptorType);
+    const U32 bufferSize = filePacket.bufferSize() + static_cast<U32>(sizeof(FwPacketDescriptorType));
     FW_ASSERT(this->m_buffer.getData() != nullptr);
     FW_ASSERT(this->m_buffer.getSize() >= bufferSize, static_cast<FwAssertArgType>(bufferSize),
               static_cast<FwAssertArgType>(this->m_buffer.getSize()));


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

A conversion warning is reported on FileDownlink when building on RHEL8, which was not caught in CI for https://github.com/nasa/fprime/pull/3488

## Future Work

Get a RHEL8 machine in CI
