### PR TITLE
Fix F Prime location in LedBlinker CI

### DIFF
--- a/.github/workflows/ext-aarch64-linux-led-blinker.yml
+++ b/.github/workflows/ext-aarch64-linux-led-blinker.yml
@@ -23,6 +23,7 @@ env:
   AARCH64_TOOLCHAIN_DIR: /tmp/aarch64-toolchain
   AARCH64_TOOLCHAIN_URL: https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
   ARM_TOOLS_PATH: /tmp/aarch64-toolchain
+  FPRIME_LOCATION: ./lib/fprime
 
 jobs:
   get-branch:
@@ -46,11 +47,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-          path: ./fprime
+          path: ${{ env.FPRIME_LOCATION }}
           fetch-depth: 0
-      - uses: ./fprime/.github/actions/setup
+      - uses: ./lib/fprime/.github/actions/setup
         with:
-          location: ./fprime
+          location: ${{ env.FPRIME_LOCATION }}
       - name: "Download and Setup AArch64 Linux Toolchain"
         run: |
           mkdir -p ${AARCH64_TOOLCHAIN_DIR}

--- a/.github/workflows/ext-aarch64-linux-led-blinker.yml
+++ b/.github/workflows/ext-aarch64-linux-led-blinker.yml
@@ -100,7 +100,7 @@ jobs:
           . venv/bin/activate
           mkdir -p ci-logs
           chmod +x ./build-artifacts/aarch64-linux/LedBlinker/bin/LedBlinker
-          fprime-gds --ip-client --framing-selection fprime -d ./build-artifacts/aarch64-linux/LedBlinker --logs ./ci-logs &
+          fprime-gds --ip-client -d ./build-artifacts/aarch64-linux/LedBlinker --logs ./ci-logs &
           sleep 10
           pytest --dictionary ./build-artifacts/aarch64-linux/LedBlinker/dict/LedBlinkerTopologyDictionary.json ./int/led_integration_tests.py
       - name: 'Archive logs'

--- a/.github/workflows/ext-build-led-blinker.yml
+++ b/.github/workflows/ext-build-led-blinker.yml
@@ -31,6 +31,7 @@ jobs:
     uses: ./.github/workflows/reusable-project-builder.yml
     with: 
       target_repository: fprime-community/fprime-workshop-led-blinker
+      fprime_location: lib/fprime
       build_location: LedBlinker
       run_unit_tests: true
       target_ref: ${{ needs.get-branch.outputs.target-branch }}

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -94,7 +94,7 @@ jobs:
           . venv/bin/activate
           mkdir -p ci-logs
           chmod +x ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker
-          fprime-gds --ip-client --framing-selection fprime -d ./build-artifacts/raspberrypi/LedBlinker --logs ./ci-logs &
+          fprime-gds --ip-client -d ./build-artifacts/raspberrypi/LedBlinker --logs ./ci-logs &
           sleep 10
           pytest --dictionary ./build-artifacts/raspberrypi/LedBlinker/dict/LedBlinkerTopologyDictionary.json ./int/led_integration_tests.py
       - name: 'Archive logs'

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -21,6 +21,7 @@ concurrency:
 
 env:
   RPI_TOOLCHAIN_DIR: /tmp/rpi-toolchain
+  FPRIME_LOCATION: ./lib/fprime
 
 jobs:
   get-branch:
@@ -44,11 +45,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-          path: ./fprime
+          path: ${{ env.FPRIME_LOCATION }}
           fetch-depth: 0
-      - uses: ./fprime/.github/actions/setup
+      - uses: ./lib/fprime/.github/actions/setup
         with:
-          location: ./fprime
+          location: ${{ env.FPRIME_LOCATION }}
       - name: "Setup RPI Toolchain"
         uses: fprime-community/setup-rpi-sysroot@main
       - name: "Generate RPI Build Cache"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Following up on https://github.com/fprime-community/fprime-workshop-led-blinker/pull/122

F´ submodule location changed, so this updates the CI accordingly.=