### PR TITLE
Fix EXIT not handled in dispatchDirective

### DIFF
--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -356,41 +356,46 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
 // dispatches a deserialized sequencer directive to the right handler.
 void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy::DirectiveId& id) {
     switch (id) {
+        case Fpy::DirectiveId::INVALID: {
+            // coding err
+            FW_ASSERT(0);
+            return;
+        }
         case Fpy::DirectiveId::WAIT_REL: {
             this->directive_waitRel_internalInterfaceInvoke(directive.waitRel);
-            break;
+            return;
         }
         case Fpy::DirectiveId::WAIT_ABS: {
             this->directive_waitAbs_internalInterfaceInvoke(directive.waitAbs);
-            break;
+            return;
         }
         case Fpy::DirectiveId::SET_SER_REG: {
             this->directive_setSerReg_internalInterfaceInvoke(directive.setSerReg);
-            break;
+            return;
         }
         case Fpy::DirectiveId::GOTO: {
             this->directive_goto_internalInterfaceInvoke(directive.gotoDirective);
-            break;
+            return;
         }
         case Fpy::DirectiveId::IF: {
             this->directive_if_internalInterfaceInvoke(directive.ifDirective);
-            break;
+            return;
         }
         case Fpy::DirectiveId::NO_OP: {
             this->directive_noOp_internalInterfaceInvoke(directive.noOp);
-            break;
+            return;
         }
         case Fpy::DirectiveId::GET_TLM: {
             this->directive_getTlm_internalInterfaceInvoke(directive.getTlm);
-            break;
+            return;
         }
         case Fpy::DirectiveId::GET_PRM: {
             this->directive_getPrm_internalInterfaceInvoke(directive.getPrm);
-            break;
+            return;
         }
         case Fpy::DirectiveId::CMD: {
             this->directive_cmd_internalInterfaceInvoke(directive.cmd);
-            break;
+            return;
         }
             // fallthrough on purpose
         case Fpy::DirectiveId::DESER_SER_REG_8:
@@ -398,11 +403,11 @@ void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy:
         case Fpy::DirectiveId::DESER_SER_REG_2:
         case Fpy::DirectiveId::DESER_SER_REG_1: {
             this->directive_deserSerReg_internalInterfaceInvoke(directive.deserSerReg);
-            break;
+            return;
         }
         case Fpy::DirectiveId::SET_REG: {
             this->directive_setReg_internalInterfaceInvoke(directive.setReg);
-            break;
+            return;
         }
             // fallthrough on purpose
         case Fpy::DirectiveId::OR:
@@ -418,16 +423,19 @@ void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy:
         case Fpy::DirectiveId::SLE:
         case Fpy::DirectiveId::SGE: {
             this->directive_binaryCmp_internalInterfaceInvoke(directive.binaryCmp);
-            break;
+            return;
         }
         case Fpy::DirectiveId::NOT: {
             this->directive_not_internalInterfaceInvoke(directive.notDirective);
-            break;
+            return;
         }
-        default: {
-            FW_ASSERT(0, id);  // coding error, forgot to add switch case/port for this directive
+        case Fpy::DirectiveId::EXIT: {
+            this->directive_exit_internalInterfaceInvoke(directive.exit);
+            return;
         }
     }
+    // coding err
+    FW_ASSERT(0, static_cast<FwAssertArgType>(id));
 }
 
 Signal FpySequencer::checkShouldWake() {

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -1181,6 +1181,26 @@ TEST_F(FpySequencerTester, deserialize_getPrm) {
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
 }
 
+TEST_F(FpySequencerTester, deserialize_exit) {
+    FpySequencer::DirectiveUnion actual;
+    FpySequencer_ExitDirective dir(false);
+    add_EXIT(dir);
+    Fw::Success result = tester_deserializeDirective(seq.getstatements()[0], actual);
+    ASSERT_EQ(result, Fw::Success::SUCCESS);
+    ASSERT_EQ(actual.exit, dir);
+    // write some junk after buf, make sure it fails
+    seq.getstatements()[0].getargBuf().serialize(123);
+    result = tester_deserializeDirective(seq.getstatements()[0], actual);
+    ASSERT_EQ(result, Fw::Success::FAILURE);
+    ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
+    this->clearHistory();
+    // clear args, make sure it fails
+    seq.getstatements()[0].getargBuf().resetSer();
+    result = tester_deserializeDirective(seq.getstatements()[0], actual);
+    ASSERT_EQ(result, Fw::Success::FAILURE);
+    ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
+}
+
 // caught a bug
 TEST_F(FpySequencerTester, checkTimers) {
     allocMem();

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
@@ -253,6 +253,16 @@ void FpySequencerTester::add_BINARY_CMP(FpySequencer_BinaryCmpDirective dir) {
     addDirective(dir.get_op(), buf);
 }
 
+void FpySequencerTester::add_EXIT(bool success) {
+    add_EXIT(FpySequencer_ExitDirective(success));
+}
+
+void FpySequencerTester::add_EXIT(FpySequencer_ExitDirective dir) {
+    Fw::StatementArgBuffer buf;
+    FW_ASSERT(buf.serialize(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    addDirective(Fpy::DirectiveId::EXIT, buf);
+}
+
 //! Handle a text event
 void FpySequencerTester::textLogIn(FwEventIdType id,                //!< The event ID
                                    const Fw::Time& timeTag,         //!< The time
@@ -476,6 +486,9 @@ void FpySequencerTester::tester_setState(Svc::FpySequencer_SequencerStateMachine
     FpySequencer_SequencerStateMachineTester::setState(this->cmp.m_stateMachine_sequencer, state);
 }
 
+void FpySequencerTester::tester_dispatchDirective(const FpySequencer::DirectiveUnion& directive, const Fpy::DirectiveId& id) {
+    this->cmp.dispatchDirective(directive, id);
+}
 
 // End UT private/protected access
 

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
@@ -103,6 +103,8 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     void add_SET_REG(FpySequencer_SetRegDirective dir);
     void add_BINARY_CMP(U8 lhs, U8 rhs, U8 res, Fpy::DirectiveId op);
     void add_BINARY_CMP(FpySequencer_BinaryCmpDirective dir);
+    void add_EXIT(bool success);
+    void add_EXIT(FpySequencer_ExitDirective dir);
     //! Handle a text event
     void textLogIn(FwEventIdType id,                //!< The event ID
                    const Fw::Time& timeTag,         //!< The time
@@ -166,6 +168,7 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     void tester_doDispatch();
     void tester_setState(Svc::FpySequencer_SequencerStateMachineStateMachineBase::State state);
     Svc::FpySequencer_SequencerStateMachineStateMachineBase::State tester_getState();
+    void tester_dispatchDirective(const FpySequencer::DirectiveUnion& directive, const Fpy::DirectiveId& id);
 
   public:
     // ----------------------------------------------------------------------


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3828   |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

This PR fixes a missing case in a switch statement, and removes the "default" case so that the compiler will warn us if we are missing any other cases.

## Rationale

Fixes a bug and prevents it from happening again.
