### PR TITLE
Update Drv IP stack to use FwSizeType instead of U32

### DIFF
--- a/Drv/Ip/IpSocket.cpp
+++ b/Drv/Ip/IpSocket.cpp
@@ -129,14 +129,14 @@ SocketIpStatus IpSocket::open(SocketDescriptor& socketDescriptor) {
     return status;
 }
 
-SocketIpStatus IpSocket::send(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size) {
+SocketIpStatus IpSocket::send(const SocketDescriptor& socketDescriptor, const U8* const data, const FwSizeType size) {
     FW_ASSERT(data != nullptr);
     FW_ASSERT(size > 0);
 
-    U32 total = 0;
-    I32 sent = 0;
+    FwSizeType total = 0;
+    FwSignedSizeType sent = 0;
     // Attempt to send out data and retry as necessary
-    for (U32 i = 0; (i < SOCKET_MAX_ITERATIONS) && (total < size); i++) {
+    for (FwSizeType i = 0; (i < SOCKET_MAX_ITERATIONS) && (total < size); i++) {
         errno = 0;
         // Send using my specific protocol
         sent = this->sendProtocol(socketDescriptor, data + total, size - total);
@@ -153,7 +153,7 @@ SocketIpStatus IpSocket::send(const SocketDescriptor& socketDescriptor, const U8
             return SOCK_SEND_ERROR;
         }
         FW_ASSERT(sent > 0, static_cast<FwAssertArgType>(sent));
-        total += static_cast<U32>(sent);
+        total += static_cast<FwSizeType>(sent);
     }
     // Failed to retry enough to send all data
     if (total < size) {
@@ -164,16 +164,16 @@ SocketIpStatus IpSocket::send(const SocketDescriptor& socketDescriptor, const U8
     return SOCK_SUCCESS;
 }
 
-SocketIpStatus IpSocket::recv(const SocketDescriptor& socketDescriptor, U8* data, U32& req_read) {
+SocketIpStatus IpSocket::recv(const SocketDescriptor& socketDescriptor, U8* data, FwSizeType& req_read) {
     // TODO: Uncomment FW_ASSERT for socketDescriptor.fd once we fix TcpClientTester to not pass in uninitialized
     // socketDescriptor
     //  FW_ASSERT(socketDescriptor.fd != -1, static_cast<FwAssertArgType>(socketDescriptor.fd));
     FW_ASSERT(data != nullptr);
 
-    I32 bytes_received_or_status;  // Stores the return value from recvProtocol
+    FwSignedSizeType bytes_received_or_status;  // Stores the return value from recvProtocol
 
     // Loop primarily for EINTR. Other conditions should lead to an earlier exit.
-    for (U32 i = 0; i < SOCKET_MAX_ITERATIONS; i++) {
+    for (FwSizeType i = 0; i < SOCKET_MAX_ITERATIONS; i++) {
         errno = 0;
         // Pass the current value of req_read (max buffer size) to recvProtocol.
         // recvProtocol returns bytes read or -1 on error.
@@ -181,7 +181,7 @@ SocketIpStatus IpSocket::recv(const SocketDescriptor& socketDescriptor, U8* data
 
         if (bytes_received_or_status > 0) {
             // Successfully read data
-            req_read = static_cast<U32>(bytes_received_or_status);
+            req_read = static_cast<FwSizeType>(bytes_received_or_status);
             return SOCK_SUCCESS;
         } else if (bytes_received_or_status == 0) {
             // Handle zero return based on protocol-specific behavior

--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -116,7 +116,7 @@ class IpSocket {
      * \param size: size of data to send
      * \return status of the send, SOCK_DISCONNECTED to reopen, SOCK_SUCCESS on success, something else on error
      */
-    virtual SocketIpStatus send(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size);
+    virtual SocketIpStatus send(const SocketDescriptor& socketDescriptor, const U8* const data, const FwSizeType size);
     /**
      * \brief receive data from the IP socket from the given buffer
      *
@@ -133,7 +133,7 @@ class IpSocket {
      * \param size: maximum size of data buffer to fill
      * \return status of the send, SOCK_DISCONNECTED to reopen, SOCK_SUCCESS on success, something else on error
      */
-    SocketIpStatus recv(const SocketDescriptor& fd, U8* const data, U32& size);
+    SocketIpStatus recv(const SocketDescriptor& fd, U8* const data, FwSizeType& size);
 
     /**
      * \brief closes the socket
@@ -198,7 +198,9 @@ class IpSocket {
      * \param size: size of data to send
      * \return: size of data sent, or -1 on error.
      */
-    virtual I32 sendProtocol(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size) = 0;
+    virtual FwSignedSizeType sendProtocol(const SocketDescriptor& socketDescriptor,
+                                          const U8* const data,
+                                          const FwSizeType size) = 0;
 
     /**
      * \brief Protocol specific implementation of recv.  Called directly with error handling from recv.
@@ -207,7 +209,9 @@ class IpSocket {
      * \param size: size of data buffer
      * \return: size of data received, or -1 on error.
      */
-    virtual I32 recvProtocol(const SocketDescriptor& socketDescriptor, U8* const data, const U32 size) = 0;
+    virtual FwSignedSizeType recvProtocol(const SocketDescriptor& socketDescriptor,
+                                          U8* const data,
+                                          const FwSizeType size) = 0;
 
     /**
      * \brief Handle zero return from recvProtocol

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -102,7 +102,7 @@ SocketIpStatus SocketComponentHelper::reopen() {
     return status;
 }
 
-SocketIpStatus SocketComponentHelper::send(const U8* const data, const U32 size) {
+SocketIpStatus SocketComponentHelper::send(const U8* const data, const FwSizeType size) {
     SocketIpStatus status = SOCK_SUCCESS;
     this->m_lock.lock();
     SocketDescriptor descriptor = this->m_descriptor;
@@ -157,7 +157,7 @@ bool SocketComponentHelper::running() {
     return running;
 }
 
-SocketIpStatus SocketComponentHelper::recv(U8* data, U32& size) {
+SocketIpStatus SocketComponentHelper::recv(U8* data, FwSizeType& size) {
     SocketIpStatus status = SOCK_SUCCESS;
     // Check for previously disconnected socket
     this->m_lock.lock();
@@ -195,8 +195,7 @@ void SocketComponentHelper::readLoop() {
             Fw::Buffer buffer = this->getBuffer();
             U8* data = buffer.getData();
             FW_ASSERT(data);
-            FW_ASSERT_NO_OVERFLOW(buffer.getSize(), U32);
-            U32 size = static_cast<U32>(buffer.getSize());
+            FwSizeType size = buffer.getSize();
             // recv blocks, so it may have been a while since its done an isOpened check
             status = this->recv(data, size);
             if ((status != SOCK_SUCCESS) && (status != SOCK_INTERRUPTED_TRY_AGAIN) &&

--- a/Drv/Ip/SocketComponentHelper.hpp
+++ b/Drv/Ip/SocketComponentHelper.hpp
@@ -99,7 +99,7 @@ class SocketComponentHelper {
      * \param size: size of data to send
      * \return status of send, SOCK_SUCCESS for success, something else on error
      */
-    SocketIpStatus send(const U8* const data, const U32 size);
+    SocketIpStatus send(const U8* const data, const FwSizeType size);
 
     /**
      * \brief receive data from the IP socket from the given buffer
@@ -109,7 +109,7 @@ class SocketComponentHelper {
      * \param size: maximum size of data buffer to fill
      * \return status of the send, SOCK_DISCONNECTED to reopen, SOCK_SUCCESS on success, something else on error
      */
-    SocketIpStatus recv(U8* data, U32& size);
+    SocketIpStatus recv(U8* data, FwSizeType& size);
 
     /**
      * \brief close the socket communications

--- a/Drv/Ip/TcpClientSocket.cpp
+++ b/Drv/Ip/TcpClientSocket.cpp
@@ -27,12 +27,12 @@
 #include <taskLib.h>
 #include <vxWorks.h>
 #include <cstring>
-#else defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+#elif defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <unistd.h>
-// #else
-// #error OS not supported for IP Socket Communications
+#else
+#error OS not supported for IP Socket Communications
 #endif
 
 #include <cstdio>

--- a/Drv/Ip/TcpClientSocket.cpp
+++ b/Drv/Ip/TcpClientSocket.cpp
@@ -85,12 +85,16 @@ SocketIpStatus TcpClientSocket::openProtocol(SocketDescriptor& socketDescriptor)
     return SOCK_SUCCESS;
 }
 
-I32 TcpClientSocket::sendProtocol(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size) {
-    return static_cast<I32>(::send(socketDescriptor.fd, data, size, SOCKET_IP_SEND_FLAGS));
+FwSignedSizeType TcpClientSocket::sendProtocol(const SocketDescriptor& socketDescriptor,
+                                               const U8* const data,
+                                               const FwSizeType size) {
+    return static_cast<FwSignedSizeType>(::send(socketDescriptor.fd, data, size, SOCKET_IP_SEND_FLAGS));
 }
 
-I32 TcpClientSocket::recvProtocol(const SocketDescriptor& socketDescriptor, U8* const data, const U32 size) {
-    return static_cast<I32>(::recv(socketDescriptor.fd, data, size, SOCKET_IP_RECV_FLAGS));
+FwSignedSizeType TcpClientSocket::recvProtocol(const SocketDescriptor& socketDescriptor,
+                                               U8* const data,
+                                               const FwSizeType size) {
+    return static_cast<FwSignedSizeType>(::recv(socketDescriptor.fd, data, size, SOCKET_IP_RECV_FLAGS));
 }
 
 }  // namespace Drv

--- a/Drv/Ip/TcpClientSocket.cpp
+++ b/Drv/Ip/TcpClientSocket.cpp
@@ -27,12 +27,12 @@
 #include <taskLib.h>
 #include <vxWorks.h>
 #include <cstring>
-#elif defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+#else defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <unistd.h>
-#else
-#error OS not supported for IP Socket Communications
+// #else
+// #error OS not supported for IP Socket Communications
 #endif
 
 #include <cstdio>
@@ -88,13 +88,15 @@ SocketIpStatus TcpClientSocket::openProtocol(SocketDescriptor& socketDescriptor)
 FwSignedSizeType TcpClientSocket::sendProtocol(const SocketDescriptor& socketDescriptor,
                                                const U8* const data,
                                                const FwSizeType size) {
-    return static_cast<FwSignedSizeType>(::send(socketDescriptor.fd, data, size, SOCKET_IP_SEND_FLAGS));
+    return static_cast<FwSignedSizeType>(
+        ::send(socketDescriptor.fd, data, static_cast<size_t>(size), SOCKET_IP_SEND_FLAGS));
 }
 
 FwSignedSizeType TcpClientSocket::recvProtocol(const SocketDescriptor& socketDescriptor,
                                                U8* const data,
                                                const FwSizeType size) {
-    return static_cast<FwSignedSizeType>(::recv(socketDescriptor.fd, data, size, SOCKET_IP_RECV_FLAGS));
+    return static_cast<FwSignedSizeType>(
+        ::recv(socketDescriptor.fd, data, static_cast<size_t>(size), SOCKET_IP_RECV_FLAGS));
 }
 
 }  // namespace Drv

--- a/Drv/Ip/TcpClientSocket.hpp
+++ b/Drv/Ip/TcpClientSocket.hpp
@@ -56,7 +56,9 @@ class TcpClientSocket : public IpSocket {
      * \param size: size of data to send
      * \return: size of data sent, or -1 on error.
      */
-    I32 sendProtocol(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size) override;
+    FwSignedSizeType sendProtocol(const SocketDescriptor& socketDescriptor,
+                                  const U8* const data,
+                                  const FwSizeType size) override;
     /**
      * \brief Protocol specific implementation of recv.  Called directly with error handling from recv.
      * \param socketDescriptor: descriptor to recv from
@@ -64,7 +66,9 @@ class TcpClientSocket : public IpSocket {
      * \param size: size of data buffer
      * \return: size of data received, or -1 on error.
      */
-    I32 recvProtocol(const SocketDescriptor& socketDescriptor, U8* const data, const U32 size) override;
+    FwSignedSizeType recvProtocol(const SocketDescriptor& socketDescriptor,
+                                  U8* const data,
+                                  const FwSizeType size) override;
 };
 }  // namespace Drv
 

--- a/Drv/Ip/TcpServerSocket.cpp
+++ b/Drv/Ip/TcpServerSocket.cpp
@@ -119,15 +119,17 @@ SocketIpStatus TcpServerSocket::openProtocol(SocketDescriptor& socketDescriptor)
     return SOCK_SUCCESS;
 }
 
-I32 TcpServerSocket::sendProtocol(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size) {
-    return static_cast<I32>(::send(socketDescriptor.fd, data, size, SOCKET_IP_SEND_FLAGS));
+FwSignedSizeType TcpServerSocket::sendProtocol(const SocketDescriptor& socketDescriptor,
+                                               const U8* const data,
+                                               const FwSizeType size) {
+    return static_cast<FwSignedSizeType>(::send(socketDescriptor.fd, data, size, SOCKET_IP_SEND_FLAGS));
 }
 
-I32 TcpServerSocket::recvProtocol(const SocketDescriptor& socketDescriptor, U8* const data, const U32 size) {
-    I32 size_buf;
+FwSignedSizeType TcpServerSocket::recvProtocol(const SocketDescriptor& socketDescriptor,
+                                               U8* const data,
+                                               const FwSizeType size) {
     // recv will return 0 if the client has done an orderly shutdown
-    size_buf = static_cast<I32>(::recv(socketDescriptor.fd, data, size, SOCKET_IP_RECV_FLAGS));
-    return size_buf;
+    return static_cast<FwSignedSizeType>(::recv(socketDescriptor.fd, data, size, SOCKET_IP_RECV_FLAGS));
 }
 
 }  // namespace Drv

--- a/Drv/Ip/TcpServerSocket.cpp
+++ b/Drv/Ip/TcpServerSocket.cpp
@@ -122,14 +122,16 @@ SocketIpStatus TcpServerSocket::openProtocol(SocketDescriptor& socketDescriptor)
 FwSignedSizeType TcpServerSocket::sendProtocol(const SocketDescriptor& socketDescriptor,
                                                const U8* const data,
                                                const FwSizeType size) {
-    return static_cast<FwSignedSizeType>(::send(socketDescriptor.fd, data, size, SOCKET_IP_SEND_FLAGS));
+    return static_cast<FwSignedSizeType>(
+        ::send(socketDescriptor.fd, data, static_cast<size_t>(size), SOCKET_IP_SEND_FLAGS));
 }
 
 FwSignedSizeType TcpServerSocket::recvProtocol(const SocketDescriptor& socketDescriptor,
                                                U8* const data,
                                                const FwSizeType size) {
     // recv will return 0 if the client has done an orderly shutdown
-    return static_cast<FwSignedSizeType>(::recv(socketDescriptor.fd, data, size, SOCKET_IP_RECV_FLAGS));
+    return static_cast<FwSignedSizeType>(
+        ::recv(socketDescriptor.fd, data, static_cast<size_t>(size), SOCKET_IP_RECV_FLAGS));
 }
 
 }  // namespace Drv

--- a/Drv/Ip/TcpServerSocket.hpp
+++ b/Drv/Ip/TcpServerSocket.hpp
@@ -76,7 +76,9 @@ class TcpServerSocket : public IpSocket {
      * \param size: size of data to send
      * \return: size of data sent, or -1 on error.
      */
-    I32 sendProtocol(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size) override;
+    FwSignedSizeType sendProtocol(const SocketDescriptor& socketDescriptor,
+                                  const U8* const data,
+                                  const FwSizeType size) override;
     /**
      * \brief Protocol specific implementation of recv.  Called directly with error handling from recv.
      * \param socketDescriptor: descriptor to recv from
@@ -84,7 +86,9 @@ class TcpServerSocket : public IpSocket {
      * \param size: size of data buffer
      * \return: size of data received, or -1 on error.
      */
-    I32 recvProtocol(const SocketDescriptor& socketDescriptor, U8* const data, const U32 size) override;
+    FwSignedSizeType recvProtocol(const SocketDescriptor& socketDescriptor,
+                                  U8* const data,
+                                  const FwSizeType size) override;
 };
 }  // namespace Drv
 

--- a/Drv/Ip/UdpSocket.cpp
+++ b/Drv/Ip/UdpSocket.cpp
@@ -199,9 +199,9 @@ FwSignedSizeType UdpSocket::sendProtocol(const SocketDescriptor& socketDescripto
     FW_ASSERT(socketDescriptor.fd >= 0);           // File descriptor should be valid
     FW_ASSERT(data != nullptr);                    // Data pointer should not be null
 
-    return static_cast<FwSignedSizeType>(::sendto(socketDescriptor.fd, data, size, SOCKET_IP_SEND_FLAGS,
-                                                  reinterpret_cast<struct sockaddr*>(&this->m_addr_send),
-                                                  sizeof(this->m_addr_send)));
+    return static_cast<FwSignedSizeType>(
+        ::sendto(socketDescriptor.fd, data, static_cast<size_t>(size), SOCKET_IP_SEND_FLAGS,
+                 reinterpret_cast<struct sockaddr*>(&this->m_addr_send), sizeof(this->m_addr_send)));
 }
 
 FwSignedSizeType UdpSocket::recvProtocol(const SocketDescriptor& socketDescriptor,
@@ -216,9 +216,9 @@ FwSignedSizeType UdpSocket::recvProtocol(const SocketDescriptor& socketDescripto
     (void)::memset(&sender_addr, 0, sizeof(sender_addr));
 
     socklen_t sender_addr_len = sizeof(sender_addr);
-    FwSignedSizeType received =
-        static_cast<FwSignedSizeType>(::recvfrom(socketDescriptor.fd, data, size, SOCKET_IP_RECV_FLAGS,
-                                                 reinterpret_cast<struct sockaddr*>(&sender_addr), &sender_addr_len));
+    FwSignedSizeType received = static_cast<FwSignedSizeType>(
+        ::recvfrom(socketDescriptor.fd, data, static_cast<size_t>(size), SOCKET_IP_RECV_FLAGS,
+                   reinterpret_cast<struct sockaddr*>(&sender_addr), &sender_addr_len));
     // If we have not configured a send port, set it to the source of the last received packet
     if (received >= 0 && this->m_addr_send.sin_port == 0) {
         this->m_addr_send = sender_addr;

--- a/Drv/Ip/UdpSocket.cpp
+++ b/Drv/Ip/UdpSocket.cpp
@@ -192,17 +192,21 @@ SocketIpStatus UdpSocket::openProtocol(SocketDescriptor& socketDescriptor) {
     return status;
 }
 
-I32 UdpSocket::sendProtocol(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size) {
+FwSignedSizeType UdpSocket::sendProtocol(const SocketDescriptor& socketDescriptor,
+                                         const U8* const data,
+                                         const FwSizeType size) {
     FW_ASSERT(this->m_addr_send.sin_family != 0);  // Make sure the address was previously setup
     FW_ASSERT(socketDescriptor.fd >= 0);           // File descriptor should be valid
     FW_ASSERT(data != nullptr);                    // Data pointer should not be null
 
-    return static_cast<I32>(::sendto(socketDescriptor.fd, data, size, SOCKET_IP_SEND_FLAGS,
-                                     reinterpret_cast<struct sockaddr*>(&this->m_addr_send),
-                                     sizeof(this->m_addr_send)));
+    return static_cast<FwSignedSizeType>(::sendto(socketDescriptor.fd, data, size, SOCKET_IP_SEND_FLAGS,
+                                                  reinterpret_cast<struct sockaddr*>(&this->m_addr_send),
+                                                  sizeof(this->m_addr_send)));
 }
 
-I32 UdpSocket::recvProtocol(const SocketDescriptor& socketDescriptor, U8* const data, const U32 size) {
+FwSignedSizeType UdpSocket::recvProtocol(const SocketDescriptor& socketDescriptor,
+                                         U8* const data,
+                                         const FwSizeType size) {
     FW_ASSERT(this->m_addr_recv.sin_family != 0);  // Make sure the address was previously setup
     FW_ASSERT(socketDescriptor.fd >= 0);           // File descriptor should be valid
     FW_ASSERT(data != nullptr);                    // Data pointer should not be null
@@ -212,8 +216,9 @@ I32 UdpSocket::recvProtocol(const SocketDescriptor& socketDescriptor, U8* const 
     (void)::memset(&sender_addr, 0, sizeof(sender_addr));
 
     socklen_t sender_addr_len = sizeof(sender_addr);
-    I32 received = static_cast<I32>(::recvfrom(socketDescriptor.fd, data, size, SOCKET_IP_RECV_FLAGS,
-                                               reinterpret_cast<struct sockaddr*>(&sender_addr), &sender_addr_len));
+    FwSignedSizeType received =
+        static_cast<FwSignedSizeType>(::recvfrom(socketDescriptor.fd, data, size, SOCKET_IP_RECV_FLAGS,
+                                                 reinterpret_cast<struct sockaddr*>(&sender_addr), &sender_addr_len));
     // If we have not configured a send port, set it to the source of the last received packet
     if (received >= 0 && this->m_addr_send.sin_port == 0) {
         this->m_addr_send = sender_addr;
@@ -223,14 +228,14 @@ I32 UdpSocket::recvProtocol(const SocketDescriptor& socketDescriptor, U8* const 
     return received;
 }
 
-SocketIpStatus UdpSocket::send(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size) {
+SocketIpStatus UdpSocket::send(const SocketDescriptor& socketDescriptor, const U8* const data, const FwSizeType size) {
     // Note: socketDescriptor.fd can be -1 in some test cases
     FW_ASSERT((size == 0) || (data != nullptr));
 
     // Special case for zero-length datagrams in UDP
     if (size == 0) {
         errno = 0;
-        I32 sent = this->sendProtocol(socketDescriptor, data, 0);
+        FwSignedSizeType sent = this->sendProtocol(socketDescriptor, data, 0);
         if (sent == -1) {
             if (errno == EINTR) {
                 // For zero-length datagrams, we'll just try once more if interrupted

--- a/Drv/Ip/UdpSocket.hpp
+++ b/Drv/Ip/UdpSocket.hpp
@@ -109,7 +109,7 @@ class UdpSocket : public IpSocket {
      * \param size: size of data to send
      * \return: status of the send operation
      */
-    SocketIpStatus send(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size) override;
+    SocketIpStatus send(const SocketDescriptor& socketDescriptor, const U8* const data, const FwSizeType size) override;
 
   protected:
     /**
@@ -131,7 +131,9 @@ class UdpSocket : public IpSocket {
      * \param size: size of data to send
      * \return: size of data sent, or -1 on error.
      */
-    I32 sendProtocol(const SocketDescriptor& socketDescriptor, const U8* const data, const U32 size) override;
+    FwSignedSizeType sendProtocol(const SocketDescriptor& socketDescriptor,
+                                  const U8* const data,
+                                  const FwSizeType size) override;
     /**
      * \brief Protocol specific implementation of recv.  Called directly with error handling from recv.
      * \param socketDescriptor: descriptor to recv from
@@ -139,7 +141,9 @@ class UdpSocket : public IpSocket {
      * \param size: size of data buffer
      * \return: size of data received, or -1 on error.
      */
-    I32 recvProtocol(const SocketDescriptor& socketDescriptor, U8* const data, const U32 size) override;
+    FwSignedSizeType recvProtocol(const SocketDescriptor& socketDescriptor,
+                                  U8* const data,
+                                  const FwSizeType size) override;
     /**
      * \brief Handle zero return from recvProtocol for UDP
      *

--- a/Drv/Ip/test/ut/SocketTestHelper.cpp
+++ b/Drv/Ip/test/ut/SocketTestHelper.cpp
@@ -15,7 +15,7 @@
 namespace Drv {
 namespace Test {
 
-const U32 MAX_DRV_TEST_MESSAGE_SIZE = 1024;
+const FwSizeType MAX_DRV_TEST_MESSAGE_SIZE = 1024;
 
 void force_recv_timeout(int fd, Drv::IpSocket& socket) {
     // Set timeout socket option
@@ -43,10 +43,10 @@ void validate_random_buffer(Fw::Buffer& buffer, U8* data) {
     buffer.setSize(0);
 }
 
-U32 fill_random_buffer(Fw::Buffer& buffer) {
+FwSizeType fill_random_buffer(Fw::Buffer& buffer) {
     buffer.setSize(static_cast<FwSizeType>(STest::Pick::lowerUpper(1, static_cast<U32>(buffer.getSize()))));
     fill_random_data(buffer.getData(), buffer.getSize());
-    return static_cast<U32>(buffer.getSize());
+    return buffer.getSize();
 }
 
 void drain(Drv::IpSocket& receiver, Drv::SocketDescriptor& receiver_fd) {
@@ -54,18 +54,18 @@ void drain(Drv::IpSocket& receiver, Drv::SocketDescriptor& receiver_fd) {
     // Drain the server in preparation for close
     while (status == Drv::SOCK_SUCCESS || status == Drv::SOCK_NO_DATA_AVAILABLE) {
         U8 buffer[1];
-        U32 size = sizeof buffer;
+        FwSizeType size = sizeof buffer;
         status = receiver.recv(receiver_fd, buffer, size);
     }
     ASSERT_EQ(status, Drv::SocketIpStatus::SOCK_DISCONNECTED) << "Socket did not disconnect as expected";
 }
 
-void receive_all(Drv::IpSocket& receiver, Drv::SocketDescriptor& receiver_fd, U8* buffer, U32 size) {
+void receive_all(Drv::IpSocket& receiver, Drv::SocketDescriptor& receiver_fd, U8* buffer, FwSizeType size) {
     ASSERT_NE(buffer, nullptr);
-    U32 received_size = 0;
+    FwSizeType received_size = 0;
     Drv::SocketIpStatus status;
     do {
-        U32 size_in_out = size - received_size;
+        FwSizeType size_in_out = size - received_size;
         status = receiver.recv(receiver_fd, buffer + received_size, size_in_out);
         ASSERT_TRUE((status == Drv::SOCK_NO_DATA_AVAILABLE || status == Drv::SOCK_SUCCESS));
         received_size += size_in_out;
@@ -77,7 +77,7 @@ void send_recv(Drv::IpSocket& sender,
                Drv::IpSocket& receiver,
                Drv::SocketDescriptor& sender_fd,
                Drv::SocketDescriptor& receiver_fd) {
-    U32 size = MAX_DRV_TEST_MESSAGE_SIZE;
+    FwSizeType size = MAX_DRV_TEST_MESSAGE_SIZE;
 
     U8 buffer_out[MAX_DRV_TEST_MESSAGE_SIZE] = {0};
     U8 buffer_in[MAX_DRV_TEST_MESSAGE_SIZE] = {0};

--- a/Drv/Ip/test/ut/SocketTestHelper.hpp
+++ b/Drv/Ip/test/ut/SocketTestHelper.hpp
@@ -47,7 +47,7 @@ void validate_random_buffer(Fw::Buffer& buffer, U8* data);
  * Fill random data into the buffer (using a random length).
  * @param buffer: buffer to fill.
  */
-U32 fill_random_buffer(Fw::Buffer& buffer);
+FwSizeType fill_random_buffer(Fw::Buffer& buffer);
 
 /**
  * Send/receive pair.
@@ -75,7 +75,7 @@ void drain(Drv::IpSocket& receiver, Drv::SocketDescriptor& drain_fd);
  * @param buffer: buffer
  * @param size: size to receive
  */
-void receive_all(Drv::IpSocket& receiver, Drv::SocketDescriptor& receiver_fd, U8* buffer, U32 size);
+void receive_all(Drv::IpSocket& receiver, Drv::SocketDescriptor& receiver_fd, U8* buffer, FwSizeType size);
 
 /**
  * Wait on socket change.

--- a/Drv/Ip/test/ut/TestUdp.cpp
+++ b/Drv/Ip/test/ut/TestUdp.cpp
@@ -120,8 +120,8 @@ TEST(UdpZeroLength, TestZeroLengthUdpDatagram) {
 
     // Receive the zero-length datagram using the F' socket wrapper
     U8 recv_buf[1] = {0xFF};
-    U32 recv_buf_len = 1;
-    I32 recv_status = receiver.recv(recv_fd, recv_buf, recv_buf_len);
+    FwSizeType recv_buf_len = 1;
+    FwSignedSizeType recv_status = receiver.recv(recv_fd, recv_buf, recv_buf_len);
 
     // Expect 0 (success) for a zero-length datagram.
     ASSERT_EQ(recv_status, 0) << "Expected recv_status 0 for zero-length datagram, but got " << recv_status
@@ -159,23 +159,23 @@ TEST(Ephemeral, TestEphemeralPorts) {
 
     // Send a test message
     const char* msg = "hello from ephemeral sender";
-    U32 msg_len = static_cast<U32>(strlen(msg) + 1);
+    FwSizeType msg_len = static_cast<FwSizeType>(strlen(msg) + 1);
     ASSERT_EQ(sender.send(send_fd, reinterpret_cast<const U8*>(msg), msg_len), Drv::SOCK_SUCCESS);
 
     // Receive the message and capture sender's port
     char recv_buf[64] = {0};
-    U32 recv_buf_len = sizeof(recv_buf);
+    FwSizeType recv_buf_len = sizeof(recv_buf);
     ASSERT_EQ(receiver.recv(recv_fd, reinterpret_cast<U8*>(recv_buf), recv_buf_len), Drv::SOCK_SUCCESS);
     ASSERT_STREQ(msg, recv_buf);
 
     // Receiver sends a response back to sender
     const char* reply = "reply from receiver";
-    U32 reply_len = static_cast<U32>(strlen(reply) + 1);
+    FwSizeType reply_len = static_cast<FwSizeType>(strlen(reply) + 1);
     ASSERT_EQ(receiver.send(recv_fd, reinterpret_cast<const U8*>(reply), reply_len), Drv::SOCK_SUCCESS);
 
     // Sender receives the response
     char reply_buf[64] = {0};
-    U32 reply_buf_len = sizeof(reply_buf);
+    FwSizeType reply_buf_len = sizeof(reply_buf);
     ASSERT_EQ(sender.recv(send_fd, reinterpret_cast<U8*>(reply_buf), reply_buf_len), Drv::SOCK_SUCCESS);
     ASSERT_STREQ(reply, reply_buf);
 

--- a/Drv/TcpClient/TcpClientComponentImpl.cpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.cpp
@@ -28,8 +28,6 @@ SocketIpStatus TcpClientComponentImpl::configure(const char* hostname,
                                                  const U32 send_timeout_seconds,
                                                  const U32 send_timeout_microseconds,
                                                  FwSizeType buffer_size) {
-    // Check that ensures the configured buffer size fits within the limits fixed-width type, U32
-    FW_ASSERT(buffer_size <= std::numeric_limits<U32>::max(), static_cast<FwAssertArgType>(buffer_size));
     m_allocation_size = buffer_size;  // Store the buffer size
     return m_socket.configure(hostname, port, send_timeout_seconds, send_timeout_microseconds);
 }
@@ -45,7 +43,7 @@ IpSocket& TcpClientComponentImpl::getSocketHandler() {
 }
 
 Fw::Buffer TcpClientComponentImpl::getBuffer() {
-    return allocate_out(0, static_cast<U32>(m_allocation_size));
+    return allocate_out(0, m_allocation_size);
 }
 
 void TcpClientComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status) {
@@ -71,8 +69,7 @@ void TcpClientComponentImpl::connected() {
 // ----------------------------------------------------------------------
 
 Drv::ByteStreamStatus TcpClientComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
-    FW_ASSERT_NO_OVERFLOW(fwBuffer.getSize(), U32);
-    Drv::SocketIpStatus status = send(fwBuffer.getData(), static_cast<U32>(fwBuffer.getSize()));
+    Drv::SocketIpStatus status = send(fwBuffer.getData(), fwBuffer.getSize());
     Drv::ByteStreamStatus returnStatus;
     switch (status) {
         case SOCK_INTERRUPTED_TRY_AGAIN:

--- a/Drv/TcpClient/test/ut/TcpClientTester.cpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.cpp
@@ -57,7 +57,7 @@ void TcpClientTester ::test_with_loop(U32 iterations, bool recv_thread) {
 
     // Loop through a bunch of client disconnects
     for (U32 i = 0; i < iterations; i++) {
-        U32 size = sizeof(m_data_storage);
+        FwSizeType size = sizeof(m_data_storage);
 
         // Not testing with reconnect thread, we will need to open ourselves
         if (not recv_thread) {

--- a/Drv/TcpClient/test/ut/TcpClientTester.hpp
+++ b/Drv/TcpClient/test/ut/TcpClientTester.hpp
@@ -23,7 +23,7 @@ namespace Drv {
 
 class TcpClientTester : public TcpClientGTestBase {
     // Maximum size of histories storing events, telemetry, and port outputs
-    static const U32 MAX_HISTORY_SIZE = 1000;
+    static const FwSizeType MAX_HISTORY_SIZE = 1000;
     // Instance ID supplied to the component instance under test
     static const FwEnumStoreType TEST_INSTANCE_ID = 0;
     // Queue depth supplied to component instance under test

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -29,11 +29,7 @@ SocketIpStatus TcpServerComponentImpl::configure(const char* hostname,
                                                  const U32 send_timeout_seconds,
                                                  const U32 send_timeout_microseconds,
                                                  FwSizeType buffer_size) {
-    // Check that ensures the configured buffer size fits within the limits fixed-width type, U32
-
-    FW_ASSERT(buffer_size <= std::numeric_limits<U32>::max(), static_cast<FwAssertArgType>(buffer_size));
     m_allocation_size = buffer_size;  // Store the buffer size
-                                      //
     (void)m_socket.configure(hostname, port, send_timeout_seconds, send_timeout_microseconds);
     return startup();
 }
@@ -53,7 +49,7 @@ IpSocket& TcpServerComponentImpl::getSocketHandler() {
 }
 
 Fw::Buffer TcpServerComponentImpl::getBuffer() {
-    return allocate_out(0, static_cast<U32>(m_allocation_size));
+    return allocate_out(0, m_allocation_size);
 }
 
 void TcpServerComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status) {
@@ -120,8 +116,7 @@ void TcpServerComponentImpl::readLoop() {
 // ----------------------------------------------------------------------
 
 Drv::ByteStreamStatus TcpServerComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
-    FW_ASSERT_NO_OVERFLOW(fwBuffer.getSize(), U32);
-    Drv::SocketIpStatus status = this->send(fwBuffer.getData(), static_cast<U32>(fwBuffer.getSize()));
+    Drv::SocketIpStatus status = this->send(fwBuffer.getData(), fwBuffer.getSize());
     Drv::ByteStreamStatus returnStatus;
     switch (status) {
         case SOCK_INTERRUPTED_TRY_AGAIN:

--- a/Drv/TcpServer/test/ut/TcpServerTester.cpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.cpp
@@ -58,7 +58,7 @@ void TcpServerTester ::test_with_loop(U32 iterations, bool recv_thread) {
         client.configure("127.0.0.1", this->component.getListenPort(), 0, 100);
         status2 = client.open(client_fd);
         EXPECT_EQ(status2, Drv::SocketIpStatus::SOCK_SUCCESS) << "Failed to connect client";
-        U32 size = sizeof(m_data_storage);
+        FwSizeType size = sizeof(m_data_storage);
 
         // Not testing with reconnect thread, we will need to open ourselves
         if (not recv_thread) {

--- a/Drv/TcpServer/test/ut/TcpServerTester.hpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.hpp
@@ -23,7 +23,7 @@ namespace Drv {
 
 class TcpServerTester : public TcpServerGTestBase {
     // Maximum size of histories storing events, telemetry, and port outputs
-    static const U32 MAX_HISTORY_SIZE = 1000;
+    static const FwSizeType MAX_HISTORY_SIZE = 1000;
     // Instance ID supplied to the component instance under test
     static const FwEnumStoreType TEST_INSTANCE_ID = 0;
     // Queue depth supplied to component instance under test

--- a/Drv/Udp/UdpComponentImpl.cpp
+++ b/Drv/Udp/UdpComponentImpl.cpp
@@ -32,9 +32,7 @@ SocketIpStatus UdpComponentImpl::configureSend(const char* hostname,
 }
 
 SocketIpStatus UdpComponentImpl::configureRecv(const char* hostname, const U16 port, FwSizeType buffer_size) {
-    FW_ASSERT(buffer_size <= std::numeric_limits<U32>::max(), static_cast<FwAssertArgType>(buffer_size));
     m_allocation_size = buffer_size;  // Store the buffer size
-
     return m_socket.configureRecv(hostname, port);
 }
 
@@ -53,7 +51,7 @@ IpSocket& UdpComponentImpl::getSocketHandler() {
 }
 
 Fw::Buffer UdpComponentImpl::getBuffer() {
-    return allocate_out(0, static_cast<U32>(m_allocation_size));
+    return allocate_out(0, m_allocation_size);
 }
 
 void UdpComponentImpl::sendBuffer(Fw::Buffer buffer, SocketIpStatus status) {
@@ -79,8 +77,7 @@ void UdpComponentImpl::connected() {
 // ----------------------------------------------------------------------
 
 Drv::ByteStreamStatus UdpComponentImpl::send_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
-    FW_ASSERT_NO_OVERFLOW(fwBuffer.getSize(), U32);
-    Drv::SocketIpStatus status = send(fwBuffer.getData(), static_cast<U32>(fwBuffer.getSize()));
+    Drv::SocketIpStatus status = send(fwBuffer.getData(), fwBuffer.getSize());
     Drv::ByteStreamStatus returnStatus;
     switch (status) {
         case SOCK_INTERRUPTED_TRY_AGAIN:

--- a/Drv/Udp/test/ut/UdpTester.cpp
+++ b/Drv/Udp/test/ut/UdpTester.cpp
@@ -58,7 +58,7 @@ void UdpTester::test_with_loop(U32 iterations, bool recv_thread) {
     // Loop through a bunch of client disconnects
     for (U32 i = 0; i < iterations; i++) {
         Drv::UdpSocket udp2;
-        U32 size = sizeof(m_data_storage);
+        FwSizeType size = sizeof(m_data_storage);
 
         // Not testing with reconnect thread, we will need to open ourselves
         if (not recv_thread) {

--- a/Drv/Udp/test/ut/UdpTester.hpp
+++ b/Drv/Udp/test/ut/UdpTester.hpp
@@ -23,7 +23,7 @@ namespace Drv {
 
 class UdpTester : public UdpGTestBase {
     // Maximum size of histories storing events, telemetry, and port outputs
-    static const U32 MAX_HISTORY_SIZE = 1000;
+    static const FwSizeType MAX_HISTORY_SIZE = 1000;
     // Instance ID supplied to the component instance under test
     static const FwEnumStoreType TEST_INSTANCE_ID = 0;
     // Queue depth supplied to component instance under test


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/3809

## Rationale

Configurable types

## AI Usage ([policy](../AI_POLICY.md))

Some VSCode autocomplete
