### PR TITLE
Adding FW_CASSERT_1 macro for C

### DIFF
--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -180,6 +180,7 @@ I8 SwAssert(FILE_NAME_ARG file,
 // define C asserts with C linkage
 extern "C" {
 I8 CAssert0(FILE_NAME_ARG file, FwSizeType lineNo);
+I8 CAssert1(FILE_NAME_ARG file, FwAssertArgType arg1, FwSizeType lineNo);
 }
 
 I8 CAssert0(FILE_NAME_ARG file, FwSizeType lineNo) {
@@ -188,6 +189,17 @@ I8 CAssert0(FILE_NAME_ARG file, FwSizeType lineNo) {
         Fw::defaultReportAssert(file, lineNo, 0, 0, 0, 0, 0, 0, 0, assertMsg, static_cast<FwSizeType>(sizeof(assertMsg)));
     } else {
         Fw::s_assertHook->reportAssert(file, lineNo, 0, 0, 0, 0, 0, 0, 0);
+        Fw::s_assertHook->doAssert();
+    }
+    return 0;
+}
+
+I8 CAssert1(FILE_NAME_ARG file, FwAssertArgType arg1, FwSizeType lineNo) {
+    if (nullptr == Fw::s_assertHook) {
+        CHAR assertMsg[FW_ASSERT_TEXT_SIZE];
+        Fw::defaultReportAssert(file, lineNo, 1, arg1, 0, 0, 0, 0, 0, assertMsg, static_cast<FwSizeType>(sizeof(assertMsg)));
+    } else {
+        Fw::s_assertHook->reportAssert(file, lineNo, 1, arg1, 0, 0, 0, 0, 0);
         Fw::s_assertHook->doAssert();
     }
     return 0;

--- a/Fw/Types/CAssert.h
+++ b/Fw/Types/CAssert.h
@@ -17,18 +17,22 @@ extern "C" {
 #if FW_ASSERT_LEVEL == FW_NO_ASSERT
 
 #define FW_CASSERT(...)
+#define FW_CASSERT_1(cond, arg1)
 
 #else  // ASSERT is defined
 
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
 #define FILE_NAME_ARG U32
 #define FW_CASSERT(cond) ((void)((cond) ? (0) : (CAssert0(ASSERT_FILE_ID, __LINE__))))
+#define FW_CASSERT_1(cond, arg1) ((void)((cond) ? (0) : (CAssert1(ASSERT_FILE_ID, (FwAssertArgType)(arg1), __LINE__))))
 #else
 #define FILE_NAME_ARG const CHAR*
 #define FW_CASSERT(cond) ((void)((cond) ? (0) : (CAssert0((FILE_NAME_ARG)(__FILE__), __LINE__))))
+#define FW_CASSERT_1(cond, arg1) ((void)((cond) ? (0) : (CAssert1((FILE_NAME_ARG)(__FILE__), (FwAssertArgType)(arg1), __LINE__))))
 #endif
 
 I8 CAssert0(FILE_NAME_ARG file, FwSizeType lineNo);  //!< C assert function
+I8 CAssert1(FILE_NAME_ARG file, FwAssertArgType arg1, FwSizeType lineNo);  //!< C assert function with one argument
 
 #endif  // ASSERT is defined
 

--- a/Fw/Types/CMakeLists.txt
+++ b/Fw/Types/CMakeLists.txt
@@ -38,6 +38,7 @@ register_fprime_ut(
     "${CMAKE_CURRENT_LIST_DIR}/test/ut/ExternalSerializeBufferTest.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/test/ut/AssertTypesTest.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/test/ut/TypesTest.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/test/ut/CAssertTest.cpp"
   DEPENDS
     Os
 )

--- a/Fw/Types/test/ut/CAssertTest.cpp
+++ b/Fw/Types/test/ut/CAssertTest.cpp
@@ -12,41 +12,57 @@
  * in embedded systems.
  */
 
-// Define a simple test assert hook
+// Define an Assert handler
 class TestAssertHook : public Fw::AssertHook {
     public:
-        TestAssertHook() : m_asserted(false), m_numArgs(0), m_arg1(0) {}
+        TestAssertHook() {}
         virtual ~TestAssertHook() {}
-        
         void reportAssert(FILE_NAME_ARG file,
-                         FwSizeType lineNo,
-                         FwSizeType numArgs,
-                         FwAssertArgType arg1,
-                         FwAssertArgType arg2,
-                         FwAssertArgType arg3,
-                         FwAssertArgType arg4,
-                         FwAssertArgType arg5,
-                         FwAssertArgType arg6) {
-            m_file = file;
-            m_lineNo = lineNo;
-            m_numArgs = numArgs;
-            m_arg1 = arg1;
-        }
-        
-        void doAssert() { m_asserted = true; }
-        
-        bool assertFailed() const { return m_asserted; }
-        FwSizeType getNumArgs() const { return m_numArgs; }
-        FwAssertArgType getArg1() const { return m_arg1; }
-        
-    private:
-        bool m_asserted;
-        FILE_NAME_ARG m_file;
-        FwSizeType m_lineNo;
-        FwSizeType m_numArgs;
-        FwAssertArgType m_arg1;
-};
+                        FwSizeType lineNo,
+                        FwSizeType numArgs,
+                        FwAssertArgType arg1,
+                        FwAssertArgType arg2,
+                        FwAssertArgType arg3,
+                        FwAssertArgType arg4,
+                        FwAssertArgType arg5,
+                        FwAssertArgType arg6) {
+            this->m_file = file;
+            this->m_lineNo = lineNo;
+            this->m_numArgs = numArgs;
+            this->m_arg1 = arg1;
+        };
 
+        void doAssert() { this->m_asserted = true; }
+
+        FILE_NAME_ARG getFile() { return this->m_file; }
+
+        FwSizeType getLineNo() { return this->m_lineNo; }
+
+        FwSizeType getNumArgs() { return this->m_numArgs; }
+
+        FwAssertArgType getArg1() { return this->m_arg1; }
+
+        bool asserted() {
+            bool didAssert = this->m_asserted;
+            this->m_asserted = false;
+            return didAssert;
+        }
+
+    private:
+#if FW_ASSERT_LEVEL == FW_FILEID_ASSERT
+        // Setting this to a non-zero initially as the test
+        // should set it to 0.
+        FILE_NAME_ARG m_file = 1; 
+#else
+        FILE_NAME_ARG m_file = nullptr;
+#endif
+        FwSizeType m_lineNo = 0;
+        FwSizeType m_numArgs = 0;
+        FwAssertArgType m_arg1 = 0;
+        bool m_asserted = false;
+    };
+
+    
 // Test that FW_CASSERT_1 macro compiles and works correctly when true
 TEST(CAssertTest, CAssert1Macro) {
     // Disable old-style cast warnings for this test since we're testing C macros
@@ -104,7 +120,7 @@ TEST(CAssertTest, CAssert1MacroFailure) {
     FW_CASSERT_1(testValue == 999, testValue); // This should trigger the assert hook
     
     // Verify that assertion was triggered
-    EXPECT_TRUE(hook.assertFailed());
+    EXPECT_TRUE(hook.asserted());
     EXPECT_EQ(hook.getNumArgs(), 1U);
     EXPECT_EQ(hook.getArg1(), static_cast<FwAssertArgType>(testValue));
     
@@ -132,7 +148,7 @@ TEST(CAssertTest, CAssertMacroFailure) {
     FW_CASSERT(1 == 2); // This should trigger the assert hook
     
     // Verify that assertion was triggered
-    EXPECT_TRUE(hook.assertFailed());
+    EXPECT_TRUE(hook.asserted());
     EXPECT_EQ(hook.getNumArgs(), 0U); // FW_CASSERT has no arguments
     
     // Deregister hook

--- a/Fw/Types/test/ut/CAssertTest.cpp
+++ b/Fw/Types/test/ut/CAssertTest.cpp
@@ -1,15 +1,53 @@
-#include <config/FpConfig.hpp>
 #include <gtest/gtest.h>
+#include <Fw/FPrimeBasicTypes.hpp>
+#include <Fw/Types/CAssert.h>
+#include <Fw/Types/Assert.hpp>
 
 /**
  * \file CAssertTest.cpp
  * \brief Tests for FW_CASSERT_1 macro functionality
+ * 
+ * Note: F' C assertions use an assert hook system rather than directly
+ * terminating the program. This allows for configurable assert handling
+ * in embedded systems.
  */
 
-#include <Fw/Types/Assert.hpp>
-#include <Fw/Types/CAssert.h>
+// Define a simple test assert hook
+class TestAssertHook : public Fw::AssertHook {
+    public:
+        TestAssertHook() : m_asserted(false), m_numArgs(0), m_arg1(0) {}
+        virtual ~TestAssertHook() {}
+        
+        void reportAssert(FILE_NAME_ARG file,
+                         FwSizeType lineNo,
+                         FwSizeType numArgs,
+                         FwAssertArgType arg1,
+                         FwAssertArgType arg2,
+                         FwAssertArgType arg3,
+                         FwAssertArgType arg4,
+                         FwAssertArgType arg5,
+                         FwAssertArgType arg6) {
+            m_file = file;
+            m_lineNo = lineNo;
+            m_numArgs = numArgs;
+            m_arg1 = arg1;
+        }
+        
+        void doAssert() { m_asserted = true; }
+        
+        bool assertFailed() const { return m_asserted; }
+        FwSizeType getNumArgs() const { return m_numArgs; }
+        FwAssertArgType getArg1() const { return m_arg1; }
+        
+    private:
+        bool m_asserted;
+        FILE_NAME_ARG m_file;
+        FwSizeType m_lineNo;
+        FwSizeType m_numArgs;
+        FwAssertArgType m_arg1;
+};
 
-// Test that FW_CASSERT_1 macro compiles and works correctly
+// Test that FW_CASSERT_1 macro compiles and works correctly when true
 TEST(CAssertTest, CAssert1Macro) {
     // Disable old-style cast warnings for this test since we're testing C macros
     #pragma GCC diagnostic push
@@ -20,10 +58,6 @@ TEST(CAssertTest, CAssert1Macro) {
     
     // This should not trigger an assertion since condition is true
     FW_CASSERT_1(testValue == 42, testValue);
-    
-    // This should compile but not execute assertion in normal builds
-    // In debug builds with assertions enabled, this would trigger
-    FW_CASSERT_1(testValue != 0, testValue);
     
     // Test with different argument types
     U32 uintValue = 100;
@@ -37,3 +71,76 @@ TEST(CAssertTest, CAssert1Macro) {
     // Verify that the macro expands correctly
     EXPECT_TRUE(true); // If we get here, the macro compiled successfully
 }
+
+// Test basic FW_CASSERT macro (no arguments)
+TEST(CAssertTest, CAssertMacro) {
+    // Disable old-style cast warnings for this test since we're testing C macros
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wold-style-cast"
+    
+    // Test basic assertion with true condition
+    FW_CASSERT(1 == 1);
+    FW_CASSERT(true);
+    
+    #pragma GCC diagnostic pop
+    
+    // If we reach here, compilation and execution were successful
+    EXPECT_TRUE(true);
+}
+
+// Test that FW_CASSERT_1 properly triggers assert hook when condition is false
+TEST(CAssertTest, CAssert1MacroFailure) {
+#if FW_ASSERT_LEVEL != FW_NO_ASSERT
+    // Disable old-style cast warnings for this test since we're testing C macros
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wold-style-cast"
+    
+    // Create and register test assert hook
+    TestAssertHook hook;
+    hook.registerHook();
+    
+    // Test FW_CASSERT_1 with failing condition
+    int testValue = 42;
+    FW_CASSERT_1(testValue == 999, testValue); // This should trigger the assert hook
+    
+    // Verify that assertion was triggered
+    EXPECT_TRUE(hook.assertFailed());
+    EXPECT_EQ(hook.getNumArgs(), 1U);
+    EXPECT_EQ(hook.getArg1(), static_cast<FwAssertArgType>(testValue));
+    
+    // Deregister hook
+    hook.deregisterHook();
+    
+    #pragma GCC diagnostic pop
+#else
+    GTEST_SKIP() << "Assertions are disabled (FW_ASSERT_LEVEL == FW_NO_ASSERT), skipping assert failure test";
+#endif
+}
+
+// Test that FW_CASSERT properly triggers assert hook when condition is false
+TEST(CAssertTest, CAssertMacroFailure) {
+#if FW_ASSERT_LEVEL != FW_NO_ASSERT
+    // Disable old-style cast warnings for this test since we're testing C macros
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wold-style-cast"
+    
+    // Create and register test assert hook
+    TestAssertHook hook;
+    hook.registerHook();
+    
+    // Test FW_CASSERT with failing condition
+    FW_CASSERT(1 == 2); // This should trigger the assert hook
+    
+    // Verify that assertion was triggered
+    EXPECT_TRUE(hook.assertFailed());
+    EXPECT_EQ(hook.getNumArgs(), 0U); // FW_CASSERT has no arguments
+    
+    // Deregister hook
+    hook.deregisterHook();
+    
+    #pragma GCC diagnostic pop
+#else
+    GTEST_SKIP() << "Assertions are disabled (FW_ASSERT_LEVEL == FW_NO_ASSERT), skipping assert failure test";
+#endif
+}
+

--- a/Fw/Types/test/ut/CAssertTest.cpp
+++ b/Fw/Types/test/ut/CAssertTest.cpp
@@ -1,0 +1,39 @@
+#include <config/FpConfig.hpp>
+#include <gtest/gtest.h>
+
+/**
+ * \file CAssertTest.cpp
+ * \brief Tests for FW_CASSERT_1 macro functionality
+ */
+
+#include <Fw/Types/Assert.hpp>
+#include <Fw/Types/CAssert.h>
+
+// Test that FW_CASSERT_1 macro compiles and works correctly
+TEST(CAssertTest, CAssert1Macro) {
+    // Disable old-style cast warnings for this test since we're testing C macros
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wold-style-cast"
+    
+    // Test that the macro compiles without errors
+    int testValue = 42;
+    
+    // This should not trigger an assertion since condition is true
+    FW_CASSERT_1(testValue == 42, testValue);
+    
+    // This should compile but not execute assertion in normal builds
+    // In debug builds with assertions enabled, this would trigger
+    FW_CASSERT_1(testValue != 0, testValue);
+    
+    // Test with different argument types
+    U32 uintValue = 100;
+    FW_CASSERT_1(uintValue > 0, uintValue);
+    
+    I32 intValue = -1;
+    FW_CASSERT_1(intValue < 0, intValue);
+    
+    #pragma GCC diagnostic pop
+    
+    // Verify that the macro expands correctly
+    EXPECT_TRUE(true); // If we get here, the macro compiled successfully
+}

--- a/docs/user-manual/framework/assert.md
+++ b/docs/user-manual/framework/assert.md
@@ -37,6 +37,29 @@ available on all processor architectures. The types that are available
 is a configurable feature of the architecture and is typically set by
 compiler arguments.
 
+## C Assertion Macros
+
+For C code, the framework provides `FW_CASSERT` macros in Fw/Types/CAssert.h:
+
+- `FW_CASSERT(cond)` - Basic assertion with condition only
+- `FW_CASSERT_1(cond, arg1)` - Assertion with condition and one argument for reporting
+
+The C assertion macros support the same argument types as the C++ version and integrate with the same assertion hook system.
+
+### Example C Assertion Usage
+
+```c
+#include <Fw/Types/CAssert.h>
+
+void example_function(int value) {
+    // Basic assertion
+    FW_CASSERT(value > 0);
+
+    // Assertion with argument reporting
+    FW_CASSERT_1(value <= 1000, value);
+}
+```
+
 The assert can be configured in the following ways:
 
   - FW\_ASSERT\_LEVEL Sets the level or reporting for the asserts.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3451  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Adding FW_CASSERT_1 macro to support a 1-arg assert in C

## Rationale

There was no equivalent for the "heritage" (C) FSW_ASSERT_1() which will report an argument

## Testing/Review Recommendations

Added UT for testing the assert

## Future Work

None
