### PR TITLE
Updates `Types.fpp` to use optimized sizes for enumerations

### DIFF
--- a/Fw/Types/Types.fpp
+++ b/Fw/Types/Types.fpp
@@ -7,14 +7,14 @@ module Fw {
   type PolyType
 
   @ Serialization status
-  enum SerialStatus {
+  enum SerialStatus : U8 {
     OK, @< Serialization operation succeeded
     FORMAT_ERROR @< Data was the wrong format (e.g. wrong packet type)
     NO_ROOM_LEFT  @< No room left in the buffer to serialize data
   }
 
   @ Deserialization status
-  enum DeserialStatus {
+  enum DeserialStatus : U8 {
     OK = 0
     BUFFER_EMPTY = 3 @< Deserialization buffer was empty when trying to read data
     FORMAT_ERROR = 4  @< Deserialization data had incorrect values (unexpected data types)
@@ -23,62 +23,62 @@ module Fw {
   }
 
   @ Enabled and disabled states
-  enum Enabled {
+  enum Enabled : U8 {
     DISABLED @< Disabled state
     ENABLED @< Enabled state
   }
 
   @ On and off states
-  enum On {
+  enum On : U8 {
     OFF @< Off state
     ON @< On state
   }
 
   @ Logic states
-  enum Logic {
+  enum Logic : U8 {
     LOW @< Logic low state
     HIGH @< Logic high state
   }
 
   @ Open and closed states
-  enum Open {
+  enum Open : U8 {
     CLOSED @< Closed state
     OPEN @< Open state
   }
 
   @ Direction states
-  enum Direction {
+  enum Direction : U8 {
     IN @< In direction
     OUT @< Out direction
     INOUT @< In/Out direction
   }
 
   @ Active and inactive states
-  enum Active {
+  enum Active : U8 {
     INACTIVE @< Inactive state
     ACTIVE @< Active state
   }
 
   @ Health states
-  enum Health {
+  enum Health : U8 {
     HEALTHY @< Healthy state
     SICK @< Sick state
     FAILED @< Failed state
   }
 
   @ Success/Failure
-  enum Success {
+  enum Success : U8 {
       FAILURE @< Representing failure
       SUCCESS @< Representing success
   }
 
   @ Wait or don't wait for something
-  enum Wait {
+  enum Wait : U8 {
     WAIT @< Wait for something
     NO_WAIT @< Don't wait for something
   }
 
-  enum Completed {
+  enum Completed : U8 {
     COMPLETED @< Completed successfully
     CANCELED @< Canceled before completion
     FAILED @< Failed to complete


### PR DESCRIPTION
- Update enumerations in Types.fpp to use U8 instead of the default I32; the full I32 size is not needed for these simple enumerations

| | |
|:---|:---|
|**_Related Issue(s)_**|  n/a |
|**_Has Unit Tests (y/n)_**|  n |
|**_Documentation Included (y/n)_**|  n |

---
## Change Description

This change request modifies the enumeration size for all enums listed in `Types.fpp` from the default I32 type to the smaller U8 type.

## Rationale

This change will improve the memory footprint for telemetry channels that are defined by structs that contain members of types defined in this file.  Particularly useful in memory-constrained systems that use F-Prime.

## Testing/Review Recommendations

The change is straightforward.  One review item worth considering would be using I8 instead of U8 as the type.  In either case, all enums are well within the bounds of either type.  I don't know if F-Prime has a preference to use the signed version of the type for these enums or if unsigned is fine.  

## Future Work

No planned future work associated with this issue.
