### PR TITLE
Bugfixes and updates to requirements.txt

### DIFF
--- a/Svc/FrameAccumulator/FrameAccumulator.cpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.cpp
@@ -128,6 +128,7 @@ void FrameAccumulator ::processRing() {
             if (buffer.isValid()) {
                 // Copy data out of ring buffer into the allocated buffer
                 Fw::SerializeStatus serialize_status = this->m_inRing.peek(buffer.getData(), size_out);
+                buffer.setSize(size_out);
                 FW_ASSERT(serialize_status == Fw::SerializeStatus::FW_SERIALIZE_OK);
                 // Consume (rotate) the data from the ring buffer
                 serialize_status = this->m_inRing.rotate(size_out);

--- a/Svc/FrameAccumulator/FrameAccumulator.cpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.cpp
@@ -128,7 +128,7 @@ void FrameAccumulator ::processRing() {
             if (buffer.isValid()) {
                 // Copy data out of ring buffer into the allocated buffer
                 Fw::SerializeStatus serialize_status = this->m_inRing.peek(buffer.getData(), size_out);
-                buffer.setSize(size_out);
+                buffer.setSize(static_cast<Fw::Buffer::SizeType>(size_out));
                 FW_ASSERT(serialize_status == Fw::SerializeStatus::FW_SERIALIZE_OK);
                 // Consume (rotate) the data from the ring buffer
                 serialize_status = this->m_inRing.rotate(size_out);

--- a/cmake/target/dictionary.cmake
+++ b/cmake/target/dictionary.cmake
@@ -35,8 +35,8 @@ function(dictionary_add_deployment_target MODULE TARGET SOURCES DEPENDENCIES FUL
     list(REMOVE_ITEM DEPENDENCIES "${MODULE}")
     # Loop through all recursive dependencies and find dictionary targets
     foreach(DEPENDENCY IN LISTS DEPENDENCIES)
-        get_target_property(DICTIONARY_FILES "${DEPENDENCY}" FPRIME_DICTIONARIES)
         if (TARGET "${DEPENDENCY}_${TARGET}")
+            get_target_property(DICTIONARY_FILES "${DEPENDENCY}" FPRIME_DICTIONARIES)
             fprime_cmake_ASSERT("No dictionary files defined for ${DEPENDENCY}" DICTIONARY_FILES)
             # Install the files as a component. This is done here so it is output to the deployment directory
             install(FILES ${DICTIONARY_FILES} DESTINATION ${TOOLCHAIN_NAME}/${MODULE}/dict COMPONENT "${MODULE}_${DEPENDENCY}_${TARGET}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ chardet==5.2.0
 charset-normalizer==3.4.0
 click==8.1.7
 # CMake versions prior to 3.24.2 were not signed correctly for modern macOS versions
-cmake==3.24.2
+cmake==3.26.0
 colorlog==6.8.2
 cookiecutter==2.6.0
 CT3==3.3.3.post1


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Bugfix in cmake when building dictionaries.
Bugfix in accumulator: need to set the size otherwise there is a possibility buffer's allocated size is larger than expected. This is true when using a staticmemory allocator where the static memory is e.g. 256 but the requested size is 128.
Updated cmake version requirement. Some toolchain files need this newer version.

## Rationale

Bugfix

## Testing/Review Recommendations

CI

## Future Work

None
