### PR TITLE
Support resending last message on failure

### DIFF
--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -33,12 +33,7 @@ ComQueue ::ComQueue(const char* const compName)
       m_state(WAITING),
       m_allocationId(static_cast<FwEnumStoreType>(-1)),
       m_allocator(nullptr),
-      m_allocation(nullptr)
-#if FW_COM_BUFFER_RETRY_ON_FAILURE
-      ,
-      m_hasRetried(true)
-#endif
-{
+      m_allocation(nullptr) {
     // Initialize throttles to "off"
     for (FwIndexType i = 0; i < TOTAL_PORT_COUNT; i++) {
         this->m_throttle[i] = false;
@@ -56,7 +51,8 @@ void ComQueue ::cleanup() {
 
 void ComQueue::configure(QueueConfigurationTable queueConfig,
                          FwEnumStoreType allocationId,
-                         Fw::MemAllocator& allocator) {
+                         Fw::MemAllocator& allocator,
+                         bool retryOnFailure) {
     FwIndexType currentPriorityIndex = 0;
     FwSizeType totalAllocation = 0;
 
@@ -130,6 +126,8 @@ void ComQueue::configure(QueueConfigurationTable queueConfig,
     // Safety check that all memory was used as expected
     FW_ASSERT(allocationOffset == totalAllocation, static_cast<FwAssertArgType>(allocationOffset),
               static_cast<FwAssertArgType>(totalAllocation));
+    
+    this->m_retryOnFailure = retryOnFailure;
 }
 // ----------------------------------------------------------------------
 // Handler implementations for user-defined typed input ports
@@ -159,21 +157,20 @@ void ComQueue::comStatusIn_handler(const FwIndexType portNum, Fw::Success& condi
         // On success, the queue should be processed. On failure, the component should still wait.
         case WAITING:
             if (condition.e == Fw::Success::SUCCESS) {
-#if FW_COM_BUFFER_RETRY_ON_FAILURE
-                this->m_hasRetried = false;
-#endif
                 this->m_state = READY;
-                this->processQueue();
+                // The last buffer will not be resent if retry is not configured.
+                if (this->m_tryBufferResend) {
+                    this->m_tryBufferResend = false;
+                    this->dataOut_out(0, this->m_outBuffer, this->m_context);
+                } else {
+                    this->processQueue();
+                }
                 // A message may or may not be sent. Thus, READY or WAITING are acceptable final states.
                 FW_ASSERT((this->m_state == WAITING || this->m_state == READY),
                           static_cast<FwAssertArgType>(this->m_state));
             } else {
-#if FW_COM_BUFFER_RETRY_ON_FAILURE
-                if (!this->m_hasRetried) {
-                    this->m_hasRetried = true;
-                    this->dataOut_out(0, this->m_outBuffer, this->m_context);
-                }
-#endif
+                // Buffer will never be resent if retry has not been configured.
+                this->m_tryBufferResend = this->m_retryOnFailure;
                 this->m_state = WAITING;
             }
             break;
@@ -277,11 +274,8 @@ void ComQueue::sendComBuffer(Fw::ComBuffer& comBuffer, FwIndexType queueIndex) {
     this->dataOut_out(0, outBuffer, context);
     // Set state to WAITING for the status to come back
     this->m_state = WAITING;
-
-#if FW_COM_BUFFER_RETRY_ON_FAILURE
     this->m_context = context;
-    this->m_outBuffer = buffer;
-#endif
+    this->m_outBuffer = outBuffer;
 }
 
 void ComQueue::sendBuffer(Fw::Buffer& buffer, FwIndexType queueIndex) {
@@ -299,11 +293,8 @@ void ComQueue::sendBuffer(Fw::Buffer& buffer, FwIndexType queueIndex) {
     this->dataOut_out(0, buffer, context);
     // Set state to WAITING for the status to come back
     this->m_state = WAITING;
-
-#if FW_COM_BUFFER_RETRY_ON_FAILURE
     this->m_context = context;
     this->m_outBuffer = buffer;
-#endif
 }
 
 void ComQueue::processQueue() {

--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -33,7 +33,12 @@ ComQueue ::ComQueue(const char* const compName)
       m_state(WAITING),
       m_allocationId(static_cast<FwEnumStoreType>(-1)),
       m_allocator(nullptr),
-      m_allocation(nullptr) {
+      m_allocation(nullptr)
+#if FW_COM_BUFFER_RETRY_ON_FAILURE
+      ,
+      m_hasRetried(true)
+#endif
+{
     // Initialize throttles to "off"
     for (FwIndexType i = 0; i < TOTAL_PORT_COUNT; i++) {
         this->m_throttle[i] = false;
@@ -154,12 +159,21 @@ void ComQueue::comStatusIn_handler(const FwIndexType portNum, Fw::Success& condi
         // On success, the queue should be processed. On failure, the component should still wait.
         case WAITING:
             if (condition.e == Fw::Success::SUCCESS) {
+#if FW_COM_BUFFER_RETRY_ON_FAILURE
+                this->m_hasRetried = false;
+#endif
                 this->m_state = READY;
                 this->processQueue();
                 // A message may or may not be sent. Thus, READY or WAITING are acceptable final states.
                 FW_ASSERT((this->m_state == WAITING || this->m_state == READY),
                           static_cast<FwAssertArgType>(this->m_state));
             } else {
+#if FW_COM_BUFFER_RETRY_ON_FAILURE
+                if (!this->m_hasRetried) {
+                    this->m_hasRetried = true;
+                    this->dataOut_out(0, this->m_outBuffer, this->m_context);
+                }
+#endif
                 this->m_state = WAITING;
             }
             break;
@@ -263,6 +277,11 @@ void ComQueue::sendComBuffer(Fw::ComBuffer& comBuffer, FwIndexType queueIndex) {
     this->dataOut_out(0, outBuffer, context);
     // Set state to WAITING for the status to come back
     this->m_state = WAITING;
+
+#if FW_COM_BUFFER_RETRY_ON_FAILURE
+    this->m_context = context;
+    this->m_outBuffer = buffer;
+#endif
 }
 
 void ComQueue::sendBuffer(Fw::Buffer& buffer, FwIndexType queueIndex) {
@@ -280,6 +299,11 @@ void ComQueue::sendBuffer(Fw::Buffer& buffer, FwIndexType queueIndex) {
     this->dataOut_out(0, buffer, context);
     // Set state to WAITING for the status to come back
     this->m_state = WAITING;
+
+#if FW_COM_BUFFER_RETRY_ON_FAILURE
+    this->m_context = context;
+    this->m_outBuffer = buffer;
+#endif
 }
 
 void ComQueue::processQueue() {

--- a/Svc/ComQueue/ComQueue.hpp
+++ b/Svc/ComQueue/ComQueue.hpp
@@ -92,16 +92,6 @@ class ComQueue final : public ComQueueComponentBase {
         WAITING  //!< Component is waiting for status of the last sent message
     };
 
-    /**
-     * Storage for the last sent message. Required in case an attempt is made to resend the message on receiving
-     * Fw::Success::FAILURE.
-     */
-#if FW_COM_BUFFER_RETRY_ON_FAILURE
-    ComCfg::FrameContext m_context; //!< Keep context of the last message sent
-    Fw::Buffer m_outBuffer;         //!< Keep last message sent
-    bool m_hasRetried;              //!< Check if retry has been done
-#endif
-
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction
@@ -122,7 +112,8 @@ class ComQueue final : public ComQueueComponentBase {
     //! queue metadata stored `m_prioritizedList` and then sorts that list by priority.
     void configure(QueueConfigurationTable queueConfig,  //!< Table of the configuration properties for the component
                    FwEnumStoreType allocationId,         //!< Identifier used  when dealing with the Fw::MemAllocator
-                   Fw::MemAllocator& allocator           //!< Fw::MemAllocator used to acquire memory
+                   Fw::MemAllocator& allocator,          //!< Fw::MemAllocator used to acquire memory
+                   bool retryOnFailure                   //!< Enable ComQueue to resend the last message on failure
     );
 
     //! Deallocate resources and cleanup ComQueue
@@ -216,6 +207,15 @@ class ComQueue final : public ComQueueComponentBase {
     FwEnumStoreType m_allocationId;  //!< Component's allocation ID
     Fw::MemAllocator* m_allocator;   //!< Pointer to Fw::MemAllocator instance for deallocation
     void* m_allocation;              //!< Pointer to allocated memory
+
+    /**
+     * Storage for the last sent message. Required in case an attempt is made to resend the message on receiving
+     * Fw::Success::FAILURE.
+     */
+    ComCfg::FrameContext m_context; //!< Keep context of the last sent message
+    Fw::Buffer m_outBuffer;         //!< Store last sent message
+    bool m_tryBufferResend = false; //!< Mark whether a message needs to be resent
+    bool m_retryOnFailure = false;  //!< Flag to enable resend on failure
 };
 
 }  // end namespace Svc

--- a/Svc/ComQueue/ComQueue.hpp
+++ b/Svc/ComQueue/ComQueue.hpp
@@ -92,6 +92,16 @@ class ComQueue final : public ComQueueComponentBase {
         WAITING  //!< Component is waiting for status of the last sent message
     };
 
+    /**
+     * Storage for the last sent message. Required in case an attempt is made to resend the message on receiving
+     * Fw::Success::FAILURE.
+     */
+#if FW_COM_BUFFER_RETRY_ON_FAILURE
+    ComCfg::FrameContext m_context; //!< Keep context of the last message sent
+    Fw::Buffer m_outBuffer;         //!< Keep last message sent
+    bool m_hasRetried;              //!< Check if retry has been done
+#endif
+
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Svc/ComQueue/docs/sdd.md
+++ b/Svc/ComQueue/docs/sdd.md
@@ -58,7 +58,7 @@ The diagram below shows the `Svc::ComQueue` component.
 `Svc::ComQueue` maintains the following state:
 1. `m_queues`: An array of `Types::Queue` used to queue per-port messages.
 2. `m_prioritizedList`: An instance of `Svc::ComQueue::QueueMetadata` storing the priority-order queue metadata.
-3. `m_state`: Instance of `Svc::ComQueue::SendState` representing the state of the component. See: 4.3.1 State Machine
+3. `m_state`: Instance of `Svc::ComQueue::SendState` representing the state of the component. See: 4.2.1 State Machine
 4. `m_throttle`: An array of flags that throttle the per-port queue overflow messages.
 
 ### 4.2.1 State Machine

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -170,11 +170,6 @@ extern "C" {
 #define FW_COM_BUFFER_MAX_SIZE 512
 #endif
 
-// Try resending the last message on failure.
-#ifndef FW_COM_BUFFER_RETRY_ON_FAILURE
-#define FW_COM_BUFFER_RETRY_ON_FAILURE 0  //!< Disable resend on failure
-#endif
-
 // Specifies the size of the buffer attached to state machine signals.
 #ifndef FW_SM_SIGNAL_BUFFER_MAX_SIZE
 #define FW_SM_SIGNAL_BUFFER_MAX_SIZE 128  // Not to exceed max value of FwSizeType

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -170,6 +170,11 @@ extern "C" {
 #define FW_COM_BUFFER_MAX_SIZE 512
 #endif
 
+// Try resending the last message on failure.
+#ifndef FW_COM_BUFFER_RETRY_ON_FAILURE
+#define FW_COM_BUFFER_RETRY_ON_FAILURE 0  //!< Disable resend on failure
+#endif
+
 // Specifies the size of the buffer attached to state machine signals.
 #ifndef FW_SM_SIGNAL_BUFFER_MAX_SIZE
 #define FW_SM_SIGNAL_BUFFER_MAX_SIZE 128  // Not to exceed max value of FwSizeType


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3994 |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

<!-- A description of the changes contained in the PR. -->
Update Svc::ComQueue to resend the last message on failure. Make this change config-driven.
## Rationale

<!-- A rationale for this change. e.g. fixes bug, or most projects need XYZ feature. -->
Enable ComQueue to retry sending the last message when it receives `Fw::Success::FAILURE` instead of simply waiting till it receives `Fw::Success::SUCCESS`.
## Testing/Review Recommendations

<!-- Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality. -->

## Future Work

<!-- Note any additional work that will be done relating to this issue. -->
- Refine/rework implementation
- Add tests
- Modify docs
## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). -->
None