### PR TITLE
Add venv requirements for running framework tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ The tests can be run using the following commands:
 
 ```bash
 # Go into the fprime directory
-cp MY_FPRIME_DIRECTORY
+cd MY_FPRIME_DIRECTORY
 
 # Run CI tests on fprime
 ./ci/tests/Framework.bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,11 +147,24 @@ The automatic checking system will run all our unit tests and integration tests 
 process will take time. Try to run the unit tests locally during development before submitting a PR and use the
 automatic checks as a safety net.
 
+Building and running the tests has the same Python virtual environment requirements as developing an F´ project, which
+is usually set up by fprime-bootstrap. Steps to set up the environment outside a project are included below.
+
 The tests can be run using the following commands:
 
 ```bash
 # Go into the fprime directory
 cd MY_FPRIME_DIRECTORY
+
+# Set up and activate a Python virtual environment, if none already:
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Make sure Python packages from ./requirements.txt are installed and up-to-date:
+pip install -Ur requirements.txt
+
+# Initialize googletest submodule:
+git submodule update --init --recursive
 
 # Run CI tests on fprime
 ./ci/tests/Framework.bash


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Add documentation to CONTRIBUTING.md regarding environment setup for framework development. The tests did not build or run following the instructions as-written.

## Rationale

I spent an hour or so figuring out why the bash scripts to run tests was failing to build and run the tests and then how to access the `fprime-util` commands referenced there from outside of a project. The tutorials only mention how to access the tools as part of fprime-bootstrap, which sets up a project.

## Testing/Review Recommendations

I then realized I'm not sure if the requirements for framework development are the same as those for user-level project development. Is installing the ./requirements.txt the best (most-complete) first-time setup for framework developers, or is ./requirements.txt intended specifically to track requirements for project development? Any other setup an experienced fprime developer would recommend right off the bat?

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None.
