### PR TITLE
Fix framework UT shutoff regression

### DIFF
--- a/cmake/FPrime.cmake
+++ b/cmake/FPrime.cmake
@@ -197,6 +197,8 @@ function(fprime_setup_included_code)
     if (BUILD_TESTING)
         add_subdirectory("${FPRIME_FRAMEWORK_PATH}/STest/" "${CMAKE_BINARY_DIR}/F-Prime/STest")
     endif()
+    # By default we shutoff framework UTs
+    set(__FPRIME_NO_UT_GEN__ ON)
     # Check if we are allowing framework UTs
     if (FPRIME_ENABLE_FRAMEWORK_UTS)
         set(__FPRIME_NO_UT_GEN__ OFF)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

These lines appear to have been inadvertently removed in commit 80bb781 (#3685).

## Rationale

I expect `FPRIME_ENABLE_FRAMEWORK_UTS=OFF` to disable running framework unit tests, and this regression caused them to start running again. Since not all of the framework unit tests can be compiled in my environment, this is a big problem.

## Testing/Review Recommendations

N/A

## Future Work

Maybe we need a test case for this.
