### PR TITLE
Make Os.RawTime comparable for equality

### DIFF
--- a/Os/RawTime.cpp
+++ b/Os/RawTime.cpp
@@ -77,4 +77,13 @@ RawTime::Status RawTime::getDiffUsec(const RawTime& other, U32& result) const {
     return status;
 }
 
+bool RawTime::operator==(const RawTime& other) const {
+    Fw::TimeInterval interval;
+    Status status = this->getTimeInterval(other, interval);
+    // If we error out, then the values are either:
+    //    1) impossible to compare, in which case it's perfectly reasonable to consider them different, or
+    //    2) too far apart to fit in a TimeInterval, in which case they are definitely different
+    return status == Status::OP_OK && interval.getSeconds() == 0 && interval.getUSeconds() == 0;
+}
+
 }  // namespace Os

--- a/Os/RawTime.hpp
+++ b/Os/RawTime.hpp
@@ -178,6 +178,8 @@ class RawTime final : public RawTimeInterface {
     //! \return Status indicating the result of the operation.
     Status getDiffUsec(const RawTime& other, U32& result) const;
 
+    //! \brief Compare whether two RawTime objects are the same (i.e. refer to the same microsecond)
+    bool operator==(const RawTime& other) const;
 
   private:
     // This section is used to store the implementation-defined RawTime handle. To Os::RawTime and fprime, this type is


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Implement operator== for Os.RawTime.

## Rationale

This allows Os.RawTime to be used in FPP structs, for example:

```
    struct Status {
        timestamp: Os.RawTime
    }
```

## Testing/Review Recommendations

No specific recommendations.

## Future Work

Should be unit tested eventually.
