### PR TITLE
Deprecated 'bool noLength' versions of serialize and deserialize.

### DIFF
--- a/Fw/Dp/test/util/DpContainerHeader.hpp
+++ b/Fw/Dp/test/util/DpContainerHeader.hpp
@@ -76,7 +76,7 @@ struct DpContainerHeader {
         FwSizeType size = sizeof this->m_userData;
         status = deserializer.deserialize(this->m_userData, size, Fw::Serialization::OMIT_LENGTH);
         DP_CONTAINER_HEADER_ASSERT_EQ(status, FW_SERIALIZE_OK);
-        DP_CONTAINER_HEADER_ASSERT_EQ(size, sizeof this->m_userData);        
+        DP_CONTAINER_HEADER_ASSERT_EQ(size, sizeof this->m_userData);
         // Deserialize the data product state
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::DP_STATE_OFFSET);
         status = deserializer.deserialize(this->m_dpState);

--- a/Fw/Dp/test/util/DpContainerHeader.hpp
+++ b/Fw/Dp/test/util/DpContainerHeader.hpp
@@ -74,10 +74,9 @@ struct DpContainerHeader {
         // Deserialize the user data
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::USER_DATA_OFFSET);
         FwSizeType size = sizeof this->m_userData;
-        const bool omitLength = true;
-        status = deserializer.deserialize(this->m_userData, size, omitLength);
+        status = deserializer.deserialize(this->m_userData, size, Fw::Serialization::OMIT_LENGTH);
         DP_CONTAINER_HEADER_ASSERT_EQ(status, FW_SERIALIZE_OK);
-        DP_CONTAINER_HEADER_ASSERT_EQ(size, sizeof this->m_userData);
+        DP_CONTAINER_HEADER_ASSERT_EQ(size, sizeof this->m_userData);        
         // Deserialize the data product state
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::DP_STATE_OFFSET);
         status = deserializer.deserialize(this->m_dpState);

--- a/Fw/Log/AmpcsEvrLogPacket.cpp
+++ b/Fw/Log/AmpcsEvrLogPacket.cpp
@@ -25,7 +25,7 @@ namespace Fw {
 
         SerializeStatus stat;
 
-        stat = buffer.serialize(this->m_taskName, AMPCS_EVR_TASK_NAME_LEN, true);
+        stat = buffer.serialize(this->m_taskName, AMPCS_EVR_TASK_NAME_LEN, Fw::Serialization::OMIT_LENGTH);
         if (stat != FW_SERIALIZE_OK) {
             return stat;
         }
@@ -45,7 +45,7 @@ namespace Fw {
             return stat;
         }
 
-        return buffer.serialize(this->m_logBuffer.getBuffAddr(),m_logBuffer.getBuffLength(),true);
+        return buffer.serialize(this->m_logBuffer.getBuffAddr(),m_logBuffer.getBuffLength(),Fw::Serialization::OMIT_LENGTH);
 
     }
 

--- a/Fw/Log/LogPacket.cpp
+++ b/Fw/Log/LogPacket.cpp
@@ -35,7 +35,7 @@ namespace Fw {
         }
 
         // We want to add data but not size for the ground software
-        return buffer.serialize(this->m_logBuffer.getBuffAddr(),m_logBuffer.getBuffLength(),true);
+        return buffer.serialize(this->m_logBuffer.getBuffAddr(),m_logBuffer.getBuffLength(),Fw::Serialization::OMIT_LENGTH);
 
     }
 
@@ -57,7 +57,7 @@ namespace Fw {
 
         // remainder of buffer must be telemetry value
         FwSizeType size = buffer.getBuffLeft();
-        stat = buffer.deserialize(this->m_logBuffer.getBuffAddr(),size,true);
+        stat = buffer.deserialize(this->m_logBuffer.getBuffAddr(), size, Fw::Serialization::OMIT_LENGTH);
         if (stat == FW_SERIALIZE_OK) {
             // Shouldn't fail
             stat = this->m_logBuffer.setBuffLen(size);

--- a/Fw/Log/LogPacket.cpp
+++ b/Fw/Log/LogPacket.cpp
@@ -57,7 +57,7 @@ namespace Fw {
 
         // remainder of buffer must be telemetry value
         FwSizeType size = buffer.getBuffLeft();
-        stat = buffer.deserialize(this->m_logBuffer.getBuffAddr(), size, Fw::Serialization::OMIT_LENGTH);
+        stat = buffer.deserialize(this->m_logBuffer.getBuffAddr(),size,Fw::Serialization::OMIT_LENGTH);
         if (stat == FW_SERIALIZE_OK) {
             // Shouldn't fail
             stat = this->m_logBuffer.setBuffLen(size);

--- a/Fw/Tlm/TlmPacket.cpp
+++ b/Fw/Tlm/TlmPacket.cpp
@@ -85,7 +85,7 @@ namespace Fw {
         }
 
         // telemetry buffer
-        stat = this->m_tlmBuffer.serialize(buffer.getBuffAddr(),buffer.getBuffLength(),true);
+        stat = this->m_tlmBuffer.serialize(buffer.getBuffAddr(),buffer.getBuffLength(),Fw::Serialization::OMIT_LENGTH);
         if (stat != Fw::FW_SERIALIZE_OK) {
             return stat;
         }
@@ -114,7 +114,7 @@ namespace Fw {
         }
 
         // telemetry buffer
-        stat = this->m_tlmBuffer.deserialize(buffer.getBuffAddr(),bufferSize,true);
+        stat = this->m_tlmBuffer.deserialize(buffer.getBuffAddr(),bufferSize,Fw::Serialization::OMIT_LENGTH);
         if (stat != Fw::FW_SERIALIZE_OK) {
             return stat;
         }
@@ -136,7 +136,7 @@ namespace Fw {
             return stat;
         }
         // Serialize the ComBuffer
-        return buffer.serialize(this->m_tlmBuffer.getBuffAddr(),m_tlmBuffer.getBuffLength(),true);
+        return buffer.serialize(this->m_tlmBuffer.getBuffAddr(),m_tlmBuffer.getBuffLength(),Fw::Serialization::OMIT_LENGTH);
     }
 
     SerializeStatus TlmPacket::deserialize(SerializeBufferBase& buffer) {
@@ -148,7 +148,7 @@ namespace Fw {
         }
         // deserialize the channel value entry buffers
         FwSizeType size = buffer.getBuffLeft();
-        stat = buffer.deserialize(this->m_tlmBuffer.getBuffAddr(),size,true);
+        stat = buffer.deserialize(this->m_tlmBuffer.getBuffAddr(),size,Fw::Serialization::OMIT_LENGTH);
         if (stat == FW_SERIALIZE_OK) {
             // Shouldn't fail
             stat = this->m_tlmBuffer.setBuffLen(size);

--- a/Fw/Types/SerialBuffer.cpp
+++ b/Fw/Types/SerialBuffer.cpp
@@ -35,13 +35,11 @@ void SerialBuffer ::fill() {
 }
 
 SerializeStatus SerialBuffer ::pushBytes(const U8* const addr, const FwSizeType n) {
-    // "true" means "just push the bytes"
-    return this->serialize(const_cast<U8*>(addr), n, true);
+    return this->serialize(const_cast<U8*>(addr), n, Fw::Serialization::OMIT_LENGTH);
 }
 
 SerializeStatus SerialBuffer ::popBytes(U8* const addr, FwSizeType n) {
-    // "true" means "just pop the bytes"
-    return this->deserialize(addr, n, true);
+    return this->deserialize(addr, n, Fw::Serialization::OMIT_LENGTH);
 }
 
 }  // namespace Fw

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -227,7 +227,7 @@ SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::Siz
 
 SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::SizeType length, bool noLength) {
     return this->serialize(buff, static_cast<FwSizeType>(length),
-    noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
+        noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
 }
 
 SerializeStatus SerializeBufferBase::serialize(const U8* buff, FwSizeType length, Fw::Serialization::t mode) {

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -225,11 +225,6 @@ SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::Siz
     return this->serialize(buff, static_cast<FwSizeType>(length), Serialization::INCLUDE_LENGTH);
 }
 
-SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::SizeType length, bool noLength) {
-    return this->serialize(buff, static_cast<FwSizeType>(length),
-                           noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
-}
-
 SerializeStatus SerializeBufferBase::serialize(const U8* buff, FwSizeType length, Fw::Serialization::t mode) {
     // First serialize length
     SerializeStatus stat;
@@ -503,14 +498,6 @@ SerializeStatus SerializeBufferBase::deserialize(U8* buff, Serializable::SizeTyp
     return status;
 }
 
-SerializeStatus SerializeBufferBase::deserialize(U8* buff, Serializable::SizeType& length, bool noLength) {
-    FwSizeType length_in_out = static_cast<FwSizeType>(length);
-    SerializeStatus status =
-        this->deserialize(buff, length_in_out, noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
-    length = static_cast<Serializable::SizeType>(length_in_out);
-    return status;
-}
-
 SerializeStatus SerializeBufferBase::deserialize(U8* buff, FwSizeType& length, Serialization::t mode) {
     FW_ASSERT(this->getBuffAddr());
 
@@ -695,7 +682,7 @@ SerializeStatus SerializeBufferBase::copyRawOffset(SerializeBufferBase& dest, Se
     }
 
     // otherwise, serialize bytes to destination without writing length
-    SerializeStatus stat = dest.serialize(&this->getBuffAddr()[this->m_deserLoc], size, true);
+    SerializeStatus stat = dest.serialize(&this->getBuffAddr()[this->m_deserLoc], size, Fw::Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         this->m_deserLoc += size;
     }

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -227,7 +227,7 @@ SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::Siz
 
 SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::SizeType length, bool noLength) {
     return this->serialize(buff, static_cast<FwSizeType>(length),
-        noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
+                           noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
 }
 
 SerializeStatus SerializeBufferBase::serialize(const U8* buff, FwSizeType length, Fw::Serialization::t mode) {

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -225,6 +225,11 @@ SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::Siz
     return this->serialize(buff, static_cast<FwSizeType>(length), Serialization::INCLUDE_LENGTH);
 }
 
+SerializeStatus SerializeBufferBase::serialize(const U8* buff, Serializable::SizeType length, bool noLength) {
+    return this->serialize(buff, static_cast<FwSizeType>(length),
+    noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
+}
+
 SerializeStatus SerializeBufferBase::serialize(const U8* buff, FwSizeType length, Fw::Serialization::t mode) {
     // First serialize length
     SerializeStatus stat;
@@ -494,6 +499,14 @@ SerializeStatus SerializeBufferBase::deserialize(F32& val) {
 SerializeStatus SerializeBufferBase::deserialize(U8* buff, Serializable::SizeType& length) {
     FwSizeType length_in_out = static_cast<FwSizeType>(length);
     SerializeStatus status = this->deserialize(buff, length_in_out, Serialization::INCLUDE_LENGTH);
+    length = static_cast<Serializable::SizeType>(length_in_out);
+    return status;
+}
+
+SerializeStatus SerializeBufferBase::deserialize(U8* buff, Serializable::SizeType& length, bool noLength) {
+    FwSizeType length_in_out = static_cast<FwSizeType>(length);
+    SerializeStatus status =
+        this->deserialize(buff, length_in_out, noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH);
     length = static_cast<Serializable::SizeType>(length_in_out);
     return status;
 }

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -86,7 +86,8 @@ class SerializeBufferBase {
         const void* val);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
 
     //! serialize data buffer
-    SerializeStatus serialize(const U8* buff, FwSizeType length, bool noLength);
+    DEPRECATED(SerializeStatus serialize(const U8* buff, Serializable::SizeType length, bool noLength),
+               "Use serialize(const U8* buff, FwSizeType length, Serialization::t mode) instead");
     //! serialize data buffer
     SerializeStatus serialize(const U8* buff, FwSizeType length);
 
@@ -132,7 +133,8 @@ class SerializeBufferBase {
     SerializeStatus deserialize(void*& val);  //!< deserialize point value (careful, pointer value only, not contents)
 
     //! deserialize data buffer
-    SerializeStatus deserialize(U8* buff, FwSizeType& length, bool noLength);
+    DEPRECATED(SerializeStatus deserialize(U8* buff, Serializable::SizeType& length, bool noLength),
+    "Use deserialize(U8* buff, FwSizeType& length, Serialization::t mode) instead");
 
     //! deserialize data buffer
     SerializeStatus deserialize(U8* buff, FwSizeType& length);

--- a/Svc/CmdSequencer/FPrimeSequence.cpp
+++ b/Svc/CmdSequencer/FPrimeSequence.cpp
@@ -411,7 +411,7 @@ namespace Svc {
     FwSizeType size = recordSize;
     Fw::SerializeStatus status = comBuffer.setBuffLen(recordSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = buffer.deserialize(comBuffer.getBuffAddr(), size, true);
+    status = buffer.deserialize(comBuffer.getBuffAddr(), size, Fw::Serialization::OMIT_LENGTH);
     return status;
   }
 

--- a/Svc/CmdSequencer/formats/AMPCSSequence.cpp
+++ b/Svc/CmdSequencer/formats/AMPCSSequence.cpp
@@ -450,7 +450,7 @@ namespace Svc {
     U8 *const addr = comBuffer.getBuffAddr();
     FW_ASSERT(addr != nullptr);
     // true means "don't serialize the length"
-    status = buffer.deserialize(&addr[fixedBuffLen], size, true);
+    status = buffer.deserialize(&addr[fixedBuffLen], size, Fw::Serialization::OMIT_LENGTH);
     return status;
   }
 

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/Records.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/Records.cpp
@@ -35,8 +35,7 @@ namespace Svc {
           ASSERT_EQ(Fw::FW_SERIALIZE_OK, dest.serialize(cmdLength));
           ASSERT_EQ(
               Fw::FW_SERIALIZE_OK,
-              // true means "don't serialize the length"
-              dest.serialize(addr, cmdLength, true)
+              dest.serialize(addr, cmdLength, Fw::Serialization::OMIT_LENGTH)
           );
         }
 

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/FPrime/Records.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/FPrime/Records.cpp
@@ -40,8 +40,7 @@ namespace Svc {
             ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serialize(cmdDescriptor));
             ASSERT_EQ(
                 Fw::FW_SERIALIZE_OK,
-                // true means "don't serialize the size"
-                destBuffer.serialize(buffAddr, size, true)
+                destBuffer.serialize(buffAddr, size, Fw::Serialization::OMIT_LENGTH)
             );
           }
         }

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -297,7 +297,7 @@ Signal FpySequencer::cmd_directiveHandler(const FpySequencer_CmdDirective& direc
         error = DirectiveError::CMD_SERIALIZE_FAILURE;
         return Signal::stmtResponse_failure;
     }
-    stat = cmdBuf.serialize(directive.getargBuf(), directive.get_argBufSize(), true);
+    stat = cmdBuf.serialize(directive.getargBuf(), directive.get_argBufSize(), Fw::Serialization::OMIT_LENGTH);
     if (stat != Fw::SerializeStatus::FW_SERIALIZE_OK) {
         error = DirectiveError::CMD_SERIALIZE_FAILURE;
         return Signal::stmtResponse_failure;

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -110,7 +110,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
             }
 
             // okay, it will fit. put it in
-            status = argBuf.deserialize(deserializedDirective.setSerReg.getvalue(), valueSize, true);
+            status = argBuf.deserialize(deserializedDirective.setSerReg.getvalue(), valueSize, Fw::Serialization::OMIT_LENGTH);
 
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.getopCode(), this->m_runtime.nextStatementIndex - 1,
@@ -202,7 +202,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
             }
 
             // okay, it will fit. put it in
-            status = argBuf.deserialize(deserializedDirective.cmd.getargBuf(), cmdArgBufSize, true);
+            status = argBuf.deserialize(deserializedDirective.cmd.getargBuf(), cmdArgBufSize, Fw::Serialization::OMIT_LENGTH);
 
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.getopCode(), this->m_runtime.nextStatementIndex - 1,

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -234,7 +234,7 @@ TEST_F(FpySequencerTester, cmd) {
     Fw::ComBuffer expected;
     ASSERT_EQ(expected.serialize(Fw::ComPacketType::FW_PACKET_COMMAND), Fw::SerializeStatus::FW_SERIALIZE_OK);
     ASSERT_EQ(expected.serialize(directive.getopCode()), Fw::SerializeStatus::FW_SERIALIZE_OK);
-    ASSERT_EQ(expected.serialize(data, sizeof(data), true), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(expected.serialize(data, sizeof(data), Fw::Serialization::OMIT_LENGTH), Fw::SerializeStatus::FW_SERIALIZE_OK);
     ASSERT_from_cmdOut_SIZE(1);
     ASSERT_from_cmdOut(0, expected, 0);
     this->clearHistory();

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
@@ -156,7 +156,7 @@ void FpySequencerTester::add_SET_SER_REG(U8 serRegIdx, Fw::StatementArgBuffer va
 void FpySequencerTester::add_SET_SER_REG(FpySequencer_SetSerRegDirective dir) {
     Fw::StatementArgBuffer buf;
     FW_ASSERT(buf.serialize(dir.getindex()) == Fw::SerializeStatus::FW_SERIALIZE_OK);
-    FW_ASSERT(buf.serialize(dir.getvalue(), dir.get_valueSize(), true) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serialize(dir.getvalue(), dir.get_valueSize(), Fw::Serialization::OMIT_LENGTH) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::SET_SER_REG, buf);
 }
 
@@ -202,7 +202,7 @@ void FpySequencerTester::add_CMD(FwOpcodeType opcode) {
 void FpySequencerTester::add_CMD(FpySequencer_CmdDirective dir) {
     Fw::StatementArgBuffer buf;
     FW_ASSERT(buf.serialize(dir.getopCode()) == Fw::SerializeStatus::FW_SERIALIZE_OK);
-    FW_ASSERT(buf.serialize(dir.getargBuf(), dir.get_argBufSize(), true) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serialize(dir.getargBuf(), dir.get_argBufSize(), Fw::Serialization::OMIT_LENGTH) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::CMD, buf);
 }
 

--- a/Svc/FramingProtocol/FprimeProtocol.cpp
+++ b/Svc/FramingProtocol/FprimeProtocol.cpp
@@ -40,12 +40,12 @@ void FprimeFraming::frame(const U8* const data, const U32 size, Fw::ComPacketTyp
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Serialize data
-    status = serializer.serialize(data, size, true);  // Serialize without length
+    status = serializer.serialize(data, size, Fw::Serialization::OMIT_LENGTH);  // Serialize without length
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Calculate and add transmission hash
     Utils::Hash::hash(buffer.getData(), static_cast<FwSizeType>(totalSize - HASH_DIGEST_LENGTH), hash);
-    status = serializer.serialize(hash.getBuffAddr(), HASH_DIGEST_LENGTH, true);
+    status = serializer.serialize(hash.getBuffAddr(), HASH_DIGEST_LENGTH, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     buffer.setSize(totalSize);

--- a/docs/user-manual/framework/ground-interface.md
+++ b/docs/user-manual/framework/ground-interface.md
@@ -126,7 +126,7 @@ class MyFrameProtocol : public Svc::FramingProtocol {
         auto serializer = my_framed_data.getSerializer();
         serializer.serialize(0xdeadbeef); // Some start word
         serializer.serialize(size);       // Write size
-        serializer.serialize(data, size, true); // Data copied to buffer no length included
+        serializer.serialize(data, size, Fw::Serialization::OMIT_LENGTH); // Data copied to buffer no length included
         m_interface.send(my_framed_data);
     }
 };


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3784 |
|**_Has Unit Tests (y/n)_**| y, pre-existing |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Deprecated 'bool noLength' versions of serialize and deserialize in favour of using the 'Serialization::t mode' versions.

## Rationale

Code cleanup and consistency. Adhering to Code Style Guidelines.

## Testing/Review Recommendations

UTs have been updated. No regressions.

## Future Work

None.
