### PR TITLE
Switch Fw::Buffer size to FwSizeType instead of U32

### DIFF
--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -195,7 +195,7 @@ void SocketComponentHelper::readLoop() {
             Fw::Buffer buffer = this->getBuffer();
             U8* data = buffer.getData();
             FW_ASSERT(data);
-            FW_ASSERT(buffer.getSize() < std::numeric_limits<U32>::max(),
+            FW_ASSERT(buffer.getSize() <= std::numeric_limits<U32>::max(),
                       static_cast<FwAssertArgType>(buffer.getSize()));
             U32 size = static_cast<U32>(buffer.getSize());
             // recv blocks, so it may have been a while since its done an isOpened check

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -195,8 +195,7 @@ void SocketComponentHelper::readLoop() {
             Fw::Buffer buffer = this->getBuffer();
             U8* data = buffer.getData();
             FW_ASSERT(data);
-            FW_ASSERT(buffer.getSize() <= std::numeric_limits<U32>::max(),
-                      static_cast<FwAssertArgType>(buffer.getSize()));
+            FW_ASSERT_NO_OVERFLOW(buffer.getSize(), U32);
             U32 size = static_cast<U32>(buffer.getSize());
             // recv blocks, so it may have been a while since its done an isOpened check
             status = this->recv(data, size);

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -195,7 +195,9 @@ void SocketComponentHelper::readLoop() {
             Fw::Buffer buffer = this->getBuffer();
             U8* data = buffer.getData();
             FW_ASSERT(data);
-            U32 size = buffer.getSize();
+            FW_ASSERT(buffer.getSize() < std::numeric_limits<U32>::max(),
+                      static_cast<FwAssertArgType>(buffer.getSize()));
+            U32 size = static_cast<U32>(buffer.getSize());
             // recv blocks, so it may have been a while since its done an isOpened check
             status = this->recv(data, size);
             if ((status != SOCK_SUCCESS) && (status != SOCK_INTERRUPTED_TRY_AGAIN) && (status != SOCK_NO_DATA_AVAILABLE)) {

--- a/Drv/Ip/test/ut/SocketTestHelper.cpp
+++ b/Drv/Ip/test/ut/SocketTestHelper.cpp
@@ -25,15 +25,15 @@ void force_recv_timeout(int fd, Drv::IpSocket& socket) {
     setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<char *>(&timeout), sizeof(timeout));
 }
 
-void validate_random_data(U8 *data, U8 *truth, U32 size) {
-    for (U32 i = 0; i < size; i++) {
+void validate_random_data(U8 *data, U8 *truth, FwSizeType size) {
+    for (FwSizeType i = 0; i < size; i++) {
         ASSERT_EQ(data[i], truth[i]);
     }
 }
 
-void fill_random_data(U8 *data, U32 size) {
+void fill_random_data(U8 *data, FwSizeType size) {
     ASSERT_NE(size, 0u) << "Trying to fill random data of size 0";
-    for (U32 i = 0; i < size; i++) {
+    for (FwSizeType i = 0; i < size; i++) {
         data[i] = static_cast<U8>(STest::Pick::any());
     }
 }
@@ -44,7 +44,7 @@ void validate_random_buffer(Fw::Buffer &buffer, U8 *data) {
 }
 
 U32 fill_random_buffer(Fw::Buffer &buffer) {
-    buffer.setSize(STest::Pick::lowerUpper(1, buffer.getSize()));
+    buffer.setSize(static_cast<FwSizeType>(STest::Pick::lowerUpper(1, static_cast<U32>(buffer.getSize()))));
     fill_random_data(buffer.getData(), buffer.getSize());
     return static_cast<U32>(buffer.getSize());
 }

--- a/Drv/Ip/test/ut/SocketTestHelper.hpp
+++ b/Drv/Ip/test/ut/SocketTestHelper.hpp
@@ -27,14 +27,14 @@ void force_recv_timeout(int fd, Drv::IpSocket &socket);
  * @param truth: truth data to validate
  * @param size: size to validate
  */
-void validate_random_data(U8 *data, U8 *truth, U32 size);
+void validate_random_data(U8 *data, U8 *truth, FwSizeType size);
 
 /**
  * Fills in the given data buffer with randomly picked data.
  * @param data: data to file
  * @param size: size of fill
  */
-void fill_random_data(U8 *data, U32 size);
+void fill_random_data(U8 *data, FwSizeType size);
 
 /**
  * Validates a given buffer against the data provided.

--- a/Drv/LinuxI2cDriver/LinuxI2cDriver.cpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriver.cpp
@@ -78,8 +78,9 @@ namespace Drv {
       }
       // make sure it isn't a null pointer
       FW_ASSERT(serBuffer.getData());
+      FW_ASSERT_NO_OVERFLOW(serBuffer.getSize(), size_t);
       // write data
-      stat = static_cast<int>(write(this->m_fd, serBuffer.getData(), serBuffer.getSize()));
+      stat = static_cast<int>(write(this->m_fd, serBuffer.getData(), static_cast<size_t>(serBuffer.getSize())));
       if (stat == -1) {
 	  return I2cStatus::I2C_WRITE_ERR;
       }
@@ -130,6 +131,10 @@ namespace Drv {
     // make sure they are not null pointers
     FW_ASSERT(writeBuffer.getData());
     FW_ASSERT(readBuffer.getData());
+    // make sure downcasts are safe
+    FW_ASSERT_NO_OVERFLOW(addr, U16);
+    FW_ASSERT_NO_OVERFLOW(writeBuffer.getSize(), U16);
+    FW_ASSERT_NO_OVERFLOW(readBuffer.getSize(), U16);
 
     struct i2c_msg rdwr_msgs[2];
 

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -45,7 +45,8 @@ namespace Drv {
         memset(&tr, 0, sizeof(tr));
         tr.tx_buf = reinterpret_cast<__u64>(writeBuffer.getData());
         tr.rx_buf = reinterpret_cast<__u64>(readBuffer.getData());
-        tr.len = writeBuffer.getSize();
+        FW_ASSERT_NO_OVERFLOW(writeBuffer.getSize(), __u32);
+        tr.len = static_cast<__u32>(writeBuffer.getSize());
 /*
             .speed_hz = 0,
             .delay_usecs = 0,

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
@@ -90,7 +90,7 @@ namespace Drv {
             int m_fd;
             FwIndexType m_device;
             FwIndexType m_select;
-            U32 m_bytes;
+            FwSizeType m_bytes;
 
     };
 

--- a/Drv/LinuxUartDriver/LinuxUartDriver.cpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.cpp
@@ -341,8 +341,7 @@ void LinuxUartDriver ::serialReadTaskEntry(void* ptr) {
 
         // Read until something is received or an error occurs. Only loop when
         // stat == 0 as this is the timeout condition and the read should spin
-        FW_ASSERT(buff.getSize() <= std::numeric_limits<size_t>::max(),
-                  static_cast<FwAssertArgType>(buff.getSize()));
+        FW_ASSERT_NO_OVERFLOW(buff.getSize(), size_t);
         while ((stat == 0) && !comp->m_quitReadThread) {
             stat = static_cast<int>(::read(comp->m_fd, buff.getData(), static_cast<size_t>(buff.getSize())));
         }

--- a/Drv/LinuxUartDriver/LinuxUartDriver.cpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.cpp
@@ -341,8 +341,10 @@ void LinuxUartDriver ::serialReadTaskEntry(void* ptr) {
 
         // Read until something is received or an error occurs. Only loop when
         // stat == 0 as this is the timeout condition and the read should spin
+        FW_ASSERT(buff.getSize() <= std::numeric_limits<size_t>::max(),
+                  static_cast<FwAssertArgType>(buff.getSize()));
         while ((stat == 0) && !comp->m_quitReadThread) {
-            stat = static_cast<int>(::read(comp->m_fd, buff.getData(), buff.getSize()));
+            stat = static_cast<int>(::read(comp->m_fd, buff.getData(), static_cast<size_t>(buff.getSize())));
         }
         buff.setSize(0);
 

--- a/Drv/LinuxUartDriver/LinuxUartDriver.cpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.cpp
@@ -35,7 +35,7 @@ bool LinuxUartDriver::open(const char* const device,
                            UartBaudRate baud,
                            UartFlowControl fc,
                            UartParity parity,
-                           U32 allocationSize) {
+                           FwSizeType allocationSize) {
     FW_ASSERT(device != nullptr);
     int fd = -1;
     int stat = -1;

--- a/Drv/LinuxUartDriver/LinuxUartDriver.hpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.hpp
@@ -67,7 +67,7 @@ class LinuxUartDriver final : public LinuxUartDriverComponentBase {
     enum UartParity { PARITY_NONE, PARITY_ODD, PARITY_EVEN };
 
     // Open device with specified baud and flow control.
-    bool open(const char* const device, UartBaudRate baud, UartFlowControl fc, UartParity parity, U32 allocationSize);
+    bool open(const char* const device, UartBaudRate baud, UartFlowControl fc, UartParity parity, FwSizeType allocationSize);
 
     //! start the serial poll thread.
     //! buffSize is the max receive buffer size

--- a/Drv/LinuxUartDriver/LinuxUartDriver.hpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.hpp
@@ -104,7 +104,7 @@ class LinuxUartDriver final : public LinuxUartDriverComponentBase {
                                 ) override;
 
     int m_fd;  //!< file descriptor returned for I/O device
-    U32 m_allocationSize; //!< size of allocation request to memory manager
+    FwSizeType m_allocationSize; //!< size of allocation request to memory manager
     const char* m_device;  //!< original device path
 
     //! This method will be called by the new thread to wait for input on the serial port.

--- a/Drv/TcpClient/TcpClientComponentImpl.cpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.cpp
@@ -77,8 +77,7 @@ void TcpClientComponentImpl::connected() {
 // ----------------------------------------------------------------------
 
 void TcpClientComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
-    FW_ASSERT(fwBuffer.getSize() <= std::numeric_limits<U32>::max(),
-              static_cast<FwAssertArgType>(fwBuffer.getSize()));
+    FW_ASSERT_NO_OVERFLOW(fwBuffer.getSize(), U32);
     Drv::SocketIpStatus status = send(fwBuffer.getData(), static_cast<U32>(fwBuffer.getSize()));
     Drv::ByteStreamStatus returnStatus;
     switch (status) {

--- a/Drv/TcpClient/TcpClientComponentImpl.cpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.cpp
@@ -77,7 +77,9 @@ void TcpClientComponentImpl::connected() {
 // ----------------------------------------------------------------------
 
 void TcpClientComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
-    Drv::SocketIpStatus status = send(fwBuffer.getData(), fwBuffer.getSize());
+    FW_ASSERT(fwBuffer.getSize() <= std::numeric_limits<U32>::max(),
+              static_cast<FwAssertArgType>(fwBuffer.getSize()));
+    Drv::SocketIpStatus status = send(fwBuffer.getData(), static_cast<U32>(fwBuffer.getSize()));
     Drv::ByteStreamStatus returnStatus;
     switch (status) {
         case SOCK_INTERRUPTED_TRY_AGAIN:

--- a/Drv/TcpClient/test/ut/TcpClientTester.cpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.cpp
@@ -214,7 +214,7 @@ void TcpClientTester ::test_buffer_deallocation() {
 Fw::Buffer TcpClientTester ::
     from_allocate_handler(
         const FwIndexType portNum,
-        U32 size
+        FwSizeType size
     )
   {
     this->pushFromPortEntry_allocate(size);

--- a/Drv/TcpClient/test/ut/TcpClientTester.hpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.hpp
@@ -87,7 +87,7 @@ namespace Drv {
       //!
       Fw::Buffer from_allocate_handler(
           const FwIndexType portNum, /*!< The port number*/
-          U32 size
+          FwSizeType size
       ) override;
 
     private:

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -125,7 +125,9 @@ void TcpServerComponentImpl::readLoop() {
 // ----------------------------------------------------------------------
 
 void TcpServerComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
-    Drv::SocketIpStatus status = this->send(fwBuffer.getData(), fwBuffer.getSize());
+    FW_ASSERT(fwBuffer.getSize() <= std::numeric_limits<U32>::max(),
+              static_cast<FwAssertArgType>(fwBuffer.getSize()));
+    Drv::SocketIpStatus status = this->send(fwBuffer.getData(), static_cast<U32>(fwBuffer.getSize()));
     Drv::ByteStreamStatus returnStatus;
     switch (status) {
         case SOCK_INTERRUPTED_TRY_AGAIN:

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -125,8 +125,7 @@ void TcpServerComponentImpl::readLoop() {
 // ----------------------------------------------------------------------
 
 void TcpServerComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
-    FW_ASSERT(fwBuffer.getSize() <= std::numeric_limits<U32>::max(),
-              static_cast<FwAssertArgType>(fwBuffer.getSize()));
+    FW_ASSERT_NO_OVERFLOW(fwBuffer.getSize(), U32);
     Drv::SocketIpStatus status = this->send(fwBuffer.getData(), static_cast<U32>(fwBuffer.getSize()));
     Drv::ByteStreamStatus returnStatus;
     switch (status) {

--- a/Drv/TcpServer/test/ut/TcpServerTester.cpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.cpp
@@ -245,7 +245,7 @@ void TcpServerTester ::from_recv_handler(const FwIndexType portNum, Fw::Buffer& 
 Fw::Buffer TcpServerTester ::
     from_allocate_handler(
         const FwIndexType portNum,
-        U32 size
+        FwSizeType size
     )
   {
     this->pushFromPortEntry_allocate(size);

--- a/Drv/TcpServer/test/ut/TcpServerTester.hpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.hpp
@@ -99,7 +99,7 @@ namespace Drv {
       //!
       Fw::Buffer from_allocate_handler(
           const FwIndexType portNum, /*!< The port number*/
-          U32 size
+          FwSizeType size
       ) override;
 
     private:

--- a/Drv/Udp/UdpComponentImpl.cpp
+++ b/Drv/Udp/UdpComponentImpl.cpp
@@ -83,7 +83,9 @@ void UdpComponentImpl::connected() {
 // ----------------------------------------------------------------------
 
 void UdpComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
-    Drv::SocketIpStatus status = send(fwBuffer.getData(), fwBuffer.getSize());
+    FW_ASSERT(fwBuffer.getSize() <= std::numeric_limits<U32>::max(),
+              static_cast<FwAssertArgType>(fwBuffer.getSize()));
+    Drv::SocketIpStatus status = send(fwBuffer.getData(), static_cast<U32>(fwBuffer.getSize()));
     Drv::ByteStreamStatus returnStatus;
     switch (status) {
         case SOCK_INTERRUPTED_TRY_AGAIN:

--- a/Drv/Udp/UdpComponentImpl.cpp
+++ b/Drv/Udp/UdpComponentImpl.cpp
@@ -83,8 +83,7 @@ void UdpComponentImpl::connected() {
 // ----------------------------------------------------------------------
 
 void UdpComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
-    FW_ASSERT(fwBuffer.getSize() <= std::numeric_limits<U32>::max(),
-              static_cast<FwAssertArgType>(fwBuffer.getSize()));
+    FW_ASSERT_NO_OVERFLOW(fwBuffer.getSize(), U32);
     Drv::SocketIpStatus status = send(fwBuffer.getData(), static_cast<U32>(fwBuffer.getSize()));
     Drv::ByteStreamStatus returnStatus;
     switch (status) {

--- a/Drv/Udp/test/ut/UdpTester.cpp
+++ b/Drv/Udp/test/ut/UdpTester.cpp
@@ -185,7 +185,7 @@ void UdpTester ::from_recv_handler(const FwIndexType portNum, Fw::Buffer& recvBu
 Fw::Buffer UdpTester ::
     from_allocate_handler(
         const FwIndexType portNum,
-        U32 size
+        FwSizeType size
     )
   {
     this->pushFromPortEntry_allocate(size);

--- a/Drv/Udp/test/ut/UdpTester.hpp
+++ b/Drv/Udp/test/ut/UdpTester.hpp
@@ -95,7 +95,7 @@ namespace Drv {
       //!
       Fw::Buffer from_allocate_handler(
           const FwIndexType portNum, /*!< The port number*/
-          U32 size
+          FwSizeType size
       ) override;
 
     private:

--- a/Fw/Buffer/Buffer.cpp
+++ b/Fw/Buffer/Buffer.cpp
@@ -29,7 +29,7 @@ Buffer::Buffer(const Buffer& src)
     }
 }
 
-Buffer::Buffer(U8* data, SizeType size, U32 context)
+Buffer::Buffer(U8* data, FwSizeType size, U32 context)
     : Serializable(), m_serialize_repr(), m_bufferData(data), m_size(size), m_context(context) {
     if (m_bufferData != nullptr) {
         this->m_serialize_repr.setExtBuffer(this->m_bufferData, this->m_size);
@@ -57,7 +57,7 @@ U8* Buffer::getData() const {
     return this->m_bufferData;
 }
 
-Buffer::SizeType Buffer::getSize() const {
+FwSizeType Buffer::getSize() const {
     return this->m_size;
 }
 
@@ -72,7 +72,7 @@ void Buffer::setData(U8* const data) {
     }
 }
 
-void Buffer::setSize(const SizeType size) {
+void Buffer::setSize(const FwSizeType size) {
     this->m_size = size;
     if (m_bufferData != nullptr) {
         this->m_serialize_repr.setExtBuffer(this->m_bufferData, this->m_size);
@@ -83,7 +83,7 @@ void Buffer::setContext(const U32 context) {
     this->m_context = context;
 }
 
-void Buffer::set(U8* const data, const SizeType size, const U32 context) {
+void Buffer::set(U8* const data, const FwSizeType size, const U32 context) {
     this->m_bufferData = data;
     this->m_size = size;
     if (m_bufferData != nullptr) {
@@ -94,8 +94,7 @@ void Buffer::set(U8* const data, const SizeType size, const U32 context) {
 
 Fw::ExternalSerializeBufferWithMemberCopy Buffer::getSerializer() {
     if (this->isValid()) {
-        Fw::ExternalSerializeBufferWithMemberCopy esb(this->m_bufferData,
-                                                      static_cast<Fw::Serializable::SizeType>(this->m_size));
+        Fw::ExternalSerializeBufferWithMemberCopy esb(this->m_bufferData, this->m_size);
         esb.resetSer();
         return esb;
     } else {
@@ -105,9 +104,8 @@ Fw::ExternalSerializeBufferWithMemberCopy Buffer::getSerializer() {
 
 Fw::ExternalSerializeBufferWithMemberCopy Buffer::getDeserializer() {
     if (this->isValid()) {
-        Fw::ExternalSerializeBufferWithMemberCopy esb(this->m_bufferData,
-                                                      static_cast<Fw::Serializable::SizeType>(this->m_size));
-        Fw::SerializeStatus stat = esb.setBuffLen(static_cast<Fw::Serializable::SizeType>(this->m_size));
+        Fw::ExternalSerializeBufferWithMemberCopy esb(this->m_bufferData, this->m_size);
+        Fw::SerializeStatus stat = esb.setBuffLen(this->m_size);
         FW_ASSERT(stat == Fw::FW_SERIALIZE_OK);
         return esb;
     } else {

--- a/Fw/Buffer/Buffer.fpp
+++ b/Fw/Buffer/Buffer.fpp
@@ -13,7 +13,7 @@ module Fw {
   @ Returns the buffer
   port BufferGet(
                   @ The requested size
-                  $size: U32
+                  $size: FwSizeType
                 ) -> Fw.Buffer
 
 }

--- a/Fw/Buffer/Buffer.hpp
+++ b/Fw/Buffer/Buffer.hpp
@@ -189,7 +189,7 @@ class Buffer : public Fw::Serializable {
   private:
     Fw::ExternalSerializeBuffer m_serialize_repr;  //<! Representation for serialization and deserialization functions
     U8* m_bufferData;                              //<! data - A pointer to the data
-    FwSizeType m_size;                               //<! size - The data size in bytes
+    FwSizeType m_size;                             //<! size - The data size in bytes
     U32 m_context;                                 //!< Creation context for disposal
 };
 }  // end namespace Fw

--- a/Fw/Buffer/Buffer.hpp
+++ b/Fw/Buffer/Buffer.hpp
@@ -48,8 +48,8 @@ class Buffer : public Fw::Serializable {
     friend class Fw::BufferTester;
 
   public:
-    //! The size type for a buffer
-    using SizeType = U32;
+    //! The size type for a buffer - for backwards compatibility
+    using SizeType = FwSizeType;
 
     enum {
         SERIALIZED_SIZE = sizeof(SizeType) + sizeof(U32) + sizeof(U8*),  //!< Size of Fw::Buffer when serialized
@@ -73,7 +73,7 @@ class Buffer : public Fw::Serializable {
     //! \param data: data pointer to wrap
     //! \param size: size of data located at data pointer
     //! \param context: user-specified context to track creation. Default: no context
-    Buffer(U8* data, SizeType size, U32 context = NO_CONTEXT);
+    Buffer(U8* data, FwSizeType size, U32 context = NO_CONTEXT);
 
     //! Assignment operator to set given buffer's members from another without copying wrapped data
     //!
@@ -167,7 +167,7 @@ class Buffer : public Fw::Serializable {
 
     //! Sets creation context
     //!
-    void setContext(SizeType context);
+    void setContext(U32 context);
 
     //! Sets all values
     //! \param data: data pointer to wrap

--- a/Fw/Buffer/Buffer.hpp
+++ b/Fw/Buffer/Buffer.hpp
@@ -151,7 +151,7 @@ class Buffer : public Fw::Serializable {
 
     //! Returns size of wrapped data
     //!
-    SizeType getSize() const;
+    FwSizeType getSize() const;
 
     //! Returns creation context
     //!
@@ -163,7 +163,7 @@ class Buffer : public Fw::Serializable {
 
     //! Sets pointer to wrapped data and the size of the given data
     //!
-    void setSize(SizeType size);
+    void setSize(FwSizeType size);
 
     //! Sets creation context
     //!
@@ -173,7 +173,7 @@ class Buffer : public Fw::Serializable {
     //! \param data: data pointer to wrap
     //! \param size: size of data located at data pointer
     //! \param context: user-specified context to track creation. Default: no context
-    void set(U8* data, SizeType size, U32 context = NO_CONTEXT);
+    void set(U8* data, FwSizeType size, U32 context = NO_CONTEXT);
 
 #if FW_SERIALIZABLE_TO_STRING || BUILD_UT
     //! Supports writing this buffer to a string representation
@@ -189,7 +189,7 @@ class Buffer : public Fw::Serializable {
   private:
     Fw::ExternalSerializeBuffer m_serialize_repr;  //<! Representation for serialization and deserialization functions
     U8* m_bufferData;                              //<! data - A pointer to the data
-    SizeType m_size;                               //<! size - The data size in bytes
+    FwSizeType m_size;                               //<! size - The data size in bytes
     U32 m_context;                                 //!< Creation context for disposal
 };
 }  // end namespace Fw

--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -45,6 +45,11 @@
 #endif
 #endif  // if ASSERT is defined
 
+// Helper macro asserting that a value fits into a type without overflow. Helpful for checking before static casts
+#define FW_ASSERT_NO_OVERFLOW(value, T) \
+    FW_ASSERT((value) <= std::numeric_limits<T>::max(), \
+              static_cast<FwAssertArgType>(value))
+
 // F' Assertion functions can technically return even though the intention is for the assertion to terminate the
 // program. This breaks static analysis depending on assertions, since the analyzer has to assume the assertion will
 // return. When supported, annotate assertion functions as noreturn when statically analyzing.

--- a/Svc/BufferManager/Events.fppi
+++ b/Svc/BufferManager/Events.fppi
@@ -1,6 +1,6 @@
 @ The BufferManager was unable to allocate a requested buffer
 event NoBuffsAvailable(
-                        $size: U32 @< The requested size
+                        $size: FwSizeType @< The requested size
                       ) \
   severity warning high \
   id 0x00 \

--- a/Svc/BufferRepeater/BufferRepeater.cpp
+++ b/Svc/BufferRepeater/BufferRepeater.cpp
@@ -68,7 +68,9 @@ void BufferRepeater ::portIn_handler(FwIndexType portNum, /*!< The port number*/
             Fw::Buffer new_allocation = this->allocate_out(0, buffer.getSize());
             if (this->check_allocation(i, new_allocation, buffer)) {
                 // Clone the data and send it
-                ::memcpy(new_allocation.getData(), buffer.getData(), buffer.getSize());
+                FW_ASSERT(buffer.getSize() <= std::numeric_limits<size_t>::max(),
+                          static_cast<FwAssertArgType>(buffer.getSize()));
+                ::memcpy(new_allocation.getData(), buffer.getData(), static_cast<size_t>(buffer.getSize()));
                 new_allocation.setSize(buffer.getSize());
                 this->portOut_out(i, new_allocation);
             }

--- a/Svc/BufferRepeater/BufferRepeater.cpp
+++ b/Svc/BufferRepeater/BufferRepeater.cpp
@@ -68,8 +68,7 @@ void BufferRepeater ::portIn_handler(FwIndexType portNum, /*!< The port number*/
             Fw::Buffer new_allocation = this->allocate_out(0, buffer.getSize());
             if (this->check_allocation(i, new_allocation, buffer)) {
                 // Clone the data and send it
-                FW_ASSERT(buffer.getSize() <= std::numeric_limits<size_t>::max(),
-                          static_cast<FwAssertArgType>(buffer.getSize()));
+                FW_ASSERT_NO_OVERFLOW(buffer.getSize(), size_t);
                 ::memcpy(new_allocation.getData(), buffer.getData(), static_cast<size_t>(buffer.getSize()));
                 new_allocation.setSize(buffer.getSize());
                 this->portOut_out(i, new_allocation);

--- a/Svc/BufferRepeater/BufferRepeater.fpp
+++ b/Svc/BufferRepeater/BufferRepeater.fpp
@@ -26,7 +26,7 @@ module Svc {
     @ Soft failure in allocation
     event AllocationSoftFailure(
                             $port: I32 @< The port index that needed an allocation
-                            $size: U32 @< The requested allocation size
+                            $size: FwSizeType @< The requested allocation size
                           ) \
         severity warning high \
         id 0 \
@@ -36,7 +36,7 @@ module Svc {
     @ Hard failure in allocation
     event AllocationHardFailure(
                             $port: I32 @< The port index that needed an allocation
-                            $size: U32 @< The requested allocation size
+                            $size: FwSizeType @< The requested allocation size
                           ) \
         severity fatal \
         id 1 \

--- a/Svc/BufferRepeater/test/ut/BufferRepeaterTester.cpp
+++ b/Svc/BufferRepeater/test/ut/BufferRepeaterTester.cpp
@@ -104,7 +104,7 @@ void BufferRepeaterTester ::testFailure(BufferRepeater::BufferRepeaterFailureOpt
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-Fw::Buffer BufferRepeaterTester ::from_allocate_handler(const FwIndexType portNum, U32 size) {
+Fw::Buffer BufferRepeaterTester ::from_allocate_handler(const FwIndexType portNum, FwSizeType size) {
     this->pushFromPortEntry_allocate(size);
     Fw::Buffer new_buffer;
 

--- a/Svc/BufferRepeater/test/ut/BufferRepeaterTester.hpp
+++ b/Svc/BufferRepeater/test/ut/BufferRepeaterTester.hpp
@@ -53,7 +53,7 @@ class BufferRepeaterTester : public BufferRepeaterGTestBase {
     //! Handler for from_allocate
     //!
     Fw::Buffer from_allocate_handler(const FwIndexType portNum, /*!< The port number*/
-                                     U32 size);
+                                     FwSizeType size);
 
     //! Handler for from_deallocate
     //!

--- a/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
@@ -50,7 +50,7 @@ void SpacePacketDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data,
     // so we need to add 1 to the length to get the actual data size
     U16 pkt_length = static_cast<U16>(header.getpacketDataLength() + 1);
     if (pkt_length > data.getSize() - SpacePacketHeader::SERIALIZED_SIZE) {
-        U32 maxDataAvailable = data.getSize() - SpacePacketHeader::SERIALIZED_SIZE;
+        FwSizeType maxDataAvailable = data.getSize() - SpacePacketHeader::SERIALIZED_SIZE;
         this->log_WARNING_HI_InvalidLength(pkt_length, maxDataAvailable);
         this->dataReturnOut_out(0, data, context);  // Drop the packet
         return;

--- a/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.fpp
+++ b/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.fpp
@@ -9,7 +9,7 @@ module Ccsds {
         output port validateApidSeqCount: Ccsds.ApidSequenceCount
 
         @ Deframing received an invalid frame length
-        event InvalidLength(transmitted: U16, actual: U32) \
+        event InvalidLength(transmitted: U16, actual: FwSizeType) \
             severity warning high \
             format "Invalid length received. Header specified packet byte size of {} | Actual received data length: {}"
 

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
@@ -92,7 +92,7 @@ U16 SpacePacketFramerTester ::from_getApidSeqCount_handler(FwIndexType portNum,
 }
 
 Fw::Buffer SpacePacketFramerTester ::from_bufferAllocate_handler(FwIndexType portNum,
-                                                           U32 size) {
+                                                           FwSizeType size) {
     return Fw::Buffer(this->m_internalDataBuffer, size);
 }
 

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
@@ -65,7 +65,7 @@ class SpacePacketFramerTester final : public SpacePacketFramerGTestBase {
                                      const ComCfg::APID& apid,
                                      U16 sequenceCount) override;
 
-    Fw::Buffer from_bufferAllocate_handler(FwIndexType portNum, U32 size) override;
+    Fw::Buffer from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) override;
 
   private:
     // ----------------------------------------------------------------------

--- a/Svc/Ccsds/TmFramer/test/ut/TmFramerTester.cpp
+++ b/Svc/Ccsds/TmFramer/test/ut/TmFramerTester.cpp
@@ -118,7 +118,7 @@ void TmFramerTester ::testSeqCountWrapAround() {
 void TmFramerTester ::testInputBufferTooLarge() {
     const FwSizeType tooLargeSize = ComCfg::TmFrameFixedSize; // This is too large since we need room for header+trailer as well
     U8 bufferData[tooLargeSize];
-    Fw::Buffer buffer(bufferData, static_cast<Fw::Buffer::SizeType>(tooLargeSize));
+    Fw::Buffer buffer(bufferData, tooLargeSize);
     ComCfg::FrameContext defaultContext;
     // Send a buffer larger than the 
     ASSERT_DEATH_IF_SUPPORTED(this->invoke_to_dataIn(0, buffer, defaultContext), "TmFramer.cpp");

--- a/Svc/DpManager/test/ut/DpManagerTester.cpp
+++ b/Svc/DpManager/test/ut/DpManagerTester.cpp
@@ -24,7 +24,7 @@ DpManagerTester ::~DpManagerTester() {}
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-Fw::Buffer DpManagerTester::from_bufferGetOut_handler(const FwIndexType portNum, U32 size) {
+Fw::Buffer DpManagerTester::from_bufferGetOut_handler(const FwIndexType portNum, FwSizeType size) {
     this->abstractState.bufferGetOutPortNumOpt = TestUtils::Option<FwIndexType>::some(portNum);
     this->pushFromPortEntry_bufferGetOut(size);
     Fw::Buffer buffer;

--- a/Svc/DpManager/test/ut/DpManagerTester.hpp
+++ b/Svc/DpManager/test/ut/DpManagerTester.hpp
@@ -39,7 +39,7 @@ class DpManagerTester : public DpManagerGTestBase {
 
     //! Handler for from_bufferGetOut
     Fw::Buffer from_bufferGetOut_handler(const FwIndexType portNum,  //!< The port number
-                                         U32 size                        //!< The size
+                                         FwSizeType size                        //!< The size
     );
 
     //! Handler for from_productResponseOut

--- a/Svc/DpWriter/DpWriter.fpp
+++ b/Svc/DpWriter/DpWriter.fpp
@@ -70,7 +70,7 @@ module Svc {
 
     @ Received buffer is too small to hold a data product packet
     event BufferTooSmallForPacket(
-                          bufferSize: U32 @< The incoming buffer size
+                          bufferSize: FwSizeType @< The incoming buffer size
                           minSize: U32 @< The minimum required size
                         ) \
       severity warning high \
@@ -79,7 +79,7 @@ module Svc {
 
     @ The received buffer has an invalid header hash
     event InvalidHeaderHash(
-                             bufferSize: U32 @< The incoming buffer size
+                             bufferSize: FwSizeType @< The incoming buffer size
                              storedHash: U32 @< The stored hash value
                              computedHash: U32 @< The computed hash value
                            ) \
@@ -89,7 +89,7 @@ module Svc {
 
     @ Error occurred when deserializing the packet header
     event InvalidHeader(
-                         bufferSize: U32 @< The incoming buffer size
+                         bufferSize: FwSizeType @< The incoming buffer size
                          errorCode: U32 @< The error code
                        ) \
       severity warning high \
@@ -98,7 +98,7 @@ module Svc {
 
     @ Received buffer is too small to hold the data specified in the header
     event BufferTooSmallForData(
-                          bufferSize: U32 @< The incoming buffer size
+                          bufferSize: FwSizeType @< The incoming buffer size
                           minSize: U32 @< The minimum required size
                         ) \
       severity warning high \

--- a/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
+++ b/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
@@ -57,7 +57,7 @@ void TestState ::action__BufferSendIn__OK() {
     ASSERT_EVENTS_FileWritten_SIZE(1);
     Fw::FileNameString fileName;
     this->constructDpFileName(container.getId(), container.getTimeTag(), fileName);
-    ASSERT_EVENTS_FileWritten(0, buffer.getSize(), fileName.toChar());
+    ASSERT_EVENTS_FileWritten(0, static_cast<U32>(buffer.getSize()), fileName.toChar());
     // Check processing types
     this->checkProcTypes(container);
     // Check DP notification

--- a/Svc/FprimeFramer/FprimeFramer.cpp
+++ b/Svc/FprimeFramer/FprimeFramer.cpp
@@ -34,13 +34,13 @@ void FprimeFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const 
     FW_ASSERT(frameSize <= std::numeric_limits<Fw::Buffer::SizeType>::max(), static_cast<FwAssertArgType>(frameSize));
 
     // Allocate frame buffer
-    Fw::Buffer frameBuffer = this->bufferAllocate_out(0, static_cast<Fw::Buffer::SizeType>(frameSize));
+    Fw::Buffer frameBuffer = this->bufferAllocate_out(0, frameSize);
     auto frameSerializer = frameBuffer.getSerializer();
     Fw::SerializeStatus status;
 
     // Serialize the header
     // 0xDEADBEEF is already set as the default value for the header startWord field in the FPP type definition
-    header.setlengthField(data.getSize());
+    header.setlengthField(static_cast<FprimeProtocol::TokenType>(data.getSize()));
     status = frameSerializer.serialize(header);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
@@ -82,7 +82,7 @@ void FprimeFramerTester ::testNominalFraming() {
 // Test Harness: Handler implementations for output ports
 // ----------------------------------------------------------------------
 
-Fw::Buffer FprimeFramerTester::from_bufferAllocate_handler(FwIndexType portNum, U32 size){
+Fw::Buffer FprimeFramerTester::from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size){
     this->pushFromPortEntry_bufferAllocate(size);
     this->m_buffer.setData(this->m_buffer_slot);
     this->m_buffer.setSize(size);

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTester.hpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTester.hpp
@@ -64,7 +64,7 @@ class FprimeFramerTester final : public FprimeFramerGTestBase {
     // Test Harness: Handler implementations for output ports
     // ----------------------------------------------------------------------
 
-    Fw::Buffer from_bufferAllocate_handler(FwIndexType portNum, U32 size) override;
+    Fw::Buffer from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) override;
 
   private:
     // ----------------------------------------------------------------------

--- a/Svc/FprimeRouter/test/ut/FprimeRouterTester.cpp
+++ b/Svc/FprimeRouter/test/ut/FprimeRouterTester.cpp
@@ -114,7 +114,7 @@ void FprimeRouterTester::connectPortsExceptUnknownData() {
 // ----------------------------------------------------------------------
 // Port handler overrides
 // ----------------------------------------------------------------------
-Fw::Buffer FprimeRouterTester::from_bufferAllocate_handler(FwIndexType portNum, U32 size) {
+Fw::Buffer FprimeRouterTester::from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) {
     this->pushFromPortEntry_bufferAllocate(size);
     this->m_buffer.setData(this->m_buffer_slot);
     this->m_buffer.setSize(size);

--- a/Svc/FprimeRouter/test/ut/FprimeRouterTester.hpp
+++ b/Svc/FprimeRouter/test/ut/FprimeRouterTester.hpp
@@ -83,7 +83,7 @@ class FprimeRouterTester : public FprimeRouterGTestBase {
     // Port handler overrides
     // ----------------------------------------------------------------------
     //! Overriding bufferAllocate handler to be able to request a buffer in component tests
-    Fw::Buffer from_bufferAllocate_handler(FwIndexType portNum, U32 size) override;
+    Fw::Buffer from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) override;
 
   private:
     // ----------------------------------------------------------------------

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
@@ -208,7 +208,7 @@ void FrameAccumulatorTester ::mockAccumulateFullFrame(U32& frame_size, U32& buff
 // ----------------------------------------------------------------------
 Fw::Buffer FrameAccumulatorTester ::from_bufferAllocate_handler(
         FwIndexType portNum,
-        U32 size
+        FwSizeType size
     )
   {
     this->pushFromPortEntry_bufferAllocate(size);

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.hpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.hpp
@@ -87,7 +87,7 @@ class FrameAccumulatorTester : public FrameAccumulatorGTestBase {
     // Port handler overrides
     // ----------------------------------------------------------------------
     //! Overriding bufferAllocate handler to be able to request a buffer in component tests
-    Fw::Buffer from_bufferAllocate_handler(FwIndexType portNum, U32 size) override;
+    Fw::Buffer from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) override;
 
   private:
     // ----------------------------------------------------------------------

--- a/Svc/GenericHub/test/ut/GenericHubTester.cpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.cpp
@@ -206,7 +206,7 @@ void GenericHubTester ::from_portOut_handler(FwIndexType portNum,        /*!< Th
     ASSERT_from_buffersOut_SIZE(0);
 }
 
-Fw::Buffer GenericHubTester ::from_dataOutAllocate_handler(const FwIndexType portNum, const U32 size) {
+Fw::Buffer GenericHubTester ::from_dataOutAllocate_handler(const FwIndexType portNum, const FwSizeType size) {
     EXPECT_EQ(m_allocate.getData(), nullptr) << "Allocation buffer is still in use";
     EXPECT_LE(size, sizeof(m_data_for_allocation)) << "Allocation buffer is still in use";
     m_allocate.set(m_data_for_allocation, size);

--- a/Svc/GenericHub/test/ut/GenericHubTester.hpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.hpp
@@ -98,7 +98,7 @@ class GenericHubTester : public GenericHubGTestBase {
     //! Handler for from_dataOutAllocate
     //!
     Fw::Buffer from_dataOutAllocate_handler(const FwIndexType portNum, /*!< The port number*/
-                                            U32 size);
+                                            FwSizeType size);
 
     //! Handler for from_dataOut
     //!

--- a/Svc/StaticMemory/StaticMemoryComponentImpl.cpp
+++ b/Svc/StaticMemory/StaticMemoryComponentImpl.cpp
@@ -48,7 +48,7 @@ void StaticMemoryComponentImpl ::bufferDeallocate_handler(const FwIndexType port
     m_allocated[portNum] = false;
 }
 
-Fw::Buffer StaticMemoryComponentImpl ::bufferAllocate_handler(const FwIndexType portNum, Fw::Buffer::SizeType size) {
+Fw::Buffer StaticMemoryComponentImpl ::bufferAllocate_handler(const FwIndexType portNum, FwSizeType size) {
     FW_ASSERT(portNum < static_cast<FwIndexType>(FW_NUM_ARRAY_ELEMENTS(m_static_memory)));
     FW_ASSERT(size <= sizeof(m_static_memory[portNum])); // It is a topology error to ask for too much from this component
     FW_ASSERT(not m_allocated[portNum], static_cast<FwAssertArgType>(portNum)); // It is also an error to allocate again before returning

--- a/Svc/StaticMemory/StaticMemoryComponentImpl.hpp
+++ b/Svc/StaticMemory/StaticMemoryComponentImpl.hpp
@@ -50,7 +50,7 @@ class StaticMemoryComponentImpl final : public StaticMemoryComponentBase {
     //! Handler implementation for bufferAllocate
     //!
     Fw::Buffer bufferAllocate_handler(const FwIndexType portNum, /*!< The port number*/
-                                      U32 size);
+                                      FwSizeType size);
 
     bool m_allocated[NUM_BUFFERALLOCATE_INPUT_PORTS];
     U8 m_static_memory[NUM_BUFFERALLOCATE_INPUT_PORTS][STATIC_MEMORY_ALLOCATION_SIZE];


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix #3782 
