### PR TITLE
Fixed invalid FW_ASSERT in LinuxUartDriver. Replaced with FW_ASSERT_NO_OVERFLOW.

### DIFF
--- a/Drv/LinuxUartDriver/LinuxUartDriver.cpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.cpp
@@ -298,8 +298,7 @@ void LinuxUartDriver ::send_handler(const FwIndexType portNum, Fw::Buffer& serBu
         status = Drv::ByteStreamStatus::OTHER_ERROR;
     } else {
         unsigned char *data = serBuffer.getData();
-        FW_ASSERT(static_cast<size_t>(serBuffer.getSize()) <= std::numeric_limits<size_t>::max(),
-                  static_cast<FwAssertArgType>(serBuffer.getSize()));
+        FW_ASSERT_NO_OVERFLOW(serBuffer.getSize(), size_t);
         size_t xferSize = static_cast<size_t>(serBuffer.getSize());
 
         ssize_t stat = ::write(this->m_fd, data, xferSize);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3597 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Replaced invalid `FW_ASSERT` in `LinuxUartDriver` with a more appropriate `FW_ASSERT_NO_OVERFLOW`.

## Rationale

The previous `FW_ASSERT` did not properly check for overflow.

## Testing/Review Recommendations

None

## Future Work

None
