### PR TITLE
Fix ambiguous error for .serialize() overloads

### DIFF
--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -360,7 +360,7 @@ void FileDownlink ::sendCancelPacket() {
               static_cast<FwAssertArgType>(filePacket.bufferSize() + sizeof(FwPacketDescriptorType)));
 
     // Serialize the packet descriptor FW_PACKET_FILE to the buffer
-    Fw::SerializeStatus status = buffer.getSerializer().serialize(static_cast<U32>(Fw::ComPacket::FW_PACKET_FILE));
+    Fw::SerializeStatus status = buffer.getSerializer().serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_FILE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType),
                             buffer.getSize() - static_cast<Fw::Buffer::SizeType>(sizeof(FwPacketDescriptorType)));
@@ -398,7 +398,7 @@ void FileDownlink ::sendFilePacket(const Fw::FilePacket& filePacket) {
     FW_ASSERT(this->m_buffer.getSize() >= bufferSize, static_cast<FwAssertArgType>(bufferSize),
               static_cast<FwAssertArgType>(this->m_buffer.getSize()));
     // Serialize packet descriptor FW_PACKET_FILE to the buffer
-    Fw::SerializeStatus status = this->m_buffer.getSerializer().serialize(static_cast<U32>(Fw::ComPacket::FW_PACKET_FILE));
+    Fw::SerializeStatus status = this->m_buffer.getSerializer().serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_FILE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // Serialize the filePacket content into the buffer, offset by the size of the packet descriptor
     Fw::Buffer offsetBuffer(

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -360,7 +360,7 @@ void FileDownlink ::sendCancelPacket() {
               static_cast<FwAssertArgType>(filePacket.bufferSize() + sizeof(FwPacketDescriptorType)));
 
     // Serialize the packet descriptor FW_PACKET_FILE to the buffer
-    Fw::SerializeStatus status = buffer.getSerializer().serialize(static_cast<U8>(Fw::ComPacket::FW_PACKET_FILE));
+    Fw::SerializeStatus status = buffer.getSerializer().serialize(static_cast<U32>(Fw::ComPacket::FW_PACKET_FILE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType),
                             buffer.getSize() - static_cast<Fw::Buffer::SizeType>(sizeof(FwPacketDescriptorType)));
@@ -398,7 +398,7 @@ void FileDownlink ::sendFilePacket(const Fw::FilePacket& filePacket) {
     FW_ASSERT(this->m_buffer.getSize() >= bufferSize, static_cast<FwAssertArgType>(bufferSize),
               static_cast<FwAssertArgType>(this->m_buffer.getSize()));
     // Serialize packet descriptor FW_PACKET_FILE to the buffer
-    Fw::SerializeStatus status = this->m_buffer.getSerializer().serialize(static_cast<U8>(Fw::ComPacket::FW_PACKET_FILE));
+    Fw::SerializeStatus status = this->m_buffer.getSerializer().serialize(static_cast<U32>(Fw::ComPacket::FW_PACKET_FILE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // Serialize the filePacket content into the buffer, offset by the size of the packet descriptor
     Fw::Buffer offsetBuffer(

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -360,7 +360,7 @@ void FileDownlink ::sendCancelPacket() {
               static_cast<FwAssertArgType>(filePacket.bufferSize() + sizeof(FwPacketDescriptorType)));
 
     // Serialize the packet descriptor FW_PACKET_FILE to the buffer
-    Fw::SerializeStatus status = buffer.getSerializer().serialize(Fw::ComPacket::FW_PACKET_FILE);
+    Fw::SerializeStatus status = buffer.getSerializer().serialize(static_cast<U8>(Fw::ComPacket::FW_PACKET_FILE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType),
                             buffer.getSize() - static_cast<Fw::Buffer::SizeType>(sizeof(FwPacketDescriptorType)));
@@ -398,7 +398,7 @@ void FileDownlink ::sendFilePacket(const Fw::FilePacket& filePacket) {
     FW_ASSERT(this->m_buffer.getSize() >= bufferSize, static_cast<FwAssertArgType>(bufferSize),
               static_cast<FwAssertArgType>(this->m_buffer.getSize()));
     // Serialize packet descriptor FW_PACKET_FILE to the buffer
-    Fw::SerializeStatus status = this->m_buffer.getSerializer().serialize(Fw::ComPacket::FW_PACKET_FILE);
+    Fw::SerializeStatus status = this->m_buffer.getSerializer().serialize(static_cast<U8>(Fw::ComPacket::FW_PACKET_FILE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // Serialize the filePacket content into the buffer, offset by the size of the packet descriptor
     Fw::Buffer offsetBuffer(

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -50,7 +50,7 @@ Signal FpySequencer::dispatchStatement() {
 Fw::Success FpySequencer::dispatchCommand(const Fpy::Statement& stmt) {
     FW_ASSERT(stmt.gettype() == Fpy::StatementType::COMMAND);
     Fw::ComBuffer cmdBuf;
-    Fw::SerializeStatus stat = cmdBuf.serialize(Fw::ComPacket::FW_PACKET_COMMAND);
+    Fw::SerializeStatus stat = cmdBuf.serialize(static_cast<U8>(Fw::ComPacket::FW_PACKET_COMMAND));
     // TODO should I assert here? this really shouldn't fail, I should just add a static assert
     // on com buf size and then assert here
     if (stat != Fw::SerializeStatus::FW_SERIALIZE_OK) {

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -50,7 +50,7 @@ Signal FpySequencer::dispatchStatement() {
 Fw::Success FpySequencer::dispatchCommand(const Fpy::Statement& stmt) {
     FW_ASSERT(stmt.gettype() == Fpy::StatementType::COMMAND);
     Fw::ComBuffer cmdBuf;
-    Fw::SerializeStatus stat = cmdBuf.serialize(static_cast<U32>(Fw::ComPacket::FW_PACKET_COMMAND));
+    Fw::SerializeStatus stat = cmdBuf.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_COMMAND));
     // TODO should I assert here? this really shouldn't fail, I should just add a static assert
     // on com buf size and then assert here
     if (stat != Fw::SerializeStatus::FW_SERIALIZE_OK) {

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -50,7 +50,7 @@ Signal FpySequencer::dispatchStatement() {
 Fw::Success FpySequencer::dispatchCommand(const Fpy::Statement& stmt) {
     FW_ASSERT(stmt.gettype() == Fpy::StatementType::COMMAND);
     Fw::ComBuffer cmdBuf;
-    Fw::SerializeStatus stat = cmdBuf.serialize(static_cast<U8>(Fw::ComPacket::FW_PACKET_COMMAND));
+    Fw::SerializeStatus stat = cmdBuf.serialize(static_cast<U32>(Fw::ComPacket::FW_PACKET_COMMAND));
     // TODO should I assert here? this really shouldn't fail, I should just add a static assert
     // on com buf size and then assert here
     if (stat != Fw::SerializeStatus::FW_SERIALIZE_OK) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

Add `static_cast<U32>` to the `.serialize()` calls within [`FileDownlink.cpp`](https://github.com/nasa/fprime/blob/7f5710ace0c9bc2b1109b64f6b36c3d31102a933/Svc/FileDownlink/FileDownlink.cpp#L363) and [`FpySequencerRunState.cpp`](https://github.com/nasa/fprime/blob/7f5710ace0c9bc2b1109b64f6b36c3d31102a933/Svc/FpySequencer/FpySequencerRunState.cpp#L53).

## Rationale

Older versions of GCC (i.e. GCC 11.3.1) aren't that clever at picking one of the overloaded functions for `.serialize()`. So it gives the error:
```sh
fprime/Svc/FpySequencer/FpySequencerRunState.cpp:53:48: error: call of overloaded 'serialize(Fw::ComPacket::ComPacketType)' is ambiguous
   53 |     Fw::SerializeStatus stat = cmdBuf.serialize(Fw::ComPacket::FW_PACKET_COMMAND);
      |                                ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from fprime/Fw/Com/ComPacket.hpp:11,
                 from fprime/Svc/FpySequencer/FpySequencerRunState.cpp:2:
fprime/Fw/Types/Serializable.hpp:63:21: note: candidate: 'Fw::SerializeStatus Fw::SerializeBufferBase::serialize(U8)'
   63 |     SerializeStatus serialize(U8 val);  //!< serialize 8-bit unsigned int
      |                     ^~~~~~~~~
fprime/Fw/Types/Serializable.hpp:64:21: note: candidate: 'Fw::SerializeStatus Fw::SerializeBufferBase::serialize(I8)'
   64 |     SerializeStatus serialize(I8 val);  //!< serialize 8-bit signed int
      |                     ^~~~~~~~~
fprime/Fw/Types/Serializable.hpp:67:21: note: candidate: 'Fw::SerializeStatus Fw::SerializeBufferBase::serialize(U16)'
   67 |     SerializeStatus serialize(U16 val);  //!< serialize 16-bit unsigned int
      |                     ^~~~~~~~~

... etc.
```

I chose to cast as `U32` based on unit tests. `Fw.Com` has a `U32` context that causes the UT to fail if casted as an `U8` (specifically [`FpySequencerTestMain.cpp:772`](https://github.com/nasa/fprime/blob/7f5710ace0c9bc2b1109b64f6b36c3d31102a933/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp#L772).

## Testing/Review Recommendations

I tested this on `fprime-arduino` toolchains since some of them use older GCC versions. 

Review:
Make sure it is fine to cast as a `U32`.

## Future Work

N/A
