### PR TITLE
Add file status

### DIFF
--- a/Os/File.hpp
+++ b/Os/File.hpp
@@ -37,6 +37,7 @@ class FileInterface {
         NOT_SUPPORTED,     //!< Kernel or file system does not support operation
         INVALID_MODE,      //!< Mode for file access is invalid for current operation
         INVALID_ARGUMENT,  //!< Invalid argument passed in
+	NO_MORE_RESOURCES, //!< No more available resources
         OTHER_ERROR,       //!<  A catch-all for other errors. Have to look in implementation-specific code
         MAX_STATUS         //!< Maximum value of status
     };

--- a/Os/File.hpp
+++ b/Os/File.hpp
@@ -27,19 +27,19 @@ class FileInterface {
     };
 
     enum Status {
-        OP_OK,             //!<  Operation was successful
-        DOESNT_EXIST,      //!<  File doesn't exist (for read)
-        NO_SPACE,          //!<  No space left
-        NO_PERMISSION,     //!<  No permission to read/write file
-        BAD_SIZE,          //!<  Invalid size parameter
-        NOT_OPENED,        //!<  file hasn't been opened yet
-        FILE_EXISTS,       //!< file already exist (for CREATE with O_EXCL enabled)
-        NOT_SUPPORTED,     //!< Kernel or file system does not support operation
-        INVALID_MODE,      //!< Mode for file access is invalid for current operation
-        INVALID_ARGUMENT,  //!< Invalid argument passed in
-	NO_MORE_RESOURCES, //!< No more available resources
-        OTHER_ERROR,       //!<  A catch-all for other errors. Have to look in implementation-specific code
-        MAX_STATUS         //!< Maximum value of status
+        OP_OK,              //!<  Operation was successful
+        DOESNT_EXIST,       //!<  File doesn't exist (for read)
+        NO_SPACE,           //!<  No space left
+        NO_PERMISSION,      //!<  No permission to read/write file
+        BAD_SIZE,           //!<  Invalid size parameter
+        NOT_OPENED,         //!<  file hasn't been opened yet
+        FILE_EXISTS,        //!< file already exist (for CREATE with O_EXCL enabled)
+        NOT_SUPPORTED,      //!< Kernel or file system does not support operation
+        INVALID_MODE,       //!< Mode for file access is invalid for current operation
+        INVALID_ARGUMENT,   //!< Invalid argument passed in
+        NO_MORE_RESOURCES,  //!< No more available resources
+        OTHER_ERROR,        //!<  A catch-all for other errors. Have to look in implementation-specific code
+        MAX_STATUS          //!< Maximum value of status
     };
 
     enum OverwriteType {

--- a/Os/Models/File.fpp
+++ b/Os/Models/File.fpp
@@ -16,6 +16,7 @@ enum FileStatus {
     NOT_SUPPORTED,    @< Kernel or file system does not support operation
     INVALID_MODE,     @< Mode for file access is invalid for current operation
     INVALID_ARGUMENT, @< Invalid argument passed in
+    NO_MORE_RESOURCES,@< No more available resources
     OTHER_ERROR,      @< A catch-all for other errors. Have to look in implementation-specific code
 }
 @ FPP shadow-enum representing Os::File::Mode

--- a/Os/Models/Models.cpp
+++ b/Os/Models/Models.cpp
@@ -46,6 +46,8 @@ static_assert(static_cast<Os::FileStatus::T>(Os::File::Status::INVALID_MODE) == 
               "File status and FPP shadow enum do not match");
 static_assert(static_cast<Os::FileStatus::T>(Os::File::Status::INVALID_ARGUMENT) == Os::FileStatus::T::INVALID_ARGUMENT,
               "File status and FPP shadow enum do not match");
+static_assert(static_cast<Os::FileStatus::T>(Os::File::Status::NO_MORE_RESOURCES) == Os::FileStatus::T::NO_MORE_RESOURCES,
+              "File status and FPP shadow enum do not match");
 static_assert(static_cast<Os::FileStatus::T>(Os::File::Status::OTHER_ERROR) == Os::FileStatus::T::OTHER_ERROR,
               "File status and FPP shadow enum do not match");
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  https://github.com/nasa/fprime/issues/3568|
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Adding a status `NO_MORE_RESOURCES` to Os::File::Status

## Rationale

OSAL implementations of Os::File may need this error number.

## Testing/Review Recommendations

CI

## Future Work

N/A
