### PR TITLE
Add Fw::TimeInterval constructor for computing delta between start/en…

### DIFF
--- a/Fw/Time/TimeInterval.cpp
+++ b/Fw/Time/TimeInterval.cpp
@@ -10,10 +10,9 @@ TimeInterval::TimeInterval(U32 seconds, U32 useconds) : Serializable() {
     this->set(seconds, useconds);
 }
 
-TimeInterval::TimeInterval(Time start, Time end) : Serializable() {
-    Time sub = Time::sub(end, start);
-    this->set(sub.getSeconds(), sub.getUSeconds());
-}
+TimeInterval::TimeInterval(const Time& start, const Time& end)
+    : TimeInterval(TimeInterval::sub(TimeInterval(end.getSeconds(), end.getUSeconds()),
+                                     TimeInterval(start.getSeconds(), start.getUSeconds()))) {}
 
 void TimeInterval::set(U32 seconds, U32 useconds) {
     // Assert microseconds portion is less than 10^6

--- a/Fw/Time/TimeInterval.cpp
+++ b/Fw/Time/TimeInterval.cpp
@@ -10,6 +10,11 @@ TimeInterval::TimeInterval(U32 seconds, U32 useconds) : Serializable() {
     this->set(seconds, useconds);
 }
 
+TimeInterval::TimeInterval(Time start, Time end) : Serializable() {
+    Time sub = Time::sub(end, start);
+    this->set(sub.getSeconds(), sub.getUSeconds());
+}
+
 void TimeInterval::set(U32 seconds, U32 useconds) {
     // Assert microseconds portion is less than 10^6
     FW_ASSERT(useconds < 1000000, static_cast<FwAssertArgType>(useconds));

--- a/Fw/Time/TimeInterval.hpp
+++ b/Fw/Time/TimeInterval.hpp
@@ -21,14 +21,14 @@ class TimeInterval : public Serializable {
   public:
     enum { SERIALIZED_SIZE = sizeof(U32) * 2 };
 
-    TimeInterval() = default;                 // !< Default constructor
-    ~TimeInterval() = default;                // !< Default destructor
-    TimeInterval(const TimeInterval& other);  // !< Copy constructor
-    TimeInterval(U32 seconds, U32 useconds);  // !< Constructor with member values as arguments
-    TimeInterval(Time start, Time end);       // !< Constructor with start / end times as arguments
-    void set(U32 seconds, U32 useconds);      // !< Sets value of time stored
-    U32 getSeconds() const;                   // !< Gets seconds part of time
-    U32 getUSeconds() const;                  // !< Gets microseconds part of time
+    TimeInterval() = default;                          // !< Default constructor
+    ~TimeInterval() = default;                         // !< Default destructor
+    TimeInterval(const TimeInterval& other);           // !< Copy constructor
+    TimeInterval(U32 seconds, U32 useconds);           // !< Constructor with member values as arguments
+    TimeInterval(const Time& start, const Time& end);  // !< Constructor with start / end times as arguments
+    void set(U32 seconds, U32 useconds);               // !< Sets value of time stored
+    U32 getSeconds() const;                            // !< Gets seconds part of time
+    U32 getUSeconds() const;                           // !< Gets microseconds part of time
 
     SerializeStatus serializeTo(SerializeBufferBase& buffer) const override;  // !< Serialize method
     SerializeStatus deserializeFrom(SerializeBufferBase& buffer) override;    // !< Deserialize method

--- a/Fw/Time/TimeInterval.hpp
+++ b/Fw/Time/TimeInterval.hpp
@@ -2,6 +2,7 @@
 #define FW_TIME_INTERVAL_HPP
 
 #include <Fw/FPrimeBasicTypes.hpp>
+#include <Fw/Time/Time.hpp>
 #include <Fw/Time/TimeIntervalValueSerializableAc.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/Serializable.hpp>
@@ -24,6 +25,7 @@ class TimeInterval : public Serializable {
     ~TimeInterval() = default;                // !< Default destructor
     TimeInterval(const TimeInterval& other);  // !< Copy constructor
     TimeInterval(U32 seconds, U32 useconds);  // !< Constructor with member values as arguments
+    TimeInterval(Time start, Time end);       // !< Constructor with start / end times as arguments
     void set(U32 seconds, U32 useconds);      // !< Sets value of time stored
     U32 getSeconds() const;                   // !< Gets seconds part of time
     U32 getUSeconds() const;                  // !< Gets microseconds part of time

--- a/Fw/Time/test/ut/TimeIntervalTester.cpp
+++ b/Fw/Time/test/ut/TimeIntervalTester.cpp
@@ -27,10 +27,7 @@ void TimeIntervalTester::test_TimeIntervalInstantiateTest() {
     ASSERT_EQ(time.getUSeconds(), 2);
     std::cout << time2 << std::endl;
 
-    Fw::TimeInterval time3(
-        Fw::Time(10, 20),
-        Fw::Time(20, 40)
-    );
+    Fw::TimeInterval time3(Fw::Time(10, 20), Fw::Time(20, 40));
     ASSERT_EQ(time3.getSeconds(), 10);
     ASSERT_EQ(time3.getUSeconds(), 20);
     std::cout << time3 << std::endl;

--- a/Fw/Time/test/ut/TimeIntervalTester.cpp
+++ b/Fw/Time/test/ut/TimeIntervalTester.cpp
@@ -1,4 +1,5 @@
 #include "TimeIntervalTester.hpp"
+#include <Fw/Time/Time.hpp>
 #include <iostream>
 
 namespace Fw {
@@ -25,6 +26,14 @@ void TimeIntervalTester::test_TimeIntervalInstantiateTest() {
     ASSERT_EQ(time.getSeconds(), 1);
     ASSERT_EQ(time.getUSeconds(), 2);
     std::cout << time2 << std::endl;
+
+    Fw::TimeInterval time3(
+        Fw::Time(10, 20),
+        Fw::Time(20, 40)
+    );
+    ASSERT_EQ(time3.getSeconds(), 10);
+    ASSERT_EQ(time3.getUSeconds(), 20);
+    std::cout << time3 << std::endl;
 }
 
 void TimeIntervalTester::test_TimeIntervalComparisonTest() {


### PR DESCRIPTION
This PR adds a convenience constructor to `Fw::TimeInterval` to compute a time interval given a start/end time. This is needed for cleaner code generation for https://github.com/nasa/fpp/issues/776