### PR TITLE
Fix version check error message

### DIFF
--- a/cmake/required.cmake
+++ b/cmake/required.cmake
@@ -14,8 +14,8 @@ find_program(FPUTIL NAMES fprime-util)
 locate_fpp_tools()
 
 set(FPRIME__INTERNAL_FRAGMENT "pip install -r \"${FPRIME_FRAMEWORK_PATH}/requirements.txt\"")
-set(FPRIME__INTERNAL_TO_INSTALL_MESSAGE "Install with:\n  '${FRAGMENT}'")
-set(FPRIME__INTERNAL_TO_REINSTALL "Reinstall with:\n  '${FRAGMENT} -U --force-reinstall'")
+set(FPRIME__INTERNAL_TO_INSTALL_MESSAGE "Install with:\n  '${FPRIME__INTERNAL_FRAGMENT}'")
+set(FPRIME__INTERNAL_TO_REINSTALL "Reinstall with:\n  '${FPRIME__INTERNAL_FRAGMENT} -U --force-reinstall'")
 # Check python was found
 if (NOT FPUTIL)
     message(FATAL_ERROR " fprime-util was not found. ${FPRIME__INTERNAL_TO_INSTALL_MESSAGE}")


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Before:

```
[cmake] CMake Error at lib/fprime/cmake/required.cmake:27 (message):
[cmake]    fpp-tools version incompatible. Found v3.0.0a7, expected v3.0.0a8.. Reinstall with:
[cmake]     ' -U --force-reinstall'
```

After:

```
[cmake] CMake Error at lib/fprime/cmake/required.cmake:27 (message):
[cmake]    fpp-tools version incompatible. Found v3.0.0a7, expected v3.0.0a8.. Reinstall with:
[cmake]     'pip install -r "/workspaces/scythe/lib/fprime/requirements.txt" -U --force-reinstall'
```

## Rationale

Fix incorrect error message.

## Testing/Review Recommendations

N/A

## Future Work

No future work, unless you want to add a unit test for this.
