### PR TITLE
Add seqRunIn port to FpySequencer

### DIFF
--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -305,6 +305,20 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
     }
 }
 
+//! Handler for input port seqRunIn
+void FpySequencer::seqRunIn_handler(FwIndexType portNum,
+                                    const Fw::StringBase& filename
+) {
+    // can only run a seq while in idle
+    if (sequencer_getState() != State::IDLE) {
+        this->log_WARNING_HI_InvalidSeqRunCall(static_cast<I32>(sequencer_getState()));
+        return;
+    }
+
+    // seqRunIn is never blocking
+    this->sequencer_sendSignal_cmd_RUN(FpySequencer_SequenceExecutionArgs(filename, FpySequencer_BlockState::NO_BLOCK));
+}
+
 //! Handler for input port tlmWrite
 void FpySequencer::tlmWrite_handler(FwIndexType portNum,  //!< The port number
                                     U32 context           //!< The call order

--- a/Svc/FpySequencer/FpySequencer.fpp
+++ b/Svc/FpySequencer/FpySequencer.fpp
@@ -43,6 +43,10 @@ module Svc {
         # least important, lowest prio
         async input port tlmWrite: Svc.Sched priority 1 assert
 
+        @ port for requests to run sequences
+        # same priority as RUN cmd
+        async input port seqRunIn: Svc.CmdSeqIn priority 7 assert
+
         @ Ping out port
         output port pingOut: Svc.Ping
 

--- a/Svc/FpySequencer/FpySequencer.hpp
+++ b/Svc/FpySequencer/FpySequencer.hpp
@@ -355,6 +355,11 @@ class FpySequencer : public FpySequencerComponentBase {
                                const Fw::CmdResponse& response  //!< The command response argument
                                ) override;
 
+    //! Handler for input port seqRunIn
+    void seqRunIn_handler(FwIndexType portNum,
+                          const Fw::StringBase& filename
+                          ) override;
+
     //! Handler for input port pingIn
     void pingIn_handler(FwIndexType portNum,  //!< The port number
                         U32 key               //!< Value to return to pinger

--- a/Svc/FpySequencer/FpySequencerEvents.fppi
+++ b/Svc/FpySequencer/FpySequencerEvents.fppi
@@ -2,6 +2,10 @@ event InvalidCommand($state: I32) \
     severity warning high \
     format "Cannot run command in state {}"
 
+event InvalidSeqRunCall($state: I32) \
+    severity warning high \
+    format "Cannot run sequence from a port in state {}"
+
 event FileOpenError(
     filePath: string
     errorCode: I32

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -1107,6 +1107,29 @@ TEST_F(FpySequencerTester, tlmWrite) {
     // make sure that all tlm is written every call
     ASSERT_TLM_SIZE(9);
 }
+
+TEST_F(FpySequencerTester, seqRunIn) {
+    allocMem();
+    add_NO_OP();
+    writeToFile("test.bin");
+
+    invoke_to_seqRunIn(0, Fw::String("test.bin"));
+    cmp.doDispatch();
+    dispatchUntilState(State::VALIDATING);
+    dispatchUntilState(State::RUNNING_AWAITING_STATEMENT_RESPONSE);
+    dispatchUntilState(State::IDLE);
+
+    this->clearHistory();
+
+    // try running while already running
+    cmp.m_stateMachine_sequencer.m_state = State::RUNNING_DISPATCH_STATEMENT;
+    invoke_to_seqRunIn(0, Fw::String("test.bin"));
+    // dispatch cmd
+    cmp.doDispatch();
+    ASSERT_EVENTS_InvalidSeqRunCall_SIZE(1);
+    removeFile("test.bin");
+}
+
 }  // namespace Svc
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3679 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Implements #3679 adding a seqRun port to the FpySequencer.

## Rationale

Feature parity with CmdSequencer.
