### PR TITLE
Add command dispatcher configuration item to toggle opcode registration events

### DIFF
--- a/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
@@ -33,12 +33,16 @@ void CommandDispatcherImpl::compCmdReg_handler(FwIndexType portNum, FwOpcodeType
             this->m_entryTable[slot].opcode = opCode;
             this->m_entryTable[slot].port = portNum;
             this->m_entryTable[slot].used = true;
+            #if CMD_DISPATCHER_ENABLE_OPCODE_REGISTER_EVENTS
             this->log_DIAGNOSTIC_OpCodeRegistered(opCode, portNum, static_cast<I32>(slot));
+            #endif
             slotFound = true;
         } else if ((this->m_entryTable[slot].used) && (this->m_entryTable[slot].opcode == opCode) &&
                    (this->m_entryTable[slot].port == portNum) && (not slotFound)) {
             slotFound = true;
+            #if CMD_DISPATCHER_ENABLE_OPCODE_REGISTER_EVENTS
             this->log_DIAGNOSTIC_OpCodeReregistered(opCode, portNum);
+            #endif
         } else if (this->m_entryTable[slot].used) {  // make sure no duplicates
             FW_ASSERT(this->m_entryTable[slot].opcode != opCode, static_cast<FwAssertArgType>(opCode));
         }

--- a/default/config/CommandDispatcherImplCfg.hpp
+++ b/default/config/CommandDispatcherImplCfg.hpp
@@ -15,6 +15,12 @@ enum {
     CMD_DISPATCHER_SEQUENCER_TABLE_SIZE = 25, // !< The size of the table holding commands in progress
 };
 
-
+// Toggles whether events are triggered during command opcode registration. Disabling this can be
+// useful for memory-constrained systems with limited downlink buffer space as the events can crowd
+// out more useful events during initialization.
+#ifndef CMD_DISPATCHER_ENABLE_OPCODE_REGISTER_EVENTS
+#define CMD_DISPATCHER_ENABLE_OPCODE_REGISTER_EVENTS \
+    1  //!< Indicates whether or not command opcode registration events are triggered
+#endif
 
 #endif /* CMDDISPATCHER_COMMANDDISPATCHERIMPLCFG_HPP_ */


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR adds a new pre-processor flag `CMD_DISPATCHER_ENABLE_OPCODE_REGISTER_EVENTS` to the command dispatcher configuration in `config/CommandDispatcherImplCfg.hpp` which can be used to enable/disable the command opcode registration (and re-registration) events that are downlinked during command registration. This is enabled by default to preserve existing behavior.

## Rationale

This change is useful for memory-constrained systems where the size of downlink buffers must be restricted. If a deployment contains a sufficient number of commands (which can be exacerbated by the auto-generated parameter commands) the opcode registration causes a large number of diagnostic events which can fill the downlink buffer and crowd out more useful initialization events that occur later on. This change adds a simple compile-time flag which can toggle these events off and clean up the initialization event stream.

## Testing/Review Recommendations

Run with the flag set and verify that there is no change to existing behavior, then run with the flag unset and verify that opcode registration events are no longer downlinked during the command registration phase.

## Future Work

N/A
