### PR TITLE
Add event ID filters to text logger components

### DIFF
--- a/Svc/ActiveTextLogger/ActiveTextLogger.cpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.cpp
@@ -21,7 +21,8 @@ ActiveTextLogger::ActiveTextLogger(const char* name) : ActiveTextLoggerComponent
 ActiveTextLogger::~ActiveTextLogger() {}
 
 void ActiveTextLogger::configure(const FwEventIdType* filteredIds, FwSizeType count) {
-    FW_ASSERT(count < ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE, count, ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE);
+    FW_ASSERT(count < ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE,
+              static_cast<FwAssertArgType>(count), ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE);
 
     this->m_numFilteredIDs = count;
     for (FwSizeType entry = 0; entry < count; entry++) {

--- a/Svc/ActiveTextLogger/ActiveTextLogger.cpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.cpp
@@ -21,8 +21,8 @@ ActiveTextLogger::ActiveTextLogger(const char* name) : ActiveTextLoggerComponent
 ActiveTextLogger::~ActiveTextLogger() {}
 
 void ActiveTextLogger::configure(const FwEventIdType* filteredIds, FwSizeType count) {
-    FW_ASSERT(count < ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE,
-              static_cast<FwAssertArgType>(count), ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE);
+    FW_ASSERT(count < ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE, static_cast<FwAssertArgType>(count),
+              ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE);
 
     this->m_numFilteredIDs = count;
     for (FwSizeType entry = 0; entry < count; entry++) {

--- a/Svc/ActiveTextLogger/ActiveTextLogger.cpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.cpp
@@ -20,7 +20,7 @@ ActiveTextLogger::ActiveTextLogger(const char* name) : ActiveTextLoggerComponent
 
 ActiveTextLogger::~ActiveTextLogger() {}
 
-void ActiveTextLogger::configure(FwEventIdType* filteredIds, FwSizeType count) {
+void ActiveTextLogger::configure(const FwEventIdType* filteredIds, FwSizeType count) {
     FW_ASSERT(count < ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE, count, ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE);
 
     this->m_numFilteredIDs = count;

--- a/Svc/ActiveTextLogger/ActiveTextLogger.cpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.cpp
@@ -9,6 +9,8 @@
 #include <ctime>
 
 namespace Svc {
+static_assert(std::numeric_limits<FwSizeType>::max() >= ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE,
+              "ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE must fit within range of FwSizeType");
 
 // ----------------------------------------------------------------------
 // Initialization/Exiting
@@ -17,6 +19,15 @@ namespace Svc {
 ActiveTextLogger::ActiveTextLogger(const char* name) : ActiveTextLoggerComponentBase(name), m_log_file() {}
 
 ActiveTextLogger::~ActiveTextLogger() {}
+
+void ActiveTextLogger::configure(FwEventIdType* filteredIds, FwSizeType count) {
+    FW_ASSERT(count < ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE, count, ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE);
+
+    this->m_numFilteredIDs = count;
+    for (FwSizeType entry = 0; entry < count; entry++) {
+        this->m_filteredIDs[entry] = filteredIds[entry];
+    }
+}
 
 // ----------------------------------------------------------------------
 // Handlers to implement for typed input ports
@@ -31,6 +42,12 @@ void ActiveTextLogger::TextLogger_handler(FwIndexType portNum,
     // TKC - 5/3/2018 - remove diagnostic
     if (Fw::LogSeverity::DIAGNOSTIC == severity.e) {
         return;
+    }
+    // Check event ID filters
+    for (FwSizeType i = 0; i < this->m_numFilteredIDs; i++) {
+        if (this->m_filteredIDs[i] == id) {
+            return;
+        }
     }
 
     // Format the string here, so that it is done in the task context

--- a/Svc/ActiveTextLogger/ActiveTextLogger.cpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.cpp
@@ -16,7 +16,8 @@ static_assert(std::numeric_limits<FwSizeType>::max() >= ACTIVE_TEXT_LOGGER_ID_FI
 // Initialization/Exiting
 // ----------------------------------------------------------------------
 
-ActiveTextLogger::ActiveTextLogger(const char* name) : ActiveTextLoggerComponentBase(name), m_log_file() {}
+ActiveTextLogger::ActiveTextLogger(const char* name)
+    : ActiveTextLoggerComponentBase(name), m_log_file(), m_numFilteredIDs(0) {}
 
 ActiveTextLogger::~ActiveTextLogger() {}
 

--- a/Svc/ActiveTextLogger/ActiveTextLogger.hpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.hpp
@@ -8,7 +8,7 @@
 
 #include <Svc/ActiveTextLogger/ActiveTextLoggerComponentAc.hpp>
 #include <Svc/ActiveTextLogger/LogFile.hpp>
-#include <config/PassiveTextLoggerCfg.hpp>
+#include <config/ActiveTextLoggerCfg.hpp>
 
 namespace Svc {
 

--- a/Svc/ActiveTextLogger/ActiveTextLogger.hpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.hpp
@@ -51,7 +51,7 @@ class ActiveTextLogger final : public ActiveTextLoggerComponentBase {
     bool set_log_file(const char* fileName, const U32 maxSize, const U32 maxBackups = 10);
 
     //! Configure component with event ID filters
-    void configure(FwEventIdType* filteredIds, FwSizeType count);
+    void configure(const FwEventIdType* filteredIds, FwSizeType count);
 
   private:
     // ----------------------------------------------------------------------

--- a/Svc/ActiveTextLogger/ActiveTextLogger.hpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.hpp
@@ -8,6 +8,7 @@
 
 #include <Svc/ActiveTextLogger/ActiveTextLoggerComponentAc.hpp>
 #include <Svc/ActiveTextLogger/LogFile.hpp>
+#include <config/PassiveTextLoggerCfg.hpp>
 
 namespace Svc {
 
@@ -48,6 +49,9 @@ class ActiveTextLogger final : public ActiveTextLoggerComponentBase {
     //!
     //!  \return true if creating the file was successful, false otherwise
     bool set_log_file(const char* fileName, const U32 maxSize, const U32 maxBackups = 10);
+
+    //! Configure component with event ID filters
+    void configure(FwEventIdType* filteredIds, FwSizeType count);
 
   private:
     // ----------------------------------------------------------------------
@@ -100,6 +104,10 @@ class ActiveTextLogger final : public ActiveTextLoggerComponentBase {
 
     // The optional file to text logs to:
     LogFile m_log_file;
+
+    // Event ID filters
+    FwSizeType m_numFilteredIDs;
+    FwEventIdType m_filteredIDs[ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE];
 };
 
 }  // namespace Svc

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
@@ -13,7 +13,7 @@ class ConsoleTextLoggerImpl final : public PassiveTextLoggerComponentBase {
     ~ConsoleTextLoggerImpl();
 
     //! Configure component with event ID filters
-    void configure(FwEventIdType* filteredIds, FwSizeType count);
+    void configure(const FwEventIdType* filteredIds, FwSizeType count);
 
   private:
     // downcalls for input ports

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
@@ -2,6 +2,7 @@
 #define SVC_TEXT_LOGGER_IMPL_HPP
 
 #include <Svc/PassiveConsoleTextLogger/PassiveTextLoggerComponentAc.hpp>
+#include <config/PassiveTextLoggerCfg.hpp>
 
 namespace Svc {
 
@@ -11,6 +12,9 @@ class ConsoleTextLoggerImpl final : public PassiveTextLoggerComponentBase {
     ConsoleTextLoggerImpl(const char* compName);
     ~ConsoleTextLoggerImpl();
 
+    //! Configure component with event ID filters
+    void configure(FwEventIdType* filteredIds, FwSizeType count);
+
   private:
     // downcalls for input ports
     void TextLogger_handler(FwIndexType portNum,
@@ -18,6 +22,10 @@ class ConsoleTextLoggerImpl final : public PassiveTextLoggerComponentBase {
                             Fw::Time& timeTag,
                             const Fw::LogSeverity& severity,
                             Fw::TextLogString& text);
+
+    // Event ID filters
+    FwSizeType m_numFilteredIDs;
+    FwEventIdType m_filteredIDs[TEXT_LOGGER_ID_FILTER_SIZE];
 };
 
 }  // namespace Svc

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp
@@ -25,7 +25,7 @@ class ConsoleTextLoggerImpl final : public PassiveTextLoggerComponentBase {
 
     // Event ID filters
     FwSizeType m_numFilteredIDs;
-    FwEventIdType m_filteredIDs[TEXT_LOGGER_ID_FILTER_SIZE];
+    FwEventIdType m_filteredIDs[PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE];
 };
 
 }  // namespace Svc

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
@@ -4,16 +4,34 @@
 #include <Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp>
 
 namespace Svc {
+static_assert(std::numeric_limits<FwSizeType>::max() >= TEXT_LOGGER_ID_FILTER_SIZE,
+              "TEXT_LOGGER_ID_FILTER_SIZE must fit within range of FwSizeType");
 
-ConsoleTextLoggerImpl::ConsoleTextLoggerImpl(const char* compName) : PassiveTextLoggerComponentBase(compName) {}
+ConsoleTextLoggerImpl::ConsoleTextLoggerImpl(const char* compName) : PassiveTextLoggerComponentBase(compName), m_numFilteredIDs(0) {}
 
 ConsoleTextLoggerImpl::~ConsoleTextLoggerImpl() {}
+
+void ConsoleTextLoggerImpl::configure(FwEventIdType* filteredIds, FwSizeType count) {
+    FW_ASSERT(count < TEXT_LOGGER_ID_FILTER_SIZE, count, TEXT_LOGGER_ID_FILTER_SIZE);
+
+    this->m_numFilteredIDs = count;
+    for (FwSizeType entry = 0; entry < count; entry++) {
+        this->m_filteredIDs[entry] = filteredIds[entry];
+    }
+}
 
 void ConsoleTextLoggerImpl::TextLogger_handler(FwIndexType portNum,
                                                FwEventIdType id,
                                                Fw::Time& timeTag,
                                                const Fw::LogSeverity& severity,
                                                Fw::TextLogString& text) {
+    // Check event ID filters
+    for (FwSizeType i = 0; i < this->m_numFilteredIDs; i++) {
+        if (this->m_filteredIDs[i] == id) {
+            return;
+        }
+    }
+
     const char* severityString = nullptr;
     switch (severity.e) {
         case Fw::LogSeverity::FATAL:

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
@@ -11,7 +11,7 @@ ConsoleTextLoggerImpl::ConsoleTextLoggerImpl(const char* compName) : PassiveText
 
 ConsoleTextLoggerImpl::~ConsoleTextLoggerImpl() {}
 
-void ConsoleTextLoggerImpl::configure(FwEventIdType* filteredIds, FwSizeType count) {
+void ConsoleTextLoggerImpl::configure(const FwEventIdType* filteredIds, FwSizeType count) {
     FW_ASSERT(count < PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE, count, PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE);
 
     this->m_numFilteredIDs = count;

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
@@ -12,7 +12,8 @@ ConsoleTextLoggerImpl::ConsoleTextLoggerImpl(const char* compName) : PassiveText
 ConsoleTextLoggerImpl::~ConsoleTextLoggerImpl() {}
 
 void ConsoleTextLoggerImpl::configure(const FwEventIdType* filteredIds, FwSizeType count) {
-    FW_ASSERT(count < PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE, count, PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE);
+    FW_ASSERT(count < PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE,
+              static_cast<FwAssertArgType>(count), PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE);
 
     this->m_numFilteredIDs = count;
     for (FwSizeType entry = 0; entry < count; entry++) {

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
@@ -4,15 +4,15 @@
 #include <Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImpl.hpp>
 
 namespace Svc {
-static_assert(std::numeric_limits<FwSizeType>::max() >= TEXT_LOGGER_ID_FILTER_SIZE,
-              "TEXT_LOGGER_ID_FILTER_SIZE must fit within range of FwSizeType");
+static_assert(std::numeric_limits<FwSizeType>::max() >= PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE,
+              "PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE must fit within range of FwSizeType");
 
 ConsoleTextLoggerImpl::ConsoleTextLoggerImpl(const char* compName) : PassiveTextLoggerComponentBase(compName), m_numFilteredIDs(0) {}
 
 ConsoleTextLoggerImpl::~ConsoleTextLoggerImpl() {}
 
 void ConsoleTextLoggerImpl::configure(FwEventIdType* filteredIds, FwSizeType count) {
-    FW_ASSERT(count < TEXT_LOGGER_ID_FILTER_SIZE, count, TEXT_LOGGER_ID_FILTER_SIZE);
+    FW_ASSERT(count < PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE, count, PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE);
 
     this->m_numFilteredIDs = count;
     for (FwSizeType entry = 0; entry < count; entry++) {

--- a/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
+++ b/Svc/PassiveConsoleTextLogger/ConsoleTextLoggerImplCommon.cpp
@@ -7,13 +7,14 @@ namespace Svc {
 static_assert(std::numeric_limits<FwSizeType>::max() >= PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE,
               "PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE must fit within range of FwSizeType");
 
-ConsoleTextLoggerImpl::ConsoleTextLoggerImpl(const char* compName) : PassiveTextLoggerComponentBase(compName), m_numFilteredIDs(0) {}
+ConsoleTextLoggerImpl::ConsoleTextLoggerImpl(const char* compName)
+    : PassiveTextLoggerComponentBase(compName), m_numFilteredIDs(0) {}
 
 ConsoleTextLoggerImpl::~ConsoleTextLoggerImpl() {}
 
 void ConsoleTextLoggerImpl::configure(const FwEventIdType* filteredIds, FwSizeType count) {
-    FW_ASSERT(count < PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE,
-              static_cast<FwAssertArgType>(count), PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE);
+    FW_ASSERT(count < PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE, static_cast<FwAssertArgType>(count),
+              PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE);
 
     this->m_numFilteredIDs = count;
     for (FwSizeType entry = 0; entry < count; entry++) {

--- a/default/config/ActiveTextLoggerCfg.hpp
+++ b/default/config/ActiveTextLoggerCfg.hpp
@@ -1,0 +1,8 @@
+#ifndef Config_ActiveTextLoggerCfg_HPP_
+#define Config_ActiveTextLoggerCfg_HPP_
+
+enum {
+    ACTIVE_TEXT_LOGGER_ID_FILTER_SIZE = 25, //!< Size of event ID filter
+};
+
+#endif /* Config_ActiveTextLoggerCfg_HPP_ */

--- a/default/config/CMakeLists.txt
+++ b/default/config/CMakeLists.txt
@@ -15,6 +15,7 @@ register_fprime_config(
     HEADERS
         "${CMAKE_CURRENT_LIST_DIR}/EventManagerCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/ActiveRateGroupCfg.hpp"
+        "${CMAKE_CURRENT_LIST_DIR}/ActiveTextLoggerCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/BufferManagerComponentImplCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/CommandDispatcherImplCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/DpCatalogCfg.hpp"

--- a/default/config/CMakeLists.txt
+++ b/default/config/CMakeLists.txt
@@ -24,6 +24,7 @@ register_fprime_config(
         "${CMAKE_CURRENT_LIST_DIR}/FpConfig.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/FPrimeNumericalConfig.h"
         "${CMAKE_CURRENT_LIST_DIR}/IpCfg.hpp"
+        "${CMAKE_CURRENT_LIST_DIR}/PassiveTextLoggerCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/PrmDbImplCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/PrmDbImplTesterCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/StaticMemoryConfig.hpp"

--- a/default/config/PassiveTextLoggerCfg.hpp
+++ b/default/config/PassiveTextLoggerCfg.hpp
@@ -2,7 +2,7 @@
 #define Config_PassiveTextLoggerCfg_HPP_
 
 enum {
-    TEXT_LOGGER_ID_FILTER_SIZE = 25, //!< Size of event ID filter
+    PASSIVE_TEXT_LOGGER_ID_FILTER_SIZE = 25, //!< Size of event ID filter
 };
 
 #endif /* Config_PassiveTextLoggerCfg_HPP_ */

--- a/default/config/PassiveTextLoggerCfg.hpp
+++ b/default/config/PassiveTextLoggerCfg.hpp
@@ -1,0 +1,8 @@
+#ifndef Config_PassiveTextLoggerCfg_HPP_
+#define Config_PassiveTextLoggerCfg_HPP_
+
+enum {
+    TEXT_LOGGER_ID_FILTER_SIZE = 25, //!< Size of event ID filter
+};
+
+#endif /* Config_PassiveTextLoggerCfg_HPP_ */


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4027 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Adds new `configure` interfaces to `ActiveTextLogger` and `PassiveTextLogger` components which can be used to add event ID filters. These filters are used to exclude messages from being logged at runtime.

Also adds configuration files which set the maximum amount of filters that can be added. This was done to mimic the filtering in the `EventManager` component.

## Rationale

Currently no method exists to configure specific event filters for the active/passive text logger components. Such filters are useful for memory-constrained systems where the size of downlink buffers must be restricted. This gives projects the flexibility to restrict the verbosity that comes from events in built-in components.

See #4027 for additional details.

## Testing/Review Recommendations

Configure the text loggers to filter out specific events during deployment initialization and verify that they are no longer logged to their respective destinations.

## Future Work

<!-- Note any additional work that will be done relating to this issue. -->

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None.