### PR TITLE
PRIVATE->private and PROTECTED->protected updates in RPI (nasa#3446)

### DIFF
--- a/RPI/RpiDemo/RpiDemoComponentImpl.hpp
+++ b/RPI/RpiDemo/RpiDemoComponentImpl.hpp
@@ -50,7 +50,7 @@ namespace RPI {
       //!
       ~RpiDemoComponentImpl();
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Handler implementations for user-defined typed input ports
@@ -78,7 +78,7 @@ namespace RPI {
         Fw::Buffer& buffer,
         const Drv::ByteStreamStatus& status) override;
 
-    PRIVATE:
+    private:
 
       // ----------------------------------------------------------------------
       // Command handler implementations


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3446  |
|**_Has Unit Tests (y/n)_**| Yes - existing |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

Updates to `fprime/RPI`:

* `PRIVATE` -> `private`

## Rationale

#3446

## Testing/Review Recommendations

N/A

## Future Work

Additional PRs to be opened for further updates corresponding to #3446