### PR TITLE
Updates for Svc/DpWriter corresponding to UT cmake udpate for protected/private

### DIFF
--- a/Svc/DpWriter/test/ut/DpWriterTester.cpp
+++ b/Svc/DpWriter/test/ut/DpWriterTester.cpp
@@ -88,4 +88,36 @@ void DpWriterTester::checkTelemetry() {
     TESTER_CHECK_CHANNEL(NumErrors);
 }
 
+void DpWriterTester::doDispatch() {
+    this->component.doDispatch();
+}
+
+FwIndexType DpWriterTester::getBufferTooSmallForDataThrottleCount() {
+    return this->component.DpWriterComponentBase::m_BufferTooSmallForDataThrottle;
+}
+
+FwIndexType DpWriterTester::getBufferTooSmallForPacketThrottleCount() {
+    return this->component.DpWriterComponentBase::m_BufferTooSmallForPacketThrottle;
+}
+
+FwIndexType DpWriterTester::getFileOpenErrorThrottleCount() {
+    return this->component.DpWriterComponentBase::m_FileOpenErrorThrottle;
+}
+
+FwIndexType DpWriterTester::getFileWriteErrorThrottleCount() {
+    return this->component.DpWriterComponentBase::m_FileWriteErrorThrottle;
+}
+
+FwIndexType DpWriterTester::getInvalidBufferThrottleCount() {
+    return this->component.DpWriterComponentBase::m_InvalidBufferThrottle;
+}
+
+FwIndexType DpWriterTester::getInvalidHeaderHashThrottleCount() {
+    return this->component.DpWriterComponentBase::m_InvalidHeaderHashThrottle;
+}
+
+FwIndexType DpWriterTester::getInvalidHeaderThrottleCount() {
+    return this->component.DpWriterComponentBase::m_InvalidHeaderThrottle;
+}
+
 }  // namespace Svc

--- a/Svc/DpWriter/test/ut/DpWriterTester.hpp
+++ b/Svc/DpWriter/test/ut/DpWriterTester.hpp
@@ -100,6 +100,71 @@ class DpWriterTester : public DpWriterGTestBase {
 
     //! The component under test
     DpWriter component;
+
+  public:
+    // ----------------------------------------------------------------------
+    // Accessor methods for protected/private members
+    // ----------------------------------------------------------------------
+
+    //! Dispatch a message
+    void doDispatch();
+
+    //! Get the EVENTID_INVALIDBUFFER_THROTTLE value
+    static FwSizeType getInvalidBufferThrottle() {
+      return DpWriterComponentBase::EVENTID_INVALIDBUFFER_THROTTLE;
+    }
+
+    //! Get the EVENTID_BUFFERTOOSMALLFORPACKET_THROTTLE value
+    static FwSizeType getBufferTooSmallForPacketThrottle() {
+      return DpWriterComponentBase::EVENTID_BUFFERTOOSMALLFORPACKET_THROTTLE;
+    }
+
+    //! Get the EVENTID_INVALIDHEADERHASH_THROTTLE value
+    static FwSizeType getInvalidHeaderHashThrottle() {
+      return DpWriterComponentBase::EVENTID_INVALIDHEADERHASH_THROTTLE;
+    }
+
+    //! Get the EVENTID_INVALIDHEADER_THROTTLE value
+    static FwSizeType getInvalidHeaderThrottle() {
+      return DpWriterComponentBase::EVENTID_INVALIDHEADER_THROTTLE;
+    }
+
+    //! Get the EVENTID_FILEOPENERROR_THROTTLE value
+    static FwSizeType getFileOpenErrorThrottle() {
+      return DpWriterComponentBase::EVENTID_FILEOPENERROR_THROTTLE;
+    }
+
+    //! Get the EVENTID_FILEWRITEERROR_THROTTLE value
+    static FwSizeType getFileWriteErrorThrottle() {
+      return DpWriterComponentBase::EVENTID_FILEWRITEERROR_THROTTLE;
+    }
+
+    //! Get the OPCODE_CLEAR_EVENT_THROTTLE value
+    static FwOpcodeType getOpCodeClearEventThrottle() {
+      return DpWriterComponentBase::OPCODE_CLEAR_EVENT_THROTTLE;
+    }
+
+    //! Get the m_BufferTooSmallForDataThrottle value
+    FwIndexType getBufferTooSmallForDataThrottleCount();
+
+    //! Get the m_BufferTooSmallForPacketThrottle value
+    FwIndexType getBufferTooSmallForPacketThrottleCount();
+
+    //! Get the m_FileOpenErrorThrottle value
+    FwIndexType getFileOpenErrorThrottleCount();
+
+    //! Get the m_FileWriteErrorThrottle value
+    FwIndexType getFileWriteErrorThrottleCount();
+
+    //! Get the m_InvalidBufferThrottle value
+    FwIndexType getInvalidBufferThrottleCount();
+
+    //! Get the m_InvalidHeaderHashThrottle value
+    FwIndexType getInvalidHeaderHashThrottleCount();
+
+    //! Get the m_InvalidHeaderThrottle value
+    FwIndexType getInvalidHeaderThrottleCount();
+
 };
 
 }  // namespace Svc

--- a/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
+++ b/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
@@ -46,7 +46,7 @@ void TestState ::action__BufferSendIn__OK() {
     Fw::Buffer buffer = this->abstractState.getDpBuffer();
     // Send the buffer
     this->invoke_to_bufferSendIn(0, buffer);
-    this->component.doDispatch();
+    this->doDispatch();
     // Deserialize the container header
     Fw::DpContainer container;
     container.setBuffer(buffer);
@@ -92,9 +92,9 @@ void TestState ::action__BufferSendIn__InvalidBuffer() {
     Fw::Buffer buffer;
     // Send the buffer
     this->invoke_to_bufferSendIn(0, buffer);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check events
-    if (this->abstractState.m_invalidBufferEventCount < DpWriterComponentBase::EVENTID_INVALIDBUFFER_THROTTLE) {
+    if (this->abstractState.m_invalidBufferEventCount < Svc::DpWriterTester::getInvalidBufferThrottle()) {
         ASSERT_EVENTS_SIZE(1);
         ASSERT_EVENTS_InvalidBuffer_SIZE(1);
         this->abstractState.m_invalidBufferEventCount++;
@@ -129,10 +129,10 @@ void TestState ::action__BufferSendIn__BufferTooSmallForPacket() {
     Fw::Buffer buffer(this->abstractState.m_bufferData, bufferSize);
     // Send the buffer
     this->invoke_to_bufferSendIn(0, buffer);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check events
     if (this->abstractState.m_bufferTooSmallForPacketEventCount <
-        DpWriterComponentBase::EVENTID_BUFFERTOOSMALLFORPACKET_THROTTLE) {
+        Svc::DpWriterTester::getBufferTooSmallForPacketThrottle()) {
         ASSERT_EVENTS_SIZE(1);
         ASSERT_EVENTS_BufferTooSmallForPacket(0, bufferSize, minPacketSize);
         this->abstractState.m_bufferTooSmallForPacketEventCount++;
@@ -176,9 +176,9 @@ void TestState ::action__BufferSendIn__InvalidHeaderHash() {
     container.setHeaderHash(storedHashBuffer);
     // Send the buffer
     this->invoke_to_bufferSendIn(0, buffer);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check events
-    if (this->abstractState.m_invalidHeaderHashEventCount < DpWriterComponentBase::EVENTID_INVALIDHEADERHASH_THROTTLE) {
+    if (this->abstractState.m_invalidHeaderHashEventCount < Svc::DpWriterTester::getInvalidHeaderHashThrottle()) {
         ASSERT_EVENTS_SIZE(1);
         ASSERT_EVENTS_InvalidHeaderHash(0, buffer.getSize(), storedHash, computedHash);
         this->abstractState.m_invalidHeaderHashEventCount++;
@@ -219,9 +219,9 @@ void TestState ::action__BufferSendIn__InvalidHeader() {
     container.updateHeaderHash();
     // Send the buffer
     this->invoke_to_bufferSendIn(0, buffer);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check events
-    if (this->abstractState.m_invalidHeaderEventCount < DpWriterComponentBase::EVENTID_INVALIDHEADER_THROTTLE) {
+    if (this->abstractState.m_invalidHeaderEventCount < Svc::DpWriterTester::getInvalidHeaderThrottle()) {
         ASSERT_EVENTS_SIZE(1);
         ASSERT_EVENTS_InvalidHeader(0, buffer.getSize(), static_cast<U32>(Fw::FW_SERIALIZE_FORMAT_ERROR));
         this->abstractState.m_invalidHeaderEventCount++;
@@ -265,9 +265,9 @@ void TestState ::action__BufferSendIn__BufferTooSmallForData() {
     container.serializeHeader();
     // Send the buffer
     this->invoke_to_bufferSendIn(0, buffer);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check events
-    if (this->abstractState.m_bufferTooSmallForDataEventCount < DpWriterComponentBase::EVENTID_INVALIDHEADER_THROTTLE) {
+    if (this->abstractState.m_bufferTooSmallForDataEventCount < Svc::DpWriterTester::getInvalidHeaderThrottle()) {
         ASSERT_EVENTS_SIZE(1);
         ASSERT_EVENTS_BufferTooSmallForData(0, buffer.getSize(), static_cast<U32>(container.getPacketSize()));
         this->abstractState.m_bufferTooSmallForDataEventCount++;
@@ -309,9 +309,9 @@ void TestState ::action__BufferSendIn__FileOpenError() {
     container.deserializeHeader();
     // Send the buffer
     this->invoke_to_bufferSendIn(0, buffer);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check events
-    if (this->abstractState.m_fileOpenErrorEventCount < DpWriterComponentBase::EVENTID_FILEOPENERROR_THROTTLE) {
+    if (this->abstractState.m_fileOpenErrorEventCount < Svc::DpWriterTester::getFileOpenErrorThrottle()) {
         ASSERT_EVENTS_SIZE(1);
         Fw::FileNameString fileName;
         this->constructDpFileName(container.getId(), container.getTimeTag(), fileName);
@@ -366,9 +366,9 @@ void TestState ::action__BufferSendIn__FileWriteError() {
     fileData.writeSizeResult = STest::Pick::lowerUpper(0, static_cast<U32>(fileSize));
     // Send the buffer
     this->invoke_to_bufferSendIn(0, buffer);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check events
-    if (this->abstractState.m_fileWriteErrorEventCount < DpWriterComponentBase::EVENTID_FILEWRITEERROR_THROTTLE) {
+    if (this->abstractState.m_fileWriteErrorEventCount < Svc::DpWriterTester::getFileWriteErrorThrottle()) {
         ASSERT_EVENTS_SIZE(1);
         Fw::FileNameString fileName;
         this->constructDpFileName(container.getId(), container.getTimeTag(), fileName);

--- a/Svc/DpWriter/test/ut/Rules/CLEAR_EVENT_THROTTLE.cpp
+++ b/Svc/DpWriter/test/ut/Rules/CLEAR_EVENT_THROTTLE.cpp
@@ -30,18 +30,18 @@ void TestState ::action__CLEAR_EVENT_THROTTLE__OK() {
     const FwEnumStoreType instance = static_cast<FwEnumStoreType>(STest::Pick::any());
     const U32 cmdSeq = STest::Pick::any();
     this->sendCmd_CLEAR_EVENT_THROTTLE(instance, cmdSeq);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check the command response
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, DpWriterComponentBase::OPCODE_CLEAR_EVENT_THROTTLE, cmdSeq, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, DpWriterTester::getOpCodeClearEventThrottle(), cmdSeq, Fw::CmdResponse::OK);
     // Check the concrete state
-    ASSERT_EQ(this->component.DpWriterComponentBase::m_BufferTooSmallForDataThrottle, 0);
-    ASSERT_EQ(this->component.DpWriterComponentBase::m_BufferTooSmallForPacketThrottle, 0);
-    ASSERT_EQ(this->component.DpWriterComponentBase::m_FileOpenErrorThrottle, 0);
-    ASSERT_EQ(this->component.DpWriterComponentBase::m_FileWriteErrorThrottle, 0);
-    ASSERT_EQ(this->component.DpWriterComponentBase::m_InvalidBufferThrottle, 0);
-    ASSERT_EQ(this->component.DpWriterComponentBase::m_InvalidHeaderHashThrottle, 0);
-    ASSERT_EQ(this->component.DpWriterComponentBase::m_InvalidHeaderThrottle, 0);
+    ASSERT_EQ(this->getBufferTooSmallForDataThrottleCount(), 0);
+    ASSERT_EQ(this->getBufferTooSmallForPacketThrottleCount(), 0);
+    ASSERT_EQ(this->getFileOpenErrorThrottleCount(), 0);
+    ASSERT_EQ(this->getFileWriteErrorThrottleCount(), 0);
+    ASSERT_EQ(this->getInvalidBufferThrottleCount(), 0);
+    ASSERT_EQ(this->getInvalidHeaderHashThrottleCount(), 0);
+    ASSERT_EQ(this->getInvalidHeaderThrottleCount(), 0);
     // Update the abstract state
     this->abstractState.m_bufferTooSmallForDataEventCount = 0;
     this->abstractState.m_bufferTooSmallForPacketEventCount = 0;
@@ -59,7 +59,7 @@ namespace CLEAR_EVENT_THROTTLE {
 // ----------------------------------------------------------------------
 
 void Tester ::OK() {
-    for (FwSizeType i = 0; i <= DpWriterComponentBase::EVENTID_INVALIDBUFFER_THROTTLE; i++) {
+    for (FwSizeType i = 0; i <= DpWriterTester::getInvalidBufferThrottle(); i++) {
         Testers::bufferSendIn.ruleInvalidBuffer.apply(this->testState);
     }
     this->ruleOK.apply(this->testState);

--- a/Svc/DpWriter/test/ut/Rules/SchedIn.cpp
+++ b/Svc/DpWriter/test/ut/Rules/SchedIn.cpp
@@ -29,7 +29,7 @@ void TestState ::action__SchedIn__OK() {
     // Invoke schedIn port
     const U32 context = STest::Pick::any();
     this->invoke_to_schedIn(0, context);
-    this->component.doDispatch();
+    this->doDispatch();
     // Check telemetry
     this->checkTelemetry();
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3446  |
|**_Has Unit Tests (y/n)_**| Yes - Existing |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

I locally updated `fprime/cmake/settings.cmake` to change `-DPROTECTED=protected -DPRIVATE=private`. This causes additional build errors beyond all our updates in manual code for PRIVATE->private and PROTECTED->protected due to auto-coded files which use PRIVATE, PROTECTED. This set of changes is associated with fixing `Svc/DpWriter` so that the UTs in this directory can build and pass.

Approach in this case was:

1) Add accessor methods to DpWriterTester

## Rationale

#3446

## Future Work

1. Note that this PR **does not** include the update to fprime/cmake/settings.cmake itself - this will be done at the end
2. Note that this PR **does not** include re-naming the flight code <X>Impl to <X> (separate issue)