### PR TITLE
PRIVATE->private and PROTECTED->protected updates in Os/File.hpp (#3446)

### DIFF
--- a/Os/File.hpp
+++ b/Os/File.hpp
@@ -8,7 +8,11 @@
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <Os/Os.hpp>
 
+// Forward declation for UTs
+namespace Os {namespace Test {namespace FileTest {struct Tester;}}}
+
 namespace Os {
+
 //! \brief base implementation of FileHandle
 //!
 struct FileHandle {};
@@ -213,6 +217,9 @@ class FileInterface {
 };
 
 class File final : public FileInterface {
+
+  friend struct Os::Test::FileTest::Tester;
+
   public:
     //! \brief constructor
     //!
@@ -504,7 +511,8 @@ class File final : public FileInterface {
     Status finalizeCrc(U32& crc);
 
   private:
-    PRIVATE : static const U32 INITIAL_CRC = 0xFFFFFFFF;  //!< Initial value for CRC calculation
+    static const U32 INITIAL_CRC = 0xFFFFFFFF;            //!< Initial value for CRC calculation
+
     Mode m_mode = Mode::OPEN_NO_MODE;                     //!< Stores mode for error checking
     const CHAR* m_path = nullptr;                         //!< Path last opened
 

--- a/Os/File.hpp
+++ b/Os/File.hpp
@@ -8,7 +8,7 @@
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <Os/Os.hpp>
 
-// Forward declation for UTs
+// Forward declaration for UTs
 namespace Os {namespace Test {namespace FileTest {struct Tester;}}}
 
 namespace Os {

--- a/Os/Posix/test/ut/PosixFileTests.cpp
+++ b/Os/Posix/test/ut/PosixFileTests.cpp
@@ -13,7 +13,7 @@
 #include <csignal>
 namespace Os {
 namespace Test {
-namespace File {
+namespace FileTest {
 
 std::vector<std::shared_ptr<const std::string> > FILES;
 
@@ -129,8 +129,8 @@ class PosixTester : public Tester {
 
 };
 
-std::unique_ptr<Os::Test::File::Tester> get_tester_implementation() {
-    return std::unique_ptr<Os::Test::File::Tester>(new Os::Test::File::PosixTester());
+std::unique_ptr<Os::Test::FileTest::Tester> get_tester_implementation() {
+    return std::unique_ptr<Os::Test::FileTest::Tester>(new Os::Test::FileTest::PosixTester());
 }
 
 }  // namespace File

--- a/Os/Stub/test/ut/StubFileTests.cpp
+++ b/Os/Stub/test/ut/StubFileTests.cpp
@@ -11,7 +11,7 @@
 
 namespace Os {
 namespace Test {
-namespace File {
+namespace FileTest {
 
 //! Set up for the test ensures that the test can run at all
 //!
@@ -59,8 +59,8 @@ class StubsTester : public Tester {
 
 };
 
-std::unique_ptr<Os::Test::File::Tester> get_tester_implementation() {
-    return std::unique_ptr<Os::Test::File::Tester>(new Os::Test::File::StubsTester());
+std::unique_ptr<Os::Test::FileTest::Tester> get_tester_implementation() {
+    return std::unique_ptr<Os::Test::FileTest::Tester>(new Os::Test::FileTest::StubsTester());
 }
 
 

--- a/Os/test/ut/file/CommonTests.cpp
+++ b/Os/test/ut/file/CommonTests.cpp
@@ -8,19 +8,19 @@
 
 static const U32 RANDOM_BOUND = 1000;
 
-Os::Test::File::Tester::Tester() {
+Os::Test::FileTest::Tester::Tester() {
     // Wipe out the file system with a fresh copy
     SyntheticFile::setFileSystem(std::unique_ptr<SyntheticFileSystem>(new SyntheticFileSystem()));
 }
 
-Functionality::Functionality() : tester(Os::Test::File::get_tester_implementation()) {}
+Functionality::Functionality() : tester(Os::Test::FileTest::get_tester_implementation()) {}
 
 void Functionality::SetUp() {
-    Os::Test::File::setUp(false);
+    Os::Test::FileTest::setUp(false);
 }
 
 void Functionality::TearDown() {
-    Os::Test::File::tearDown();
+    Os::Test::FileTest::tearDown();
 }
 
 void FunctionalIO::SetUp() {
@@ -34,23 +34,23 @@ void FunctionalIO::SetUp() {
 
 // Ensure that open mode changes work reliably
 TEST_F(Functionality, OpenWithCreation) {
-    Os::Test::File::Tester::OpenFileCreate rule(false);
+    Os::Test::FileTest::Tester::OpenFileCreate rule(false);
     rule.apply(*tester);
 }
 
 // Ensure that close mode changes work reliably
 TEST_F(Functionality, Close) {
-    Os::Test::File::Tester::OpenFileCreate create_rule(false);
-    Os::Test::File::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate create_rule(false);
+    Os::Test::FileTest::Tester::CloseFile close_rule;
     create_rule.apply(*tester);
     close_rule.apply(*tester);
 }
 
 // Ensure that the assignment operator works correctly
 TEST_F(Functionality, AssignmentOperator) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::CopyAssignment copy_rule;
-    Os::Test::File::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::CopyAssignment copy_rule;
+    Os::Test::FileTest::Tester::CloseFile close_rule;
     open_rule.apply(*tester);
     copy_rule.apply(*tester);
     close_rule.apply(*tester);
@@ -58,9 +58,9 @@ TEST_F(Functionality, AssignmentOperator) {
 
 // Ensure the copy constructor works correctly
 TEST_F(Functionality, CopyConstructor) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::CopyConstruction copy_rule;
-    Os::Test::File::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::CopyConstruction copy_rule;
+    Os::Test::FileTest::Tester::CloseFile close_rule;
     open_rule.apply(*tester);
     copy_rule.apply(*tester);
     close_rule.apply(*tester);
@@ -68,8 +68,8 @@ TEST_F(Functionality, CopyConstructor) {
 
 // Ensure that open on existence works
 TEST_F(FunctionalIO, OpenWithCreationExists) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::CloseFile close_rule;
     open_rule.apply(*tester);
     close_rule.apply(*tester);
     open_rule.apply(*tester);
@@ -77,9 +77,9 @@ TEST_F(FunctionalIO, OpenWithCreationExists) {
 
 // Ensure that open on existence with overwrite works
 TEST_F(Functionality, OpenWithCreationOverwrite) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::OpenFileCreateOverwrite open_overwrite(false);
-    Os::Test::File::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::OpenFileCreateOverwrite open_overwrite(false);
+    Os::Test::FileTest::Tester::CloseFile close_rule;
     open_rule.apply(*tester);
     close_rule.apply(*tester);
     open_overwrite.apply(*tester);
@@ -87,38 +87,38 @@ TEST_F(Functionality, OpenWithCreationOverwrite) {
 
 // Ensure that open mode changes work reliably
 TEST_F(Functionality, OpenInvalidModes) {
-    Os::Test::File::Tester::OpenFileCreate original_open(false);
-    Os::Test::File::Tester::OpenInvalidModes invalid_open;
+    Os::Test::FileTest::Tester::OpenFileCreate original_open(false);
+    Os::Test::FileTest::Tester::OpenInvalidModes invalid_open;
     original_open.apply(*tester);
     invalid_open.apply(*tester);
 }
 
 // Ensure that Os::File properly refuses preallocate calls when not open
 TEST_F(Functionality, PreallocateWithoutOpen) {
-    Os::Test::File::Tester::PreallocateWithoutOpen rule;
+    Os::Test::FileTest::Tester::PreallocateWithoutOpen rule;
     rule.apply(*tester);
 }
 
 // Ensure that Os::File properly refuses seek calls when not open
 TEST_F(Functionality, SeekWithoutOpen) {
-    Os::Test::File::Tester::SeekWithoutOpen rule;
+    Os::Test::FileTest::Tester::SeekWithoutOpen rule;
     rule.apply(*tester);
 }
 
 // Ensure that Os::File properly refuses seek calls when not open
 TEST_F(FunctionalIO, SeekInvalidSize) {
-    Os::Test::File::Tester::OpenFileCreate original_open(false);
-    Os::Test::File::Tester::SeekInvalidSize rule;
+    Os::Test::FileTest::Tester::OpenFileCreate original_open(false);
+    Os::Test::FileTest::Tester::SeekInvalidSize rule;
     original_open.apply(*tester);
     rule.apply(*tester);
 }
 
 // Ensure that Os::File properly refuses flush calls when not open and when reading
 TEST_F(Functionality, FlushInvalidModes) {
-    Os::Test::File::Tester::FlushInvalidModes flush_rule;
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::CloseFile close_rule;
-    Os::Test::File::Tester::OpenForRead open_read;
+    Os::Test::FileTest::Tester::FlushInvalidModes flush_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenForRead open_read;
 
     // Test flush in closed state
     flush_rule.apply(*tester);
@@ -136,10 +136,10 @@ TEST_F(Functionality, FlushInvalidModes) {
 
 // Ensure that Os::File properly refuses read calls when not open and when reading
 TEST_F(Functionality, ReadInvalidModes) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::CloseFile close_rule;
-    Os::Test::File::Tester::OpenForWrite open_write;
-    Os::Test::File::Tester::ReadInvalidModes read_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenForWrite open_write;
+    Os::Test::FileTest::Tester::ReadInvalidModes read_rule;
 
     // Test read in closed state
     read_rule.apply(*tester);
@@ -161,10 +161,10 @@ TEST_F(Functionality, ReadInvalidModes) {
 
 // Ensure that Os::File properly refuses write calls when not open and when reading
 TEST_F(Functionality, WriteInvalidModes) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::CloseFile close_rule;
-    Os::Test::File::Tester::OpenForRead open_read;
-    Os::Test::File::Tester::WriteInvalidModes write_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenForRead open_read;
+    Os::Test::FileTest::Tester::WriteInvalidModes write_rule;
 
     // Test write in closed state
     write_rule.apply(*tester);
@@ -183,13 +183,13 @@ TEST_F(Functionality, WriteInvalidModes) {
 
 // Ensure a write followed by a read produces valid data
 TEST_F(FunctionalIO, WriteSeekAppendReadBack) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::OpenForAppend open_append_rule(false);
-    Os::Test::File::Tester::Write write_rule;
-    Os::Test::File::Tester::Seek seek_rule;
-    Os::Test::File::Tester::CloseFile close_rule;
-    Os::Test::File::Tester::OpenForRead open_read;
-    Os::Test::File::Tester::Read read_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::OpenForAppend open_append_rule(false);
+    Os::Test::FileTest::Tester::Write write_rule;
+    Os::Test::FileTest::Tester::Seek seek_rule;
+    Os::Test::FileTest::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenForRead open_read;
+    Os::Test::FileTest::Tester::Read read_rule;
 
     open_rule.apply(*tester);
     write_rule.apply(*tester);
@@ -208,11 +208,11 @@ TEST_F(FunctionalIO, WriteSeekAppendReadBack) {
 
 // Ensure a write followed by a read produces valid data
 TEST_F(FunctionalIO, WriteReadBack) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::Write write_rule;
-    Os::Test::File::Tester::CloseFile close_rule;
-    Os::Test::File::Tester::OpenForRead open_read;
-    Os::Test::File::Tester::Read read_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::Write write_rule;
+    Os::Test::FileTest::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenForRead open_read;
+    Os::Test::FileTest::Tester::Read read_rule;
 
     open_rule.apply(*tester);
     write_rule.apply(*tester);
@@ -223,12 +223,12 @@ TEST_F(FunctionalIO, WriteReadBack) {
 
 // Ensure a write followed by a read produces valid data
 TEST_F(FunctionalIO, WriteReadSeek) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::Write write_rule;
-    Os::Test::File::Tester::CloseFile close_rule;
-    Os::Test::File::Tester::OpenForRead open_read;
-    Os::Test::File::Tester::Read read_rule;
-    Os::Test::File::Tester::Seek seek_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::Write write_rule;
+    Os::Test::FileTest::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenForRead open_read;
+    Os::Test::FileTest::Tester::Read read_rule;
+    Os::Test::FileTest::Tester::Seek seek_rule;
 
     open_rule.apply(*tester);
     write_rule.apply(*tester);
@@ -240,11 +240,11 @@ TEST_F(FunctionalIO, WriteReadSeek) {
 
 // Ensure a write followed by a full crc produces valid results
 TEST_F(FunctionalIO, WriteFullCrc) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::Write write_rule;
-    Os::Test::File::Tester::CloseFile close_rule;
-    Os::Test::File::Tester::OpenForRead open_read;
-    Os::Test::File::Tester::FullCrc crc_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::Write write_rule;
+    Os::Test::FileTest::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenForRead open_read;
+    Os::Test::FileTest::Tester::FullCrc crc_rule;
 
     open_rule.apply(*tester);
     write_rule.apply(*tester);
@@ -255,12 +255,12 @@ TEST_F(FunctionalIO, WriteFullCrc) {
 
 // Ensure a write followed by a partial crc produces valid results
 TEST_F(FunctionalIO, WritePartialCrc) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::Write write_rule;
-    Os::Test::File::Tester::CloseFile close_rule;
-    Os::Test::File::Tester::OpenForRead open_read;
-    Os::Test::File::Tester::IncrementalCrc crc_rule;
-    Os::Test::File::Tester::FinalizeCrc finalize_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::Write write_rule;
+    Os::Test::FileTest::Tester::CloseFile close_rule;
+    Os::Test::FileTest::Tester::OpenForRead open_read;
+    Os::Test::FileTest::Tester::IncrementalCrc crc_rule;
+    Os::Test::FileTest::Tester::FinalizeCrc finalize_rule;
 
     open_rule.apply(*tester);
     write_rule.apply(*tester);
@@ -272,9 +272,9 @@ TEST_F(FunctionalIO, WritePartialCrc) {
 
 // Ensure a preallocate produces valid sizes
 TEST_F(FunctionalIO, Flush) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::Write write_rule;
-    Os::Test::File::Tester::Flush flush_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::Write write_rule;
+    Os::Test::FileTest::Tester::Flush flush_rule;
 
     open_rule.apply(*tester);
     write_rule.apply(*tester);
@@ -283,8 +283,8 @@ TEST_F(FunctionalIO, Flush) {
 
 // Ensure a preallocate produces valid sizes
 TEST_F(FunctionalIO, Preallocate) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::Preallocate preallocate_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::Preallocate preallocate_rule;
 
     open_rule.apply(*tester);
     preallocate_rule.apply(*tester);
@@ -293,26 +293,26 @@ TEST_F(FunctionalIO, Preallocate) {
 // Randomized testing on the interfaces
 TEST_F(Functionality, RandomizedInterfaceTesting) {
     // Enumerate all rules and construct an instance of each
-    Os::Test::File::Tester::OpenFileCreateOverwrite open_file_create_overwrite_rule(true);
-    Os::Test::File::Tester::CloseFile close_file_rule;
-    Os::Test::File::Tester::CopyConstruction copy_construction;
-    Os::Test::File::Tester::CopyAssignment copy_assignment;
-    Os::Test::File::Tester::OpenInvalidModes open_invalid_modes_rule;
-    Os::Test::File::Tester::PreallocateWithoutOpen preallocate_without_open_rule;
-    Os::Test::File::Tester::SeekWithoutOpen seek_without_open_rule;
-    Os::Test::File::Tester::FlushInvalidModes flush_invalid_modes_rule;
-    Os::Test::File::Tester::ReadInvalidModes read_invalid_modes_rule;
-    Os::Test::File::Tester::WriteInvalidModes write_invalid_modes_rule;
-    Os::Test::File::Tester::OpenIllegalPath open_illegal_path;
-    Os::Test::File::Tester::OpenIllegalMode open_illegal_mode;
-    Os::Test::File::Tester::SeekIllegal seek_illegal;
-    Os::Test::File::Tester::ReadIllegalBuffer read_illegal_buffer;
-    Os::Test::File::Tester::WriteIllegalBuffer write_illegal_buffer;
-    Os::Test::File::Tester::IncrementalCrcInvalidModes incremental_invalid_mode_rule;
-    Os::Test::File::Tester::FullCrcInvalidModes full_invalid_mode_rule;
+    Os::Test::FileTest::Tester::OpenFileCreateOverwrite open_file_create_overwrite_rule(true);
+    Os::Test::FileTest::Tester::CloseFile close_file_rule;
+    Os::Test::FileTest::Tester::CopyConstruction copy_construction;
+    Os::Test::FileTest::Tester::CopyAssignment copy_assignment;
+    Os::Test::FileTest::Tester::OpenInvalidModes open_invalid_modes_rule;
+    Os::Test::FileTest::Tester::PreallocateWithoutOpen preallocate_without_open_rule;
+    Os::Test::FileTest::Tester::SeekWithoutOpen seek_without_open_rule;
+    Os::Test::FileTest::Tester::FlushInvalidModes flush_invalid_modes_rule;
+    Os::Test::FileTest::Tester::ReadInvalidModes read_invalid_modes_rule;
+    Os::Test::FileTest::Tester::WriteInvalidModes write_invalid_modes_rule;
+    Os::Test::FileTest::Tester::OpenIllegalPath open_illegal_path;
+    Os::Test::FileTest::Tester::OpenIllegalMode open_illegal_mode;
+    Os::Test::FileTest::Tester::SeekIllegal seek_illegal;
+    Os::Test::FileTest::Tester::ReadIllegalBuffer read_illegal_buffer;
+    Os::Test::FileTest::Tester::WriteIllegalBuffer write_illegal_buffer;
+    Os::Test::FileTest::Tester::IncrementalCrcInvalidModes incremental_invalid_mode_rule;
+    Os::Test::FileTest::Tester::FullCrcInvalidModes full_invalid_mode_rule;
 
     // Place these rules into a list of rules
-    STest::Rule<Os::Test::File::Tester>* rules[] = {
+    STest::Rule<Os::Test::FileTest::Tester>* rules[] = {
             &open_file_create_overwrite_rule,
             &close_file_rule,
             &copy_assignment,
@@ -333,14 +333,14 @@ TEST_F(Functionality, RandomizedInterfaceTesting) {
     };
 
     // Take the rules and place them into a random scenario
-    STest::RandomScenario<Os::Test::File::Tester> random(
+    STest::RandomScenario<Os::Test::FileTest::Tester> random(
             "Random Rules",
             rules,
             FW_NUM_ARRAY_ELEMENTS(rules)
     );
 
     // Create a bounded scenario wrapping the random scenario
-    STest::BoundedScenario<Os::Test::File::Tester> bounded(
+    STest::BoundedScenario<Os::Test::FileTest::Tester> bounded(
             "Bounded Random Rules Scenario",
             random,
             RANDOM_BOUND/10
@@ -353,34 +353,34 @@ TEST_F(Functionality, RandomizedInterfaceTesting) {
 // Ensure a write followed by a read produces valid data
 TEST_F(FunctionalIO, RandomizedTesting) {
     // Enumerate all rules and construct an instance of each
-    Os::Test::File::Tester::OpenFileCreate open_file_create_rule(true);
-    Os::Test::File::Tester::OpenFileCreateOverwrite open_file_create_overwrite_rule(true);
-    Os::Test::File::Tester::OpenForWrite open_for_write_rule(true);
-    Os::Test::File::Tester::OpenForRead open_for_read_rule(true);
-    Os::Test::File::Tester::CloseFile close_file_rule;
-    Os::Test::File::Tester::Read read_rule;
-    Os::Test::File::Tester::Write write_rule;
-    Os::Test::File::Tester::Seek seek_rule;
-    Os::Test::File::Tester::Preallocate preallocate_rule;
-    Os::Test::File::Tester::Flush flush_rule;
-    Os::Test::File::Tester::CopyConstruction copy_construction;
-    Os::Test::File::Tester::CopyAssignment copy_assignment;
-    Os::Test::File::Tester::IncrementalCrc incremental_crc_rule;
-    Os::Test::File::Tester::FinalizeCrc finalize_crc_rule;
-    Os::Test::File::Tester::FullCrc full_crc_rule;
-    Os::Test::File::Tester::OpenInvalidModes open_invalid_modes_rule;
-    Os::Test::File::Tester::PreallocateWithoutOpen preallocate_without_open_rule;
-    Os::Test::File::Tester::SeekWithoutOpen seek_without_open_rule;
-    Os::Test::File::Tester::SeekInvalidSize seek_invalid_size;
-    Os::Test::File::Tester::FlushInvalidModes flush_invalid_modes_rule;
-    Os::Test::File::Tester::ReadInvalidModes read_invalid_modes_rule;
-    Os::Test::File::Tester::WriteInvalidModes write_invalid_modes_rule;
-    Os::Test::File::Tester::IncrementalCrcInvalidModes incremental_invalid_mode_rule;
-    Os::Test::File::Tester::FullCrcInvalidModes full_invalid_mode_rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_file_create_rule(true);
+    Os::Test::FileTest::Tester::OpenFileCreateOverwrite open_file_create_overwrite_rule(true);
+    Os::Test::FileTest::Tester::OpenForWrite open_for_write_rule(true);
+    Os::Test::FileTest::Tester::OpenForRead open_for_read_rule(true);
+    Os::Test::FileTest::Tester::CloseFile close_file_rule;
+    Os::Test::FileTest::Tester::Read read_rule;
+    Os::Test::FileTest::Tester::Write write_rule;
+    Os::Test::FileTest::Tester::Seek seek_rule;
+    Os::Test::FileTest::Tester::Preallocate preallocate_rule;
+    Os::Test::FileTest::Tester::Flush flush_rule;
+    Os::Test::FileTest::Tester::CopyConstruction copy_construction;
+    Os::Test::FileTest::Tester::CopyAssignment copy_assignment;
+    Os::Test::FileTest::Tester::IncrementalCrc incremental_crc_rule;
+    Os::Test::FileTest::Tester::FinalizeCrc finalize_crc_rule;
+    Os::Test::FileTest::Tester::FullCrc full_crc_rule;
+    Os::Test::FileTest::Tester::OpenInvalidModes open_invalid_modes_rule;
+    Os::Test::FileTest::Tester::PreallocateWithoutOpen preallocate_without_open_rule;
+    Os::Test::FileTest::Tester::SeekWithoutOpen seek_without_open_rule;
+    Os::Test::FileTest::Tester::SeekInvalidSize seek_invalid_size;
+    Os::Test::FileTest::Tester::FlushInvalidModes flush_invalid_modes_rule;
+    Os::Test::FileTest::Tester::ReadInvalidModes read_invalid_modes_rule;
+    Os::Test::FileTest::Tester::WriteInvalidModes write_invalid_modes_rule;
+    Os::Test::FileTest::Tester::IncrementalCrcInvalidModes incremental_invalid_mode_rule;
+    Os::Test::FileTest::Tester::FullCrcInvalidModes full_invalid_mode_rule;
 
 
     // Place these rules into a list of rules
-    STest::Rule<Os::Test::File::Tester>* rules[] = {
+    STest::Rule<Os::Test::FileTest::Tester>* rules[] = {
         &open_file_create_rule,
         &open_file_create_overwrite_rule,
         &open_for_write_rule,
@@ -408,14 +408,14 @@ TEST_F(FunctionalIO, RandomizedTesting) {
     };
 
     // Take the rules and place them into a random scenario
-    STest::RandomScenario<Os::Test::File::Tester> random(
+    STest::RandomScenario<Os::Test::FileTest::Tester> random(
         "Random Rules",
         rules,
         FW_NUM_ARRAY_ELEMENTS(rules)
     );
 
     // Create a bounded scenario wrapping the random scenario
-    STest::BoundedScenario<Os::Test::File::Tester> bounded(
+    STest::BoundedScenario<Os::Test::FileTest::Tester> bounded(
         "Bounded Random Rules Scenario",
         random,
         RANDOM_BOUND
@@ -427,16 +427,16 @@ TEST_F(FunctionalIO, RandomizedTesting) {
 
 // Ensure that Os::File properly refuses fullCrc when not in write mode
 TEST_F(Functionality, FullCrcInvalidMode) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::FullCrcInvalidModes rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::FullCrcInvalidModes rule;
     open_rule.apply(*tester);
     rule.apply(*tester);
 }
 
 // Ensure that Os::File properly refuses incrementalCrc when not in write mode
 TEST_F(Functionality, IncrementalCrcInvalidMode) {
-    Os::Test::File::Tester::OpenFileCreate open_rule(false);
-    Os::Test::File::Tester::IncrementalCrcInvalidModes rule;
+    Os::Test::FileTest::Tester::OpenFileCreate open_rule(false);
+    Os::Test::FileTest::Tester::IncrementalCrcInvalidModes rule;
     open_rule.apply(*tester);
     rule.apply(*tester);
 }
@@ -444,30 +444,30 @@ TEST_F(Functionality, IncrementalCrcInvalidMode) {
 
 // Ensure open prevents nullptr as path
 TEST_F(InvalidArguments, OpenBadPath) {
-    Os::Test::File::Tester::OpenIllegalPath rule;
+    Os::Test::FileTest::Tester::OpenIllegalPath rule;
     rule.apply(*tester);
 }
 
 // Ensure open prevents bad modes
 TEST_F(InvalidArguments, OpenBadMode) {
-    Os::Test::File::Tester::OpenIllegalMode rule;
+    Os::Test::FileTest::Tester::OpenIllegalMode rule;
     rule.apply(*tester);
 }
 
 // Ensure preallocate prevents bad length
 TEST_F(InvalidArguments, SeekAbsoluteWithNegativeLength) {
-    Os::Test::File::Tester::SeekIllegal rule;
+    Os::Test::FileTest::Tester::SeekIllegal rule;
     rule.apply(*tester);
 }
 
 // Ensure read prevents bad buffer pointers
 TEST_F(InvalidArguments, ReadInvalidBuffer) {
-    Os::Test::File::Tester::ReadIllegalBuffer rule;
+    Os::Test::FileTest::Tester::ReadIllegalBuffer rule;
     rule.apply(*tester);
 }
 
 // Ensure write prevents bad buffer pointers
 TEST_F(InvalidArguments, WriteInvalidBuffer) {
-    Os::Test::File::Tester::WriteIllegalBuffer rule;
+    Os::Test::FileTest::Tester::WriteIllegalBuffer rule;
     rule.apply(*tester);
 }

--- a/Os/test/ut/file/CommonTests.hpp
+++ b/Os/test/ut/file/CommonTests.hpp
@@ -9,7 +9,7 @@
 #define OS_TEST_UT_COMMON_FILE_TESTS_HPP
 namespace Os {
 namespace Test {
-namespace File {
+namespace FileTest {
 
 //! Set up function as defined by the unit test implementor
 void setUp(bool requires_io  //!< Does this test require functional io devices
@@ -18,7 +18,7 @@ void setUp(bool requires_io  //!< Does this test require functional io devices
 //! Tear down function as defined by the unit test implementor
 void tearDown();
 
-}  // namespace File
+}  // namespace FileTest
 }  // namespace Test
 }  // namespace Os
 
@@ -35,7 +35,7 @@ class Functionality : public ::testing::Test {
     void TearDown() override;
 
     //! Tester/state implementation
-    std::unique_ptr<Os::Test::File::Tester> tester;
+    std::unique_ptr<Os::Test::FileTest::Tester> tester;
 };
 
 //! Interface testing

--- a/Os/test/ut/file/FileRules.cpp
+++ b/Os/test/ut/file/FileRules.cpp
@@ -12,7 +12,7 @@ extern "C" {
 // For testing, limit files to 32K
 const FwSizeType FILE_DATA_MAXIMUM = 32 * 1024;
 
-Os::File::Status Os::Test::File::Tester::shadow_open(const std::string &path, Os::File::Mode open_mode, bool overwrite) {
+Os::File::Status Os::Test::FileTest::Tester::shadow_open(const std::string &path, Os::File::Mode open_mode, bool overwrite) {
     Os::File::Status status = this->m_shadow.open(path.c_str(), open_mode, overwrite ? Os::File::OverwriteType::OVERWRITE : Os::File::OverwriteType::NO_OVERWRITE);
     if (Os::File::Status::OP_OK == status) {
         this->m_current_path = path;
@@ -25,7 +25,7 @@ Os::File::Status Os::Test::File::Tester::shadow_open(const std::string &path, Os
     return status;
 }
 
-void Os::Test::File::Tester::shadow_close() {
+void Os::Test::FileTest::Tester::shadow_close() {
     this->m_shadow.close();
     this->m_current_path.clear();
     this->m_mode = Os::File::Mode::OPEN_NO_MODE;
@@ -33,7 +33,7 @@ void Os::Test::File::Tester::shadow_close() {
     ASSERT_TRUE(this->m_current_path.empty());
 }
 
-std::vector<U8> Os::Test::File::Tester::shadow_read(FwSizeType size) {
+std::vector<U8> Os::Test::FileTest::Tester::shadow_read(FwSizeType size) {
     std::vector<U8> output;
     output.resize(size);
     Os::File::Status status = m_shadow.read(output.data(), size, Os::File::WaitType::WAIT);
@@ -42,7 +42,7 @@ std::vector<U8> Os::Test::File::Tester::shadow_read(FwSizeType size) {
     return output;
 }
 
-void Os::Test::File::Tester::shadow_write(const std::vector<U8>& write_data) {
+void Os::Test::FileTest::Tester::shadow_write(const std::vector<U8>& write_data) {
     FwSizeType size = static_cast<FwSizeType>(write_data.size());
     FwSizeType original_size = size;
     Os::File::Status status = Os::File::OP_OK;
@@ -53,22 +53,22 @@ void Os::Test::File::Tester::shadow_write(const std::vector<U8>& write_data) {
     ASSERT_EQ(size, original_size);
 }
 
-void Os::Test::File::Tester::shadow_seek(const FwSignedSizeType offset, const bool absolute) {
+void Os::Test::FileTest::Tester::shadow_seek(const FwSignedSizeType offset, const bool absolute) {
     Os::File::Status status = m_shadow.seek(offset, absolute ?Os::File::SeekType::ABSOLUTE : Os::File::SeekType::RELATIVE);
     ASSERT_EQ(status, Os::File::Status::OP_OK);
 }
 
-void Os::Test::File::Tester::shadow_preallocate(const FwSizeType offset, const FwSizeType length) {
+void Os::Test::FileTest::Tester::shadow_preallocate(const FwSizeType offset, const FwSizeType length) {
     Os::File::Status status = m_shadow.preallocate(offset, length);
     ASSERT_EQ(status, Os::File::Status::OP_OK);
 }
 
-void Os::Test::File::Tester::shadow_flush() {
+void Os::Test::FileTest::Tester::shadow_flush() {
     Os::File::Status status = m_shadow.flush();
     ASSERT_EQ(status, Os::File::Status::OP_OK);
 }
 
-void Os::Test::File::Tester::shadow_crc(U32& crc) {
+void Os::Test::FileTest::Tester::shadow_crc(U32& crc) {
     crc = this->m_independent_crc;
     SyntheticFileData& data = *reinterpret_cast<SyntheticFileData*>(this->m_shadow.getHandle());
 
@@ -80,7 +80,7 @@ void Os::Test::File::Tester::shadow_crc(U32& crc) {
     this->m_independent_crc = Os::File::INITIAL_CRC;
 }
 
-void Os::Test::File::Tester::shadow_partial_crc(FwSizeType& size) {
+void Os::Test::FileTest::Tester::shadow_partial_crc(FwSizeType& size) {
     SyntheticFileData data = *reinterpret_cast<SyntheticFileData*>(this->m_shadow.getHandle());
 
     // Calculate CRC on full file starting at m_pointer
@@ -92,14 +92,14 @@ void Os::Test::File::Tester::shadow_partial_crc(FwSizeType& size) {
     }
 }
 
-void Os::Test::File::Tester::shadow_finalize(U32& crc) {
+void Os::Test::FileTest::Tester::shadow_finalize(U32& crc) {
     crc = this->m_independent_crc;
     this->m_independent_crc = Os::File::INITIAL_CRC;
 }
 
 
-Os::Test::File::Tester::FileState Os::Test::File::Tester::current_file_state() {
-    Os::Test::File::Tester::FileState state;
+Os::Test::FileTest::Tester::FileState Os::Test::FileTest::Tester::current_file_state() {
+    Os::Test::FileTest::Tester::FileState state;
     // Invariant: mode must not be closed, or path must be nullptr
     EXPECT_TRUE((Os::File::Mode::OPEN_NO_MODE != this->m_file.m_mode) || (nullptr == this->m_file.m_path));
 
@@ -115,7 +115,7 @@ Os::Test::File::Tester::FileState Os::Test::File::Tester::current_file_state() {
     return state;
 }
 
-void Os::Test::File::Tester::assert_valid_mode_status(Os::File::Status &status) const {
+void Os::Test::FileTest::Tester::assert_valid_mode_status(Os::File::Status &status) const {
     if (Os::File::Mode::OPEN_NO_MODE == this->m_mode) {
         ASSERT_EQ(status, Os::File::Status::NOT_OPENED);
     } else {
@@ -124,7 +124,7 @@ void Os::Test::File::Tester::assert_valid_mode_status(Os::File::Status &status) 
 }
 
 
-void Os::Test::File::Tester::assert_file_consistent() {
+void Os::Test::FileTest::Tester::assert_file_consistent() {
     // Ensure file mode
     ASSERT_EQ(this->m_mode, this->m_file.m_mode);
     // Ensure CRC match
@@ -162,7 +162,7 @@ void Os::Test::File::Tester::assert_file_consistent() {
     }
 }
 
-void Os::Test::File::Tester::assert_file_opened(const std::string &path, Os::File::Mode newly_opened_mode, bool overwrite) {
+void Os::Test::FileTest::Tester::assert_file_opened(const std::string &path, Os::File::Mode newly_opened_mode, bool overwrite) {
     // Assert the that the file is opened in some mode
     ASSERT_NE(this->m_file.m_mode, Os::File::Mode::OPEN_NO_MODE);
     ASSERT_TRUE(this->m_file.isOpen()) << "`isOpen()` failed to indicate file is open";
@@ -191,12 +191,12 @@ void Os::Test::File::Tester::assert_file_opened(const std::string &path, Os::Fil
     }
 }
 
-void Os::Test::File::Tester::assert_file_closed() {
+void Os::Test::FileTest::Tester::assert_file_closed() {
     ASSERT_EQ(this->m_file.m_mode, Os::File::Mode::OPEN_NO_MODE) << "File is in unexpected mode";
     ASSERT_FALSE(this->m_file.isOpen()) << "`isOpen()` failed to indicate file is open";
 }
 
-void Os::Test::File::Tester::assert_file_read(const std::vector<U8>& state_data, const unsigned char *read_data, FwSizeType size_read) {
+void Os::Test::FileTest::Tester::assert_file_read(const std::vector<U8>& state_data, const unsigned char *read_data, FwSizeType size_read) {
     // Functional tests
     if (functional()) {
         ASSERT_EQ(size_read, state_data.size());
@@ -209,7 +209,7 @@ void Os::Test::File::Tester::assert_file_read(const std::vector<U8>& state_data,
     }
 }
 
-void Os::Test::File::Tester::assert_file_write(const std::vector<U8>& write_data, FwSizeType size_written) {
+void Os::Test::FileTest::Tester::assert_file_write(const std::vector<U8>& write_data, FwSizeType size_written) {
     ASSERT_EQ(size_written, write_data.size());
     FwSizeType file_size = 0;
     FwSizeType shadow_size = 0;
@@ -223,7 +223,7 @@ void Os::Test::File::Tester::assert_file_write(const std::vector<U8>& write_data
     ASSERT_EQ(file_position, shadow_position);
 }
 
-void Os::Test::File::Tester::assert_file_seek(const FwSizeType original_position, const FwSignedSizeType seek_desired, const bool absolute) {
+void Os::Test::FileTest::Tester::assert_file_seek(const FwSizeType original_position, const FwSignedSizeType seek_desired, const bool absolute) {
     FwSizeType new_position = 0;
     FwSizeType shadow_position = 0;
 
@@ -243,20 +243,20 @@ void Os::Test::File::Tester::assert_file_seek(const FwSizeType original_position
 //  OpenFile: base rule for all open rules
 //
 // ------------------------------------------------------------------------------------------------------
-Os::Test::File::Tester::OpenBaseRule::OpenBaseRule(const char *rule_name,
+Os::Test::FileTest::Tester::OpenBaseRule::OpenBaseRule(const char *rule_name,
                                                    Os::File::Mode mode,
                                                    const bool overwrite,
                                                    const bool randomize_filename)
-        : STest::Rule<Os::Test::File::Tester>(rule_name), m_mode(mode),
+        : STest::Rule<Os::Test::FileTest::Tester>(rule_name), m_mode(mode),
           m_overwrite(overwrite ? Os::File::OverwriteType::OVERWRITE : Os::File::OverwriteType::NO_OVERWRITE),
           m_random(randomize_filename) {}
 
-bool Os::Test::File::Tester::OpenBaseRule::precondition(const Os::Test::File::Tester &state  //!< The test state
+bool Os::Test::FileTest::Tester::OpenBaseRule::precondition(const Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     return state.m_mode == Os::File::Mode::OPEN_NO_MODE;
 }
 
-void Os::Test::File::Tester::OpenBaseRule::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::OpenBaseRule::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s mode %d\n", this->getName(), this->m_mode);
     // Initial variables used for this test
@@ -286,8 +286,8 @@ void Os::Test::File::Tester::OpenBaseRule::action(Os::Test::File::Tester &state 
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::OpenFileCreate::OpenFileCreate(const bool randomize_filename)
-        : Os::Test::File::Tester::OpenBaseRule("OpenFileCreate", Os::File::Mode::OPEN_CREATE, false,
+Os::Test::FileTest::Tester::OpenFileCreate::OpenFileCreate(const bool randomize_filename)
+        : Os::Test::FileTest::Tester::OpenBaseRule("OpenFileCreate", Os::File::Mode::OPEN_CREATE, false,
                                                randomize_filename) {}
 
 
@@ -296,8 +296,8 @@ Os::Test::File::Tester::OpenFileCreate::OpenFileCreate(const bool randomize_file
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::OpenFileCreateOverwrite::OpenFileCreateOverwrite(const bool randomize_filename)
-        : Os::Test::File::Tester::OpenBaseRule("OpenFileCreate", Os::File::Mode::OPEN_CREATE, true,
+Os::Test::FileTest::Tester::OpenFileCreateOverwrite::OpenFileCreateOverwrite(const bool randomize_filename)
+        : Os::Test::FileTest::Tester::OpenBaseRule("OpenFileCreate", Os::File::Mode::OPEN_CREATE, true,
                                                randomize_filename) {}
 
 
@@ -306,8 +306,8 @@ Os::Test::File::Tester::OpenFileCreateOverwrite::OpenFileCreateOverwrite(const b
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::OpenForWrite::OpenForWrite(const bool randomize_filename)
-        : Os::Test::File::Tester::OpenBaseRule("OpenForWrite",
+Os::Test::FileTest::Tester::OpenForWrite::OpenForWrite(const bool randomize_filename)
+        : Os::Test::FileTest::Tester::OpenBaseRule("OpenForWrite",
         // Randomized write mode
                                                static_cast<Os::File::Mode>(STest::Pick::lowerUpper(
                                                        Os::File::Mode::OPEN_WRITE,
@@ -327,8 +327,8 @@ Os::Test::File::Tester::OpenForWrite::OpenForWrite(const bool randomize_filename
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::OpenForAppend::OpenForAppend(const bool randomize_filename)
-        : Os::Test::File::Tester::OpenBaseRule("OpenForAppend",
+Os::Test::FileTest::Tester::OpenForAppend::OpenForAppend(const bool randomize_filename)
+        : Os::Test::FileTest::Tester::OpenBaseRule("OpenForAppend",
         // Randomized write mode
                                                Os::File::Mode::OPEN_APPEND,
         // Randomized overwrite
@@ -346,8 +346,8 @@ Os::Test::File::Tester::OpenForAppend::OpenForAppend(const bool randomize_filena
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::OpenForRead::OpenForRead(const bool randomize_filename)
-        : Os::Test::File::Tester::OpenBaseRule("OpenForRead", Os::File::Mode::OPEN_READ,
+Os::Test::FileTest::Tester::OpenForRead::OpenForRead(const bool randomize_filename)
+        : Os::Test::FileTest::Tester::OpenBaseRule("OpenForRead", Os::File::Mode::OPEN_READ,
         // Randomized overwrite
                                                static_cast<bool>(STest::Pick::lowerUpper(0, 1)),
                                                randomize_filename) {}
@@ -357,14 +357,14 @@ Os::Test::File::Tester::OpenForRead::OpenForRead(const bool randomize_filename)
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::CloseFile::CloseFile() : STest::Rule<Os::Test::File::Tester>("CloseFile") {}
+Os::Test::FileTest::Tester::CloseFile::CloseFile() : STest::Rule<Os::Test::FileTest::Tester>("CloseFile") {}
 
-bool Os::Test::File::Tester::CloseFile::precondition(const Os::Test::File::Tester &state  //!< The test state
+bool Os::Test::FileTest::Tester::CloseFile::precondition(const Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     return Os::File::Mode::OPEN_NO_MODE != state.m_mode;
 }
 
-void Os::Test::File::Tester::CloseFile::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::CloseFile::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     // Make sure test state and file state synchronized
@@ -383,20 +383,20 @@ void Os::Test::File::Tester::CloseFile::action(Os::Test::File::Tester &state  //
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::Read::Read() :
-        STest::Rule<Os::Test::File::Tester>("Read") {
+Os::Test::FileTest::Tester::Read::Read() :
+        STest::Rule<Os::Test::FileTest::Tester>("Read") {
 }
 
 
-bool Os::Test::File::Tester::Read::precondition(
-        const Os::Test::File::Tester &state //!< The test state
+bool Os::Test::FileTest::Tester::Read::precondition(
+        const Os::Test::FileTest::Tester &state //!< The test state
 ) {
     return Os::File::Mode::OPEN_READ == state.m_mode;
 }
 
 
-void Os::Test::File::Tester::Read::action(
-        Os::Test::File::Tester &state //!< The test state
+void Os::Test::FileTest::Tester::Read::action(
+        Os::Test::FileTest::Tester &state //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     U8 buffer[FILE_DATA_MAXIMUM];
@@ -420,20 +420,20 @@ void Os::Test::File::Tester::Read::action(
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::Write::Write() :
-        STest::Rule<Os::Test::File::Tester>("Write") {
+Os::Test::FileTest::Tester::Write::Write() :
+        STest::Rule<Os::Test::FileTest::Tester>("Write") {
 }
 
 
-bool Os::Test::File::Tester::Write::precondition(
-        const Os::Test::File::Tester &state //!< The test state
+bool Os::Test::FileTest::Tester::Write::precondition(
+        const Os::Test::FileTest::Tester &state //!< The test state
 ) {
     return Os::File::Mode::OPEN_CREATE <= state.m_mode;
 }
 
 
-void Os::Test::File::Tester::Write::action(
-        Os::Test::File::Tester &state //!< The test state
+void Os::Test::FileTest::Tester::Write::action(
+        Os::Test::FileTest::Tester &state //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     U8 buffer[FILE_DATA_MAXIMUM];
@@ -463,20 +463,20 @@ void Os::Test::File::Tester::Write::action(
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::Seek::Seek() :
-        STest::Rule<Os::Test::File::Tester>("Seek") {
+Os::Test::FileTest::Tester::Seek::Seek() :
+        STest::Rule<Os::Test::FileTest::Tester>("Seek") {
 }
 
 
-bool Os::Test::File::Tester::Seek::precondition(
-        const Os::Test::File::Tester &state //!< The test state
+bool Os::Test::FileTest::Tester::Seek::precondition(
+        const Os::Test::FileTest::Tester &state //!< The test state
 ) {
     return Os::File::Mode::OPEN_NO_MODE < state.m_mode;
 }
 
 
-void Os::Test::File::Tester::Seek::action(
-        Os::Test::File::Tester &state //!< The test state
+void Os::Test::FileTest::Tester::Seek::action(
+        Os::Test::FileTest::Tester &state //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     FwSignedSizeType seek_offset = 0;
@@ -503,20 +503,20 @@ void Os::Test::File::Tester::Seek::action(
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::Preallocate::Preallocate() :
-        STest::Rule<Os::Test::File::Tester>("Preallocate") {
+Os::Test::FileTest::Tester::Preallocate::Preallocate() :
+        STest::Rule<Os::Test::FileTest::Tester>("Preallocate") {
 }
 
 
-bool Os::Test::File::Tester::Preallocate::precondition(
-        const Os::Test::File::Tester &state //!< The test state
+bool Os::Test::FileTest::Tester::Preallocate::precondition(
+        const Os::Test::FileTest::Tester &state //!< The test state
 ) {
     return Os::File::Mode::OPEN_CREATE <= state.m_mode;
 }
 
 
-void Os::Test::File::Tester::Preallocate::action(
-        Os::Test::File::Tester &state //!< The test state
+void Os::Test::FileTest::Tester::Preallocate::action(
+        Os::Test::FileTest::Tester &state //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -537,20 +537,20 @@ void Os::Test::File::Tester::Preallocate::action(
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::Flush::Flush() :
-        STest::Rule<Os::Test::File::Tester>("Flush") {
+Os::Test::FileTest::Tester::Flush::Flush() :
+        STest::Rule<Os::Test::FileTest::Tester>("Flush") {
 }
 
 
-bool Os::Test::File::Tester::Flush::precondition(
-        const Os::Test::File::Tester &state //!< The test state
+bool Os::Test::FileTest::Tester::Flush::precondition(
+        const Os::Test::FileTest::Tester &state //!< The test state
 ) {
     return Os::File::Mode::OPEN_CREATE <= state.m_mode;
 }
 
 
-void Os::Test::File::Tester::Flush::action(
-        Os::Test::File::Tester &state //!< The test state
+void Os::Test::FileTest::Tester::Flush::action(
+        Os::Test::FileTest::Tester &state //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -573,15 +573,15 @@ void Os::Test::File::Tester::Flush::action(
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::OpenInvalidModes::OpenInvalidModes()
-        : STest::Rule<Os::Test::File::Tester>("OpenInvalidModes") {}
+Os::Test::FileTest::Tester::OpenInvalidModes::OpenInvalidModes()
+        : STest::Rule<Os::Test::FileTest::Tester>("OpenInvalidModes") {}
 
-bool Os::Test::File::Tester::OpenInvalidModes::precondition(const Os::Test::File::Tester &state  //!< The test state
+bool Os::Test::FileTest::Tester::OpenInvalidModes::precondition(const Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     return Os::File::Mode::OPEN_NO_MODE != state.m_mode;
 }
 
-void Os::Test::File::Tester::OpenInvalidModes::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::OpenInvalidModes::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -604,16 +604,16 @@ void Os::Test::File::Tester::OpenInvalidModes::action(Os::Test::File::Tester &st
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::PreallocateWithoutOpen::PreallocateWithoutOpen()
-        : STest::Rule<Os::Test::File::Tester>("PreallocateWithoutOpen") {}
+Os::Test::FileTest::Tester::PreallocateWithoutOpen::PreallocateWithoutOpen()
+        : STest::Rule<Os::Test::FileTest::Tester>("PreallocateWithoutOpen") {}
 
-bool Os::Test::File::Tester::PreallocateWithoutOpen::precondition(
-        const Os::Test::File::Tester &state  //!< The test state
+bool Os::Test::FileTest::Tester::PreallocateWithoutOpen::precondition(
+        const Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     return Os::File::Mode::OPEN_NO_MODE == state.m_mode;
 }
 
-void Os::Test::File::Tester::PreallocateWithoutOpen::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::PreallocateWithoutOpen::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -633,14 +633,14 @@ void Os::Test::File::Tester::PreallocateWithoutOpen::action(Os::Test::File::Test
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::SeekWithoutOpen::SeekWithoutOpen() : STest::Rule<Os::Test::File::Tester>("SeekWithoutOpen") {}
+Os::Test::FileTest::Tester::SeekWithoutOpen::SeekWithoutOpen() : STest::Rule<Os::Test::FileTest::Tester>("SeekWithoutOpen") {}
 
-bool Os::Test::File::Tester::SeekWithoutOpen::precondition(const Os::Test::File::Tester &state  //!< The test state
+bool Os::Test::FileTest::Tester::SeekWithoutOpen::precondition(const Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     return Os::File::Mode::OPEN_NO_MODE == state.m_mode;
 }
 
-void Os::Test::File::Tester::SeekWithoutOpen::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::SeekWithoutOpen::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -660,19 +660,19 @@ void Os::Test::File::Tester::SeekWithoutOpen::action(Os::Test::File::Tester &sta
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::SeekInvalidSize::SeekInvalidSize() : STest::Rule<Os::Test::File::Tester>("SeekInvalidSize") {}
+Os::Test::FileTest::Tester::SeekInvalidSize::SeekInvalidSize() : STest::Rule<Os::Test::FileTest::Tester>("SeekInvalidSize") {}
 
-bool Os::Test::File::Tester::SeekInvalidSize::precondition(const Os::Test::File::Tester &state  //!< The test state
+bool Os::Test::FileTest::Tester::SeekInvalidSize::precondition(const Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     FwSizeType position = 0;
     // Operation is effectively constant
-    Os::File::Status status = const_cast<Os::Test::File::Tester&>(state).m_file.position(position);
+    Os::File::Status status = const_cast<Os::Test::FileTest::Tester&>(state).m_file.position(position);
     return (Os::File::Mode::OPEN_NO_MODE < state.m_mode) &&
        // Limitation of the test harness: max random value is U32_MAX, thus we need at least 1 byte headroom
        (status == Os::File::Status::OP_OK) && (position < std::numeric_limits<U32>::max());
 }
 
-void Os::Test::File::Tester::SeekInvalidSize::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::SeekInvalidSize::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -695,15 +695,15 @@ void Os::Test::File::Tester::SeekInvalidSize::action(Os::Test::File::Tester &sta
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::FlushInvalidModes::FlushInvalidModes()
-        : STest::Rule<Os::Test::File::Tester>("FlushInvalidModes") {}
+Os::Test::FileTest::Tester::FlushInvalidModes::FlushInvalidModes()
+        : STest::Rule<Os::Test::FileTest::Tester>("FlushInvalidModes") {}
 
-bool Os::Test::File::Tester::FlushInvalidModes::precondition(const Os::Test::File::Tester &state  //!< The test state
+bool Os::Test::FileTest::Tester::FlushInvalidModes::precondition(const Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     return Os::File::Mode::OPEN_NO_MODE == state.m_mode || Os::File::Mode::OPEN_READ == state.m_mode;
 }
 
-void Os::Test::File::Tester::FlushInvalidModes::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::FlushInvalidModes::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -723,15 +723,15 @@ void Os::Test::File::Tester::FlushInvalidModes::action(Os::Test::File::Tester &s
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::ReadInvalidModes::ReadInvalidModes()
-        : STest::Rule<Os::Test::File::Tester>("ReadInvalidModes") {}
+Os::Test::FileTest::Tester::ReadInvalidModes::ReadInvalidModes()
+        : STest::Rule<Os::Test::FileTest::Tester>("ReadInvalidModes") {}
 
-bool Os::Test::File::Tester::ReadInvalidModes::precondition(const Os::Test::File::Tester &state  //!< The test state
+bool Os::Test::FileTest::Tester::ReadInvalidModes::precondition(const Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     return Os::File::Mode::OPEN_READ != state.m_mode;
 }
 
-void Os::Test::File::Tester::ReadInvalidModes::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::ReadInvalidModes::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     U8 buffer[10];
@@ -755,15 +755,15 @@ void Os::Test::File::Tester::ReadInvalidModes::action(Os::Test::File::Tester &st
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::WriteInvalidModes::WriteInvalidModes()
-        : STest::Rule<Os::Test::File::Tester>("WriteInvalidModes") {}
+Os::Test::FileTest::Tester::WriteInvalidModes::WriteInvalidModes()
+        : STest::Rule<Os::Test::FileTest::Tester>("WriteInvalidModes") {}
 
-bool Os::Test::File::Tester::WriteInvalidModes::precondition(const Os::Test::File::Tester &state  //!< The test state
+bool Os::Test::FileTest::Tester::WriteInvalidModes::precondition(const Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     return Os::File::Mode::OPEN_NO_MODE == state.m_mode || Os::File::Mode::OPEN_READ == state.m_mode;
 }
 
-void Os::Test::File::Tester::WriteInvalidModes::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::WriteInvalidModes::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     U8 buffer[10];
@@ -786,9 +786,9 @@ void Os::Test::File::Tester::WriteInvalidModes::action(Os::Test::File::Tester &s
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::AssertRule::AssertRule(const char *name) : STest::Rule<Os::Test::File::Tester>(name) {}
+Os::Test::FileTest::Tester::AssertRule::AssertRule(const char *name) : STest::Rule<Os::Test::FileTest::Tester>(name) {}
 
-bool Os::Test::File::Tester::AssertRule::precondition(const Os::Test::File::Tester &state  //!< The test state
+bool Os::Test::FileTest::Tester::AssertRule::precondition(const Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     return true;
 }
@@ -798,9 +798,9 @@ bool Os::Test::File::Tester::AssertRule::precondition(const Os::Test::File::Test
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::OpenIllegalPath::OpenIllegalPath() : Os::Test::File::Tester::AssertRule("OpenIllegalPath") {}
+Os::Test::FileTest::Tester::OpenIllegalPath::OpenIllegalPath() : Os::Test::FileTest::Tester::AssertRule("OpenIllegalPath") {}
 
-void Os::Test::File::Tester::OpenIllegalPath::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::OpenIllegalPath::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -820,9 +820,9 @@ void Os::Test::File::Tester::OpenIllegalPath::action(Os::Test::File::Tester &sta
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::OpenIllegalMode::OpenIllegalMode() : Os::Test::File::Tester::AssertRule("OpenIllegalMode") {}
+Os::Test::FileTest::Tester::OpenIllegalMode::OpenIllegalMode() : Os::Test::FileTest::Tester::AssertRule("OpenIllegalMode") {}
 
-void Os::Test::File::Tester::OpenIllegalMode::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::OpenIllegalMode::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -833,7 +833,7 @@ void Os::Test::File::Tester::OpenIllegalMode::action(Os::Test::File::Tester &sta
             state.m_file.open(random_filename->c_str(),
                               (mode == 0) ? Os::File::Mode::MAX_OPEN_MODE : Os::File::Mode::OPEN_NO_MODE,
                               overwrite ? Os::File::OverwriteType::OVERWRITE : Os::File::OverwriteType::NO_OVERWRITE),
-                              Os::Test::File::Tester::ASSERT_IN_FILE_CPP);
+                              Os::Test::FileTest::Tester::ASSERT_IN_FILE_CPP);
     state.assert_file_consistent();
 }
 
@@ -842,13 +842,13 @@ void Os::Test::File::Tester::OpenIllegalMode::action(Os::Test::File::Tester &sta
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::SeekIllegal::SeekIllegal() : Os::Test::File::Tester::AssertRule("SeekIllegal") {}
+Os::Test::FileTest::Tester::SeekIllegal::SeekIllegal() : Os::Test::FileTest::Tester::AssertRule("SeekIllegal") {}
 
-void Os::Test::File::Tester::SeekIllegal::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::SeekIllegal::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
-    ASSERT_DEATH_IF_SUPPORTED(state.m_file.seek(-1, Os::File::SeekType::ABSOLUTE), Os::Test::File::Tester::ASSERT_IN_FILE_CPP);
+    ASSERT_DEATH_IF_SUPPORTED(state.m_file.seek(-1, Os::File::SeekType::ABSOLUTE), Os::Test::FileTest::Tester::ASSERT_IN_FILE_CPP);
     state.assert_file_consistent();
 }
 
@@ -857,10 +857,10 @@ void Os::Test::File::Tester::SeekIllegal::action(Os::Test::File::Tester &state  
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::ReadIllegalBuffer::ReadIllegalBuffer()
-        : Os::Test::File::Tester::AssertRule("ReadIllegalBuffer") {}
+Os::Test::FileTest::Tester::ReadIllegalBuffer::ReadIllegalBuffer()
+        : Os::Test::FileTest::Tester::AssertRule("ReadIllegalBuffer") {}
 
-void Os::Test::File::Tester::ReadIllegalBuffer::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::ReadIllegalBuffer::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -868,7 +868,7 @@ void Os::Test::File::Tester::ReadIllegalBuffer::action(Os::Test::File::Tester &s
     bool random_wait = static_cast<bool>(STest::Pick::lowerUpper(0, 1));
     ASSERT_DEATH_IF_SUPPORTED(
             state.m_file.read(nullptr, size, random_wait ? Os::File::WaitType::WAIT : Os::File::WaitType::NO_WAIT),
-            Os::Test::File::Tester::ASSERT_IN_FILE_CPP);
+            Os::Test::FileTest::Tester::ASSERT_IN_FILE_CPP);
     state.assert_file_consistent();
 }
 
@@ -877,10 +877,10 @@ void Os::Test::File::Tester::ReadIllegalBuffer::action(Os::Test::File::Tester &s
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::WriteIllegalBuffer::WriteIllegalBuffer()
-        : Os::Test::File::Tester::AssertRule("WriteIllegalBuffer") {}
+Os::Test::FileTest::Tester::WriteIllegalBuffer::WriteIllegalBuffer()
+        : Os::Test::FileTest::Tester::AssertRule("WriteIllegalBuffer") {}
 
-void Os::Test::File::Tester::WriteIllegalBuffer::action(Os::Test::File::Tester &state  //!< The test state
+void Os::Test::FileTest::Tester::WriteIllegalBuffer::action(Os::Test::FileTest::Tester &state  //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -888,7 +888,7 @@ void Os::Test::File::Tester::WriteIllegalBuffer::action(Os::Test::File::Tester &
     bool random_wait = static_cast<bool>(STest::Pick::lowerUpper(0, 1));
     ASSERT_DEATH_IF_SUPPORTED(
             state.m_file.write(nullptr, size, random_wait ? Os::File::WaitType::WAIT : Os::File::WaitType::NO_WAIT),
-            Os::Test::File::Tester::ASSERT_IN_FILE_CPP);
+            Os::Test::FileTest::Tester::ASSERT_IN_FILE_CPP);
     state.assert_file_consistent();
 }
 
@@ -897,17 +897,17 @@ void Os::Test::File::Tester::WriteIllegalBuffer::action(Os::Test::File::Tester &
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::CopyAssignment::CopyAssignment() :
-    STest::Rule<Os::Test::File::Tester>("CopyAssignment") {}
+Os::Test::FileTest::Tester::CopyAssignment::CopyAssignment() :
+    STest::Rule<Os::Test::FileTest::Tester>("CopyAssignment") {}
 
 
-bool Os::Test::File::Tester::CopyAssignment::precondition(const Os::Test::File::Tester& state //!< The test state
+bool Os::Test::FileTest::Tester::CopyAssignment::precondition(const Os::Test::FileTest::Tester& state //!< The test state
 ) {
   return true;
 }
 
 
-void Os::Test::File::Tester::CopyAssignment::action(Os::Test::File::Tester& state //!< The test state
+void Os::Test::FileTest::Tester::CopyAssignment::action(Os::Test::FileTest::Tester& state //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -922,17 +922,17 @@ void Os::Test::File::Tester::CopyAssignment::action(Os::Test::File::Tester& stat
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::CopyConstruction::CopyConstruction() :
-    STest::Rule<Os::Test::File::Tester>("CopyConstruction") {}
+Os::Test::FileTest::Tester::CopyConstruction::CopyConstruction() :
+    STest::Rule<Os::Test::FileTest::Tester>("CopyConstruction") {}
 
 
-bool Os::Test::File::Tester::CopyConstruction::precondition(const Os::Test::File::Tester& state //!< The test state
+bool Os::Test::FileTest::Tester::CopyConstruction::precondition(const Os::Test::FileTest::Tester& state //!< The test state
 ) {
   return true;
 }
 
 
-void Os::Test::File::Tester::CopyConstruction::action(Os::Test::File::Tester& state //!< The test state
+void Os::Test::FileTest::Tester::CopyConstruction::action(Os::Test::FileTest::Tester& state //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -947,18 +947,18 @@ void Os::Test::File::Tester::CopyConstruction::action(Os::Test::File::Tester& st
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::FullCrc::FullCrc() :
-    STest::Rule<Os::Test::File::Tester>("FullCrc") {}
+Os::Test::FileTest::Tester::FullCrc::FullCrc() :
+    STest::Rule<Os::Test::FileTest::Tester>("FullCrc") {}
 
-bool Os::Test::File::Tester::FullCrc::precondition(
-        const Os::Test::File::Tester& state //!< The test state
+bool Os::Test::FileTest::Tester::FullCrc::precondition(
+        const Os::Test::FileTest::Tester& state //!< The test state
 ) {
     return state.m_mode == Os::File::Mode::OPEN_READ;
 }
 
 
-void Os::Test::File::Tester::FullCrc::action(
-        Os::Test::File::Tester& state //!< The test state
+void Os::Test::FileTest::Tester::FullCrc::action(
+        Os::Test::FileTest::Tester& state //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     U32 crc = 1;
@@ -976,19 +976,19 @@ void Os::Test::File::Tester::FullCrc::action(
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::IncrementalCrc::IncrementalCrc() :
-    STest::Rule<Os::Test::File::Tester>("IncrementalCrc") {}
+Os::Test::FileTest::Tester::IncrementalCrc::IncrementalCrc() :
+    STest::Rule<Os::Test::FileTest::Tester>("IncrementalCrc") {}
 
 
-bool Os::Test::File::Tester::IncrementalCrc::precondition(
-        const Os::Test::File::Tester& state //!< The test state
+bool Os::Test::FileTest::Tester::IncrementalCrc::precondition(
+        const Os::Test::FileTest::Tester& state //!< The test state
 ) {
     return state.m_mode == Os::File::Mode::OPEN_READ;
 }
 
 
-void Os::Test::File::Tester::IncrementalCrc::action(
-        Os::Test::File::Tester& state //!< The test state
+void Os::Test::FileTest::Tester::IncrementalCrc::action(
+        Os::Test::FileTest::Tester& state //!< The test state
 ){
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -1007,17 +1007,17 @@ void Os::Test::File::Tester::IncrementalCrc::action(
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::FinalizeCrc::FinalizeCrc() :
-    STest::Rule<Os::Test::File::Tester>("FinalizeCrc") {}
+Os::Test::FileTest::Tester::FinalizeCrc::FinalizeCrc() :
+    STest::Rule<Os::Test::FileTest::Tester>("FinalizeCrc") {}
 
-bool Os::Test::File::Tester::FinalizeCrc::precondition(
-        const Os::Test::File::Tester& state //!< The test state
+bool Os::Test::FileTest::Tester::FinalizeCrc::precondition(
+        const Os::Test::FileTest::Tester& state //!< The test state
 ) {
     return true;
 }
 
-void Os::Test::File::Tester::FinalizeCrc::action(
-        Os::Test::File::Tester& state //!< The test state
+void Os::Test::FileTest::Tester::FinalizeCrc::action(
+        Os::Test::FileTest::Tester& state //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     U32 crc = 1;
@@ -1035,18 +1035,18 @@ void Os::Test::File::Tester::FinalizeCrc::action(
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::FullCrcInvalidModes::FullCrcInvalidModes() :
-    STest::Rule<Os::Test::File::Tester>("FullCrcInvalidModes") {}
+Os::Test::FileTest::Tester::FullCrcInvalidModes::FullCrcInvalidModes() :
+    STest::Rule<Os::Test::FileTest::Tester>("FullCrcInvalidModes") {}
 
 
-bool Os::Test::File::Tester::FullCrcInvalidModes::precondition(
-        const Os::Test::File::Tester& state //!< The test state
+bool Os::Test::FileTest::Tester::FullCrcInvalidModes::precondition(
+        const Os::Test::FileTest::Tester& state //!< The test state
 ) {
     return Os::File::Mode::OPEN_READ != state.m_mode;
 }
 
-void Os::Test::File::Tester::FullCrcInvalidModes::action(
-        Os::Test::File::Tester& state //!< The test state
+void Os::Test::FileTest::Tester::FullCrcInvalidModes::action(
+        Os::Test::FileTest::Tester& state //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();
@@ -1068,19 +1068,19 @@ void Os::Test::File::Tester::FullCrcInvalidModes::action(
 //
 // ------------------------------------------------------------------------------------------------------
 
-Os::Test::File::Tester::IncrementalCrcInvalidModes::IncrementalCrcInvalidModes() :
-    STest::Rule<Os::Test::File::Tester>("IncrementalCrcInvalidModes") {}
+Os::Test::FileTest::Tester::IncrementalCrcInvalidModes::IncrementalCrcInvalidModes() :
+    STest::Rule<Os::Test::FileTest::Tester>("IncrementalCrcInvalidModes") {}
 
 
-bool Os::Test::File::Tester::IncrementalCrcInvalidModes::precondition(
-        const Os::Test::File::Tester& state //!< The test state
+bool Os::Test::FileTest::Tester::IncrementalCrcInvalidModes::precondition(
+        const Os::Test::FileTest::Tester& state //!< The test state
 ) {
     return Os::File::Mode::OPEN_READ != state.m_mode;;
 }
 
 
-void Os::Test::File::Tester::IncrementalCrcInvalidModes::action(
-        Os::Test::File::Tester& state //!< The test state
+void Os::Test::FileTest::Tester::IncrementalCrcInvalidModes::action(
+        Os::Test::FileTest::Tester& state //!< The test state
 ) {
     printf("--> Rule: %s \n", this->getName());
     state.assert_file_consistent();

--- a/Os/test/ut/file/FileRules.hpp
+++ b/Os/test/ut/file/FileRules.hpp
@@ -9,7 +9,7 @@
 //  OpenFile: base rule for all open rules
 //
 // ------------------------------------------------------------------------------------------------------
-struct OpenBaseRule : public STest::Rule<Os::Test::File::Tester> {
+struct OpenBaseRule : public STest::Rule<Os::Test::FileTest::Tester> {
     //! Constructor
     OpenBaseRule(const char *rule_name, Os::File::Mode mode = Os::File::Mode::OPEN_CREATE, const bool overwrite = false,
                  const bool randomize_filename = false);
@@ -23,11 +23,11 @@ struct OpenBaseRule : public STest::Rule<Os::Test::File::Tester> {
     // ----------------------------------------------------------------------
 
     //! Precondition
-    bool precondition(const Os::Test::File::Tester &state  //!< The test state
+    bool precondition(const Os::Test::FileTest::Tester &state  //!< The test state
     );
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -101,7 +101,7 @@ struct OpenForRead : public OpenBaseRule {
 // Rule:  CloseFile
 //
 // ------------------------------------------------------------------------------------------------------
-struct CloseFile : public STest::Rule<Os::Test::File::Tester> {
+struct CloseFile : public STest::Rule<Os::Test::FileTest::Tester> {
     // ----------------------------------------------------------------------
     // Construction
     // ----------------------------------------------------------------------
@@ -114,11 +114,11 @@ struct CloseFile : public STest::Rule<Os::Test::File::Tester> {
     // ----------------------------------------------------------------------
 
     //! Precondition
-    bool precondition(const Os::Test::File::Tester &state  //!< The test state
+    bool precondition(const Os::Test::FileTest::Tester &state  //!< The test state
     );
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -127,7 +127,7 @@ struct CloseFile : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  Read
 //
 // ------------------------------------------------------------------------------------------------------
-struct Read : public STest::Rule<Os::Test::File::Tester> {
+struct Read : public STest::Rule<Os::Test::FileTest::Tester> {
 
     // ----------------------------------------------------------------------
     // Construction
@@ -142,12 +142,12 @@ struct Read : public STest::Rule<Os::Test::File::Tester> {
 
     //! Precondition
     bool precondition(
-            const Os::Test::File::Tester &state //!< The test state
+            const Os::Test::FileTest::Tester &state //!< The test state
     );
 
     //! Action
     void action(
-            Os::Test::File::Tester &state //!< The test state
+            Os::Test::FileTest::Tester &state //!< The test state
     );
 
 };
@@ -157,7 +157,7 @@ struct Read : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  Write
 //
 // ------------------------------------------------------------------------------------------------------
-struct Write : public STest::Rule<Os::Test::File::Tester> {
+struct Write : public STest::Rule<Os::Test::FileTest::Tester> {
 
     // ----------------------------------------------------------------------
     // Construction
@@ -172,12 +172,12 @@ struct Write : public STest::Rule<Os::Test::File::Tester> {
 
     //! Precondition
     bool precondition(
-            const Os::Test::File::Tester &state //!< The test state
+            const Os::Test::FileTest::Tester &state //!< The test state
     );
 
     //! Action
     void action(
-            Os::Test::File::Tester &state //!< The test state
+            Os::Test::FileTest::Tester &state //!< The test state
     );
 
 };
@@ -187,7 +187,7 @@ struct Write : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  Seek
 //
 // ------------------------------------------------------------------------------------------------------
-struct Seek : public STest::Rule<Os::Test::File::Tester> {
+struct Seek : public STest::Rule<Os::Test::FileTest::Tester> {
 
     // ----------------------------------------------------------------------
     // Construction
@@ -202,12 +202,12 @@ struct Seek : public STest::Rule<Os::Test::File::Tester> {
 
     //! Precondition
     bool precondition(
-            const Os::Test::File::Tester &state //!< The test state
+            const Os::Test::FileTest::Tester &state //!< The test state
     );
 
     //! Action
     void action(
-            Os::Test::File::Tester &state //!< The test state
+            Os::Test::FileTest::Tester &state //!< The test state
     );
 
 };
@@ -216,7 +216,7 @@ struct Seek : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  Preallocate
 //
 // ------------------------------------------------------------------------------------------------------
-struct Preallocate : public STest::Rule<Os::Test::File::Tester> {
+struct Preallocate : public STest::Rule<Os::Test::FileTest::Tester> {
 
     // ----------------------------------------------------------------------
     // Construction
@@ -231,12 +231,12 @@ struct Preallocate : public STest::Rule<Os::Test::File::Tester> {
 
     //! Precondition
     bool precondition(
-            const Os::Test::File::Tester &state //!< The test state
+            const Os::Test::FileTest::Tester &state //!< The test state
     );
 
     //! Action
     void action(
-            Os::Test::File::Tester &state //!< The test state
+            Os::Test::FileTest::Tester &state //!< The test state
     );
 
 };
@@ -246,7 +246,7 @@ struct Preallocate : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  Flush
 //
 // ------------------------------------------------------------------------------------------------------
-struct Flush : public STest::Rule<Os::Test::File::Tester> {
+struct Flush : public STest::Rule<Os::Test::FileTest::Tester> {
 
     // ----------------------------------------------------------------------
     // Construction
@@ -261,12 +261,12 @@ struct Flush : public STest::Rule<Os::Test::File::Tester> {
 
     //! Precondition
     bool precondition(
-            const Os::Test::File::Tester &state //!< The test state
+            const Os::Test::FileTest::Tester &state //!< The test state
     );
 
     //! Action
     void action(
-            Os::Test::File::Tester &state //!< The test state
+            Os::Test::FileTest::Tester &state //!< The test state
     );
 
 };
@@ -276,7 +276,7 @@ struct Flush : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  OpenInvalidModes
 //
 // ------------------------------------------------------------------------------------------------------
-struct OpenInvalidModes : public STest::Rule<Os::Test::File::Tester> {
+struct OpenInvalidModes : public STest::Rule<Os::Test::FileTest::Tester> {
     // ----------------------------------------------------------------------
     // Construction
     // ----------------------------------------------------------------------
@@ -289,11 +289,11 @@ struct OpenInvalidModes : public STest::Rule<Os::Test::File::Tester> {
     // ----------------------------------------------------------------------
 
     //! Precondition
-    bool precondition(const Os::Test::File::Tester &state  //!< The test state
+    bool precondition(const Os::Test::FileTest::Tester &state  //!< The test state
     );
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -301,7 +301,7 @@ struct OpenInvalidModes : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  PreallocateWithoutOpen
 //
 // ------------------------------------------------------------------------------------------------------
-struct PreallocateWithoutOpen : public STest::Rule<Os::Test::File::Tester> {
+struct PreallocateWithoutOpen : public STest::Rule<Os::Test::FileTest::Tester> {
     // ----------------------------------------------------------------------
     // Construction
     // ----------------------------------------------------------------------
@@ -314,11 +314,11 @@ struct PreallocateWithoutOpen : public STest::Rule<Os::Test::File::Tester> {
     // ----------------------------------------------------------------------
 
     //! Precondition
-    bool precondition(const Os::Test::File::Tester &state  //!< The test state
+    bool precondition(const Os::Test::FileTest::Tester &state  //!< The test state
     );
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -326,7 +326,7 @@ struct PreallocateWithoutOpen : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  SeekWithoutOpen
 //
 // ------------------------------------------------------------------------------------------------------
-struct SeekWithoutOpen : public STest::Rule<Os::Test::File::Tester> {
+struct SeekWithoutOpen : public STest::Rule<Os::Test::FileTest::Tester> {
     // ----------------------------------------------------------------------
     // Construction
     // ----------------------------------------------------------------------
@@ -339,11 +339,11 @@ struct SeekWithoutOpen : public STest::Rule<Os::Test::File::Tester> {
     // ----------------------------------------------------------------------
 
     //! Precondition
-    bool precondition(const Os::Test::File::Tester &state  //!< The test state
+    bool precondition(const Os::Test::FileTest::Tester &state  //!< The test state
     );
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -351,7 +351,7 @@ struct SeekWithoutOpen : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  SeekInvalidSize
 //
 // ------------------------------------------------------------------------------------------------------
-struct SeekInvalidSize : public STest::Rule<Os::Test::File::Tester> {
+struct SeekInvalidSize : public STest::Rule<Os::Test::FileTest::Tester> {
     // ----------------------------------------------------------------------
     // Construction
     // ----------------------------------------------------------------------
@@ -364,11 +364,11 @@ struct SeekInvalidSize : public STest::Rule<Os::Test::File::Tester> {
     // ----------------------------------------------------------------------
 
     //! Precondition
-    bool precondition(const Os::Test::File::Tester &state  //!< The test state
+    bool precondition(const Os::Test::FileTest::Tester &state  //!< The test state
     );
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -376,7 +376,7 @@ struct SeekInvalidSize : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  FlushInvalidModes
 //
 // ------------------------------------------------------------------------------------------------------
-struct FlushInvalidModes : public STest::Rule<Os::Test::File::Tester> {
+struct FlushInvalidModes : public STest::Rule<Os::Test::FileTest::Tester> {
     // ----------------------------------------------------------------------
     // Construction
     // ----------------------------------------------------------------------
@@ -389,11 +389,11 @@ struct FlushInvalidModes : public STest::Rule<Os::Test::File::Tester> {
     // ----------------------------------------------------------------------
 
     //! Precondition
-    bool precondition(const Os::Test::File::Tester &state  //!< The test state
+    bool precondition(const Os::Test::FileTest::Tester &state  //!< The test state
     );
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -401,7 +401,7 @@ struct FlushInvalidModes : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  ReadInvalidModes
 //
 // ------------------------------------------------------------------------------------------------------
-struct ReadInvalidModes : public STest::Rule<Os::Test::File::Tester> {
+struct ReadInvalidModes : public STest::Rule<Os::Test::FileTest::Tester> {
     // ----------------------------------------------------------------------
     // Construction
     // ----------------------------------------------------------------------
@@ -414,11 +414,11 @@ struct ReadInvalidModes : public STest::Rule<Os::Test::File::Tester> {
     // ----------------------------------------------------------------------
 
     //! Precondition
-    bool precondition(const Os::Test::File::Tester &state  //!< The test state
+    bool precondition(const Os::Test::FileTest::Tester &state  //!< The test state
     );
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -426,7 +426,7 @@ struct ReadInvalidModes : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  WriteInvalidModes
 //
 // ------------------------------------------------------------------------------------------------------
-struct WriteInvalidModes : public STest::Rule<Os::Test::File::Tester> {
+struct WriteInvalidModes : public STest::Rule<Os::Test::FileTest::Tester> {
     // ----------------------------------------------------------------------
     // Construction
     // ----------------------------------------------------------------------
@@ -439,11 +439,11 @@ struct WriteInvalidModes : public STest::Rule<Os::Test::File::Tester> {
     // ----------------------------------------------------------------------
 
     //! Precondition
-    bool precondition(const Os::Test::File::Tester &state  //!< The test state
+    bool precondition(const Os::Test::FileTest::Tester &state  //!< The test state
     );
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -451,7 +451,7 @@ struct WriteInvalidModes : public STest::Rule<Os::Test::File::Tester> {
 // Base Rule:  AssertRule
 //
 // ------------------------------------------------------------------------------------------------------
-struct AssertRule : public STest::Rule<Os::Test::File::Tester> {
+struct AssertRule : public STest::Rule<Os::Test::FileTest::Tester> {
     // ----------------------------------------------------------------------
     // Construction
     // ----------------------------------------------------------------------
@@ -464,11 +464,11 @@ struct AssertRule : public STest::Rule<Os::Test::File::Tester> {
     // ----------------------------------------------------------------------
 
     //! Precondition
-    bool precondition(const Os::Test::File::Tester &state  //!< The test state
+    bool precondition(const Os::Test::FileTest::Tester &state  //!< The test state
     );
 
     //! Action
-    virtual void action(Os::Test::File::Tester &state  //!< The test state
+    virtual void action(Os::Test::FileTest::Tester &state  //!< The test state
     ) = 0;
 };
 
@@ -489,7 +489,7 @@ struct OpenIllegalPath : public AssertRule {
     // ----------------------------------------------------------------------
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     ) override;
 };
 
@@ -510,7 +510,7 @@ struct OpenIllegalMode : public AssertRule {
     // ----------------------------------------------------------------------
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -531,7 +531,7 @@ struct SeekIllegal : public AssertRule {
     // ----------------------------------------------------------------------
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -552,7 +552,7 @@ struct ReadIllegalBuffer : public AssertRule {
     // ----------------------------------------------------------------------
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -573,7 +573,7 @@ struct WriteIllegalBuffer : public AssertRule {
     // ----------------------------------------------------------------------
 
     //! Action
-    void action(Os::Test::File::Tester &state  //!< The test state
+    void action(Os::Test::FileTest::Tester &state  //!< The test state
     );
 };
 
@@ -581,7 +581,7 @@ struct WriteIllegalBuffer : public AssertRule {
 // Rule:  CopyAssignment
 //
 // ------------------------------------------------------------------------------------------------------
-struct CopyAssignment : public STest::Rule<Os::Test::File::Tester> {
+struct CopyAssignment : public STest::Rule<Os::Test::FileTest::Tester> {
 
         // ----------------------------------------------------------------------
         // Construction
@@ -596,12 +596,12 @@ struct CopyAssignment : public STest::Rule<Os::Test::File::Tester> {
 
         //! Precondition
         bool precondition(
-            const Os::Test::File::Tester& state //!< The test state
+            const Os::Test::FileTest::Tester& state //!< The test state
         );
 
         //! Action
         void action(
-            Os::Test::File::Tester& state //!< The test state
+            Os::Test::FileTest::Tester& state //!< The test state
         );
 
 };
@@ -610,7 +610,7 @@ struct CopyAssignment : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  CopyConstruction
 //
 // ------------------------------------------------------------------------------------------------------
-struct CopyConstruction : public STest::Rule<Os::Test::File::Tester> {
+struct CopyConstruction : public STest::Rule<Os::Test::FileTest::Tester> {
 
         // ----------------------------------------------------------------------
         // Construction
@@ -625,12 +625,12 @@ struct CopyConstruction : public STest::Rule<Os::Test::File::Tester> {
 
         //! Precondition
         bool precondition(
-            const Os::Test::File::Tester& state //!< The test state
+            const Os::Test::FileTest::Tester& state //!< The test state
         );
 
         //! Action
         void action(
-            Os::Test::File::Tester& state //!< The test state
+            Os::Test::FileTest::Tester& state //!< The test state
         );
 
 };
@@ -639,7 +639,7 @@ struct CopyConstruction : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  FullCrc
 //
 // ------------------------------------------------------------------------------------------------------
-struct FullCrc : public STest::Rule<Os::Test::File::Tester> {
+struct FullCrc : public STest::Rule<Os::Test::FileTest::Tester> {
 
         // ----------------------------------------------------------------------
         // Construction
@@ -654,12 +654,12 @@ struct FullCrc : public STest::Rule<Os::Test::File::Tester> {
 
         //! Precondition
         bool precondition(
-            const Os::Test::File::Tester& state //!< The test state
+            const Os::Test::FileTest::Tester& state //!< The test state
         );
 
         //! Action
         void action(
-            Os::Test::File::Tester& state //!< The test state
+            Os::Test::FileTest::Tester& state //!< The test state
         );
 };
 
@@ -667,7 +667,7 @@ struct FullCrc : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  IncrementalCrc
 //
 // ------------------------------------------------------------------------------------------------------
-struct IncrementalCrc : public STest::Rule<Os::Test::File::Tester> {
+struct IncrementalCrc : public STest::Rule<Os::Test::FileTest::Tester> {
 
         // ----------------------------------------------------------------------
         // Construction
@@ -682,12 +682,12 @@ struct IncrementalCrc : public STest::Rule<Os::Test::File::Tester> {
 
         //! Precondition
         bool precondition(
-            const Os::Test::File::Tester& state //!< The test state
+            const Os::Test::FileTest::Tester& state //!< The test state
         );
 
         //! Action
         void action(
-            Os::Test::File::Tester& state //!< The test state
+            Os::Test::FileTest::Tester& state //!< The test state
         );
 
 };
@@ -696,7 +696,7 @@ struct IncrementalCrc : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  FinalizeCrc
 //
 // ------------------------------------------------------------------------------------------------------
-struct FinalizeCrc : public STest::Rule<Os::Test::File::Tester> {
+struct FinalizeCrc : public STest::Rule<Os::Test::FileTest::Tester> {
 
         // ----------------------------------------------------------------------
         // Construction
@@ -711,12 +711,12 @@ struct FinalizeCrc : public STest::Rule<Os::Test::File::Tester> {
 
         //! Precondition
         bool precondition(
-            const Os::Test::File::Tester& state //!< The test state
+            const Os::Test::FileTest::Tester& state //!< The test state
         );
 
         //! Action
         void action(
-            Os::Test::File::Tester& state //!< The test state
+            Os::Test::FileTest::Tester& state //!< The test state
         );
 
 };
@@ -725,7 +725,7 @@ struct FinalizeCrc : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  FullCrcInvalidModes
 //
 // ------------------------------------------------------------------------------------------------------
-struct FullCrcInvalidModes : public STest::Rule<Os::Test::File::Tester> {
+struct FullCrcInvalidModes : public STest::Rule<Os::Test::FileTest::Tester> {
 
         // ----------------------------------------------------------------------
         // Construction
@@ -740,12 +740,12 @@ struct FullCrcInvalidModes : public STest::Rule<Os::Test::File::Tester> {
 
         //! Precondition
         bool precondition(
-            const Os::Test::File::Tester& state //!< The test state
+            const Os::Test::FileTest::Tester& state //!< The test state
         );
 
         //! Action
         void action(
-            Os::Test::File::Tester& state //!< The test state
+            Os::Test::FileTest::Tester& state //!< The test state
         );
 };
 
@@ -753,7 +753,7 @@ struct FullCrcInvalidModes : public STest::Rule<Os::Test::File::Tester> {
 // Rule:  IncrementalCrcInvalidModes
 //
 // ------------------------------------------------------------------------------------------------------
-struct IncrementalCrcInvalidModes : public STest::Rule<Os::Test::File::Tester> {
+struct IncrementalCrcInvalidModes : public STest::Rule<Os::Test::FileTest::Tester> {
 
         // ----------------------------------------------------------------------
         // Construction
@@ -768,11 +768,11 @@ struct IncrementalCrcInvalidModes : public STest::Rule<Os::Test::File::Tester> {
 
         //! Precondition
         bool precondition(
-            const Os::Test::File::Tester& state //!< The test state
+            const Os::Test::FileTest::Tester& state //!< The test state
         );
 
         //! Action
         void action(
-            Os::Test::File::Tester& state //!< The test state
+            Os::Test::FileTest::Tester& state //!< The test state
         );
 };

--- a/Os/test/ut/file/RulesHeaders.hpp
+++ b/Os/test/ut/file/RulesHeaders.hpp
@@ -17,7 +17,7 @@
 
 namespace Os {
 namespace Test {
-namespace File {
+namespace FileTest {
 
 struct Tester {
     //! State data for an open OS file.
@@ -153,8 +153,8 @@ struct Tester {
 //! Get the tester implementation for the given backend.
 //! \return pointer to tester subclass implementation
 //!
-std::unique_ptr<Os::Test::File::Tester> get_tester_implementation();
-}  // namespace File
+std::unique_ptr<Os::Test::FileTest::Tester> get_tester_implementation();
+}  // namespace FileTester
 }  // namespace Test
 }  // namespace Os
 #endif  // __RULES_HEADERS__


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3446  |
|**_Has Unit Tests (y/n)_**| Yes - existing |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

Updates to `Os/File.hpp`:

* `PRIVATE` -> `private`

There were issues with existing namespaces and class names conflicting, so I first (1) updated the Os::Test::File namespace from `File` -> `FileTest` and made the corresponding updates where that namespace was used, and then (2) added a `friend struct` until no build errors.