### PR TITLE
UT: Do not add `-g` flag if `CMAKE_BUILD_TYPE` is set to "Release"

### DIFF
--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -23,5 +23,12 @@ set(CMAKE_C_EXTENSIONS OFF)
 
 # fprime unit testing methodology requires the following flags
 if (BUILD_TESTING)
-    add_compile_options(-g -DBUILD_UT -DPROTECTED=public -DPRIVATE=public -DSTATIC=)
+    add_compile_options(-DBUILD_UT -DPROTECTED=public -DPRIVATE=public -DSTATIC=)
+
+    # By default when CMake testing is enabled `CMAKE_BUILD_TYPE` is set to "Debug".
+    # If, in a deployment's top-level CMakeLists.txt, `CMAKE_BUILD_TYPE` is explicitly set to
+    # "Release" this should be respected and the debug flag should be omitted
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_compile_options(-g)
+    endif()
 endif()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

By default when CMake testing is enabled `CMAKE_BUILD_TYPE` is set to "Debug". This PR will not break any backwards compatibility.

If, in a deployment's top-level CMakeLists.txt, `CMAKE_BUILD_TYPE` is explicitly set to "Release" this should be respected and the debug flag should be omitted

## Rationale

This is needed in order to work around compile times for AC files with very long `toString()` impls (for example, AC array data types with thousands of args). When `-g` is used, the UT builds fail to complete (that is, fail to complete within any human/reasonable time).
