### PR TITLE
docs: Update Mozilla CoC link to a non-archived resource

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -128,7 +128,7 @@ For answers to common questions about this code of conduct, see the FAQ at
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
+[Mozilla CoC]: https://www.mozilla.org/en-US/about/governance/policies/participation
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
 


### PR DESCRIPTION
Hello F´ team,

This pull request addresses an outdated link in the `CODE_OF_CONDUCT.md` file.

The current link for Mozilla's code of conduct enforcement ladder points to `https://github.com/mozilla/diversity`. This repository has been archived by Mozilla and is now read-only. 

This change updates the link to point directly to the canonical, actively maintained resource, the Mozilla Community Participation Guidelines.

- **Old Link:** `https://github.com/mozilla/diversity` (Archived)
- **New Link:** `https://www.mozilla.org/en-US/about/governance/policies/participation`

This ensures that contributors are directed to a valid resource and avoids relying on a link to an archived repository, which is not a best practice.

Thank you for your consideration!