### PR TITLE
Support disabling Svc/GenericHub

### DIFF
--- a/Svc/CMakeLists.txt
+++ b/Svc/CMakeLists.txt
@@ -42,7 +42,6 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/FprimeProtocol/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/FprimeRouter/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/FrameAccumulator/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/FramingProtocol/")
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/GenericHub/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Health/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/OsTime/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PassiveRateGroup")
@@ -57,6 +56,12 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SystemResources/")
 
 # Subtopologies
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Subtopologies/")
+
+# Serial hub component included by default,
+# but can be disabled if FW_PORT_SERIALIZATION=0 is desired.
+if (FPRIME_ENABLE_SERIAL_HUBS)
+	add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/GenericHub/")
+endif()
 
 # Text logger components included by default, 
 # but can be disabled if FW_ENABLE_TEXT_LOGGING=0 is desired.

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -133,6 +133,21 @@ option(FPRIME_ENABLE_AUTOCODER_UTS "Enable autocoder UT generation" OFF)
 option(FPRIME_ENABLE_UT_COVERAGE "Calculate unit test coverage" ON)
 
 ####
+# `FPRIME_ENABLE_SERIAL_HUBS:`
+#
+# When FPRIME_ENABLE_SERIAL_HUBS is set, the Svc/GenericHub component is included in
+# the build. When unset, those components are excluded, allowing FpConfig.hpp:FW_PORT_SERIALIZATION to be unset as
+# well, to save space. Svc/GenericHub will fail to build if FW_PORT_SERIALIZATION=0.
+#
+# **Values:**
+# - ON: (default) retains the Svc/GenericHub component in the target list
+# - OFF: removes Svc/GenericHub component from the target list
+#
+# e.g. `-DFPRIME_ENABLE_SERIAL_HUBS=OFF`
+####
+option(FPRIME_ENABLE_SERIAL_HUBS "Enable serial hubs in build" ON)
+
+####
 # `FPRIME_ENABLE_TEXT_LOGGERS:`
 #
 # When FPRIME_ENABLE_TEXT_LOGGERS is set, the ActiveTextLogger and PassiveConsoleTextLogger 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Add FPRIME_ENABLE_SERIAL_HUBS cmake option to disable compilation of Svc/GenericHub.

## Rationale

This allows FW_PORT_SERIALIZATION to be set to 0.

## Testing/Review Recommendations

N/A

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Not used.