### PR TITLE
Moving snprintf to platform such that platforms may override it

### DIFF
--- a/cmake/platform/unix/Platform/CMakeLists.txt
+++ b/cmake/platform/unix/Platform/CMakeLists.txt
@@ -15,6 +15,7 @@ register_fprime_config(
         Os_Mutex_Posix
         Os_Generic_PriorityQueue
         Os_RawTime_Posix
+        Fw_StringFormat_snprintf
         # No posix API
         Os_Cpu_Stub
         Os_Memory_Stub

--- a/default/config/CMakeLists.txt
+++ b/default/config/CMakeLists.txt
@@ -29,6 +29,4 @@ register_fprime_config(
         "${CMAKE_CURRENT_LIST_DIR}/StaticMemoryConfig.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/TlmChanImplCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/TlmPacketizerCfg.hpp"
-    CHOOSES_IMPLEMENTATIONS
-        Fw_StringFormat_snprintf
 )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixing `snprintf` choice by moving it into platform