### PR TITLE
Removed sock fd assert on IpSocket

### DIFF
--- a/Drv/Ip/IpSocket.cpp
+++ b/Drv/Ip/IpSocket.cpp
@@ -130,7 +130,6 @@ SocketIpStatus IpSocket::open(SocketDescriptor& socketDescriptor) {
 }
 
 SocketIpStatus IpSocket::send(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size) {
-    FW_ASSERT(socketDescriptor.fd != -1, static_cast<FwAssertArgType>(socketDescriptor.fd));
     FW_ASSERT(data != nullptr);
     FW_ASSERT(size > 0);
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
#3888 

|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Removed unnecessary assert for the `socketDescription.fd` when sending data out. 

## Rationale

When the FSW streams out data to a _e.g._ TCP client, and the client disconnects abruptly, the assert get's triggered, crashing the FSW instance, instead of letting it fail to send in the `sendProtocol()` function further below in the `IpSocket::send()` function.

## Testing/Review Recommendations


## Future Work

