### PR TITLE
Call destructors when ExternalArray releases memory for which it has called constructors

### DIFF
--- a/Fw/DataStructures/ExternalArray.hpp
+++ b/Fw/DataStructures/ExternalArray.hpp
@@ -53,7 +53,7 @@ class ExternalArray final {
     ExternalArray(const ExternalArray<T>& a) : m_elements(a.m_elements), m_size(a.m_size) {}
 
     //! Destructor
-    ~ExternalArray() { this->releaseElements(); }
+    ~ExternalArray() { this->releaseStorage(); }
 
   public:
     // ----------------------------------------------------------------------
@@ -112,7 +112,7 @@ class ExternalArray final {
     void setStorage(T* elements,     //!< The array elements
                     FwSizeType size  //!< The size
     ) {
-        this->releaseElements();
+        this->releaseStorage();
         this->m_elements = elements;
         this->m_size = size;
         this->m_destroyElementsOnRelease = false;
@@ -130,7 +130,7 @@ class ExternalArray final {
         // Check that data.size is large enough to hold the array
         FW_ASSERT(size * sizeof(T) <= data.size);
         // Destroy the elements if required
-        this->releaseElements();
+        this->releaseStorage();
         // Initialize the array members
         this->m_elements = reinterpret_cast<T*>(data.bytes);
         // Construct the array members in place
@@ -169,9 +169,9 @@ class ExternalArray final {
     // Private member functions
     // ----------------------------------------------------------------------
 
-    //! Destroy the array elements if required
-    void releaseElements() {
-        if (this->m_destroyElementsOnRelease) {
+    //! Release the backing storage
+    void releaseStorage() {
+        if ((this->m_elements != nullptr) && this->m_destroyElementsOnRelease) {
             for (FwSizeType i = 0; i < this->m_size; i++) {
                 this->m_elements[i].~T();
             }
@@ -190,7 +190,7 @@ class ExternalArray final {
     //! The size
     FwSizeType m_size = 0;
 
-    //! Whether to destroy the array elements when the external memory is released
+    //! Whether to destroy the array elements when the backing storage is released
     bool m_destroyElementsOnRelease = false;
 };
 

--- a/Fw/DataStructures/ExternalArray.hpp
+++ b/Fw/DataStructures/ExternalArray.hpp
@@ -53,7 +53,7 @@ class ExternalArray final {
     ExternalArray(const ExternalArray<T>& a) : m_elements(a.m_elements), m_size(a.m_size) {}
 
     //! Destructor
-    ~ExternalArray() { this->destroyElements(); }
+    ~ExternalArray() { this->releaseElements(); }
 
   public:
     // ----------------------------------------------------------------------
@@ -112,10 +112,10 @@ class ExternalArray final {
     void setStorage(T* elements,     //!< The array elements
                     FwSizeType size  //!< The size
     ) {
-        this->destroyElements();
+        this->releaseElements();
         this->m_elements = elements;
         this->m_size = size;
-        this->m_destroyElements = false;
+        this->m_destroyElementsOnRelease = false;
     }
 
     //! Set the backing storage (untyped data)
@@ -130,7 +130,7 @@ class ExternalArray final {
         // Check that data.size is large enough to hold the array
         FW_ASSERT(size * sizeof(T) <= data.size);
         // Destroy the elements if required
-        this->destroyElements();
+        this->releaseElements();
         // Initialize the array members
         this->m_elements = reinterpret_cast<T*>(data.bytes);
         // Construct the array members in place
@@ -144,7 +144,7 @@ class ExternalArray final {
         // Set the size
         this->m_size = size;
         // Destroy elements on release of memory
-        this->m_destroyElements = true;
+        this->m_destroyElementsOnRelease = true;
     }
 
   public:
@@ -170,12 +170,12 @@ class ExternalArray final {
     // ----------------------------------------------------------------------
 
     //! Destroy the array elements if required
-    void destroyElements() {
-        if (this->m_destroyElements) {
+    void releaseElements() {
+        if (this->m_destroyElementsOnRelease) {
             for (FwSizeType i = 0; i < this->m_size; i++) {
                 this->m_elements[i].~T();
             }
-            this->m_destroyElements = false;
+            this->m_destroyElementsOnRelease = false;
         }
     }
 
@@ -191,7 +191,7 @@ class ExternalArray final {
     FwSizeType m_size = 0;
 
     //! Whether to destroy the array elements when the external memory is released
-    bool m_destroyElements = false;
+    bool m_destroyElementsOnRelease = false;
 };
 
 }  // namespace Fw

--- a/Fw/DataStructures/ExternalArray.hpp
+++ b/Fw/DataStructures/ExternalArray.hpp
@@ -53,7 +53,7 @@ class ExternalArray final {
     ExternalArray(const ExternalArray<T>& a) : m_elements(a.m_elements), m_size(a.m_size) {}
 
     //! Destructor
-    ~ExternalArray() = default;
+    ~ExternalArray() { this->destroyElements(); }
 
   public:
     // ----------------------------------------------------------------------
@@ -112,8 +112,10 @@ class ExternalArray final {
     void setStorage(T* elements,     //!< The array elements
                     FwSizeType size  //!< The size
     ) {
+        this->destroyElements();
         this->m_elements = elements;
         this->m_size = size;
+        this->m_destroyElements = false;
     }
 
     //! Set the backing storage (untyped data)
@@ -127,6 +129,8 @@ class ExternalArray final {
         FW_ASSERT(reinterpret_cast<uintptr_t>(data.bytes) % alignof(T) == 0);
         // Check that data.size is large enough to hold the array
         FW_ASSERT(size * sizeof(T) <= data.size);
+        // Destroy the elements if required
+        this->destroyElements();
         // Initialize the array members
         this->m_elements = reinterpret_cast<T*>(data.bytes);
         // Construct the array members in place
@@ -139,6 +143,8 @@ class ExternalArray final {
         }
         // Set the size
         this->m_size = size;
+        // Destroy elements on release of memory
+        this->m_destroyElements = true;
     }
 
   public:
@@ -160,6 +166,21 @@ class ExternalArray final {
 
   private:
     // ----------------------------------------------------------------------
+    // Private member functions
+    // ----------------------------------------------------------------------
+
+    //! Destroy the array elements if required
+    void destroyElements() {
+        if (this->m_destroyElements) {
+            for (FwSizeType i = 0; i < this->m_size; i++) {
+                this->m_elements[i].~T();
+            }
+            this->m_destroyElements = false;
+        }
+    }
+
+  private:
+    // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
 
@@ -168,6 +189,9 @@ class ExternalArray final {
 
     //! The size
     FwSizeType m_size = 0;
+
+    //! Whether to destroy the array elements when the external memory is released
+    bool m_destroyElements = false;
 };
 
 }  // namespace Fw

--- a/Fw/DataStructures/ExternalArray.hpp
+++ b/Fw/DataStructures/ExternalArray.hpp
@@ -143,7 +143,7 @@ class ExternalArray final {
         }
         // Set the size
         this->m_size = size;
-        // Destroy elements on release of memory
+        // Destroy elements on release of storage
         this->m_destroyElementsOnRelease = true;
     }
 

--- a/Fw/DataStructures/ExternalArray.hpp
+++ b/Fw/DataStructures/ExternalArray.hpp
@@ -129,7 +129,7 @@ class ExternalArray final {
         FW_ASSERT(reinterpret_cast<uintptr_t>(data.bytes) % alignof(T) == 0);
         // Check that data.size is large enough to hold the array
         FW_ASSERT(size * sizeof(T) <= data.size);
-        // Destroy the elements if required
+        // Release the backing storage
         this->releaseStorage();
         // Initialize the array members
         this->m_elements = reinterpret_cast<T*>(data.bytes);

--- a/Fw/DataStructures/docs/ExternalArray.md
+++ b/Fw/DataStructures/docs/ExternalArray.md
@@ -24,7 +24,7 @@ It stores a pointer to the backing memory _M_.
 |----|----|-------|-------------|
 |`m_elements`|`T*`|Pointer to backing memory or `nullptr`|`nullptr`|
 |`m_size`|`FwSizeType`|Stores the size (number of elements) of the array|0|
-|`m_destroyElements`|`bool`|Whether to destroy the array elements when the external memory is released|`false`|
+|`m_destroyElementsOnRelease`|`bool`|Whether to destroy the array elements when the external memory is released|`false`|
 
 <a name="Public-Constructors-and-Destructors"></a>
 ## 3. Public Constructors and Destructors
@@ -105,7 +105,7 @@ ExternalArray<U32> a2(a1);
 ~ExternalArray()
 ```
 
-Call `destroyElements()`.
+Call `releaseElements()`.
 
 ## 4. Public Member Functions
 
@@ -232,9 +232,9 @@ void setStorage(T* elements, FwSizeType size)
 `elements` must point to a primitive array of at least `size`
 elements of type `T`.
 
-1. Call `destroyElements()`.
+1. Call `releaseElements()`.
 
-1. Set `m_elements = elements` and `m_size = size` and `m_destroyElements = true`.
+1. Set `m_elements = elements` and `m_size = size` and `m_destroyElementsOnRelease = true`.
 
 _Example:_
 ```c++
@@ -259,7 +259,7 @@ and must contain at least [`getByteArraySize(size)`](#52-getbytearraysize) bytes
 
 1. Assert that `size * sizeof(T) <= data.size`.
 
-1. Call `destroyElements()`.
+1. Call `releaseElements()`.
 
 1. Initialize `m_elements` with `data.bytes`.
 
@@ -267,7 +267,7 @@ and must contain at least [`getByteArraySize(size)`](#52-getbytearraysize) bytes
 
 1. Initialize `m_size` with `size`.
 
-1. Set `m_destroyElements = true`.
+1. Set `m_destroyElementsOnRelease = true`.
 
 _Example:_
 ```c++
@@ -315,11 +315,11 @@ ASSERT_EQ(byteArraySize, 10 * sizeof(U32));
 ### 6.1. destroyElements
 
 ```c++
-void destroyElements()
+void releaseElements()
 ```
 
-If `m_destroyElements` then
+If `m_destroyElementsOnRelease` then
 
 1. Call the destructor on each element of `m_elements`.
 
-2. Set `m_destroyElements = false`.
+2. Set `m_destroyElementsOnRelease = false`.

--- a/Fw/DataStructures/docs/ExternalArray.md
+++ b/Fw/DataStructures/docs/ExternalArray.md
@@ -315,7 +315,7 @@ ASSERT_EQ(byteArraySize, 10 * sizeof(U32));
 ### 6.1. destroyElements
 
 ```c++
-destroyElements()
+void destroyElements()
 ```
 
 If `m_destroyElements` then

--- a/Fw/DataStructures/docs/ExternalArray.md
+++ b/Fw/DataStructures/docs/ExternalArray.md
@@ -24,6 +24,7 @@ It stores a pointer to the backing memory _M_.
 |----|----|-------|-------------|
 |`m_elements`|`T*`|Pointer to backing memory or `nullptr`|`nullptr`|
 |`m_size`|`FwSizeType`|Stores the size (number of elements) of the array|0|
+|`m_destroyElements`|`bool`|Whether to destroy the array elements when the external memory is released|`false`|
 
 <a name="Public-Constructors-and-Destructors"></a>
 ## 3. Public Constructors and Destructors
@@ -104,7 +105,7 @@ ExternalArray<U32> a2(a1);
 ~ExternalArray()
 ```
 
-Defined as `= default`.
+Call `destroyElements()`.
 
 ## 4. Public Member Functions
 
@@ -231,7 +232,9 @@ void setStorage(T* elements, FwSizeType size)
 `elements` must point to a primitive array of at least `size`
 elements of type `T`.
 
-Set `m_elements = elements` and `m_size = size`.
+1. Call `destroyElements()`.
+
+1. Set `m_elements = elements` and `m_size = size` and `m_destroyElements = true`.
 
 _Example:_
 ```c++
@@ -256,11 +259,15 @@ and must contain at least [`getByteArraySize(size)`](#52-getbytearraysize) bytes
 
 1. Assert that `size * sizeof(T) <= data.size`.
 
+1. Call `destroyElements()`.
+
 1. Initialize `m_elements` with `data.bytes`.
 
 1. Construct the objects pointed to by `m_elements` in place.
 
 1. Initialize `m_size` with `size`.
+
+1. Set `m_destroyElements = true`.
 
 _Example:_
 ```c++
@@ -302,3 +309,17 @@ const FwSizeType size = 10;
 const FwSizeType byteArraySize = ExternalArray<U32>::getByteArraySize(size);
 ASSERT_EQ(byteArraySize, 10 * sizeof(U32));
 ```
+
+## 6. Private Member Functions
+
+### 6.1. destroyElements
+
+```c++
+destroyElements()
+```
+
+If `m_destroyElements` then
+
+1. Call the destructor on each element of `m_elements`.
+
+2. Set `m_destroyElements = false`.

--- a/Fw/DataStructures/docs/ExternalArray.md
+++ b/Fw/DataStructures/docs/ExternalArray.md
@@ -24,7 +24,7 @@ It stores a pointer to the backing memory _M_.
 |----|----|-------|-------------|
 |`m_elements`|`T*`|Pointer to backing memory or `nullptr`|`nullptr`|
 |`m_size`|`FwSizeType`|Stores the size (number of elements) of the array|0|
-|`m_destroyElementsOnRelease`|`bool`|Whether to destroy the array elements when the external storage is released|`false`|
+|`m_destroyElementsOnRelease`|`bool`|Whether to destroy the array elements when the backing storage is released|`false`|
 
 <a name="Public-Constructors-and-Destructors"></a>
 ## 3. Public Constructors and Destructors

--- a/Fw/DataStructures/docs/ExternalArray.md
+++ b/Fw/DataStructures/docs/ExternalArray.md
@@ -24,7 +24,7 @@ It stores a pointer to the backing memory _M_.
 |----|----|-------|-------------|
 |`m_elements`|`T*`|Pointer to backing memory or `nullptr`|`nullptr`|
 |`m_size`|`FwSizeType`|Stores the size (number of elements) of the array|0|
-|`m_destroyElementsOnRelease`|`bool`|Whether to destroy the array elements when the external memory is released|`false`|
+|`m_destroyElementsOnRelease`|`bool`|Whether to destroy the array elements when the external storage is released|`false`|
 
 <a name="Public-Constructors-and-Destructors"></a>
 ## 3. Public Constructors and Destructors
@@ -105,7 +105,7 @@ ExternalArray<U32> a2(a1);
 ~ExternalArray()
 ```
 
-Call `releaseElements()`.
+Call `releaseStorage()`.
 
 ## 4. Public Member Functions
 
@@ -232,7 +232,7 @@ void setStorage(T* elements, FwSizeType size)
 `elements` must point to a primitive array of at least `size`
 elements of type `T`.
 
-1. Call `releaseElements()`.
+1. Call `releaseStorage()`.
 
 1. Set `m_elements = elements` and `m_size = size` and `m_destroyElementsOnRelease = true`.
 
@@ -259,7 +259,7 @@ and must contain at least [`getByteArraySize(size)`](#52-getbytearraysize) bytes
 
 1. Assert that `size * sizeof(T) <= data.size`.
 
-1. Call `releaseElements()`.
+1. Call `releaseStorage()`.
 
 1. Initialize `m_elements` with `data.bytes`.
 
@@ -312,10 +312,10 @@ ASSERT_EQ(byteArraySize, 10 * sizeof(U32));
 
 ## 6. Private Member Functions
 
-### 6.1. destroyElements
+### 6.1. releaseStorage
 
 ```c++
-void releaseElements()
+void releaseStorage()
 ```
 
 If `m_destroyElementsOnRelease` then


### PR DESCRIPTION
Closes #4135.