### PR TITLE
Update Cross Compilation Tutorial 

### DIFF
--- a/docs/tutorials/cross-compilation.md
+++ b/docs/tutorials/cross-compilation.md
@@ -170,11 +170,11 @@ First, in a terminal upload the software to hardware platform. This is done with
 ```sh
 # For ARM 64-bit hardware
 # In: project root folder
-scp -r build-artifacts/aarch64-linux/<name-of-deployment> <username>@<device-address>:deployment
+scp build-artifacts/aarch64-linux/<name-of-deployment>/bin/<name-of-deployment> <username>@<device-address>:deployment
 
 # For ARM 32-bit hardware
 # In: project root folder
-scp -r build-artifacts/arm-hf-linux/<name-of-deployment> <username>@<device-address>:deployment
+scp build-artifacts/arm-hf-linux/<name-of-deployment>/bin/<name-of-deployment> <username>@<device-address>:deployment
 ```
 > Users must fill in the username and device address above.
 
@@ -188,7 +188,7 @@ fprime-gds -n --dictionary build-artifacts/aarch64-linux/<name-of-deployment>/di
 
 # For ARM 32-bit hardware
 # In: project root folder
-fprime-gds -n --dictionary build-artifacts/aarch64-linux/<name-of-deployment>/dict/<App Dictionary>.json --ip-client --ip-address <device-address>
+fprime-gds -n --dictionary build-artifacts/arm-hf-linux/<name-of-deployment>/dict/<App Dictionary>.json --ip-client --ip-address <device-address>
 ```
 > [!NOTE]
 > This depends on a flight software deployment that uses TcpServer as the communications driver implementation.
@@ -196,7 +196,7 @@ fprime-gds -n --dictionary build-artifacts/aarch64-linux/<name-of-deployment>/di
 In another terminal SSH into the device and run the uploaded software:
 ```sh
 ssh <username>@<device-address>
-deployment/bin/<name-of-deployment> -a 0.0.0.0 -p 50000
+./deployment -a 0.0.0.0 -p 50000
 ```
 > User should fill in the username and device address above and ensure the correct executable is supplied.
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3473  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Changing `scp` to only upload deployment binary. 

## Rationale

Issues of copying files have come up due running `scp` for the entire deployment folder instead of just the binary that is the bare minimum for running the deployment binary.
See discussion under #3473 for more. 

## Testing/Review Recommendations

Can test on LED Blinker tutorial while connect to Hardware to test if the deployment works. 

## Future Work

N/A 

## AI Usage ([policy](../GENERATIVE_AI.md))

N/A 
