### PR TITLE
Fix Intermittent UT failure in FprimeDeframer

### DIFF
--- a/Svc/FprimeDeframer/FprimeDeframer.cpp
+++ b/Svc/FprimeDeframer/FprimeDeframer.cpp
@@ -58,15 +58,18 @@ void FprimeDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, cons
         return;
     }
     // -------- Attempt to extract APID from Payload --------
-    // If PacketDescriptor translates to an invalid APID, let it default to FW_PACKET_UNKNOWN
-    // and let downstream components (e.g. custom router) handle it
-    FwPacketDescriptorType packetDescriptor;
-    status = deserializer.deserialize(packetDescriptor);
-    FW_ASSERT(status == Fw::SerializeStatus::FW_SERIALIZE_OK, status);
     ComCfg::FrameContext contextCopy = context;
-    // If a valid descriptor is deserialized, set it in the context
-    if (packetDescriptor < ComCfg::Apid::INVALID_UNINITIALIZED) {
-        contextCopy.set_apid(static_cast<ComCfg::Apid::T>(packetDescriptor));
+    // Skip if the framed data is too short to contain a FwPacketDescriptor
+    if (deserializer.getBuffLeft() >= FprimeProtocol::FrameTrailer::SERIALIZED_SIZE + sizeof(FwPacketDescriptorType)) {
+        // If PacketDescriptor translates to an invalid APID, let it default to FW_PACKET_UNKNOWN
+        // and let downstream components (e.g. custom router) handle it
+        FwPacketDescriptorType packetDescriptor;
+        status = deserializer.deserialize(packetDescriptor);
+        FW_ASSERT(status == Fw::SerializeStatus::FW_SERIALIZE_OK, status);
+        // If a valid descriptor is deserialized, set it in the context
+        if ((packetDescriptor < ComCfg::Apid::INVALID_UNINITIALIZED)) {
+            contextCopy.set_apid(static_cast<ComCfg::Apid::T>(packetDescriptor));
+        }
     }
 
     // ---------------- Validate Frame Trailer ----------------

--- a/Svc/FprimeDeframer/FprimeDeframer.cpp
+++ b/Svc/FprimeDeframer/FprimeDeframer.cpp
@@ -59,8 +59,10 @@ void FprimeDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, cons
     }
     // -------- Attempt to extract APID from Payload --------
     ComCfg::FrameContext contextCopy = context;
-    // Skip if the framed data is too short to contain a FwPacketDescriptor
-    if (deserializer.getBuffLeft() >= FprimeProtocol::FrameTrailer::SERIALIZED_SIZE + sizeof(FwPacketDescriptorType)) {
+    if (deserializer.getBuffLeft() < FprimeProtocol::FrameTrailer::SERIALIZED_SIZE + sizeof(FwPacketDescriptorType)) {
+        // Not enough data to read a valid FwPacketDescriptor, emit event and skip attempting to read an APID
+        this->log_WARNING_LO_PayloadTooShort();
+    } else {
         // If PacketDescriptor translates to an invalid APID, let it default to FW_PACKET_UNKNOWN
         // and let downstream components (e.g. custom router) handle it
         FwPacketDescriptorType packetDescriptor;

--- a/Svc/FprimeDeframer/FprimeDeframer.fpp
+++ b/Svc/FprimeDeframer/FprimeDeframer.fpp
@@ -30,6 +30,11 @@ module Svc {
       severity warning high \
       format "Frame dropped: The transmitted frame checksum does not match that computed by the receiver"
 
+    @ An invalid frame was received (not enough data to contain a valid FwPacketDescriptor type)
+    event PayloadTooShort \
+      severity warning low \
+      format "The received buffer is too short to contain a valid FwPacketDescriptor"
+
     ###############################################################################
     # Standard AC Ports for Events 
     ###############################################################################

--- a/Svc/FprimeProtocol/docs/sdd.md
+++ b/Svc/FprimeProtocol/docs/sdd.md
@@ -5,7 +5,7 @@ The F Prime protocol is a minimal communications protocol that is used by defaul
 A frame for F Prime protocol consists of 4 fields:
 - Start word: A 32-bit start word that is used to identify the start of a frame. The start word is always `0xDEADBEEF`.
 - Payload length: A 32-bit field that specifies the length of the payload data in bytes.
-- Payload data: A variable-length field that contains the payload data (usually an [F Prime packet](../../../Fw/Com/ComPacket.hpp)), of length specified by the payload length field.
+- Payload data: A variable-length field that contains the payload data in the form of an [F Prime packet](../../../Fw/Com/ComPacket.hpp), of length specified by the payload length field. Note: an F Prime packet contains always at least a (configurable width) `FwPacketDescriptorType` field, which is used to identify the type of packet.
 - CRC: A 32-bit CRC field that is used to verify the integrity of the frame.
 
 ## F Prime frame format


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/4158

## Rationale

### UT failure explanation

`FprimeDeframer` would go ahead and attempt to deserialize an APID from the data regardless of how much data is available. In cases where there's less data in the frame than `sizeof(FwPacketDescriptor)`, then it would deserialize garbage data (the CRC value). This was never an operational scenario because we always have at least a full `FwPacketDescriptor` in our packet data, but this is still a quirk that needs fixing.

It started being intermittent recently because the garbage-deserialized `FwPacketDescriptor` data is checked to be `< ComCfg::Apid::INVALID_UNINITIALIZED` (=2048), which for a random U32 was pretty hard to get. We switched to `FwPacketDescriptor` to U16 and the intermittence started being noticeable. 

Was rightfully caught by random values in UTs. Go `STest::Random` !!

### Proposed fix 
Only attempt to harvest the APID from the encapsulated data if there is enough valid data to begin with.
