### PR TITLE
Fix sign-compare warning in Os::Posix::File, Svc::ComQueue, and Svc::…

### DIFF
--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -7,6 +7,7 @@
 #include <Fw/Types/Assert.hpp>
 #include <Svc/ComQueue/ComQueue.hpp>
 #include "Fw/Types/BasicTypes.hpp"
+#include <type_traits>
 
 namespace Svc {
 
@@ -14,8 +15,11 @@ namespace Svc {
 // Construction, initialization, and destruction
 // ----------------------------------------------------------------------
 
+using FwUnsignedIndexType = std::make_unsigned<FwIndexType>::type;
+
 ComQueue ::QueueConfigurationTable ::QueueConfigurationTable() {
-    static_assert(std::numeric_limits<FwIndexType>::max() >= FW_NUM_ARRAY_ELEMENTS(this->entries), "Number of entries must fit into FwIndexType");
+    static_assert(static_cast<FwUnsignedIndexType>(std::numeric_limits<FwIndexType>::max()) >= FW_NUM_ARRAY_ELEMENTS(this->entries),
+                  "Number of entries must fit into FwIndexType");
     for (FwIndexType i = 0; i < static_cast<FwIndexType>(FW_NUM_ARRAY_ELEMENTS(this->entries)); i++) {
         this->entries[i].priority = 0;
         this->entries[i].depth = 0;

--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -74,8 +74,8 @@ void TlmPacketizer::setPacketList(const TlmPacketizerPacketList& packetList,
             entryToUse->ignored = false;
             entryToUse->id = id;
             // the offset into the buffer will be the current packet length
-            // the offset must fit within FwIndexType to allow for negative values
-            FW_ASSERT(packetLen <= std::numeric_limits<FwSignedSizeType>::max(), static_cast<FwAssertArgType>(packetLen));
+            // the offset must fit within FwSignedSizeType to allow for negative values
+            FW_ASSERT(packetLen <= static_cast<FwSizeType>(std::numeric_limits<FwSignedSizeType>::max()), static_cast<FwAssertArgType>(packetLen));
             entryToUse->packetOffset[pktEntry] = static_cast<FwSignedSizeType>(packetLen);
 
             packetLen += packetList.list[pktEntry]->list[tlmEntry].size;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/3506 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Cast limits of the signed types to unsigned types in order to use them in comparisons.
For Os::Posix::File and Svc::TlmPacketizer **it is assumed** that `FwSizeType` is **always** equivalent to unsigned `FwSignedSizeType`. Otherwise, the `std::make_unsigned` should be used for this pair as well.

## Rationale

Avoid sign-compare warning.
Fix https://github.com/nasa/fprime/issues/3506

## Testing/Review Recommendations

Please pay attention to aforementioned assumption: `FwSizeType`  == unsigned `FwSignedSizeType`.
In Svc/TlmPacketizer/TlmPacketizer.cpp line 77 I've changed `FwIndexType` to `FwSignedSizeType`. If this is wrong, then maybe the source code should be updated: `FwSignedSizeType->FwIndexType`.

## Future Work

Now the code is buildable. However, tests in Svc_BufferLogger_ut_exe are failed:
```
15/86 Test #15: Svc_BufferLogger_ut_exe .........................***Failed    5.09 sec
[==========] Running 9 tests from 4 test suites.
[----------] Global test environment set-up.
[----------] 1 test from Test
[ RUN      ] Test.LogNoInit
[       OK ] Test.LogNoInit (12 ms)
[----------] 1 test from Test (12 ms total)

[----------] 3 tests from TestErrors
[ RUN      ] TestErrors.LogFileOpen
[       OK ] TestErrors.LogFileOpen (330 ms)
[ RUN      ] TestErrors.LogFileWrite
[       OK ] TestErrors.LogFileWrite (387 ms)
[ RUN      ] TestErrors.LogFileValidation
/home/alexkus/fprime/fprime/build-fprime-automatic-native-ut/F-Prime/Svc/BufferLogger/BufferLoggerGTestBase.cpp:154: Failure
Expected equality of these values:
  size
    Which is: 2
  this->eventsSize
    Which is: 1

/home/alexkus/fprime/fprime/Svc/BufferLogger/test/ut/Errors.cpp:177
  Value:    Total size of all event histories
  Expected: 2
  Actual:   1

/home/alexkus/fprime/fprime/build-fprime-automatic-native-ut/F-Prime/Svc/BufferLogger/BufferLoggerGTestBase.cpp:279: Failure
Expected: (this->eventHistory_BL_LogFileValidationError->size()) > (__index), actual: 0 vs 0

/home/alexkus/fprime/fprime/Svc/BufferLogger/test/ut/Errors.cpp:191
  Value:    Index into history of event BL_LogFileValidationError
  Expected: Less than size of history (0)
  Actual:   0

[  FAILED  ] TestErrors.LogFileValidation (76 ms)
[----------] 3 tests from TestErrors (794 ms total)

[----------] 4 tests from TestLogging
[ RUN      ] TestLogging.BufferSendIn
[       OK ] TestLogging.BufferSendIn (1567 ms)
[ RUN      ] TestLogging.CloseFile
[       OK ] TestLogging.CloseFile (557 ms)
[ RUN      ] TestLogging.ComIn
[       OK ] TestLogging.ComIn (1938 ms)
[ RUN      ] TestLogging.OnOff
[       OK ] TestLogging.OnOff (194 ms)
[----------] 4 tests from TestLogging (4258 ms total)

[----------] 1 test from TestHealth
[ RUN      ] TestHealth.Ping
[       OK ] TestHealth.Ping (4 ms)
[----------] 1 test from TestHealth (4 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 4 test suites ran. (5070 ms total)
[  PASSED  ] 8 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] TestErrors.LogFileValidation

 1 FAILED TEST
```
Probably, this should be segregated into a dedicated issue.