### PR TITLE
Restrict TCP subtopologies to supported platforms

### DIFF
--- a/Svc/Subtopologies/ComCcsds/CMakeLists.txt
+++ b/Svc/Subtopologies/ComCcsds/CMakeLists.txt
@@ -1,3 +1,5 @@
+restrict_platforms(Posix SOCKETS)
+
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/ComCcsdsConfig/")
 
 register_fprime_module(

--- a/Svc/Subtopologies/ComFprime/CMakeLists.txt
+++ b/Svc/Subtopologies/ComFprime/CMakeLists.txt
@@ -1,3 +1,5 @@
+restrict_platforms(Posix SOCKETS)
+
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/ComFprimeConfig/")
 
 register_fprime_module(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Restricts ComCcsds and ComFprime to Posix SOCKETS platforms.

## Rationale

These are the same restrictions placed on Drv.TcpClient, which both of these subtopologies rely on. Without these restrictions, the F Prime framework fails to build on platforms without TCP support.

While the references to Drv.TcpClient are in the ComCcsdsConfig and ComFprimeConfig subfolders, the subtopologies depend on these configuration folders in order to compile.

## Testing/Review Recommendations

N/A

## Future Work

We ought to have CI checks that would prevent these kinds of regressions.
