### PR TITLE
Fixing a bug in the shared setup_helper to make the wait_on_started ASSERT configurable by the calling test

### DIFF
--- a/Drv/TcpServer/test/ut/TcpServerTester.hpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.hpp
@@ -51,7 +51,7 @@ namespace Drv {
       // Tests
       // ----------------------------------------------------------------------
 
-      void setup_helper(bool recv_thread, bool reconnect);
+      void setup_helper(bool recv_thread, bool reconnect, bool expect_started = true);
 
       //! Test basic messaging
       //!


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3763 |
|**_Has Unit Tests (y/n)_**| Change is to UT |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Bug fix for incorrect ASSERT for test cases that do not have automatic connection enabled. Added a new argument to be able to disable the ASSERTs.

## Rationale

This change should fix the transient issues we've been seeing with TcpServer UTs that we've been seeing in RHEL8 CI and also on MacOS. 

I was able to repro the error in a Docker container with restricted CPU resources: 

```c
89/93 Test: Drv_TcpServer_ut_exe
Command: "/fprime/build-fprime-automatic-native-ut/bin/Linux/Drv_TcpServer_ut_exe"
Directory: /fprime/build-fprime-automatic-native-ut/F-Prime/Drv/TcpServer
"Drv_TcpServer_ut_exe" start time: Jun 25 23:26 UTC
Output:
----------------------------------------------------------
[==========] Running 7 tests from 3 test suites.
[----------] Global test environment set-up.
[----------] 3 tests from Nominal
[ RUN      ] Nominal.TcpServerBufferDeallocation
[       OK ] Nominal.TcpServerBufferDeallocation (3 ms)
[ RUN      ] Nominal.TcpServerBasicMessaging
[       OK ] Nominal.TcpServerBasicMessaging (0 ms)
[ RUN      ] Nominal.TcpServerBasicReceiveThread
[       OK ] Nominal.TcpServerBasicReceiveThread (10 ms)
[----------] 3 tests from Nominal (15 ms total)

[----------] 2 tests from Reconnect
[ RUN      ] Reconnect.TcpServerMultiMessaging
[       OK ] Reconnect.TcpServerMultiMessaging (5 ms)
[ RUN      ] Reconnect.TcpServerReceiveThreadReconnect
[       OK ] Reconnect.TcpServerReceiveThreadReconnect (107 ms)
[----------] 2 tests from Reconnect (113 ms total)

[----------] 2 tests from AutoConnect
[ RUN      ] AutoConnect.AutoConnectOnSendOff
[       OK ] AutoConnect.AutoConnectOnSendOff (0 ms)
[ RUN      ] AutoConnect.AutoConnectOnRecvOff
/fprime/Drv/TcpServer/test/ut/TcpServerTester.cpp:40: Failure
Value of: this->wait_on_started(true, Drv::Test::get_configured_delay_ms()/10 + 1)
  Actual: false
Expected: true
/fprime/Drv/TcpServer/test/ut/TcpServerTester.cpp:41: Failure
Value of: component.isStarted()
  Actual: false
Expected: true
[  FAILED  ] AutoConnect.AutoConnectOnRecvOff (1168 ms)
[----------] 2 tests from AutoConnect (1169 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 3 test suites ran. (1298 ms total)
[  PASSED  ] 6 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] AutoConnect.AutoConnectOnRecvOff

 1 FAILED TEST
<end of output>
Test time =   2.06 sec
----------------------------------------------------------
Test Failed.
"Drv_TcpServer_ut_exe" end time: Jun 25 23:26 UTC
"Drv_TcpServer_ut_exe" time elapsed: 00:00:02
----------------------------------------------------------
```

Note: I wasn't able to confirm for certain this is the same error that appears in CI. The CI logs are not archived. There is a possibility that this is not the same error that we are encountering in CI.

## Testing/Review Recommendations

N/A
 
## Future Work

No further work
