### PR TITLE
Fix ISR handler invocation in Drv::BlockDriver

### DIFF
--- a/Drv/BlockDriver/BlockDriverImpl.cpp
+++ b/Drv/BlockDriver/BlockDriverImpl.cpp
@@ -41,7 +41,7 @@ namespace Drv {
         FW_ASSERT(arg);
         // cast argument to component instance
         BlockDriverImpl* compPtr = static_cast<BlockDriverImpl*>(arg);
-        compPtr->InterruptReport_internalInterfaceHandler(0);
+        compPtr->InterruptReport_internalInterfaceInvoke(0);
     }
 
     void BlockDriverImpl::PingIn_handler(

--- a/Drv/BlockDriver/CMakeLists.txt
+++ b/Drv/BlockDriver/CMakeLists.txt
@@ -11,3 +11,19 @@ set(SOURCE_FILES
 )
 
 register_fprime_module()
+
+### Unit Tests ###
+set(UT_SOURCE_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/BlockDriver.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/BlockDriverTestMain.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/BlockDriverTester.cpp"
+)
+set(UT_MOD_DEPS
+  STest
+)
+set(UT_AUTO_HELPERS ON)
+register_fprime_ut()
+set (UT_TARGET_NAME "${FPRIME_CURRENT_MODULE}_ut_exe")
+if (TARGET "${UT_TARGET_NAME}")
+    target_compile_options("${UT_TARGET_NAME}" PRIVATE -Wno-conversion)
+endif()

--- a/Drv/BlockDriver/docs/sdd.md
+++ b/Drv/BlockDriver/docs/sdd.md
@@ -10,8 +10,9 @@ The requirements for `Drv::BlockDriver` are as follows:
 
 Requirement | Description | Verification Method
 ----------- | ----------- | -------------------
-ISF-BDV-001 | The `Drv::BlockDriver` component shall loop back packets from its input port to its output port | System test
-ISF-BDV-002 | The `Drv::BlockDriver` component shall send a timing interrupt whenever `callIsr()` is invoked | System test
+ISF-BDV-001 | The `Drv::BlockDriver` component shall loop back packets from its input port to its output port | System test, unit test
+ISF-BDV-002 | The `Drv::BlockDriver` component shall loop back the key value from  `PingIn` port to `PingOut` port | System test, unit test
+ISF-BDV-003 | The `Drv::BlockDriver` component shall send a timing interrupt whenever `callIsr()` is invoked | System test, unit test
 
 ## 3. Design
 
@@ -36,6 +37,7 @@ TBD
 Date | Description
 ---- | -----------
 4/20/2017 | Initial Version
+5/11/2025 | Add requirement for ping key loopback
 
 
 

--- a/Drv/BlockDriver/test/ut/BlockDriverTestMain.cpp
+++ b/Drv/BlockDriver/test/ut/BlockDriverTestMain.cpp
@@ -1,0 +1,32 @@
+// ======================================================================
+// \title  BlockDriverTestMain.cpp
+// \author root
+// \brief  cpp file for BlockDriver component test main function
+// ======================================================================
+
+#include "BlockDriverTester.hpp"
+
+TEST(Nominal, testDataLoopBack) {
+  Drv::BlockDriverTester tester;
+  tester.testDataLoopBack();
+}
+
+TEST(Nominal, testPing) {
+  Drv::BlockDriverTester tester;
+  tester.testPing();
+}
+
+TEST(Nominal, testIsrInvocation) {
+  Drv::BlockDriverTester tester;
+  tester.testIsrInvocation();
+}
+
+TEST(Nominal, testCycleIncrement) {
+  Drv::BlockDriverTester tester;
+  tester.testCycleIncrement();
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/Drv/BlockDriver/test/ut/BlockDriverTester.cpp
+++ b/Drv/BlockDriver/test/ut/BlockDriverTester.cpp
@@ -1,0 +1,113 @@
+// ======================================================================
+// \title  BlockDriverTester.cpp
+// \author root
+// \brief  cpp file for BlockDriver component test harness implementation class
+// ======================================================================
+
+#include "BlockDriverTester.hpp"
+
+namespace Drv {
+
+  // ----------------------------------------------------------------------
+  // Construction and destruction
+  // ----------------------------------------------------------------------
+
+  BlockDriverTester ::
+    BlockDriverTester() :
+      BlockDriverGTestBase("BlockDriverTester", BlockDriverTester::MAX_HISTORY_SIZE),
+      component("BlockDriver")
+  {
+    this->initComponents();
+    this->connectPorts();
+  }
+
+  BlockDriverTester ::
+    ~BlockDriverTester()
+  {
+
+  }
+
+  // ----------------------------------------------------------------------
+  // Tests
+  // ----------------------------------------------------------------------
+
+  void BlockDriverTester ::
+    testDataLoopBack()
+  {
+    const U8 data[] = {1, 2, 3, 4, 5, 6, 7};
+    Drv::DataBuffer dataBuffer(data, 7);
+
+    this->clearHistory();
+
+    // input data
+    this->invoke_to_BufferIn(0, dataBuffer);
+
+    this->component.doDispatch();
+
+    // verify data output
+    ASSERT_from_BufferOut_SIZE(1);
+    ASSERT_from_BufferOut(0, dataBuffer);
+  }
+
+  void BlockDriverTester ::
+    testPing()
+  {
+    const U32 key = 42;
+
+    this->clearHistory();
+
+    // call Ping port with the key
+    this->invoke_to_PingIn(0, key);
+
+    this->component.doDispatch();
+
+    // verify Ping output
+    ASSERT_from_PingOut_SIZE(1);
+    ASSERT_from_PingOut(0, key);
+  }
+
+  void BlockDriverTester ::
+    testIsrInvocation()
+  {
+    this->clearHistory();
+
+    this->component.callIsr();
+
+    // verify telemetry right after ISR call: it shall be empty
+    // the ISR is run in the internal thread
+    ASSERT_TLM_SIZE(0);
+    ASSERT_TLM_BD_Cycles_SIZE(0);
+
+    this->component.doDispatch();
+
+    // now the telemetry shall be updated
+    ASSERT_TLM_SIZE(1);
+    ASSERT_TLM_BD_Cycles_SIZE(1);
+    ASSERT_TLM_BD_Cycles(0, 0);
+  }
+
+  void BlockDriverTester ::
+    testCycleIncrement()
+  {
+    this->clearHistory();
+
+    // call ISR
+    this->component.callIsr();
+    this->component.doDispatch();
+
+    // there shall be one report with 0 cycle
+    ASSERT_TLM_SIZE(1);
+    ASSERT_TLM_BD_Cycles_SIZE(1);
+    ASSERT_TLM_BD_Cycles(0, 0);
+
+    // call ISR once again
+    this->component.callIsr();
+    this->component.doDispatch();
+
+    // there shall be one more report with 1 cycle
+    ASSERT_TLM_SIZE(2);
+    ASSERT_TLM_BD_Cycles_SIZE(2);
+    ASSERT_TLM_BD_Cycles(1, 1);
+  }
+
+}

--- a/Drv/BlockDriver/test/ut/BlockDriverTester.hpp
+++ b/Drv/BlockDriver/test/ut/BlockDriverTester.hpp
@@ -1,0 +1,89 @@
+// ======================================================================
+// \title  BlockDriverTester.hpp
+// \author root
+// \brief  hpp file for BlockDriver component test harness implementation class
+// ======================================================================
+
+#ifndef Drv_BlockDriverTester_HPP
+#define Drv_BlockDriverTester_HPP
+
+#include "Drv/BlockDriver/BlockDriverGTestBase.hpp"
+#include "Drv/BlockDriver/BlockDriver.hpp"
+
+namespace Drv {
+
+  class BlockDriverTester final :
+    public BlockDriverGTestBase
+  {
+
+    public:
+
+      // ----------------------------------------------------------------------
+      // Constants
+      // ----------------------------------------------------------------------
+
+      // Maximum size of histories storing events, telemetry, and port outputs
+      static const FwSizeType MAX_HISTORY_SIZE = 10;
+
+      // Instance ID supplied to the component instance under test
+      static const FwEnumStoreType TEST_INSTANCE_ID = 0;
+
+      // Queue depth supplied to the component instance under test
+      static const FwSizeType TEST_INSTANCE_QUEUE_DEPTH = 10;
+
+    public:
+
+      // ----------------------------------------------------------------------
+      // Construction and destruction
+      // ----------------------------------------------------------------------
+
+      //! Construct object BlockDriverTester
+      BlockDriverTester();
+
+      //! Destroy object BlockDriverTester
+      ~BlockDriverTester();
+
+    public:
+
+      // ----------------------------------------------------------------------
+      // Tests
+      // ----------------------------------------------------------------------
+
+      //! Test data loop back port
+      void testDataLoopBack();
+
+      //! Test Ping port
+      void testPing();
+
+      //! Test ISR invocation
+      void testIsrInvocation();
+
+      //! Test ISR cycle increment
+      void testCycleIncrement();
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Helper functions
+      // ----------------------------------------------------------------------
+
+      //! Connect ports
+      void connectPorts();
+
+      //! Initialize components
+      void initComponents();
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
+
+      //! The component under test
+      BlockDriver component;
+
+  };
+
+}
+
+#endif


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/3235 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Use InterruptReport_internalInterfaceInvoke to handle the ISR according to the issue description.
Added some nominal unit tests for data loop back and for ISR.

## Rationale

Fix https://github.com/nasa/fprime/issues/3235.

## Testing/Review Recommendations

N/A.

## Future Work

Fix TBD in chapter 4. Dictionaries in SDD. Please share the intention of this chapter - I'll fix it.
