### PR TITLE
Adds calls to cmdResponse_out for both OK and EXECUTION_ERROR conditions Fixes #3897

### DIFF
--- a/Svc/OsTime/OsTime.cpp
+++ b/Svc/OsTime/OsTime.cpp
@@ -38,14 +38,14 @@ void OsTime::SetCurrentTime_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, U32 seco
     Os::RawTime::Status stat = time_now.now();
     if (stat != Os::RawTime::OP_OK) {
         this->log_WARNING_HI_SetCurrentTimeError(stat);
-        this->sendCommandResponse(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        this->cmdResponse_out(opCode,cmdSeq,Fw::CmdResponse::EXECUTION_ERROR);
         return;
     }
     Os::ScopeLock lock(m_epoch_lock);
     m_epoch_fw_time = Fw::Time(seconds_now, 0);
     m_epoch_os_time = time_now;
     m_epoch_valid = true;
-    this->sendCommandResponse(opCode, cmdSeq, Fw::CmdResponse::OK);
+    this->cmdResponse_out(opCode,cmdSeq,Fw::CmdResponse::OK);
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/OsTime/OsTime.cpp
+++ b/Svc/OsTime/OsTime.cpp
@@ -38,12 +38,14 @@ void OsTime::SetCurrentTime_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, U32 seco
     Os::RawTime::Status stat = time_now.now();
     if (stat != Os::RawTime::OP_OK) {
         this->log_WARNING_HI_SetCurrentTimeError(stat);
+        this->sendCommandResponse(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
         return;
     }
     Os::ScopeLock lock(m_epoch_lock);
     m_epoch_fw_time = Fw::Time(seconds_now, 0);
     m_epoch_os_time = time_now;
     m_epoch_valid = true;
+    this->sendCommandResponse(opCode, cmdSeq, Fw::CmdResponse::OK);
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3897 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Adds calls to cmdResponse_out in Svc::OsTime::SetCurrentTime_cmdHandler for both OK and EXECUTION_ERROR conditions.

## Rationale

Fixes #3897.

## Testing/Review Recommendations

Run unit tests

## Future Work

None
