### PR TITLE
Rename STATEMENT_TIMEOUT_SECS telemetry not to conflict with parameter

### DIFF
--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -376,7 +376,7 @@ void FpySequencer::parameterUpdated(FwPrmIdType id) {
     Fw::ParamValid valid;
     switch (id) {
         case PARAMID_STATEMENT_TIMEOUT_SECS: {
-            this->tlmWrite_STATEMENT_TIMEOUT_SECS(this->paramGet_STATEMENT_TIMEOUT_SECS(valid));
+            this->tlmWrite_PRM_STATEMENT_TIMEOUT_SECS(this->paramGet_STATEMENT_TIMEOUT_SECS(valid));
             break;
         }
         default: {

--- a/Svc/FpySequencer/FpySequencerTelemetry.fppi
+++ b/Svc/FpySequencer/FpySequencerTelemetry.fppi
@@ -43,4 +43,4 @@ telemetry DebugBreakpointIdx: U32 update on change
 telemetry Debug: DebugTelemetry update on change
 
 @ value of prm STATEMENT_TIMEOUT_SECS
-telemetry STATEMENT_TIMEOUT_SECS: F32 update on change
+telemetry PRM_STATEMENT_TIMEOUT_SECS: F32 update on change


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3816 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

The STATEMENT_TIMEOUT_SECS parameter should have a diff name than the tlm chan, to differentiate it from the tlm.


## Rationale

This causes ambiguity when referring to FpySequencer.STATEMENT_TIMEOUT_SECS

