### PR TITLE
Updates for Svc/FpySquencer corresponding to UT cmake update for protected/private

### DIFF
--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -607,7 +607,7 @@ TEST_F(FpySequencerTester, cmd_VALIDATE) {
 
 TEST_F(FpySequencerTester, cmd_RUN_VALIDATED) {
     // should fail because in idle
-    cmp.m_stateMachine_sequencer.m_state = State::IDLE;
+    this->tester_setState(State::IDLE);
     sendCmd_RUN_VALIDATED(0, 0, FpySequencer_BlockState::NO_BLOCK);
     dispatchCurrentMessages(cmp);
     ASSERT_CMD_RESPONSE_SIZE(1);

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -543,13 +543,13 @@ TEST_F(FpySequencerTester, cmd_RUN) {
     dispatchUntilState(State::IDLE);
     ASSERT_EQ(tester_get_m_statementsDispatched(), 1);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::OK);
     this->clearHistory();
 
     sendCmd_RUN(0, 0, Fw::String("test.bin"), FpySequencer_BlockState::NO_BLOCK);
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::OK);
     dispatchUntilState(State::VALIDATING);
     dispatchUntilState(State::RUNNING_AWAITING_STATEMENT_RESPONSE);
     dispatchUntilState(State::IDLE);
@@ -564,16 +564,16 @@ TEST_F(FpySequencerTester, cmd_RUN) {
     dispatchUntilState(State::VALIDATING);
     dispatchUntilState(State::IDLE);
 
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::EXECUTION_ERROR);
 
     this->clearHistory();
 
     // try running while already running
-    cmp.m_stateMachine_sequencer.m_state = State::RUNNING_DISPATCH_STATEMENT;
+    this->tester_setState(State::RUNNING_DISPATCH_STATEMENT);
     sendCmd_RUN(0, 0, Fw::String("invalid seq"), FpySequencer_BlockState::BLOCK);
     // dispatch cmd
-    cmp.doDispatch();
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    this->tester_doDispatch();
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::EXECUTION_ERROR);
     removeFile("test.bin");
 }
 
@@ -583,7 +583,7 @@ TEST_F(FpySequencerTester, cmd_VALIDATE) {
     dispatchUntilState(State::VALIDATING);
     dispatchUntilState(State::IDLE);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_VALIDATE, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_VALIDATE(), 0, Fw::CmdResponse::EXECUTION_ERROR);
     this->clearHistory();
 
     allocMem();
@@ -595,14 +595,14 @@ TEST_F(FpySequencerTester, cmd_VALIDATE) {
     ASSERT_EQ(tester_get_m_statementsDispatched(), 0);
     dispatchUntilState(State::AWAITING_CMD_RUN_VALIDATED);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_VALIDATE, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_VALIDATE(), 0, Fw::CmdResponse::OK);
     this->clearHistory();
 
-    cmp.m_stateMachine_sequencer.m_state = State::VALIDATING;
+    this->tester_setState(State::VALIDATING);
     sendCmd_VALIDATE(0, 0, Fw::String("test.bin"));
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_VALIDATE, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_VALIDATE(), 0, Fw::CmdResponse::EXECUTION_ERROR);
 }
 
 TEST_F(FpySequencerTester, cmd_RUN_VALIDATED) {
@@ -611,7 +611,7 @@ TEST_F(FpySequencerTester, cmd_RUN_VALIDATED) {
     sendCmd_RUN_VALIDATED(0, 0, FpySequencer_BlockState::NO_BLOCK);
     dispatchCurrentMessages(cmp);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN_VALIDATED, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN_VALIDATED(), 0, Fw::CmdResponse::EXECUTION_ERROR);
     this->clearHistory();
 
     allocMem();
@@ -622,9 +622,9 @@ TEST_F(FpySequencerTester, cmd_RUN_VALIDATED) {
     this->clearHistory();
     // should succeed immediately
     sendCmd_RUN_VALIDATED(0, 0, FpySequencer_BlockState::NO_BLOCK);
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN_VALIDATED, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN_VALIDATED(), 0, Fw::CmdResponse::OK);
     // should go back to IDLE because sequence is bad
     dispatchUntilState(State::IDLE);
     ASSERT_CMD_RESPONSE_SIZE(1);
@@ -635,32 +635,32 @@ TEST_F(FpySequencerTester, cmd_RUN_VALIDATED) {
     this->clearHistory();
     // should succeed immediately
     sendCmd_RUN_VALIDATED(0, 0, FpySequencer_BlockState::BLOCK);
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(0);
     // should go back to IDLE because sequence is bad
     dispatchUntilState(State::IDLE);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN_VALIDATED, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN_VALIDATED(), 0, Fw::CmdResponse::OK);
 }
 
 TEST_F(FpySequencerTester, cmd_CANCEL) {
-    cmp.m_stateMachine_sequencer.m_state = State::IDLE;
+    this->tester_setState(State::IDLE);
     sendCmd_CANCEL(0, 0);
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(1);
     // should fail if we're in IDLE
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_CANCEL, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_CANCEL(), 0, Fw::CmdResponse::EXECUTION_ERROR);
 
     dispatchCurrentMessages(cmp);
-    ASSERT_EQ(cmp.sequencer_getState(), State::IDLE);
+    ASSERT_EQ(this->tester_getState(), State::IDLE);
 
     this->clearHistory();
-    cmp.m_stateMachine_sequencer.m_state = State::RUNNING_SLEEPING;
+    this->tester_setState(State::RUNNING_SLEEPING);
     sendCmd_CANCEL(0, 0);
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(1);
     // should succeed instantly
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_CANCEL, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_CANCEL(), 0, Fw::CmdResponse::OK);
     // should go back to idle
     dispatchUntilState(State::IDLE);
 }
@@ -669,43 +669,43 @@ TEST_F(FpySequencerTester, cmd_DEBUG_CLEAR_BREAKPOINT) {
     tester_get_m_debug_ptr()->breakOnBreakpoint = true;
     sendCmd_DEBUG_CLEAR_BREAKPOINT(0, 0);
     // dispatch cmd
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(1);
     // should always work
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_DEBUG_CLEAR_BREAKPOINT, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_DEBUG_CLEAR_BREAKPOINT(), 0, Fw::CmdResponse::OK);
     // dispatch signal
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_FALSE(tester_get_m_debug_ptr()->breakOnBreakpoint);
 }
 
 TEST_F(FpySequencerTester, cmd_DEBUG_SET_BREAKPOINT) {
     sendCmd_DEBUG_SET_BREAKPOINT(0, 0, 123, true);
     // dispatch cmd handler
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(1);
     // should always work
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_DEBUG_SET_BREAKPOINT, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_DEBUG_SET_BREAKPOINT(), 0, Fw::CmdResponse::OK);
     // dispatch signal
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_TRUE(tester_get_m_debug_ptr()->breakOnBreakpoint);
     ASSERT_TRUE(tester_get_m_debug_ptr()->breakOnlyOnceOnBreakpoint);
     ASSERT_EQ(tester_get_m_debug_ptr()->breakpointIndex, 123);
 }
 
 TEST_F(FpySequencerTester, cmd_DEBUG_BREAK) {
-    cmp.m_stateMachine_sequencer.m_state = State::IDLE;
+    this->tester_setState(State::IDLE);
     tester_get_m_debug_ptr()->breakOnBreakpoint = false;
     tester_get_m_debug_ptr()->breakOnlyOnceOnBreakpoint = false;
     sendCmd_DEBUG_BREAK(0, 0, true);
     dispatchCurrentMessages(cmp);
     ASSERT_CMD_RESPONSE_SIZE(1);
     // should fail in idle
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_DEBUG_BREAK, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_DEBUG_BREAK(), 0, Fw::CmdResponse::EXECUTION_ERROR);
     ASSERT_FALSE(tester_get_m_debug_ptr()->breakOnBreakpoint);
 
     // now try while running
     this->clearHistory();
-    cmp.m_stateMachine_sequencer.m_state = State::RUNNING_AWAITING_STATEMENT_RESPONSE;
+    this->tester_setState(State::RUNNING_AWAITING_STATEMENT_RESPONSE);
     sendCmd_DEBUG_BREAK(0, 0, true);
     // dispatch cmd handler
     dispatchCurrentMessages(cmp);
@@ -713,31 +713,31 @@ TEST_F(FpySequencerTester, cmd_DEBUG_BREAK) {
     dispatchCurrentMessages(cmp);
     ASSERT_CMD_RESPONSE_SIZE(1);
     // should work in running
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_DEBUG_BREAK, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_DEBUG_BREAK(), 0, Fw::CmdResponse::OK);
     ASSERT_TRUE(tester_get_m_debug_ptr()->breakOnBreakpoint);
     ASSERT_TRUE(tester_get_m_debug_ptr()->breakOnlyOnceOnBreakpoint);
 }
 
 TEST_F(FpySequencerTester, cmd_DEBUG_CONTINUE) {
-    cmp.m_stateMachine_sequencer.m_state = State::IDLE;
+    this->tester_setState(State::IDLE);
     sendCmd_DEBUG_CONTINUE(0, 0);
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(1);
     // should fail in IDLE
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_DEBUG_CONTINUE, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_DEBUG_CONTINUE(), 0, Fw::CmdResponse::EXECUTION_ERROR);
     this->clearHistory();
 
-    cmp.m_stateMachine_sequencer.m_state = State::RUNNING_DEBUG_BROKEN;
+    this->tester_setState(State::RUNNING_DEBUG_BROKEN);
     sendCmd_DEBUG_CONTINUE(0, 0);
     // dispatch cmd handler
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(1);
     // should work in debug_broken
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_DEBUG_CONTINUE, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_DEBUG_CONTINUE(), 0, Fw::CmdResponse::OK);
     // dispatch signal handler
-    cmp.doDispatch();
+    this->tester_doDispatch();
     // should have gone to dispatch stmt
-    ASSERT_EQ(cmp.sequencer_getState(), State::RUNNING_DISPATCH_STATEMENT);
+    ASSERT_EQ(this->tester_getState(), State::RUNNING_DISPATCH_STATEMENT);
 }
 
 TEST_F(FpySequencerTester, readHeader) {
@@ -1196,7 +1196,7 @@ TEST_F(FpySequencerTester, checkTimers) {
     invoke_to_checkTimers(0, 0);
     dispatchCurrentMessages(cmp);
     // should not leave sleep
-    ASSERT_EQ(cmp.sequencer_getState(), State::RUNNING_SLEEPING);
+    ASSERT_EQ(this->tester_getState(), State::RUNNING_SLEEPING);
 
     time = Fw::Time(10, 0);
     setTestTime(time);
@@ -1204,7 +1204,7 @@ TEST_F(FpySequencerTester, checkTimers) {
     // should leave sleep
     dispatchUntilState(State::IDLE);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::OK);
     clearHistory();
 
     // okay now make sure it also works for checking timeout
@@ -1219,25 +1219,25 @@ TEST_F(FpySequencerTester, checkTimers) {
     invoke_to_checkTimers(0, 0);
     dispatchCurrentMessages(cmp);
     // should not leave sleep
-    ASSERT_EQ(cmp.sequencer_getState(), State::RUNNING_SLEEPING);
+    ASSERT_EQ(this->tester_getState(), State::RUNNING_SLEEPING);
     time = Fw::Time(15, 0);
     setTestTime(time);
     invoke_to_checkTimers(0, 0);
     dispatchUntilState(State::IDLE);
     ASSERT_CMD_RESPONSE_SIZE(1);
     // timed out, should give exec error
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::EXECUTION_ERROR);
 }
 
 TEST_F(FpySequencerTester, ping) {
     invoke_to_pingIn(0, 0);
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_from_pingOut_SIZE(1);
 }
 
 TEST_F(FpySequencerTester, cmdResponse) {
     invoke_to_cmdResponseIn(0, 0, 0, Fw::CmdResponse::OK);
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_EVENTS_CmdResponseWhileNotRunningSequence_SIZE(1);
     clearHistory();
 
@@ -1249,7 +1249,7 @@ TEST_F(FpySequencerTester, cmdResponse) {
     sendCmd_RUN(0, 0, Fw::String("test.bin"), FpySequencer_BlockState::BLOCK);
     dispatchUntilState(State::RUNNING_AWAITING_STATEMENT_RESPONSE);
     // once we're here, we should have just added the cmd dir to the queue
-    cmp.doDispatch();
+    this->tester_doDispatch();
     // dispatch once more to execute the cmd dir, sending out the command
 
     // should be 256 for seq idx and 256 for cmd idx
@@ -1257,7 +1257,7 @@ TEST_F(FpySequencerTester, cmdResponse) {
     // should be successful
     dispatchUntilState(State::IDLE);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::OK);
     clearHistory();
     // let's try that again but with a command that fails
     tester_set_m_sequencesStarted(255);
@@ -1269,7 +1269,7 @@ TEST_F(FpySequencerTester, cmdResponse) {
     dispatchUntilState(State::IDLE);
     // should fail seq
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::EXECUTION_ERROR);
     clearHistory();
 
     tester_set_m_sequencesStarted(255);
@@ -1282,14 +1282,14 @@ TEST_F(FpySequencerTester, cmdResponse) {
     invoke_to_cmdResponseIn(0, 123, 0x00FF0100, Fw::CmdResponse::OK);
     // should fail on seq idx, but should stay in running
     dispatchCurrentMessages(cmp);
-    ASSERT_EQ(cmp.sequencer_getState(), State::RUNNING_AWAITING_STATEMENT_RESPONSE);
+    ASSERT_EQ(this->tester_getState(), State::RUNNING_AWAITING_STATEMENT_RESPONSE);
 
     // okay now send right seq idx but wrong cmd idx
     invoke_to_cmdResponseIn(0, 123, 0x01000101, Fw::CmdResponse::OK);
     // should fail on cmd idx and go back to IDLE
     dispatchUntilState(State::IDLE);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::EXECUTION_ERROR);
     clearHistory();
 
     // okay now have a command response come in from this seq
@@ -1305,7 +1305,7 @@ TEST_F(FpySequencerTester, cmdResponse) {
     invoke_to_cmdResponseIn(0, 123, 0x01000100, Fw::CmdResponse::OK);
     dispatchUntilState(State::IDLE);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::EXECUTION_ERROR);
     clearHistory();
 
     // okay now have the wrong opcode come in
@@ -1319,13 +1319,13 @@ TEST_F(FpySequencerTester, cmdResponse) {
     invoke_to_cmdResponseIn(0, 456, 0x01000100, Fw::CmdResponse::OK);
     dispatchUntilState(State::IDLE);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::EXECUTION_ERROR);
     clearHistory();
 }
 
 TEST_F(FpySequencerTester, tlmWrite) {
     invoke_to_tlmWrite(0, 0);
-    cmp.doDispatch();
+    this->tester_doDispatch();
     // make sure that all tlm is written every call
     ASSERT_TLM_SIZE(10);
 }
@@ -1336,7 +1336,7 @@ TEST_F(FpySequencerTester, seqRunIn) {
     writeToFile("test.bin");
 
     invoke_to_seqRunIn(0, Fw::String("test.bin"));
-    cmp.doDispatch();
+    this->tester_doDispatch();
     dispatchUntilState(State::VALIDATING);
     dispatchUntilState(State::RUNNING_AWAITING_STATEMENT_RESPONSE);
     dispatchUntilState(State::IDLE);
@@ -1344,10 +1344,10 @@ TEST_F(FpySequencerTester, seqRunIn) {
     this->clearHistory();
 
     // try running while already running
-    cmp.m_stateMachine_sequencer.m_state = State::RUNNING_DISPATCH_STATEMENT;
+    this->tester_setState(State::RUNNING_DISPATCH_STATEMENT);
     invoke_to_seqRunIn(0, Fw::String("test.bin"));
     // dispatch cmd
-    cmp.doDispatch();
+    this->tester_doDispatch();
     ASSERT_EVENTS_InvalidSeqRunCall_SIZE(1);
     removeFile("test.bin");
 }

--- a/Svc/FpySequencer/test/ut/FpySequencerTestSequences.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestSequences.cpp
@@ -7,7 +7,7 @@ TEST_F(FpySequencerTester, Empty) {
     writeAndRun();
     dispatchUntilState(State::IDLE);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::OK);
 }
 
 TEST_F(FpySequencerTester, Full) {
@@ -18,12 +18,12 @@ TEST_F(FpySequencerTester, Full) {
     writeAndRun();
     dispatchUntilState(State::IDLE, Fpy::MAX_SEQUENCE_STATEMENT_COUNT * 4);
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FpySequencer::OPCODE_RUN, 0, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, FpySequencerTester::get_OPCODE_RUN(), 0, Fw::CmdResponse::OK);
 }
 
 TEST_F(FpySequencerTester, ComplexControlFlow) {
     allocMem();
-    
+
     nextTlmId = 123;
     ASSERT_EQ(nextTlmValue.serialize(true), Fw::SerializeStatus::FW_SERIALIZE_OK);
     add_GET_TLM(0, 1, 123);
@@ -52,7 +52,7 @@ TEST_F(FpySequencerTester, ComplexControlFlow) {
 
 TEST_F(FpySequencerTester, OrOfTlmAndReg) {
     allocMem();
-    
+
     nextTlmId = 123;
     ASSERT_EQ(nextTlmValue.serialize(true), Fw::SerializeStatus::FW_SERIALIZE_OK);
     add_GET_TLM(0, 1, 123);
@@ -83,7 +83,7 @@ TEST_F(FpySequencerTester, OrOfTlmAndReg) {
 
 TEST_F(FpySequencerTester, CmpIntTlm) {
     allocMem();
-    
+
     nextTlmId = 123;
     ASSERT_EQ(nextTlmValue.serialize(999), Fw::SerializeStatus::FW_SERIALIZE_OK);
     add_GET_TLM(0, 1, 123);

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
@@ -463,6 +463,20 @@ Fw::ExternalSerializeBuffer* FpySequencerTester::tester_get_m_sequenceBuffer_ptr
 Svc::FpySequencer::Debug* FpySequencerTester::tester_get_m_debug_ptr() {
     return &(this->cmp.m_debug);
 }
+
+void FpySequencerTester::tester_doDispatch() {
+    this->cmp.doDispatch();
+}
+
+Svc::FpySequencer_SequencerStateMachineStateMachineBase::State FpySequencerTester::tester_getState() {
+    return this->cmp.m_stateMachine_sequencer.getState();
+}
+
+void FpySequencerTester::tester_setState(Svc::FpySequencer_SequencerStateMachineStateMachineBase::State state) {
+    FpySequencer_SequencerStateMachineTester::setState(this->cmp.m_stateMachine_sequencer, state);
+}
+
+
 // End UT private/protected access
 
 }  // namespace Svc

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
@@ -163,6 +163,78 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     Svc::Signal tester_checkStatementTimeout();
     Svc::Signal tester_checkShouldWake();
     Svc::FpySequencer::Telemetry* tester_get_m_tlm_ptr();
+    void tester_doDispatch();
+    void tester_setState(Svc::FpySequencer_SequencerStateMachineStateMachineBase::State state);
+    Svc::FpySequencer_SequencerStateMachineStateMachineBase::State tester_getState();
+
+  public:
+    // ----------------------------------------------------------------------
+    // Static methods for accessing protected opcodes
+    // ----------------------------------------------------------------------
+
+    //! Get the OPCODE_RUN value
+    static FwOpcodeType get_OPCODE_RUN() {
+        return FpySequencerComponentBase::OPCODE_RUN;
+    }
+
+    //! Get the OPCODE_VALIDATE value
+    static FwOpcodeType get_OPCODE_VALIDATE() {
+        return FpySequencerComponentBase::OPCODE_VALIDATE;
+    }
+
+    //! Get the OPCODE_RUN_VALIDATED value
+    static FwOpcodeType get_OPCODE_RUN_VALIDATED() {
+        return FpySequencerComponentBase::OPCODE_RUN_VALIDATED;
+    }
+
+    //! Get the OPCODE_CANCEL value
+    static FwOpcodeType get_OPCODE_CANCEL() {
+        return FpySequencerComponentBase::OPCODE_CANCEL;
+    }
+
+    //! Get the OPCODE_DEBUG_CLEAR_BREAKPOINT value
+    static FwOpcodeType get_OPCODE_DEBUG_CLEAR_BREAKPOINT() {
+        return FpySequencerComponentBase::OPCODE_DEBUG_CLEAR_BREAKPOINT;
+    }
+
+    //! Get the OPCODE_DEBUG_SET_BREAKPOINT value
+    static FwOpcodeType get_OPCODE_DEBUG_SET_BREAKPOINT() {
+        return FpySequencerComponentBase::OPCODE_DEBUG_SET_BREAKPOINT;
+    }
+
+    //! Get the OPCODE_DEBUG_BREAK value
+    static FwOpcodeType get_OPCODE_DEBUG_BREAK() {
+        return FpySequencerComponentBase::OPCODE_DEBUG_BREAK;
+    }
+
+    //! Get the OPCODE_DEBUG_CONTINUE value
+    static FwOpcodeType get_OPCODE_DEBUG_CONTINUE() {
+        return FpySequencerComponentBase::OPCODE_DEBUG_CONTINUE;
+    }
+
+
+};
+
+class FpySequencer_SequencerStateMachineTester {
+    // ----------------------------------------------------------------------
+    // Construction and destruction
+    // ----------------------------------------------------------------------
+
+  public:
+    //! Construct object FpySequencer_SequencerStateMachineTester
+    //!
+    FpySequencer_SequencerStateMachineTester();
+
+    //! Destroy object FpySequencer_SequencerStateMachineTester
+    //!
+    ~FpySequencer_SequencerStateMachineTester();
+
+    // ----------------------------------------------------------------------
+    // Test access to private and protected methods and members
+    // ----------------------------------------------------------------------
+    static void setState(FpySequencer_SequencerStateMachineStateMachineBase& sm, State s){
+        sm.m_state = s;
+    }
 
 };
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3446  |
|**_Has Unit Tests (y/n)_**| Yes - Existing |
|**_Documentation Included (y/n)_**| N/A |

---
## Change Description

I locally updated `fprime/cmake/settings.cmake` to change `-DPROTECTED=protected -DPRIVATE=private`. This causes additional build errors beyond all our updates in manual code for PRIVATE->private and PROTECTED->protected due to auto-coded files which use PRIVATE, PROTECTED. This set of changes is associated with fixing `Svc/FpySquencer` so that the UTs in this directory can build and pass.

Approach in this case was:

1) Add accessor methods to FpySquencerTester
2) Implementing new friend of the statemachine class **!! This will require FPP update !!**

## Rationale

#3446

## Future Work

1. Note that this PR **does not** include the update to fprime/cmake/settings.cmake itself - this will be done at the end
2. Note that this PR **does not** include re-naming the flight code <X>Impl to <X> (separate issue)