### PR TITLE
Fix memory leak in ComStub when reads fail

### DIFF
--- a/Svc/ComStub/ComStub.cpp
+++ b/Svc/ComStub/ComStub.cpp
@@ -43,6 +43,8 @@ void ComStub::drvReceiveIn_handler(const FwIndexType portNum,
     if (recvStatus.e == Drv::ByteStreamStatus::OP_OK) {
         ComCfg::FrameContext emptyContext; // ComStub knows nothing about the received bytes, so use an empty context
         this->dataOut_out(0, recvBuffer, emptyContext);
+    } else {
+        this->drvReceiveReturnOut_out(0, recvBuffer);
     }
 }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

drvReceiveIn passes ownership of recvBuffer, but ComStub only took care of deallocating the buffer if the read operation succeeded. If a communications driver indicates that a read did not succeed (for example with status RECV_NO_DATA), the buffer is lost and memory is leaked.

## Rationale

Memory leaks cause FSW to fail to operate correctly.

## Testing/Review Recommendations

This should probably be unit tested to prevent regressions, but that's not covered in this PR.

## Future Work

It would be worth thinking about how we could avoid these sorts of buffer handling problems in the future.
