### PR TITLE
Add static_cast to ambiguous serialize call in FpySequencer

### DIFF
--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -289,7 +289,7 @@ Signal FpySequencer::getPrm_directiveHandler(const FpySequencer_GetPrmDirective&
 
 Signal FpySequencer::cmd_directiveHandler(const FpySequencer_CmdDirective& directive, DirectiveError& error) {
     Fw::ComBuffer cmdBuf;
-    Fw::SerializeStatus stat = cmdBuf.serialize(Fw::ComPacketType::FW_PACKET_COMMAND);
+    Fw::SerializeStatus stat = cmdBuf.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_COMMAND));
     // TODO should I assert here? this really shouldn't fail, I should just add a static assert
     // on com buf size and then assert here
     if (stat != Fw::SerializeStatus::FW_SERIALIZE_OK) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| N/A  |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**| N |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

Add `static_cast<FwPacketDescriptorType>` to `serialize()` call in `FpySequencer`

## Rationale

Older compilers can't decide which overloaded option to use without being specific with a `static_cast`

```
/path/to/lib/fprime/Svc/FpySequencer/FpySequencerDirectives.cpp:292:48: error: call of overloaded 'serialize(ComCfg::APID::T)' is ambiguous
  292 |     Fw::SerializeStatus stat = cmdBuf.serialize(Fw::ComPacketType::FW_PACKET_COMMAND);
      |                                ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /path/to/lib/fprime/Fw/Com/ComPacket.hpp:11,
                 from /home/ethan/Git/jpl/fprime-tutorial-arduino-blinker/lib/fprime/Svc/FpySequencer/FpySequencerDirectives.cpp:2:
/path/to/lib/fprime/Fw/Types/Serializable.hpp:163:21: note: candidate: 'Fw::SerializeStatus Fw::SerializeBufferBase::serialize(U8)'
  163 |     SerializeStatus serialize(U8 val);
      |                     ^~~~~~~~~
/path/to/lib/fprime/Fw/Types/Serializable.hpp:164:21: note: candidate: 'Fw::SerializeStatus Fw::SerializeBufferBase::serialize(I8)'
  164 |     SerializeStatus serialize(I8 val);
      |                     ^~~~~~~~~
/path/to/lib/fprime/Fw/Types/Serializable.hpp:166:21: note: candidate: 'Fw::SerializeStatus Fw::SerializeBufferBase::serialize(U16)'
  166 |     SerializeStatus serialize(U16 val);

...
```

## Testing/Review Recommendations

N/A

## Future Work

N/A

## AI Usage ([policy](../AI_POLICY.md))

N/A
