### PR TITLE
Update GenericHub ports to use Svc.ComDataWithContext

### DIFF
--- a/Svc/GenericHub/GenericHub.fpp
+++ b/Svc/GenericHub/GenericHub.fpp
@@ -39,16 +39,16 @@ module Svc {
     output port bufferDeallocate: Fw.BufferSend
 
     @ Data output to remote hub
-    output port dataOut:  Svc.ComDataWithContext
+    output port dataOut: Svc.ComDataWithContext
 
     @ Buffer returned from dataOut
-    sync input port bufferReturnIn:  Svc.ComDataWithContext
+    sync input port bufferReturnIn: Svc.ComDataWithContext
 
     @ Data input from remote hub
-    sync input port dataIn:  Svc.ComDataWithContext
+    sync input port dataIn: Svc.ComDataWithContext
 
     @ Deallocation of buffer passed into data in
-    output port dataInDeallocate: Fw.BufferSend
+    output port dataInDeallocate: Svc.ComDataWithContext
 
     @ Allocation of buffer passed to passed out dataOut
     output port dataOutAllocate: Fw.BufferGet

--- a/Svc/GenericHub/GenericHub.fpp
+++ b/Svc/GenericHub/GenericHub.fpp
@@ -39,10 +39,10 @@ module Svc {
     output port bufferDeallocate: Fw.BufferSend
 
     @ Data output to remote hub
-    output port dataOut: Svc.ComDataWithContext
+    output port dataOut: Fw.BufferSend
 
     @ Buffer returned from dataOut
-    sync input port bufferReturnIn: Svc.ComDataWithContext
+    sync input port bufferReturnIn: Fw.BufferSend
 
     @ Data input from remote hub
     sync input port dataIn: Svc.ComDataWithContext

--- a/Svc/GenericHub/GenericHub.fpp
+++ b/Svc/GenericHub/GenericHub.fpp
@@ -39,13 +39,13 @@ module Svc {
     output port bufferDeallocate: Fw.BufferSend
 
     @ Data output to remote hub
-    output port dataOut: Fw.BufferSend
+    output port dataOut:  Svc.ComDataWithContext
 
     @ Buffer returned from dataOut
-    sync input port bufferReturnIn: Fw.BufferSend
+    sync input port bufferReturnIn:  Svc.ComDataWithContext
 
     @ Data input from remote hub
-    sync input port dataIn: Fw.BufferSend
+    sync input port dataIn:  Svc.ComDataWithContext
 
     @ Deallocation of buffer passed into data in
     output port dataInDeallocate: Fw.BufferSend

--- a/Svc/GenericHub/GenericHubComponentImpl.cpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.cpp
@@ -73,6 +73,7 @@ void GenericHubComponentImpl ::dataIn_handler(const FwIndexType portNum, Fw::Buf
     U32 port = 0;
     FwBuffSizeType size = 0;
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    ComCfg::FrameContext nullContext;
 
     // Context is not used in the hub pattern
     (void) context;
@@ -99,7 +100,7 @@ void GenericHubComponentImpl ::dataIn_handler(const FwIndexType portNum, Fw::Buf
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         portOut_out(static_cast<FwIndexType>(port), wrapper);
         // Deallocate the existing buffer
-        dataInDeallocate_out(0, fwBuffer);
+        dataInDeallocate_out(0, fwBuffer, nullContext);
     } else if (type == HUB_TYPE_BUFFER) {
         // Fw::Buffers can reuse the existing data buffer as the storage type!  No deallocation done.
         fwBuffer.set(rawData, rawSize, fwBuffer.getContext());
@@ -124,7 +125,7 @@ void GenericHubComponentImpl ::dataIn_handler(const FwIndexType portNum, Fw::Buf
         this->LogSend_out(static_cast<FwIndexType>(port), id, timeTag, severity, args);
 
         // Deallocate the existing buffer
-        dataInDeallocate_out(0, fwBuffer);
+        dataInDeallocate_out(0, fwBuffer, nullContext);
     } else if (type == HUB_TYPE_CHANNEL) {
         FwChanIdType id;
         Fw::Time timeTag;
@@ -142,7 +143,7 @@ void GenericHubComponentImpl ::dataIn_handler(const FwIndexType portNum, Fw::Buf
         this->TlmSend_out(static_cast<FwIndexType>(port), id, timeTag, val);
 
         // Deallocate the existing buffer
-        dataInDeallocate_out(0, fwBuffer);
+        dataInDeallocate_out(0, fwBuffer, nullContext);
     }
 }
 

--- a/Svc/GenericHub/GenericHubComponentImpl.cpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.cpp
@@ -45,9 +45,7 @@ void GenericHubComponentImpl ::send_data(const HubType type,
     status = serialize.serialize(data, size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     outgoing.setSize(static_cast<U32>(serialize.getBuffLength()));
-    // Send data out, context is not used in the hub pattern
-    ComCfg::FrameContext nullContext;
-    dataOut_out(0, outgoing, nullContext);
+    dataOut_out(0, outgoing);
 }
 
 // ----------------------------------------------------------------------
@@ -59,10 +57,8 @@ void GenericHubComponentImpl ::buffersIn_handler(const FwIndexType portNum, Fw::
 }
 
 void GenericHubComponentImpl ::bufferReturnIn_handler(const FwIndexType portNum,
-                                                      Fw::Buffer& fwBuffer,
-                                                      const ComCfg::FrameContext& context) {
-    // Return the buffer irrespective of the supplied context
-    (void) context;
+                                                      Fw::Buffer& fwBuffer) {
+    // Deallocate the returned buffer
     bufferDeallocate_out(0, fwBuffer);
 }
 

--- a/Svc/GenericHub/GenericHubComponentImpl.cpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.cpp
@@ -45,7 +45,9 @@ void GenericHubComponentImpl ::send_data(const HubType type,
     status = serialize.serialize(data, size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     outgoing.setSize(static_cast<U32>(serialize.getBuffLength()));
-    dataOut_out(0, outgoing);
+    // Send data out, context is not used in the hub pattern
+    ComCfg::FrameContext nullContext;
+    dataOut_out(0, outgoing, nullContext);
 }
 
 // ----------------------------------------------------------------------
@@ -56,16 +58,24 @@ void GenericHubComponentImpl ::buffersIn_handler(const FwIndexType portNum, Fw::
     send_data(HUB_TYPE_BUFFER, portNum, fwBuffer.getData(), fwBuffer.getSize());
 }
 
-void GenericHubComponentImpl ::bufferReturnIn_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
+void GenericHubComponentImpl ::bufferReturnIn_handler(const FwIndexType portNum,
+                                                      Fw::Buffer& fwBuffer,
+                                                      const ComCfg::FrameContext& context) {
+    // Return the buffer irrespective of the supplied context
+    (void) context;
     bufferDeallocate_out(0, fwBuffer);
 }
 
-void GenericHubComponentImpl ::dataIn_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
+void GenericHubComponentImpl ::dataIn_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer,
+                                              const ComCfg::FrameContext& context) {
     HubType type = HUB_TYPE_MAX;
     U32 type_in = 0;
     U32 port = 0;
     FwBuffSizeType size = 0;
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+
+    // Context is not used in the hub pattern
+    (void) context;
 
     // Representation of incoming data prepped for serialization
     auto incoming = fwBuffer.getDeserializer();

--- a/Svc/GenericHub/GenericHubComponentImpl.hpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.hpp
@@ -53,36 +53,42 @@ class GenericHubComponentImpl final : public GenericHubComponentBase {
 
     //! Handler implementation for buffersIn
     //!
-    void buffersIn_handler(const FwIndexType portNum, /*!< The port number*/
-                           Fw::Buffer& fwBuffer);
+    void buffersIn_handler(const FwIndexType portNum, /*!< The port number */
+                           Fw::Buffer& fwBuffer       /*!< Input buffer to forward */
+    ) override;
 
     //! Handler implementation for bufferReturnIn
     //!
-    void bufferReturnIn_handler(const FwIndexType portNum, /*!< The port number*/
-                                Fw::Buffer& fwBuffer);
+    void bufferReturnIn_handler(const FwIndexType portNum,          /*!< The port number */
+                                Fw::Buffer& fwBuffer,               /*!< Buffer sent via dataOut being returned */
+                                const ComCfg::FrameContext& context /*!< Context of the returned buffer */
+    ) override;
 
     //! Handler implementation for dataIn
     //!
-    void dataIn_handler(const FwIndexType portNum, /*!< The port number*/
-                        Fw::Buffer& fwBuffer);
+    void dataIn_handler(const FwIndexType portNum,          /*!< The port number */
+                        Fw::Buffer& fwBuffer,               /*!< Buffer from the remote hub */
+                        const ComCfg::FrameContext& context /*!< Context of the returned buffer */
+    ) override;
 
     //! Handler implementation for LogRecv
     //!
-    void LogRecv_handler(const FwIndexType portNum,   /*!< The port number*/
+    void LogRecv_handler(const FwIndexType portNum,       /*!< The port number */
                          FwEventIdType id,                /*!< Log ID */
                          Fw::Time& timeTag,               /*!< Time Tag */
                          const Fw::LogSeverity& severity, /*!< The severity argument */
                          Fw::LogBuffer& args              /*!< Buffer containing serialized log entry */
-    );
+    ) override;
 
     //! Handler implementation for TlmRecv
     //!
     void TlmRecv_handler(const FwIndexType portNum, /*!< The port number*/
-                         FwChanIdType id,               /*!< Telemetry Channel ID */
-                         Fw::Time& timeTag,             /*!< Time Tag */
-                         Fw::TlmBuffer& val             /*!< Buffer containing serialized telemetry value */
-    );
+                         FwChanIdType id,           /*!< Telemetry Channel ID */
+                         Fw::Time& timeTag,         /*!< Time Tag */
+                         Fw::TlmBuffer& val         /*!< Buffer containing serialized telemetry value */
+    ) override;
 
+  private:
     // ----------------------------------------------------------------------
     // Handler implementations for user-defined serial input ports
     // ----------------------------------------------------------------------
@@ -91,9 +97,12 @@ class GenericHubComponentImpl final : public GenericHubComponentBase {
     //!
     void portIn_handler(FwIndexType portNum,        /*!< The port number*/
                         Fw::SerializeBufferBase& Buffer /*!< The serialization buffer*/
-    );
+    ) override;
 
-    // Helpers and members
+  private:
+    // ----------------------------------------------------------------------
+    // Private helpers
+    // ----------------------------------------------------------------------
     void send_data(const HubType type, const FwIndexType port, const U8* data, const FwSizeType size);
 };
 

--- a/Svc/GenericHub/GenericHubComponentImpl.hpp
+++ b/Svc/GenericHub/GenericHubComponentImpl.hpp
@@ -59,9 +59,8 @@ class GenericHubComponentImpl final : public GenericHubComponentBase {
 
     //! Handler implementation for bufferReturnIn
     //!
-    void bufferReturnIn_handler(const FwIndexType portNum,          /*!< The port number */
-                                Fw::Buffer& fwBuffer,               /*!< Buffer sent via dataOut being returned */
-                                const ComCfg::FrameContext& context /*!< Context of the returned buffer */
+    void bufferReturnIn_handler(const FwIndexType portNum, /*!< The port number */
+                                Fw::Buffer& fwBuffer       /*!< Buffer sent via dataOut being returned */
     ) override;
 
     //! Handler implementation for dataIn

--- a/Svc/GenericHub/test/ut/GenericHubTester.cpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.cpp
@@ -171,8 +171,9 @@ void GenericHubTester ::from_dataOut_handler(const FwIndexType portNum, Fw::Buff
     ASSERT_LT(fwBuffer.getData(), m_data_for_allocation + sizeof(m_data_for_allocation))
         << "Incorrect data pointer deallocated";
     // Reuse m_allocate to pass into the otherside of the hub
-    this->pushFromPortEntry_dataOut(fwBuffer);
-    invoke_to_dataIn(0, fwBuffer);
+    ComCfg::FrameContext nullContext;
+    this->pushFromPortEntry_dataOut(fwBuffer, nullContext);
+    invoke_to_dataIn(0, fwBuffer, nullContext);
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/GenericHub/test/ut/GenericHubTester.cpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.cpp
@@ -222,13 +222,15 @@ void GenericHubTester ::from_bufferDeallocate_handler(const FwIndexType portNum,
 }
 
 void GenericHubTester ::from_dataInDeallocate_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
+    ComCfg::FrameContext nullContext;
+
     ASSERT_NE(fwBuffer.getData(), nullptr) << "Empty buffer to deallocate";
     ASSERT_GE(fwBuffer.getData(), m_data_for_allocation) << "Incorrect data pointer deallocated";
     ASSERT_LT(fwBuffer.getData(), m_data_for_allocation + sizeof(m_data_for_allocation))
         << "Incorrect data pointer deallocated";
 
     m_allocate.set(nullptr, 0);
-    this->pushFromPortEntry_dataInDeallocate(fwBuffer);
+    this->pushFromPortEntry_dataInDeallocate(fwBuffer, nullContext);
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/GenericHub/test/ut/GenericHubTester.cpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.cpp
@@ -171,8 +171,8 @@ void GenericHubTester ::from_dataOut_handler(const FwIndexType portNum, Fw::Buff
     ASSERT_LT(fwBuffer.getData(), m_data_for_allocation + sizeof(m_data_for_allocation))
         << "Incorrect data pointer deallocated";
     // Reuse m_allocate to pass into the otherside of the hub
+    this->pushFromPortEntry_dataOut(fwBuffer);
     ComCfg::FrameContext nullContext;
-    this->pushFromPortEntry_dataOut(fwBuffer, nullContext);
     invoke_to_dataIn(0, fwBuffer, nullContext);
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ fprime-fpp-to-dict==3.0.0a13
 fprime-fpp-to-json==3.0.0a13
 fprime-fpp-to-xml==3.0.0a13
 fprime-fpp-to-layout==3.0.0a13
-fprime-gds==v4.0.2a1
+fprime-gds==4.0.2a1
 fprime-tools==4.0.0a6
 fprime-visual==1.0.2
 gcovr==8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ fprime-fpp-to-dict==3.0.0a13
 fprime-fpp-to-json==3.0.0a13
 fprime-fpp-to-xml==3.0.0a13
 fprime-fpp-to-layout==3.0.0a13
-fprime-gds==4.0.0a7
+fprime-gds==v4.0.2a1
 fprime-tools==4.0.0a6
 fprime-visual==1.0.2
 gcovr==8.2


### PR DESCRIPTION
Contains updates to the `GenericHub` ports to allow it to connect to the new F' Framer/Deframer. This is done by changing the necessary ports from `Fw.BufferSend` to `Svc.ComDataWithContext`

Note the context used is currently null.