### PR TITLE
Add logic for assert failure short circuiting in `AssertFatalAdapter`

### DIFF
--- a/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
+++ b/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
@@ -44,6 +44,8 @@ AssertFatalAdapterComponentImpl ::AssertFatalAdapterComponentImpl(const char* co
     this->m_adapter.regAssertReporter(this);
     // register adapter
     this->m_adapter.registerHook();
+    // Assert handling not in progress
+    this->m_inAssert = false;
 }
 
 AssertFatalAdapterComponentImpl ::~AssertFatalAdapterComponentImpl() {}
@@ -99,11 +101,13 @@ void AssertFatalAdapterComponentImpl::reportAssert(FILE_NAME_ARG file,
                             sizeof(msg));
     Fw::Logger::log("%s\n", msg);
 
-    // Handle the case where the ports aren't connected yet
-    if (not this->isConnected_Log_OutputPort(0)) {
+    // Handle the case where the ports aren't connected yet or assert handling already in progress
+    if (not this->isConnected_Log_OutputPort(0) || this->m_inAssert) {
         assert(0);
         return;
     }
+    // Since log calls below can also fail assert checks, guard against cascading failures
+    this->m_inAssert = true;
 
     switch (numArgs) {
         case 0:
@@ -138,5 +142,7 @@ void AssertFatalAdapterComponentImpl::reportAssert(FILE_NAME_ARG file,
             this->log_FATAL_AF_UNEXPECTED_ASSERT(fileArg, static_cast<U32>(lineNo), static_cast<U32>(numArgs));
             break;
     }
+    // Reset assert handling guard
+    this->m_inAssert = false;
 }
 }  // end namespace Svc

--- a/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
+++ b/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.cpp
@@ -44,8 +44,8 @@ AssertFatalAdapterComponentImpl ::AssertFatalAdapterComponentImpl(const char* co
     this->m_adapter.regAssertReporter(this);
     // register adapter
     this->m_adapter.registerHook();
-    // Assert handling not in progress
-    this->m_inAssert = false;
+    // Initialize the assert counter
+    this->m_assertCount = 0;
 }
 
 AssertFatalAdapterComponentImpl ::~AssertFatalAdapterComponentImpl() {}
@@ -101,13 +101,14 @@ void AssertFatalAdapterComponentImpl::reportAssert(FILE_NAME_ARG file,
                             sizeof(msg));
     Fw::Logger::log("%s\n", msg);
 
-    // Handle the case where the ports aren't connected yet or assert handling already in progress
-    if (not this->isConnected_Log_OutputPort(0) || this->m_inAssert) {
+    // Increment active assert counter
+    this->m_assertCount++;
+
+    // Handle the case where the ports aren't connected yet or we've surpassed the maximum cascading FW_ASSERT failures
+    if (not this->isConnected_Log_OutputPort(0) || this->m_assertCount > FW_ASSERT_COUNT_MAX) {
         assert(0);
         return;
     }
-    // Since log calls below can also fail assert checks, guard against cascading failures
-    this->m_inAssert = true;
 
     switch (numArgs) {
         case 0:
@@ -142,7 +143,7 @@ void AssertFatalAdapterComponentImpl::reportAssert(FILE_NAME_ARG file,
             this->log_FATAL_AF_UNEXPECTED_ASSERT(fileArg, static_cast<U32>(lineNo), static_cast<U32>(numArgs));
             break;
     }
-    // Reset assert handling guard
-    this->m_inAssert = false;
+    // Assert processing complete, decrement active assert counter
+    this->m_assertCount--;
 }
 }  // end namespace Svc

--- a/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.hpp
+++ b/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.hpp
@@ -68,6 +68,7 @@ class AssertFatalAdapterComponentImpl final : public AssertFatalAdapterComponent
     };
 
     AssertFatalAdapter m_adapter;
+    bool m_inAssert;
 };
 
 }  // end namespace Svc

--- a/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.hpp
+++ b/Svc/AssertFatalAdapter/AssertFatalAdapterComponentImpl.hpp
@@ -68,7 +68,7 @@ class AssertFatalAdapterComponentImpl final : public AssertFatalAdapterComponent
     };
 
     AssertFatalAdapter m_adapter;
-    bool m_inAssert;
+    FwSizeType m_assertCount;
 };
 
 }  // end namespace Svc

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -327,6 +327,10 @@ extern "C" {
 #define FW_FILE_CHUNK_SIZE 512  //!< Chunk size for working with files in the OSAL layer
 #endif
 
+#ifndef FW_ASSERT_COUNT_MAX
+#define FW_ASSERT_COUNT_MAX 10  //!< Maximum number of cascading FW_ASSERT check failures before forcing a system assert
+#endif
+
 // *** NOTE configuration checks are in Fw/Cfg/ConfigCheck.cpp in order to have
 // the type definitions in Fw/Types/BasicTypes available.
 #ifdef  __cplusplus


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| No additions to current unit tests, tests pass |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

This change adds guard logic to `AssertFatalAdapter::reportAssert` to prevent an infinite loop of cascading assert reporting in the case where a FW_ASSERT check fails in the log_FATAL port calls.

## Rationale

In the event of a system running low on resources to allocate additional buffer memory for the serialized data used in the log_FATAL port calls, FW_ASSERT checks in those port calls can trip, causing an infinite loop.  This guard check short circuits that infinite loop and forces the second FW_ASSERT check failure to exit early and hand off to the system-level assert handler.

## Testing/Review Recommendations

This logic change was tested with a deployment that has constrained memory resources.  Upon triggering a FW_ASSERT check failure, the log_FATAL port call also failed to get buffer space for the filename data serialization, resulting in a second FW_ASSERT check failure.  With this logic in place, both asserts were logged and the system-level assert processing was allowed to proceed.  Notably, the FATAL event was never actually issued, due to the second FW_ASSERT check failure, but the infinite cascade of assert check failures did not occur.

## Future Work

I couldn't see a clear way to test this in the existing unit tests, but that may be worth exploring further.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). -->
