### PR TITLE
Add a repository dirtiness indicator to the auto-generated version information

### DIFF
--- a/cmake/target/version/generate_version_info.py
+++ b/cmake/target/version/generate_version_info.py
@@ -28,7 +28,7 @@ FALLBACK_VERSION = "v3.5.0"  # Keep up-to-date on release tag
 
 def get_version_str(working_dir, fallback=FALLBACK_VERSION):
     """
-    System call to get the version. It uses `git describe --tags --always --dirty` to get a standard version string as used
+    System call to get the version. It uses `git describe --tags --always --dirty --broken` to get a standard version string as used
     across fprime. The working directory should be set to a (project, library, fprime) from which to obtain the version.
 
     Args:
@@ -39,7 +39,8 @@ def get_version_str(working_dir, fallback=FALLBACK_VERSION):
     """
     try:
         output = subprocess.check_output(
-            ["git", "describe", "--tags", "--always", "--dirty"], cwd=working_dir
+            ["git", "describe", "--tags", "--always", "--dirty", "--broken"],
+            cwd=working_dir
         )
         return output.strip().decode("ascii")
     except Exception:

--- a/cmake/target/version/generate_version_info.py
+++ b/cmake/target/version/generate_version_info.py
@@ -28,7 +28,7 @@ FALLBACK_VERSION = "v3.5.0"  # Keep up-to-date on release tag
 
 def get_version_str(working_dir, fallback=FALLBACK_VERSION):
     """
-    System call to get the version. It uses `git describe --tags --always` to get a standard version string as used
+    System call to get the version. It uses `git describe --tags --always --dirty` to get a standard version string as used
     across fprime. The working directory should be set to a (project, library, fprime) from which to obtain the version.
 
     Args:
@@ -39,7 +39,7 @@ def get_version_str(working_dir, fallback=FALLBACK_VERSION):
     """
     try:
         output = subprocess.check_output(
-            ["git", "describe", "--tags", "--always"], cwd=working_dir
+            ["git", "describe", "--tags", "--always", "--dirty"], cwd=working_dir
         )
         return output.strip().decode("ascii")
     except Exception:

--- a/cmake/target/version/generate_version_info.py
+++ b/cmake/target/version/generate_version_info.py
@@ -40,7 +40,7 @@ def get_version_str(working_dir, fallback=FALLBACK_VERSION):
     try:
         output = subprocess.check_output(
             ["git", "describe", "--tags", "--always", "--dirty", "--broken"],
-            cwd=working_dir
+            cwd=working_dir,
         )
         return output.strip().decode("ascii")
     except Exception:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| N/A  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This change makes a small modification to the version auto-coder script `generate_version_info.py` to include the `--dirty` flag when calling `git describe`. This will show whether a build has any un-committed changes in its repository or any of its dependencies.

for example:
```bash
# before:
$ git describe --tags --always
v4.0.0a1-104-gb217fc79a
# after:
$ git describe --tags --always --dirty
v4.0.0a1-104-gb217fc79a-dirty
```

## Rationale

This change is useful for an operator to see whether or not the binary that is running was built from a dirty repository or with dirty dependencies, and creates useful breadcrumbs in the version telemetry.

## Testing/Review Recommendations

Should hopefully be straightforward to test, create a build from a clean repository and compare to a build created from a dirty repository.

## Future Work

One thing to consider might be this note from the `git describe` manual:

> If a repository is corrupt and Git cannot determine if there is local modification, Git will error out, unless ‘--broken’ is given, which appends the suffix "-broken" instead.

Is it worth supporting this functionality for a corrupt repository? If so, it might be useful to include the `--broken` flag in this command as well.