### PR TITLE
Fix project-builder by checking out submodules

### DIFF
--- a/.github/workflows/reusable-project-builder.yml
+++ b/.github/workflows/reusable-project-builder.yml
@@ -80,7 +80,7 @@ jobs:
       - name: "Checkout target repository"
         uses: actions/checkout@v4
         with:
-          submodules: false
+          submodules: recursive
           repository: ${{ inputs.target_repository }}
           ref: ${{ inputs.target_ref }}
       - name: "Overlay current F´ revision"

--- a/.github/workflows/reusable-project-builder.yml
+++ b/.github/workflows/reusable-project-builder.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Checkout target repository"
         uses: actions/checkout@v4
         with:
-          submodules: true 
+          submodules: recursive 
           repository: ${{ inputs.target_repository }}
           ref: ${{ inputs.target_ref }}
       - name: "Overlay current F´ revision"

--- a/.github/workflows/reusable-project-builder.yml
+++ b/.github/workflows/reusable-project-builder.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Checkout target repository"
         uses: actions/checkout@v4
         with:
-          submodules: false 
+          submodules: true 
           repository: ${{ inputs.target_repository }}
           ref: ${{ inputs.target_ref }}
       - name: "Overlay current F´ revision"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Project builder workflow was failing on fprime-examples since we now use submodules. This option was set to false originally to make sure there's no issue when shadowing the fprime core repo. But there should be no issue, and it should be ok to set to true