### PR TITLE
Linux should not default to stubbed drivers

### DIFF
--- a/Drv/LinuxI2cDriver/LinuxI2cDriver.cpp
+++ b/Drv/LinuxI2cDriver/LinuxI2cDriver.cpp
@@ -80,8 +80,8 @@ namespace Drv {
       FW_ASSERT(serBuffer.getData());
       FW_ASSERT_NO_OVERFLOW(serBuffer.getSize(), size_t);
       // write data
-      stat = static_cast<int>(write(this->m_fd, serBuffer.getData(), static_cast<size_t>(serBuffer.getSize())));
-      if (stat == -1) {
+      ssize_t status_write = write(this->m_fd, serBuffer.getData(), static_cast<size_t>(serBuffer.getSize()));
+      if (status_write == -1) {
 	  return I2cStatus::I2C_WRITE_ERR;
       }
       return I2cStatus::I2C_OK;
@@ -107,8 +107,9 @@ namespace Drv {
       // make sure it isn't a null pointer
       FW_ASSERT(serBuffer.getData());
       // read data
-      stat = static_cast<int>(read(this->m_fd, serBuffer.getData(), serBuffer.getSize()));
-      if (stat == -1) {
+      FW_ASSERT_NO_OVERFLOW(serBuffer.getSize(), size_t);
+      ssize_t status_read = read(this->m_fd, serBuffer.getData(), static_cast<size_t>(serBuffer.getSize()));
+      if (status_read == -1) {
 	  return I2cStatus::I2C_READ_ERR;
       }
       return I2cStatus::I2C_OK;

--- a/Drv/LinuxSpiDriver/Telemetry.fppi
+++ b/Drv/LinuxSpiDriver/Telemetry.fppi
@@ -1,2 +1,2 @@
 @ Bytes Sent/Received
-telemetry SPI_Bytes: U32 id 0
+telemetry SPI_Bytes: FwSizeType id 0

--- a/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
@@ -46,14 +46,15 @@ void SpacePacketFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, c
     U16 packetIdentification = 0;
     ComCfg::APID::T apid = context.getapid();
     FW_ASSERT((apid >> SpacePacketSubfields::ApidWidth) == 0,
-              static_cast<FwAssertArgType>(apid));                                    // apid must fit in 11 bits
-    packetIdentification |= static_cast<U16>(apid) & SpacePacketSubfields::ApidMask;  // 11 bit APID
+              static_cast<FwAssertArgType>(apid));  // apid must fit in 11 bits
+    packetIdentification |= static_cast<U16>(apid) & static_cast<U16>(SpacePacketSubfields::ApidMask);  // 11 bit APID
 
     U16 sequenceCount = this->getApidSeqCount_out(0, apid, 0);  // retrieve the sequence count for this APID
     U16 packetSequenceControl = 0;
     packetSequenceControl |=
         0x3 << SpacePacketSubfields::SeqFlagsOffset;  // Sequence Flags 0b11 = unsegmented User Data
-    packetSequenceControl |= sequenceCount & SpacePacketSubfields::SeqCountMask;  // 14 bit sequence count
+    packetSequenceControl |=
+        sequenceCount & static_cast<U16>(SpacePacketSubfields::SeqCountMask);  // 14 bit sequence count
 
     FW_ASSERT(data.getSize() <= std::numeric_limits<U16>::max(), static_cast<FwAssertArgType>(data.getSize()));
     U16 packetDataLength =

--- a/cmake/platform/Linux.cmake
+++ b/cmake/platform/Linux.cmake
@@ -6,10 +6,6 @@
 FIND_PACKAGE ( Threads REQUIRED )
 set(FPRIME_USE_POSIX ON)
 set(FPRIME_HAS_SOCKETS ON)
-# Set platform default for stubbed drivers
-if (NOT DEFINED FPRIME_USE_STUBBED_DRIVERS)
-   set(FPRIME_USE_STUBBED_DRIVERS ON)
-endif()
 # Add unix include path which is compatible with Linux for PlatformTypes.hpp
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/unix/Platform/")
 # Override unix implementations with LINUX specific ones


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Linux should not default to stubbed drivers.  This was a regression.