### PR TITLE
Updates for Svc/BufferAccumulator corresponding to UT cmake update for protected/private

### DIFF
--- a/Svc/BufferAccumulator/test/ut/Accumulate.cpp
+++ b/Svc/BufferAccumulator/test/ut/Accumulate.cpp
@@ -23,7 +23,7 @@ namespace Accumulate {
 void BufferAccumulatorTester ::OK() {
   ASSERT_EQ(BufferAccumulator_OpState::DRAIN, this->component.m_mode.e);
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::ACCUMULATE);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_EQ(BufferAccumulator_OpState::ACCUMULATE, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(0);
 
@@ -35,12 +35,12 @@ void BufferAccumulatorTester ::OK() {
     Fw::Buffer b(data, size, bufferID);
     buffers[i] = b;
     this->invoke_to_bufferSendInFill(0, buffers[i]);
-    this->dispatchOne();
+    this->doDispatch();
     ASSERT_FROM_PORT_HISTORY_SIZE(0);
   }
 
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::DRAIN);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_EQ(BufferAccumulator_OpState::DRAIN, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(1);
   ASSERT_from_bufferSendOutDrain_SIZE(1);
@@ -49,7 +49,7 @@ void BufferAccumulatorTester ::OK() {
   U32 expectedNumBuffers = 1;
   for (U32 i = 0; i < MAX_NUM_BUFFERS; ++i) {
     this->invoke_to_bufferSendInReturn(0, buffers[i]);
-    this->dispatchOne();
+    this->doDispatch();
     ++expectedNumBuffers;
     if (i + 1 < MAX_NUM_BUFFERS) {
       ++expectedNumBuffers;

--- a/Svc/BufferAccumulator/test/ut/Accumulate.cpp
+++ b/Svc/BufferAccumulator/test/ut/Accumulate.cpp
@@ -23,7 +23,7 @@ namespace Accumulate {
 void BufferAccumulatorTester ::OK() {
   ASSERT_EQ(BufferAccumulator_OpState::DRAIN, this->component.m_mode.e);
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::ACCUMULATE);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_EQ(BufferAccumulator_OpState::ACCUMULATE, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(0);
 
@@ -35,12 +35,12 @@ void BufferAccumulatorTester ::OK() {
     Fw::Buffer b(data, size, bufferID);
     buffers[i] = b;
     this->invoke_to_bufferSendInFill(0, buffers[i]);
-    this->component.doDispatch();
+    this->dispatchOne();
     ASSERT_FROM_PORT_HISTORY_SIZE(0);
   }
 
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::DRAIN);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_EQ(BufferAccumulator_OpState::DRAIN, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(1);
   ASSERT_from_bufferSendOutDrain_SIZE(1);
@@ -49,7 +49,7 @@ void BufferAccumulatorTester ::OK() {
   U32 expectedNumBuffers = 1;
   for (U32 i = 0; i < MAX_NUM_BUFFERS; ++i) {
     this->invoke_to_bufferSendInReturn(0, buffers[i]);
-    this->component.doDispatch();
+    this->dispatchOne();
     ++expectedNumBuffers;
     if (i + 1 < MAX_NUM_BUFFERS) {
       ++expectedNumBuffers;

--- a/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.cpp
+++ b/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.cpp
@@ -130,4 +130,8 @@ void BufferAccumulatorTester ::initComponents() {
   this->component.init(QUEUE_DEPTH, INSTANCE);
 }
 
+void BufferAccumulatorTester ::dispatchOne() {
+  this->component.doDispatch();
+}
+
 }  // end namespace Svc

--- a/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.cpp
+++ b/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.cpp
@@ -130,7 +130,7 @@ void BufferAccumulatorTester ::initComponents() {
   this->component.init(QUEUE_DEPTH, INSTANCE);
 }
 
-void BufferAccumulatorTester ::dispatchOne() {
+void BufferAccumulatorTester ::doDispatch() {
   this->component.doDispatch();
 }
 

--- a/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.hpp
+++ b/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.hpp
@@ -81,6 +81,14 @@ class BufferAccumulatorTester : public BufferAccumulatorGTestBase {
 
   //! Whether to allocate/deallocate a queue for the user
   bool doAllocateQueue;
+
+
+  // ----------------------------------------------------------------------
+  //  Methods
+  // ----------------------------------------------------------------------
+
+  //! Helper method to call doDispatch
+  void dispatchOne(void);
 };
 
 }  // end namespace Svc

--- a/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.hpp
+++ b/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.hpp
@@ -88,7 +88,7 @@ class BufferAccumulatorTester : public BufferAccumulatorGTestBase {
   // ----------------------------------------------------------------------
 
   //! Helper method to call doDispatch
-  void dispatchOne(void);
+  void doDispatch(void);
 };
 
 }  // end namespace Svc

--- a/Svc/BufferAccumulator/test/ut/Drain.cpp
+++ b/Svc/BufferAccumulator/test/ut/Drain.cpp
@@ -35,11 +35,11 @@ void BufferAccumulatorTester ::OK() {
     Fw::Buffer b(data, size, bufferID);
     buffers[i] = b;
     this->invoke_to_bufferSendInFill(0, buffers[i]);
-    this->component.doDispatch();
+    this->dispatchOne();
     ASSERT_from_bufferSendOutDrain_SIZE(i + 1);
     ASSERT_from_bufferSendOutDrain(i, buffers[i]);
     this->invoke_to_bufferSendInReturn(0, buffers[i]);
-    this->component.doDispatch();
+    this->dispatchOne();
     ASSERT_from_bufferSendOutReturn(i, buffers[i]);
   }
 
@@ -48,7 +48,7 @@ void BufferAccumulatorTester ::OK() {
 
 void BufferAccumulatorTester ::PartialDrainOK() {
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::ACCUMULATE);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_CMD_RESPONSE_SIZE(1);
   ASSERT_CMD_RESPONSE(0, BufferAccumulator::OPCODE_BA_SETMODE, 0,
                       Fw::CmdResponse::OK);
@@ -63,10 +63,10 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     Fw::Buffer b(data, size, bufferID);
     buffers[i] = b;
     this->invoke_to_bufferSendInFill(0, buffers[i]);
-    this->component.doDispatch();
+    this->dispatchOne();
 
     this->sendCmd_BA_DrainBuffers(0, 0, 1, BufferAccumulator_BlockMode::BLOCK);
-    this->component.doDispatch();
+    this->dispatchOne();
     ASSERT_EVENTS_BA_PartialDrainDone_SIZE(i + 1);
     ASSERT_EVENTS_BA_PartialDrainDone(i, 1u);
     // + 1 for first BufferAccumulator_OpState::ACCUMULATE command; + 1 for
@@ -79,7 +79,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     ASSERT_from_bufferSendOutDrain(i, buffers[i]);
 
     this->invoke_to_bufferSendInReturn(0, buffers[i]);
-    this->component.doDispatch();
+    this->dispatchOne();
     ASSERT_from_bufferSendOutReturn(i, buffers[i]);
 
     ASSERT_EVENTS_BA_PartialDrainDone_SIZE(i + 1);
@@ -99,7 +99,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     Fw::Buffer b(data, size, bufferID);
     buffers[i] = b;
     this->invoke_to_bufferSendInFill(0, buffers[i]);
-    this->component.doDispatch();
+    this->dispatchOne();
     ASSERT_FROM_PORT_HISTORY_SIZE(0);
   }
 
@@ -108,7 +108,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     ASSERT_from_bufferSendOutDrain_SIZE(i);
 
     this->sendCmd_BA_DrainBuffers(0, 0, 1, BufferAccumulator_BlockMode::BLOCK);
-    this->component.doDispatch();
+    this->dispatchOne();
     ASSERT_CMD_RESPONSE_SIZE(i + 1);
     ASSERT_CMD_RESPONSE(i, BufferAccumulator::OPCODE_BA_DRAINBUFFERS, 0,
                         Fw::CmdResponse::OK);
@@ -121,7 +121,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     ASSERT_from_bufferSendOutDrain_SIZE(i + 1);
     ASSERT_from_bufferSendOutDrain(i, buffers[i]);
     this->invoke_to_bufferSendInReturn(0, buffers[i]);
-    this->component.doDispatch();
+    this->dispatchOne();
     ASSERT_from_bufferSendOutReturn(i, buffers[i]);
 
     ASSERT_EVENTS_BA_PartialDrainDone_SIZE(i + 1);
@@ -140,7 +140,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     Fw::Buffer b(data, size, bufferID);
     buffers[i] = b;
     this->invoke_to_bufferSendInFill(0, buffers[i]);
-    this->component.doDispatch();
+    this->dispatchOne();
     ASSERT_FROM_PORT_HISTORY_SIZE(0);
   }
 
@@ -152,7 +152,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
   ASSERT_EVENTS_BA_PartialDrainDone_SIZE(0);
   this->sendCmd_BA_DrainBuffers(0, 0, MAX_NUM_BUFFERS,
                                 BufferAccumulator_BlockMode::BLOCK);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_CMD_RESPONSE_SIZE(0);
 
   for (U32 i = 0; i < MAX_NUM_BUFFERS; ++i) {
@@ -170,7 +170,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     ASSERT_from_bufferSendOutDrain_SIZE(i + 1);
     ASSERT_from_bufferSendOutDrain(i, buffers[i]);
     this->invoke_to_bufferSendInReturn(0, buffers[i]);
-    this->component.doDispatch();
+    this->dispatchOne();
     ASSERT_from_bufferSendOutReturn(i, buffers[i]);
   }
 

--- a/Svc/BufferAccumulator/test/ut/Drain.cpp
+++ b/Svc/BufferAccumulator/test/ut/Drain.cpp
@@ -35,11 +35,11 @@ void BufferAccumulatorTester ::OK() {
     Fw::Buffer b(data, size, bufferID);
     buffers[i] = b;
     this->invoke_to_bufferSendInFill(0, buffers[i]);
-    this->dispatchOne();
+    this->doDispatch();
     ASSERT_from_bufferSendOutDrain_SIZE(i + 1);
     ASSERT_from_bufferSendOutDrain(i, buffers[i]);
     this->invoke_to_bufferSendInReturn(0, buffers[i]);
-    this->dispatchOne();
+    this->doDispatch();
     ASSERT_from_bufferSendOutReturn(i, buffers[i]);
   }
 
@@ -48,7 +48,7 @@ void BufferAccumulatorTester ::OK() {
 
 void BufferAccumulatorTester ::PartialDrainOK() {
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::ACCUMULATE);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_CMD_RESPONSE_SIZE(1);
   ASSERT_CMD_RESPONSE(0, BufferAccumulator::OPCODE_BA_SETMODE, 0,
                       Fw::CmdResponse::OK);
@@ -63,10 +63,10 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     Fw::Buffer b(data, size, bufferID);
     buffers[i] = b;
     this->invoke_to_bufferSendInFill(0, buffers[i]);
-    this->dispatchOne();
+    this->doDispatch();
 
     this->sendCmd_BA_DrainBuffers(0, 0, 1, BufferAccumulator_BlockMode::BLOCK);
-    this->dispatchOne();
+    this->doDispatch();
     ASSERT_EVENTS_BA_PartialDrainDone_SIZE(i + 1);
     ASSERT_EVENTS_BA_PartialDrainDone(i, 1u);
     // + 1 for first BufferAccumulator_OpState::ACCUMULATE command; + 1 for
@@ -79,7 +79,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     ASSERT_from_bufferSendOutDrain(i, buffers[i]);
 
     this->invoke_to_bufferSendInReturn(0, buffers[i]);
-    this->dispatchOne();
+    this->doDispatch();
     ASSERT_from_bufferSendOutReturn(i, buffers[i]);
 
     ASSERT_EVENTS_BA_PartialDrainDone_SIZE(i + 1);
@@ -99,7 +99,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     Fw::Buffer b(data, size, bufferID);
     buffers[i] = b;
     this->invoke_to_bufferSendInFill(0, buffers[i]);
-    this->dispatchOne();
+    this->doDispatch();
     ASSERT_FROM_PORT_HISTORY_SIZE(0);
   }
 
@@ -108,7 +108,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     ASSERT_from_bufferSendOutDrain_SIZE(i);
 
     this->sendCmd_BA_DrainBuffers(0, 0, 1, BufferAccumulator_BlockMode::BLOCK);
-    this->dispatchOne();
+    this->doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(i + 1);
     ASSERT_CMD_RESPONSE(i, BufferAccumulator::OPCODE_BA_DRAINBUFFERS, 0,
                         Fw::CmdResponse::OK);
@@ -121,7 +121,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     ASSERT_from_bufferSendOutDrain_SIZE(i + 1);
     ASSERT_from_bufferSendOutDrain(i, buffers[i]);
     this->invoke_to_bufferSendInReturn(0, buffers[i]);
-    this->dispatchOne();
+    this->doDispatch();
     ASSERT_from_bufferSendOutReturn(i, buffers[i]);
 
     ASSERT_EVENTS_BA_PartialDrainDone_SIZE(i + 1);
@@ -140,7 +140,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     Fw::Buffer b(data, size, bufferID);
     buffers[i] = b;
     this->invoke_to_bufferSendInFill(0, buffers[i]);
-    this->dispatchOne();
+    this->doDispatch();
     ASSERT_FROM_PORT_HISTORY_SIZE(0);
   }
 
@@ -152,7 +152,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
   ASSERT_EVENTS_BA_PartialDrainDone_SIZE(0);
   this->sendCmd_BA_DrainBuffers(0, 0, MAX_NUM_BUFFERS,
                                 BufferAccumulator_BlockMode::BLOCK);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_CMD_RESPONSE_SIZE(0);
 
   for (U32 i = 0; i < MAX_NUM_BUFFERS; ++i) {
@@ -170,7 +170,7 @@ void BufferAccumulatorTester ::PartialDrainOK() {
     ASSERT_from_bufferSendOutDrain_SIZE(i + 1);
     ASSERT_from_bufferSendOutDrain(i, buffers[i]);
     this->invoke_to_bufferSendInReturn(0, buffers[i]);
-    this->dispatchOne();
+    this->doDispatch();
     ASSERT_from_bufferSendOutReturn(i, buffers[i]);
   }
 

--- a/Svc/BufferAccumulator/test/ut/Errors.cpp
+++ b/Svc/BufferAccumulator/test/ut/Errors.cpp
@@ -23,7 +23,7 @@ namespace Errors {
 void BufferAccumulatorTester ::PartialDrain() {
   ASSERT_EQ(BufferAccumulator_OpState::DRAIN, this->component.m_mode.e);
   this->sendCmd_BA_DrainBuffers(0, 0, 1, BufferAccumulator_BlockMode::BLOCK);
-  this->component.doDispatch();  // will fail - we are still in
+  this->dispatchOne();  // will fail - we are still in
                                  // BufferAccumulator_OpState::DRAIN mode
   ASSERT_EQ(BufferAccumulator_OpState::DRAIN, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(0);
@@ -32,12 +32,12 @@ void BufferAccumulatorTester ::PartialDrain() {
   ASSERT_EQ(0u, this->component.m_numToDrain);
 
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::ACCUMULATE);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_EQ(BufferAccumulator_OpState::ACCUMULATE, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(0);
 
   this->sendCmd_BA_DrainBuffers(0, 0, 10, BufferAccumulator_BlockMode::BLOCK);
-  this->component.doDispatch();  // will succeed - now we are in ACCUMULATE
+  this->dispatchOne();  // will succeed - now we are in ACCUMULATE
   ASSERT_EQ(BufferAccumulator_OpState::ACCUMULATE, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(
       0);  // would be first buffer out, but we are empty
@@ -49,8 +49,7 @@ void BufferAccumulatorTester ::PartialDrain() {
   ASSERT_EQ(10u, this->component.m_numToDrain);
 
   this->sendCmd_BA_DrainBuffers(0, 0, 1, BufferAccumulator_BlockMode::BLOCK);
-  this->component
-      .doDispatch();  // will fail - we are still doing a partial drain
+  this->dispatchOne();  // will fail - we are still doing a partial drain
   ASSERT_EVENTS_BA_StillDraining_SIZE(1);
   ASSERT_EVENTS_BA_StillDraining(0, 0u, 10u);
   ASSERT_EVENTS_BA_PartialDrainDone_SIZE(0);  // partial drain not done
@@ -69,57 +68,57 @@ void BufferAccumulatorTester ::QueueFull() {
   // Go to Accumulate mode
   ASSERT_EQ(BufferAccumulator_OpState::DRAIN, this->component.m_mode.e);
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::ACCUMULATE);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_EQ(BufferAccumulator_OpState::ACCUMULATE, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(0);
 
   // Fill up the buffer queue
   for (U32 i = 0; i < MAX_NUM_BUFFERS; ++i) {
     this->invoke_to_bufferSendInFill(0, buffer);
-    this->component.doDispatch();
+    this->dispatchOne();
     ASSERT_FROM_PORT_HISTORY_SIZE(0);
   }
 
   // Send another buffer and expect an event
   this->invoke_to_bufferSendInFill(0, buffer);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_EVENTS_SIZE(1);
   ASSERT_EVENTS_BA_QueueFull_SIZE(1);
 
   // Send another buffer and expect no new event
   this->invoke_to_bufferSendInFill(0, buffer);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_EVENTS_SIZE(1);
 
   // Drain one buffer
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::DRAIN);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_FROM_PORT_HISTORY_SIZE(1);
   ASSERT_from_bufferSendOutDrain_SIZE(1);
   ASSERT_from_bufferSendOutDrain(0, buffer);
 
   // Send another buffer and expect an event
   this->invoke_to_bufferSendInFill(0, buffer);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_EVENTS_SIZE(2);
   ASSERT_EVENTS_BA_BufferAccepted_SIZE(1);
 
   // Return the original buffer in order to drain one buffer
   this->invoke_to_bufferSendInReturn(0, buffer);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_FROM_PORT_HISTORY_SIZE(3);
   ASSERT_from_bufferSendOutDrain_SIZE(2);
   ASSERT_from_bufferSendOutDrain(1, buffer);
 
   // Send another buffer and expect no new event
   this->invoke_to_bufferSendInFill(0, buffer);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_EVENTS_SIZE(2);
   ASSERT_EVENTS_BA_BufferAccepted_SIZE(1);
 
   // Send another buffer and expect an event
   this->invoke_to_bufferSendInFill(0, buffer);
-  this->component.doDispatch();
+  this->dispatchOne();
   ASSERT_EVENTS_SIZE(3);
   ASSERT_EVENTS_BA_QueueFull_SIZE(2);
 

--- a/Svc/BufferAccumulator/test/ut/Errors.cpp
+++ b/Svc/BufferAccumulator/test/ut/Errors.cpp
@@ -23,7 +23,7 @@ namespace Errors {
 void BufferAccumulatorTester ::PartialDrain() {
   ASSERT_EQ(BufferAccumulator_OpState::DRAIN, this->component.m_mode.e);
   this->sendCmd_BA_DrainBuffers(0, 0, 1, BufferAccumulator_BlockMode::BLOCK);
-  this->dispatchOne();  // will fail - we are still in
+  this->doDispatch();  // will fail - we are still in
                                  // BufferAccumulator_OpState::DRAIN mode
   ASSERT_EQ(BufferAccumulator_OpState::DRAIN, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(0);
@@ -32,12 +32,12 @@ void BufferAccumulatorTester ::PartialDrain() {
   ASSERT_EQ(0u, this->component.m_numToDrain);
 
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::ACCUMULATE);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_EQ(BufferAccumulator_OpState::ACCUMULATE, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(0);
 
   this->sendCmd_BA_DrainBuffers(0, 0, 10, BufferAccumulator_BlockMode::BLOCK);
-  this->dispatchOne();  // will succeed - now we are in ACCUMULATE
+  this->doDispatch();  // will succeed - now we are in ACCUMULATE
   ASSERT_EQ(BufferAccumulator_OpState::ACCUMULATE, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(
       0);  // would be first buffer out, but we are empty
@@ -49,7 +49,7 @@ void BufferAccumulatorTester ::PartialDrain() {
   ASSERT_EQ(10u, this->component.m_numToDrain);
 
   this->sendCmd_BA_DrainBuffers(0, 0, 1, BufferAccumulator_BlockMode::BLOCK);
-  this->dispatchOne();  // will fail - we are still doing a partial drain
+  this->doDispatch();  // will fail - we are still doing a partial drain
   ASSERT_EVENTS_BA_StillDraining_SIZE(1);
   ASSERT_EVENTS_BA_StillDraining(0, 0u, 10u);
   ASSERT_EVENTS_BA_PartialDrainDone_SIZE(0);  // partial drain not done
@@ -68,57 +68,57 @@ void BufferAccumulatorTester ::QueueFull() {
   // Go to Accumulate mode
   ASSERT_EQ(BufferAccumulator_OpState::DRAIN, this->component.m_mode.e);
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::ACCUMULATE);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_EQ(BufferAccumulator_OpState::ACCUMULATE, this->component.m_mode.e);
   ASSERT_FROM_PORT_HISTORY_SIZE(0);
 
   // Fill up the buffer queue
   for (U32 i = 0; i < MAX_NUM_BUFFERS; ++i) {
     this->invoke_to_bufferSendInFill(0, buffer);
-    this->dispatchOne();
+    this->doDispatch();
     ASSERT_FROM_PORT_HISTORY_SIZE(0);
   }
 
   // Send another buffer and expect an event
   this->invoke_to_bufferSendInFill(0, buffer);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_EVENTS_SIZE(1);
   ASSERT_EVENTS_BA_QueueFull_SIZE(1);
 
   // Send another buffer and expect no new event
   this->invoke_to_bufferSendInFill(0, buffer);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_EVENTS_SIZE(1);
 
   // Drain one buffer
   this->sendCmd_BA_SetMode(0, 0, BufferAccumulator_OpState::DRAIN);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_FROM_PORT_HISTORY_SIZE(1);
   ASSERT_from_bufferSendOutDrain_SIZE(1);
   ASSERT_from_bufferSendOutDrain(0, buffer);
 
   // Send another buffer and expect an event
   this->invoke_to_bufferSendInFill(0, buffer);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_EVENTS_SIZE(2);
   ASSERT_EVENTS_BA_BufferAccepted_SIZE(1);
 
   // Return the original buffer in order to drain one buffer
   this->invoke_to_bufferSendInReturn(0, buffer);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_FROM_PORT_HISTORY_SIZE(3);
   ASSERT_from_bufferSendOutDrain_SIZE(2);
   ASSERT_from_bufferSendOutDrain(1, buffer);
 
   // Send another buffer and expect no new event
   this->invoke_to_bufferSendInFill(0, buffer);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_EVENTS_SIZE(2);
   ASSERT_EVENTS_BA_BufferAccepted_SIZE(1);
 
   // Send another buffer and expect an event
   this->invoke_to_bufferSendInFill(0, buffer);
-  this->dispatchOne();
+  this->doDispatch();
   ASSERT_EVENTS_SIZE(3);
   ASSERT_EVENTS_BA_QueueFull_SIZE(2);
 

--- a/Svc/BufferAccumulator/test/ut/Health.cpp
+++ b/Svc/BufferAccumulator/test/ut/Health.cpp
@@ -20,7 +20,7 @@ void BufferAccumulatorTester ::Ping() {
   U32 key = 42;
 
   this->invoke_to_pingIn(0, key);
-  this->component.doDispatch();
+  this->dispatchOne();
 
   ASSERT_EVENTS_SIZE(0);
   ASSERT_from_pingOut_SIZE(1);

--- a/Svc/BufferAccumulator/test/ut/Health.cpp
+++ b/Svc/BufferAccumulator/test/ut/Health.cpp
@@ -20,7 +20,7 @@ void BufferAccumulatorTester ::Ping() {
   U32 key = 42;
 
   this->invoke_to_pingIn(0, key);
-  this->dispatchOne();
+  this->doDispatch();
 
   ASSERT_EVENTS_SIZE(0);
   ASSERT_from_pingOut_SIZE(1);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3446  |
|**_Has Unit Tests (y/n)_**| Yes - Existing |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

I locally updated `fprime/cmake/settings.cmake` to change `-DPROTECTED=protected -DPRIVATE=private`. This causes additional build errors beyond all our updates in manual code for PRIVATE->private and PROTECTED->protected due to auto-coded files which use PRIVATE, PROTECTED. This set of changes is associated with fixing `Svc/BufferAccumulatorTester` so that the UTs in this directory can build and pass.

Approach in this case was:

Added a helper dispatchOne to (base) BufferAccumulatorTester which is an existing friend in the autocoded file

## Rationale

#3446

## Future Work

Note that this PR does **does not** include the update to `fprime/cmake/settings.cmake` itself