### PR TITLE
Add upper-bound limit to for loop in Os::FileSystem

### DIFF
--- a/Os/FileSystem.cpp
+++ b/Os/FileSystem.cpp
@@ -43,7 +43,7 @@ FileSystem::Status FileSystem::_rename(const char* sourcePath, const char* destP
 FileSystem::Status FileSystem::_getWorkingDirectory(char* path, FwSizeType bufferSize) {
     FW_ASSERT(&this->m_delegate == reinterpret_cast<FileSystemInterface*>(&this->m_handle_storage[0]));
     FW_ASSERT(path != nullptr);
-    FW_ASSERT(bufferSize > 0); // because bufferSize=0 would trigger a malloc in some implementations (e.g. Posix)
+    FW_ASSERT(bufferSize > 0);  // because bufferSize=0 would trigger a malloc in some implementations (e.g. Posix)
     return this->m_delegate._getWorkingDirectory(path, bufferSize);
 }
 
@@ -61,14 +61,13 @@ FileSystem::Status FileSystem::_getFreeSpace(const char* path, FwSizeType& total
 
 void FileSystem::init() {
     // Force trigger on the fly singleton setup
-    (void) FileSystem::getSingleton();
+    (void)FileSystem::getSingleton();
 }
 
 FileSystem& FileSystem::getSingleton() {
     static FileSystem s_singleton;
     return s_singleton;
 }
-
 
 // ------------------------------------------------------------
 // Static functions calling implementation-specific operations
@@ -98,7 +97,6 @@ FileSystem::Status FileSystem::getFreeSpace(const char* path, FwSizeType& totalB
     return FileSystem::getSingleton()._getFreeSpace(path, totalBytes, freeBytes);
 }
 
-
 // ------------------------------------------------------------
 // Additional functions built on top of OS-specific operations
 // ------------------------------------------------------------
@@ -108,7 +106,8 @@ FileSystem::Status FileSystem::createDirectory(const char* path, bool errorIfAlr
     Status status = Status::OP_OK;
     Os::Directory dir;
     // If errorIfAlreadyExists is true, use CREATE_EXCLUSIVE mode, otherwise use CREATE_IF_MISSING
-    Directory::OpenMode mode = errorIfAlreadyExists ? Directory::OpenMode::CREATE_EXCLUSIVE : Directory::OpenMode::CREATE_IF_MISSING;
+    Directory::OpenMode mode =
+        errorIfAlreadyExists ? Directory::OpenMode::CREATE_EXCLUSIVE : Directory::OpenMode::CREATE_IF_MISSING;
     Directory::Status dirStatus = dir.open(path, mode);
     dir.close();
     if (dirStatus != Directory::OP_OK) {
@@ -144,11 +143,11 @@ FileSystem::PathType FileSystem::getPathType(const char* path) {
         return PathType::DIRECTORY;
     }
     return PathType::NOT_EXIST;
-} // end getPathType
+}  // end getPathType
 
 bool FileSystem::exists(const char* path) {
     return FileSystem::getPathType(path) != PathType::NOT_EXIST;
-} // end exists
+}  // end exists
 
 FileSystem::Status FileSystem::copyFile(const char* sourcePath, const char* destPath) {
     FW_ASSERT(sourcePath != nullptr);
@@ -173,7 +172,7 @@ FileSystem::Status FileSystem::copyFile(const char* sourcePath, const char* dest
     fs_status = FileSystem::copyFileData(source, destination, sourceFileSize);
 
     return fs_status;
-} // end copyFile
+}  // end copyFile
 
 FileSystem::Status FileSystem::appendFile(const char* sourcePath, const char* destPath, bool createMissingDest) {
     Os::File source;
@@ -204,7 +203,7 @@ FileSystem::Status FileSystem::appendFile(const char* sourcePath, const char* de
     fs_status = FileSystem::copyFileData(source, destination, sourceFileSize);
 
     return fs_status;
-} // end appendFile
+}  // end appendFile
 
 FileSystem::Status FileSystem::moveFile(const char* source, const char* destination) {
     Status status = Status::OP_OK;
@@ -237,7 +236,6 @@ FileSystem::Status FileSystem::getFileSize(const char* path, FwSizeType& size) {
     return FileSystem::OP_OK;
 }
 
-
 // ------------------------------------------------------------
 // Internal helper functions
 // ------------------------------------------------------------
@@ -259,7 +257,7 @@ FileSystem::Status FileSystem::handleFileError(File::Status fileStatus) {
             status = FileSystem::OTHER_ERROR;
     }
     return status;
-} // end handleFileError
+}  // end handleFileError
 
 FileSystem::Status FileSystem::handleDirectoryError(Directory::Status dirStatus) {
     FileSystem::Status status = FileSystem::OTHER_ERROR;
@@ -281,7 +279,7 @@ FileSystem::Status FileSystem::handleDirectoryError(Directory::Status dirStatus)
             status = FileSystem::OTHER_ERROR;
     }
     return status;
-} // end handleFileError
+}  // end handleFileError
 
 FileSystem::Status FileSystem::copyFileData(File& source, File& destination, FwSizeType size) {
     static_assert(FILE_SYSTEM_FILE_CHUNK_SIZE != 0, "FILE_SYSTEM_FILE_CHUNK_SIZE must be >0");

--- a/Os/FileSystem.cpp
+++ b/Os/FileSystem.cpp
@@ -291,8 +291,13 @@ FileSystem::Status FileSystem::copyFileData(File& source, File& destination, FwS
     FwSizeType copiedSize = 0;
     FwSizeType chunkSize = FILE_SYSTEM_FILE_CHUNK_SIZE;
 
+    // Loop up to 2 times for each by, bounded to prevent infinite loop
+    const FwSizeType maximum =
+        (size > (std::numeric_limits<FwSizeType>::max() / 2)) ? std::numeric_limits<FwSizeType>::max() : size * 2;
+
     // Copy the file in chunks - loop until all data is copied
-    for (copiedSize = 0; copiedSize < size; copiedSize += chunkSize) {
+    FwSizeType i = 0;
+    for (copiedSize = 0; (copiedSize < size) && (i < maximum); copiedSize += chunkSize, i++) {
         // chunkSize is FILE_SYSTEM_FILE_CHUNK_SIZE unless size-copiedSize is less than that
         // in which case chunkSize is size-copiedSize, ensuring the last chunk reads the remaining data
         chunkSize = FW_MIN(FILE_SYSTEM_FILE_CHUNK_SIZE, size - copiedSize);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/3534|
|**_Has Unit Tests (y/n)_**|y  |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Adding upper-bound limit to for loop

## Rationale

Avoid infinite loops when `chunkSize` is modified in the for-loop body to 0

## Testing/Review Recommendations

CI

## Future Work

Note any additional work that will be done relating to this issue.
