### PR TITLE
Updated LOG/TLM buffer size limit

### DIFF
--- a/Fw/FPrimeBasicTypes.hpp
+++ b/Fw/FPrimeBasicTypes.hpp
@@ -50,7 +50,7 @@ static_assert(FW_CMD_STRING_MAX_SIZE + sizeof(FwSizeStoreType) <= FW_CMD_ARG_BUF
               "FW_CMD_STRING_MAX_SIZE cannot be larger than FW_CMD_ARG_BUFFER_MAX_SIZE");
 static_assert(FW_LOG_STRING_MAX_SIZE + sizeof(FwSizeStoreType) <= FW_LOG_BUFFER_MAX_SIZE,
               "FW_LOG_STRING_MAX_SIZE cannot be larger than FW_LOG_BUFFER_MAX_SIZE");
-static_assert(FW_TLM_STRING_MAX_SIZE + sizeof(FwSizeStoreType) <= FW_TLM_BUFFER_MAX_SIZE,
+static_assert(FW_TLM_STRING_MAX_SIZE + sizeof(FwTlmPacketizeIdType) <= FW_TLM_BUFFER_MAX_SIZE,
               "FW_TLM_STRING_MAX_SIZE cannot be larger than FW_TLM_BUFFER_MAX_SIZE");
 static_assert(FW_PARAM_STRING_MAX_SIZE + sizeof(FwSizeStoreType) <= FW_PARAM_BUFFER_MAX_SIZE,
               "FW_PARAM_STRING_MAX_SIZE cannot be larger than FW_PARAM_BUFFER_MAX_SIZE");

--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -2,6 +2,10 @@
 #include <Fw/Time/Time.hpp>
 
 namespace Fw {
+#ifdef FW_TIME_SERIALIZED_SIZE
+static_assert(FW_TIME_SERIALIZED_SIZE == Fw::Time::SERIALIZED_SIZE, "FW_TIME_SERIALIZED_SIZE macro is wrong");
+#endif 
+
 const Time ZERO_TIME = Time();
 
 Time::Time() : m_val() {

--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -4,7 +4,7 @@
 namespace Fw {
 #ifdef FW_TIME_SERIALIZED_SIZE
 static_assert(FW_TIME_SERIALIZED_SIZE == Fw::Time::SERIALIZED_SIZE, "FW_TIME_SERIALIZED_SIZE macro is wrong");
-#endif 
+#endif
 
 const Time ZERO_TIME = Time();
 

--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -4,7 +4,7 @@
 namespace Fw {
 #ifdef FW_TIME_SERIALIZED_SIZE
 static_assert(FW_TIME_SERIALIZED_SIZE == Fw::Time::SERIALIZED_SIZE, "FW_TIME_SERIALIZED_SIZE macro is wrong");
-static_assert(Fw::Time::SERIALIZED_SIZE == Fw::TimeValue::SERIALIZED_SIZE, "Time sizes mismatched!");
+static_assert(FW_TIME_SERIALIZED_SIZE == Fw::TimeValue::SERIALIZED_SIZE, "Time sizes mismatched!");
 #endif
 
 const Time ZERO_TIME = Time();

--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -4,6 +4,7 @@
 namespace Fw {
 #ifdef FW_TIME_SERIALIZED_SIZE
 static_assert(FW_TIME_SERIALIZED_SIZE == Fw::Time::SERIALIZED_SIZE, "FW_TIME_SERIALIZED_SIZE macro is wrong");
+static_assert(Fw::Time::SERIALIZED_SIZE == Fw::TimeValue::SERIALIZED_SIZE, "Time sizes mismatched!");
 #endif
 
 const Time ZERO_TIME = Time();

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -198,11 +198,12 @@ extern "C" {
 // Serialized size of time to use when calculating available space in Fw::ComBuffer 
 #ifndef FW_TIME_SERIALIZED_SIZE
 #define FW_TIME_SERIALIZED_SIZE (11)
-#endif 
+#endif
 
 // Specifies the size of the buffer that contains the serialized log arguments.
 #ifndef FW_LOG_BUFFER_MAX_SIZE
-#define FW_LOG_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - FW_TIME_SERIALIZED_SIZE - sizeof(FwEventIdType) - sizeof(FwPacketDescriptorType))
+#define FW_LOG_BUFFER_MAX_SIZE \
+    (FW_COM_BUFFER_MAX_SIZE - FW_TIME_SERIALIZED_SIZE - sizeof(FwEventIdType) - sizeof(FwPacketDescriptorType))
 #endif
 
 // Specifies the maximum size of a string in a log event
@@ -213,7 +214,8 @@ extern "C" {
 
 // Specifies the size of the buffer that contains the serialized telemetry value.
 #ifndef FW_TLM_BUFFER_MAX_SIZE
-#define FW_TLM_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - FW_TIME_SERIALIZED_SIZE - sizeof(FwChanIdType) - sizeof(FwPacketDescriptorType))
+#define FW_TLM_BUFFER_MAX_SIZE \
+    (FW_COM_BUFFER_MAX_SIZE - FW_TIME_SERIALIZED_SIZE - sizeof(FwChanIdType) - sizeof(FwPacketDescriptorType))
 #endif
 
 // Specifies the size of the buffer that contains statement args for the FpySequencer

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -195,7 +195,7 @@ extern "C" {
 #define FW_CMD_CHECK_RESIDUAL 1  //!< Check for leftover command bytes
 #endif
 
-// Serialized size of time to use when calculating available space in Fw::ComBuffer 
+// Serialized size of time to use when calculating available space in Fw::ComBuffer
 #ifndef FW_TIME_SERIALIZED_SIZE
 #define FW_TIME_SERIALIZED_SIZE (11)
 #endif

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -195,9 +195,14 @@ extern "C" {
 #define FW_CMD_CHECK_RESIDUAL 1  //!< Check for leftover command bytes
 #endif
 
+// Serialized size of time to use when calculating available space in Fw::ComBuffer 
+#ifndef FW_TIME_SERIALIZED_SIZE
+#define FW_TIME_SERIALIZED_SIZE (11)
+#endif 
+
 // Specifies the size of the buffer that contains the serialized log arguments.
 #ifndef FW_LOG_BUFFER_MAX_SIZE
-#define FW_LOG_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - sizeof(FwEventIdType) - sizeof(FwPacketDescriptorType))
+#define FW_LOG_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - FW_TIME_SERIALIZED_SIZE - sizeof(FwEventIdType) - sizeof(FwPacketDescriptorType))
 #endif
 
 // Specifies the maximum size of a string in a log event
@@ -208,7 +213,7 @@ extern "C" {
 
 // Specifies the size of the buffer that contains the serialized telemetry value.
 #ifndef FW_TLM_BUFFER_MAX_SIZE
-#define FW_TLM_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - sizeof(FwChanIdType) - sizeof(FwPacketDescriptorType))
+#define FW_TLM_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - FW_TIME_SERIALIZED_SIZE - sizeof(FwChanIdType) - sizeof(FwPacketDescriptorType))
 #endif
 
 // Specifies the size of the buffer that contains statement args for the FpySequencer


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  n|
|**_Documentation Included (y/n)_**|  n|
|**_Generative AI was used in this contribution (y/n)_**|  n|

---
## Change Description

1. Added a `FW_TIME_SERIALIZED_SIZE`  macro to FpConfig.h
2. Updated the calculation for `FW_LOG_BUFFER_MAX_SIZE` & `FW_TLM_BUFFER_MAX_SIZE`  in `FpConfig.h` to use the new macro 
3. Added an assert to Time.cpp to verify the macro's value was not out of date (if macro was defined) 
4. Updated the static assert in `FPrimeBasicTypes.hpp` that checks `FW_TLM_STRING_MAX_SIZE` to use `FwTlmPacketizeIdType` instead of `FwSizeStoreType` 

## Rationale
According to `docs/user-manual/framework/configuring-fprime.md`, `FW_LOG_BUFFER_MAX_SIZE` & `FW_TLM_BUFFER_MAX_SIZE` should be the number of bytes available for argument data in each packet types.

However, the current method of calculating those values does not account for the space used by storing the serialized value of a Fw::Time object into the com buffer. As a result, the static asserts in FPrimeBasicTypes.hpp which check that FW_LOG_STRING_MAX_SIZE & FW_TLM_STRING_MAX_SIZE are sized so they can fit into a com buffer aren't working as intended.
```
static_assert(FW_LOG_STRING_MAX_SIZE + sizeof(FwSizeStoreType) <= FW_LOG_BUFFER_MAX_SIZE,
              "FW_LOG_STRING_MAX_SIZE cannot be larger than FW_LOG_BUFFER_MAX_SIZE");
static_assert(FW_TLM_STRING_MAX_SIZE + sizeof(FwSizeStoreType) <= FW_TLM_BUFFER_MAX_SIZE,
              "FW_TLM_STRING_MAX_SIZE cannot be larger than FW_TLM_BUFFER_MAX_SIZE");
```

The solution I recommend is adding a macro (TIME_SERIALIZED_SIZE), using that macro to calculating FW_TLM_BUFFER_MAX_SIZE/FW_LOG_BUFFER_MAX_SIZE, and then checking that the value of TIME_SERIALIZED_SIZE is correct with a static assert in Time.cpp. (A macro is used instead of relying on Fw::Time::SERIALIZED_SIZE because Time.hpp cannot be included into `FpConfig.h`

While investigating the static asserts in FPrimeBasicTypes.hpp , I also noticed that the static assert for FW_TLM_STRING_MAX_SIZE  was using `sizeof(FwSizeStoreType)` instead of `sizeof(FwTlmPacketizeIdType)` (they're both U16 values so it's functionally correct but I recommend updating to improve clarity)

## Testing/Review Recommendations

To verify the static asserts were not working as expected, set `FW_COM_BUFFER_MAX_SIZE` to 70 and set `TLM_LOG_STRING_MAX_SIZE` to 61, you'll observe that the static assert fails with the below message. Then set `TLM_LOG_STRING_MAX_SIZE ` to 60 and the build will pass.
```
In file included from <path>/fprime/Fw/Types/Assert.hpp:4:
<path>/fprime/Fw/FPrimeBasicTypes.hpp:51:15: error: static assertion failed due to requirement '61 + sizeof(unsigned short) <= (70 - sizeof(unsigned int) - sizeof(unsigned int))': FW_LOG_STRING_MAX_SIZE cannot be larger than FW_LOG_BUFFER_MAX_SIZE
   51 | static_assert(FW_LOG_STRING_MAX_SIZE + sizeof(FwSizeStoreType) <= FW_LOG_BUFFER_MAX_SIZE,
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<build_path>/F-Prime/default/config/../config/FpConfig.h:207:32: note: expanded from macro 'FW_LOG_STRING_MAX_SIZE'
  207 | #define FW_LOG_STRING_MAX_SIZE 61  //!< Max size of log string parameter type
      |                                ^
 <path>/fprime/Fw/FPrimeBasicTypes.hpp:51:64: note: expression evaluates to '63 <= 62'
   51 | static_assert(FW_LOG_STRING_MAX_SIZE + sizeof(FwSizeStoreType) <= FW_LOG_BUFFER_MAX_SIZE,
```
Then compare that to the  `Fw::LogPacket::serializeTo()` function (in Fw/Log/LogPacket.cpp) which stores the com packet base, event/log ID, and then time tag before adding the argument data. The serialized size of time is 11 bytes, so there's no way a 60 byte string could fit into ComBuffer. 

## Future Work

<!-- Note any additional work that will be done relating to this issue. -->

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). -->
