### PR TITLE
Updates for Svc/CmdSequencer corresponding to UT cmake update for protected/private

### DIFF
--- a/Svc/CmdSequencer/test/ut/AMPCS.cpp
+++ b/Svc/CmdSequencer/test/ut/AMPCS.cpp
@@ -46,7 +46,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_RUN,
+          this->getRunOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -74,7 +74,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_RUN,
+          this->getRunOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );

--- a/Svc/CmdSequencer/test/ut/CmdSequencerTester.hpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerTester.hpp
@@ -42,6 +42,35 @@ namespace Svc {
       static const FwSizeType TEST_SEQ_BUFFER_SIZE = 255;
 
     protected:
+      // ----------------------------------------------------------------------
+      // Accessor methods for opcodes
+      // ----------------------------------------------------------------------
+
+      static FwOpcodeType getRunOpcode() {
+          return CmdSequencerComponentBase::OPCODE_CS_RUN;
+      }
+
+      static FwOpcodeType getStartOpcode() {
+          return CmdSequencerComponentBase::OPCODE_CS_START;
+      }
+
+      static FwOpcodeType getAutoOpcode() {
+          return CmdSequencerComponentBase::OPCODE_CS_AUTO;
+      }
+
+      static FwOpcodeType getManualOpcode() {
+          return CmdSequencerComponentBase::OPCODE_CS_MANUAL;
+      }
+
+      static FwOpcodeType getStepOpcode() {
+          return CmdSequencerComponentBase::OPCODE_CS_STEP;
+      }
+
+      static FwOpcodeType getValidateOpcode() {
+          return CmdSequencerComponentBase::OPCODE_CS_VALIDATE;
+      }
+
+    protected:
 
       // ----------------------------------------------------------------------
       // Types

--- a/Svc/CmdSequencer/test/ut/ImmediateBase.cpp
+++ b/Svc/CmdSequencer/test/ut/ImmediateBase.cpp
@@ -121,7 +121,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_START,
+          this->getStartOpcode(),
           startCmdSeq,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -154,7 +154,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_START,
+          this->getStartOpcode(),
           startCmdSeq,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -169,7 +169,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_AUTO,
+          this->getAutoOpcode(),
           autoCmdSeq,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -184,7 +184,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_MANUAL,
+          this->getManualOpcode(),
           manualCmdSeq,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -269,7 +269,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_STEP,
+          this->getStepOpcode(),
           stepCmdSeq,
           Fw::CmdResponse::EXECUTION_ERROR
       );

--- a/Svc/CmdSequencer/test/ut/InvalidFiles.cpp
+++ b/Svc/CmdSequencer/test/ut/InvalidFiles.cpp
@@ -51,7 +51,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_RUN,
+          this->getRunOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -87,7 +87,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_VALIDATE,
+          this->getValidateOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -106,7 +106,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_RUN,
+          this->getRunOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -137,7 +137,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_VALIDATE,
+          this->getValidateOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -169,7 +169,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_VALIDATE,
+          this->getValidateOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -192,7 +192,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_RUN,
+          this->getRunOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -229,7 +229,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_VALIDATE,
+          this->getValidateOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -256,7 +256,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_RUN,
+          this->getRunOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -284,7 +284,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_RUN,
+          this->getRunOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -308,7 +308,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_VALIDATE,
+          this->getValidateOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -356,7 +356,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_RUN,
+          this->getRunOpcode(),
           0,
           Fw::CmdResponse(Fw::CmdResponse::EXECUTION_ERROR)
       );
@@ -384,7 +384,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_VALIDATE,
+          this->getValidateOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -403,7 +403,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_RUN,
+          this->getRunOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -433,7 +433,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_VALIDATE,
+          this->getValidateOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -453,7 +453,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_RUN,
+          this->getRunOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -484,7 +484,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_VALIDATE,
+          this->getValidateOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );
@@ -503,7 +503,7 @@ namespace Svc {
       ASSERT_CMD_RESPONSE_SIZE(1);
       ASSERT_CMD_RESPONSE(
           0,
-          CmdSequencerComponentBase::OPCODE_CS_RUN,
+          this->getRunOpcode(),
           0,
           Fw::CmdResponse::EXECUTION_ERROR
       );

--- a/Svc/CmdSequencer/test/ut/NoRecords.cpp
+++ b/Svc/CmdSequencer/test/ut/NoRecords.cpp
@@ -55,7 +55,7 @@ namespace Svc {
             ASSERT_CMD_RESPONSE_SIZE(1);
             ASSERT_CMD_RESPONSE(
                 0,
-                CmdSequencerComponentBase::OPCODE_CS_VALIDATE,
+                this->getValidateOpcode(),
                 0,
                 Fw::CmdResponse::EXECUTION_ERROR
             );
@@ -68,7 +68,7 @@ namespace Svc {
             RunNoRecords()
         {
             SequenceFiles::NoRecordsFile file(this->format);
-            
+
             // Set the time
             Fw::Time testTime(TB_WORKSTATION_TIME, 0, 0);
             this->setTestTime(testTime);
@@ -84,7 +84,7 @@ namespace Svc {
             ASSERT_CMD_RESPONSE_SIZE(1);
             ASSERT_CMD_RESPONSE(
                 0,
-                CmdSequencerComponentBase::OPCODE_CS_RUN,
+                this->getRunOpcode(),
                 0,
                 Fw::CmdResponse::EXECUTION_ERROR
             );


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3446  |
|**_Has Unit Tests (y/n)_**| Yes - Existing |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

I locally updated `fprime/cmake/settings.cmake` to change `-DPROTECTED=protected -DPRIVATE=private`. This causes additional build errors beyond all our updates in manual code for PRIVATE->private and PROTECTED->protected due to auto-coded files which use PRIVATE, PROTECTED. This set of changes is associated with fixing `Svc/CmdSequencer` so that the UTs in this directory can build and pass.

Approach in this case was:

1. Add protected accessor methods for opcodes

## Rationale

#3446

## Future Work

1. Note that this PR **does not** include the update to fprime/cmake/settings.cmake itself - this will be done at the end
2. Note that this PR **does not** include re-naming the flight code <X>Impl to <X> (separate issue)