### PR TITLE
Adding note about explicitly identifying ports that need priority in SDD

### DIFF
--- a/docs/user-manual/overview/development-practice.md
+++ b/docs/user-manual/overview/development-practice.md
@@ -144,7 +144,7 @@ will be done automatically:
 8. The user is given the option to generate a unit test directory with necessary
    unit test files within it.
 9. An SDD file is generated with documentation about ports, commands, events,  
-   telemetry, parameters, and time of creation already filled out. Note: Developers should explicitly state in the SDD if they use the FDD `priority` for their ports.
+   telemetry, parameters, and time of creation already filled out. Note: Developers should explicitly state in the SDD if they use the FPP `priority` for their ports.
 
 The `fprime-util new --component` uses the built-in cookiecutter template by default, 
 but users can substitute their own component template by using the component_cookiecutter 

--- a/docs/user-manual/overview/development-practice.md
+++ b/docs/user-manual/overview/development-practice.md
@@ -144,7 +144,7 @@ will be done automatically:
 8. The user is given the option to generate a unit test directory with necessary
    unit test files within it.
 9. An SDD file is generated with documentation about ports, commands, events,  
-   telemetry, parameters, and time of creation already filled out
+   telemetry, parameters, and time of creation already filled out. Note: Developers should explicitly state in the SDD if they use the FDD `priority` for their ports.
 
 The `fprime-util new --component` uses the built-in cookiecutter template by default, 
 but users can substitute their own component template by using the component_cookiecutter 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3267 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Updating Development Practice Documentation to include note about explicitly calling out ports that require FPP `priority` in the Component SDDs.

## Rationale

VxWorks queues were found to not implement priority causing unexpected behaviour. 

## Testing/Review Recommendations

Documentation-only change.

## Future Work

Also add note to https://github.com/nasa/fprime/wiki/F%C2%B4-Style-Guidelines which I don't have access to write to.
