### PR TITLE
Updates for Svc/DpManager corresponding to UT cmake update for protected/private

### DIFF
--- a/Svc/DpManager/test/ut/DpManagerTester.cpp
+++ b/Svc/DpManager/test/ut/DpManagerTester.cpp
@@ -80,4 +80,13 @@ void DpManagerTester::checkTelemetry() {
     TESTER_CHECK_CHANNEL(NumBytes);
 }
 
+
+void DpManagerTester::doDispatch() {
+    this->component.doDispatch();
+}
+
+FwIndexType DpManagerTester::getBufferAllocationFailedThrottleCount() {
+    return this->component.DpManagerComponentBase::m_BufferAllocationFailedThrottle;
+}
+
 }  // end namespace Svc

--- a/Svc/DpManager/test/ut/DpManagerTester.hpp
+++ b/Svc/DpManager/test/ut/DpManagerTester.hpp
@@ -82,6 +82,28 @@ class DpManagerTester : public DpManagerGTestBase {
 
     //! The component under test
     DpManager component;
+
+    public:
+      // ----------------------------------------------------------------------
+      // Accessor methods for protected/private members
+      // ----------------------------------------------------------------------
+
+      //! Dispatch
+      void doDispatch();
+
+      //! Get the m_BufferAllocationFailedThrottle value
+      FwIndexType getBufferAllocationFailedThrottleCount();
+
+      //! Get the OPCODE_CLEAR_EVENT_THROTTLE value
+      static FwOpcodeType getClearEventThrottleOpcode() {
+        return DpManagerComponentBase::OPCODE_CLEAR_EVENT_THROTTLE;
+      }
+
+      //! Get the EVENTID_BUFFERALLOCATIONFAILED_THROTTLE value
+      static FwSizeType getBufferAllocationFailedThrottle() {
+        return DpManagerComponentBase::EVENTID_BUFFERALLOCATIONFAILED_THROTTLE;
+      }
+
 };
 
 }  // end namespace Svc

--- a/Svc/DpManager/test/ut/Rules/CLEAR_EVENT_THROTTLE.cpp
+++ b/Svc/DpManager/test/ut/Rules/CLEAR_EVENT_THROTTLE.cpp
@@ -30,12 +30,12 @@ void TestState::action__CLEAR_EVENT_THROTTLE__OK() {
     const FwEnumStoreType instance = static_cast<FwEnumStoreType>(STest::Pick::any());
     const U32 cmdSeq = STest::Pick::any();
     this->sendCmd_CLEAR_EVENT_THROTTLE(instance, cmdSeq);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check the command response
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, DpManagerComponentBase::OPCODE_CLEAR_EVENT_THROTTLE, cmdSeq, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::DpManagerTester::getClearEventThrottleOpcode(), cmdSeq, Fw::CmdResponse::OK);
     // Check the state
-    ASSERT_EQ(this->component.DpManagerComponentBase::m_BufferAllocationFailedThrottle, 0);
+    ASSERT_EQ(Svc::DpManagerTester::getBufferAllocationFailedThrottleCount(), 0);
     this->abstractState.bufferAllocationFailedEventCount = 0;
 }
 
@@ -47,7 +47,7 @@ namespace CLEAR_EVENT_THROTTLE {
 
 void Tester::OK() {
     Testers::bufferGetStatus.ruleInvalid.apply(this->testState);
-    for (FwSizeType i = 0; i <= DpManagerComponentBase::EVENTID_BUFFERALLOCATIONFAILED_THROTTLE; ++i) {
+    for (FwSizeType i = 0; i <= Svc::DpManagerTester::getBufferAllocationFailedThrottle(); ++i) {
         Testers::productRequestIn.ruleBufferInvalid.apply(this->testState);
     }
     this->ruleOK.apply(this->testState);

--- a/Svc/DpManager/test/ut/Rules/ProductGetIn.cpp
+++ b/Svc/DpManager/test/ut/Rules/ProductGetIn.cpp
@@ -67,7 +67,7 @@ void TestState ::action__ProductGetIn__BufferInvalid() {
     ASSERT_EQ(status, Fw::Success::FAILURE);
     // Check events
     if (this->abstractState.bufferAllocationFailedEventCount <
-        DpManagerComponentBase::EVENTID_BUFFERALLOCATIONFAILED_THROTTLE) {
+        Svc::DpManagerTester::getBufferAllocationFailedThrottle()) {
         ASSERT_EVENTS_SIZE(1);
         ASSERT_EVENTS_BufferAllocationFailed(0, id);
         ++this->abstractState.bufferAllocationFailedEventCount;

--- a/Svc/DpManager/test/ut/Rules/ProductRequestIn.cpp
+++ b/Svc/DpManager/test/ut/Rules/ProductRequestIn.cpp
@@ -34,7 +34,7 @@ void TestState::action__ProductRequestIn__BufferValid() {
     const auto id = static_cast<FwDpIdType>(STest::Pick::lowerUpper(0, static_cast<U32>(std::numeric_limits<FwDpIdType>::max())));
     const FwSizeType size = this->abstractState.getBufferSize();
     this->invoke_to_productRequestIn(portNum, id, size);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check events
     ASSERT_EVENTS_SIZE(0);
     // Update test state
@@ -65,10 +65,10 @@ void TestState ::action__ProductRequestIn__BufferInvalid() {
     const FwDpIdType id = static_cast<FwDpIdType>(STest::Pick::lowerUpper(0, static_cast<U32>(std::numeric_limits<FwDpIdType>::max())));
     const FwSizeType size = this->abstractState.getBufferSize();
     this->invoke_to_productRequestIn(portNum, id, size);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check events
     if (this->abstractState.bufferAllocationFailedEventCount <
-        DpManagerComponentBase::EVENTID_BUFFERALLOCATIONFAILED_THROTTLE) {
+        Svc::DpManagerTester::getBufferAllocationFailedThrottle()) {
         ASSERT_EVENTS_SIZE(1);
         ASSERT_EVENTS_BufferAllocationFailed(0, id);
         ++this->abstractState.bufferAllocationFailedEventCount;

--- a/Svc/DpManager/test/ut/Rules/ProductSendIn.cpp
+++ b/Svc/DpManager/test/ut/Rules/ProductSendIn.cpp
@@ -33,7 +33,7 @@ void TestState ::action__ProductSendIn__OK() {
     const FwSizeType size = this->abstractState.getBufferSize();
     const Fw::Buffer buffer(this->abstractState.bufferData, static_cast<Fw::Buffer::SizeType>(size));
     this->invoke_to_productSendIn(portNum, id, buffer);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check events
     ASSERT_EVENTS_SIZE(0);
     // Update test state

--- a/Svc/DpManager/test/ut/Rules/SchedIn.cpp
+++ b/Svc/DpManager/test/ut/Rules/SchedIn.cpp
@@ -29,7 +29,7 @@ void TestState ::action__SchedIn__OK() {
     // Invoke schedIn port
     const U32 context = STest::Pick::any();
     this->invoke_to_schedIn(0, context);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check telemetry
     this->checkTelemetry();
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3446  |
|**_Has Unit Tests (y/n)_**| Yes - Existing |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

I locally updated `fprime/cmake/settings.cmake` to change `-DPROTECTED=protected -DPRIVATE=private`. This causes additional build errors beyond all our updates in manual code for PRIVATE->private and PROTECTED->protected due to auto-coded files which use PRIVATE, PROTECTED. This set of changes is associated with fixing `Svc/DpManager` so that the UTs in this directory can build and pass.

Approach in this case was:

1) Add accessor methods to DpManagerTester for tests in Rules

## Rationale

#3446

## Future Work

1. Note that this PR **does not** include the update to fprime/cmake/settings.cmake itself - this will be done at the end
2. Note that this PR **does not** include re-naming the flight code <X>Impl to <X> (separate issue)