### PR TITLE
Fix ComStub UTs type warnings

### DIFF
--- a/Svc/ComStub/test/ut/ComStubTester.cpp
+++ b/Svc/ComStub/test/ut/ComStubTester.cpp
@@ -86,7 +86,7 @@ void ComStubTester ::test_fail() {
 
 void ComStubTester ::test_retry() {
     this->test_initial();
-    FwIndexType MAX_ITERS = this->component.RETRY_LIMIT + 1;
+    FwIndexType MAX_ITERS = static_cast<FwIndexType>(this->component.RETRY_LIMIT + 1);
 
     // Make small individual buffers for testing
     U8 storage[MAX_ITERS][8]; 
@@ -115,7 +115,7 @@ void ComStubTester ::test_retry() {
 
 void ComStubTester ::test_retry_reset() {
     this->test_initial();
-    FwIndexType MAX_ITERS = this->component.RETRY_LIMIT + 1;
+    FwIndexType MAX_ITERS = static_cast<FwIndexType>(this->component.RETRY_LIMIT + 1);
     U32 expected_drvDataOut_count = 0;
 
     // Make small individual buffers for testing


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix warnings that appeared on RHEL8 compilers after https://github.com/nasa/fprime/pull/3486
