### PR TITLE
Fix subtopology dictionary installation and redundant installation

### DIFF
--- a/cmake/target/dictionary.cmake
+++ b/cmake/target/dictionary.cmake
@@ -32,9 +32,9 @@ endfunction(dictionary_add_global_target)
 function(dictionary_add_deployment_target MODULE TARGET SOURCES DEPENDENCIES FULL_DEPENDENCIES)
     # Create deployment level target and remove the module from the list of dependencies
     add_custom_target("${MODULE}_${TARGET}")
-    list(REMOVE_ITEM FULL_DEPENDENCIES "${MODULE}")
+    list(REMOVE_ITEM DEPENDENCIES "${MODULE}")
     # Loop through all recursive dependencies and find dictionary targets
-    foreach(DEPENDENCY IN LISTS FULL_DEPENDENCIES)
+    foreach(DEPENDENCY IN LISTS DEPENDENCIES)
         get_target_property(DICTIONARY_FILES "${DEPENDENCY}" FPRIME_DICTIONARIES)
         if (TARGET "${DEPENDENCY}_${TARGET}")
             fprime_cmake_ASSERT("No dictionary files defined for ${DEPENDENCY}" DICTIONARY_FILES)

--- a/cmake/target/target.cmake
+++ b/cmake/target/target.cmake
@@ -178,8 +178,10 @@ function(setup_module_targets BUILD_TARGET)
     endif()
 
     # Now run through each of the determined targets
+    set(DEPENDENCIES ${MODULE_LINK_LIBRARIES} ${MODULE_INTERFACE_LINK_LIBRARIES})
+    list(REMOVE_DUPLICATES DEPENDENCIES)
     foreach(FPRIME_TARGET IN LISTS TARGETS)
-        setup_single_target("${FPRIME_TARGET}" "${BUILD_TARGET}" "${MODULE_SOURCES}" "${MODULE_LINK_LIBRARIES};${MODULE_INTERFACE_LINK_LIBRARIES}")
+        setup_single_target("${FPRIME_TARGET}" "${BUILD_TARGET}" "${MODULE_SOURCES}" "${DEPENDENCIES}")
     endforeach()
 endfunction(setup_module_targets)
 #### Documentation links


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This will fix the broken CI by only installing top-level dictionaries.  I also removed redundant dependencies causing replicated (no-op) dictionary installs so the output is cleaner.