### PR TITLE
Mark legacy serialize and deserialize methods as DEPRECATED. Upgrade remaining references to legacy methods.

### DIFF
--- a/FppTestProject/FppTest/component/active/test/ut/ActiveTestTester.cpp
+++ b/FppTestProject/FppTest/component/active/test/ut/ActiveTestTester.cpp
@@ -46,32 +46,32 @@ Fw::ParamValid ActiveTestTester ::from_prmGetIn_handler(const FwIndexType portNu
 
     switch (id - id_base) {
         case ActiveTestComponentBase::PARAMID_PARAMBOOL:
-            status = val.serialize(boolPrm.args.val);
+            status = val.serializeFrom(boolPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case ActiveTestComponentBase::PARAMID_PARAMU32:
-            status = val.serialize(u32Prm.args.val);
+            status = val.serializeFrom(u32Prm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case ActiveTestComponentBase::PARAMID_PARAMSTRING:
-            status = val.serialize(stringPrm.args.val);
+            status = val.serializeFrom(stringPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case ActiveTestComponentBase::PARAMID_PARAMENUM:
-            status = val.serialize(enumPrm.args.val);
+            status = val.serializeFrom(enumPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case ActiveTestComponentBase::PARAMID_PARAMARRAY:
-            status = val.serialize(arrayPrm.args.val);
+            status = val.serializeFrom(arrayPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case ActiveTestComponentBase::PARAMID_PARAMSTRUCT:
-            status = val.serialize(structPrm.args.val);
+            status = val.serializeFrom(structPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
     }
@@ -89,32 +89,32 @@ void ActiveTestTester ::from_prmSetIn_handler(const FwIndexType portNum, FwPrmId
 
     switch (id - id_base) {
         case ActiveTestComponentBase::PARAMID_PARAMBOOL:
-            status = val.deserialize(boolPrm.args.val);
+            status = val.deserializeTo(boolPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case ActiveTestComponentBase::PARAMID_PARAMU32:
-            status = val.deserialize(u32Prm.args.val);
+            status = val.deserializeTo(u32Prm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case ActiveTestComponentBase::PARAMID_PARAMSTRING:
-            status = val.deserialize(stringPrm.args.val);
+            status = val.deserializeTo(stringPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case ActiveTestComponentBase::PARAMID_PARAMENUM:
-            status = val.deserialize(enumPrm.args.val);
+            status = val.deserializeTo(enumPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case ActiveTestComponentBase::PARAMID_PARAMARRAY:
-            status = val.deserialize(arrayPrm.args.val);
+            status = val.deserializeTo(arrayPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case ActiveTestComponentBase::PARAMID_PARAMSTRUCT:
-            status = val.deserialize(structPrm.args.val);
+            status = val.deserializeTo(structPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
     }
@@ -138,27 +138,27 @@ Fw::SerializeStatus ActiveTestTester::ActiveTestComponentBaseParamExternalDelega
     switch (local_id) {
         // ParamBoolExternal
         case ActiveTestComponentBase::PARAMID_PARAMBOOLEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamBoolExternal);
+            stat = buff.deserializeTo(this->m_param_ParamBoolExternal);
             break;
         // ParamI32External
         case ActiveTestComponentBase::PARAMID_PARAMI32EXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamI32External);
+            stat = buff.deserializeTo(this->m_param_ParamI32External);
             break;
         // ParamStringExternal
         case ActiveTestComponentBase::PARAMID_PARAMSTRINGEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamStringExternal);
+            stat = buff.deserializeTo(this->m_param_ParamStringExternal);
             break;
         // ParamEnumExternal
         case ActiveTestComponentBase::PARAMID_PARAMENUMEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamEnumExternal);
+            stat = buff.deserializeTo(this->m_param_ParamEnumExternal);
             break;
         // ParamArrayExternal
         case ActiveTestComponentBase::PARAMID_PARAMARRAYEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamArrayExternal);
+            stat = buff.deserializeTo(this->m_param_ParamArrayExternal);
             break;
         // ParamStructExternal
         case ActiveTestComponentBase::PARAMID_PARAMSTRUCTEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamStructExternal);
+            stat = buff.deserializeTo(this->m_param_ParamStructExternal);
             break;
         default:
             // Unknown ID should not have gotten here
@@ -179,27 +179,27 @@ Fw::SerializeStatus ActiveTestTester::ActiveTestComponentBaseParamExternalDelega
     switch (local_id) {
         // ParamBoolExternal
         case ActiveTestComponentBase::PARAMID_PARAMBOOLEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamBoolExternal);
+            stat = buff.serializeFrom(this->m_param_ParamBoolExternal);
             break;
         // ParamI32External
         case ActiveTestComponentBase::PARAMID_PARAMI32EXTERNAL:
-            stat = buff.serialize(this->m_param_ParamI32External);
+            stat = buff.serializeFrom(this->m_param_ParamI32External);
             break;
         // ParamStringExternal
         case ActiveTestComponentBase::PARAMID_PARAMSTRINGEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamStringExternal);
+            stat = buff.serializeFrom(this->m_param_ParamStringExternal);
             break;
         // ParamEnumExternal
         case ActiveTestComponentBase::PARAMID_PARAMENUMEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamEnumExternal);
+            stat = buff.serializeFrom(this->m_param_ParamEnumExternal);
             break;
         // ParamArrayExternal
         case ActiveTestComponentBase::PARAMID_PARAMARRAYEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamArrayExternal);
+            stat = buff.serializeFrom(this->m_param_ParamArrayExternal);
             break;
         // ParamStructExternal
         case ActiveTestComponentBase::PARAMID_PARAMSTRUCTEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamStructExternal);
+            stat = buff.serializeFrom(this->m_param_ParamStructExternal);
             break;
         default:
             // Unknown ID should not have gotten here

--- a/FppTestProject/FppTest/component/passive/test/ut/PassiveTestTester.cpp
+++ b/FppTestProject/FppTest/component/passive/test/ut/PassiveTestTester.cpp
@@ -45,32 +45,32 @@ Fw::ParamValid PassiveTestTester ::from_prmGetIn_handler(const FwIndexType portN
 
     switch (id - id_base) {
         case PassiveTestComponentBase::PARAMID_PARAMBOOL:
-            status = val.serialize(boolPrm.args.val);
+            status = val.serializeFrom(boolPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case PassiveTestComponentBase::PARAMID_PARAMU32:
-            status = val.serialize(u32Prm.args.val);
+            status = val.serializeFrom(u32Prm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case PassiveTestComponentBase::PARAMID_PARAMSTRING:
-            status = val.serialize(stringPrm.args.val);
+            status = val.serializeFrom(stringPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case PassiveTestComponentBase::PARAMID_PARAMENUM:
-            status = val.serialize(enumPrm.args.val);
+            status = val.serializeFrom(enumPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case PassiveTestComponentBase::PARAMID_PARAMARRAY:
-            status = val.serialize(arrayPrm.args.val);
+            status = val.serializeFrom(arrayPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case PassiveTestComponentBase::PARAMID_PARAMSTRUCT:
-            status = val.serialize(structPrm.args.val);
+            status = val.serializeFrom(structPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
     }
@@ -88,32 +88,32 @@ void PassiveTestTester ::from_prmSetIn_handler(const FwIndexType portNum, FwPrmI
 
     switch (id - id_base) {
         case PassiveTestComponentBase::PARAMID_PARAMBOOL:
-            status = val.deserialize(boolPrm.args.val);
+            status = val.deserializeTo(boolPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case PassiveTestComponentBase::PARAMID_PARAMU32:
-            status = val.deserialize(u32Prm.args.val);
+            status = val.deserializeTo(u32Prm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case PassiveTestComponentBase::PARAMID_PARAMSTRING:
-            status = val.deserialize(stringPrm.args.val);
+            status = val.deserializeTo(stringPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case PassiveTestComponentBase::PARAMID_PARAMENUM:
-            status = val.deserialize(enumPrm.args.val);
+            status = val.deserializeTo(enumPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case PassiveTestComponentBase::PARAMID_PARAMARRAY:
-            status = val.deserialize(arrayPrm.args.val);
+            status = val.deserializeTo(arrayPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case PassiveTestComponentBase::PARAMID_PARAMSTRUCT:
-            status = val.deserialize(structPrm.args.val);
+            status = val.deserializeTo(structPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
     }
@@ -137,27 +137,27 @@ Fw::SerializeStatus PassiveTestTester::PassiveTestComponentBaseParamExternalDele
     switch (local_id) {
         // ParamBoolExternal
         case PassiveTestComponentBase::PARAMID_PARAMBOOLEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamBoolExternal);
+            stat = buff.deserializeTo(this->m_param_ParamBoolExternal);
             break;
         // ParamI32External
         case PassiveTestComponentBase::PARAMID_PARAMI32EXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamI32External);
+            stat = buff.deserializeTo(this->m_param_ParamI32External);
             break;
         // ParamStringExternal
         case PassiveTestComponentBase::PARAMID_PARAMSTRINGEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamStringExternal);
+            stat = buff.deserializeTo(this->m_param_ParamStringExternal);
             break;
         // ParamEnumExternal
         case PassiveTestComponentBase::PARAMID_PARAMENUMEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamEnumExternal);
+            stat = buff.deserializeTo(this->m_param_ParamEnumExternal);
             break;
         // ParamArrayExternal
         case PassiveTestComponentBase::PARAMID_PARAMARRAYEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamArrayExternal);
+            stat = buff.deserializeTo(this->m_param_ParamArrayExternal);
             break;
         // ParamStructExternal
         case PassiveTestComponentBase::PARAMID_PARAMSTRUCTEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamStructExternal);
+            stat = buff.deserializeTo(this->m_param_ParamStructExternal);
             break;
         default:
             // Unknown ID should not have gotten here
@@ -178,27 +178,27 @@ Fw::SerializeStatus PassiveTestTester::PassiveTestComponentBaseParamExternalDele
     switch (local_id) {
         // ParamBoolExternal
         case PassiveTestComponentBase::PARAMID_PARAMBOOLEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamBoolExternal);
+            stat = buff.serializeFrom(this->m_param_ParamBoolExternal);
             break;
         // ParamI32External
         case PassiveTestComponentBase::PARAMID_PARAMI32EXTERNAL:
-            stat = buff.serialize(this->m_param_ParamI32External);
+            stat = buff.serializeFrom(this->m_param_ParamI32External);
             break;
         // ParamStringExternal
         case PassiveTestComponentBase::PARAMID_PARAMSTRINGEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamStringExternal);
+            stat = buff.serializeFrom(this->m_param_ParamStringExternal);
             break;
         // ParamEnumExternal
         case PassiveTestComponentBase::PARAMID_PARAMENUMEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamEnumExternal);
+            stat = buff.serializeFrom(this->m_param_ParamEnumExternal);
             break;
         // ParamArrayExternal
         case PassiveTestComponentBase::PARAMID_PARAMARRAYEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamArrayExternal);
+            stat = buff.serializeFrom(this->m_param_ParamArrayExternal);
             break;
         // ParamStructExternal
         case PassiveTestComponentBase::PARAMID_PARAMSTRUCTEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamStructExternal);
+            stat = buff.serializeFrom(this->m_param_ParamStructExternal);
             break;
         default:
             // Unknown ID should not have gotten here

--- a/FppTestProject/FppTest/component/queued/test/ut/QueuedTestTester.cpp
+++ b/FppTestProject/FppTest/component/queued/test/ut/QueuedTestTester.cpp
@@ -46,32 +46,32 @@ Fw::ParamValid QueuedTestTester ::from_prmGetIn_handler(const FwIndexType portNu
 
     switch (id - id_base) {
         case QueuedTestComponentBase::PARAMID_PARAMBOOL:
-            status = val.serialize(boolPrm.args.val);
+            status = val.serializeFrom(boolPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case QueuedTestComponentBase::PARAMID_PARAMU32:
-            status = val.serialize(u32Prm.args.val);
+            status = val.serializeFrom(u32Prm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case QueuedTestComponentBase::PARAMID_PARAMSTRING:
-            status = val.serialize(stringPrm.args.val);
+            status = val.serializeFrom(stringPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case QueuedTestComponentBase::PARAMID_PARAMENUM:
-            status = val.serialize(enumPrm.args.val);
+            status = val.serializeFrom(enumPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case QueuedTestComponentBase::PARAMID_PARAMARRAY:
-            status = val.serialize(arrayPrm.args.val);
+            status = val.serializeFrom(arrayPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case QueuedTestComponentBase::PARAMID_PARAMSTRUCT:
-            status = val.serialize(structPrm.args.val);
+            status = val.serializeFrom(structPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
     }
@@ -89,32 +89,32 @@ void QueuedTestTester ::from_prmSetIn_handler(const FwIndexType portNum, FwPrmId
 
     switch (id - id_base) {
         case QueuedTestComponentBase::PARAMID_PARAMBOOL:
-            status = val.deserialize(boolPrm.args.val);
+            status = val.deserializeTo(boolPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case QueuedTestComponentBase::PARAMID_PARAMU32:
-            status = val.deserialize(u32Prm.args.val);
+            status = val.deserializeTo(u32Prm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case QueuedTestComponentBase::PARAMID_PARAMSTRING:
-            status = val.deserialize(stringPrm.args.val);
+            status = val.deserializeTo(stringPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case QueuedTestComponentBase::PARAMID_PARAMENUM:
-            status = val.deserialize(enumPrm.args.val);
+            status = val.deserializeTo(enumPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case QueuedTestComponentBase::PARAMID_PARAMARRAY:
-            status = val.deserialize(arrayPrm.args.val);
+            status = val.deserializeTo(arrayPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
 
         case QueuedTestComponentBase::PARAMID_PARAMSTRUCT:
-            status = val.deserialize(structPrm.args.val);
+            status = val.deserializeTo(structPrm.args.val);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
             break;
     }
@@ -138,27 +138,27 @@ Fw::SerializeStatus QueuedTestTester::QueuedTestComponentBaseParamExternalDelega
     switch (local_id) {
         // ParamBoolExternal
         case QueuedTestComponentBase::PARAMID_PARAMBOOLEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamBoolExternal);
+            stat = buff.deserializeTo(this->m_param_ParamBoolExternal);
             break;
         // ParamI32External
         case QueuedTestComponentBase::PARAMID_PARAMI32EXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamI32External);
+            stat = buff.deserializeTo(this->m_param_ParamI32External);
             break;
         // ParamStringExternal
         case QueuedTestComponentBase::PARAMID_PARAMSTRINGEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamStringExternal);
+            stat = buff.deserializeTo(this->m_param_ParamStringExternal);
             break;
         // ParamEnumExternal
         case QueuedTestComponentBase::PARAMID_PARAMENUMEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamEnumExternal);
+            stat = buff.deserializeTo(this->m_param_ParamEnumExternal);
             break;
         // ParamArrayExternal
         case QueuedTestComponentBase::PARAMID_PARAMARRAYEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamArrayExternal);
+            stat = buff.deserializeTo(this->m_param_ParamArrayExternal);
             break;
         // ParamStructExternal
         case QueuedTestComponentBase::PARAMID_PARAMSTRUCTEXTERNAL:
-            stat = buff.deserialize(this->m_param_ParamStructExternal);
+            stat = buff.deserializeTo(this->m_param_ParamStructExternal);
             break;
         default:
             // Unknown ID should not have gotten here
@@ -179,27 +179,27 @@ Fw::SerializeStatus QueuedTestTester::QueuedTestComponentBaseParamExternalDelega
     switch (local_id) {
         // ParamBoolExternal
         case QueuedTestComponentBase::PARAMID_PARAMBOOLEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamBoolExternal);
+            stat = buff.serializeFrom(this->m_param_ParamBoolExternal);
             break;
         // ParamI32External
         case QueuedTestComponentBase::PARAMID_PARAMI32EXTERNAL:
-            stat = buff.serialize(this->m_param_ParamI32External);
+            stat = buff.serializeFrom(this->m_param_ParamI32External);
             break;
         // ParamStringExternal
         case QueuedTestComponentBase::PARAMID_PARAMSTRINGEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamStringExternal);
+            stat = buff.serializeFrom(this->m_param_ParamStringExternal);
             break;
         // ParamEnumExternal
         case QueuedTestComponentBase::PARAMID_PARAMENUMEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamEnumExternal);
+            stat = buff.serializeFrom(this->m_param_ParamEnumExternal);
             break;
         // ParamArrayExternal
         case QueuedTestComponentBase::PARAMID_PARAMARRAYEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamArrayExternal);
+            stat = buff.serializeFrom(this->m_param_ParamArrayExternal);
             break;
         // ParamStructExternal
         case QueuedTestComponentBase::PARAMID_PARAMSTRUCTEXTERNAL:
-            stat = buff.serialize(this->m_param_ParamStructExternal);
+            stat = buff.serializeFrom(this->m_param_ParamStructExternal);
             break;
         default:
             // Unknown ID should not have gotten here

--- a/FppTestProject/FppTest/component/tests/CmdTests.hpp
+++ b/FppTestProject/FppTest/component/tests/CmdTests.hpp
@@ -171,7 +171,7 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_NO_ARGS, 1, Fw::CmdResponse::OK);             \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serialize(0);                                                                                   \
+        buf.serializeFrom(0);                                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_NO_ARGS, buf);                          \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
         ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_NO_ARGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
@@ -192,37 +192,37 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test incorrect deserialization of second argument */                                             \
-        buf.serialize(data.args.val1);                                                                      \
+        buf.serializeFrom(data.args.val1);                                                                      \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
         ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test incorrect deserialization of third argument */                                              \
-        buf.serialize(data.args.val2);                                                                      \
+        buf.serializeFrom(data.args.val2);                                                                      \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
         ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test incorrect deserialization of fourth argument */                                             \
-        buf.serialize(data.args.val3);                                                                      \
+        buf.serializeFrom(data.args.val3);                                                                      \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(4);                                                                        \
         ASSERT_CMD_RESPONSE(3, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test incorrect deserialization of fifth argument */                                              \
-        buf.serialize(data.args.val4);                                                                      \
+        buf.serializeFrom(data.args.val4);                                                                      \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(5);                                                                        \
         ASSERT_CMD_RESPONSE(4, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test incorrect deserialization of sixth argument */                                              \
-        buf.serialize(data.args.val5);                                                                      \
+        buf.serializeFrom(data.args.val5);                                                                      \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(6);                                                                        \
         ASSERT_CMD_RESPONSE(5, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test success */                                                                                  \
-        buf.serialize(data.args.val6);                                                                      \
+        buf.serializeFrom(data.args.val6);                                                                      \
         this->invoke##ASYNC##Command(data);                                                                 \
                                                                                                             \
         ASSERT_CMD_RESPONSE_SIZE(7);                                                                        \
@@ -235,7 +235,7 @@
         ASSERT_EQ(component.primitiveCmd.args.val6, data.args.val6);                                        \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serialize(data.args.val5);                                                                      \
+        buf.serializeFrom(data.args.val5);                                                                      \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(8);                                                                        \
         ASSERT_CMD_RESPONSE(7, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
@@ -256,13 +256,13 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
                                                                                                             \
         /* Test incorrect serialization of second argument */                                               \
-        buf.serialize(data.args.val1);                                                                      \
+        buf.serializeFrom(data.args.val1);                                                                      \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                          \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
         ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
                                                                                                             \
         /* Test success */                                                                                  \
-        buf.serialize(data.args.val2);                                                                      \
+        buf.serializeFrom(data.args.val2);                                                                      \
         this->invoke##ASYNC##Command(data);                                                                 \
                                                                                                             \
         ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
@@ -271,7 +271,7 @@
         ASSERT_EQ(component.stringCmd.args.val2, data.args.val2);                                           \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serialize(data.args.val1);                                                                      \
+        buf.serializeFrom(data.args.val1);                                                                      \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                          \
         ASSERT_CMD_RESPONSE_SIZE(4);                                                                        \
         ASSERT_CMD_RESPONSE(3, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
@@ -292,7 +292,7 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::FORMAT_ERROR);      \
                                                                                                             \
         /* Test success */                                                                                  \
-        buf.serialize(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                       \
         this->invoke##ASYNC##Command(data);                                                                 \
                                                                                                             \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
@@ -300,7 +300,7 @@
         ASSERT_EQ(component.enumCmd.args.val, data.args.val);                                               \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serialize(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                       \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                             \
         ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
         ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::FORMAT_ERROR);      \
@@ -321,7 +321,7 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::FORMAT_ERROR);     \
                                                                                                             \
         /* Test success */                                                                                  \
-        buf.serialize(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                       \
         this->invoke##ASYNC##Command(data);                                                                 \
                                                                                                             \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
@@ -329,7 +329,7 @@
         ASSERT_EQ(component.arrayCmd.args.val, data.args.val);                                              \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serialize(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                       \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                            \
         ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
         ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::FORMAT_ERROR);     \
@@ -350,7 +350,7 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::FORMAT_ERROR);    \
                                                                                                             \
         /* Test success */                                                                                  \
-        buf.serialize(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                       \
         this->invoke##ASYNC##Command(data);                                                                 \
                                                                                                             \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
@@ -358,7 +358,7 @@
         ASSERT_EQ(component.structCmd.args.val, data.args.val);                                             \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serialize(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                       \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                           \
         ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
         ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::FORMAT_ERROR);    \

--- a/FppTestProject/FppTest/component/tests/CmdTests.hpp
+++ b/FppTestProject/FppTest/component/tests/CmdTests.hpp
@@ -171,7 +171,7 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_NO_ARGS, 1, Fw::CmdResponse::OK);             \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serializeFrom(0);                                                                                   \
+        buf.serializeFrom(0);                                                                               \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_NO_ARGS, buf);                          \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
         ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_NO_ARGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
@@ -192,37 +192,37 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test incorrect deserialization of second argument */                                             \
-        buf.serializeFrom(data.args.val1);                                                                      \
+        buf.serializeFrom(data.args.val1);                                                                  \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
         ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test incorrect deserialization of third argument */                                              \
-        buf.serializeFrom(data.args.val2);                                                                      \
+        buf.serializeFrom(data.args.val2);                                                                  \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
         ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test incorrect deserialization of fourth argument */                                             \
-        buf.serializeFrom(data.args.val3);                                                                      \
+        buf.serializeFrom(data.args.val3);                                                                  \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(4);                                                                        \
         ASSERT_CMD_RESPONSE(3, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test incorrect deserialization of fifth argument */                                              \
-        buf.serializeFrom(data.args.val4);                                                                      \
+        buf.serializeFrom(data.args.val4);                                                                  \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(5);                                                                        \
         ASSERT_CMD_RESPONSE(4, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test incorrect deserialization of sixth argument */                                              \
-        buf.serializeFrom(data.args.val5);                                                                      \
+        buf.serializeFrom(data.args.val5);                                                                  \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(6);                                                                        \
         ASSERT_CMD_RESPONSE(5, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
                                                                                                             \
         /* Test success */                                                                                  \
-        buf.serializeFrom(data.args.val6);                                                                      \
+        buf.serializeFrom(data.args.val6);                                                                  \
         this->invoke##ASYNC##Command(data);                                                                 \
                                                                                                             \
         ASSERT_CMD_RESPONSE_SIZE(7);                                                                        \
@@ -235,7 +235,7 @@
         ASSERT_EQ(component.primitiveCmd.args.val6, data.args.val6);                                        \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serializeFrom(data.args.val5);                                                                      \
+        buf.serializeFrom(data.args.val5);                                                                  \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_PRIMITIVE, buf);                        \
         ASSERT_CMD_RESPONSE_SIZE(8);                                                                        \
         ASSERT_CMD_RESPONSE(7, component.OPCODE_CMD##_ASYNC##_PRIMITIVE, 1, Fw::CmdResponse::FORMAT_ERROR); \
@@ -256,13 +256,13 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
                                                                                                             \
         /* Test incorrect serialization of second argument */                                               \
-        buf.serializeFrom(data.args.val1);                                                                      \
+        buf.serializeFrom(data.args.val1);                                                                  \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                          \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
         ASSERT_CMD_RESPONSE(1, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
                                                                                                             \
         /* Test success */                                                                                  \
-        buf.serializeFrom(data.args.val2);                                                                      \
+        buf.serializeFrom(data.args.val2);                                                                  \
         this->invoke##ASYNC##Command(data);                                                                 \
                                                                                                             \
         ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
@@ -271,7 +271,7 @@
         ASSERT_EQ(component.stringCmd.args.val2, data.args.val2);                                           \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serializeFrom(data.args.val1);                                                                      \
+        buf.serializeFrom(data.args.val1);                                                                  \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRINGS, buf);                          \
         ASSERT_CMD_RESPONSE_SIZE(4);                                                                        \
         ASSERT_CMD_RESPONSE(3, component.OPCODE_CMD##_ASYNC##_STRINGS, 1, Fw::CmdResponse::FORMAT_ERROR);   \
@@ -292,7 +292,7 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::FORMAT_ERROR);      \
                                                                                                             \
         /* Test success */                                                                                  \
-        buf.serializeFrom(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                   \
         this->invoke##ASYNC##Command(data);                                                                 \
                                                                                                             \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
@@ -300,7 +300,7 @@
         ASSERT_EQ(component.enumCmd.args.val, data.args.val);                                               \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serializeFrom(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ENUM, buf);                             \
         ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
         ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ENUM, 1, Fw::CmdResponse::FORMAT_ERROR);      \
@@ -321,7 +321,7 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::FORMAT_ERROR);     \
                                                                                                             \
         /* Test success */                                                                                  \
-        buf.serializeFrom(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                   \
         this->invoke##ASYNC##Command(data);                                                                 \
                                                                                                             \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
@@ -329,7 +329,7 @@
         ASSERT_EQ(component.arrayCmd.args.val, data.args.val);                                              \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serializeFrom(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_ARRAY, buf);                            \
         ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
         ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_ARRAY, 1, Fw::CmdResponse::FORMAT_ERROR);     \
@@ -350,7 +350,7 @@
         ASSERT_CMD_RESPONSE(0, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::FORMAT_ERROR);    \
                                                                                                             \
         /* Test success */                                                                                  \
-        buf.serializeFrom(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                   \
         this->invoke##ASYNC##Command(data);                                                                 \
                                                                                                             \
         ASSERT_CMD_RESPONSE_SIZE(2);                                                                        \
@@ -358,7 +358,7 @@
         ASSERT_EQ(component.structCmd.args.val, data.args.val);                                             \
                                                                                                             \
         /* Test too many arguments */                                                                       \
-        buf.serializeFrom(data.args.val);                                                                       \
+        buf.serializeFrom(data.args.val);                                                                   \
         this->invoke##ASYNC##Command(component.OPCODE_CMD##_ASYNC##_STRUCT, buf);                           \
         ASSERT_CMD_RESPONSE_SIZE(3);                                                                        \
         ASSERT_CMD_RESPONSE(2, component.OPCODE_CMD##_ASYNC##_STRUCT, 1, Fw::CmdResponse::FORMAT_ERROR);    \

--- a/FppTestProject/FppTest/component/tests/PortTests.hpp
+++ b/FppTestProject/FppTest/component/tests/PortTests.hpp
@@ -288,7 +288,7 @@
         U8 invalidData2[sizeof(U32)];                                                                               \
         Fw::SerialBuffer invalidBuf2(invalidData2, sizeof(invalidData2));                                           \
                                                                                                                     \
-        status = invalidBuf2.serializeFrom(port.args.val1);                                                             \
+        status = invalidBuf2.serializeFrom(port.args.val1);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, invalidBuf2);                               \
@@ -299,10 +299,10 @@
         U8 invalidData3[sizeof(U32) * 2];                                                                           \
         Fw::SerialBuffer invalidBuf3(invalidData3, sizeof(invalidData3));                                           \
                                                                                                                     \
-        status = invalidBuf3.serializeFrom(port.args.val1);                                                             \
+        status = invalidBuf3.serializeFrom(port.args.val1);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf3.serializeFrom(port.args.val2);                                                             \
+        status = invalidBuf3.serializeFrom(port.args.val2);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, invalidBuf3);                               \
@@ -313,13 +313,13 @@
         U8 invalidData4[(sizeof(U32) * 2) + sizeof(F32)];                                                           \
         Fw::SerialBuffer invalidBuf4(invalidData4, sizeof(invalidData4));                                           \
                                                                                                                     \
-        status = invalidBuf4.serializeFrom(port.args.val1);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val1);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf4.serializeFrom(port.args.val2);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val2);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf4.serializeFrom(port.args.val3);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val3);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, invalidBuf4);                               \
@@ -330,16 +330,16 @@
         U8 invalidData5[(sizeof(U32) * 2) + (sizeof(F32) * 2)];                                                     \
         Fw::SerialBuffer invalidBuf5(invalidData5, sizeof(invalidData5));                                           \
                                                                                                                     \
-        status = invalidBuf5.serializeFrom(port.args.val1);                                                             \
+        status = invalidBuf5.serializeFrom(port.args.val1);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf5.serializeFrom(port.args.val2);                                                             \
+        status = invalidBuf5.serializeFrom(port.args.val2);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf5.serializeFrom(port.args.val3);                                                             \
+        status = invalidBuf5.serializeFrom(port.args.val3);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf5.serializeFrom(port.args.val4);                                                             \
+        status = invalidBuf5.serializeFrom(port.args.val4);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, invalidBuf5);                               \
@@ -350,19 +350,19 @@
         U8 invalidData6[(sizeof(U32) * 2) + (sizeof(F32) * 2) + sizeof(U8)];                                        \
         Fw::SerialBuffer invalidBuf6(invalidData6, sizeof(invalidData6));                                           \
                                                                                                                     \
-        status = invalidBuf6.serializeFrom(port.args.val1);                                                             \
+        status = invalidBuf6.serializeFrom(port.args.val1);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf6.serializeFrom(port.args.val2);                                                             \
+        status = invalidBuf6.serializeFrom(port.args.val2);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf6.serializeFrom(port.args.val3);                                                             \
+        status = invalidBuf6.serializeFrom(port.args.val3);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf6.serializeFrom(port.args.val4);                                                             \
+        status = invalidBuf6.serializeFrom(port.args.val4);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf6.serializeFrom(port.args.val5);                                                             \
+        status = invalidBuf6.serializeFrom(port.args.val5);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, invalidBuf6);                               \
@@ -373,22 +373,22 @@
         U8 data[InputPrimitiveArgsPort::SERIALIZED_SIZE];                                                           \
         Fw::SerialBuffer buf(data, sizeof(data));                                                                   \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val1);                                                                     \
+        status = buf.serializeFrom(port.args.val1);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val2);                                                                     \
+        status = buf.serializeFrom(port.args.val2);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val3);                                                                     \
+        status = buf.serializeFrom(port.args.val3);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val4);                                                                     \
+        status = buf.serializeFrom(port.args.val4);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val5);                                                                     \
+        status = buf.serializeFrom(port.args.val5);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val6);                                                                     \
+        status = buf.serializeFrom(port.args.val6);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, buf);                                       \
@@ -413,7 +413,7 @@
         U8 invalidData2[FppTest::Types::String1::SERIALIZED_SIZE];                                                  \
         Fw::SerialBuffer invalidBuf2(invalidData2, sizeof(invalidData2));                                           \
                                                                                                                     \
-        status = invalidBuf2.serializeFrom(port.args.val1);                                                             \
+        status = invalidBuf2.serializeFrom(port.args.val1);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRING, invalidBuf2);                                  \
@@ -424,10 +424,10 @@
         U8 invalidData3[FppTest::Types::String1::SERIALIZED_SIZE * 2];                                              \
         Fw::SerialBuffer invalidBuf3(invalidData3, sizeof(invalidData3));                                           \
                                                                                                                     \
-        status = invalidBuf3.serializeFrom(port.args.val1);                                                             \
+        status = invalidBuf3.serializeFrom(port.args.val1);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf3.serializeFrom(port.args.val2);                                                             \
+        status = invalidBuf3.serializeFrom(port.args.val2);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRING, invalidBuf3);                                  \
@@ -438,13 +438,13 @@
         U8 invalidData4[(FppTest::Types::String1::SERIALIZED_SIZE * 2) + FppTest::Types::String2::SERIALIZED_SIZE]; \
         Fw::SerialBuffer invalidBuf4(invalidData4, sizeof(invalidData4));                                           \
                                                                                                                     \
-        status = invalidBuf4.serializeFrom(port.args.val1);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val1);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf4.serializeFrom(port.args.val2);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val2);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf4.serializeFrom(port.args.val3);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val3);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRING, invalidBuf4);                                  \
@@ -455,16 +455,16 @@
         U8 data[InputStringArgsPort::SERIALIZED_SIZE];                                                              \
         Fw::SerialBuffer buf(data, sizeof(data));                                                                   \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val1);                                                                     \
+        status = buf.serializeFrom(port.args.val1);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val2);                                                                     \
+        status = buf.serializeFrom(port.args.val2);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val3);                                                                     \
+        status = buf.serializeFrom(port.args.val3);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val4);                                                                     \
+        status = buf.serializeFrom(port.args.val4);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRING, buf);                                          \
@@ -489,7 +489,7 @@
         U8 invalidData2[FormalParamEnum::SERIALIZED_SIZE];                                                          \
         Fw::SerialBuffer invalidBuf2(invalidData2, sizeof(invalidData2));                                           \
                                                                                                                     \
-        status = invalidBuf2.serializeFrom(port.args.val1);                                                             \
+        status = invalidBuf2.serializeFrom(port.args.val1);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::ENUM, invalidBuf2);                                    \
@@ -500,16 +500,16 @@
         U8 data[InputEnumArgsPort::SERIALIZED_SIZE];                                                                \
         Fw::SerialBuffer buf(data, sizeof(data));                                                                   \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val1);                                                                     \
+        status = buf.serializeFrom(port.args.val1);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val2);                                                                     \
+        status = buf.serializeFrom(port.args.val2);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val3);                                                                     \
+        status = buf.serializeFrom(port.args.val3);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val4);                                                                     \
+        status = buf.serializeFrom(port.args.val4);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::ENUM, buf);                                            \
@@ -534,7 +534,7 @@
         U8 invalidData2[FormalParamArray::SERIALIZED_SIZE];                                                         \
         Fw::SerialBuffer invalidBuf2(invalidData2, sizeof(invalidData2));                                           \
                                                                                                                     \
-        status = invalidBuf2.serializeFrom(port.args.val1);                                                             \
+        status = invalidBuf2.serializeFrom(port.args.val1);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::ARRAY, invalidBuf2);                                   \
@@ -544,22 +544,22 @@
         U8 data[InputArrayArgsPort::SERIALIZED_SIZE];                                                               \
         Fw::SerialBuffer buf(data, sizeof(data));                                                                   \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val1);                                                                     \
+        status = buf.serializeFrom(port.args.val1);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val2);                                                                     \
+        status = buf.serializeFrom(port.args.val2);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val3);                                                                     \
+        status = buf.serializeFrom(port.args.val3);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val4);                                                                     \
+        status = buf.serializeFrom(port.args.val4);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val5);                                                                     \
+        status = buf.serializeFrom(port.args.val5);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val6);                                                                     \
+        status = buf.serializeFrom(port.args.val6);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::ARRAY, buf);                                           \
@@ -584,7 +584,7 @@
         U8 invalidData2[FormalParamStruct::SERIALIZED_SIZE];                                                        \
         Fw::SerialBuffer invalidBuf2(invalidData2, sizeof(invalidData2));                                           \
                                                                                                                     \
-        status = invalidBuf2.serializeFrom(port.args.val1);                                                             \
+        status = invalidBuf2.serializeFrom(port.args.val1);                                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRUCT, invalidBuf2);                                  \
@@ -594,10 +594,10 @@
         U8 data[InputStructArgsPort::SERIALIZED_SIZE];                                                              \
         Fw::SerialBuffer buf(data, sizeof(data));                                                                   \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val1);                                                                     \
+        status = buf.serializeFrom(port.args.val1);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serializeFrom(port.args.val2);                                                                     \
+        status = buf.serializeFrom(port.args.val2);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRUCT, buf);                                          \
@@ -707,22 +707,22 @@
         F32 f32, f32Ref;                                                                     \
         bool b, bRef;                                                                        \
                                                                                              \
-        status = this->primitiveBuf.deserializeTo(u32);                                        \
+        status = this->primitiveBuf.deserializeTo(u32);                                      \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->primitiveBuf.deserializeTo(u32Ref);                                     \
+        status = this->primitiveBuf.deserializeTo(u32Ref);                                   \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->primitiveBuf.deserializeTo(f32);                                        \
+        status = this->primitiveBuf.deserializeTo(f32);                                      \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->primitiveBuf.deserializeTo(f32Ref);                                     \
+        status = this->primitiveBuf.deserializeTo(f32Ref);                                   \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->primitiveBuf.deserializeTo(b);                                          \
+        status = this->primitiveBuf.deserializeTo(b);                                        \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->primitiveBuf.deserializeTo(bRef);                                       \
+        status = this->primitiveBuf.deserializeTo(bRef);                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
         ASSERT_EQ(u32, port.args.val1);                                                      \
@@ -738,16 +738,16 @@
         FppTest::Types::String1 str80, str80Ref;                                             \
         FppTest::Types::String2 str100, str100Ref;                                           \
                                                                                              \
-        status = this->stringBuf.deserializeTo(str80);                                         \
+        status = this->stringBuf.deserializeTo(str80);                                       \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->stringBuf.deserializeTo(str80Ref);                                      \
+        status = this->stringBuf.deserializeTo(str80Ref);                                    \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->stringBuf.deserializeTo(str100);                                        \
+        status = this->stringBuf.deserializeTo(str100);                                      \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->stringBuf.deserializeTo(str100Ref);                                     \
+        status = this->stringBuf.deserializeTo(str100Ref);                                   \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
         ASSERT_EQ(str80, port.args.val1);                                                    \
@@ -760,10 +760,10 @@
         Fw::SerializeStatus status;                                                          \
         FormalParamEnum en, enRef;                                                           \
                                                                                              \
-        status = this->enumBuf.deserializeTo(en);                                              \
+        status = this->enumBuf.deserializeTo(en);                                            \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->enumBuf.deserializeTo(enRef);                                           \
+        status = this->enumBuf.deserializeTo(enRef);                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
         ASSERT_EQ(en, port.args.val1);                                                       \
@@ -774,10 +774,10 @@
         Fw::SerializeStatus status;                                                          \
         FormalParamArray a, aRef;                                                            \
                                                                                              \
-        status = this->arrayBuf.deserializeTo(a);                                              \
+        status = this->arrayBuf.deserializeTo(a);                                            \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->arrayBuf.deserializeTo(aRef);                                           \
+        status = this->arrayBuf.deserializeTo(aRef);                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
         ASSERT_EQ(a, port.args.val1);                                                        \
@@ -788,10 +788,10 @@
         Fw::SerializeStatus status;                                                          \
         FormalParamStruct s, sRef;                                                           \
                                                                                              \
-        status = this->structBuf.deserializeTo(s);                                             \
+        status = this->structBuf.deserializeTo(s);                                           \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->structBuf.deserializeTo(sRef);                                          \
+        status = this->structBuf.deserializeTo(sRef);                                        \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
         ASSERT_EQ(s, port.args.val1);                                                        \

--- a/FppTestProject/FppTest/component/tests/PortTests.hpp
+++ b/FppTestProject/FppTest/component/tests/PortTests.hpp
@@ -288,7 +288,7 @@
         U8 invalidData2[sizeof(U32)];                                                                               \
         Fw::SerialBuffer invalidBuf2(invalidData2, sizeof(invalidData2));                                           \
                                                                                                                     \
-        status = invalidBuf2.serialize(port.args.val1);                                                             \
+        status = invalidBuf2.serializeFrom(port.args.val1);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, invalidBuf2);                               \
@@ -299,10 +299,10 @@
         U8 invalidData3[sizeof(U32) * 2];                                                                           \
         Fw::SerialBuffer invalidBuf3(invalidData3, sizeof(invalidData3));                                           \
                                                                                                                     \
-        status = invalidBuf3.serialize(port.args.val1);                                                             \
+        status = invalidBuf3.serializeFrom(port.args.val1);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf3.serialize(port.args.val2);                                                             \
+        status = invalidBuf3.serializeFrom(port.args.val2);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, invalidBuf3);                               \
@@ -313,13 +313,13 @@
         U8 invalidData4[(sizeof(U32) * 2) + sizeof(F32)];                                                           \
         Fw::SerialBuffer invalidBuf4(invalidData4, sizeof(invalidData4));                                           \
                                                                                                                     \
-        status = invalidBuf4.serialize(port.args.val1);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val1);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf4.serialize(port.args.val2);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val2);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf4.serialize(port.args.val3);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val3);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, invalidBuf4);                               \
@@ -330,16 +330,16 @@
         U8 invalidData5[(sizeof(U32) * 2) + (sizeof(F32) * 2)];                                                     \
         Fw::SerialBuffer invalidBuf5(invalidData5, sizeof(invalidData5));                                           \
                                                                                                                     \
-        status = invalidBuf5.serialize(port.args.val1);                                                             \
+        status = invalidBuf5.serializeFrom(port.args.val1);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf5.serialize(port.args.val2);                                                             \
+        status = invalidBuf5.serializeFrom(port.args.val2);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf5.serialize(port.args.val3);                                                             \
+        status = invalidBuf5.serializeFrom(port.args.val3);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf5.serialize(port.args.val4);                                                             \
+        status = invalidBuf5.serializeFrom(port.args.val4);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, invalidBuf5);                               \
@@ -350,19 +350,19 @@
         U8 invalidData6[(sizeof(U32) * 2) + (sizeof(F32) * 2) + sizeof(U8)];                                        \
         Fw::SerialBuffer invalidBuf6(invalidData6, sizeof(invalidData6));                                           \
                                                                                                                     \
-        status = invalidBuf6.serialize(port.args.val1);                                                             \
+        status = invalidBuf6.serializeFrom(port.args.val1);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf6.serialize(port.args.val2);                                                             \
+        status = invalidBuf6.serializeFrom(port.args.val2);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf6.serialize(port.args.val3);                                                             \
+        status = invalidBuf6.serializeFrom(port.args.val3);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf6.serialize(port.args.val4);                                                             \
+        status = invalidBuf6.serializeFrom(port.args.val4);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf6.serialize(port.args.val5);                                                             \
+        status = invalidBuf6.serializeFrom(port.args.val5);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, invalidBuf6);                               \
@@ -373,22 +373,22 @@
         U8 data[InputPrimitiveArgsPort::SERIALIZED_SIZE];                                                           \
         Fw::SerialBuffer buf(data, sizeof(data));                                                                   \
                                                                                                                     \
-        status = buf.serialize(port.args.val1);                                                                     \
+        status = buf.serializeFrom(port.args.val1);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val2);                                                                     \
+        status = buf.serializeFrom(port.args.val2);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val3);                                                                     \
+        status = buf.serializeFrom(port.args.val3);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val4);                                                                     \
+        status = buf.serializeFrom(port.args.val4);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val5);                                                                     \
+        status = buf.serializeFrom(port.args.val5);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val6);                                                                     \
+        status = buf.serializeFrom(port.args.val6);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::PRIMITIVE, buf);                                       \
@@ -413,7 +413,7 @@
         U8 invalidData2[FppTest::Types::String1::SERIALIZED_SIZE];                                                  \
         Fw::SerialBuffer invalidBuf2(invalidData2, sizeof(invalidData2));                                           \
                                                                                                                     \
-        status = invalidBuf2.serialize(port.args.val1);                                                             \
+        status = invalidBuf2.serializeFrom(port.args.val1);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRING, invalidBuf2);                                  \
@@ -424,10 +424,10 @@
         U8 invalidData3[FppTest::Types::String1::SERIALIZED_SIZE * 2];                                              \
         Fw::SerialBuffer invalidBuf3(invalidData3, sizeof(invalidData3));                                           \
                                                                                                                     \
-        status = invalidBuf3.serialize(port.args.val1);                                                             \
+        status = invalidBuf3.serializeFrom(port.args.val1);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf3.serialize(port.args.val2);                                                             \
+        status = invalidBuf3.serializeFrom(port.args.val2);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRING, invalidBuf3);                                  \
@@ -438,13 +438,13 @@
         U8 invalidData4[(FppTest::Types::String1::SERIALIZED_SIZE * 2) + FppTest::Types::String2::SERIALIZED_SIZE]; \
         Fw::SerialBuffer invalidBuf4(invalidData4, sizeof(invalidData4));                                           \
                                                                                                                     \
-        status = invalidBuf4.serialize(port.args.val1);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val1);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf4.serialize(port.args.val2);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val2);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = invalidBuf4.serialize(port.args.val3);                                                             \
+        status = invalidBuf4.serializeFrom(port.args.val3);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRING, invalidBuf4);                                  \
@@ -455,16 +455,16 @@
         U8 data[InputStringArgsPort::SERIALIZED_SIZE];                                                              \
         Fw::SerialBuffer buf(data, sizeof(data));                                                                   \
                                                                                                                     \
-        status = buf.serialize(port.args.val1);                                                                     \
+        status = buf.serializeFrom(port.args.val1);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val2);                                                                     \
+        status = buf.serializeFrom(port.args.val2);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val3);                                                                     \
+        status = buf.serializeFrom(port.args.val3);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val4);                                                                     \
+        status = buf.serializeFrom(port.args.val4);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRING, buf);                                          \
@@ -489,7 +489,7 @@
         U8 invalidData2[FormalParamEnum::SERIALIZED_SIZE];                                                          \
         Fw::SerialBuffer invalidBuf2(invalidData2, sizeof(invalidData2));                                           \
                                                                                                                     \
-        status = invalidBuf2.serialize(port.args.val1);                                                             \
+        status = invalidBuf2.serializeFrom(port.args.val1);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::ENUM, invalidBuf2);                                    \
@@ -500,16 +500,16 @@
         U8 data[InputEnumArgsPort::SERIALIZED_SIZE];                                                                \
         Fw::SerialBuffer buf(data, sizeof(data));                                                                   \
                                                                                                                     \
-        status = buf.serialize(port.args.val1);                                                                     \
+        status = buf.serializeFrom(port.args.val1);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val2);                                                                     \
+        status = buf.serializeFrom(port.args.val2);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val3);                                                                     \
+        status = buf.serializeFrom(port.args.val3);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val4);                                                                     \
+        status = buf.serializeFrom(port.args.val4);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::ENUM, buf);                                            \
@@ -534,7 +534,7 @@
         U8 invalidData2[FormalParamArray::SERIALIZED_SIZE];                                                         \
         Fw::SerialBuffer invalidBuf2(invalidData2, sizeof(invalidData2));                                           \
                                                                                                                     \
-        status = invalidBuf2.serialize(port.args.val1);                                                             \
+        status = invalidBuf2.serializeFrom(port.args.val1);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::ARRAY, invalidBuf2);                                   \
@@ -544,22 +544,22 @@
         U8 data[InputArrayArgsPort::SERIALIZED_SIZE];                                                               \
         Fw::SerialBuffer buf(data, sizeof(data));                                                                   \
                                                                                                                     \
-        status = buf.serialize(port.args.val1);                                                                     \
+        status = buf.serializeFrom(port.args.val1);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val2);                                                                     \
+        status = buf.serializeFrom(port.args.val2);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val3);                                                                     \
+        status = buf.serializeFrom(port.args.val3);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val4);                                                                     \
+        status = buf.serializeFrom(port.args.val4);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val5);                                                                     \
+        status = buf.serializeFrom(port.args.val5);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val6);                                                                     \
+        status = buf.serializeFrom(port.args.val6);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::ARRAY, buf);                                           \
@@ -584,7 +584,7 @@
         U8 invalidData2[FormalParamStruct::SERIALIZED_SIZE];                                                        \
         Fw::SerialBuffer invalidBuf2(invalidData2, sizeof(invalidData2));                                           \
                                                                                                                     \
-        status = invalidBuf2.serialize(port.args.val1);                                                             \
+        status = invalidBuf2.serializeFrom(port.args.val1);                                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRUCT, invalidBuf2);                                  \
@@ -594,10 +594,10 @@
         U8 data[InputStructArgsPort::SERIALIZED_SIZE];                                                              \
         Fw::SerialBuffer buf(data, sizeof(data));                                                                   \
                                                                                                                     \
-        status = buf.serialize(port.args.val1);                                                                     \
+        status = buf.serializeFrom(port.args.val1);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
-        status = buf.serialize(port.args.val2);                                                                     \
+        status = buf.serializeFrom(port.args.val2);                                                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRUCT, buf);                                          \
@@ -707,22 +707,22 @@
         F32 f32, f32Ref;                                                                     \
         bool b, bRef;                                                                        \
                                                                                              \
-        status = this->primitiveBuf.deserialize(u32);                                        \
+        status = this->primitiveBuf.deserializeTo(u32);                                        \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->primitiveBuf.deserialize(u32Ref);                                     \
+        status = this->primitiveBuf.deserializeTo(u32Ref);                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->primitiveBuf.deserialize(f32);                                        \
+        status = this->primitiveBuf.deserializeTo(f32);                                        \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->primitiveBuf.deserialize(f32Ref);                                     \
+        status = this->primitiveBuf.deserializeTo(f32Ref);                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->primitiveBuf.deserialize(b);                                          \
+        status = this->primitiveBuf.deserializeTo(b);                                          \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->primitiveBuf.deserialize(bRef);                                       \
+        status = this->primitiveBuf.deserializeTo(bRef);                                       \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
         ASSERT_EQ(u32, port.args.val1);                                                      \
@@ -738,16 +738,16 @@
         FppTest::Types::String1 str80, str80Ref;                                             \
         FppTest::Types::String2 str100, str100Ref;                                           \
                                                                                              \
-        status = this->stringBuf.deserialize(str80);                                         \
+        status = this->stringBuf.deserializeTo(str80);                                         \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->stringBuf.deserialize(str80Ref);                                      \
+        status = this->stringBuf.deserializeTo(str80Ref);                                      \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->stringBuf.deserialize(str100);                                        \
+        status = this->stringBuf.deserializeTo(str100);                                        \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->stringBuf.deserialize(str100Ref);                                     \
+        status = this->stringBuf.deserializeTo(str100Ref);                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
         ASSERT_EQ(str80, port.args.val1);                                                    \
@@ -760,10 +760,10 @@
         Fw::SerializeStatus status;                                                          \
         FormalParamEnum en, enRef;                                                           \
                                                                                              \
-        status = this->enumBuf.deserialize(en);                                              \
+        status = this->enumBuf.deserializeTo(en);                                              \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->enumBuf.deserialize(enRef);                                           \
+        status = this->enumBuf.deserializeTo(enRef);                                           \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
         ASSERT_EQ(en, port.args.val1);                                                       \
@@ -774,10 +774,10 @@
         Fw::SerializeStatus status;                                                          \
         FormalParamArray a, aRef;                                                            \
                                                                                              \
-        status = this->arrayBuf.deserialize(a);                                              \
+        status = this->arrayBuf.deserializeTo(a);                                              \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->arrayBuf.deserialize(aRef);                                           \
+        status = this->arrayBuf.deserializeTo(aRef);                                           \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
         ASSERT_EQ(a, port.args.val1);                                                        \
@@ -788,10 +788,10 @@
         Fw::SerializeStatus status;                                                          \
         FormalParamStruct s, sRef;                                                           \
                                                                                              \
-        status = this->structBuf.deserialize(s);                                             \
+        status = this->structBuf.deserializeTo(s);                                             \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
-        status = this->structBuf.deserialize(sRef);                                          \
+        status = this->structBuf.deserializeTo(sRef);                                          \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
         ASSERT_EQ(s, port.args.val1);                                                        \

--- a/FppTestProject/FppTest/dp/test/ut/DpTestTester.cpp
+++ b/FppTestProject/FppTest/dp/test/ut/DpTestTester.cpp
@@ -101,11 +101,11 @@ void DpTestTester::productRecvIn_Container1_SUCCESS() {
     for (FwSizeType i = 0; i < expectedNumElts; ++i) {
         FwDpIdType id;
         U32 elt;
-        status = deserializer.deserialize(id);
+        status = deserializer.deserializeTo(id);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         const FwDpIdType expectedId = this->component.getIdBase() + DpTest::RecordId::U32Record;
         ASSERT_EQ(id, expectedId);
-        status = deserializer.deserialize(elt);
+        status = deserializer.deserializeTo(elt);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         ASSERT_EQ(elt, this->component.u32RecordData);
     }
@@ -136,11 +136,11 @@ void DpTestTester::productRecvIn_Container2_SUCCESS() {
     for (FwSizeType i = 0; i < expectedNumElts; ++i) {
         FwDpIdType id;
         DpTest_Data elt;
-        status = deserializer.deserialize(id);
+        status = deserializer.deserializeTo(id);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         const FwDpIdType expectedId = this->component.getIdBase() + DpTest::RecordId::DataRecord;
         ASSERT_EQ(id, expectedId);
-        status = deserializer.deserialize(elt);
+        status = deserializer.deserializeTo(elt);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         ASSERT_EQ(elt.get_u16Field(), this->component.dataRecordData);
     }
@@ -174,7 +174,7 @@ void DpTestTester::productRecvIn_Container3_SUCCESS() {
     Fw::TestUtil::DpContainerHeader::checkDeserialAtOffset(deserializer, Fw::DpContainer::DATA_OFFSET);
     for (FwSizeType i = 0; i < expectedNumElts; ++i) {
         FwDpIdType id;
-        status = deserializer.deserialize(id);
+        status = deserializer.deserializeTo(id);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         const FwDpIdType expectedId = this->component.getIdBase() + DpTest::RecordId::U8ArrayRecord;
         ASSERT_EQ(id, expectedId);
@@ -184,7 +184,7 @@ void DpTestTester::productRecvIn_Container3_SUCCESS() {
         ASSERT_EQ(size, this->u8ArrayRecordData.size());
         for (FwSizeType j = 0; j < size; ++j) {
             U8 byte;
-            status = deserializer.deserialize(byte);
+            status = deserializer.deserializeTo(byte);
             ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
             ASSERT_EQ(byte, this->u8ArrayRecordData.at(j));
         }
@@ -219,7 +219,7 @@ void DpTestTester::productRecvIn_Container4_SUCCESS() {
     Fw::TestUtil::DpContainerHeader::checkDeserialAtOffset(deserializer, Fw::DpContainer::DATA_OFFSET);
     for (FwSizeType i = 0; i < expectedNumElts; ++i) {
         FwDpIdType id;
-        status = deserializer.deserialize(id);
+        status = deserializer.deserializeTo(id);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         const FwDpIdType expectedId = this->component.getIdBase() + DpTest::RecordId::U32ArrayRecord;
         ASSERT_EQ(id, expectedId);
@@ -229,7 +229,7 @@ void DpTestTester::productRecvIn_Container4_SUCCESS() {
         ASSERT_EQ(size, this->u32ArrayRecordData.size());
         for (FwSizeType j = 0; j < size; ++j) {
             U32 elt;
-            status = deserializer.deserialize(elt);
+            status = deserializer.deserializeTo(elt);
             ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
             ASSERT_EQ(elt, this->u32ArrayRecordData.at(j));
         }
@@ -264,7 +264,7 @@ void DpTestTester::productRecvIn_Container5_SUCCESS() {
     Fw::TestUtil::DpContainerHeader::checkDeserialAtOffset(deserializer, Fw::DpContainer::DATA_OFFSET);
     for (FwSizeType i = 0; i < expectedNumElts; ++i) {
         FwDpIdType id;
-        status = deserializer.deserialize(id);
+        status = deserializer.deserializeTo(id);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         const FwDpIdType expectedId = this->component.getIdBase() + DpTest::RecordId::DataArrayRecord;
         ASSERT_EQ(id, expectedId);
@@ -274,7 +274,7 @@ void DpTestTester::productRecvIn_Container5_SUCCESS() {
         ASSERT_EQ(size, this->dataArrayRecordData.size());
         for (FwSizeType j = 0; j < size; ++j) {
             DpTest_Data elt;
-            status = deserializer.deserialize(elt);
+            status = deserializer.deserializeTo(elt);
             ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
             ASSERT_EQ(elt, this->dataArrayRecordData.at(j));
         }
@@ -309,11 +309,11 @@ void DpTestTester::productRecvIn_Container6_SUCCESS() {
     for (FwSizeType i = 0; i < expectedNumElts; ++i) {
         FwDpIdType id;
         Fw::String elt;
-        status = deserializer.deserialize(id);
+        status = deserializer.deserializeTo(id);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         const FwDpIdType expectedId = this->component.getIdBase() + DpTest::RecordId::StringRecord;
         ASSERT_EQ(id, expectedId);
-        status = deserializer.deserialize(elt);
+        status = deserializer.deserializeTo(elt);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         ASSERT_EQ(elt, es);
     }
@@ -350,7 +350,7 @@ void DpTestTester::productRecvIn_Container7_SUCCESS() {
     Fw::TestUtil::DpContainerHeader::checkDeserialAtOffset(deserializer, Fw::DpContainer::DATA_OFFSET);
     for (FwSizeType i = 0; i < expectedNumElts; ++i) {
         FwDpIdType id;
-        status = deserializer.deserialize(id);
+        status = deserializer.deserializeTo(id);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         const FwDpIdType expectedId = this->component.getIdBase() + DpTest::RecordId::StringArrayRecord;
         ASSERT_EQ(id, expectedId);
@@ -360,7 +360,7 @@ void DpTestTester::productRecvIn_Container7_SUCCESS() {
         ASSERT_EQ(size, arraySize);
         for (FwSizeType j = 0; j < size; ++j) {
             Fw::String elt;
-            status = deserializer.deserialize(elt);
+            status = deserializer.deserializeTo(elt);
             ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
             ASSERT_EQ(elt, es);
         }

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTestAbsTypeTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTestAbsTypeTester.cpp
@@ -61,7 +61,7 @@ void BasicGuardTestAbsTypeTester::smStateBasicGuardTestAbsType_stateMachineOverf
     ASSERT_EQ(smId, SmId::smStateBasicGuardTestAbsType);
     ASSERT_EQ(static_cast<SmState_BasicGuardTestAbsType::Signal>(signal), SmState_BasicGuardTestAbsType::Signal::s);
     SmHarness::TestAbsType value;
-    const auto status = buffer.deserialize(value);
+    const auto status = buffer.deserializeTo(value);
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(buffer.getBuffLeft(), 0);
     ASSERT_EQ(value, this->m_value);

--- a/FppTestProject/FppTest/struct/NonPrimitiveStructTest.cpp
+++ b/FppTestProject/FppTest/struct/NonPrimitiveStructTest.cpp
@@ -71,11 +71,11 @@ class NonPrimitiveStructTest : public ::testing::Test {
         Fw::SerializeStatus status;
 
         // Serialize
-        status = buf.serialize(s);
+        status = buf.serializeFrom(s);
         ASSERT_NE(status, Fw::FW_SERIALIZE_OK);
 
         // Deserialize
-        status = buf.deserialize(s);
+        status = buf.deserializeTo(s);
         ASSERT_NE(status, Fw::FW_SERIALIZE_OK);
     }
 
@@ -256,13 +256,13 @@ TEST_F(NonPrimitiveStructTest, Serialization) {
     Fw::SerialBuffer buf(data, sizeof(data));
 
     // Serialize
-    status = buf.serialize(s);
+    status = buf.serializeFrom(s);
 
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(buf.getBuffLength(), serializedSize);
 
     // Deserialize
-    status = buf.deserialize(sCopy);
+    status = buf.deserializeTo(sCopy);
 
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(s, sCopy);

--- a/FppTestProject/FppTest/struct/PrimitiveStructTest.cpp
+++ b/FppTestProject/FppTest/struct/PrimitiveStructTest.cpp
@@ -45,11 +45,11 @@ class PrimitiveStructTest : public ::testing::Test {
         Fw::SerializeStatus status;
 
         // Serialize
-        status = buf.serialize(s);
+        status = buf.serializeFrom(s);
         ASSERT_NE(status, Fw::FW_SERIALIZE_OK);
 
         // Deserialize
-        status = buf.deserialize(s);
+        status = buf.deserializeTo(s);
         ASSERT_NE(status, Fw::FW_SERIALIZE_OK);
     }
 
@@ -168,13 +168,13 @@ TEST_F(PrimitiveStructTest, Serialization) {
     Fw::SerialBuffer buf(data, sizeof(data));
 
     // Serialize
-    status = buf.serialize(s);
+    status = buf.serializeFrom(s);
 
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(buf.getBuffLength(), Primitive::SERIALIZED_SIZE);
 
     // Deserialize
-    status = buf.deserialize(sCopy);
+    status = buf.deserializeTo(sCopy);
 
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(s, sCopy);

--- a/FppTestProject/FppTest/typed_tests/ArrayTest.hpp
+++ b/FppTestProject/FppTest/typed_tests/ArrayTest.hpp
@@ -179,13 +179,13 @@ TYPED_TEST_P(ArrayTest, Serialization) {
     Fw::SerialBuffer buf(data, sizeof(data));
 
     // Serialize
-    status = buf.serialize(a);
+    status = buf.serializeFrom(a);
 
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(buf.getBuffLength(), serializedSize);
 
     // Deserialize
-    status = buf.deserialize(aCopy);
+    status = buf.deserializeTo(aCopy);
 
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(a, aCopy);
@@ -196,13 +196,13 @@ TYPED_TEST_P(ArrayTest, Serialization) {
     Fw::SerialBuffer buf2(data2, sizeof(data2));
 
     // Serialize
-    status = buf2.serialize(a);
+    status = buf2.serializeFrom(a);
 
     ASSERT_NE(status, Fw::FW_SERIALIZE_OK);
     ASSERT_NE(buf2.getBuffLength(), serializedSize);
 
     // Deserialize
-    status = buf2.deserialize(aCopy2);
+    status = buf2.deserializeTo(aCopy2);
 
     ASSERT_NE(status, Fw::FW_SERIALIZE_OK);
 }

--- a/FppTestProject/FppTest/typed_tests/EnumTest.hpp
+++ b/FppTestProject/FppTest/typed_tests/EnumTest.hpp
@@ -165,23 +165,23 @@ TYPED_TEST_P(EnumTest, Serialization) {
     Fw::SerialBuffer buf(data, sizeof(data));
 
     // Serialize the enums
-    status = buf.serialize(validEnum);
+    status = buf.serializeFrom(validEnum);
 
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(buf.getBuffLength(), sizeof(typename TypeParam::SerialType));
 
-    status = buf.serialize(invalidEnum);
+    status = buf.serializeFrom(invalidEnum);
 
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(buf.getBuffLength(), sizeof(typename TypeParam::SerialType) * 2);
 
     // Deserialize the enums
-    status = buf.deserialize(validEnumCopy);
+    status = buf.deserializeTo(validEnumCopy);
 
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(validEnumCopy, validEnum);
 
-    status = buf.deserialize(invalidEnumCopy);
+    status = buf.deserializeTo(invalidEnumCopy);
 
     ASSERT_EQ(status, Fw::FW_DESERIALIZE_FORMAT_ERROR);
 }

--- a/Fw/Buffer/test/ut/TestBuffer.cpp
+++ b/Fw/Buffer/test/ut/TestBuffer.cpp
@@ -91,25 +91,25 @@ class BufferTester {
         // Test serialization and that it stops before overflowing
         auto serializer = buffer.getSerializer();
         for (U32 i = 0; i < sizeof(data) / 4; i++) {
-            ASSERT_EQ(serializer.serialize(i), Fw::FW_SERIALIZE_OK);
+            ASSERT_EQ(serializer.serializeFrom(i), Fw::FW_SERIALIZE_OK);
         }
-        Fw::SerializeStatus stat = serializer.serialize(100);
+        Fw::SerializeStatus stat = serializer.serializeFrom(100);
         ASSERT_NE(stat, Fw::FW_SERIALIZE_OK);
 
         // And that another call to repr resets it
         serializer.resetSer();
-        ASSERT_EQ(serializer.serialize(0), Fw::FW_SERIALIZE_OK);
+        ASSERT_EQ(serializer.serializeFrom(0), Fw::FW_SERIALIZE_OK);
 
         // Now deserialize all the things
         auto deserializer = buffer.getDeserializer();
         U32 out;
         for (U32 i = 0; i < sizeof(data) / 4; i++) {
-            ASSERT_EQ(deserializer.deserialize(out), Fw::FW_SERIALIZE_OK);
+            ASSERT_EQ(deserializer.deserializeTo(out), Fw::FW_SERIALIZE_OK);
             ASSERT_EQ(i, out);
         }
-        ASSERT_NE(deserializer.deserialize(out), Fw::FW_SERIALIZE_OK);
+        ASSERT_NE(deserializer.deserializeTo(out), Fw::FW_SERIALIZE_OK);
         deserializer.setBuffLen(buffer.getSize());
-        ASSERT_EQ(deserializer.deserialize(out), Fw::FW_SERIALIZE_OK);
+        ASSERT_EQ(deserializer.deserializeTo(out), Fw::FW_SERIALIZE_OK);
         ASSERT_EQ(0, out);
     }
 
@@ -123,11 +123,11 @@ class BufferTester {
         buffer.setContext(1234);
 
         Fw::ExternalSerializeBuffer externalSerializeBuffer(wire, sizeof(wire));
-        externalSerializeBuffer.serialize(buffer);
+        externalSerializeBuffer.serializeFrom(buffer);
         Fw::SerializeBufferBaseTester::verifySerLocLT(externalSerializeBuffer, sizeof(data));
 
         Fw::Buffer buffer_new;
-        externalSerializeBuffer.deserialize(buffer_new);
+        externalSerializeBuffer.deserializeTo(buffer_new);
         ASSERT_EQ(buffer_new, buffer);
     }
 };

--- a/Fw/Comp/ActiveComponentBase.cpp
+++ b/Fw/Comp/ActiveComponentBase.cpp
@@ -52,7 +52,7 @@ void ActiveComponentBase::start(FwTaskPriorityType priority,
 
 void ActiveComponentBase::exit() {
     ActiveComponentExitSerializableBuffer exitBuff;
-    SerializeStatus stat = exitBuff.serialize(static_cast<I32>(ACTIVE_COMPONENT_EXIT));
+    SerializeStatus stat = exitBuff.serializeFrom(static_cast<I32>(ACTIVE_COMPONENT_EXIT));
     FW_ASSERT(FW_SERIALIZE_OK == stat, static_cast<FwAssertArgType>(stat));
     (void)this->m_queue.send(exitBuff, 0, Os::Queue::BlockingType::NONBLOCKING);
 }

--- a/Fw/Dp/DpContainer.cpp
+++ b/Fw/Dp/DpContainer.cpp
@@ -45,39 +45,39 @@ Fw::SerializeStatus DpContainer::deserializeHeader() {
     // Deserialize the packet type
     if (status == Fw::FW_SERIALIZE_OK) {
         FwPacketDescriptorType packetDescriptor;
-        status = deserializer.deserialize(packetDescriptor);
+        status = deserializer.deserializeTo(packetDescriptor);
         if (packetDescriptor != ComPacketType::FW_PACKET_DP) {
             status = Fw::FW_SERIALIZE_FORMAT_ERROR;
         }
     }
     // Deserialize the container id
     if (status == Fw::FW_SERIALIZE_OK) {
-        status = deserializer.deserialize(this->m_id);
+        status = deserializer.deserializeTo(this->m_id);
     }
     // Deserialize the priority
     if (status == Fw::FW_SERIALIZE_OK) {
-        status = deserializer.deserialize(this->m_priority);
+        status = deserializer.deserializeTo(this->m_priority);
     }
     // Deserialize the time tag
     if (status == Fw::FW_SERIALIZE_OK) {
-        status = deserializer.deserialize(this->m_timeTag);
+        status = deserializer.deserializeTo(this->m_timeTag);
     }
     // Deserialize the processing types
     if (status == Fw::FW_SERIALIZE_OK) {
-        status = deserializer.deserialize(this->m_procTypes);
+        status = deserializer.deserializeTo(this->m_procTypes);
     }
     // Deserialize the user data
     if (status == Fw::FW_SERIALIZE_OK) {
         const FwSizeType requestedSize = sizeof this->m_userData;
         FwSizeType receivedSize = requestedSize;
-        status = deserializer.deserialize(this->m_userData, receivedSize, Fw::Serialization::OMIT_LENGTH);
+        status = deserializer.deserializeTo(this->m_userData, receivedSize, Fw::Serialization::OMIT_LENGTH);
         if (receivedSize != requestedSize) {
             status = Fw::FW_DESERIALIZE_SIZE_MISMATCH;
         }
     }
     // Deserialize the data product state
     if (status == Fw::FW_SERIALIZE_OK) {
-        status = deserializer.deserialize(this->m_dpState);
+        status = deserializer.deserializeTo(this->m_dpState);
     }
     // Deserialize the data size
     if (status == Fw::FW_SERIALIZE_OK) {
@@ -91,26 +91,26 @@ void DpContainer::serializeHeader() {
     auto serializer = this->m_buffer.getSerializer();
     // Serialize the packet type
     Fw::SerializeStatus status =
-        serializer.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_DP));
+        serializer.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_DP));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the container id
-    status = serializer.serialize(this->m_id);
+    status = serializer.serializeFrom(this->m_id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the priority
-    status = serializer.serialize(this->m_priority);
+    status = serializer.serializeFrom(this->m_priority);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the time tag
-    status = serializer.serialize(this->m_timeTag);
+    status = serializer.serializeFrom(this->m_timeTag);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the processing types
-    status = serializer.serialize(this->m_procTypes);
+    status = serializer.serializeFrom(this->m_procTypes);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the user data
-    status = serializer.serialize(this->m_userData, static_cast<FwSizeType>(sizeof this->m_userData),
+    status = serializer.serializeFrom(this->m_userData, static_cast<FwSizeType>(sizeof this->m_userData),
                                   Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the data product state
-    status = serializer.serialize(this->m_dpState);
+    status = serializer.serializeFrom(this->m_dpState);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the data size
     status = serializer.serializeSize(this->m_dataSize);

--- a/Fw/Dp/DpContainer.cpp
+++ b/Fw/Dp/DpContainer.cpp
@@ -107,7 +107,7 @@ void DpContainer::serializeHeader() {
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the user data
     status = serializer.serializeFrom(this->m_userData, static_cast<FwSizeType>(sizeof this->m_userData),
-                                  Fw::Serialization::OMIT_LENGTH);
+                                      Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the data product state
     status = serializer.serializeFrom(this->m_dpState);

--- a/Fw/Dp/test/ut/TestMain.cpp
+++ b/Fw/Dp/test/ut/TestMain.cpp
@@ -169,7 +169,7 @@ TEST(Header, BadPacketDescriptor) {
     // Set the packet descriptor to a bad value
     auto serializer = buffer.getSerializer();
     const FwPacketDescriptorType badPacketDescriptor = Fw::ComPacketType::FW_PACKET_DP + 1;
-    Fw::SerializeStatus status = serializer.serialize(badPacketDescriptor);
+    Fw::SerializeStatus status = serializer.serializeFrom(badPacketDescriptor);
     ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     // Use the buffer to create a container
     DpContainer container;

--- a/Fw/Dp/test/util/DpContainerHeader.hpp
+++ b/Fw/Dp/test/util/DpContainerHeader.hpp
@@ -52,34 +52,34 @@ struct DpContainerHeader {
         FwPacketDescriptorType packetDescriptor = Fw::ComPacketType::FW_PACKET_UNKNOWN;
         // Deserialize the packet descriptor
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::PACKET_DESCRIPTOR_OFFSET);
-        Fw::SerializeStatus status = deserializer.deserialize(packetDescriptor);
+        Fw::SerializeStatus status = deserializer.deserializeTo(packetDescriptor);
         DP_CONTAINER_HEADER_ASSERT_EQ(status, FW_SERIALIZE_OK);
         DP_CONTAINER_HEADER_ASSERT_EQ(packetDescriptor, Fw::ComPacketType::FW_PACKET_DP);
         // Deserialize the container id
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::ID_OFFSET);
-        status = deserializer.deserialize(this->m_id);
+        status = deserializer.deserializeTo(this->m_id);
         DP_CONTAINER_HEADER_ASSERT_EQ(status, FW_SERIALIZE_OK);
         // Deserialize the priority
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::PRIORITY_OFFSET);
-        status = deserializer.deserialize(this->m_priority);
+        status = deserializer.deserializeTo(this->m_priority);
         DP_CONTAINER_HEADER_ASSERT_EQ(status, FW_SERIALIZE_OK);
         // Deserialize the time tag
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::TIME_TAG_OFFSET);
-        status = deserializer.deserialize(this->m_timeTag);
+        status = deserializer.deserializeTo(this->m_timeTag);
         DP_CONTAINER_HEADER_ASSERT_EQ(status, FW_SERIALIZE_OK);
         // Deserialize the processing type
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::PROC_TYPES_OFFSET);
-        status = deserializer.deserialize(this->m_procTypes);
+        status = deserializer.deserializeTo(this->m_procTypes);
         DP_CONTAINER_HEADER_ASSERT_EQ(status, FW_SERIALIZE_OK);
         // Deserialize the user data
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::USER_DATA_OFFSET);
         FwSizeType size = sizeof this->m_userData;
-        status = deserializer.deserialize(this->m_userData, size, Fw::Serialization::OMIT_LENGTH);
+        status = deserializer.deserializeTo(this->m_userData, size, Fw::Serialization::OMIT_LENGTH);
         DP_CONTAINER_HEADER_ASSERT_EQ(status, FW_SERIALIZE_OK);
         DP_CONTAINER_HEADER_ASSERT_EQ(size, sizeof this->m_userData);
         // Deserialize the data product state
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::DP_STATE_OFFSET);
-        status = deserializer.deserialize(this->m_dpState);
+        status = deserializer.deserializeTo(this->m_dpState);
         DP_CONTAINER_HEADER_ASSERT_EQ(status, FW_SERIALIZE_OK);
         // Deserialize the data size
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::DATA_SIZE_OFFSET);

--- a/Fw/FilePacket/DataPacket.cpp
+++ b/Fw/FilePacket/DataPacket.cpp
@@ -38,12 +38,12 @@ SerializeStatus FilePacket::DataPacket ::toBuffer(Buffer& buffer) const {
 SerializeStatus FilePacket::DataPacket ::fromSerialBuffer(SerialBuffer& serialBuffer) {
     FW_ASSERT(this->m_header.m_type == T_DATA);
 
-    SerializeStatus status = serialBuffer.deserialize(this->m_byteOffset);
+    SerializeStatus status = serialBuffer.deserializeTo(this->m_byteOffset);
     if (status != FW_SERIALIZE_OK) {
         return status;
     }
 
-    status = serialBuffer.deserialize(this->m_dataSize);
+    status = serialBuffer.deserializeTo(this->m_dataSize);
     if (status != FW_SERIALIZE_OK) {
         return status;
     }
@@ -72,12 +72,12 @@ SerializeStatus FilePacket::DataPacket ::toSerialBuffer(SerialBuffer& serialBuff
         return status;
     }
 
-    status = serialBuffer.serialize(this->m_byteOffset);
+    status = serialBuffer.serializeFrom(this->m_byteOffset);
     if (status != FW_SERIALIZE_OK) {
         return status;
     }
 
-    status = serialBuffer.serialize(this->m_dataSize);
+    status = serialBuffer.serializeFrom(this->m_dataSize);
     if (status != FW_SERIALIZE_OK) {
         return status;
     }

--- a/Fw/FilePacket/EndPacket.cpp
+++ b/Fw/FilePacket/EndPacket.cpp
@@ -43,7 +43,7 @@ void FilePacket::EndPacket ::getChecksum(CFDP::Checksum& checksum) const {
 SerializeStatus FilePacket::EndPacket ::fromSerialBuffer(SerialBuffer& serialBuffer) {
     FW_ASSERT(this->m_header.m_type == T_END);
 
-    const SerializeStatus status = serialBuffer.deserialize(this->m_checksumValue);
+    const SerializeStatus status = serialBuffer.deserializeTo(this->m_checksumValue);
 
     return status;
 }
@@ -58,7 +58,7 @@ SerializeStatus FilePacket::EndPacket ::toSerialBuffer(SerialBuffer& serialBuffe
         return status;
     }
 
-    status = serialBuffer.serialize(this->m_checksumValue);
+    status = serialBuffer.serializeFrom(this->m_checksumValue);
     if (status != FW_SERIALIZE_OK) {
         return status;
     }

--- a/Fw/FilePacket/Header.cpp
+++ b/Fw/FilePacket/Header.cpp
@@ -28,13 +28,13 @@ SerializeStatus FilePacket::Header ::fromSerialBuffer(SerialBuffer& serialBuffer
     U8 new_type;
     SerializeStatus status;
 
-    status = serialBuffer.deserialize(new_type);
+    status = serialBuffer.deserializeTo(new_type);
     if (status != FW_SERIALIZE_OK) {
         return status;
     }
     this->m_type = static_cast<Type>(new_type);
 
-    status = serialBuffer.deserialize(this->m_sequenceIndex);
+    status = serialBuffer.deserializeTo(this->m_sequenceIndex);
 
     return status;
 }
@@ -43,12 +43,12 @@ SerializeStatus FilePacket::Header ::toSerialBuffer(SerialBuffer& serialBuffer) 
     const U8 type_casted = static_cast<U8>(this->m_type);
     SerializeStatus status;
 
-    status = serialBuffer.serialize(type_casted);
+    status = serialBuffer.serializeFrom(type_casted);
     if (status != FW_SERIALIZE_OK) {
         return status;
     }
 
-    status = serialBuffer.serialize(this->m_sequenceIndex);
+    status = serialBuffer.serializeFrom(this->m_sequenceIndex);
     if (status != FW_SERIALIZE_OK) {
         return status;
     }

--- a/Fw/FilePacket/PathName.cpp
+++ b/Fw/FilePacket/PathName.cpp
@@ -30,7 +30,7 @@ U32 FilePacket::PathName ::bufferSize() const {
 
 SerializeStatus FilePacket::PathName ::fromSerialBuffer(SerialBuffer& serialBuffer) {
     {
-        const SerializeStatus status = serialBuffer.deserialize(this->m_length);
+        const SerializeStatus status = serialBuffer.deserializeTo(this->m_length);
 
         if (status != FW_SERIALIZE_OK) {
             return status;
@@ -54,7 +54,7 @@ SerializeStatus FilePacket::PathName ::fromSerialBuffer(SerialBuffer& serialBuff
 
 SerializeStatus FilePacket::PathName ::toSerialBuffer(SerialBuffer& serialBuffer) const {
     {
-        const SerializeStatus status = serialBuffer.serialize(this->m_length);
+        const SerializeStatus status = serialBuffer.serializeFrom(this->m_length);
 
         if (status != FW_SERIALIZE_OK) {
             return status;

--- a/Fw/FilePacket/StartPacket.cpp
+++ b/Fw/FilePacket/StartPacket.cpp
@@ -38,7 +38,7 @@ SerializeStatus FilePacket::StartPacket ::fromSerialBuffer(SerialBuffer& serialB
     FW_ASSERT(this->m_header.m_type == T_START);
 
     {
-        const SerializeStatus status = serialBuffer.deserialize(this->m_fileSize);
+        const SerializeStatus status = serialBuffer.deserializeTo(this->m_fileSize);
 
         if (status != FW_SERIALIZE_OK) {
             return status;
@@ -76,7 +76,7 @@ SerializeStatus FilePacket::StartPacket ::toSerialBuffer(SerialBuffer& serialBuf
     }
 
     {
-        const SerializeStatus status = serialBuffer.serialize(this->m_fileSize);
+        const SerializeStatus status = serialBuffer.serializeFrom(this->m_fileSize);
 
         if (status != FW_SERIALIZE_OK) {
             return status;

--- a/Fw/Log/test/ut/LogTest.cpp
+++ b/Fw/Log/test/ut/LogTest.cpp
@@ -8,7 +8,7 @@ TEST(FwLogTest, LogPacketSerialize) {
 
     Fw::LogPacket pktIn;
     Fw::LogBuffer buffIn;
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffIn.serialize(static_cast<U32>(12)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffIn.serializeFrom(static_cast<U32>(12)));
     Fw::Time timeIn(TimeBase::TB_WORKSTATION_TIME, 10, 11);
 
     pktIn.setId(10);
@@ -16,20 +16,20 @@ TEST(FwLogTest, LogPacketSerialize) {
     pktIn.setLogBuffer(buffIn);
 
     Fw::ComBuffer comBuff;
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(pktIn));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(pktIn));
 
     // Deserialize data
     Fw::LogPacket pktOut;
     Fw::LogBuffer buffOut;
     Fw::Time timeOut(TimeBase::TB_WORKSTATION_TIME, 10, 11);
 
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.deserialize(pktOut));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.deserializeTo(pktOut));
     ASSERT_EQ(pktOut.getId(), 10u);
     ASSERT_EQ(pktOut.getTimeTag(), timeOut);
     U32 valOut = 0;
     buffOut = pktOut.getLogBuffer();
     buffOut.resetDeser();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffOut.deserialize(valOut));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffOut.deserializeTo(valOut));
     ASSERT_EQ(valOut, 12u);
 
     // serialize string
@@ -38,8 +38,8 @@ TEST(FwLogTest, LogPacketSerialize) {
 
     str1 = "Foo";
     buffOut.resetSer();
-    str1.serialize(buffOut);
-    str2.deserialize(buffOut);
+    str1.serializeTo(buffOut);
+    str2.deserializeFrom(buffOut);
     ASSERT_EQ(str1, str2);
 }
 

--- a/Fw/SerializableFile/SerializableFile.cpp
+++ b/Fw/SerializableFile/SerializableFile.cpp
@@ -51,7 +51,7 @@ SerializableFile::Status SerializableFile::load(const char* fileName, Serializab
     SerializeStatus serStatus;
     serStatus = this->m_buffer.setBuffLen(length);
     FW_ASSERT(FW_SERIALIZE_OK == serStatus, serStatus);
-    serStatus = serializable.deserialize(this->m_buffer);
+    serStatus = serializable.deserializeFrom(this->m_buffer);
     if (FW_SERIALIZE_OK != serStatus) {
         return DESERIALIZATION_ERROR;
     }
@@ -61,7 +61,7 @@ SerializableFile::Status SerializableFile::load(const char* fileName, Serializab
 
 SerializableFile::Status SerializableFile::save(const char* fileName, Serializable& serializable) {
     this->reset();
-    SerializeStatus serStatus = serializable.serialize(this->m_buffer);
+    SerializeStatus serStatus = serializable.serializeTo(this->m_buffer);
     FW_ASSERT(FW_SERIALIZE_OK == serStatus, serStatus);
 
     Os::File file;

--- a/Fw/Tlm/test/ut/TlmTest.cpp
+++ b/Fw/Tlm/test/ut/TlmTest.cpp
@@ -7,7 +7,7 @@ TEST(FwTlmTest, TlmPacketSerializeSingle) {
 
     Fw::TlmPacket pktIn;
     Fw::TlmBuffer buffIn;
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffIn.serialize(static_cast<U32>(12)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffIn.serializeFrom(static_cast<U32>(12)));
     Fw::Time timeIn(TimeBase::TB_WORKSTATION_TIME, 10, 11);
     FwChanIdType id = 10;
 
@@ -30,7 +30,7 @@ TEST(FwTlmTest, TlmPacketSerializeSingle) {
     ASSERT_EQ(10u, id);
     U32 valOut = 0;
     buffOut.resetDeser();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffOut.deserialize(valOut));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffOut.deserializeTo(valOut));
     ASSERT_EQ(valOut, 12u);
 }
 
@@ -52,7 +52,7 @@ TEST(FwTlmTest, TlmPacketSerializeFill) {
         // Serialize data
 
         Fw::TlmBuffer buffIn;
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffIn.serialize(static_cast<U32>(entry)));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffIn.serializeFrom(static_cast<U32>(entry)));
         Fw::Time timeIn(TimeBase::TB_WORKSTATION_TIME, entry + 1, entry + 2);
         FwChanIdType id = static_cast<FwChanIdType>(NUM_ENTRIES - entry);
 
@@ -62,7 +62,7 @@ TEST(FwTlmTest, TlmPacketSerializeFill) {
     // Next one should fail because it's full
     {
         Fw::TlmBuffer buffIn;
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffIn.serialize(static_cast<U32>(12)));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffIn.serializeFrom(static_cast<U32>(12)));
         Fw::Time timeIn(TimeBase::TB_WORKSTATION_TIME, 10, 11);
         FwChanIdType id = 10;
 
@@ -87,7 +87,7 @@ TEST(FwTlmTest, TlmPacketSerializeFill) {
         Fw::Time expTime(TimeBase::TB_WORKSTATION_TIME, entry + 1, entry + 2);
         ASSERT_EQ(expTime, timeOut);
         U32 val = 0;
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffOut.deserialize(val));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffOut.deserializeTo(val));
         ASSERT_EQ(entry, val);
     }
 

--- a/Fw/Types/SerialBuffer.cpp
+++ b/Fw/Types/SerialBuffer.cpp
@@ -35,11 +35,11 @@ void SerialBuffer ::fill() {
 }
 
 SerializeStatus SerialBuffer ::pushBytes(const U8* const addr, const FwSizeType n) {
-    return this->serialize(const_cast<U8*>(addr), n, Fw::Serialization::OMIT_LENGTH);
+    return this->serializeFrom(const_cast<U8*>(addr), n, Fw::Serialization::OMIT_LENGTH);
 }
 
 SerializeStatus SerialBuffer ::popBytes(U8* const addr, FwSizeType n) {
-    return this->deserialize(addr, n, Fw::Serialization::OMIT_LENGTH);
+    return this->deserializeTo(addr, n, Fw::Serialization::OMIT_LENGTH);
 }
 
 }  // namespace Fw

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -36,9 +36,17 @@ class Serializable {
     // Legacy methods for backward compatibility
     // ----------------------------------------------------------------------
 
-    SerializeStatus serialize(SerializeBufferBase& buffer) const { return this->serializeTo(buffer); }
+    DEPRECATED(SerializeStatus serialize(SerializeBufferBase& buffer) const,
+               "Use serializeTo(SerializeBufferBase& buffer) instead")
+    {
+        return this->serializeTo(buffer);
+    }
 
-    SerializeStatus deserialize(SerializeBufferBase& buffer) { return this->deserializeFrom(buffer); }
+    DEPRECATED(SerializeStatus deserialize(SerializeBufferBase& buffer),
+               "Use deserializeFrom(SerializeBufferBase& buffer) instead")
+    {
+        return this->deserializeFrom(buffer);
+    }
 
 #if FW_SERIALIZABLE_TO_STRING || FW_ENABLE_TEXT_LOGGING || BUILD_UT
     virtual void toString(StringBase& text) const;  //!< generate text from serializable
@@ -160,55 +168,59 @@ class SerializeBufferBase {
     // Serialization methods
     // ----------------------------------------------------------------------
 
-    SerializeStatus serialize(U8 val);
-    SerializeStatus serialize(I8 val);
+    DEPRECATED(SerializeStatus serialize(U8 val), "Use serializeFrom(U8 val) instead");
+    DEPRECATED(SerializeStatus serialize(I8 val), "Use serializeFrom(I8 val) instead");
 #if FW_HAS_16_BIT == 1
-    SerializeStatus serialize(U16 val);
-    SerializeStatus serialize(I16 val);
+    DEPRECATED(SerializeStatus serialize(U16 val), "Use serializeFrom(U16 val) instead");
+    DEPRECATED(SerializeStatus serialize(I16 val), "Use serializeFrom(I16 val) instead");
 #endif
 #if FW_HAS_32_BIT == 1
-    SerializeStatus serialize(U32 val);
-    SerializeStatus serialize(I32 val);
+    DEPRECATED(SerializeStatus serialize(U32 val), "Use serializeFrom(U32 val) instead");
+    DEPRECATED(SerializeStatus serialize(I32 val), "Use serializeFrom(I32 val) instead");
 #endif
 #if FW_HAS_64_BIT == 1
-    SerializeStatus serialize(U64 val);
-    SerializeStatus serialize(I64 val);
+    DEPRECATED(SerializeStatus serialize(U64 val), "Use serializeFrom(U64 val) instead");
+    DEPRECATED(SerializeStatus serialize(I64 val), "Use serializeFrom(I64 val) instead");
 #endif
-    SerializeStatus serialize(F32 val);
-    SerializeStatus serialize(F64 val);
-    SerializeStatus serialize(bool val);
-    SerializeStatus serialize(const void* val);
-    DEPRECATED(SerializeStatus serialize(const U8* buff, FwSizeType length, bool noLength),
-               "Use serialize(const U8* buff, FwSizeType length, Serialization::t mode) instead");
-    SerializeStatus serialize(const U8* buff, FwSizeType length);
-    SerializeStatus serialize(const U8* buff, FwSizeType length, Serialization::t mode);
-    SerializeStatus serialize(const Serializable& val);
-    SerializeStatus serialize(const SerializeBufferBase& val);
 
-    SerializeStatus deserialize(U8& val);
-    SerializeStatus deserialize(I8& val);
+    DEPRECATED(SerializeStatus serialize(F32 val), "Use serializeFrom(F32 val) instead");
+    DEPRECATED(SerializeStatus serialize(F64 val), "Use serializeFrom(F64 val) instead");
+    DEPRECATED(SerializeStatus serialize(bool val), "Use serializeFrom(bool val) instead");
+    DEPRECATED(SerializeStatus serialize(const void* val), "Use serializeFrom(const void* val) instead");
+    DEPRECATED(SerializeStatus serialize(const U8* buff, FwSizeType length, bool noLength),
+                "Use serialize(const U8* buff, FwSizeType length, Serialization::t mode) instead");
+    DEPRECATED(SerializeStatus serialize(const U8* buff, FwSizeType length), "Use serializeFrom(const U8* buff, FwSizeType length) instead");
+    DEPRECATED(SerializeStatus serialize(const U8* buff, FwSizeType length, Serialization::t mode), 
+                "Use serializeFrom(const U8* buff, FwSizeType length, Serialization::t mode) instead");
+    DEPRECATED(SerializeStatus serialize(const Serializable& val), "Use serializeFrom(const Serializable& val) instead");
+    DEPRECATED(SerializeStatus serialize(const SerializeBufferBase& val), "Use serializeFrom(const SerializeBufferBase& val) instead");
+
+    DEPRECATED(SerializeStatus deserialize(U8& val), "Use deserializeTo(U8& val) instead");
+    DEPRECATED(SerializeStatus deserialize(I8& val), "Use deserializeTo(I8& val) instead");
 #if FW_HAS_16_BIT == 1
-    SerializeStatus deserialize(U16& val);
-    SerializeStatus deserialize(I16& val);
+    DEPRECATED(SerializeStatus deserialize(U16& val), "Use deserializeTo(U16& val) instead");
+    DEPRECATED(SerializeStatus deserialize(I16& val), "Use deserializeTo(I16& val) instead");
 #endif
 #if FW_HAS_32_BIT == 1
-    SerializeStatus deserialize(U32& val);
-    SerializeStatus deserialize(I32& val);
+    DEPRECATED(SerializeStatus deserialize(U32& val), "Use deserializeTo(U32& val) instead");
+    DEPRECATED(SerializeStatus deserialize(I32& val), "Use deserializeTo(I32& val) instead");
 #endif
 #if FW_HAS_64_BIT == 1
-    SerializeStatus deserialize(U64& val);
-    SerializeStatus deserialize(I64& val);
+    DEPRECATED(SerializeStatus deserialize(U64& val), "Use deserializeTo(U64& val) instead");
+    DEPRECATED(SerializeStatus deserialize(I64& val), "Use deserializeTo(I64& val) instead");
 #endif
-    SerializeStatus deserialize(F32& val);
-    SerializeStatus deserialize(F64& val);
-    SerializeStatus deserialize(bool& val);
-    SerializeStatus deserialize(void*& val);
+
+    DEPRECATED(SerializeStatus deserialize(F32& val), "Use deserializeTo(F32& val) instead");
+    DEPRECATED(SerializeStatus deserialize(F64& val), "Use deserializeTo(F64& val) instead");
+    DEPRECATED(SerializeStatus deserialize(bool& val), "Use deserializeTo(bool& val) instead");
+    DEPRECATED(SerializeStatus deserialize(void*& val), "Use deserializeTo(void*& val) instead");
     DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length, bool noLength),
-               "Use deserialize(U8* buff, FwSizeType& length, Serialization::t mode) instead");
-    SerializeStatus deserialize(U8* buff, FwSizeType& length);
-    SerializeStatus deserialize(U8* buff, FwSizeType& length, Serialization::t mode);
-    SerializeStatus deserialize(Serializable& val);
-    SerializeStatus deserialize(SerializeBufferBase& val);
+                "Use deserialize(U8* buff, FwSizeType& length, Serialization::t mode) instead");
+    DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length), "Use deserializeTo(U8* buff, FwSizeType& length) instead");
+    DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length, Serialization::t mode), 
+                "Use deserializeTo(U8* buff, FwSizeType& length, Serialization::t mode) instead");
+    DEPRECATED(SerializeStatus deserialize(Serializable& val), "Use deserializeTo(Serializable& val) instead");
+    DEPRECATED(SerializeStatus deserialize(SerializeBufferBase& val), "Use deserializeTo(SerializeBufferBase& val) instead");
 
     void resetSer();    //!< reset to beginning of buffer to reuse for serialization
     void resetDeser();  //!< reset deserialization to beginning

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -37,14 +37,12 @@ class Serializable {
     // ----------------------------------------------------------------------
 
     DEPRECATED(SerializeStatus serialize(SerializeBufferBase& buffer) const,
-               "Use serializeTo(SerializeBufferBase& buffer) instead")
-    {
+               "Use serializeTo(SerializeBufferBase& buffer) instead") {
         return this->serializeTo(buffer);
     }
 
     DEPRECATED(SerializeStatus deserialize(SerializeBufferBase& buffer),
-               "Use deserializeFrom(SerializeBufferBase& buffer) instead")
-    {
+               "Use deserializeFrom(SerializeBufferBase& buffer) instead") {
         return this->deserializeFrom(buffer);
     }
 
@@ -188,12 +186,15 @@ class SerializeBufferBase {
     DEPRECATED(SerializeStatus serialize(bool val), "Use serializeFrom(bool val) instead");
     DEPRECATED(SerializeStatus serialize(const void* val), "Use serializeFrom(const void* val) instead");
     DEPRECATED(SerializeStatus serialize(const U8* buff, FwSizeType length, bool noLength),
-                "Use serialize(const U8* buff, FwSizeType length, Serialization::t mode) instead");
-    DEPRECATED(SerializeStatus serialize(const U8* buff, FwSizeType length), "Use serializeFrom(const U8* buff, FwSizeType length) instead");
-    DEPRECATED(SerializeStatus serialize(const U8* buff, FwSizeType length, Serialization::t mode), 
-                "Use serializeFrom(const U8* buff, FwSizeType length, Serialization::t mode) instead");
-    DEPRECATED(SerializeStatus serialize(const Serializable& val), "Use serializeFrom(const Serializable& val) instead");
-    DEPRECATED(SerializeStatus serialize(const SerializeBufferBase& val), "Use serializeFrom(const SerializeBufferBase& val) instead");
+               "Use serialize(const U8* buff, FwSizeType length, Serialization::t mode) instead");
+    DEPRECATED(SerializeStatus serialize(const U8* buff, FwSizeType length),
+               "Use serializeFrom(const U8* buff, FwSizeType length) instead");
+    DEPRECATED(SerializeStatus serialize(const U8* buff, FwSizeType length, Serialization::t mode),
+               "Use serializeFrom(const U8* buff, FwSizeType length, Serialization::t mode) instead");
+    DEPRECATED(SerializeStatus serialize(const Serializable& val),
+               "Use serializeFrom(const Serializable& val) instead");
+    DEPRECATED(SerializeStatus serialize(const SerializeBufferBase& val),
+               "Use serializeFrom(const SerializeBufferBase& val) instead");
 
     DEPRECATED(SerializeStatus deserialize(U8& val), "Use deserializeTo(U8& val) instead");
     DEPRECATED(SerializeStatus deserialize(I8& val), "Use deserializeTo(I8& val) instead");
@@ -215,12 +216,14 @@ class SerializeBufferBase {
     DEPRECATED(SerializeStatus deserialize(bool& val), "Use deserializeTo(bool& val) instead");
     DEPRECATED(SerializeStatus deserialize(void*& val), "Use deserializeTo(void*& val) instead");
     DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length, bool noLength),
-                "Use deserialize(U8* buff, FwSizeType& length, Serialization::t mode) instead");
-    DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length), "Use deserializeTo(U8* buff, FwSizeType& length) instead");
-    DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length, Serialization::t mode), 
-                "Use deserializeTo(U8* buff, FwSizeType& length, Serialization::t mode) instead");
+               "Use deserialize(U8* buff, FwSizeType& length, Serialization::t mode) instead");
+    DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length),
+               "Use deserializeTo(U8* buff, FwSizeType& length) instead");
+    DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length, Serialization::t mode),
+               "Use deserializeTo(U8* buff, FwSizeType& length, Serialization::t mode) instead");
     DEPRECATED(SerializeStatus deserialize(Serializable& val), "Use deserializeTo(Serializable& val) instead");
-    DEPRECATED(SerializeStatus deserialize(SerializeBufferBase& val), "Use deserializeTo(SerializeBufferBase& val) instead");
+    DEPRECATED(SerializeStatus deserialize(SerializeBufferBase& val),
+               "Use deserializeTo(SerializeBufferBase& val) instead");
 
     void resetSer();    //!< reset to beginning of buffer to reuse for serialization
     void resetDeser();  //!< reset deserialization to beginning

--- a/Fw/Types/StringBase.cpp
+++ b/Fw/Types/StringBase.cpp
@@ -149,16 +149,6 @@ SerializeStatus StringBase::serializeTo(SerializeBufferBase& buffer, SizeType ma
     return buffer.serializeFrom(reinterpret_cast<const U8*>(this->toChar()), len, Serialization::INCLUDE_LENGTH);
 }
 
-// Deprecated method for backward compatibility
-SerializeStatus StringBase::serialize(SerializeBufferBase& buffer) const {
-    return this->serializeTo(buffer);
-}
-
-// Deprecated method for backward compatibility
-SerializeStatus StringBase::serialize(SerializeBufferBase& buffer, SizeType maxLength) const {
-    return this->serializeTo(buffer, maxLength);
-}
-
 SerializeStatus StringBase::deserializeFrom(SerializeBufferBase& buffer) {
     // Get the max size of the deserialized string
     const SizeType maxSize = this->maxLength();

--- a/Fw/Types/StringBase.hpp
+++ b/Fw/Types/StringBase.hpp
@@ -70,8 +70,17 @@ class StringBase : public Serializable {
     virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, SizeType maxLen) const;
     SerializeStatus deserializeFrom(SerializeBufferBase& buffer) override;
 
-    SerializeStatus serialize(SerializeBufferBase& buffer) const;
-    virtual SerializeStatus serialize(SerializeBufferBase& buffer, SizeType maxLen) const;
+    DEPRECATED(SerializeStatus serialize(SerializeBufferBase& buffer) const,
+               "Use serializeTo(SerializeBufferBase& buffer) instead")
+    {
+        return this->serializeTo(buffer);
+    }
+
+    DEPRECATED(SerializeStatus serialize(SerializeBufferBase& buffer, SizeType maxLen) const,
+               "Use serializeTo(SerializeBufferBase& buffer, SizeType maxLen) instead")
+    {
+        return this->serializeTo(buffer, maxLen);
+    }
 
 #ifdef BUILD_UT
     // to support GoogleTest framework in unit tests

--- a/Fw/Types/StringBase.hpp
+++ b/Fw/Types/StringBase.hpp
@@ -71,14 +71,12 @@ class StringBase : public Serializable {
     SerializeStatus deserializeFrom(SerializeBufferBase& buffer) override;
 
     DEPRECATED(SerializeStatus serialize(SerializeBufferBase& buffer) const,
-               "Use serializeTo(SerializeBufferBase& buffer) instead")
-    {
+               "Use serializeTo(SerializeBufferBase& buffer) instead") {
         return this->serializeTo(buffer);
     }
 
     DEPRECATED(SerializeStatus serialize(SerializeBufferBase& buffer, SizeType maxLen) const,
-               "Use serializeTo(SerializeBufferBase& buffer, SizeType maxLen) instead")
-    {
+               "Use serializeTo(SerializeBufferBase& buffer, SizeType maxLen) instead") {
         return this->serializeTo(buffer, maxLen);
     }
 

--- a/Fw/Types/test/ut/ExternalSerializeBufferTest.cpp
+++ b/Fw/Types/test/ut/ExternalSerializeBufferTest.cpp
@@ -16,7 +16,7 @@ void serializeOK(Fw::ExternalSerializeBuffer& esb) {
     ASSERT_EQ(esb.getBuffLength(), 0);
     for (SizeType i = 0; i < buffCapacity; i++) {
         const U8 value = static_cast<U8>(i);
-        const Fw::SerializeStatus status = esb.serialize(value);
+        const Fw::SerializeStatus status = esb.serializeFrom(value);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
     }
     ASSERT_EQ(esb.getBuffLength(), buffCapacity);
@@ -24,7 +24,7 @@ void serializeOK(Fw::ExternalSerializeBuffer& esb) {
 
 void serializeFail(Fw::ExternalSerializeBuffer& esb) {
     ASSERT_EQ(esb.getBuffLength(), esb.getBuffCapacity());
-    const Fw::SerializeStatus status = esb.serialize(static_cast<U8>(0));
+    const Fw::SerializeStatus status = esb.serializeFrom(static_cast<U8>(0));
     ASSERT_EQ(status, Fw::FW_SERIALIZE_NO_ROOM_LEFT);
 }
 
@@ -33,7 +33,7 @@ void deserializeOK(Fw::ExternalSerializeBuffer& esb) {
     ASSERT_EQ(esb.getBuffLeft(), buffCapacity);
     for (SizeType i = 0; i < buffCapacity; i++) {
         U8 value = 0;
-        const Fw::SerializeStatus status = esb.deserialize(value);
+        const Fw::SerializeStatus status = esb.deserializeTo(value);
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
         ASSERT_EQ(value, static_cast<U8>(i));
     }
@@ -43,7 +43,7 @@ void deserializeOK(Fw::ExternalSerializeBuffer& esb) {
 void deserializeFail(Fw::ExternalSerializeBuffer& esb) {
     U8 value = 0;
     ASSERT_EQ(esb.getBuffLeft(), 0);
-    const Fw::SerializeStatus status = esb.deserialize(value);
+    const Fw::SerializeStatus status = esb.deserializeTo(value);
     ASSERT_EQ(status, Fw::FW_DESERIALIZE_BUFFER_EMPTY);
 }
 

--- a/Fw/Types/test/ut/SerializeBufferBaseTester.hpp
+++ b/Fw/Types/test/ut/SerializeBufferBaseTester.hpp
@@ -35,7 +35,7 @@ class SerializeBufferBaseTester {
         FwSizeType prevSerLoc = buff.m_serLoc;
 
         // Serialize the value
-        Fw::SerializeStatus status = buff.serialize(value);
+        Fw::SerializeStatus status = buff.serializeFrom(value);
 
         // Verify serialization was successful and pointer advanced correctly
         ASSERT_EQ(Fw::FW_SERIALIZE_OK, status);
@@ -47,7 +47,7 @@ class SerializeBufferBaseTester {
         FwSizeType prevSerLoc = buff.m_serLoc;
 
         // Serialize the value
-        Fw::SerializeStatus status = buff.serialize(value);
+        Fw::SerializeStatus status = buff.serializeFrom(value);
 
         // Verify serialization was successful and pointer advanced correctly
         ASSERT_EQ(Fw::FW_SERIALIZE_OK, status);
@@ -58,7 +58,7 @@ class SerializeBufferBaseTester {
     static void verifyU8Deserialization(Fw::SerializeBufferBase& buff, U8& actualValue, U8 expectedValue) {
         FwSizeType prevDeserLoc = buff.m_deserLoc;
 
-        Fw::SerializeStatus status = buff.deserialize(actualValue);
+        Fw::SerializeStatus status = buff.deserializeTo(actualValue);
 
         ASSERT_EQ(Fw::FW_SERIALIZE_OK, status);
         ASSERT_EQ(expectedValue, actualValue);
@@ -68,7 +68,7 @@ class SerializeBufferBaseTester {
     static void verifyI8Deserialization(Fw::SerializeBufferBase& buff, I8& actualValue, I8 expectedValue) {
         FwSizeType prevDeserLoc = buff.m_deserLoc;
 
-        Fw::SerializeStatus status = buff.deserialize(actualValue);
+        Fw::SerializeStatus status = buff.deserializeTo(actualValue);
 
         ASSERT_EQ(Fw::FW_SERIALIZE_OK, status);
         ASSERT_EQ(expectedValue, actualValue);

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -118,12 +118,12 @@ TEST(SerializationTest, Serialization1) {
     // Test shorts
 
     buff.resetSer();
-    stat1 = buff.serialize(u16t1);
+    stat1 = buff.serializeFrom(u16t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 2);
     ASSERT_EQ(0xAB, ptr[0]);
     ASSERT_EQ(0xCD, ptr[1]);
-    stat2 = buff.deserialize(u16t2);
+    stat2 = buff.deserializeTo(u16t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u16t1, u16t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 2);
@@ -137,13 +137,13 @@ TEST(SerializationTest, Serialization1) {
     I16 i16t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serialize(i16t1);
+    stat1 = buff.serializeFrom(i16t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 2);
     // 2s complement
     ASSERT_EQ(0xAB, ptr[0]);
     ASSERT_EQ(0xCD, ptr[1]);
-    stat2 = buff.deserialize(i16t2);
+    stat2 = buff.deserializeTo(i16t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i16t1, i16t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 2);
@@ -153,10 +153,10 @@ TEST(SerializationTest, Serialization1) {
     i16t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serialize(i16t1);
+    stat1 = buff.serializeFrom(i16t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 2);
-    stat2 = buff.deserialize(i16t2);
+    stat2 = buff.deserializeTo(i16t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i16t1, i16t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 2);
@@ -173,14 +173,14 @@ TEST(SerializationTest, Serialization1) {
     // Test ints
 
     buff.resetSer();
-    stat1 = buff.serialize(u32t1);
+    stat1 = buff.serializeFrom(u32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
     ASSERT_EQ(0xAB, ptr[0]);
     ASSERT_EQ(0xCD, ptr[1]);
     ASSERT_EQ(0xEF, ptr[2]);
     ASSERT_EQ(0x12, ptr[3]);
-    stat2 = buff.deserialize(u32t2);
+    stat2 = buff.deserializeTo(u32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u32t1, u32t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
@@ -194,14 +194,14 @@ TEST(SerializationTest, Serialization1) {
     I32 i32t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serialize(i32t1);
+    stat1 = buff.serializeFrom(i32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
     ASSERT_EQ(0xAB, ptr[0]);
     ASSERT_EQ(0xCD, ptr[1]);
     ASSERT_EQ(0xEF, ptr[2]);
     ASSERT_EQ(0x12, ptr[3]);
-    stat2 = buff.deserialize(i32t2);
+    stat2 = buff.deserializeTo(i32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
     ASSERT_EQ(i32t1, i32t2);
@@ -211,10 +211,10 @@ TEST(SerializationTest, Serialization1) {
     i32t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serialize(i32t1);
+    stat1 = buff.serializeFrom(i32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
-    stat2 = buff.deserialize(i32t2);
+    stat2 = buff.deserializeTo(i32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
     ASSERT_EQ(i32t1, i32t2);
@@ -231,7 +231,7 @@ TEST(SerializationTest, Serialization1) {
     // Test ints
 
     buff.resetSer();
-    stat1 = buff.serialize(u64t1);
+    stat1 = buff.serializeFrom(u64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
     ASSERT_EQ(0x01, ptr[0]);
@@ -242,7 +242,7 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(0xAB, ptr[5]);
     ASSERT_EQ(0xCD, ptr[6]);
     ASSERT_EQ(0xEF, ptr[7]);
-    stat2 = buff.deserialize(u64t2);
+    stat2 = buff.deserializeTo(u64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u64t1, u64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
@@ -256,7 +256,7 @@ TEST(SerializationTest, Serialization1) {
     I64 i64t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serialize(i64t1);
+    stat1 = buff.serializeFrom(i64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
     ASSERT_EQ(0x01, ptr[0]);
@@ -267,7 +267,7 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(0xAB, ptr[5]);
     ASSERT_EQ(0xCD, ptr[6]);
     ASSERT_EQ(0xEF, ptr[7]);
-    stat2 = buff.deserialize(i64t2);
+    stat2 = buff.deserializeTo(i64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i64t1, i64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
@@ -277,10 +277,10 @@ TEST(SerializationTest, Serialization1) {
     i64t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serialize(i64t1);
+    stat1 = buff.serializeFrom(i64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
-    stat2 = buff.deserialize(i64t2);
+    stat2 = buff.deserializeTo(i64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i64t1, i64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
@@ -297,14 +297,14 @@ TEST(SerializationTest, Serialization1) {
     // Test ints
 
     buff.resetSer();
-    stat1 = buff.serialize(f32t1);
+    stat1 = buff.serializeFrom(f32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
     ASSERT_EQ(0xBF, ptr[0]);
     ASSERT_EQ(0x9D, ptr[1]);
     ASSERT_EQ(0x70, ptr[2]);
     ASSERT_EQ(0xA4, ptr[3]);
-    stat2 = buff.deserialize(f32t2);
+    stat2 = buff.deserializeTo(f32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_FLOAT_EQ(f32t1, f32t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
@@ -318,7 +318,7 @@ TEST(SerializationTest, Serialization1) {
     F64 f64t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serialize(f64t1);
+    stat1 = buff.serializeFrom(f64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
     ASSERT_EQ(0x40, ptr[0]);
@@ -329,7 +329,7 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(0x26, ptr[5]);
     ASSERT_EQ(0x8B, ptr[6]);
     ASSERT_EQ(0xA6, ptr[7]);
-    stat2 = buff.deserialize(f64t2);
+    stat2 = buff.deserializeTo(f64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_DOUBLE_EQ(f64t1, f64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
@@ -343,9 +343,9 @@ TEST(SerializationTest, Serialization1) {
     bool boolt2 = false;
 
     buff.resetSer();
-    stat1 = buff.serialize(boolt1);
+    stat1 = buff.serializeFrom(boolt1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat2 = buff.deserialize(boolt2);
+    stat2 = buff.deserializeTo(boolt2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(boolt1, boolt2);
 
@@ -360,9 +360,9 @@ TEST(SerializationTest, Serialization1) {
     void* ptrt2 = nullptr;
 
     buff.resetSer();
-    stat1 = buff.serialize(ptrt1);
+    stat1 = buff.serializeFrom(ptrt1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat2 = buff.deserialize(ptrt2);
+    stat2 = buff.deserializeTo(ptrt2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(ptrt1, ptrt2);
 
@@ -393,9 +393,9 @@ TEST(SerializationTest, Serialization1) {
     // Test skipping:
 
     buff.resetSer();
-    stat1 = buff.serialize(u32t1);
+    stat1 = buff.serializeFrom(u32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat2 = buff.serialize(u32t2);
+    stat2 = buff.serializeFrom(u32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
 
     // should fail:
@@ -417,7 +417,7 @@ TEST(SerializationTest, Serialization1) {
     stat1 = buff.deserializeSkip(4);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     U32 u32val;
-    stat2 = buff.deserialize(u32val);
+    stat2 = buff.deserializeTo(u32val);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u32t2, u32val);
 
@@ -442,29 +442,29 @@ TEST(SerializationTest, Serialization1) {
     ptrt2 = nullptr;
 
     buff.resetSer();
-    stat1 = buff.serialize(u8t1);
+    stat1 = buff.serializeFrom(u8t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff.serialize(i8t1);
+    stat1 = buff.serializeFrom(i8t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff.serialize(u16t1);
+    stat1 = buff.serializeFrom(u16t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff.serialize(i16t1);
+    stat1 = buff.serializeFrom(i16t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff.serialize(u32t1);
+    stat1 = buff.serializeFrom(u32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff.serialize(i32t1);
+    stat1 = buff.serializeFrom(i32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff.serialize(u64t1);
+    stat1 = buff.serializeFrom(u64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff.serialize(i64t1);
+    stat1 = buff.serializeFrom(i64t1);
     printf("i64t1 in stat: %d\n", stat1);
-    stat1 = buff.serialize(f32t1);
+    stat1 = buff.serializeFrom(f32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff.serialize(f64t1);
+    stat1 = buff.serializeFrom(f64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff.serialize(boolt1);
+    stat1 = buff.serializeFrom(boolt1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff.serialize(ptrt1);
+    stat1 = buff.serializeFrom(ptrt1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
 
     // TKC - commented out due to fprime-util choking on output
@@ -472,69 +472,69 @@ TEST(SerializationTest, Serialization1) {
 
     // Serialize second buffer and test for equality
     buff2.resetSer();
-    stat1 = buff2.serialize(u8t1);
+    stat1 = buff2.serializeFrom(u8t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff2.serialize(i8t1);
+    stat1 = buff2.serializeFrom(i8t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff2.serialize(u16t1);
+    stat1 = buff2.serializeFrom(u16t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff2.serialize(i16t1);
+    stat1 = buff2.serializeFrom(i16t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff2.serialize(u32t1);
+    stat1 = buff2.serializeFrom(u32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff2.serialize(i32t1);
+    stat1 = buff2.serializeFrom(i32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff2.serialize(u64t1);
+    stat1 = buff2.serializeFrom(u64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff2.serialize(i64t1);
+    stat1 = buff2.serializeFrom(i64t1);
     printf("i64t1 in stat: %d\n", stat1);
-    stat1 = buff2.serialize(f32t1);
+    stat1 = buff2.serializeFrom(f32t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff2.serialize(f64t1);
+    stat1 = buff2.serializeFrom(f64t1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff2.serialize(boolt1);
+    stat1 = buff2.serializeFrom(boolt1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat1 = buff2.serialize(ptrt1);
+    stat1 = buff2.serializeFrom(ptrt1);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
 
     ASSERT_EQ(buff, buff2);
 
     // deserialize
 
-    stat2 = buff.deserialize(u8t2);
+    stat2 = buff.deserializeTo(u8t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u8t1, u8t2);
-    stat2 = buff.deserialize(i8t2);
+    stat2 = buff.deserializeTo(i8t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i8t1, i8t2);
-    stat2 = buff.deserialize(u16t2);
+    stat2 = buff.deserializeTo(u16t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u16t1, u16t2);
-    stat2 = buff.deserialize(i16t2);
+    stat2 = buff.deserializeTo(i16t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i16t1, i16t2);
-    stat2 = buff.deserialize(u32t2);
+    stat2 = buff.deserializeTo(u32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u32t1, u32t2);
-    stat2 = buff.deserialize(i32t2);
+    stat2 = buff.deserializeTo(i32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i32t1, i32t2);
-    stat2 = buff.deserialize(u64t2);
+    stat2 = buff.deserializeTo(u64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u64t1, u64t2);
-    stat2 = buff.deserialize(i64t2);
+    stat2 = buff.deserializeTo(i64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i64t1, i64t2);
-    stat2 = buff.deserialize(f32t2);
+    stat2 = buff.deserializeTo(f32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_FLOAT_EQ(f32t1, f32t2);
-    stat2 = buff.deserialize(f64t2);
+    stat2 = buff.deserializeTo(f64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_DOUBLE_EQ(f64t1, f64t2);
-    stat2 = buff.deserialize(boolt2);
+    stat2 = buff.deserializeTo(boolt2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(boolt1, boolt2);
-    stat2 = buff.deserialize(ptrt2);
+    stat2 = buff.deserializeTo(ptrt2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(ptrt1, ptrt2);
 
@@ -558,40 +558,40 @@ TEST(SerializationTest, Serialization1) {
     boolt2 = false;
     ptrt2 = nullptr;
 
-    stat2 = buff.deserialize(u8t2);
+    stat2 = buff.deserializeTo(u8t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u8t1, u8t2);
-    stat2 = buff.deserialize(i8t2);
+    stat2 = buff.deserializeTo(i8t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i8t1, i8t2);
-    stat2 = buff.deserialize(u16t2);
+    stat2 = buff.deserializeTo(u16t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u16t1, u16t2);
-    stat2 = buff.deserialize(i16t2);
+    stat2 = buff.deserializeTo(i16t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i16t1, i16t2);
-    stat2 = buff.deserialize(u32t2);
+    stat2 = buff.deserializeTo(u32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u32t1, u32t2);
-    stat2 = buff.deserialize(i32t2);
+    stat2 = buff.deserializeTo(i32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i32t1, i32t2);
-    stat2 = buff.deserialize(u64t2);
+    stat2 = buff.deserializeTo(u64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u64t1, u64t2);
-    stat2 = buff.deserialize(i64t2);
+    stat2 = buff.deserializeTo(i64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i64t1, i64t2);
-    stat2 = buff.deserialize(f32t2);
+    stat2 = buff.deserializeTo(f32t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_FLOAT_EQ(f32t1, f32t2);
-    stat2 = buff.deserialize(f64t2);
+    stat2 = buff.deserializeTo(f64t2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_DOUBLE_EQ(f64t1, f64t2);
-    stat2 = buff.deserialize(boolt2);
+    stat2 = buff.deserializeTo(boolt2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(boolt1, boolt2);
-    stat2 = buff.deserialize(ptrt2);
+    stat2 = buff.deserializeTo(ptrt2);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(ptrt1, ptrt2);
 
@@ -602,16 +602,16 @@ TEST(SerializationTest, Serialization1) {
     str1 = "Foo";
     str2 = "BarBlat";
     buff.resetSer();
-    str1.serialize(buff);
-    str2.deserialize(buff);
+    str1.serializeTo(buff);
+    str2.deserializeFrom(buff);
     ASSERT_EQ(str1, str2);
 
     // serialize string template
     Fw::StringTemplate<80> strTmpl1("Foo");
     Fw::StringTemplate<80> strTmpl2("Bar");
     buff.resetSer();
-    strTmpl1.serialize(buff);
-    strTmpl2.deserialize(buff);
+    strTmpl1.serializeTo(buff);
+    strTmpl2.deserializeFrom(buff);
     ASSERT_EQ(strTmpl1, strTmpl2);
 }
 
@@ -626,20 +626,20 @@ struct TestStruct {
 class MySerializable : public Fw::Serializable {
   public:
     Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer) const override {
-        buffer.serialize(m_testStruct.m_u32);
-        buffer.serialize(m_testStruct.m_u16);
-        buffer.serialize(m_testStruct.m_u8);
-        buffer.serialize(m_testStruct.m_f32);
-        buffer.serialize(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
+        buffer.serializeFrom(m_testStruct.m_u32);
+        buffer.serializeFrom(m_testStruct.m_u16);
+        buffer.serializeFrom(m_testStruct.m_u8);
+        buffer.serializeFrom(m_testStruct.m_f32);
+        buffer.serializeFrom(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
         return Fw::FW_SERIALIZE_OK;
     }
 
     Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer) override {
-        buffer.serialize(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
-        buffer.serialize(m_testStruct.m_f32);
-        buffer.serialize(m_testStruct.m_u8);
-        buffer.serialize(m_testStruct.m_u16);
-        buffer.serialize(m_testStruct.m_u32);
+        buffer.serializeFrom(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
+        buffer.serializeFrom(m_testStruct.m_f32);
+        buffer.serializeFrom(m_testStruct.m_u8);
+        buffer.serializeFrom(m_testStruct.m_u16);
+        buffer.serializeFrom(m_testStruct.m_u32);
         return Fw::FW_SERIALIZE_OK;
     }
 
@@ -1262,8 +1262,8 @@ TEST(PerformanceTest, F64SerPerfTest) {
 
     for (FwSizeType iter = 0; iter < iters; iter++) {
         buff.resetSer();
-        buff.serialize(in);
-        buff.deserialize(out);
+        buff.serializeFrom(in);
+        buff.deserializeTo(out);
     }
 
     timer.stop();

--- a/Os/Stub/test/ut/StubQueueTests.cpp
+++ b/Os/Stub/test/ut/StubQueueTests.cpp
@@ -91,7 +91,7 @@ TEST(Interface, SendBuffer) {
     U8 storage[messageSize];
     Fw::ExternalSerializeBuffer buffer(storage, sizeof storage);
     Fw::String message = "hello";
-    buffer.serialize(message);
+    buffer.serializeFrom(message);
 
     ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(name, depth, messageSize));
     Os::Stub::Queue::Test::StaticData::data.sendStatus = Os::QueueInterface::Status::UNKNOWN_ERROR;

--- a/Os/test/ut/rawtime/RawTimeRules.cpp
+++ b/Os/test/ut/rawtime/RawTimeRules.cpp
@@ -108,12 +108,12 @@ void Os::Test::RawTime::Tester::Serialization::action(Os::Test::RawTime::Tester&
 
     auto serializer = buffer.getSerializer();
 
-    state.m_times[index].serialize(serializer);
+    state.m_times[index].serializeTo(serializer);
 
     auto deserializer = buffer.getDeserializer();
 
     Os::RawTime raw_time;
-    raw_time.deserialize(deserializer);
+    raw_time.deserializeFrom(deserializer);
 
     // We make sure that serialization and deserialization are successful by deserializing
     // into a new Os::RawTime object and comparing the difference between the original RawTime

--- a/Ref/SendBuffApp/SendBuffComponentImpl.cpp
+++ b/Ref/SendBuffApp/SendBuffComponentImpl.cpp
@@ -44,7 +44,7 @@ void SendBuffImpl::SchedIn_handler(FwIndexType portNum, U32 context) {
         // reset buffer
         this->m_testBuff.resetSer();
         // serialize packet id
-        Fw::SerializeStatus serStat = this->m_testBuff.serialize(this->m_currPacketId);
+        Fw::SerializeStatus serStat = this->m_testBuff.serializeFrom(this->m_currPacketId);
         FW_ASSERT(serStat == Fw::FW_SERIALIZE_OK);
         // increment packet id
         this->m_currPacketId++;
@@ -68,10 +68,10 @@ void SendBuffImpl::SchedIn_handler(FwIndexType portNum, U32 context) {
             this->log_WARNING_HI_PacketErrorInserted(this->m_currPacketId - 1);
         }
         // serialize data
-        serStat = this->m_testBuff.serialize(testData, dataSize);
+        serStat = this->m_testBuff.serializeFrom(testData, dataSize);
         FW_ASSERT(serStat == Fw::FW_SERIALIZE_OK);
         // serialize checksum
-        serStat = this->m_testBuff.serialize(csum);
+        serStat = this->m_testBuff.serializeFrom(csum);
         FW_ASSERT(serStat == Fw::FW_SERIALIZE_OK);
         // send data
         this->Data_out(0, this->m_testBuff);

--- a/Svc/BufferLogger/test/ut/BufferLoggerTester.cpp
+++ b/Svc/BufferLogger/test/ut/BufferLoggerTester.cpp
@@ -197,7 +197,7 @@ void BufferLoggerTester ::checkLogFileIntegrity(const char* const fileName,
         Fw::SerialBuffer comBuffLength(buf, length);
         comBuffLength.fill();
         SIZE_TYPE bufferSize;
-        const Fw::SerializeStatus serializeStatus = comBuffLength.deserialize(bufferSize);
+        const Fw::SerializeStatus serializeStatus = comBuffLength.deserializeTo(bufferSize);
         ASSERT_EQ(Fw::FW_SERIALIZE_OK, serializeStatus);
         ASSERT_EQ(sizeof(data), bufferSize);
         // Read and check the buffer

--- a/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
@@ -43,7 +43,7 @@ void SpacePacketDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data,
     FW_ASSERT(data.getSize() > SpacePacketHeader::SERIALIZED_SIZE, static_cast<FwAssertArgType>(data.getSize()));
 
     SpacePacketHeader header;
-    Fw::SerializeStatus status = data.getDeserializer().deserialize(header);
+    Fw::SerializeStatus status = data.getDeserializer().deserializeTo(header);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Space Packet protocol defines the Data Length as number of bytes minus 1

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
@@ -115,8 +115,8 @@ Fw::Buffer SpacePacketDeframerTester ::assemblePacket(U16 apid,
     header.set_packetDataLength(lengthToken);
 
     Fw::ExternalSerializeBuffer serializer(static_cast<U8*>(this->m_packetBuffer), sizeof(this->m_packetBuffer));
-    serializer.serialize(header);
-    serializer.serialize(packetData, packetDataLen, Fw::Serialization::OMIT_LENGTH);
+    serializer.serializeFrom(header);
+    serializer.serializeFrom(packetData, packetDataLen, Fw::Serialization::OMIT_LENGTH);
     return Fw::Buffer(this->m_packetBuffer,
                       static_cast<Fw::Buffer::SizeType>(packetDataLen + SpacePacketHeader::SERIALIZED_SIZE));
 }

--- a/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
@@ -67,9 +67,9 @@ void SpacePacketFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, c
     // -----------------------------------------------
     // Serialize the packet
     // -----------------------------------------------
-    status = frameSerializer.serialize(header);
+    status = frameSerializer.serializeFrom(header);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = frameSerializer.serialize(data.getData(), data.getSize(), Fw::Serialization::OMIT_LENGTH);
+    status = frameSerializer.serializeFrom(data.getData(), data.getSize(), Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     this->dataOut_out(0, frameBuffer, context);

--- a/Svc/Ccsds/TcDeframer/TcDeframer.cpp
+++ b/Svc/Ccsds/TcDeframer/TcDeframer.cpp
@@ -55,7 +55,7 @@ void TcDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const Co
               static_cast<FwAssertArgType>(data.getSize()));
 
     TCHeader header;
-    Fw::SerializeStatus status = data.getDeserializer().deserialize(header);
+    Fw::SerializeStatus status = data.getDeserializer().deserializeTo(header);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     // TC protocol defines the Frame Length as number of bytes minus 1, so we add 1 back to get length in bytes
     U16 total_frame_length = static_cast<U16>((header.get_vcIdAndLength() & TCSubfields::FrameLengthMask) + 1);
@@ -89,7 +89,7 @@ void TcDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const Co
     TCTrailer trailer;
     auto deserializer = data.getDeserializer();
     deserializer.moveDeserToOffset(total_frame_length - TCTrailer::SERIALIZED_SIZE);
-    status = deserializer.deserialize(trailer);
+    status = deserializer.deserializeTo(trailer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     U16 transmitted_crc = trailer.get_fecf();

--- a/Svc/Ccsds/TmFramer/TmFramer.cpp
+++ b/Svc/Ccsds/TmFramer/TmFramer.cpp
@@ -63,9 +63,9 @@ void TmFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const ComC
     // Create frame Fw::Buffer using member data field
     Fw::Buffer frameBuffer = Fw::Buffer(this->m_frameBuffer, sizeof(this->m_frameBuffer));
     auto frameSerializer = frameBuffer.getSerializer();
-    status = frameSerializer.serialize(header);
+    status = frameSerializer.serializeFrom(header);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = frameSerializer.serialize(data.getData(), data.getSize(), Fw::Serialization::OMIT_LENGTH);
+    status = frameSerializer.serializeFrom(data.getData(), data.getSize(), Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // As per TM Standard 4.2.2.5, fill the rest of the data field with an Idle Packet
@@ -82,7 +82,7 @@ void TmFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const ComC
     trailer.set_fecf(crc);
     // Move the serializer pointer to the end of the location where the trailer will be serialized
     frameSerializer.moveSerToOffset(ComCfg::TmFrameFixedSize - TMTrailer::SERIALIZED_SIZE);
-    status = frameSerializer.serialize(trailer);
+    status = frameSerializer.serializeFrom(trailer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     this->m_bufferState = BufferOwnershipState::NOT_OWNED;
@@ -122,9 +122,9 @@ void TmFramer ::fill_with_idle_packet(Fw::SerializeBufferBase& serializer) {
         0x3 << SpacePacketSubfields::SeqFlagsOffset);  // Sequence Flags = 0b11 (unsegmented) & unused Seq count
     header.set_packetDataLength(lengthToken);
     // Serialize header and idle data into the frame
-    serializer.serialize(header);
+    serializer.serializeFrom(header);
     for (U16 i = static_cast<U16>(startIndex + SpacePacketHeader::SERIALIZED_SIZE); i < endIndex; i++) {
-        serializer.serialize(IDLE_DATA_PATTERN);  // Idle data
+        serializer.serializeFrom(IDLE_DATA_PATTERN);  // Idle data
     }
 }
 }  // namespace Ccsds

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
@@ -86,7 +86,7 @@ void CommandDispatcherImpl::compCmdStat_handler(FwIndexType portNum,
 
 void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
     Fw::CmdPacket cmdPkt;
-    Fw::SerializeStatus stat = cmdPkt.deserialize(data);
+    Fw::SerializeStatus stat = cmdPkt.deserializeFrom(data);
 
     if (stat != Fw::FW_SERIALIZE_OK) {
         Fw::DeserialStatus serErr(static_cast<Fw::DeserialStatus::t>(stat));

--- a/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.cpp
+++ b/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.cpp
@@ -133,7 +133,7 @@ void CommandDispatcherTester::runNominalDispatch() {
     ASSERT_EQ(this->m_cmdSendCmdSeq, 0);
     // check argument
     U32 checkVal;
-    ASSERT_EQ(this->m_cmdSendArgs.deserialize(checkVal), Fw::FW_SERIALIZE_OK);
+    ASSERT_EQ(this->m_cmdSendArgs.deserializeTo(checkVal), Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(checkVal, testCmdArg);
 
     this->clearEvents();
@@ -494,7 +494,7 @@ void CommandDispatcherTester::runFailedCommand() {
     ASSERT_EQ(currSeq, this->m_cmdSendCmdSeq);
     // check argument
     U32 checkVal;
-    ASSERT_EQ(this->m_cmdSendArgs.deserialize(checkVal), Fw::FW_SERIALIZE_OK);
+    ASSERT_EQ(this->m_cmdSendArgs.deserializeTo(checkVal), Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(checkVal, testCmdArg);
 
     this->clearEvents();
@@ -547,7 +547,7 @@ void CommandDispatcherTester::runFailedCommand() {
     ASSERT_EQ(this->m_cmdSendOpCode, testOpCode);
     ASSERT_EQ(currSeq, this->m_cmdSendCmdSeq);
     // check argument
-    ASSERT_EQ(this->m_cmdSendArgs.deserialize(checkVal), Fw::FW_SERIALIZE_OK);
+    ASSERT_EQ(this->m_cmdSendArgs.deserializeTo(checkVal), Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(checkVal, testCmdArg);
 
     this->clearEvents();
@@ -601,7 +601,7 @@ void CommandDispatcherTester::runFailedCommand() {
     ASSERT_EQ(this->m_cmdSendOpCode, testOpCode);
     ASSERT_EQ(currSeq, this->m_cmdSendCmdSeq);
     // check argument
-    ASSERT_EQ(this->m_cmdSendArgs.deserialize(checkVal), Fw::FW_SERIALIZE_OK);
+    ASSERT_EQ(this->m_cmdSendArgs.deserializeTo(checkVal), Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(checkVal, testCmdArg);
 
     this->clearEvents();
@@ -748,7 +748,7 @@ void CommandDispatcherTester::runOverflowCommands() {
             ASSERT_EQ(disp, this->m_cmdSendCmdSeq);
             // check argument
             U32 checkVal;
-            ASSERT_EQ(this->m_cmdSendArgs.deserialize(checkVal), Fw::FW_SERIALIZE_OK);
+            ASSERT_EQ(this->m_cmdSendArgs.deserializeTo(checkVal), Fw::FW_SERIALIZE_OK);
             ASSERT_EQ(checkVal, testCmdArg);
         } else {
             // verify failed to find slot
@@ -841,7 +841,7 @@ void CommandDispatcherTester::runClearCommandTracking() {
     ASSERT_EQ(0u, this->m_cmdSendCmdSeq);
     // check argument
     U32 checkVal;
-    ASSERT_EQ(this->m_cmdSendArgs.deserialize(checkVal), Fw::FW_SERIALIZE_OK);
+    ASSERT_EQ(this->m_cmdSendArgs.deserializeTo(checkVal), Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(checkVal, testCmdArg);
     this->clearEvents();
 

--- a/Svc/CmdSequencer/FPrimeSequence.cpp
+++ b/Svc/CmdSequencer/FPrimeSequence.cpp
@@ -143,7 +143,7 @@ bool CmdSequencerComponentImpl::FPrimeSequence ::deserializeHeader() {
     Header& header = this->m_header;
 
     // File size
-    Fw::SerializeStatus serializeStatus = buffer.deserialize(header.m_fileSize);
+    Fw::SerializeStatus serializeStatus = buffer.deserializeTo(header.m_fileSize);
     if (serializeStatus != Fw::FW_SERIALIZE_OK) {
         this->m_events.fileInvalid(CmdSequencer_FileReadStage::DESER_SIZE, serializeStatus);
         return false;
@@ -153,21 +153,21 @@ bool CmdSequencerComponentImpl::FPrimeSequence ::deserializeHeader() {
         return false;
     }
     // Number of records
-    serializeStatus = buffer.deserialize(header.m_numRecords);
+    serializeStatus = buffer.deserializeTo(header.m_numRecords);
     if (serializeStatus != Fw::FW_SERIALIZE_OK) {
         this->m_events.fileInvalid(CmdSequencer_FileReadStage::DESER_NUM_RECORDS, serializeStatus);
         return false;
     }
     // Time base
     TimeBase tbase;
-    serializeStatus = buffer.deserialize(tbase);
+    serializeStatus = buffer.deserializeTo(tbase);
     if (serializeStatus != Fw::FW_SERIALIZE_OK) {
         this->m_events.fileInvalid(CmdSequencer_FileReadStage::DESER_TIME_BASE, serializeStatus);
         return false;
     }
     header.m_timeBase = (tbase);
     // Time context
-    serializeStatus = buffer.deserialize(header.m_timeContext);
+    serializeStatus = buffer.deserializeTo(header.m_timeContext);
     if (serializeStatus != Fw::FW_SERIALIZE_OK) {
         this->m_events.fileInvalid(CmdSequencer_FileReadStage::DESER_TIME_CONTEXT, serializeStatus);
         return false;
@@ -217,7 +217,7 @@ bool CmdSequencerComponentImpl::FPrimeSequence ::extractCRC() {
     Fw::SerializeStatus status = crcBuff.setBuffLen(crcSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     // Deserialize the CRC from the CRC buffer
-    status = crcBuff.deserialize(crc);
+    status = crcBuff.deserializeTo(crc);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     // Set the main buffer size to the data size
     status = buffer.setBuffLen(dataSize);
@@ -251,7 +251,7 @@ Fw::SerializeStatus CmdSequencerComponentImpl::FPrimeSequence ::deserializeDescr
     Fw::SerializeBufferBase& buffer = this->m_buffer;
     U8 descEntry;
 
-    Fw::SerializeStatus status = buffer.deserialize(descEntry);
+    Fw::SerializeStatus status = buffer.deserializeTo(descEntry);
     if (status != Fw::FW_SERIALIZE_OK) {
         return status;
     }
@@ -267,9 +267,9 @@ Fw::SerializeStatus CmdSequencerComponentImpl::FPrimeSequence ::deserializeDescr
 Fw::SerializeStatus CmdSequencerComponentImpl::FPrimeSequence ::deserializeTimeTag(Fw::Time& timeTag) {
     Fw::SerializeBufferBase& buffer = this->m_buffer;
     U32 seconds, useconds;
-    Fw::SerializeStatus status = buffer.deserialize(seconds);
+    Fw::SerializeStatus status = buffer.deserializeTo(seconds);
     if (status == Fw::FW_SERIALIZE_OK) {
-        status = buffer.deserialize(useconds);
+        status = buffer.deserializeTo(useconds);
     }
     if (status == Fw::FW_SERIALIZE_OK) {
         timeTag.set(seconds, useconds);
@@ -279,7 +279,7 @@ Fw::SerializeStatus CmdSequencerComponentImpl::FPrimeSequence ::deserializeTimeT
 
 Fw::SerializeStatus CmdSequencerComponentImpl::FPrimeSequence ::deserializeRecordSize(U32& recordSize) {
     Fw::SerializeBufferBase& buffer = this->m_buffer;
-    Fw::SerializeStatus status = buffer.deserialize(recordSize);
+    Fw::SerializeStatus status = buffer.deserializeTo(recordSize);
     if (status == Fw::FW_SERIALIZE_OK and recordSize > buffer.getBuffLeft()) {
         // Not enough data left
         status = Fw::FW_DESERIALIZE_SIZE_MISMATCH;
@@ -299,7 +299,7 @@ Fw::SerializeStatus CmdSequencerComponentImpl::FPrimeSequence ::copyCommand(Fw::
     FwSizeType size = recordSize;
     Fw::SerializeStatus status = comBuffer.setBuffLen(recordSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = buffer.deserialize(comBuffer.getBuffAddr(), size, Fw::Serialization::OMIT_LENGTH);
+    status = buffer.deserializeTo(comBuffer.getBuffAddr(), size, Fw::Serialization::OMIT_LENGTH);
     return status;
 }
 

--- a/Svc/CmdSequencer/formats/AMPCSSequence.cpp
+++ b/Svc/CmdSequencer/formats/AMPCSSequence.cpp
@@ -168,7 +168,7 @@ bool AMPCSSequence ::readCRC() {
 
 bool AMPCSSequence ::deserializeCRC() {
     bool status = true;
-    Fw::SerializeStatus serializeStatus = this->m_buffer.deserialize(this->m_crc.m_stored);
+    Fw::SerializeStatus serializeStatus = this->m_buffer.deserializeTo(this->m_crc.m_stored);
     if (serializeStatus != Fw::FW_SERIALIZE_OK) {
         this->m_events.fileInvalid(CmdSequencer_FileReadStage::READ_SEQ_CRC, serializeStatus);
         status = false;
@@ -338,7 +338,7 @@ Fw::SerializeStatus AMPCSSequence ::translateCommand(Fw::ComBuffer& comBuffer, c
     U8* const addr = comBuffer.getBuffAddr();
     FW_ASSERT(addr != nullptr);
     // true means "don't serialize the length"
-    status = buffer.deserialize(&addr[fixedBuffLen], size, Fw::Serialization::OMIT_LENGTH);
+    status = buffer.deserializeTo(&addr[fixedBuffLen], size, Fw::Serialization::OMIT_LENGTH);
     return status;
 }
 

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/CRCs.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/CRCs.cpp
@@ -78,7 +78,7 @@ void writeCRC(const U32 crc, const char* const fileName) {
     Os::File file;
     U8 buffer[sizeof crc];
     Fw::SerialBuffer serialBuffer(buffer, sizeof(buffer));
-    serialBuffer.serialize(crc);
+    serialBuffer.serializeFrom(crc);
     const U8* const addr = serialBuffer.getBuffAddr();
     Fw::String hashFileName(fileName);
     hashFileName += ".CRC32";

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/Headers.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/Headers.cpp
@@ -24,7 +24,7 @@ void serialize(Fw::SerializeBufferBase& buffer) {
 }
 
 void serialize(const U32 value, Fw::SerializeBufferBase& buffer) {
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serialize(value));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serializeFrom(value));
 }
 
 }  // namespace Headers

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/Records.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/AMPCS/Records.cpp
@@ -26,10 +26,10 @@ void serialize(const AMPCSSequence::Record::TimeFlag::t timeFlag,
     const AMPCSSequence::Record::TimeFlag::Serial::t serialTimeFlag = timeFlag;
     const AMPCSSequence::Record::CmdLength::t cmdLength = cmdField.getBuffLength();
     const U8* const addr = cmdField.getBuffAddr();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, dest.serialize(serialTimeFlag));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, dest.serialize(time));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, dest.serialize(cmdLength));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, dest.serialize(addr, cmdLength, Fw::Serialization::OMIT_LENGTH));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, dest.serializeFrom(serialTimeFlag));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, dest.serializeFrom(time));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, dest.serializeFrom(cmdLength));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, dest.serializeFrom(addr, cmdLength, Fw::Serialization::OMIT_LENGTH));
 }
 
 void serialize(const AMPCSSequence::Record::TimeFlag::t timeFlag,
@@ -38,8 +38,8 @@ void serialize(const AMPCSSequence::Record::TimeFlag::t timeFlag,
                const U32 argument,
                Fw::SerializeBufferBase& dest) {
     Fw::ComBuffer cmdField;
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, cmdField.serialize(opcode));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, cmdField.serialize(argument));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, cmdField.serializeFrom(opcode));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, cmdField.serializeFrom(argument));
     Records::serialize(timeFlag, time, cmdField, dest);
 }
 

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/DataAfterRecordsFile.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/DataAfterRecordsFile.cpp
@@ -44,8 +44,8 @@ void DataAfterRecordsFile ::serializeFPrime(Fw::SerializeBufferBase& buffer) {
     // EOS record
     FPrime::Records::serialize(CmdSequencerComponentImpl::Sequence::Record::END_OF_SEQUENCE, t, buffer);
     // Extra junk data
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serialize(static_cast<U32>(0x12345678)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serialize(static_cast<U32>(0x87654321)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serializeFrom(static_cast<U32>(0x12345678)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serializeFrom(static_cast<U32>(0x87654321)));
     // CRC
     FPrime::CRCs::serialize(buffer);
 }

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/FPrime/CRCs.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/FPrime/CRCs.cpp
@@ -24,7 +24,7 @@ void serialize(Fw::SerializeBufferBase& destBuffer) {
     crc.init();
     crc.update(destBuffer.getBuffAddr(), destBuffer.getBuffLength());
     crc.finalize();
-    ASSERT_EQ(destBuffer.serialize(crc.m_computed), Fw::FW_SERIALIZE_OK);
+    ASSERT_EQ(destBuffer.serializeFrom(crc.m_computed), Fw::FW_SERIALIZE_OK);
 }
 
 }  // namespace CRCs

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/FPrime/Headers.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/FPrime/Headers.cpp
@@ -24,10 +24,10 @@ void serialize(U32 dataSize,
                FwTimeBaseStoreType timeBase,
                FwTimeContextStoreType timeContext,
                Fw::SerializeBufferBase& destBuffer) {
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serialize(dataSize));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serialize(numRecords));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serialize(timeBase));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serialize(timeContext));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serializeFrom(dataSize));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serializeFrom(numRecords));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serializeFrom(timeBase));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serializeFrom(timeContext));
 }
 
 }  // namespace Headers

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/FPrime/Records.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/FPrime/Records.cpp
@@ -24,7 +24,7 @@ void serialize(Records::Descriptor desc,
                const Fw::ComBuffer& opcodeAndArgument,
                Fw::SerializeBufferBase& destBuffer) {
     const U8 descU8 = desc;
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serialize(descU8));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serializeFrom(descU8));
     if (desc != CmdSequencerComponentImpl::Sequence::Record::END_OF_SEQUENCE) {
         const U8* const buffAddr = opcodeAndArgument.getBuffAddr();
         const U32 size = opcodeAndArgument.getBuffLength();
@@ -32,11 +32,11 @@ void serialize(Records::Descriptor desc,
         const FwPacketDescriptorType cmdDescriptor = Fw::ComPacketType::FW_PACKET_COMMAND;
         const U32 seconds = time.getSeconds();
         const U32 uSeconds = time.getUSeconds();
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serialize(seconds));
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serialize(uSeconds));
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serialize(recSize));
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serialize(cmdDescriptor));
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serialize(buffAddr, size, Fw::Serialization::OMIT_LENGTH));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serializeFrom(seconds));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serializeFrom(uSeconds));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serializeFrom(recSize));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serializeFrom(cmdDescriptor));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, destBuffer.serializeFrom(buffAddr, size, Fw::Serialization::OMIT_LENGTH));
     }
 }
 
@@ -46,8 +46,8 @@ void serialize(Descriptor desc,
                const U32 argument,
                Fw::SerializeBufferBase& destBuffer) {
     Fw::ComBuffer opcodeAndArgument;
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, opcodeAndArgument.serialize(opcode));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, opcodeAndArgument.serialize(argument));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, opcodeAndArgument.serializeFrom(opcode));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, opcodeAndArgument.serializeFrom(argument));
     Records::serialize(desc, time, opcodeAndArgument, destBuffer);
 }
 

--- a/Svc/CmdSequencer/test/ut/SequenceFiles/SizeFieldTooLargeFile.cpp
+++ b/Svc/CmdSequencer/test/ut/SequenceFiles/SizeFieldTooLargeFile.cpp
@@ -35,13 +35,13 @@ void SizeFieldTooLargeFile ::serializeFPrime(Fw::SerializeBufferBase& buffer) {
     {
         // Descriptor
         const FPrime::Records::Descriptor descriptor = CmdSequencerComponentImpl::Sequence::Record::RELATIVE;
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serialize(static_cast<U8>(descriptor)));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serializeFrom(static_cast<U8>(descriptor)));
         // Seconds
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serialize(static_cast<U32>(0)));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serializeFrom(static_cast<U32>(0)));
         // Microseconds
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serialize(static_cast<U32>(0)));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serializeFrom(static_cast<U32>(0)));
         // Record size
-        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serialize(static_cast<U32>(2 * this->bufferSize)));
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, buffer.serializeFrom(static_cast<U32>(2 * this->bufferSize)));
     }
     // CRC
     FPrime::CRCs::serialize(buffer);

--- a/Svc/CmdSplitter/test/ut/CmdSplitterTester.cpp
+++ b/Svc/CmdSplitter/test/ut/CmdSplitterTester.cpp
@@ -30,18 +30,18 @@ CmdSplitterTester ::~CmdSplitterTester() {}
 
 Fw::ComBuffer CmdSplitterTester ::build_command_around_opcode(FwOpcodeType opcode) {
     Fw::ComBuffer comBuffer;
-    EXPECT_EQ(comBuffer.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_COMMAND)),
+    EXPECT_EQ(comBuffer.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_COMMAND)),
               Fw::FW_SERIALIZE_OK);
-    EXPECT_EQ(comBuffer.serialize(opcode), Fw::FW_SERIALIZE_OK);
+    EXPECT_EQ(comBuffer.serializeFrom(opcode), Fw::FW_SERIALIZE_OK);
 
     Fw::CmdArgBuffer args;
 
     U32 random_size = STest::Pick::lowerUpper(0, static_cast<U32>(args.getBuffCapacity()));
     args.resetSer();
     for (FwSizeType i = 0; i < random_size; i++) {
-        args.serialize(static_cast<U8>(STest::Pick::any()));
+        args.serializeFrom(static_cast<U8>(STest::Pick::any()));
     }
-    EXPECT_EQ(comBuffer.serialize(args), Fw::FW_SERIALIZE_OK);
+    EXPECT_EQ(comBuffer.serializeFrom(args), Fw::FW_SERIALIZE_OK);
     return comBuffer;
 }
 

--- a/Svc/ComLogger/ComLogger.cpp
+++ b/Svc/ComLogger/ComLogger.cpp
@@ -181,7 +181,7 @@ void ComLogger ::writeComBufferToFile(Fw::ComBuffer& data, U16 size) {
     if (this->m_storeBufferLength) {
         U8 buffer[sizeof(size)];
         Fw::SerialBuffer serialLength(&buffer[0], sizeof(size));
-        serialLength.serialize(size);
+        serialLength.serializeFrom(size);
         if (this->writeToFile(serialLength.getBuffAddr(), static_cast<U16>(serialLength.getBuffLength()))) {
             this->m_byteCount += static_cast<U32>(serialLength.getBuffLength());
         } else {

--- a/Svc/ComLogger/test/ut/ComLoggerTester.cpp
+++ b/Svc/ComLogger/test/ut/ComLoggerTester.cpp
@@ -149,7 +149,7 @@ void ComLoggerTester ::testLogging() {
             ASSERT_EQ(length, static_cast<FwSizeType>(sizeof(U16)));
             Fw::SerialBuffer comBuffLength(buf, length);
             comBuffLength.fill();
-            stat = comBuffLength.deserialize(bufferSize);
+            stat = comBuffLength.deserializeTo(bufferSize);
             ASSERT_EQ(stat, Fw::FW_SERIALIZE_OK);
             ASSERT_EQ(COM_BUFFER_LENGTH, bufferSize);
 
@@ -614,7 +614,7 @@ void ComLoggerTester ::testLoggingWithInit() {
             ASSERT_EQ(length, static_cast<FwSizeType>(sizeof(U16)));
             Fw::SerialBuffer comBuffLength(buf, length);
             comBuffLength.fill();
-            stat = comBuffLength.deserialize(bufferSize);
+            stat = comBuffLength.deserializeTo(bufferSize);
             ASSERT_EQ(stat, Fw::FW_SERIALIZE_OK);
             ASSERT_EQ(COM_BUFFER_LENGTH, bufferSize);
 

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -208,9 +208,9 @@ Fw::CmdResponse DpCatalog::loadStateFile() {
         // the source buffer was specifically sized to hold the data
 
         // Deserialize the file directory index
-        Fw::SerializeStatus status = entryBuffer.deserialize(this->m_stateFileData[entry].entry.dir);
+        Fw::SerializeStatus status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.dir);
         FW_ASSERT(Fw::FW_SERIALIZE_OK == status, status);
-        status = entryBuffer.deserialize(this->m_stateFileData[entry].entry.record);
+        status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.record);
         FW_ASSERT(Fw::FW_SERIALIZE_OK == status, status);
         this->m_stateFileData[entry].used = true;
         this->m_stateFileData[entry].visited = false;
@@ -274,10 +274,10 @@ void DpCatalog::pruneAndWriteStateFile() {
             // reset the buffer for serializing the entry
             entryBuffer.resetSer();
             // serialize the file directory index
-            Fw::SerializeStatus serStat = entryBuffer.serialize(this->m_stateFileData[entry].entry.dir);
+            Fw::SerializeStatus serStat = entryBuffer.serializeFrom(this->m_stateFileData[entry].entry.dir);
             // Should always fit
             FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, serStat);
-            serStat = entryBuffer.serialize(this->m_stateFileData[entry].entry.record);
+            serStat = entryBuffer.serializeFrom(this->m_stateFileData[entry].entry.record);
             // Should always fit
             FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, serStat);
             // write the entry
@@ -319,10 +319,10 @@ void DpCatalog::appendFileState(const DpStateEntry& entry) {
     // reset the buffer for serializing the entry
     entryBuffer.resetSer();
     // serialize the file directory index
-    Fw::SerializeStatus serStat = entryBuffer.serialize(entry.dir);
+    Fw::SerializeStatus serStat = entryBuffer.serializeFrom(entry.dir);
     // should fit
     FW_ASSERT(serStat == Fw::FW_SERIALIZE_OK, serStat);
-    serStat = entryBuffer.serialize(entry.record);
+    serStat = entryBuffer.serializeFrom(entry.record);
     // should fit
     FW_ASSERT(serStat == Fw::FW_SERIALIZE_OK, serStat);
     // write the entry

--- a/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
+++ b/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
@@ -171,7 +171,7 @@ void TestState ::action__BufferSendIn__InvalidHeaderHash() {
     // Perturb the header hash
     const U32 storedHash = computedHash + 1;
     Utils::HashBuffer storedHashBuffer;
-    const Fw::SerializeStatus serialStatus = storedHashBuffer.serialize(storedHash);
+    const Fw::SerializeStatus serialStatus = storedHashBuffer.serializeFrom(storedHash);
     ASSERT_EQ(serialStatus, Fw::FW_SERIALIZE_OK);
     container.setHeaderHash(storedHashBuffer);
     // Send the buffer

--- a/Svc/EventManager/EventManager.cpp
+++ b/Svc/EventManager/EventManager.cpp
@@ -110,7 +110,7 @@ void EventManager::loqQueue_internalInterfaceHandler(FwEventIdType id,
     this->m_logPacket.setTimeTag(timeTag);
     this->m_logPacket.setLogBuffer(args);
     this->m_comBuffer.resetSer();
-    Fw::SerializeStatus stat = this->m_logPacket.serialize(this->m_comBuffer);
+    Fw::SerializeStatus stat = this->m_logPacket.serializeTo(this->m_comBuffer);
     FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, static_cast<FwAssertArgType>(stat));
 
     if (this->isConnected_PktSend_OutputPort(0)) {

--- a/Svc/EventManager/test/ut/EventManagerTester.cpp
+++ b/Svc/EventManager/test/ut/EventManagerTester.cpp
@@ -55,7 +55,7 @@ void EventManagerTester::runWithFilters(Fw::LogSeverity filter) {
     U32 val = 10;
     FwEventIdType id = 29;
 
-    Fw::SerializeStatus stat = buff.serialize(val);
+    Fw::SerializeStatus stat = buff.serializeFrom(val);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     Fw::Time timeTag(TimeBase::TB_NONE, 0, 0);
     U32 cmdSeq = 21;
@@ -106,22 +106,22 @@ void EventManagerTester::runWithFilters(Fw::LogSeverity filter) {
     // verify contents
     // first piece should be log packet descriptor
     FwPacketDescriptorType desc;
-    stat = this->m_sentPacket.deserialize(desc);
+    stat = this->m_sentPacket.deserializeTo(desc);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(desc, static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_LOG));
     // next piece should be event ID
     FwEventIdType sentId;
-    stat = this->m_sentPacket.deserialize(sentId);
+    stat = this->m_sentPacket.deserializeTo(sentId);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(sentId, id);
     // next piece is time tag
     Fw::Time recTimeTag(TimeBase::TB_NONE, 0, 0);
-    stat = this->m_sentPacket.deserialize(recTimeTag);
+    stat = this->m_sentPacket.deserializeTo(recTimeTag);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_TRUE(timeTag == recTimeTag);
     // next piece is event argument
     U32 readVal;
-    stat = this->m_sentPacket.deserialize(readVal);
+    stat = this->m_sentPacket.deserializeTo(readVal);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(readVal, val);
     // packet should be empty
@@ -223,7 +223,7 @@ void EventManagerTester::runFilterIdNominal() {
         U32 val = 10;
         FwEventIdType id = filterID;
 
-        Fw::SerializeStatus stat = buff.serialize(val);
+        Fw::SerializeStatus stat = buff.serializeFrom(val);
         ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
         Fw::Time timeTag(TimeBase::TB_NONE, 0, 0);
 
@@ -243,7 +243,7 @@ void EventManagerTester::runFilterIdNominal() {
     U32 val = 10;
     FwEventIdType id = 1;
 
-    Fw::SerializeStatus stat = buff.serialize(val);
+    Fw::SerializeStatus stat = buff.serializeFrom(val);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     Fw::Time timeTag(TimeBase::TB_NONE, 0, 0);
 
@@ -356,7 +356,7 @@ void EventManagerTester::runEventFatal() {
     U32 cmdSeq = 21;
     REQUIREMENT("AL-004");
 
-    Fw::SerializeStatus stat = buff.serialize(val);
+    Fw::SerializeStatus stat = buff.serializeFrom(val);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     Fw::Time timeTag(TimeBase::TB_NONE, 0, 0);
 
@@ -376,22 +376,22 @@ void EventManagerTester::runEventFatal() {
     // verify contents
     // first piece should be log packet descriptor
     FwPacketDescriptorType desc;
-    stat = this->m_sentPacket.deserialize(desc);
+    stat = this->m_sentPacket.deserializeTo(desc);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(desc, static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_LOG));
     // next piece should be event ID
     FwEventIdType sentId;
-    stat = this->m_sentPacket.deserialize(sentId);
+    stat = this->m_sentPacket.deserializeTo(sentId);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(sentId, id);
     // next piece is time tag
     Fw::Time recTimeTag(TimeBase::TB_NONE, 0, 0);
-    stat = this->m_sentPacket.deserialize(recTimeTag);
+    stat = this->m_sentPacket.deserializeTo(recTimeTag);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_TRUE(timeTag == recTimeTag);
     // next piece is event argument
     U32 readVal;
-    stat = this->m_sentPacket.deserialize(readVal);
+    stat = this->m_sentPacket.deserializeTo(readVal);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(readVal, val);
     // packet should be empty
@@ -422,19 +422,19 @@ void EventManagerTester::runEventFatal() {
     ASSERT_TRUE(this->m_receivedPacket);
     // verify contents
     // first piece should be log packet descriptor
-    stat = this->m_sentPacket.deserialize(desc);
+    stat = this->m_sentPacket.deserializeTo(desc);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(desc, static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_LOG));
     // next piece should be event ID
-    stat = this->m_sentPacket.deserialize(sentId);
+    stat = this->m_sentPacket.deserializeTo(sentId);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(sentId, id);
     // next piece is time tag
-    stat = this->m_sentPacket.deserialize(recTimeTag);
+    stat = this->m_sentPacket.deserializeTo(recTimeTag);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_TRUE(timeTag == recTimeTag);
     // next piece is event argument
-    stat = this->m_sentPacket.deserialize(readVal);
+    stat = this->m_sentPacket.deserializeTo(readVal);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(readVal, val);
     // packet should be empty
@@ -453,7 +453,7 @@ void EventManagerTester::runEventFatal() {
 void EventManagerTester::writeEvent(FwEventIdType id, Fw::LogSeverity severity, U32 value) {
     Fw::LogBuffer buff;
 
-    Fw::SerializeStatus stat = buff.serialize(value);
+    Fw::SerializeStatus stat = buff.serializeFrom(value);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     Fw::Time timeTag(TimeBase::TB_NONE, 1, 2);
 
@@ -470,22 +470,22 @@ void EventManagerTester::writeEvent(FwEventIdType id, Fw::LogSeverity severity, 
     // verify contents
     // first piece should be log packet descriptor
     FwPacketDescriptorType desc;
-    stat = this->m_sentPacket.deserialize(desc);
+    stat = this->m_sentPacket.deserializeTo(desc);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(desc, static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_LOG));
     // next piece should be event ID
     FwEventIdType sentId;
-    stat = this->m_sentPacket.deserialize(sentId);
+    stat = this->m_sentPacket.deserializeTo(sentId);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(sentId, id);
     // next piece is time tag
     Fw::Time recTimeTag(TimeBase::TB_NONE, 1, 2);
-    stat = this->m_sentPacket.deserialize(recTimeTag);
+    stat = this->m_sentPacket.deserializeTo(recTimeTag);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_TRUE(timeTag == recTimeTag);
     // next piece is event argument
     U32 readVal;
-    stat = this->m_sentPacket.deserialize(readVal);
+    stat = this->m_sentPacket.deserializeTo(readVal);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
     ASSERT_EQ(readVal, value);
     // packet should be empty
@@ -512,14 +512,14 @@ void EventManagerTester::readEvent(FwEventIdType id, Fw::LogSeverity severity, U
     Fw::LogPacket packet;
     Fw::Time time(TimeBase::TB_NONE, 1, 2);
     Fw::LogBuffer logBuff;
-    ASSERT_EQ(comBuff.deserialize(packet), Fw::FW_SERIALIZE_OK);
+    ASSERT_EQ(comBuff.deserializeTo(packet), Fw::FW_SERIALIZE_OK);
 
     // read back values
     ASSERT_EQ(id, packet.getId());
     ASSERT_EQ(time, packet.getTimeTag());
     logBuff = packet.getLogBuffer();
     U32 readValue;
-    ASSERT_EQ(logBuff.deserialize(readValue), Fw::FW_SERIALIZE_OK);
+    ASSERT_EQ(logBuff.deserializeTo(readValue), Fw::FW_SERIALIZE_OK);
     ASSERT_EQ(value, readValue);
 }
 

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -361,7 +361,7 @@ void FileDownlink ::sendCancelPacket() {
 
     // Serialize the packet descriptor FW_PACKET_FILE to the buffer
     Fw::SerializeStatus status =
-        buffer.getSerializer().serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_FILE));
+        buffer.getSerializer().serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_FILE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType),
                             buffer.getSize() - static_cast<Fw::Buffer::SizeType>(sizeof(FwPacketDescriptorType)));
@@ -399,7 +399,7 @@ void FileDownlink ::sendFilePacket(const Fw::FilePacket& filePacket) {
     FW_ASSERT(this->m_buffer.getSize() >= bufferSize, static_cast<FwAssertArgType>(bufferSize),
               static_cast<FwAssertArgType>(this->m_buffer.getSize()));
     // Serialize packet descriptor FW_PACKET_FILE to the buffer
-    Fw::SerializeStatus status = this->m_buffer.getSerializer().serialize(
+    Fw::SerializeStatus status = this->m_buffer.getSerializer().serializeFrom(
         static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_FILE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // Serialize the filePacket content into the buffer, offset by the size of the packet descriptor

--- a/Svc/FileUplink/FileUplink.cpp
+++ b/Svc/FileUplink/FileUplink.cpp
@@ -46,7 +46,7 @@ void FileUplink ::bufferSendIn_handler(const FwIndexType portNum, Fw::Buffer& bu
 
     // Read the packet type from the packet buffer
     FwPacketDescriptorType packetType;
-    Fw::SerializeStatus status = buffer.getDeserializer().deserialize(packetType);
+    Fw::SerializeStatus status = buffer.getDeserializer().deserializeTo(packetType);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // If packet type is not a file packet, log + deallocate and return

--- a/Svc/FileUplink/test/ut/FileUplinkTester.cpp
+++ b/Svc/FileUplink/test/ut/FileUplinkTester.cpp
@@ -434,7 +434,7 @@ void FileUplinkTester ::sendFilePacket(const Fw::FilePacket& filePacket) {
 
     // Serialize the packet descriptor FW_PACKET_FILE to the buffer
     Fw::SerializeStatus status =
-        buffer.getSerializer().serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_FILE));
+        buffer.getSerializer().serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_FILE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // Serialize the filePacket content into the buffer after the packet descriptor token
     Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType),

--- a/Svc/FprimeDeframer/FprimeDeframer.cpp
+++ b/Svc/FprimeDeframer/FprimeDeframer.cpp
@@ -40,7 +40,7 @@ void FprimeDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, cons
     // ---------------- Validate Frame Header ----------------
     // Deserialize transmitted header into the header object
     auto deserializer = data.getDeserializer();
-    Fw::SerializeStatus status = header.deserialize(deserializer);
+    Fw::SerializeStatus status = header.deserializeFrom(deserializer);
     FW_ASSERT(status == Fw::SerializeStatus::FW_SERIALIZE_OK, status);
     // Check that deserialized start_word token matches expected value (default start_word value in the FPP object)
     const FprimeProtocol::FrameHeader defaultValue;
@@ -61,7 +61,7 @@ void FprimeDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, cons
     // If PacketDescriptor translates to an invalid APID, let it default to FW_PACKET_UNKNOWN
     // and let downstream components (e.g. custom router) handle it
     FwPacketDescriptorType packetDescriptor;
-    status = deserializer.deserialize(packetDescriptor);
+    status = deserializer.deserializeTo(packetDescriptor);
     FW_ASSERT(status == Fw::SerializeStatus::FW_SERIALIZE_OK, status);
     ComCfg::FrameContext contextCopy = context;
     // If a valid descriptor is deserialized, set it in the context
@@ -73,7 +73,7 @@ void FprimeDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, cons
     // Deserialize transmitted trailer: trailer is at offset = len(header) + len(body)
     status = deserializer.moveDeserToOffset(FprimeProtocol::FrameHeader::SERIALIZED_SIZE + header.get_lengthField());
     FW_ASSERT(status == Fw::SerializeStatus::FW_SERIALIZE_OK, status);
-    status = trailer.deserialize(deserializer);
+    status = trailer.deserializeFrom(deserializer);
     FW_ASSERT(status == Fw::SerializeStatus::FW_SERIALIZE_OK, status);
     // Compute CRC over the transmitted data (header + body)
     Utils::Hash hash;

--- a/Svc/FprimeFramer/FprimeFramer.cpp
+++ b/Svc/FprimeFramer/FprimeFramer.cpp
@@ -42,18 +42,18 @@ void FprimeFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const 
     // Serialize the header
     // 0xDEADBEEF is already set as the default value for the header startWord field in the FPP type definition
     header.set_lengthField(static_cast<FprimeProtocol::TokenType>(data.getSize()));
-    status = frameSerializer.serialize(header);
+    status = frameSerializer.serializeFrom(header);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Serialize the data
-    status = frameSerializer.serialize(data.getData(), data.getSize(), Fw::Serialization::OMIT_LENGTH);
+    status = frameSerializer.serializeFrom(data.getData(), data.getSize(), Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Serialize the trailer (with CRC computation)
     Utils::HashBuffer hashBuffer;
     Utils::Hash::hash(frameBuffer.getData(), frameSize - HASH_DIGEST_LENGTH, hashBuffer);
     trailer.set_crcField(hashBuffer.asBigEndianU32());
-    status = frameSerializer.serialize(trailer);
+    status = frameSerializer.serializeFrom(trailer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Send the full frame out - this port shall always be connected

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
@@ -69,7 +69,7 @@ void FprimeFramerTester ::testNominalFraming() {
     // Check header
     FprimeProtocol::FrameHeader defaultHeader;
     FprimeProtocol::FrameHeader outputHeader;
-    outputBuffer.getDeserializer().deserialize(outputHeader);
+    outputBuffer.getDeserializer().deserializeTo(outputHeader);
     ASSERT_EQ(outputHeader.get_startWord(), defaultHeader.get_startWord());
     ASSERT_EQ(outputHeader.get_lengthField(), sizeof(bufferData));
     // Check data

--- a/Svc/FprimeRouter/FprimeRouter.cpp
+++ b/Svc/FprimeRouter/FprimeRouter.cpp
@@ -53,7 +53,7 @@ void FprimeRouter ::dataIn_handler(FwIndexType portNum, Fw::Buffer& packetBuffer
                 Fw::Buffer packetBufferCopy = this->bufferAllocate_out(0, packetBuffer.getSize());
                 auto copySerializer = packetBufferCopy.getSerializer();
                 status = copySerializer.serializeFrom(packetBuffer.getData(), packetBuffer.getSize(),
-                                                  Fw::Serialization::OMIT_LENGTH);
+                                                      Fw::Serialization::OMIT_LENGTH);
                 FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
                 // Send the copied buffer out. It will come back on fileBufferReturnIn once the receiver is done with it
                 this->fileOut_out(0, packetBufferCopy);
@@ -69,7 +69,7 @@ void FprimeRouter ::dataIn_handler(FwIndexType portNum, Fw::Buffer& packetBuffer
                 Fw::Buffer packetBufferCopy = this->bufferAllocate_out(0, packetBuffer.getSize());
                 auto copySerializer = packetBufferCopy.getSerializer();
                 status = copySerializer.serializeFrom(packetBuffer.getData(), packetBuffer.getSize(),
-                                                  Fw::Serialization::OMIT_LENGTH);
+                                                      Fw::Serialization::OMIT_LENGTH);
                 FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
                 // Send the copied buffer out. It will come back on fileBufferReturnIn once the receiver is done with it
                 this->unknownDataOut_out(0, packetBufferCopy, context);

--- a/Svc/FprimeRouter/FprimeRouter.cpp
+++ b/Svc/FprimeRouter/FprimeRouter.cpp
@@ -52,7 +52,7 @@ void FprimeRouter ::dataIn_handler(FwIndexType portNum, Fw::Buffer& packetBuffer
                 // and FprimeRouter can handle the deallocation of the file buffer when it returns on fileBufferReturnIn
                 Fw::Buffer packetBufferCopy = this->bufferAllocate_out(0, packetBuffer.getSize());
                 auto copySerializer = packetBufferCopy.getSerializer();
-                status = copySerializer.serialize(packetBuffer.getData(), packetBuffer.getSize(),
+                status = copySerializer.serializeFrom(packetBuffer.getData(), packetBuffer.getSize(),
                                                   Fw::Serialization::OMIT_LENGTH);
                 FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
                 // Send the copied buffer out. It will come back on fileBufferReturnIn once the receiver is done with it
@@ -68,7 +68,7 @@ void FprimeRouter ::dataIn_handler(FwIndexType portNum, Fw::Buffer& packetBuffer
                 // and FprimeRouter can handle the deallocation of the unknown buffer when it returns on bufferReturnIn
                 Fw::Buffer packetBufferCopy = this->bufferAllocate_out(0, packetBuffer.getSize());
                 auto copySerializer = packetBufferCopy.getSerializer();
-                status = copySerializer.serialize(packetBuffer.getData(), packetBuffer.getSize(),
+                status = copySerializer.serializeFrom(packetBuffer.getData(), packetBuffer.getSize(),
                                                   Fw::Serialization::OMIT_LENGTH);
                 FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
                 // Send the copied buffer out. It will come back on fileBufferReturnIn once the receiver is done with it

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -41,17 +41,17 @@ void FpySequencer::handleDirectiveErrorCode(Fpy::DirectiveId id, DirectiveError 
 Fw::Success FpySequencer::sendCmd(FwOpcodeType opcode, const U8* argBuf, FwSizeType argBufSize) {
     Fw::ComBuffer cmdBuf;
     Fw::SerializeStatus stat =
-        cmdBuf.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_COMMAND));
+        cmdBuf.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_COMMAND));
     // TODO should I assert here? this really shouldn't fail, I should just add a static assert
     // on com buf size and then assert here
     if (stat != Fw::SerializeStatus::FW_SERIALIZE_OK) {
         return Fw::Success::FAILURE;
     }
-    stat = cmdBuf.serialize(opcode);
+    stat = cmdBuf.serializeFrom(opcode);
     if (stat != Fw::SerializeStatus::FW_SERIALIZE_OK) {
         return Fw::Success::FAILURE;
     }
-    stat = cmdBuf.serialize(argBuf, argBufSize, Fw::Serialization::OMIT_LENGTH);
+    stat = cmdBuf.serializeFrom(argBuf, argBufSize, Fw::Serialization::OMIT_LENGTH);
     if (stat != Fw::SerializeStatus::FW_SERIALIZE_OK) {
         return Fw::Success::FAILURE;
     }

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -162,7 +162,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
 
             // okay, it will fit. put it in
             status = argBuf.deserializeTo(deserializedDirective.constCmd.get_argBuf(), cmdArgBufSize,
-                                        Fw::Serialization::OMIT_LENGTH);
+                                          Fw::Serialization::OMIT_LENGTH);
 
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -87,7 +87,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         }
         case Fpy::DirectiveId::GOTO: {
             new (&deserializedDirective.gotoDirective) FpySequencer_GotoDirective();
-            status = argBuf.deserialize(deserializedDirective.gotoDirective);
+            status = argBuf.deserializeTo(deserializedDirective.gotoDirective);
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getBuffLeft() != 0) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
                                                                argBuf.getBuffLeft(), argBuf.getBuffLength());
@@ -97,7 +97,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         }
         case Fpy::DirectiveId::IF: {
             new (&deserializedDirective.ifDirective) FpySequencer_IfDirective();
-            status = argBuf.deserialize(deserializedDirective.ifDirective);
+            status = argBuf.deserializeTo(deserializedDirective.ifDirective);
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getBuffLeft() != 0) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
                                                                argBuf.getBuffLeft(), argBuf.getBuffLength());
@@ -118,7 +118,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         }
         case Fpy::DirectiveId::STORE_TLM_VAL: {
             new (&deserializedDirective.storeTlmVal) FpySequencer_StoreTlmValDirective();
-            status = argBuf.deserialize(deserializedDirective.storeTlmVal);
+            status = argBuf.deserializeTo(deserializedDirective.storeTlmVal);
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getBuffLeft() != 0) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
                                                                argBuf.getBuffLeft(), argBuf.getBuffLength());
@@ -128,7 +128,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         }
         case Fpy::DirectiveId::STORE_PRM: {
             new (&deserializedDirective.storePrm) FpySequencer_StorePrmDirective();
-            status = argBuf.deserialize(deserializedDirective.storePrm);
+            status = argBuf.deserializeTo(deserializedDirective.storePrm);
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getBuffLeft() != 0) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
                                                                argBuf.getBuffLeft(), argBuf.getBuffLength());
@@ -141,7 +141,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
 
             // first deserialize the opcode
             FwOpcodeType opcode;
-            status = argBuf.deserialize(opcode);
+            status = argBuf.deserializeTo(opcode);
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
                                                                argBuf.getBuffLeft(), argBuf.getBuffLength());
@@ -161,7 +161,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
             }
 
             // okay, it will fit. put it in
-            status = argBuf.deserialize(deserializedDirective.constCmd.get_argBuf(), cmdArgBufSize,
+            status = argBuf.deserializeTo(deserializedDirective.constCmd.get_argBuf(), cmdArgBufSize,
                                         Fw::Serialization::OMIT_LENGTH);
 
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
@@ -249,7 +249,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         }
         case Fpy::DirectiveId::ALLOCATE: {
             new (&deserializedDirective.allocate) FpySequencer_AllocateDirective();
-            status = argBuf.deserialize(deserializedDirective.allocate);
+            status = argBuf.deserializeTo(deserializedDirective.allocate);
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getBuffLeft() != 0) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
                                                                argBuf.getBuffLeft(), argBuf.getBuffLength());
@@ -259,7 +259,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         }
         case Fpy::DirectiveId::STORE: {
             new (&deserializedDirective.store) FpySequencer_StoreDirective();
-            status = argBuf.deserialize(deserializedDirective.store);
+            status = argBuf.deserializeTo(deserializedDirective.store);
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getBuffLeft() != 0) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
                                                                argBuf.getBuffLeft(), argBuf.getBuffLength());
@@ -269,7 +269,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         }
         case Fpy::DirectiveId::LOAD: {
             new (&deserializedDirective.load) FpySequencer_LoadDirective();
-            status = argBuf.deserialize(deserializedDirective.load);
+            status = argBuf.deserializeTo(deserializedDirective.load);
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getBuffLeft() != 0) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
                                                                argBuf.getBuffLeft(), argBuf.getBuffLength());
@@ -293,7 +293,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
 
             // okay, it will fit. put it in
             status =
-                argBuf.deserialize(deserializedDirective.pushVal.get_val(), bufSize, Fw::Serialization::OMIT_LENGTH);
+                argBuf.deserializeTo(deserializedDirective.pushVal.get_val(), bufSize, Fw::Serialization::OMIT_LENGTH);
 
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
@@ -310,7 +310,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         }
         case Fpy::DirectiveId::DISCARD: {
             new (&deserializedDirective.discard) FpySequencer_DiscardDirective();
-            status = argBuf.deserialize(deserializedDirective.discard);
+            status = argBuf.deserializeTo(deserializedDirective.discard);
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getBuffLeft() != 0) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
                                                                argBuf.getBuffLeft(), argBuf.getBuffLength());
@@ -320,7 +320,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         }
         case Fpy::DirectiveId::MEMCMP: {
             new (&deserializedDirective.memCmp) FpySequencer_MemCmpDirective();
-            status = argBuf.deserialize(deserializedDirective.memCmp);
+            status = argBuf.deserializeTo(deserializedDirective.memCmp);
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getBuffLeft() != 0) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
                                                                argBuf.getBuffLeft(), argBuf.getBuffLength());
@@ -330,7 +330,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         }
         case Fpy::DirectiveId::STACK_CMD: {
             new (&deserializedDirective.stackCmd) FpySequencer_StackCmdDirective();
-            status = argBuf.deserialize(deserializedDirective.stackCmd);
+            status = argBuf.deserializeTo(deserializedDirective.stackCmd);
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getBuffLeft() != 0) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
                                                                argBuf.getBuffLeft(), argBuf.getBuffLength());

--- a/Svc/FpySequencer/FpySequencerValidationState.cpp
+++ b/Svc/FpySequencer/FpySequencerValidationState.cpp
@@ -104,7 +104,7 @@ Fw::Success FpySequencer::validate() {
 
 Fw::Success FpySequencer::readHeader() {
     // deser header
-    Fw::SerializeStatus deserStatus = this->m_sequenceBuffer.deserialize(this->m_sequenceObj.get_header());
+    Fw::SerializeStatus deserStatus = this->m_sequenceBuffer.deserializeTo(this->m_sequenceObj.get_header());
     if (deserStatus != Fw::SerializeStatus::FW_SERIALIZE_OK) {
         this->log_WARNING_HI_FileReadDeserializeError(
             FpySequencer_FileReadStage::HEADER, this->m_sequenceFilePath, static_cast<I32>(deserStatus),
@@ -140,7 +140,7 @@ Fw::Success FpySequencer::readBody() {
     for (U8 argMappingIdx = 0; argMappingIdx < this->m_sequenceObj.get_header().get_argumentCount(); argMappingIdx++) {
         // serializable register index of arg $argMappingIdx
         // TODO should probably check that this serReg is inside range
-        deserStatus = this->m_sequenceBuffer.deserialize(this->m_sequenceObj.get_args()[argMappingIdx]);
+        deserStatus = this->m_sequenceBuffer.deserializeTo(this->m_sequenceObj.get_args()[argMappingIdx]);
         if (deserStatus != Fw::FW_SERIALIZE_OK) {
             this->log_WARNING_HI_FileReadDeserializeError(
                 FpySequencer_FileReadStage::BODY, this->m_sequenceFilePath, static_cast<I32>(deserStatus),
@@ -152,7 +152,7 @@ Fw::Success FpySequencer::readBody() {
     // deser statements
     for (U16 statementIdx = 0; statementIdx < this->m_sequenceObj.get_header().get_statementCount(); statementIdx++) {
         // deser statement
-        deserStatus = this->m_sequenceBuffer.deserialize(this->m_sequenceObj.get_statements()[statementIdx]);
+        deserStatus = this->m_sequenceBuffer.deserializeTo(this->m_sequenceObj.get_statements()[statementIdx]);
         if (deserStatus != Fw::FW_SERIALIZE_OK) {
             this->log_WARNING_HI_FileReadDeserializeError(
                 FpySequencer_FileReadStage::BODY, this->m_sequenceFilePath, static_cast<I32>(deserStatus),
@@ -164,7 +164,7 @@ Fw::Success FpySequencer::readBody() {
 }
 
 Fw::Success FpySequencer::readFooter() {
-    Fw::SerializeStatus deserStatus = this->m_sequenceBuffer.deserialize(this->m_sequenceObj.get_footer());
+    Fw::SerializeStatus deserStatus = this->m_sequenceBuffer.deserializeTo(this->m_sequenceObj.get_footer());
     if (deserStatus != Fw::FW_SERIALIZE_OK) {
         this->log_WARNING_HI_FileReadDeserializeError(
             FpySequencer_FileReadStage::FOOTER, this->m_sequenceFilePath, static_cast<I32>(deserStatus),

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -201,9 +201,9 @@ TEST_F(FpySequencerTester, cmd) {
     ASSERT_EQ(result, Signal::stmtResponse_keepWaiting);
 
     Fw::ComBuffer expected;
-    ASSERT_EQ(expected.serialize(Fw::ComPacketType::FW_PACKET_COMMAND), Fw::SerializeStatus::FW_SERIALIZE_OK);
-    ASSERT_EQ(expected.serialize(directive.get_opCode()), Fw::SerializeStatus::FW_SERIALIZE_OK);
-    ASSERT_EQ(expected.serialize(data, sizeof(data), Fw::Serialization::OMIT_LENGTH),
+    ASSERT_EQ(expected.serializeFrom(Fw::ComPacketType::FW_PACKET_COMMAND), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(expected.serializeFrom(directive.get_opCode()), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(expected.serializeFrom(data, sizeof(data), Fw::Serialization::OMIT_LENGTH),
               Fw::SerializeStatus::FW_SERIALIZE_OK);
     ASSERT_from_cmdOut_SIZE(1);
     ASSERT_from_cmdOut(0, expected, 0);
@@ -1272,7 +1272,7 @@ TEST_F(FpySequencerTester, readHeader) {
     header.set_schemaVersion(Fpy::SCHEMA_VERSION);
     header.set_statementCount(Fpy::MAX_SEQUENCE_STATEMENT_COUNT);
 
-    ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serialize(header), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serializeFrom(header), Fw::SerializeStatus::FW_SERIALIZE_OK);
 
     ASSERT_EQ(tester_readHeader(), Fw::Success::SUCCESS);
     ASSERT_EQ(tester_get_m_sequenceObj_ptr()->get_header(), header);
@@ -1286,7 +1286,7 @@ TEST_F(FpySequencerTester, readHeader) {
     // check wrong schema version
     tester_get_m_sequenceBuffer_ptr()->resetSer();
     header.set_schemaVersion(Fpy::SCHEMA_VERSION + 1);
-    ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serialize(header), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serializeFrom(header), Fw::SerializeStatus::FW_SERIALIZE_OK);
     ASSERT_EQ(tester_readHeader(), Fw::Success::FAILURE);
     ASSERT_EVENTS_WrongSchemaVersion_SIZE(1);
     header.set_schemaVersion(Fpy::SCHEMA_VERSION);
@@ -1295,7 +1295,7 @@ TEST_F(FpySequencerTester, readHeader) {
     // check too many args
     tester_get_m_sequenceBuffer_ptr()->resetSer();
     header.set_argumentCount(Fpy::MAX_SEQUENCE_ARG_COUNT + 1);
-    ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serialize(header), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serializeFrom(header), Fw::SerializeStatus::FW_SERIALIZE_OK);
     ASSERT_EQ(tester_readHeader(), Fw::Success::FAILURE);
     ASSERT_EVENTS_TooManySequenceArgs_SIZE(1);
     header.set_argumentCount(Fpy::MAX_SEQUENCE_ARG_COUNT);
@@ -1303,7 +1303,7 @@ TEST_F(FpySequencerTester, readHeader) {
     // check too many stmts
     tester_get_m_sequenceBuffer_ptr()->resetSer();
     header.set_statementCount(Fpy::MAX_SEQUENCE_STATEMENT_COUNT + 1);
-    ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serialize(header), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serializeFrom(header), Fw::SerializeStatus::FW_SERIALIZE_OK);
     ASSERT_EQ(tester_readHeader(), Fw::Success::FAILURE);
     ASSERT_EVENTS_TooManySequenceStatements_SIZE(1);
 }
@@ -1315,13 +1315,13 @@ TEST_F(FpySequencerTester, readBody) {
     // write some args mappings
     for (U32 ii = 0; ii < Fpy::MAX_SEQUENCE_ARG_COUNT; ii++) {
         // map arg idx ii to serReg pos 123
-        ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serialize(static_cast<U8>(123)),
+        ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serializeFrom(static_cast<U8>(123)),
                   Fw::SerializeStatus::FW_SERIALIZE_OK);
     }
     // write some statements
     Fpy::Statement stmt(Fpy::DirectiveId::NO_OP, Fw::StatementArgBuffer());
     for (U32 ii = 0; ii < Fpy::MAX_SEQUENCE_STATEMENT_COUNT; ii++) {
-        ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serialize(stmt), Fw::SerializeStatus::FW_SERIALIZE_OK);
+        ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serializeFrom(stmt), Fw::SerializeStatus::FW_SERIALIZE_OK);
     }
     tester_get_m_sequenceObj_ptr()->get_header().set_argumentCount(Fpy::MAX_SEQUENCE_ARG_COUNT);
     tester_get_m_sequenceObj_ptr()->get_header().set_statementCount(Fpy::MAX_SEQUENCE_STATEMENT_COUNT);
@@ -1341,7 +1341,7 @@ TEST_F(FpySequencerTester, readBody) {
     // now see what happens if we don't write enough args
     for (U32 ii = 0; ii < Fpy::MAX_SEQUENCE_ARG_COUNT - 1; ii++) {
         // map arg idx ii to serReg pos 123
-        ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serialize(static_cast<U8>(123)),
+        ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serializeFrom(static_cast<U8>(123)),
                   Fw::SerializeStatus::FW_SERIALIZE_OK);
     }
     // don't write any stmts otherwise their bytes will be interpreted as arg mappings and it will trigger
@@ -1354,12 +1354,12 @@ TEST_F(FpySequencerTester, readBody) {
     tester_get_m_sequenceObj_ptr()->get_header().set_statementCount(Fpy::MAX_SEQUENCE_STATEMENT_COUNT);
     for (U32 ii = 0; ii < Fpy::MAX_SEQUENCE_ARG_COUNT; ii++) {
         // map arg idx ii to serReg pos 123
-        ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serialize(static_cast<U8>(123)),
+        ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serializeFrom(static_cast<U8>(123)),
                   Fw::SerializeStatus::FW_SERIALIZE_OK);
     }
     // the -1 here is the intended mistake
     for (U32 ii = 0; ii < Fpy::MAX_SEQUENCE_STATEMENT_COUNT - 1; ii++) {
-        ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serialize(stmt), Fw::SerializeStatus::FW_SERIALIZE_OK);
+        ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serializeFrom(stmt), Fw::SerializeStatus::FW_SERIALIZE_OK);
     }
     ASSERT_EQ(tester_readBody(), Fw::Success::FAILURE);
 }
@@ -1371,7 +1371,7 @@ TEST_F(FpySequencerTester, readFooter) {
 
     tester_set_m_computedCRC(0x12345678);
     Fpy::Footer footer(static_cast<U32>(~0x12345678));
-    ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serialize(footer), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(tester_get_m_sequenceBuffer_ptr()->serializeFrom(footer), Fw::SerializeStatus::FW_SERIALIZE_OK);
 
     ASSERT_EQ(tester_readFooter(), Fw::Success::SUCCESS);
     ASSERT_EQ(tester_get_m_sequenceObj_ptr()->get_footer(), footer);
@@ -1545,7 +1545,7 @@ TEST_F(FpySequencerTester, deserialize_waitRel) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.waitRel, waitRel);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
@@ -1564,7 +1564,7 @@ TEST_F(FpySequencerTester, deserialize_waitAbs) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.waitAbs, waitAbs);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
@@ -1584,7 +1584,7 @@ TEST_F(FpySequencerTester, deserialize_goto) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.gotoDirective, gotoDir);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
@@ -1604,7 +1604,7 @@ TEST_F(FpySequencerTester, deserialize_if) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.ifDirective, ifDir);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
@@ -1624,7 +1624,7 @@ TEST_F(FpySequencerTester, deserialize_noOp) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.noOp, noOp);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
@@ -1643,7 +1643,7 @@ TEST_F(FpySequencerTester, deserialize_storeTlmVal) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.storeTlmVal, dir);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
@@ -1663,7 +1663,7 @@ TEST_F(FpySequencerTester, deserialize_storePrm) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.storePrm, dir);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
@@ -1683,7 +1683,7 @@ TEST_F(FpySequencerTester, deserialize_stackOp) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.stackOp, dir);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     // caught two bugs (one here, and it reminded me of this somewhere else)
     ASSERT_EQ(result, Fw::Success::FAILURE);
@@ -1704,7 +1704,7 @@ TEST_F(FpySequencerTester, deserialize_exit) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.exit, dir);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
@@ -1724,7 +1724,7 @@ TEST_F(FpySequencerTester, deserialize_discard) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.discard, dir);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
@@ -1744,7 +1744,7 @@ TEST_F(FpySequencerTester, deserialize_stackCmd) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.stackCmd, dir);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
@@ -1764,7 +1764,7 @@ TEST_F(FpySequencerTester, deserialize_memCmp) {
     ASSERT_EQ(result, Fw::Success::SUCCESS);
     ASSERT_EQ(actual.memCmp, dir);
     // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serialize(123);
+    seq.get_statements()[0].get_argBuf().serializeFrom(123);
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);

--- a/Svc/FpySequencer/test/ut/FpySequencerTestSequences.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestSequences.cpp
@@ -25,7 +25,7 @@ TEST_F(FpySequencerTester, ComplexControlFlow) {
     allocMem();
 
     nextTlmId = 123;
-    ASSERT_EQ(nextTlmValue.serialize(true), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(nextTlmValue.serializeFrom(true), Fw::SerializeStatus::FW_SERIALIZE_OK);
     add_ALLOCATE(1);
     add_STORE_TLM_VAL(123, 0);
     add_LOAD(0, 1);
@@ -43,7 +43,7 @@ TEST_F(FpySequencerTester, ComplexControlFlow) {
     ASSERT_EQ(tester_get_m_tlm_ptr()->lastDirectiveError, DirectiveError::NO_ERROR);
     ASSERT_EQ(tester_get_m_statementsDispatched(), 6);
     nextTlmValue.resetSer();
-    nextTlmValue.serialize(false);
+    nextTlmValue.serializeFrom(false);
     tester_set_m_statementsDispatched(0);
     writeAndRun();
     dispatchUntilState(State::IDLE);
@@ -54,7 +54,7 @@ TEST_F(FpySequencerTester, OrOfTlmAndReg) {
     allocMem();
 
     nextTlmId = 123;
-    ASSERT_EQ(nextTlmValue.serialize(true), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(nextTlmValue.serializeFrom(true), Fw::SerializeStatus::FW_SERIALIZE_OK);
     add_ALLOCATE(1);
     add_STORE_TLM_VAL(123, 0);
     add_LOAD(0, 1);
@@ -75,7 +75,7 @@ TEST_F(FpySequencerTester, OrOfTlmAndReg) {
     ASSERT_EQ(tester_get_m_tlm_ptr()->lastDirectiveError, DirectiveError::NO_ERROR);
     ASSERT_EQ(tester_get_m_statementsDispatched(), 8);
     nextTlmValue.resetSer();
-    nextTlmValue.serialize(false);
+    nextTlmValue.serializeFrom(false);
     tester_set_m_statementsDispatched(0);
     writeAndRun();
     dispatchUntilState(State::IDLE);
@@ -86,7 +86,7 @@ TEST_F(FpySequencerTester, CmpIntTlm) {
     allocMem();
 
     nextTlmId = 123;
-    ASSERT_EQ(nextTlmValue.serialize(static_cast<U64>(999)), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(nextTlmValue.serializeFrom(static_cast<U64>(999)), Fw::SerializeStatus::FW_SERIALIZE_OK);
     add_ALLOCATE(8);
     add_STORE_TLM_VAL(123, 0);
     add_LOAD(0, 8);
@@ -109,7 +109,7 @@ TEST_F(FpySequencerTester, CmpIntTlm) {
     ASSERT_EQ(tester_get_m_statementsDispatched(), 8);
     nextTlmValue.resetSer();
     // should fail if tlm is 998
-    nextTlmValue.serialize(static_cast<U64>(998));
+    nextTlmValue.serializeFrom(static_cast<U64>(998));
     tester_set_m_statementsDispatched(0);
     writeAndRun();
     dispatchUntilState(State::IDLE);

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
@@ -64,20 +64,20 @@ void FpySequencerTester::writeToFile(const char* name, FwSizeType maxBytes) {
     // first let's calculate the size of the body. do this by just writing the body,
     // then calculating how big that was, then clearing and writing the header, then writing the body again
     for (U32 ii = 0; ii < seq.get_header().get_argumentCount(); ii++) {
-        ASSERT_EQ(buf.serialize(seq.get_args()[ii]), Fw::SerializeStatus::FW_SERIALIZE_OK);
+        ASSERT_EQ(buf.serializeFrom(seq.get_args()[ii]), Fw::SerializeStatus::FW_SERIALIZE_OK);
     }
     for (U32 ii = 0; ii < seq.get_header().get_statementCount(); ii++) {
-        ASSERT_EQ(buf.serialize(seq.get_statements()[ii]), Fw::SerializeStatus::FW_SERIALIZE_OK);
+        ASSERT_EQ(buf.serializeFrom(seq.get_statements()[ii]), Fw::SerializeStatus::FW_SERIALIZE_OK);
     }
     seq.get_header().set_bodySize(static_cast<U32>(buf.getBuffLength()));
     buf.resetSer();
 
-    ASSERT_EQ(buf.serialize(seq.get_header()), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(buf.serializeFrom(seq.get_header()), Fw::SerializeStatus::FW_SERIALIZE_OK);
     for (U32 ii = 0; ii < seq.get_header().get_argumentCount(); ii++) {
-        ASSERT_EQ(buf.serialize(seq.get_args()[ii]), Fw::SerializeStatus::FW_SERIALIZE_OK);
+        ASSERT_EQ(buf.serializeFrom(seq.get_args()[ii]), Fw::SerializeStatus::FW_SERIALIZE_OK);
     }
     for (U32 ii = 0; ii < seq.get_header().get_statementCount(); ii++) {
-        ASSERT_EQ(buf.serialize(seq.get_statements()[ii]), Fw::SerializeStatus::FW_SERIALIZE_OK);
+        ASSERT_EQ(buf.serializeFrom(seq.get_statements()[ii]), Fw::SerializeStatus::FW_SERIALIZE_OK);
     }
 
     U32 crc = FpySequencer::CRC_INITIAL_VALUE;
@@ -85,7 +85,7 @@ void FpySequencerTester::writeToFile(const char* name, FwSizeType maxBytes) {
 
     seq.get_footer().set_crc(~crc);
 
-    ASSERT_EQ(buf.serialize(seq.get_footer()), Fw::SerializeStatus::FW_SERIALIZE_OK);
+    ASSERT_EQ(buf.serializeFrom(seq.get_footer()), Fw::SerializeStatus::FW_SERIALIZE_OK);
 
     FwSizeType intendedWriteSize = buf.getBuffLength();
     if (intendedWriteSize > maxBytes) {
@@ -143,7 +143,7 @@ void FpySequencerTester::add_GOTO(U32 stmtIdx) {
 
 void FpySequencerTester::add_GOTO(FpySequencer_GotoDirective dir) {
     Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serialize(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::GOTO, buf);
 }
 
@@ -153,7 +153,7 @@ void FpySequencerTester::add_IF(U32 gotoIfFalse) {
 
 void FpySequencerTester::add_IF(FpySequencer_IfDirective dir) {
     Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serialize(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::IF, buf);
 }
 
@@ -168,7 +168,7 @@ void FpySequencerTester::add_STORE_TLM_VAL(FwChanIdType id, Fpy::StackSizeType l
 
 void FpySequencerTester::add_STORE_TLM_VAL(FpySequencer_StoreTlmValDirective dir) {
     Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serialize(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::STORE_TLM_VAL, buf);
 }
 
@@ -178,7 +178,7 @@ void FpySequencerTester::add_STORE_PRM(FwPrmIdType id, Fpy::StackSizeType lvarOf
 
 void FpySequencerTester::add_STORE_PRM(FpySequencer_StorePrmDirective dir) {
     Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serialize(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::STORE_PRM, buf);
 }
 
@@ -188,8 +188,8 @@ void FpySequencerTester::add_CONST_CMD(FwOpcodeType opcode) {
 
 void FpySequencerTester::add_CONST_CMD(FpySequencer_ConstCmdDirective dir) {
     Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serialize(dir.get_opCode()) == Fw::SerializeStatus::FW_SERIALIZE_OK);
-    FW_ASSERT(buf.serialize(dir.get_argBuf(), dir.get__argBufSize(), Fw::Serialization::OMIT_LENGTH) ==
+    FW_ASSERT(buf.serializeFrom(dir.get_opCode()) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serializeFrom(dir.get_argBuf(), dir.get__argBufSize(), Fw::Serialization::OMIT_LENGTH) ==
               Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::CONST_CMD, buf);
 }
@@ -208,7 +208,7 @@ void FpySequencerTester::add_ALLOCATE(Fpy::StackSizeType size) {
 }
 void FpySequencerTester::add_ALLOCATE(FpySequencer_AllocateDirective dir) {
     Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serialize(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::ALLOCATE, buf);
 }
 void FpySequencerTester::add_STORE(Fpy::StackSizeType lvarOffset, Fpy::StackSizeType size) {
@@ -216,7 +216,7 @@ void FpySequencerTester::add_STORE(Fpy::StackSizeType lvarOffset, Fpy::StackSize
 }
 void FpySequencerTester::add_STORE(FpySequencer_StoreDirective dir) {
     Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serialize(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::STORE, buf);
 }
 void FpySequencerTester::add_LOAD(Fpy::StackSizeType lvarOffset, Fpy::StackSizeType size) {
@@ -224,7 +224,7 @@ void FpySequencerTester::add_LOAD(Fpy::StackSizeType lvarOffset, Fpy::StackSizeT
 }
 void FpySequencerTester::add_LOAD(FpySequencer_LoadDirective dir) {
     Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serialize(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::LOAD, buf);
 }
 template <typename T>
@@ -247,7 +247,7 @@ void FpySequencerTester::add_DISCARD(Fpy::StackSizeType size) {
 }
 void FpySequencerTester::add_DISCARD(FpySequencer_DiscardDirective dir) {
     Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serialize(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::DISCARD, buf);
 }
 void FpySequencerTester::add_STACK_CMD(Fpy::StackSizeType size) {
@@ -255,7 +255,7 @@ void FpySequencerTester::add_STACK_CMD(Fpy::StackSizeType size) {
 }
 void FpySequencerTester::add_STACK_CMD(FpySequencer_StackCmdDirective dir) {
     Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serialize(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::STACK_CMD, buf);
 }
 void FpySequencerTester::add_MEMCMP(Fpy::StackSizeType size) {
@@ -263,7 +263,7 @@ void FpySequencerTester::add_MEMCMP(Fpy::StackSizeType size) {
 }
 void FpySequencerTester::add_MEMCMP(FpySequencer_MemCmpDirective dir) {
     Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serialize(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::MEMCMP, buf);
 }
 //! Handle a text event

--- a/Svc/FrameAccumulator/FrameDetector/CcsdsTcFrameDetector.cpp
+++ b/Svc/FrameAccumulator/FrameDetector/CcsdsTcFrameDetector.cpp
@@ -34,7 +34,7 @@ FrameDetector::Status CcsdsTcFrameDetector::detect(const Types::CircularBuffer& 
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Attempt to deserialize data into the FrameHeader object
     Ccsds::TCHeader header;
-    status = header.deserialize(header_ser_buffer);
+    status = header.deserializeFrom(header_ser_buffer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     if (header.get_flagsAndScId() != this->m_expectedFlagsAndScIdToken) {
@@ -72,7 +72,7 @@ FrameDetector::Status CcsdsTcFrameDetector::detect(const Types::CircularBuffer& 
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Attempt to deserialize data into the FrameTrailer object
     Ccsds::TCTrailer trailer;
-    status = trailer.deserialize(trailer_ser_buffer);
+    status = trailer.deserializeFrom(trailer_ser_buffer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     U16 transmitted_fecf = trailer.get_fecf();
     if (transmitted_fecf != computed_fecf) {

--- a/Svc/FrameAccumulator/FrameDetector/FprimeFrameDetector.cpp
+++ b/Svc/FrameAccumulator/FrameDetector/FprimeFrameDetector.cpp
@@ -40,7 +40,7 @@ FrameDetector::Status FprimeFrameDetector::detect(const Types::CircularBuffer& d
     status = header_ser_buffer.setBuffLen(FprimeProtocol::FrameHeader::SERIALIZED_SIZE);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Attempt to deserialize data into the FrameHeader object
-    status = header.deserialize(header_ser_buffer);
+    status = header.deserializeFrom(header_ser_buffer);
     if (status != Fw::FW_SERIALIZE_OK) {
         return Status::NO_FRAME_DETECTED;
     }
@@ -69,7 +69,7 @@ FrameDetector::Status FprimeFrameDetector::detect(const Types::CircularBuffer& d
     status = trailer_ser_buffer.setBuffLen(FprimeProtocol::FrameTrailer::SERIALIZED_SIZE);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Deserialize trailer from circular buffer (peeked data) into trailer object
-    status = trailer.deserialize(trailer_ser_buffer);
+    status = trailer.deserializeFrom(trailer_ser_buffer);
     if (status != Fw::FW_SERIALIZE_OK) {
         return Status::NO_FRAME_DETECTED;
     }

--- a/Svc/FrameAccumulator/test/ut/detectors/CcsdsTcFrameDetectorTestMain.cpp
+++ b/Svc/FrameAccumulator/test/ut/detectors/CcsdsTcFrameDetectorTestMain.cpp
@@ -54,7 +54,7 @@ FwSizeType generate_random_tc_frame(Types::CircularBuffer& circular_buffer) {
 
     U8 frame_header[TCHeader::SERIALIZED_SIZE];
     Fw::ExternalSerializeBuffer header_ser_buffer(frame_header, TCHeader::SERIALIZED_SIZE);
-    tcHeader.serialize(header_ser_buffer);
+    tcHeader.serializeTo(header_ser_buffer);
 
     // Serialize header and packet data into the circular buffer
     circular_buffer.serialize(frame_header, TCHeader::SERIALIZED_SIZE);
@@ -72,7 +72,7 @@ FwSizeType generate_random_tc_frame(Types::CircularBuffer& circular_buffer) {
         crc.update(byte);
     }
     tcTrailer.set_fecf(crc.finalize());
-    tcTrailer.serialize(trailer_ser_buffer);
+    tcTrailer.serializeTo(trailer_ser_buffer);
     // Serialize trailer into the circular buffer
     circular_buffer.serialize(frame_trailer, TCTrailer::SERIALIZED_SIZE);
     return total_frame_size;

--- a/Svc/FramingProtocol/FprimeProtocol.cpp
+++ b/Svc/FramingProtocol/FprimeProtocol.cpp
@@ -32,20 +32,20 @@ void FprimeFraming::frame(const U8* const data, const U32 size, Fw::ComPacketTyp
 
     // Serialize start word
     Fw::SerializeStatus status;
-    status = serializer.serialize(FpFrameHeader::START_WORD);
+    status = serializer.serializeFrom(FpFrameHeader::START_WORD);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Serialize data size
-    status = serializer.serialize(size);
+    status = serializer.serializeFrom(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Serialize data
-    status = serializer.serialize(data, size, Fw::Serialization::OMIT_LENGTH);  // Serialize without length
+    status = serializer.serializeFrom(data, size, Fw::Serialization::OMIT_LENGTH);  // Serialize without length
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     // Calculate and add transmission hash
     Utils::Hash::hash(buffer.getData(), static_cast<FwSizeType>(totalSize - HASH_DIGEST_LENGTH), hash);
-    status = serializer.serialize(hash.getBuffAddr(), HASH_DIGEST_LENGTH, Fw::Serialization::OMIT_LENGTH);
+    status = serializer.serializeFrom(hash.getBuffAddr(), HASH_DIGEST_LENGTH, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
     buffer.setSize(totalSize);

--- a/Svc/FramingProtocol/test/ut/DeframingTester.cpp
+++ b/Svc/FramingProtocol/test/ut/DeframingTester.cpp
@@ -42,7 +42,7 @@ void DeframingTester ::serializeTokenType(FpFrameHeader::TokenType v) {
     U8 buffer[sizeof v];
     Fw::SerialBuffer sb(buffer, sizeof buffer);
     {
-        const Fw::SerializeStatus status = sb.serialize(v);
+        const Fw::SerializeStatus status = sb.serializeFrom(v);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     }
     {
@@ -57,15 +57,15 @@ Fw::ByteArray DeframingTester ::constructRandomFrame(U32 packetSize) {
     Fw::SerialBuffer sb(this->frameData, sizeof this->frameData);
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     // Serialize the start word
-    status = sb.serialize(Svc::FpFrameHeader::START_WORD);
+    status = sb.serializeFrom(Svc::FpFrameHeader::START_WORD);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // Serialize the packet size
-    status = sb.serialize(static_cast<FpFrameHeader::TokenType>(packetSize));
+    status = sb.serializeFrom(static_cast<FpFrameHeader::TokenType>(packetSize));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     // Construct the packet data
     for (U32 i = 0; i < packetSize; ++i) {
         const U8 byte = static_cast<U8>(STest::Pick::lowerUpper(0, 0xFF));
-        status = sb.serialize(byte);
+        status = sb.serializeFrom(byte);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
     }
     const FwSizeType buffLength = sb.getBuffLength();

--- a/Svc/FramingProtocol/test/ut/FramingTester.cpp
+++ b/Svc/FramingProtocol/test/ut/FramingTester.cpp
@@ -58,7 +58,7 @@ FpFrameHeader::TokenType FramingTester ::getPacketSize() {
     FpFrameHeader::TokenType packetSize = 0;
     Fw::SerialBuffer sb(&this->bufferStorage[PACKET_SIZE_OFFSET], sizeof packetSize);
     sb.fill();
-    const Fw::SerializeStatus status = sb.deserialize(packetSize);
+    const Fw::SerializeStatus status = sb.deserializeTo(packetSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     return packetSize;
 }
@@ -72,7 +72,7 @@ void FramingTester ::checkPacketType() {
     SerialPacketType serialPacketType = 0;
     Fw::SerialBuffer sb(&this->bufferStorage[PACKET_TYPE_OFFSET], sizeof serialPacketType);
     sb.fill();
-    const Fw::SerializeStatus status = sb.deserialize(serialPacketType);
+    const Fw::SerializeStatus status = sb.deserializeTo(serialPacketType);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     typedef Fw::ComPacketType PacketType;
     const PacketType pt = static_cast<PacketType>(serialPacketType);
@@ -83,7 +83,7 @@ void FramingTester ::checkStartWord() {
     FpFrameHeader::TokenType startWord = 0;
     Fw::SerialBuffer sb(&this->bufferStorage[START_WORD_OFFSET], sizeof startWord);
     sb.fill();
-    const Fw::SerializeStatus status = sb.deserialize(startWord);
+    const Fw::SerializeStatus status = sb.deserializeTo(startWord);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     ASSERT_EQ(startWord, FpFrameHeader::START_WORD);
 }

--- a/Svc/GenericHub/test/ut/GenericHubTester.cpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.cpp
@@ -84,7 +84,7 @@ void GenericHubTester ::random_fill(Fw::SerializeBufferBase& buffer, U32 max_siz
     U32 random_size = STest::Pick::lowerUpper(0, max_size);
     buffer.resetSer();
     for (U32 i = 0; i < random_size; i++) {
-        buffer.serialize(static_cast<U8>(STest::Pick::any()));
+        buffer.serializeFrom(static_cast<U8>(STest::Pick::any()));
     }
 }
 

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -159,7 +159,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
 
             // reset buffer
             buff.resetSer();
-            Fw::SerializeStatus serStat = buff.serialize(recordSize);
+            Fw::SerializeStatus serStat = buff.serializeFrom(recordSize);
             // should always work
             FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
 
@@ -185,7 +185,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
 
             // serialize parameter id
 
-            serStat = buff.serialize(this->m_db[entry].id);
+            serStat = buff.serializeFrom(this->m_db[entry].id);
             // should always work
             FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
 

--- a/Svc/PrmDb/test/ut/PrmDbTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.cpp
@@ -31,7 +31,7 @@ void PrmDbTester::runNominalPopulate() {
 
     Fw::ParamBuffer pBuff;
 
-    Fw::SerializeStatus stat = pBuff.serialize(val);
+    Fw::SerializeStatus stat = pBuff.serializeFrom(val);
     EXPECT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
     // clear all events
@@ -70,7 +70,7 @@ void PrmDbTester::runNominalPopulate() {
     val = 0x15;
     pBuff.resetSer();
 
-    stat = pBuff.serialize(val);
+    stat = pBuff.serializeFrom(val);
     EXPECT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
     // clear all events
@@ -98,7 +98,7 @@ void PrmDbTester::runNominalPopulate() {
     id = 0x25;
     val = 0x30;
     pBuff.resetSer();
-    stat = pBuff.serialize(val);
+    stat = pBuff.serializeFrom(val);
     EXPECT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
     // clear all events
@@ -197,7 +197,7 @@ void PrmDbTester::runMissingExtraParams() {
     this->clearEvents();
     // write too many entries
     for (FwPrmIdType entry = 0; entry <= PRMDB_NUM_DB_ENTRIES; entry++) {
-        EXPECT_EQ(Fw::FW_SERIALIZE_OK, pBuff.serialize(static_cast<U32>(10)));
+        EXPECT_EQ(Fw::FW_SERIALIZE_OK, pBuff.serializeFrom(static_cast<U32>(10)));
         this->invoke_to_setPrm(0, entry, pBuff);
         // dispatch message
         this->m_impl.doDispatch();
@@ -217,7 +217,7 @@ void PrmDbTester::runRefPrmFile() {
 
         Fw::ParamBuffer pBuff;
 
-        Fw::SerializeStatus stat = pBuff.serialize(val);
+        Fw::SerializeStatus stat = pBuff.serializeFrom(val);
         EXPECT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
         // clear all events
@@ -247,7 +247,7 @@ void PrmDbTester::runRefPrmFile() {
 
         Fw::ParamBuffer pBuff;
 
-        Fw::SerializeStatus stat = pBuff.serialize(val);
+        Fw::SerializeStatus stat = pBuff.serializeFrom(val);
         EXPECT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
         // clear all events
@@ -277,7 +277,7 @@ void PrmDbTester::runRefPrmFile() {
 
         Fw::ParamBuffer pBuff;
 
-        Fw::SerializeStatus stat = pBuff.serialize(val);
+        Fw::SerializeStatus stat = pBuff.serializeFrom(val);
         EXPECT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
         // clear all events
@@ -307,7 +307,7 @@ void PrmDbTester::runRefPrmFile() {
 
         Fw::ParamBuffer pBuff;
 
-        Fw::SerializeStatus stat = pBuff.serialize(val);
+        Fw::SerializeStatus stat = pBuff.serializeFrom(val);
         EXPECT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
         // clear all events

--- a/Svc/TlmChan/test/ut/TlmChanTester.cpp
+++ b/Svc/TlmChan/test/ut/TlmChanTester.cpp
@@ -124,7 +124,7 @@ void TlmChanTester::runOffNominal() {
 
     // create Telemetry item and put dummy data in to make sure it gets erased
     buff.resetSer();
-    stat = buff.serialize(val);
+    stat = buff.serializeFrom(val);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
     // Read back value
@@ -196,7 +196,7 @@ void TlmChanTester::checkBuff(FwChanIdType chanNum, FwChanIdType totalChan, FwCh
 
             // next piece is time tag
             Fw::Time recTimeTag(TimeBase::TB_NONE, 0, 0);
-            stat = this->m_rcvdBuffer[packet].deserialize(recTimeTag);
+            stat = this->m_rcvdBuffer[packet].deserializeTo(recTimeTag);
             ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
             ASSERT_TRUE(timeTag == recTimeTag);
             // next piece is event argument
@@ -231,7 +231,7 @@ void TlmChanTester::sendBuff(FwChanIdType id, U32 val) {
 
     // create telemetry item
     buff.resetSer();
-    stat = buff.serialize(val);
+    stat = buff.serializeFrom(val);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
     static bool tlc001 = false;

--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -89,10 +89,10 @@ void TlmPacketizer::setPacketList(const TlmPacketizerPacketList& packetList,
         // clear contents
         memset(this->m_fillBuffers[pktEntry].buffer.getBuffAddr(), 0, static_cast<size_t>(packetLen));
         // serialize packet descriptor and packet ID now since it will always be the same
-        Fw::SerializeStatus stat = this->m_fillBuffers[pktEntry].buffer.serialize(
+        Fw::SerializeStatus stat = this->m_fillBuffers[pktEntry].buffer.serializeFrom(
             static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM));
         FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, stat);
-        stat = this->m_fillBuffers[pktEntry].buffer.serialize(packetList.list[pktEntry]->id);
+        stat = this->m_fillBuffers[pktEntry].buffer.serializeFrom(packetList.list[pktEntry]->id);
         FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, stat);
         // set packet buffer length
         stat = this->m_fillBuffers[pktEntry].buffer.setBuffLen(packetLen);
@@ -363,7 +363,7 @@ void TlmPacketizer ::Run_handler(const FwIndexType portNum, U32 context) {
                 &this->m_sendBuffers[pkt]
                      .buffer.getBuffAddr()[sizeof(FwPacketDescriptorType) + sizeof(FwTlmPacketizeIdType)],
                 Fw::Time::SERIALIZED_SIZE);
-            Fw::SerializeStatus stat = buff.serialize(this->m_sendBuffers[pkt].latestTime);
+            Fw::SerializeStatus stat = buff.serializeFrom(this->m_sendBuffers[pkt].latestTime);
             FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, stat);
 
             this->PktSend_out(0, this->m_sendBuffers[pkt].buffer, 0);

--- a/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
+++ b/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
@@ -60,31 +60,31 @@ void TlmPacketizerTester ::pushTlmTest() {
     Fw::TlmBuffer buff;
 
     // first channel
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(20)));
     this->invoke_to_TlmRecv(0, 10, ts, buff);
 
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(15)));
     this->invoke_to_TlmRecv(0, 100, ts, buff);
 
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(14)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(14)));
     this->invoke_to_TlmRecv(0, 333, ts, buff);
 
     // second channel
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U32>(50)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(50)));
     this->invoke_to_TlmRecv(0, 10, ts, buff);
 
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U64>(1000000)));
     this->invoke_to_TlmRecv(0, 13, ts, buff);
 
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(1010)));
     this->invoke_to_TlmRecv(0, 250, ts, buff);
 
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(15)));
     this->invoke_to_TlmRecv(0, 22, ts, buff);
 }
 
@@ -94,32 +94,32 @@ void TlmPacketizerTester ::sendPacketsTest() {
     Fw::TlmBuffer buff;
 
     // first channel
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(20)));
     this->invoke_to_TlmRecv(0, 10, ts, buff);
 
     // second channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(15)));
     this->invoke_to_TlmRecv(0, 100, ts, buff);
 
     // third channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(14)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(14)));
     this->invoke_to_TlmRecv(0, 333, ts, buff);
 
     // fifth channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U64>(1000000)));
     this->invoke_to_TlmRecv(0, 13, ts, buff);
 
     // sixth channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(1010)));
     this->invoke_to_TlmRecv(0, 250, ts, buff);
 
     // seventh channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(15)));
     this->invoke_to_TlmRecv(0, 22, ts, buff);
 
     this->setTestTime(this->m_testTime);
@@ -134,24 +134,24 @@ void TlmPacketizerTester ::sendPacketsTest() {
 
     Fw::ComBuffer comBuff;
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(this->m_testTime));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(15)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(14)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(this->m_testTime));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(14)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(this->m_testTime));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(1000000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(1010)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(15)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(this->m_testTime));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(15)));
 
     ASSERT_from_PktSend(1, comBuff, static_cast<U32>(0));
 }
@@ -162,32 +162,32 @@ void TlmPacketizerTester ::sendPacketLevelsTest() {
     Fw::TlmBuffer buff;
 
     // first channel
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(20)));
     this->invoke_to_TlmRecv(0, 10, ts, buff);
 
     // second channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(15)));
     this->invoke_to_TlmRecv(0, 100, ts, buff);
 
     // third channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(14)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(14)));
     this->invoke_to_TlmRecv(0, 333, ts, buff);
 
     // fifth channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U64>(1000000)));
     this->invoke_to_TlmRecv(0, 13, ts, buff);
 
     // sixth channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(1010)));
     this->invoke_to_TlmRecv(0, 250, ts, buff);
 
     // seventh channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(15)));
     this->invoke_to_TlmRecv(0, 22, ts, buff);
 
     this->setTestTime(this->m_testTime);
@@ -202,24 +202,24 @@ void TlmPacketizerTester ::sendPacketLevelsTest() {
 
     Fw::ComBuffer comBuff;
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(this->m_testTime));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(15)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(14)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(this->m_testTime));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(14)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(this->m_testTime));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(1000000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(1010)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(15)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(this->m_testTime));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(15)));
 
     ASSERT_from_PktSend(1, comBuff, static_cast<U32>(0));
 }
@@ -240,7 +240,7 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     // first channel
     ts.set(100, 1000);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(20)));
     this->invoke_to_TlmRecv(0, 10, ts, buff);
 
     this->m_testTime.add(1, 0);
@@ -252,24 +252,24 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(0)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(0)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(0)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(0)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(0)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(0)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(0)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(0)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(0)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(0)));
 
     ASSERT_from_PktSend(1, comBuff, static_cast<U32>(0));
 
@@ -277,7 +277,7 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(15)));
     this->invoke_to_TlmRecv(0, 100, ts, buff);
 
     this->m_testTime.add(1, 0);
@@ -291,18 +291,18 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(15)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(0)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(0)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(14)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(14)));
     this->invoke_to_TlmRecv(0, 333, ts, buff);
 
     this->clearFromPortHistory();
@@ -313,18 +313,18 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(15)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(14)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(14)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U64>(1000000)));
     this->invoke_to_TlmRecv(0, 13, ts, buff);
 
     this->clearFromPortHistory();
@@ -334,19 +334,19 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(1000000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(0)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(0)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(0)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(0)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(1010)));
     this->invoke_to_TlmRecv(0, 250, ts, buff);
 
     this->clearFromPortHistory();
@@ -358,19 +358,19 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(1000000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(1010)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(0)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(0)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(15)));
     this->invoke_to_TlmRecv(0, 22, ts, buff);
 
     this->clearFromPortHistory();
@@ -380,13 +380,13 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(1000000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(1010)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(15)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(15)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
@@ -395,7 +395,7 @@ void TlmPacketizerTester ::updatePacketsTest() {
     // first channel
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U32>(1000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(1000)));
     this->invoke_to_TlmRecv(0, 10, ts, buff);
 
     this->clearFromPortHistory();
@@ -405,24 +405,24 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(1000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(15)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(14)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(1000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(14)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(1000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(1000000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(1010)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(15)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(1000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(15)));
 
     ASSERT_from_PktSend(1, comBuff, static_cast<U32>(0));
 
@@ -430,7 +430,7 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(550)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(550)));
     this->invoke_to_TlmRecv(0, 100, ts, buff);
 
     this->clearFromPortHistory();
@@ -440,18 +440,18 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(1000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(550)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(14)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(1000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(550)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(14)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(211)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(211)));
     this->invoke_to_TlmRecv(0, 333, ts, buff);
 
     this->clearFromPortHistory();
@@ -461,18 +461,18 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(1000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(550)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(211)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(1000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(550)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(211)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U64>(34441)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U64>(34441)));
     this->invoke_to_TlmRecv(0, 13, ts, buff);
 
     this->clearFromPortHistory();
@@ -482,19 +482,19 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(1000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(34441)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(1010)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(15)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(1000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(34441)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(15)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(8649)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(8649)));
     this->invoke_to_TlmRecv(0, 250, ts, buff);
 
     this->clearFromPortHistory();
@@ -504,19 +504,19 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(1000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(34441)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(8649)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(15)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(1000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(34441)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(8649)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(15)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(65)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(65)));
     this->invoke_to_TlmRecv(0, 22, ts, buff);
 
     this->clearFromPortHistory();
@@ -526,13 +526,13 @@ void TlmPacketizerTester ::updatePacketsTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(1000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(34441)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(8649)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(65)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(1000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(34441)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(8649)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(65)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 }
@@ -553,7 +553,7 @@ void TlmPacketizerTester ::ignoreTest() {
 
     // first channel
     ts.set(100, 1000);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(20)));
     this->invoke_to_TlmRecv(0, 10, ts, buff);
 
     this->m_testTime.add(1, 0);
@@ -565,24 +565,24 @@ void TlmPacketizerTester ::ignoreTest() {
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(0)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(0)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(0)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(0)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(ts));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(0)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(0)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(0)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(ts));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(0)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(0)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(0)));
 
     ASSERT_from_PktSend(1, comBuff, static_cast<U32>(0));
 
@@ -590,7 +590,7 @@ void TlmPacketizerTester ::ignoreTest() {
 
     buff.resetSer();
     ts.add(1, 0);
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(20)));
     this->invoke_to_TlmRecv(0, 25, ts, buff);
 
     this->m_testTime.add(1, 0);
@@ -609,32 +609,32 @@ void TlmPacketizerTester ::sendManualPacketTest() {
     Fw::TlmBuffer buff;
 
     // first channel
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(20)));
     this->invoke_to_TlmRecv(0, 10, ts, buff);
 
     // second channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(15)));
     this->invoke_to_TlmRecv(0, 100, ts, buff);
 
     // third channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(14)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(14)));
     this->invoke_to_TlmRecv(0, 333, ts, buff);
 
     // fifth channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U64>(1000000)));
     this->invoke_to_TlmRecv(0, 13, ts, buff);
 
     // sixth channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(1010)));
     this->invoke_to_TlmRecv(0, 250, ts, buff);
 
     // seventh channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(15)));
     this->invoke_to_TlmRecv(0, 22, ts, buff);
 
     this->setTestTime(this->m_testTime);
@@ -649,24 +649,24 @@ void TlmPacketizerTester ::sendManualPacketTest() {
 
     Fw::ComBuffer comBuff1;
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff1.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serialize(this->m_testTime));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serialize(static_cast<U16>(15)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serialize(static_cast<U8>(14)));
+              comBuff1.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serializeFrom(this->m_testTime));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serializeFrom(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serializeFrom(static_cast<U8>(14)));
 
     ASSERT_from_PktSend(0, comBuff1, static_cast<U32>(0));
 
     Fw::ComBuffer comBuff2;
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff2.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serialize(this->m_testTime));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serialize(static_cast<U64>(1000000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serialize(static_cast<U16>(1010)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serialize(static_cast<U8>(15)));
+              comBuff2.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serializeFrom(this->m_testTime));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serializeFrom(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serializeFrom(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff2.serializeFrom(static_cast<U8>(15)));
 
     ASSERT_from_PktSend(1, comBuff2, static_cast<U32>(0));
 
@@ -730,32 +730,32 @@ void TlmPacketizerTester ::setPacketLevelTest() {
     Fw::TlmBuffer buff;
 
     // first channel
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U32>(0x20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(0x20)));
     this->invoke_to_TlmRecv(0, 10, ts, buff);
 
     // second channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(0x15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(0x15)));
     this->invoke_to_TlmRecv(0, 100, ts, buff);
 
     // third channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(0x14)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(0x14)));
     this->invoke_to_TlmRecv(0, 333, ts, buff);
 
     // fifth channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U64>(0x1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U64>(0x1000000)));
     this->invoke_to_TlmRecv(0, 13, ts, buff);
 
     // sixth channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(0x1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(0x1010)));
     this->invoke_to_TlmRecv(0, 250, ts, buff);
 
     // seventh channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(0x15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(0x15)));
     this->invoke_to_TlmRecv(0, 22, ts, buff);
 
     this->setTestTime(this->m_testTime);
@@ -780,32 +780,32 @@ void TlmPacketizerTester ::setPacketLevelTest() {
 
     // send the packets
     // first channel
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U32>(0x20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(0x20)));
     this->invoke_to_TlmRecv(0, 10, ts, buff);
 
     // second channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(0x15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(0x15)));
     this->invoke_to_TlmRecv(0, 100, ts, buff);
 
     // third channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(0x14)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(0x14)));
     this->invoke_to_TlmRecv(0, 333, ts, buff);
 
     // fifth channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U64>(0x1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U64>(0x1000000)));
     this->invoke_to_TlmRecv(0, 13, ts, buff);
 
     // sixth channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U16>(0x1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U16>(0x1010)));
     this->invoke_to_TlmRecv(0, 250, ts, buff);
 
     // seventh channel
     buff.resetSer();
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serialize(static_cast<U8>(0x15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U8>(0x15)));
     this->invoke_to_TlmRecv(0, 22, ts, buff);
 
     this->setTestTime(this->m_testTime);
@@ -821,12 +821,12 @@ void TlmPacketizerTester ::setPacketLevelTest() {
 
     Fw::ComBuffer comBuff1;
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff1.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serialize(this->m_testTime));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serialize(static_cast<U32>(0x20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serialize(static_cast<U16>(0x15)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serialize(static_cast<U8>(0x14)));
+              comBuff1.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serializeFrom(this->m_testTime));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serializeFrom(static_cast<U32>(0x20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serializeFrom(static_cast<U16>(0x15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff1.serializeFrom(static_cast<U8>(0x14)));
 
     ASSERT_from_PktSend(0, comBuff1, static_cast<U32>(0));
 
@@ -839,24 +839,24 @@ void TlmPacketizerTester ::setPacketLevelTest() {
 
     Fw::ComBuffer comBuff;
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(4)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(this->m_testTime));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(15)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(14)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(4)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(this->m_testTime));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(15)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(14)));
 
     ASSERT_from_PktSend(0, comBuff, static_cast<U32>(0));
 
     comBuff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK,
-              comBuff.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<FwTlmPacketizeIdType>(8)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(this->m_testTime));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U32>(20)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U64>(1000000)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U16>(1010)));
-    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serialize(static_cast<U8>(15)));
+              comBuff.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_PACKETIZED_TLM)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<FwTlmPacketizeIdType>(8)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(this->m_testTime));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U32>(20)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U64>(1000000)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U16>(1010)));
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, comBuff.serializeFrom(static_cast<U8>(15)));
 
     ASSERT_from_PktSend(1, comBuff, static_cast<U32>(0));
 }
@@ -914,7 +914,7 @@ void TlmPacketizerTester ::getChannelValueTest() {
 
     Fw::Time timeIn(123, 456);
     Fw::TlmBuffer valIn;
-    valIn.serialize(static_cast<I32>(789));
+    valIn.serializeFrom(static_cast<I32>(789));
     this->invoke_to_TlmRecv(0, 10, timeIn, valIn);
 
     valid = this->invoke_to_TlmGet(0, 10, time, val);

--- a/Utils/Hash/libcrc/CRC32.cpp
+++ b/Utils/Hash/libcrc/CRC32.cpp
@@ -33,7 +33,7 @@ void Hash ::hash(const void* const data, const FwSizeType len, HashBuffer& buffe
     }
     HashBuffer bufferOut;
     // For CRC32 we need to return the one's complement of the result:
-    Fw::SerializeStatus status = bufferOut.serialize(~(local_hash_handle));
+    Fw::SerializeStatus status = bufferOut.serializeFrom(~(local_hash_handle));
     FW_ASSERT(Fw::FW_SERIALIZE_OK == status);
     buffer = bufferOut;
 }
@@ -54,7 +54,7 @@ void Hash ::update(const void* const data, FwSizeType len) {
 void Hash ::final(HashBuffer& buffer) {
     HashBuffer bufferOut;
     // For CRC32 we need to return the one's complement of the result:
-    Fw::SerializeStatus status = bufferOut.serialize(~(this->hash_handle));
+    Fw::SerializeStatus status = bufferOut.serializeFrom(~(this->hash_handle));
     FW_ASSERT(Fw::FW_SERIALIZE_OK == status);
     buffer = bufferOut;
 }
@@ -66,7 +66,7 @@ void Hash ::final(U32& hashvalue) {
 }
 
 void Hash ::setHashValue(HashBuffer& value) {
-    Fw::SerializeStatus status = value.deserialize(this->hash_handle);
+    Fw::SerializeStatus status = value.deserializeTo(this->hash_handle);
     FW_ASSERT(Fw::FW_SERIALIZE_OK == status);
     // Expecting `value` to already be one's complement; so doing one's complement
     // here for correct hash updates


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3944 |
|**_Has Unit Tests (y/n)_**| y, updated existing |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Marking legacy serialize and deserialize methods as DEPRECATED. Clean-up of all remaining references within the project to the legacy methods.

## Rationale

Code clarity and consistency

## Testing/Review Recommendations

Clean run of FPrime UTs and FppTestProject

## Future Work

Nothing in this repo, but will probably need to upgrade other repos to the new serialization.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None
