### PR TITLE
Removing regneration from AC files that are themselves regenerated

### DIFF
--- a/cmake/autocoder/ai_xml.cmake
+++ b/cmake/autocoder/ai_xml.cmake
@@ -19,10 +19,6 @@ autocoder_setup_for_individual_sources()
 ####
 function(ai_xml_is_supported AC_INPUT_FILE)
     ends_with(IS_SUPPORTED "${AC_INPUT_FILE}" "Ai.xml")
-    set(PREVIOUSLY_GENERATED)
-    if (ARGC GREATER_EQUAL 2)
-        set(PREVIOUSLY_GENERATED ${ARGV2})
-    endif()
 
     # Don't generate cpp/hpp files that have already been generated
     if (IS_SUPPORTED)
@@ -31,11 +27,8 @@ function(ai_xml_is_supported AC_INPUT_FILE)
         if(("${CPP_FILE}" IN_LIST PREVIOUSLY_GENERATED) AND ("${HPP_FILE}" IN_LIST PREVIOUSLY_GENERATED))
             set(IS_SUPPORTED FALSE)
         endif()
-
-        # If this Ai.xml file was not a generated product, then mark it as requiring a rebuild
-        if (NOT "${AC_INPUT_FILE}" IN_LIST PREVIOUSLY_GENERATED)
-            requires_regeneration("${AC_INPUT_FILE}")
-        endif()
+        # Requires regeneration checks for GENERATED before requiring regeneration
+        requires_regeneration("${AC_INPUT_FILE}")
     endif()
     # Note: set in PARENT_SCOPE in macro is intended. Caller **wants** to set IS_SUPPORTED in their parent's scope.
     set(IS_SUPPORTED "${IS_SUPPORTED}" PARENT_SCOPE)

--- a/cmake/autocoder/helpers.cmake
+++ b/cmake/autocoder/helpers.cmake
@@ -46,12 +46,9 @@ endmacro()
 # `AC_INPUT_FILE`: file to mark as tracked
 ####
 function(requires_regeneration AC_INPUT_FILE)
-    get_property(RECONFIGURE_LIST GLOBAL PROPERTY AUTO_RECONFIGURE_LIST)
-    get_filename_component(REAL_FILE "${AC_INPUT_FILE}" REALPATH)
-    if (NOT "${REAL_FILE}" IN_LIST RECONFIGURE_LIST)
+    get_source_file_property(IS_GENERATED "${AC_INPUT_FILE}" GENERATED)
+    if (NOT IS_GENERATED)
         set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${AC_INPUT_FILE}")
-        list(APPEND RECONFIGURE_LIST "${REAL_FILE}")
-        set_property(GLOBAL PROPERTY AUTO_RECONFIGURE_LIST "${RECONFIGURE_LIST}")
     endif()
 endfunction()
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Prevents `GENERATED` source files from being marked as `CMAKE_CONFIGURE_DEPENDS` in `requires_regeneration` instead of depending on caller's good graces.

## Rationale

Marking source files as `CMAKE_CONFIGURE_DEPENDS` that are also `GENERATED` can cause loops within the build/configure steps (build depends on configure, which via this property is dependent on build output).  

This removes the responsibility of the caller to track if a file was GENERATED, and instead queries CMake for that data instead.  Thus preventing caller error from causing regeneration cycles.