### PR TITLE
Clean up User Manual index docs

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -23,9 +23,6 @@ Tutorials walk through the essentials of F Prime development, starting with the 
 
     The LED Blinker tutorial shows how to develop an F Prime project that runs on embedded hardware. It covers manager components, hardware drivers, and cross compilation, with the goal of blinking an LED on ARM hardware. This tutorial introduces the F Prime concepts of events, telemetry, commands, and parameters.
 
-    > [!NOTE]
-    > This tutorial can be run without hardware with the exception of section 6 “Running on Hardware”.
-
     [View LED Blinker Tutorial](../../tutorials-led-blinker/docs/led-blinker.md){ .md-button .md-button--primary }
 
 -   <span class="card-title">__Math Component__</span>

--- a/docs/user-manual/index.md
+++ b/docs/user-manual/index.md
@@ -7,53 +7,16 @@ hide:
 
 The User Manual dives into F Prime concepts and usage, providing a deep understanding of how the framework operates. The different chapters are listed below.
 
+- __Overview__ - Technical overview of the F´ ecosystem.
 
-<div class="grid cards boring" markdown>
+- __Framework__ - Learn concepts and mechanisms needed to build and use an F´ application.
 
--   <span class="card-title">__Overview__</span>
+- __FPP User's Guide__ - In-depth user guide for F Prime Prime (FPP), the F´ modeling language.
 
-    ---
+- __F´ GDS__ - Learn how to use the GDS and how it can be used to test F´ applications.
 
-    Technical overview of the F´ ecosystem.
+- __Design Patterns__ - Learn about common design patterns used in F´ applications.
 
+- __Build System__ - Learn about the F´ build system and how to customize it.
 
--   <span class="card-title">__Framework__</span>
-
-    ---
-
-    Learn concepts and mechanisms needed to build and use an F´ application.
-
-
--   <span class="card-title">__FPP User's Guide__</span>
-
-    ---
-
-    In-depth user guide for F Prime Prime (FPP), the F´ modeling language.
-
--   <span class="card-title">__F´ GDS__</span>
-
-    ---
-
-    Learn how to use the GDS and how it can be used to test F´ applications.
-
--   <span class="card-title">__Design Patterns__</span>
-
-    ---
-
-    Learn about common design patterns used in F´ applications.
-
--   <span class="card-title">__Build System__</span>
-
-    ---
-
-    Learn about the F´ build system and how to customize it.
-
--   <span class="card-title">__Security__</span>
-
-    ---
-
-    Security considerations when designing and developing F´ applications.
-
-
-
-</div>
+- __Security__ - Security considerations when designing and developing F´ applications.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/3555  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

- Since User Manual's sub-topics don't contain link to their own indexes, the User Manual Index layout has been modified to a simple ordered list with descriptions
- The note originally included in the LED Blinker card of the Tutorials page has been removed
- Additionally, the hover animation has been removed from cards, since the cards are not clickable (this is included in another PR in the core website repo)

## Rationale

Make it clearer what part of the interface is clickable or leads to another page.

## Testing/Review Recommendations

N/A

## Future Work

N/A