### PR TITLE
Designate base config from non-base config

### DIFF
--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -443,7 +443,7 @@ function(fprime_add_config_build_target)
     # 2. Configuration processing must be called in-between
     ####
     fprime__process_module_setup("Library"
-        "CONFIGURATION_OVERRIDES;STATIC;INTERFACE;CHOOSES_IMPLEMENTATIONS" ${ARGN_PASS})
+        "CONFIGURATION_OVERRIDES;STATIC;INTERFACE;CHOOSES_IMPLEMENTATIONS;BASE_CONFIG" ${ARGN_PASS})
     fprime__internal_process_configuration_sources(
         "${INTERNAL_MODULE_NAME}"
         "${INTERNAL_SOURCES}"
@@ -460,7 +460,9 @@ function(fprime_add_config_build_target)
     # The new module should include the root configuration directory
     fprime_target_include_directories("${INTERNAL_MODULE_NAME}" PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/..")
     # The configuration target should depend on the new module
-    target_link_libraries("${FPRIME__INTERNAL_CONFIG_TARGET_NAME}" INTERFACE "${INTERNAL_MODULE_NAME}")
+    if (INTERNAL_BASE_CONFIG)
+        target_link_libraries("${FPRIME__INTERNAL_CONFIG_TARGET_NAME}" INTERFACE "${INTERNAL_MODULE_NAME}")
+    endif()
     # Set up the new module to be marked as FPRIME_CONFIGURATION
     append_list_property("${INTERNAL_MODULE_NAME}" GLOBAL PROPERTY "FPRIME_CONFIG_MODULES")
     set_property(TARGET "${INTERNAL_MODULE_NAME}" PROPERTY FPRIME_CONFIGURATION TRUE)

--- a/cmake/config_assembler.cmake
+++ b/cmake/config_assembler.cmake
@@ -1,7 +1,13 @@
+####
+# config_assembler.cmake:
+#
+# CMake configuration handling function.
+####
 include_guard()
 # Create a target to act as an interface to all fprime configuration modules
 set(FPRIME__INTERNAL_CONFIG_TARGET_NAME "__fprime_config")
 add_library(${FPRIME__INTERNAL_CONFIG_TARGET_NAME} INTERFACE)
+
 ####
 # Function `fprime__internal_process_configuration_sources`:
 #

--- a/cmake/platform/Darwin.cmake
+++ b/cmake/platform/Darwin.cmake
@@ -21,5 +21,6 @@ register_fprime_config(
    CHOOSES_IMPLEMENTATIONS
       Os_Cpu_Darwin
       Os_Memory_Darwin
+   BASE_CONFIG
 )
 target_compile_definitions(PlatformDarwin INTERFACE -DTGT_OS_TYPE_DARWIN)

--- a/cmake/platform/Linux.cmake
+++ b/cmake/platform/Linux.cmake
@@ -14,10 +14,11 @@ endif()
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/unix/Platform/")
 # Override unix implementations with LINUX specific ones
 register_fprime_config(
-      PlatformLinux
-   INTERFACE # No buildable files generated
-   CHOOSES_IMPLEMENTATIONS
-      Os_Cpu_Linux
-      Os_Memory_Linux
+        PlatformLinux
+    INTERFACE # No buildable files generated
+    CHOOSES_IMPLEMENTATIONS
+        Os_Cpu_Linux
+        Os_Memory_Linux
+    BASE_CONFIG
 )
 target_compile_definitions(PlatformLinux INTERFACE -DTGT_OS_TYPE_LINUX)

--- a/cmake/platform/unix/Platform/CMakeLists.txt
+++ b/cmake/platform/unix/Platform/CMakeLists.txt
@@ -21,4 +21,5 @@ register_fprime_config(
         Os_Cpu_Stub
         Os_Memory_Stub
     INTERFACE # No compilable outputs produced
+    BASE_CONFIG
 )

--- a/default/config/CMakeLists.txt
+++ b/default/config/CMakeLists.txt
@@ -29,5 +29,6 @@ register_fprime_config(
         "${CMAKE_CURRENT_LIST_DIR}/StaticMemoryConfig.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/TlmChanImplCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/TlmPacketizerCfg.hpp"
-         "${CMAKE_CURRENT_LIST_DIR}/CRCCheckerConfig.hpp"
+        "${CMAKE_CURRENT_LIST_DIR}/CRCCheckerConfig.hpp"
+    BASE_CONFIG
 )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This splits configuration into types:
- BASE_CONFIG, which is required for `Fw_Types` and dependency is inherited through `Fw_Types`
- Normal config, which must be explicitly listed as a dependency

## Rationale

This allows configuration to configure things (like component instances) that depend themselves on `Fw_Types` without introducing a configuration cycle.

## Testing/Review Recommendations

## Future Work

Note any additional work that will be done relating to this issue.
