### PR TITLE
Purge PlatformIntType and PlatformUIntType

### DIFF
--- a/Drv/Ip/IpSocket.cpp
+++ b/Drv/Ip/IpSocket.cpp
@@ -65,7 +65,7 @@ bool IpSocket::isValidPort(U16 port) {
     return true;
 }
 
-SocketIpStatus IpSocket::setupTimeouts(PlatformIntType socketFd) {
+SocketIpStatus IpSocket::setupTimeouts(int socketFd) {
 // Get the IP address from host
 #ifdef TGT_OS_TYPE_VXWORKS
     // No timeouts set on Vxworks
@@ -87,7 +87,7 @@ SocketIpStatus IpSocket::addressToIp4(const char* address, void* ip4) {
     FW_ASSERT(ip4 != nullptr);
     // Get the IP address from host
 #ifdef TGT_OS_TYPE_VXWORKS
-    PlatformIntType ip = inet_addr(address);
+    int ip = inet_addr(address);
     if (ip == ERROR) {
         return SOCK_INVALID_IP_ADDRESS;
     }
@@ -109,7 +109,7 @@ void IpSocket::close(const SocketDescriptor& socketDescriptor) {
 
 void IpSocket::shutdown(const SocketDescriptor& socketDescriptor) {
     errno = 0;
-    PlatformIntType status = ::shutdown(socketDescriptor.fd, SHUT_RDWR);
+    int status = ::shutdown(socketDescriptor.fd, SHUT_RDWR);
     // If shutdown fails, go straight to the hard-shutdown
     if (status != 0) {
         this->close(socketDescriptor);

--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -19,8 +19,8 @@
 namespace Drv {
 
 struct SocketDescriptor final {
-    PlatformIntType fd = -1; //!< Used for all sockets to track the communication file descriptor
-    PlatformIntType serverFd = -1; //!< Used for server sockets to track the listening file descriptor
+    int fd = -1; //!< Used for all sockets to track the communication file descriptor
+    int serverFd = -1; //!< Used for server sockets to track the listening file descriptor
 };
 
 /**
@@ -174,7 +174,7 @@ class IpSocket {
      * \param socketDescriptor: socket descriptor to setup
      * \return status of timeout setup
     */
-    SocketIpStatus setupTimeouts(PlatformIntType socketFd);
+    SocketIpStatus setupTimeouts(int socketFd);
 
     /**
      * \brief converts a given address in dot form x.x.x.x to an ip address. ONLY works for IPv4.

--- a/Drv/Ip/TcpClientSocket.cpp
+++ b/Drv/Ip/TcpClientSocket.cpp
@@ -48,7 +48,7 @@ bool TcpClientSocket::isValidPort(U16 port) {
 
 
 SocketIpStatus TcpClientSocket::openProtocol(SocketDescriptor& socketDescriptor) {
-    PlatformIntType socketFd = -1;
+    int socketFd = -1;
     struct sockaddr_in address;
 
     // Acquire a socket, or return error

--- a/Drv/Ip/TcpServerSocket.cpp
+++ b/Drv/Ip/TcpServerSocket.cpp
@@ -46,7 +46,7 @@ U16 TcpServerSocket::getListenPort() {
 }
 
 SocketIpStatus TcpServerSocket::startup(SocketDescriptor& socketDescriptor) {
-    PlatformIntType serverFd = -1;
+    int serverFd = -1;
     struct sockaddr_in address;
     // Acquire a socket, or return error
     if ((serverFd = ::socket(AF_INET, SOCK_STREAM, 0)) == -1) {
@@ -94,8 +94,8 @@ void TcpServerSocket::terminate(const SocketDescriptor& socketDescriptor) {
 }
 
 SocketIpStatus TcpServerSocket::openProtocol(SocketDescriptor& socketDescriptor) {
-    PlatformIntType clientFd = -1;
-    PlatformIntType serverFd = socketDescriptor.serverFd;
+    int clientFd = -1;
+    int serverFd = socketDescriptor.serverFd;
 
     // Check for not started yet, may be true in the case of start-up reconnect attempts
     if (serverFd == -1) {

--- a/Drv/Ip/UdpSocket.cpp
+++ b/Drv/Ip/UdpSocket.cpp
@@ -86,7 +86,7 @@ U16 UdpSocket::getRecvPort() {
 }
 
 
-SocketIpStatus UdpSocket::bind(const PlatformIntType fd) {
+SocketIpStatus UdpSocket::bind(const int fd) {
     struct sockaddr_in address;
     FW_ASSERT(fd != -1);
 
@@ -123,7 +123,7 @@ SocketIpStatus UdpSocket::bind(const PlatformIntType fd) {
 
 SocketIpStatus UdpSocket::openProtocol(SocketDescriptor& socketDescriptor) {
     SocketIpStatus status = SOCK_SUCCESS;
-    PlatformIntType socketFd = -1;
+    int socketFd = -1;
     struct sockaddr_in address;
 
     U16 port = this->m_port;

--- a/Drv/Ip/UdpSocket.hpp
+++ b/Drv/Ip/UdpSocket.hpp
@@ -98,7 +98,7 @@ class UdpSocket : public IpSocket {
      * \param socketDescriptor: socket descriptor used in bind
      * \return status of the bind
      */
-    SocketIpStatus bind(const PlatformIntType fd);
+    SocketIpStatus bind(const int fd);
     /**
      * \brief udp specific implementation for opening a socket.
      * \param socketDescriptor: (output) file descriptor opened. Only valid on SOCK_SUCCESS. Otherwise will be invalid

--- a/Drv/Ip/test/ut/PortSelector.cpp
+++ b/Drv/Ip/test/ut/PortSelector.cpp
@@ -13,7 +13,7 @@ namespace Test {
 
 U16 get_free_port(bool udp) {
     struct sockaddr_in address;
-    PlatformIntType socketFd = -1;
+    int socketFd = -1;
     // Acquire a socket, or return error
     if ((socketFd = ::socket(AF_INET, (udp) ? SOCK_DGRAM : SOCK_STREAM, 0)) == -1) {
         return 0;

--- a/Drv/Ip/test/ut/SocketTestHelper.cpp
+++ b/Drv/Ip/test/ut/SocketTestHelper.cpp
@@ -17,7 +17,7 @@ namespace Test {
 
 const U32 MAX_DRV_TEST_MESSAGE_SIZE = 1024;
 
-void force_recv_timeout(PlatformIntType fd, Drv::IpSocket& socket) {
+void force_recv_timeout(int fd, Drv::IpSocket& socket) {
     // Set timeout socket option
     struct timeval timeout;
     timeout.tv_sec = 0;

--- a/Drv/Ip/test/ut/SocketTestHelper.hpp
+++ b/Drv/Ip/test/ut/SocketTestHelper.hpp
@@ -19,7 +19,7 @@ static constexpr U16 MAX_ITER = 10;
  * @param fd: socket file descriptor
  * @param socket: socket to make timeout
  */
-void force_recv_timeout(PlatformIntType fd, Drv::IpSocket &socket);
+void force_recv_timeout(int fd, Drv::IpSocket &socket);
 
 /**
  * Validate random data from data against truth

--- a/Drv/LinuxGpioDriver/LinuxGpioDriver.hpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriver.hpp
@@ -70,7 +70,7 @@ class LinuxGpioDriver final : public LinuxGpioDriverComponentBase {
     Drv::GpioStatus start(const FwTaskPriorityType priority = Os::Task::TASK_PRIORITY_DEFAULT,
                           const FwSizeType stackSize = Os::Task::TASK_DEFAULT,
                           const FwSizeType cpuAffinity = Os::Task::TASK_DEFAULT,
-                          const unsigned int identifier = static_cast<unsigned int>(Os::Task::TASK_DEFAULT));
+                          const FwTaskIdType identifier = static_cast<FwTaskIdType>(Os::Task::TASK_DEFAULT));
 
     //! \brief stop interrupt detection thread
     //!

--- a/Drv/LinuxGpioDriver/LinuxGpioDriver.hpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriver.hpp
@@ -70,7 +70,7 @@ class LinuxGpioDriver final : public LinuxGpioDriverComponentBase {
     Drv::GpioStatus start(const FwTaskPriorityType priority = Os::Task::TASK_PRIORITY_DEFAULT,
                           const FwSizeType stackSize = Os::Task::TASK_DEFAULT,
                           const FwSizeType cpuAffinity = Os::Task::TASK_DEFAULT,
-                          const PlatformUIntType identifier = static_cast<PlatformUIntType>(Os::Task::TASK_DEFAULT));
+                          const unsigned int identifier = static_cast<unsigned int>(Os::Task::TASK_DEFAULT));
 
     //! \brief stop interrupt detection thread
     //!
@@ -82,17 +82,17 @@ class LinuxGpioDriver final : public LinuxGpioDriverComponentBase {
 
   private:
     //! \brief helper to setup a line handle (read or write).
-    Os::File::Status setupLineHandle(const PlatformIntType chip_descriptor,
+    Os::File::Status setupLineHandle(const int chip_descriptor,
                                      const U32 gpio,
                                      const GpioConfiguration& configuration,
                                      const Fw::Logic& default_state,
-                                     PlatformIntType& fd);
+                                     int& fd);
 
     //! \brief helper to setup a line event (interrupt)
-    Os::File::Status setupLineEvent(const PlatformIntType chip_descriptor,
+    Os::File::Status setupLineEvent(const int chip_descriptor,
                                     const U32 gpio,
                                     const GpioConfiguration& configuration,
-                                    PlatformIntType& fd);
+                                    int& fd);
 
     //! \brief poll for interrupt loop helper
     //!
@@ -129,7 +129,7 @@ class LinuxGpioDriver final : public LinuxGpioDriverComponentBase {
     GpioConfiguration m_configuration = GpioConfiguration::MAX_GPIO_CONFIGURATION;
 
     //! File descriptor for GPIO
-    PlatformIntType m_fd = -1;
+    int m_fd = -1;
 
     //! Determine if the interrupt polling thread is running
     bool m_running = false;

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverCommon.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverCommon.cpp
@@ -24,7 +24,7 @@ LinuxGpioDriver ::LinuxGpioDriver(const char* const compName) : LinuxGpioDriverC
 Drv::GpioStatus LinuxGpioDriver ::start(const FwTaskPriorityType priority,
                                         const FwSizeType stackSize,
                                         const FwSizeType cpuAffinity,
-                                        const unsigned int identifier) {
+                                        const FwTaskIdType identifier) {
     Drv::GpioStatus status = Drv::GpioStatus::INVALID_MODE;
     if (this->m_configuration < GpioConfiguration::MAX_GPIO_CONFIGURATION &&
         this->m_configuration >= GpioConfiguration::GPIO_INTERRUPT_RISING_EDGE) {

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverCommon.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverCommon.cpp
@@ -24,7 +24,7 @@ LinuxGpioDriver ::LinuxGpioDriver(const char* const compName) : LinuxGpioDriverC
 Drv::GpioStatus LinuxGpioDriver ::start(const FwTaskPriorityType priority,
                                         const FwSizeType stackSize,
                                         const FwSizeType cpuAffinity,
-                                        const PlatformUIntType identifier) {
+                                        const unsigned int identifier) {
     Drv::GpioStatus status = Drv::GpioStatus::INVALID_MODE;
     if (this->m_configuration < GpioConfiguration::MAX_GPIO_CONFIGURATION &&
         this->m_configuration >= GpioConfiguration::GPIO_INTERRUPT_RISING_EDGE) {

--- a/Drv/LinuxGpioDriver/LinuxGpioDriverStub.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriverStub.cpp
@@ -22,18 +22,18 @@ LinuxGpioDriver ::~LinuxGpioDriver() {}
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-Os::File::Status LinuxGpioDriver ::setupLineHandle(const PlatformIntType chip_descriptor,
+Os::File::Status LinuxGpioDriver ::setupLineHandle(const int chip_descriptor,
                                                    const U32 gpio,
                                                    const GpioConfiguration& configuration,
                                                    const Fw::Logic& default_state,
-                                                   PlatformIntType& fd) {
+                                                   int& fd) {
     return Os::File::Status::NOT_SUPPORTED;
 }
 
-Os::File::Status LinuxGpioDriver ::setupLineEvent(const PlatformIntType chip_descriptor,
+Os::File::Status LinuxGpioDriver ::setupLineEvent(const int chip_descriptor,
                                                   const U32 gpio,
                                                   const GpioConfiguration& configuration,
-                                                  PlatformIntType& fd) {
+                                                  int& fd) {
     return Os::File::Status::NOT_SUPPORTED;
 }
 

--- a/Drv/LinuxI2cDriver/LinuxI2cDriver.cpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriver.cpp
@@ -150,7 +150,7 @@ namespace Drv {
     rdwr_data.nmsgs = 2;
 
     //Use ioctl to perform the combined write/read transaction
-    PlatformIntType stat = ioctl(this->m_fd, I2C_RDWR, &rdwr_data);
+    int stat = ioctl(this->m_fd, I2C_RDWR, &rdwr_data);
 
     if(stat == -1){
       //Because we're using ioctl to perform the transaction we dont know exactly the type of error that occurred

--- a/Drv/LinuxI2cDriver/LinuxI2cDriver.hpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriver.hpp
@@ -69,7 +69,7 @@ namespace Drv {
 
       // Prevent unused field error when using stub
       #ifndef STUBBED_LINUX_I2C_DRIVER
-      PlatformIntType m_fd; //!< i2c file descriptor
+      int m_fd; //!< i2c file descriptor
       #endif
     };
 

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -56,7 +56,7 @@ namespace Drv {
             .pad = 0
 */
 
-        PlatformIntType stat = ioctl(this->m_fd, SPI_IOC_MESSAGE(1), &tr);
+        int stat = ioctl(this->m_fd, SPI_IOC_MESSAGE(1), &tr);
 
         if (stat < 1) {
             this->log_WARNING_HI_SPI_WriteError(this->m_device,this->m_select,stat);
@@ -74,8 +74,8 @@ namespace Drv {
 
         this->m_device = device;
         this->m_select = select;
-        PlatformIntType fd;
-        PlatformIntType ret;
+        int fd;
+        int ret;
 
         // Open:
         Fw::FileNameString devString;

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
@@ -87,7 +87,7 @@ namespace Drv {
             void SpiReadWrite_handler(const FwIndexType portNum, /*!< The port number*/
             Fw::Buffer &WriteBuffer, Fw::Buffer &readBuffer);
 
-            PlatformIntType m_fd;
+            int m_fd;
             FwIndexType m_device;
             FwIndexType m_select;
             U32 m_bytes;

--- a/Drv/LinuxUartDriver/LinuxUartDriver.cpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.cpp
@@ -37,8 +37,8 @@ bool LinuxUartDriver::open(const char* const device,
                            UartParity parity,
                            U32 allocationSize) {
     FW_ASSERT(device != nullptr);
-    PlatformIntType fd = -1;
-    PlatformIntType stat = -1;
+    int fd = -1;
+    int stat = -1;
     this->m_allocationSize = allocationSize;
 
     this->m_device = device;
@@ -126,7 +126,7 @@ bool LinuxUartDriver::open(const char* const device,
         }
     }
 
-    PlatformIntType relayRate = B0;
+    int relayRate = B0;
     switch (baud) {
         case BAUD_9600:
             relayRate = B9600;

--- a/Drv/LinuxUartDriver/LinuxUartDriver.hpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.hpp
@@ -103,7 +103,7 @@ class LinuxUartDriver final : public LinuxUartDriverComponentBase {
                                 Fw::Buffer& fwBuffer  //!< The buffer
                                 ) override;
 
-    PlatformIntType m_fd;  //!< file descriptor returned for I/O device
+    int m_fd;  //!< file descriptor returned for I/O device
     U32 m_allocationSize; //!< size of allocation request to memory manager
     const char* m_device;  //!< original device path
 

--- a/Fw/Comp/ActiveComponentBase.cpp
+++ b/Fw/Comp/ActiveComponentBase.cpp
@@ -43,7 +43,7 @@ namespace Fw {
     }
 #endif
 
-    void ActiveComponentBase::start(FwTaskPriorityType priority, Os::Task::ParamType stackSize, Os::Task::ParamType cpuAffinity, Os::Task::ParamType identifier) {
+    void ActiveComponentBase::start(FwTaskPriorityType priority, FwSizeType stackSize, FwSizeType cpuAffinity, FwTaskIdType identifier) {
         Os::TaskString taskName;
 
 #if FW_OBJECT_NAMES == 1
@@ -54,7 +54,7 @@ namespace Fw {
         // Cooperative threads tasks externalize the task loop, and as such use the state machine as their task function
         // Standard multithreading tasks use the task loop to respectively call the state machine
         Os::Task::taskRoutine routine = (m_task.isCooperative()) ? this->s_taskStateMachine : this->s_taskLoop;
-        Os::Task::Arguments arguments(taskName, routine, this, priority, stackSize, cpuAffinity, static_cast<unsigned int>(identifier));
+        Os::Task::Arguments arguments(taskName, routine, this, priority, stackSize, cpuAffinity, identifier);
         Os::Task::Status status = this->m_task.start(arguments);
         FW_ASSERT(status == Os::Task::Status::OP_OK,static_cast<FwAssertArgType>(status));
     }

--- a/Fw/Comp/ActiveComponentBase.cpp
+++ b/Fw/Comp/ActiveComponentBase.cpp
@@ -54,7 +54,7 @@ namespace Fw {
         // Cooperative threads tasks externalize the task loop, and as such use the state machine as their task function
         // Standard multithreading tasks use the task loop to respectively call the state machine
         Os::Task::taskRoutine routine = (m_task.isCooperative()) ? this->s_taskStateMachine : this->s_taskLoop;
-        Os::Task::Arguments arguments(taskName, routine, this, priority, stackSize, cpuAffinity, static_cast<PlatformUIntType>(identifier));
+        Os::Task::Arguments arguments(taskName, routine, this, priority, stackSize, cpuAffinity, static_cast<unsigned int>(identifier));
         Os::Task::Status status = this->m_task.start(arguments);
         FW_ASSERT(status == Os::Task::Status::OP_OK,static_cast<FwAssertArgType>(status));
     }

--- a/Fw/Comp/ActiveComponentBase.hpp
+++ b/Fw/Comp/ActiveComponentBase.hpp
@@ -20,10 +20,10 @@ namespace Fw {
 class ActiveComponentBase : public QueuedComponentBase {
   public:
     void start(FwTaskPriorityType priority = Os::Task::TASK_PRIORITY_DEFAULT,
-               Os::Task::ParamType stackSize = Os::Task::TASK_DEFAULT,
-               Os::Task::ParamType cpuAffinity = Os::Task::TASK_DEFAULT,
-               Os::Task::ParamType identifier =
-               Os::Task::TASK_DEFAULT);           //!< called by instantiator when task is to be started
+               FwSizeType stackSize = Os::Task::TASK_DEFAULT,
+               FwSizeType cpuAffinity = Os::Task::TASK_DEFAULT,
+               FwTaskIdType identifier =
+               static_cast<FwTaskIdType>(Os::Task::TASK_DEFAULT));  //!< called by instantiator when task is to be started
     void exit();                                  //!< exit task in active component
     Os::Task::Status join();  //!< Join the thread
     DEPRECATED(Os::Task::Status join(void** value_ptr), "Switch to .join()");  //!< Join to thread with discarded value_ptr

--- a/Fw/FPrimeBasicTypes.h
+++ b/Fw/FPrimeBasicTypes.h
@@ -35,6 +35,7 @@ extern "C" {
 #include <config/FwSignedSizeTypeAliasAc.h>
 #include <config/FwAssertArgTypeAliasAc.h>
 #include <config/FwTaskPriorityTypeAliasAc.h>
+#include <config/FwTaskIdTypeAliasAc.h>
 #include <config/FwQueuePriorityTypeAliasAc.h>
 
 #include <config/FwIdTypeAliasAc.h>

--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -6,9 +6,9 @@
 #include <cstdio>
 
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
-#define fileIdFs "Assert: 0x%08" PRIx32 ":%" PRI_unsigned int
+#define fileIdFs "Assert: 0x%08" PRIx32 ":%u"
 #else
-#define fileIdFs "Assert: \"%s:%" PRI_unsigned int "\""
+#define fileIdFs "Assert: \"%s:%u\""
 #endif
 
 namespace Fw {

--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -6,9 +6,9 @@
 #include <cstdio>
 
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
-#define fileIdFs "Assert: 0x%08" PRIx32 ":%" PRI_PlatformUIntType
+#define fileIdFs "Assert: 0x%08" PRIx32 ":%" PRI_unsigned int
 #else
-#define fileIdFs "Assert: \"%s:%" PRI_PlatformUIntType "\""
+#define fileIdFs "Assert: \"%s:%" PRI_unsigned int "\""
 #endif
 
 namespace Fw {

--- a/Fw/Types/snprintf_format.cpp
+++ b/Fw/Types/snprintf_format.cpp
@@ -27,7 +27,7 @@ Fw::FormatStatus Fw::stringFormat(char* destination, const FwSizeType maximumSiz
     else if (maximumSize > std::numeric_limits<size_t>::max()) {
         formatStatus = Fw::FormatStatus::SIZE_OVERFLOW;
     } else {
-        PlatformIntType needed_size = vsnprintf(destination, static_cast<size_t>(maximumSize), formatString, args);
+        int needed_size = vsnprintf(destination, static_cast<size_t>(maximumSize), formatString, args);
         destination[maximumSize - 1] = 0; // Force null-termination
         if (needed_size < 0) {
             formatStatus = Fw::FormatStatus::OTHER_ERROR;

--- a/Os/Posix/ConditionVariable.cpp
+++ b/Os/Posix/ConditionVariable.cpp
@@ -12,7 +12,7 @@ namespace Posix {
 namespace Mutex {
 
 PosixConditionVariable::PosixConditionVariable() {
-    PlatformIntType status = pthread_cond_init(&this->m_handle.m_condition, nullptr);
+    int status = pthread_cond_init(&this->m_handle.m_condition, nullptr);
     FW_ASSERT(status == 0, static_cast<FwAssertArgType>(status));  // If this fails, something horrible happened.
 }
 PosixConditionVariable::~PosixConditionVariable() {
@@ -21,7 +21,7 @@ PosixConditionVariable::~PosixConditionVariable() {
 
 PosixConditionVariable::Status PosixConditionVariable::pend(Os::Mutex& mutex) {
     PosixMutexHandle* mutex_handle = reinterpret_cast<PosixMutexHandle*>(mutex.getHandle());
-    PlatformIntType status = pthread_cond_wait(&this->m_handle.m_condition, &mutex_handle->m_mutex_descriptor);
+    int status = pthread_cond_wait(&this->m_handle.m_condition, &mutex_handle->m_mutex_descriptor);
     return posix_status_to_conditional_status(status);
 }
 void PosixConditionVariable::notify() {

--- a/Os/Posix/File.cpp
+++ b/Os/Posix/File.cpp
@@ -74,7 +74,7 @@ PosixFile& PosixFile::operator=(const PosixFile& other) {
 PosixFile::Status PosixFile::open(const char* filepath,
                                   PosixFile::Mode requested_mode,
                                   PosixFile::OverwriteType overwrite) {
-    PlatformIntType mode_flags = 0;
+    int mode_flags = 0;
     Status status = OP_OK;
     switch (requested_mode) {
         case OPEN_READ:
@@ -97,9 +97,9 @@ PosixFile::Status PosixFile::open(const char* filepath,
             FW_ASSERT(0, requested_mode);
             break;
     }
-    PlatformIntType descriptor = ::open(filepath, mode_flags, USER_FLAGS);
+    int descriptor = ::open(filepath, mode_flags, USER_FLAGS);
     if (PosixFileHandle::INVALID_FILE_DESCRIPTOR == descriptor) {
-        PlatformIntType errno_store = errno;
+        int errno_store = errno;
         status = Os::Posix::errno_to_file_status(errno_store);
     }
     this->m_handle.m_file_descriptor = descriptor;
@@ -124,7 +124,7 @@ PosixFile::Status PosixFile::size(FwSizeType& size_result) {
         // Seek to the end of the file to determine size
         off_t end_of_file = ::lseek(this->m_handle.m_file_descriptor, 0, SEEK_END);
         if (PosixFileHandle::ERROR_RETURN_VALUE == end_of_file) {
-            PlatformIntType errno_store = errno;
+            int errno_store = errno;
             status = Os::Posix::errno_to_file_status(errno_store);
         }
         // Return to original position
@@ -139,7 +139,7 @@ PosixFile::Status PosixFile::position(FwSizeType& position_result) {
     position_result = 0;
     off_t actual = ::lseek(this->m_handle.m_file_descriptor, 0, SEEK_CUR);
     if (PosixFileHandle::ERROR_RETURN_VALUE == actual) {
-        PlatformIntType errno_store = errno;
+        int errno_store = errno;
         status = Os::Posix::errno_to_file_status(errno_store);
     }
     // Protected by static assertion (FwSizeType >= off_t)
@@ -161,7 +161,7 @@ PosixFile::Status PosixFile::preallocate(FwSizeType offset, FwSizeType length) {
     // code is engaged to synthesize this behavior.
 #if _POSIX_C_SOURCE >= 200112L
     else {
-        PlatformIntType errno_status = ::posix_fallocate(this->m_handle.m_file_descriptor, static_cast<off_t>(offset), static_cast<off_t>(length));
+        int errno_status = ::posix_fallocate(this->m_handle.m_file_descriptor, static_cast<off_t>(offset), static_cast<off_t>(length));
         status = Os::Posix::errno_to_file_status(errno_status);
     }
 #endif
@@ -211,7 +211,7 @@ PosixFile::Status PosixFile::seek(FwSignedSizeType offset, PosixFile::SeekType s
     } else {
         off_t actual =
             ::lseek(this->m_handle.m_file_descriptor, static_cast<off_t>(offset), (seekType == SeekType::ABSOLUTE) ? SEEK_SET : SEEK_CUR);
-        PlatformIntType errno_store = errno;
+        int errno_store = errno;
         if (actual == PosixFileHandle::ERROR_RETURN_VALUE) {
             status = Os::Posix::errno_to_file_status(errno_store);
         } else if ((seekType == SeekType::ABSOLUTE) && (actual != offset)) {
@@ -224,7 +224,7 @@ PosixFile::Status PosixFile::seek(FwSignedSizeType offset, PosixFile::SeekType s
 PosixFile::Status PosixFile::flush() {
     PosixFile::Status status = OP_OK;
     if (PosixFileHandle::ERROR_RETURN_VALUE == ::fsync(this->m_handle.m_file_descriptor)) {
-        PlatformIntType errno_store = errno;
+        int errno_store = errno;
         status = Os::Posix::errno_to_file_status(errno_store);
     }
     return status;
@@ -249,7 +249,7 @@ PosixFile::Status PosixFile::read(U8* buffer, FwSizeType& size, PosixFile::WaitT
                                    static_cast<size_t>(size - accumulated));
         // Non-interrupt error
         if (PosixFileHandle::ERROR_RETURN_VALUE == read_size) {
-            PlatformIntType errno_store = errno;
+            int errno_store = errno;
             // Interrupted w/o read, try again
             if (EINTR != errno_store) {
                 continue;
@@ -291,7 +291,7 @@ PosixFile::Status PosixFile::write(const U8* buffer, FwSizeType& size, PosixFile
                     static_cast<size_t>(size - accumulated));
         // Non-interrupt error
         if (PosixFileHandle::ERROR_RETURN_VALUE == write_size || write_size < 0) {
-            PlatformIntType errno_store = errno;
+            int errno_store = errno;
             // Interrupted w/o write, try again
             if (EINTR != errno_store) {
                 continue;
@@ -304,9 +304,9 @@ PosixFile::Status PosixFile::write(const U8* buffer, FwSizeType& size, PosixFile
     size = accumulated;
     // When waiting, sync to disk
     if (wait) {
-        PlatformIntType fsync_return = ::fsync(this->m_handle.m_file_descriptor);
+        int fsync_return = ::fsync(this->m_handle.m_file_descriptor);
         if (PosixFileHandle::ERROR_RETURN_VALUE == fsync_return) {
-            PlatformIntType errno_store = errno;
+            int errno_store = errno;
             status = Os::Posix::errno_to_file_status(errno_store);
         }
     }

--- a/Os/Posix/File.hpp
+++ b/Os/Posix/File.hpp
@@ -13,11 +13,11 @@ namespace File {
 //! FileHandle class definition for posix implementations.
 //!
 struct PosixFileHandle : public FileHandle {
-    static constexpr PlatformIntType INVALID_FILE_DESCRIPTOR = -1;
-    static constexpr PlatformIntType ERROR_RETURN_VALUE = -1;
+    static constexpr int INVALID_FILE_DESCRIPTOR = -1;
+    static constexpr int ERROR_RETURN_VALUE = -1;
 
     //! Posix file descriptor
-    PlatformIntType m_file_descriptor = INVALID_FILE_DESCRIPTOR;
+    int m_file_descriptor = INVALID_FILE_DESCRIPTOR;
 };
 
 //! \brief posix implementation of Os::File

--- a/Os/Posix/Mutex.cpp
+++ b/Os/Posix/Mutex.cpp
@@ -13,7 +13,7 @@ namespace Mutex {
 PosixMutex::PosixMutex() : Os::MutexInterface(), m_handle() {
     // set attributes
     pthread_mutexattr_t attribute;
-    PlatformIntType status = pthread_mutexattr_init(&attribute);
+    int status = pthread_mutexattr_init(&attribute);
     FW_ASSERT(status == 0, static_cast<FwAssertArgType>(status));
 
     // set to normal mutex type
@@ -29,17 +29,17 @@ PosixMutex::PosixMutex() : Os::MutexInterface(), m_handle() {
 }
 
 PosixMutex::~PosixMutex() {
-    PlatformIntType status = pthread_mutex_destroy(&this->m_handle.m_mutex_descriptor);
+    int status = pthread_mutex_destroy(&this->m_handle.m_mutex_descriptor);
     FW_ASSERT(status == 0, static_cast<FwAssertArgType>(status));
 }
 
 PosixMutex::Status PosixMutex::take() {
-    PlatformIntType status = pthread_mutex_lock(&this->m_handle.m_mutex_descriptor);
+    int status = pthread_mutex_lock(&this->m_handle.m_mutex_descriptor);
     return Os::Posix::posix_status_to_mutex_status(status);
 }
 
 PosixMutex::Status PosixMutex::release() {
-    PlatformIntType status = pthread_mutex_unlock(&this->m_handle.m_mutex_descriptor);
+    int status = pthread_mutex_unlock(&this->m_handle.m_mutex_descriptor);
     return Os::Posix::posix_status_to_mutex_status(status);
 }
 

--- a/Os/Posix/RawTime.cpp
+++ b/Os/Posix/RawTime.cpp
@@ -13,7 +13,7 @@ namespace Posix {
 namespace RawTime {
 
 PosixRawTime::Status PosixRawTime::now() {
-    PlatformIntType status = clock_gettime(CLOCK_REALTIME, &this->m_handle.m_timespec);
+    int status = clock_gettime(CLOCK_REALTIME, &this->m_handle.m_timespec);
     if (status != 0) {
         return errno_to_rawtime_status(errno);
     }

--- a/Os/Posix/Task.hpp
+++ b/Os/Posix/Task.hpp
@@ -22,7 +22,7 @@ namespace Task {
     //! TaskHandle class definition for posix implementations.
     //!
     struct PosixTaskHandle : public TaskHandle {
-        static constexpr PlatformIntType SUCCESS = 0;
+        static constexpr int SUCCESS = 0;
 
         //! Posix task descriptor
         pthread_t m_task_descriptor;

--- a/Os/Posix/error.cpp
+++ b/Os/Posix/error.cpp
@@ -8,7 +8,7 @@
 namespace Os {
 namespace Posix {
 
-File::Status errno_to_file_status(PlatformIntType errno_input) {
+File::Status errno_to_file_status(int errno_input) {
     File::Status status = File::Status::OP_OK;
     switch (errno_input) {
         case 0:
@@ -48,7 +48,7 @@ File::Status errno_to_file_status(PlatformIntType errno_input) {
     return status;
 }
 
-FileSystem::Status errno_to_filesystem_status(PlatformIntType errno_input) {
+FileSystem::Status errno_to_filesystem_status(int errno_input) {
     FileSystem::Status status = FileSystem::Status::OP_OK;
     switch (errno_input) {
         case 0:
@@ -103,7 +103,7 @@ FileSystem::Status errno_to_filesystem_status(PlatformIntType errno_input) {
     return status;
 }
 
-Directory::Status errno_to_directory_status(PlatformIntType errno_input) {
+Directory::Status errno_to_directory_status(int errno_input) {
     Directory::Status status = Directory::Status::OP_OK;
     switch (errno_input) {
         case 0:
@@ -128,7 +128,7 @@ Directory::Status errno_to_directory_status(PlatformIntType errno_input) {
     return status;
 }
 
-RawTime::Status errno_to_rawtime_status(PlatformIntType errno_input) {
+RawTime::Status errno_to_rawtime_status(int errno_input) {
     RawTime::Status status = RawTime::Status::OP_OK;
     switch (errno_input) {
         case 0:
@@ -144,7 +144,7 @@ RawTime::Status errno_to_rawtime_status(PlatformIntType errno_input) {
     return status;
 }
 
-Task::Status posix_status_to_task_status(PlatformIntType posix_status) {
+Task::Status posix_status_to_task_status(int posix_status) {
     Task::Status status = Task::Status::OP_OK;
     switch (posix_status) {
         case 0:
@@ -166,7 +166,7 @@ Task::Status posix_status_to_task_status(PlatformIntType posix_status) {
     return status;
 }
 
-Mutex::Status posix_status_to_mutex_status(PlatformIntType posix_status){
+Mutex::Status posix_status_to_mutex_status(int posix_status){
     Mutex::Status status = Mutex::Status::ERROR_OTHER;
     switch (posix_status) {
         case 0:
@@ -185,7 +185,7 @@ Mutex::Status posix_status_to_mutex_status(PlatformIntType posix_status){
     return status;
 }
 
-ConditionVariable::Status posix_status_to_conditional_status(PlatformIntType posix_status) {
+ConditionVariable::Status posix_status_to_conditional_status(int posix_status) {
     ConditionVariable::Status status = ConditionVariable::Status::ERROR_OTHER;
     switch (posix_status) {
         case 0:

--- a/Os/Posix/error.hpp
+++ b/Os/Posix/error.hpp
@@ -18,44 +18,44 @@ namespace Posix {
 //! \param errno_input: errno representation of the error
 //! \return: Os::File::Status representation of the error
 //!
-Os::File::Status errno_to_file_status(PlatformIntType errno_input);
+Os::File::Status errno_to_file_status(int errno_input);
 
 //! Convert an errno representation of an error to the Os::FileSystem::Status representation.
 //! \param errno_input: errno representation of the error
 //! \return: Os::FileSystem::Status representation of the error
 //!
-Os::FileSystem::Status errno_to_filesystem_status(PlatformIntType errno_input);
+Os::FileSystem::Status errno_to_filesystem_status(int errno_input);
 
 //! Convert an errno representation of an error to the Os::FileSystem::Status representation.
 //! \param errno_input: errno representation of the error
 //! \return: Os::Directory::Status representation of the error
 //!
-Os::Directory::Status errno_to_directory_status(PlatformIntType errno_input);
+Os::Directory::Status errno_to_directory_status(int errno_input);
 
 //! Convert an errno representation of an error to the Os::RawTime::Status representation.
 //! \param errno_input: errno representation of the error
 //! \return: Os::RawTime::Status representation of the error
 //!
-Os::RawTime::Status errno_to_rawtime_status(PlatformIntType errno_input);
+Os::RawTime::Status errno_to_rawtime_status(int errno_input);
 
 //! Convert an posix task representation of an error to the Os::Task::Status representation.
 //! \param posix_status: errno representation of the error
 //! \return: Os::Task::Status representation of the error
 //!
-Os::Task::Status posix_status_to_task_status(PlatformIntType posix_status);
+Os::Task::Status posix_status_to_task_status(int posix_status);
 
 //! Convert a Posix return status (int) for mutex operations to the Os::Mutex::Status representation.
 //! \param posix_status: return status
 //! \return: Os::Mutex::Status representation of the error
 //!
-Os::Mutex::Status posix_status_to_mutex_status(PlatformIntType posix_status);
+Os::Mutex::Status posix_status_to_mutex_status(int posix_status);
 
 //! Convert a Posix return status (int) for Conditional Variable operations to the Os::ConditionVariable::Status
 //! representation.
 //! \param posix_status: return status
 //! \return: Os::ConditionVariable::Status representation of the error
 //!
-Os::ConditionVariable::Status posix_status_to_conditional_status(PlatformIntType posix_status);
+Os::ConditionVariable::Status posix_status_to_conditional_status(int posix_status);
 
 }
 }

--- a/Os/Task.cpp
+++ b/Os/Task.cpp
@@ -10,7 +10,7 @@ namespace Os {
 TaskInterface::Arguments::Arguments(const Fw::StringBase &name, const Os::TaskInterface::taskRoutine routine,
                                     void * const routine_argument, const FwTaskPriorityType priority,
                                     const FwSizeType stackSize, const FwSizeType cpuAffinity,
-                                    const PlatformUIntType identifier) :
+                                    const unsigned int identifier) :
     m_name(name),
     m_routine(routine),
     m_routine_argument(routine_argument),
@@ -87,7 +87,7 @@ Task::Status Task::start(const Fw::StringBase &name, const taskRoutine routine, 
                                        priority,
                                        stackSize,
                                        cpuAffinity,
-                                       static_cast<PlatformUIntType>(identifier)));
+                                       static_cast<unsigned int>(identifier)));
 }
 
 

--- a/Os/Task.cpp
+++ b/Os/Task.cpp
@@ -10,7 +10,7 @@ namespace Os {
 TaskInterface::Arguments::Arguments(const Fw::StringBase &name, const Os::TaskInterface::taskRoutine routine,
                                     void * const routine_argument, const FwTaskPriorityType priority,
                                     const FwSizeType stackSize, const FwSizeType cpuAffinity,
-                                    const unsigned int identifier) :
+                                    const FwTaskIdType identifier) :
     m_name(name),
     m_routine(routine),
     m_routine_argument(routine_argument),
@@ -87,7 +87,7 @@ Task::Status Task::start(const Fw::StringBase &name, const taskRoutine routine, 
                                        priority,
                                        stackSize,
                                        cpuAffinity,
-                                       static_cast<unsigned int>(identifier)));
+                                       static_cast<FwTaskIdType>(identifier)));
 }
 
 

--- a/Os/Task.hpp
+++ b/Os/Task.hpp
@@ -79,7 +79,7 @@ namespace Os {
                           const FwTaskPriorityType priority = TASK_PRIORITY_DEFAULT,
                           const FwSizeType stackSize = TASK_DEFAULT,
                           const FwSizeType cpuAffinity = TASK_DEFAULT,
-                          const unsigned int identifier = static_cast<unsigned int>(TASK_DEFAULT));
+                          const FwTaskIdType identifier = static_cast<FwTaskIdType>(TASK_DEFAULT));
 
               public:
                 const Os::TaskString m_name;
@@ -88,7 +88,7 @@ namespace Os {
                 FwTaskPriorityType m_priority;
                 FwSizeType m_stackSize;
                 FwSizeType m_cpuAffinity;
-                unsigned int m_identifier;
+                FwTaskIdType m_identifier;
             };
 
             //! \brief default constructor

--- a/Os/Task.hpp
+++ b/Os/Task.hpp
@@ -79,7 +79,7 @@ namespace Os {
                           const FwTaskPriorityType priority = TASK_PRIORITY_DEFAULT,
                           const FwSizeType stackSize = TASK_DEFAULT,
                           const FwSizeType cpuAffinity = TASK_DEFAULT,
-                          const PlatformUIntType identifier = static_cast<PlatformUIntType>(TASK_DEFAULT));
+                          const unsigned int identifier = static_cast<unsigned int>(TASK_DEFAULT));
 
               public:
                 const Os::TaskString m_name;
@@ -88,7 +88,7 @@ namespace Os {
                 FwTaskPriorityType m_priority;
                 FwSizeType m_stackSize;
                 FwSizeType m_cpuAffinity;
-                PlatformUIntType m_identifier;
+                unsigned int m_identifier;
             };
 
             //! \brief default constructor

--- a/Svc/CmdSequencer/formats/AMPCSSequence.cpp
+++ b/Svc/CmdSequencer/formats/AMPCSSequence.cpp
@@ -434,7 +434,7 @@ namespace Svc {
     for(FwIndexType i = 0; i < bytesToExtend; i++){
       status = comBuffer.serialize(zeros);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-      sizeOfZeros += sizeof(zeros);
+      sizeOfZeros += static_cast<U32>(sizeof(zeros));
     }
     // Set the buffer length
     const U32 fixedBuffLen = static_cast<U32>(comBuffer.getBuffLength());

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -602,7 +602,7 @@ namespace Svc {
   void FileDownlinkTester ::
     removeFile(const char *const name)
   {
-    const PlatformIntType status = ::unlink(name);
+    const int status = ::unlink(name);
     if (status != 0) {
       // OK if file is not there
       ASSERT_EQ(ENOENT, errno);

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -165,7 +165,7 @@ namespace Svc {
     this->log_ACTIVITY_HI_ShellCommandStarted(
           logStringCommand
       );
-    PlatformIntType status =
+    int status =
       this->systemCall(command, logFileName);
     if (status == 0) {
       this->log_ACTIVITY_HI_ShellCommandSucceeded(
@@ -256,7 +256,7 @@ namespace Svc {
   // Helper methods
   // ----------------------------------------------------------------------
 
-  PlatformIntType FileManager ::
+  int FileManager ::
     systemCall(
         const Fw::CmdStringArg& command,
         const Fw::CmdStringArg& logFileName

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -119,7 +119,7 @@ namespace Svc {
 
       //! A system command with no arguments
       //!
-      PlatformIntType systemCall(
+      int systemCall(
           const Fw::CmdStringArg& command, //!< The command
           const Fw::CmdStringArg& logFileName //!< The log file name
       ) const;

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -528,8 +528,8 @@ namespace Svc {
   void FileManagerTester ::
     system(const char *const cmd)
   {
-    const PlatformIntType status = ::system(cmd);
-    ASSERT_EQ(static_cast<PlatformIntType>(0), status);
+    const int status = ::system(cmd);
+    ASSERT_EQ(static_cast<int>(0), status);
   }
 
   void FileManagerTester ::

--- a/Svc/FileUplink/test/ut/FileUplinkTester.cpp
+++ b/Svc/FileUplink/test/ut/FileUplinkTester.cpp
@@ -721,7 +721,7 @@ namespace Svc {
     removeFile(const char *const path)
   {
     // status from unlink is a platform integer
-    const PlatformIntType status = ::unlink(path);
+    const int status = ::unlink(path);
     if (status != 0) {
       ASSERT_EQ(ENOENT, errno);
     }

--- a/cmake/platform/unix/Platform/PlatformTypes.fpp
+++ b/cmake/platform/unix/Platform/PlatformTypes.fpp
@@ -26,6 +26,10 @@ type PlatformAssertArgType = I32
 @ overridable by project.
 type PlatformTaskPriorityType = U8
 
+@ The type of task identifiers. Supplied by platform,
+@ overridable by project.
+type PlatformTaskIdType = I32
+
 @ The type of queue priorities used. Supplied by platform,
 @ overridable by project.
 type PlatformQueuePriorityType = U8

--- a/cmake/platform/unix/Platform/PlatformTypes.h
+++ b/cmake/platform/unix/Platform/PlatformTypes.h
@@ -16,12 +16,6 @@ extern "C" {
 #endif
 #include <stdint.h>
 
-typedef int PlatformIntType;
-#define PRI_PlatformIntType "d"
-
-typedef unsigned int PlatformUIntType;
-#define PRI_PlatformUIntType "u"
-
 // Linux/Darwin definitions for pointer have various sizes across platforms
 // and since these definitions need to be consistent we must ask the size.
 // Check for __SIZEOF_POINTER__ or cause error

--- a/cmake/test/data/TestConfigDeployment/override/project/FpConfig.fpp
+++ b/cmake/test/data/TestConfigDeployment/override/project/FpConfig.fpp
@@ -44,6 +44,8 @@ type FwTaskPriorityType = PlatformTaskPriorityType
 @ The type of queue priorities used.
 type FwQueuePriorityType = PlatformQueuePriorityType
 
+@ The type of task priorities used.
+type FwTaskIdType = PlatformTaskIdType
 
 ####
 # GDS type aliases:

--- a/cmake/test/data/TestConfigDeployment/settings.ini
+++ b/cmake/test/data/TestConfigDeployment/settings.ini
@@ -1,3 +1,4 @@
 [fprime]
 framework_path: ../../../..
 project_root: ..
+library_locations: ../test-config-library

--- a/default/config/FpConfig.fpp
+++ b/default/config/FpConfig.fpp
@@ -41,6 +41,9 @@ type FwQueuePriorityType = PlatformQueuePriorityType
 @ The id type.
 type FwIdType = U32
 
+@ The type of task priorities used.
+type FwTaskIdType = PlatformTaskIdType
+
 ####
 # GDS type aliases:
 # Used for the project to override types shared with GDSes and other remote systems.

--- a/docs/reference/numerical-types.md
+++ b/docs/reference/numerical-types.md
@@ -8,6 +8,9 @@ represent concepts in the system (e.g. size) and are configured to use a specifi
 
 This document describes: fixed-width types and logical types.
 
+> [!TIP]
+> Many APIs (e.g. POSIX APIs) use types such as `int` or `long`. Projects should use those types when interfacing with the API and convert into fixed-width or logical types within the calling code.
+
 ## Fixed Width Types
 
 In F´, fixed width types map to the standard definitions either in the C standard or in the `stdint.h` header as seen

--- a/docs/reference/numerical-types.md
+++ b/docs/reference/numerical-types.md
@@ -76,8 +76,6 @@ functions.
 | PlatformSignedSizeType  | Signed sizes                  | PRI_PlatformSignedSizeType  | Yes    | Minimum 4 Bytes |
 | PlatformPointerCastType | Pointers stored as integers   | PRI_PlatformPointerCastType | No     | sizeof(void*)   |
 | PlatformAssertArgType   | Argument to FW_ASSERT         | PRI_PlatformAssertArgType   | Yes/No | Any             |
-| PlatformIntType         | Deprecated (see note)         | PRI_PlatformIntType         | Yes    | sizeof(int)     |
-| PlatformUIntType        | Deprecated (see note)         | PRI_PlatformUIntType        | Yes    | sizeof(int)     |
 
 > [!WARNING]
 > `PlatformPointerCastType` values shall never be sent nor used outside the address space where a value was initialized because these values represent pointers only valid in a single address space.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Removing deprecated `PlatformIntType` and `PlatformUIntType`.