### PR TITLE
Revise array allocation in Frame Accumulator

### DIFF
--- a/Svc/FrameAccumulator/FrameAccumulator.cpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.cpp
@@ -4,10 +4,9 @@
 // \brief  cpp file for FrameAccumulator component implementation class
 // ======================================================================
 
-#include "Svc/FrameAccumulator/FrameAccumulator.hpp"
-#include <new>  // required for placement new in configure() member function
 #include "Fw/FPrimeBasicTypes.hpp"
 #include "Fw/Types/Assert.hpp"
+#include "Svc/FrameAccumulator/FrameAccumulator.hpp"
 
 namespace Svc {
 
@@ -29,8 +28,7 @@ void FrameAccumulator ::configure(const FrameDetector& detector,
                                   Fw::MemAllocator& allocator,
                                   FwSizeType store_size) {
     bool recoverable = false;
-    void* data_void = allocator.allocate(allocationId, store_size, recoverable);
-    U8* data = new (data_void) U8[store_size];
+    U8* const data = static_cast<U8*>(allocator.allocate(allocationId, store_size, recoverable));
     FW_ASSERT(data != nullptr);
     m_inRing.setup(data, store_size);
 


### PR DESCRIPTION
Avoid use of placement new with array types. This is a known defect in C++11/14, per the research conducted by @LeStarch.

Because the allocator interface returns `void*`, we can use `static_cast` to convert the allocated memory to the proper type. No `reinterpret_cast` is required.
