### PR TITLE
regex is a bit wrong. It never would work with 'Os/File.hpp'

### DIFF
--- a/Os/test/ut/file/RulesHeaders.hpp
+++ b/Os/test/ut/file/RulesHeaders.hpp
@@ -28,7 +28,7 @@ struct Tester {
     };
 
     //! Assert in File.cpp for searching death text
-    static constexpr const char* ASSERT_IN_FILE_CPP = "Assert: \".*/Os/File\\.cpp:[0-9]+\"";
+    static constexpr const char* ASSERT_IN_FILE_CPP = "Assert: \".*/?Os/File\\.cpp:[0-9]+\"";
 
     // Constructors that ensures the file is always valid
     Tester();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/4192  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**|n  |

---
## Change Description

Fixed regular expression when matching with ASSERT messages

## Rationale

Sometimes we use relative-path asserts which provide relative paths to the files. The regex was not working in this case.

## Testing/Review Recommendations

Rerun File unit tests

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None
