### PR TITLE
Add new PassiveCmdDispatcher component

### DIFF
--- a/Svc/CMakeLists.txt
+++ b/Svc/CMakeLists.txt
@@ -46,6 +46,7 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/FramingProtocol/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/GenericHub/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Health/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/OsTime/")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PassiveCmdDispatcher")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PassiveRateGroup")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PolyDb/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PrmDb/")
@@ -59,7 +60,7 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/SystemResources/")
 # Subtopologies
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Subtopologies/")
 
-# Text logger components included by default, 
+# Text logger components included by default,
 # but can be disabled if FW_ENABLE_TEXT_LOGGING=0 is desired.
 if (FPRIME_ENABLE_TEXT_LOGGERS)
 	add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PassiveConsoleTextLogger/")

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
@@ -157,7 +157,6 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
 }
 
 void CommandDispatcherImpl::CMD_NO_OP_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
-    Fw::LogStringArg no_op_string("Hello, World!");
     // Log event for NO_OP here.
     this->log_ACTIVITY_HI_NoOpReceived();
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);

--- a/Svc/CmdDispatcher/docs/sdd.md
+++ b/Svc/CmdDispatcher/docs/sdd.md
@@ -31,11 +31,11 @@ The `Svc::CmdDispatcher` component uses the following port types:
 
 Port Data Type | Name | Direction | Kind | Usage
 -------------- | ---- | --------- | ---- | -----
-[`Fw::Cmd`](../../../Fw/Cmd/docs/sdd.md) | cmdSend | Output | n/a | Send commands to components
+[`Fw::Cmd`](../../../Fw/Cmd/docs/sdd.md) | compCmdSend | Output | n/a | Send commands to components
 [`Fw::CmdResponse`](../../../Fw/Cmd/docs/sdd.md) | compCmdStat | Input | Asynchronous | Port for components to report command status
 [`Fw::CmdResponse`](../../../Fw/Cmd/docs/sdd.md) | seqCmdStatus | Output | n/a | Send command status to command buffer source
 [`Fw::Com`](../../../Fw/Com/docs/sdd.md) | seqCmdBuff | Input | Asynchronous | Receive command buffer
-[`Fw::CmdReg`](../../../Fw/Cmd/docs/sdd.md) | cmdReg | Input | Synchronous | Command Registration
+[`Fw::CmdReg`](../../../Fw/Cmd/docs/sdd.md) | compCmdReg | Input | Synchronous | Command Registration
 
 ### 3.2 Functional Description
 

--- a/Svc/PassiveCmdDispatcher/CMakeLists.txt
+++ b/Svc/PassiveCmdDispatcher/CMakeLists.txt
@@ -1,0 +1,36 @@
+####
+# F Prime CMakeLists.txt:
+#
+# SOURCES: list of source files (to be compiled)
+# AUTOCODER_INPUTS: list of files to be passed to the autocoders
+# DEPENDS: list of libraries that this module depends on
+#
+# More information in the F´ CMake API documentation:
+# https://fprime.jpl.nasa.gov/latest/docs/reference/api/cmake/API/
+#
+####
+
+# Module names are derived from the path from the nearest project/library/framework
+# root when not specifically overridden by the developer. i.e. The module defined by
+# `Ref/SignalGen/CMakeLists.txt` will be named `Ref_SignalGen`.
+
+register_fprime_library(
+    AUTOCODER_INPUTS
+        "${CMAKE_CURRENT_LIST_DIR}/PassiveCmdDispatcher.fpp"
+    SOURCES
+        "${CMAKE_CURRENT_LIST_DIR}/PassiveCmdDispatcher.cpp"
+#   DEPENDS
+#       MyPackage_MyOtherModule
+)
+
+### Unit Tests ###
+# register_fprime_ut(
+#     AUTOCODER_INPUTS
+#         "${CMAKE_CURRENT_LIST_DIR}/PassiveCmdDispatcher.fpp"
+#     SOURCES
+#         "${CMAKE_CURRENT_LIST_DIR}/test/ut/PassiveCmdDispatcherTestMain.cpp"
+#         "${CMAKE_CURRENT_LIST_DIR}/test/ut/PassiveCmdDispatcherTester.cpp"
+#     DEPENDS
+#         STest # For rules-based testing
+#     UT_AUTO_HELPERS
+# )

--- a/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.cpp
+++ b/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.cpp
@@ -4,15 +4,26 @@
 // \brief  cpp file for PassiveCmdDispatcher component implementation class
 // ======================================================================
 
-#include "Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.hpp"
+#include <Fw/Cmd/CmdPacket.hpp>
+#include <Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.hpp>
 
 namespace Svc {
+
+// Check the CMD_DISPATCHER_DISPATCH_TABLE_SIZE and CMD_DISPATCHER_SEQUENCER_TABLE_SIZE constants for overflow
+static_assert(CMD_DISPATCHER_DISPATCH_TABLE_SIZE <= std::numeric_limits<FwOpcodeType>::max(),
+              "Opcode table limited to opcode range");
+static_assert(CMD_DISPATCHER_SEQUENCER_TABLE_SIZE <= std::numeric_limits<U32>::max(),
+              "Sequencer table limited to range of U32");
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-PassiveCmdDispatcher::PassiveCmdDispatcher(const char* const compName) : PassiveCmdDispatcherComponentBase(compName) {}
+PassiveCmdDispatcher::PassiveCmdDispatcher(const char* const compName)
+    : PassiveCmdDispatcherComponentBase(compName), m_seq(0) {
+    memset(this->m_entryTable, 0, sizeof(this->m_entryTable));
+    memset(this->m_sequenceTracker, 0, sizeof(this->m_sequenceTracker));
+}
 
 PassiveCmdDispatcher::~PassiveCmdDispatcher() {}
 
@@ -21,18 +32,120 @@ PassiveCmdDispatcher::~PassiveCmdDispatcher() {}
 // ----------------------------------------------------------------------
 
 void PassiveCmdDispatcher::compCmdReg_handler(FwIndexType portNum, FwOpcodeType opCode) {
-    // TODO
+    // Search for an empty slot
+    bool slotFound = false;
+    for (FwOpcodeType slot = 0; slot < CMD_DISPATCHER_DISPATCH_TABLE_SIZE; slot++) {
+        if ((!this->m_entryTable[slot].used) && (!slotFound)) {
+            this->m_entryTable[slot].opcode = opCode;
+            this->m_entryTable[slot].port = portNum;
+            this->m_entryTable[slot].used = true;
+            slotFound = true;
+        } else if (this->m_entryTable[slot].used && (this->m_entryTable[slot].opcode == opCode) &&
+                   (this->m_entryTable[slot].port == portNum) && (!slotFound)) {
+            slotFound = true;
+        } else if (this->m_entryTable[slot].used) {
+            // Ensure that there are no duplicates
+            FW_ASSERT(this->m_entryTable[slot].opcode != opCode, static_cast<FwAssertArgType>(opCode));
+        }
+    }
+    FW_ASSERT(slotFound, static_cast<FwAssertArgType>(opCode));
 }
 
 void PassiveCmdDispatcher::compCmdStat_handler(FwIndexType portNum,
                                                FwOpcodeType opCode,
                                                U32 cmdSeq,
                                                const Fw::CmdResponse& response) {
-    // TODO
+    // Check the command response and log success/failure
+    if (response.e == Fw::CmdResponse::OK) {
+        this->log_COMMAND_OpCodeCompleted(opCode);
+    } else {
+        FW_ASSERT(response.e != Fw::CmdResponse::OK);
+        this->log_COMMAND_OpCodeError(opCode, response);
+    }
+
+    // Search for the command source
+    FwIndexType portToCall = -1;
+    U32 context;
+    for (U32 pending = 0; pending < CMD_DISPATCHER_SEQUENCER_TABLE_SIZE; pending++) {
+        if ((this->m_sequenceTracker[pending].seq == cmdSeq) && this->m_sequenceTracker[pending].used) {
+            portToCall = this->m_sequenceTracker[pending].callerPort;
+            context = this->m_sequenceTracker[pending].context;
+            FW_ASSERT(opCode == this->m_sequenceTracker[pending].opCode);
+            FW_ASSERT(portToCall < this->getNum_seqCmdStatus_OutputPorts());
+            this->m_sequenceTracker[pending].used = false;
+            break;
+        }
+    }
+    // If found, call the port to report the command status
+    if ((portToCall != -1) && this->isConnected_seqCmdStatus_OutputPort(portToCall)) {
+        // NOTE: seqCmdStatus port forwards three arguments (opCode, cmdSeq, response) but the
+        // cmdSeq value has no meaning for the calling sequencer; instead, the context value is
+        // forwarded to allow the caller to utilize it if needed.
+        this->seqCmdStatus_out(portToCall, opCode, context, response);
+    }
 }
 
 void PassiveCmdDispatcher::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
-    // TODO
+    // Deserialize the command packet
+    Fw::CmdPacket cmdPkt;
+    Fw::SerializeStatus stat = cmdPkt.deserialize(data);
+    if (stat != Fw::FW_SERIALIZE_OK) {
+        Fw::DeserialStatus serErr = static_cast<Fw::DeserialStatus::t>(stat);
+        this->log_WARNING_HI_MalformedCommand(serErr);
+        if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
+            this->seqCmdStatus_out(portNum, cmdPkt.getOpCode(), context, Fw::CmdResponse::VALIDATION_ERROR);
+        }
+        return;
+    }
+
+    // Search for the opcode in the dispatch table
+    FwOpcodeType opcode = cmdPkt.getOpCode();
+    FwOpcodeType entry;
+    bool entryFound = false;
+    for (entry = 0; entry < CMD_DISPATCHER_DISPATCH_TABLE_SIZE; entry++) {
+        if (this->m_entryTable[entry].used && (this->m_entryTable[entry].opcode == opcode)) {
+            entryFound = true;
+            break;
+        }
+    }
+    if (entryFound && this->isConnected_compCmdSend_OutputPort(this->m_entryTable[entry].port)) {
+        // Register the command in the command tracker only if the response port is connected
+        if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
+            bool pendingFound = false;
+            for (U32 pending = 0; pending < CMD_DISPATCHER_SEQUENCER_TABLE_SIZE; pending++) {
+                if (!this->m_sequenceTracker[pending].used) {
+                    pendingFound = true;
+                    this->m_sequenceTracker[pending].used = true;
+                    this->m_sequenceTracker[pending].opCode = opcode;
+                    this->m_sequenceTracker[pending].seq = this->m_seq;
+                    this->m_sequenceTracker[pending].context = context;
+                    this->m_sequenceTracker[pending].callerPort = portNum;
+                    break;
+                }
+            }
+            // If no slot was found to track the command, quit
+            if (!pendingFound) {
+                this->log_WARNING_HI_TooManyCommands(opcode);
+                if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
+                    this->seqCmdStatus_out(portNum, opcode, context, Fw::CmdResponse::EXECUTION_ERROR);
+                }
+                return;
+            }
+        }
+
+        // Pass arguments to the argument buffer and log the dispatched command
+        this->compCmdSend_out(this->m_entryTable[entry].port, opcode, this->m_seq, cmdPkt.getArgBuffer());
+        this->log_COMMAND_OpCodeDispatched(opcode, this->m_entryTable[entry].port);
+    } else {
+        // Opcode could not be found in the dispatch table, fail the command
+        this->log_WARNING_HI_InvalidCommand(opcode);
+        if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
+            this->seqCmdStatus_out(portNum, opcode, context, Fw::CmdResponse::INVALID_OPCODE);
+        }
+    }
+
+    // Increment sequence number
+    this->m_seq++;
 }
 
 // ----------------------------------------------------------------------
@@ -40,12 +153,15 @@ void PassiveCmdDispatcher::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffer
 // ----------------------------------------------------------------------
 
 void PassiveCmdDispatcher::CMD_NO_OP_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
-    // TODO
+    this->log_ACTIVITY_HI_NoOpReceived();
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }
 
 void PassiveCmdDispatcher::CMD_CLEAR_TRACKING_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
-    // TODO
+    // Clear the sequence tracking table
+    for (FwOpcodeType entry = 0; entry < CMD_DISPATCHER_SEQUENCER_TABLE_SIZE; entry++) {
+        this->m_sequenceTracker[entry].used = false;
+    }
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }
 

--- a/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.cpp
+++ b/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.cpp
@@ -1,0 +1,52 @@
+// ======================================================================
+// \title  PassiveCmdDispatcher.cpp
+// \author root
+// \brief  cpp file for PassiveCmdDispatcher component implementation class
+// ======================================================================
+
+#include "Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.hpp"
+
+namespace Svc {
+
+// ----------------------------------------------------------------------
+// Component construction and destruction
+// ----------------------------------------------------------------------
+
+PassiveCmdDispatcher::PassiveCmdDispatcher(const char* const compName) : PassiveCmdDispatcherComponentBase(compName) {}
+
+PassiveCmdDispatcher::~PassiveCmdDispatcher() {}
+
+// ----------------------------------------------------------------------
+// Handler implementations for typed input ports
+// ----------------------------------------------------------------------
+
+void PassiveCmdDispatcher::compCmdReg_handler(FwIndexType portNum, FwOpcodeType opCode) {
+    // TODO
+}
+
+void PassiveCmdDispatcher::compCmdStat_handler(FwIndexType portNum,
+                                               FwOpcodeType opCode,
+                                               U32 cmdSeq,
+                                               const Fw::CmdResponse& response) {
+    // TODO
+}
+
+void PassiveCmdDispatcher::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
+    // TODO
+}
+
+// ----------------------------------------------------------------------
+// Handler implementations for commands
+// ----------------------------------------------------------------------
+
+void PassiveCmdDispatcher::CMD_NO_OP_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
+    // TODO
+    this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
+}
+
+void PassiveCmdDispatcher::CMD_CLEAR_TRACKING_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
+    // TODO
+    this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
+}
+
+}  // namespace Svc

--- a/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.fpp
+++ b/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.fpp
@@ -1,0 +1,103 @@
+module Svc {
+
+    @ A passive component for dispatching commands
+    passive component PassiveCmdDispatcher {
+
+        ###############################################################################
+        # Commands
+        ###############################################################################
+
+        @ No-op command
+        sync command CMD_NO_OP \
+            opcode 0x0
+
+        @ Clear command tracking info to recover from components that are not returning status
+        sync command CMD_CLEAR_TRACKING \
+            opcode 0x1
+
+        ###############################################################################
+        # Events
+        ###############################################################################
+
+        @ Command dispatched
+        event OpCodeDispatched($opcode: FwOpcodeType, $port: I32) \
+            severity command \
+            id 0x0 \
+            format "Opcode 0x{x} dispatched to port {}"
+
+        @ Command success event
+        event OpCodeCompleted($opcode: FwOpcodeType) \
+            severity command \
+            id 0x1 \
+            format "Opcode 0x{x} completed"
+
+        @ Command failure event
+        event OpCodeError($opcode: FwOpcodeType, error: Fw.CmdResponse) \
+            severity command \
+            id 0x2 \
+            format "Opcode 0x{x} completed with error {}"
+
+        @ Received a malformed command packet
+        event MalformedCommand($status: Fw.DeserialStatus) \
+            severity warning high \
+            id 0x3 \
+            format "Received malformed command packet. Status: {}"
+
+        @ Received an invalid opcode
+        event InvalidCommand($opcode: FwOpcodeType) \
+            severity warning high \
+            id 0x4 \
+            format "Invalid opcode 0x{x} received"
+
+        @ Received a NO_OP command
+        event NoOpReceived \
+            severity activity high \
+            id 0x5 \
+            format "Received a NO_OP command"
+
+        ###############################################################################
+        # General Ports
+        ###############################################################################
+
+        @ Command registration input ports. Size must match the dispatch output ports.
+        sync input port compCmdReg: [CmdDispatcherComponentCommandPorts] Fw.CmdReg
+
+        @ Command dispatch output ports. Size must match the registration input ports.
+        output port compCmdSend: [CmdDispatcherComponentCommandPorts] Fw.Cmd
+
+        @ Input command status ports
+        sync input port compCmdStat: Fw.CmdResponse
+
+        @ Command buffer input port for sequencers or other sources of command buffers
+        sync input port seqCmdBuff: [CmdDispatcherSequencePorts] Fw.Com
+
+        @ Output command sequence status ports
+        output port seqCmdStatus: [CmdDispatcherSequencePorts] Fw.CmdResponse
+
+        # Port matching specifiers
+        match compCmdSend with compCmdReg
+        match seqCmdStatus with seqCmdBuff
+
+        ###############################################################################
+        # Standard AC Ports: Required for Channels, Events, Commands, and Parameters
+        ###############################################################################
+
+        @ Port for requesting the current time
+        time get port timeCaller
+
+        @ Port for sending command registrations
+        command reg port cmdRegOut
+
+        @ Port for receiving commands
+        command recv port cmdIn
+
+        @ Port for sending command responses
+        command resp port cmdResponseOut
+
+        @ Port for sending textual representation of events
+        text event port logTextOut
+
+        @ Port for sending events to downlink
+        event port logOut
+    }
+}

--- a/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.fpp
+++ b/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.fpp
@@ -49,10 +49,16 @@ module Svc {
             id 0x4 \
             format "Invalid opcode 0x{x} received"
 
+        @ Exceeded the number of commands that can be executed simultaneously
+        event TooManyCommands($opcode: FwOpcodeType) \
+            severity warning high \
+            id 0x5 \
+            format "Too many outstanding commands. Opcode: 0x{x}"
+
         @ Received a NO_OP command
         event NoOpReceived \
             severity activity high \
-            id 0x5 \
+            id 0x6 \
             format "Received a NO_OP command"
 
         ###############################################################################

--- a/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.hpp
+++ b/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.hpp
@@ -8,6 +8,7 @@
 #define Svc_PassiveCmdDispatcher_HPP
 
 #include <Svc/PassiveCmdDispatcher/PassiveCmdDispatcherComponentAc.hpp>
+#include <config/CommandDispatcherImplCfg.hpp>
 
 namespace Svc {
 
@@ -71,6 +72,29 @@ class PassiveCmdDispatcher final : public PassiveCmdDispatcherComponentBase {
     void CMD_CLEAR_TRACKING_cmdHandler(FwOpcodeType opCode,  //!< The opcode
                                        U32 cmdSeq            //!< The command sequence number
                                        ) override;
+
+    struct DispatchEntry {
+        bool used;            //!< if entry has been used yet
+        FwOpcodeType opcode;  //!< opcode of entry
+        FwIndexType port;     //!< which port the entry invokes
+    };
+
+    struct SequenceTracker {
+        bool used;               //!< if this slot is used
+        U32 seq;                 //!< command sequence number
+        FwOpcodeType opCode;     //!< opcode being tracked
+        U32 context;             //!< context passed by user
+        FwIndexType callerPort;  //!< port command source port
+    };
+
+    //!< Current command sequence number
+    U32 m_seq;
+    //! Dispatch entry table: maps incoming opcodes to the port connected to the component that
+    //! implements the command
+    DispatchEntry m_entryTable[CMD_DISPATCHER_DISPATCH_TABLE_SIZE];
+    //! Sequence tracker table: tracks commands that are being executed but are not yet complete
+    // FIXME: is this necessary since we are synchronous?
+    SequenceTracker m_sequenceTracker[CMD_DISPATCHER_SEQUENCER_TABLE_SIZE];
 };
 
 }  // namespace Svc

--- a/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.hpp
+++ b/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.hpp
@@ -1,0 +1,78 @@
+// ======================================================================
+// \title  PassiveCmdDispatcher.hpp
+// \author root
+// \brief  hpp file for PassiveCmdDispatcher component implementation class
+// ======================================================================
+
+#ifndef Svc_PassiveCmdDispatcher_HPP
+#define Svc_PassiveCmdDispatcher_HPP
+
+#include <Svc/PassiveCmdDispatcher/PassiveCmdDispatcherComponentAc.hpp>
+
+namespace Svc {
+
+class PassiveCmdDispatcher final : public PassiveCmdDispatcherComponentBase {
+  public:
+    // ----------------------------------------------------------------------
+    // Component construction and destruction
+    // ----------------------------------------------------------------------
+
+    //! Construct PassiveCmdDispatcher object
+    PassiveCmdDispatcher(const char* const compName  //!< The component name
+    );
+
+    //! Destroy PassiveCmdDispatcher object
+    ~PassiveCmdDispatcher();
+
+  private:
+    // ----------------------------------------------------------------------
+    // Handler implementations for typed input ports
+    // ----------------------------------------------------------------------
+
+    //! Handler implementation for compCmdReg
+    //!
+    //! Command registration input ports. Size must match the dispatch output ports.
+    void compCmdReg_handler(FwIndexType portNum,  //!< The port number
+                            FwOpcodeType opCode   //!< Command Op Code
+                            ) override;
+
+    //! Handler implementation for compCmdStat
+    //!
+    //! Input command status ports
+    void compCmdStat_handler(FwIndexType portNum,             //!< The port number
+                             FwOpcodeType opCode,             //!< Command Op Code
+                             U32 cmdSeq,                      //!< Command Sequence
+                             const Fw::CmdResponse& response  //!< The command response argument
+                             ) override;
+
+    //! Handler implementation for seqCmdBuff
+    //!
+    //! Command buffer input port for sequencers or other sources of command buffers
+    void seqCmdBuff_handler(FwIndexType portNum,  //!< The port number
+                            Fw::ComBuffer& data,  //!< Buffer containing packet data
+                            U32 context           //!< Call context value; meaning chosen by user
+                            ) override;
+
+  private:
+    // ----------------------------------------------------------------------
+    // Handler implementations for commands
+    // ----------------------------------------------------------------------
+
+    //! Handler implementation for command CMD_NO_OP
+    //!
+    //! No-op command
+    void CMD_NO_OP_cmdHandler(FwOpcodeType opCode,  //!< The opcode
+                              U32 cmdSeq            //!< The command sequence number
+                              ) override;
+
+    //! Handler implementation for command CMD_CLEAR_TRACKING
+    //!
+    //! Clear command tracking info to recover from components that are not returning status
+    void CMD_CLEAR_TRACKING_cmdHandler(FwOpcodeType opCode,  //!< The opcode
+                                       U32 cmdSeq            //!< The command sequence number
+                                       ) override;
+};
+
+}  // namespace Svc
+
+#endif

--- a/Svc/PassiveCmdDispatcher/docs/sdd.md
+++ b/Svc/PassiveCmdDispatcher/docs/sdd.md
@@ -1,0 +1,66 @@
+# Svc::PassiveCmdDispatcher
+
+A passive component for dispatchign commands
+
+## Usage Examples
+Add usage examples here
+
+### Diagrams
+Add diagrams here
+
+### Typical Usage
+And the typical usage of the component here
+
+## Class Diagram
+Add a class diagram here
+
+## Port Descriptions
+| Name | Description |
+|---|---|
+|---|---|
+
+## Component States
+Add component states in the chart below
+| Name | Description |
+|---|---|
+|---|---|
+
+## Sequence Diagrams
+Add sequence diagrams here
+
+## Parameters
+| Name | Description |
+|---|---|
+|---|---|
+
+## Commands
+| Name | Description |
+|---|---|
+|---|---|
+
+## Events
+| Name | Description |
+|---|---|
+|---|---|
+
+## Telemetry
+| Name | Description |
+|---|---|
+|---|---|
+
+## Unit Tests
+Add unit test descriptions in the chart below
+| Name | Description | Output | Coverage |
+|---|---|---|---|
+|---|---|---|---|
+
+## Requirements
+Add requirements in the chart below
+| Name | Description | Validation |
+|---|---|---|
+|---|---|---|
+
+## Change Log
+| Date | Description |
+|---|---|
+|---| Initial Draft |

--- a/Svc/PassiveCmdDispatcher/docs/sdd.md
+++ b/Svc/PassiveCmdDispatcher/docs/sdd.md
@@ -1,6 +1,7 @@
 # Svc::PassiveCmdDispatcher
 
-A passive component for dispatching commands.
+A passive component for dispatching commands. Designed as a pared-down, passive replacement for
+[`Svc::CmdDispatcher`](../../CmdDispatcher/docs/sdd.md).
 
 ## Usage Examples
 Add usage examples here
@@ -15,38 +16,42 @@ And the typical usage of the component here
 Add a class diagram here
 
 ## Port Descriptions
-| Name | Description |
-|---|---|
-|---|---|
+| Port Type | Name | Kind | Description |
+|---|---|---|---|
+| [`Fw::CmdReg`](../../../Fw/Cmd/docs/sdd.md) | `compCmdReg` | `sync input` | Command registration for components |
+| [`Fw::Cmd`](../../../Fw/Cmd/docs/sdd.md) | `compCmdSend` | `output` | Send commands to components |
+| [`Fw::CmdResponse`](../../../Fw/Cmd/docs/sdd.md) | `compCmdStat` | `sync input` | Port for components to report command status |
+| [`Fw::Com`](../../../Fw/Com/docs/sdd.md) | `seqCmdBuff` | `sync input` | Receive command buffer |
+| [`Fw::CmdResponse`](../../../Fw/Cmd/docs/sdd.md) | `seqCmdStatus` | `output` | Send command status to command buffer source |
 
 ## Component States
-Add component states in the chart below
-| Name | Description |
-|---|---|
-|---|---|
+`Svc::PassiveCmdDispatcher` has no state machines.
 
 ## Sequence Diagrams
 Add sequence diagrams here
 
 ## Parameters
-| Name | Description |
-|---|---|
-|---|---|
+None.
 
 ## Commands
 | Name | Description |
 |---|---|
-|---|---|
+| `CMD_NO_OP` | Basic no-op command |
+| `CMD_CLEAR_TRACKING` | Clear any command tracking status |
 
 ## Events
 | Name | Description |
 |---|---|
-|---|---|
+| `OpCodeDispatched` | Command dispatched |
+| `OpCodeCompleted` | Command completed successfully |
+| `OpCodeError` | Command completed with failure |
+| `MalformedCommand` | Received a malformed command packet |
+| `InvalidCommand` | Received an invalid opcode |
+| `TooManyCommands` | Received a command when the sequence tracker table was already full |
+| `NoOpReceived` | Output when a `CMD_NO_OP` is received |
 
 ## Telemetry
-| Name | Description |
-|---|---|
-|---|---|
+None.
 
 ## Unit Tests
 Add unit test descriptions in the chart below
@@ -63,4 +68,4 @@ Add requirements in the chart below
 ## Change Log
 | Date | Description |
 |---|---|
-|---| Initial Draft |
+| 2025-09-16 | Initial Draft |

--- a/Svc/PassiveCmdDispatcher/docs/sdd.md
+++ b/Svc/PassiveCmdDispatcher/docs/sdd.md
@@ -1,6 +1,6 @@
 # Svc::PassiveCmdDispatcher
 
-A passive component for dispatchign commands
+A passive component for dispatching commands.
 
 ## Usage Examples
 Add usage examples here


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

This PR adds a new component `PassiveCmdDispatcher` which is designed to be a pared-down, passive replacement for the active `CmdDispatcher` component. The port handlers are implemented identically, minus some extraneous events and telemetry.

## Rationale

We are running in a memory-constrained environment and need to limit our data size. One of our largest impacts comes from the `CmdDispatcher` component; see [CmdDispatcher.txt](https://github.com/user-attachments/files/22396391/CmdDispatcher.txt) for a breakdown of its memory footprint (given our configured constants). The active component base takes up a significant amount of this data size, and we do not need it to be active for our uses, so after a discussion with members of the fprime team we determined that the best solution was to replace `CmdDispatcher` with a passive equivalent. 

## Testing/Review Recommendations

This is a drop-in replacement for `CmdDispatcher`, swap it out for a `PassiveCmdDispatcher` instance in the topology and send commands thru the GDS to verify that it works.

## Future Work

Add UTs/additional documentation.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Not used.
