### PR TITLE
Display cmake target on error

### DIFF
--- a/cmake/test/src/cmake.py
+++ b/cmake/test/src/cmake.py
@@ -123,7 +123,7 @@ def assert_process_success(data_object, errors_ok=False, targets=None):
     for target, output in filtered:
         return_code, stdout, stderr = output
         assert return_code == 0, f"CMake failed building '{target}'"
-        assert stdout, "CMake generated no standard out building '{target}'"
+        assert stdout, f"CMake generated no standard out building '{target}'"
 
 
 def get_build(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description
This small PR simply evaluates and displays the `target` on assert error.

## Rationale
bug fix.

## Testing/Review Recommendations

## Future Work