### PR TITLE
Add command to OsTime to set the current time

### DIFF
--- a/Svc/OsTime/OsTime.cpp
+++ b/Svc/OsTime/OsTime.cpp
@@ -33,6 +33,19 @@ void OsTime::set_epoch(const Fw::Time& fw_time, const Os::RawTime& os_time) {
     m_epoch_valid = true;
 }
 
+void OsTime::SetCurrentTime_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, U32 seconds_now) {
+    Os::RawTime time_now;
+    Os::RawTime::Status stat = time_now.now();
+    if (stat != Os::RawTime::OP_OK) {
+        this->log_WARNING_HI_SetCurrentTimeError(stat);
+        return;
+    }
+    Os::ScopeLock lock(m_epoch_lock);
+    m_epoch_fw_time = Fw::Time(seconds_now, 0);
+    m_epoch_os_time = time_now;
+    m_epoch_valid = true;
+}
+
 // ----------------------------------------------------------------------
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------

--- a/Svc/OsTime/OsTime.fpp
+++ b/Svc/OsTime/OsTime.fpp
@@ -5,5 +5,34 @@ module Svc {
         include "../Interfaces/TimeInterface.fppi"
 
         sync input port setEpoch: OsTimeEpoch
+
+        @ Port for receiving commands
+        command recv port CmdDisp
+
+        @ Port for sending command registration requests
+        command reg port CmdReg
+
+        @ Port for sending command responses
+        command resp port CmdStatus
+
+        @ Event port
+        event port EventOut
+
+        @ Text event port
+        text event port LogText
+
+        @ Time get port
+        time get port timeCaller
+
+        sync command SetCurrentTime(seconds_now: U32) opcode 0x00
+
+        @ An error occurred while attempting to set the current time
+        event SetCurrentTimeError(
+                            status: U32 @< The error status
+                            ) \
+        severity warning high \
+        id 0x00 \
+        format "Could not set current time due to RawTime error status {}"
+
     }
 }

--- a/Svc/OsTime/OsTime.hpp
+++ b/Svc/OsTime/OsTime.hpp
@@ -49,6 +49,12 @@ class OsTime final : public OsTimeComponentBase {
                           const Fw::Time& fw_time,
                           const Os::RawTime& os_time) override;
 
+    
+    //! Handler implementation for command SetCurrentTime
+    void SetCurrentTime_cmdHandler(FwOpcodeType opCode, //!< The opcode
+                                   U32 cmdSeq, //!< The command sequence number
+                                   U32 seconds_now) override;
+
     Fw::Time m_epoch_fw_time;
     Os::RawTime m_epoch_os_time;
     bool m_epoch_valid;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Add a command to Svc.OsTime to set the current time.

## Rationale

The current implementation of F Prime GDS only allows for charting telemetry channels if the time associated with those channels is close to the current time. See https://github.com/nasa/fprime/issues/3605. In order to allow channels to be graphed on systems using OsTime, we need the ability to adjust the epoch so that the time is close to the current time. This cannot be hard-coded, as the hard-coded time would only work for less than a day (due to zoom limits), and then a rebuild would be required. So this information needs to be passed from the ground somehow, and the easiest way to do this is via a command.

## Testing/Review Recommendations

N/A

## Future Work

Hopefully https://github.com/nasa/fprime/issues/3605 will be resolved favorably.
