### PR TITLE
Replace configuration settings in FpConfig.h with FPP model elements

### DIFF
--- a/Fw/FPrimeBasicTypes.hpp
+++ b/Fw/FPrimeBasicTypes.hpp
@@ -16,15 +16,14 @@
 // ======================================================================
 #ifndef FPRIME_BASIC_TYPES_HPP
 #define FPRIME_BASIC_TYPES_HPP
-
 #include <limits>
-#include <cstddef>
 extern "C" {
 #include <Fw/FPrimeBasicTypes.h>
 }
 #include <Fw/Types/BasicTypes.hpp>
 // Needed for FwAssertTextSize and specific constants previously defined in FpConfig.h
 #include <config/FppConstantsAc.hpp>
+#include <cstddef>
 
 // Define max length of assert string
 // Note: This constant truncates file names in assertion failure event reports

--- a/Fw/FPrimeBasicTypes.hpp
+++ b/Fw/FPrimeBasicTypes.hpp
@@ -17,11 +17,12 @@
 #ifndef FPRIME_BASIC_TYPES_HPP
 #define FPRIME_BASIC_TYPES_HPP
 #include <limits>
+#include <cstddef>
 extern "C" {
 #include <Fw/FPrimeBasicTypes.h>
 }
 #include <Fw/Types/BasicTypes.hpp>
-// Needed for FwAssertTextSize
+// Needed for FwAssertTextSize and specific constants previously defined in FpConfig.h
 #include <config/FppConstantsAc.hpp>
 
 // Define max length of assert string
@@ -35,13 +36,13 @@ extern "C" {
 // Check that Fw::String is big enough to hold any string that can be given a
 // default value in FPP.
 
-static_assert(FW_FIXED_LENGTH_STRING_SIZE >= FW_CMD_STRING_MAX_SIZE,
+static_assert(static_cast<size_t>(FW_FIXED_LENGTH_STRING_SIZE) >= static_cast<size_t>(FW_CMD_STRING_MAX_SIZE),
               "A generic string should be able to hold a command string");
-static_assert(FW_FIXED_LENGTH_STRING_SIZE >= FW_LOG_STRING_MAX_SIZE,
+static_assert(static_cast<size_t>(FW_FIXED_LENGTH_STRING_SIZE) >= static_cast<size_t>(FW_LOG_STRING_MAX_SIZE),
               "A generic string should be able to hold an event string");
-static_assert(FW_FIXED_LENGTH_STRING_SIZE >= FW_TLM_STRING_MAX_SIZE,
+static_assert(static_cast<size_t>(FW_FIXED_LENGTH_STRING_SIZE) >= static_cast<size_t>(FW_TLM_STRING_MAX_SIZE),
               "A generic string should be able to hold a telemetry string");
-static_assert(FW_FIXED_LENGTH_STRING_SIZE >= FW_PARAM_STRING_MAX_SIZE,
+static_assert(static_cast<size_t>(FW_FIXED_LENGTH_STRING_SIZE) >= static_cast<size_t>(FW_PARAM_STRING_MAX_SIZE),
               "A generic string should be able to hold a parameter string");
 
 // Check that command/telemetry strings are not larger than an argument buffer

--- a/Fw/FPrimeBasicTypes.hpp
+++ b/Fw/FPrimeBasicTypes.hpp
@@ -36,13 +36,13 @@ extern "C" {
 // Check that Fw::String is big enough to hold any string that can be given a
 // default value in FPP.
 
-static_assert(static_cast<size_t>(FW_FIXED_LENGTH_STRING_SIZE) >= static_cast<size_t>(FW_CMD_STRING_MAX_SIZE),
+static_assert(FW_FIXED_LENGTH_STRING_SIZE >= static_cast<size_t>(FW_CMD_STRING_MAX_SIZE),
               "A generic string should be able to hold a command string");
-static_assert(static_cast<size_t>(FW_FIXED_LENGTH_STRING_SIZE) >= static_cast<size_t>(FW_LOG_STRING_MAX_SIZE),
+static_assert(FW_FIXED_LENGTH_STRING_SIZE >= static_cast<size_t>(FW_LOG_STRING_MAX_SIZE),
               "A generic string should be able to hold an event string");
-static_assert(static_cast<size_t>(FW_FIXED_LENGTH_STRING_SIZE) >= static_cast<size_t>(FW_TLM_STRING_MAX_SIZE),
+static_assert(FW_FIXED_LENGTH_STRING_SIZE >= static_cast<size_t>(FW_TLM_STRING_MAX_SIZE),
               "A generic string should be able to hold a telemetry string");
-static_assert(static_cast<size_t>(FW_FIXED_LENGTH_STRING_SIZE) >= static_cast<size_t>(FW_PARAM_STRING_MAX_SIZE),
+static_assert(FW_FIXED_LENGTH_STRING_SIZE >= static_cast<size_t>(FW_PARAM_STRING_MAX_SIZE),
               "A generic string should be able to hold a parameter string");
 
 // Check that command/telemetry strings are not larger than an argument buffer

--- a/Fw/FPrimeBasicTypes.hpp
+++ b/Fw/FPrimeBasicTypes.hpp
@@ -16,6 +16,7 @@
 // ======================================================================
 #ifndef FPRIME_BASIC_TYPES_HPP
 #define FPRIME_BASIC_TYPES_HPP
+
 #include <limits>
 #include <cstddef>
 extern "C" {

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -36,6 +36,7 @@ extern "C" {
 #endif
 #include <config/FPrimeNumericalConfig.h>
 #include <inttypes.h>  // Standard integer types and printf macros
+#include <cstddef>
 
 // Compiler checks
 #if defined(__GNUC__) || defined(__llvm__) || defined(PLATFORM_OVERRIDE_GCC_CLANG_CHECK)
@@ -88,8 +89,8 @@ typedef double F64;  //!< 64-bit floating point (double). Required for compiler-
 /* Useful macro definitions                                                   */
 /*----------------------------------------------------------------------------*/
 #define FW_NUM_ARRAY_ELEMENTS(a) (sizeof(a) / sizeof((a)[0]))  //!< number of elements in an array
-#define FW_MAX(a, b) (((a) > (b)) ? (a) : (b))                 //!< MAX macro
-#define FW_MIN(a, b) (((a) < (b)) ? (a) : (b))                 //!< MIN macro
+#define FW_MAX(a, b) ((static_cast<size_t>(a)) > (static_cast<size_t>(b))) ? (static_cast<size_t>(a)) : (static_cast<size_t>(b))                 //!< MAX macro
+#define FW_MIN(a, b) ((static_cast<size_t>(a)) < (static_cast<size_t>(b))) ? (static_cast<size_t>(a)) : (static_cast<size_t>(b))                 //!< MIN macro
 
 #define FW_NO_ASSERT 1  //!< Asserts turned off
 #define FW_FILEID_ASSERT \

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -89,11 +89,9 @@ typedef double F64;  //!< 64-bit floating point (double). Required for compiler-
 /*----------------------------------------------------------------------------*/
 #define FW_NUM_ARRAY_ELEMENTS(a) (sizeof(a) / sizeof((a)[0]))  //!< number of elements in an array
 #define FW_MAX(a, b) \
-    (((static_cast<U32>(a)) > (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))
-        //!< MAX macro
+    (((static_cast<U32>(a)) > (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))  //!< MAX macro
 #define FW_MIN(a, b) \
-    (((static_cast<U32>(a)) < (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))
-        //!< MIN macro
+    (((static_cast<U32>(a)) < (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))  //!< MIN macro
 
 #define FW_NO_ASSERT 1  //!< Asserts turned off
 #define FW_FILEID_ASSERT \

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -36,7 +36,6 @@ extern "C" {
 #endif
 #include <config/FPrimeNumericalConfig.h>
 #include <inttypes.h>  // Standard integer types and printf macros
-#include <cstddef>
 
 // Compiler checks
 #if defined(__GNUC__) || defined(__llvm__) || defined(PLATFORM_OVERRIDE_GCC_CLANG_CHECK)
@@ -89,8 +88,8 @@ typedef double F64;  //!< 64-bit floating point (double). Required for compiler-
 /* Useful macro definitions                                                   */
 /*----------------------------------------------------------------------------*/
 #define FW_NUM_ARRAY_ELEMENTS(a) (sizeof(a) / sizeof((a)[0]))  //!< number of elements in an array
-#define FW_MAX(a, b) ((static_cast<size_t>(a)) > (static_cast<size_t>(b))) ? (static_cast<size_t>(a)) : (static_cast<size_t>(b))                 //!< MAX macro
-#define FW_MIN(a, b) ((static_cast<size_t>(a)) < (static_cast<size_t>(b))) ? (static_cast<size_t>(a)) : (static_cast<size_t>(b))                 //!< MIN macro
+#define FW_MAX(a, b) ((static_cast<U32>(a)) > (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b))                 //!< MAX macro
+#define FW_MIN(a, b) ((static_cast<U32>(a)) < (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b))                 //!< MIN macro
 
 #define FW_NO_ASSERT 1  //!< Asserts turned off
 #define FW_FILEID_ASSERT \

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -88,8 +88,8 @@ typedef double F64;  //!< 64-bit floating point (double). Required for compiler-
 /* Useful macro definitions                                                   */
 /*----------------------------------------------------------------------------*/
 #define FW_NUM_ARRAY_ELEMENTS(a) (sizeof(a) / sizeof((a)[0]))  //!< number of elements in an array
-#define FW_MAX(a, b) (((a) > (b)) ? (a) : (b))                 //!< MAX macro
-#define FW_MIN(a, b) (((a) < (b)) ? (a) : (b))                 //!< MIN macro
+#define FW_MAX(a, b) (((static_cast<U32>(a)) > (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast(U32>(b)))                 //!< MAX macro
+#define FW_MIN(a, b) (((static_cast<U32>(a)) < (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))                 //!< MIN macro
 
 #define FW_NO_ASSERT 1  //!< Asserts turned off
 #define FW_FILEID_ASSERT \

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -88,7 +88,7 @@ typedef double F64;  //!< 64-bit floating point (double). Required for compiler-
 /* Useful macro definitions                                                   */
 /*----------------------------------------------------------------------------*/
 #define FW_NUM_ARRAY_ELEMENTS(a) (sizeof(a) / sizeof((a)[0]))  //!< number of elements in an array
-#define FW_MAX(a, b) (((static_cast<U32>(a)) > (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast(U32>(b)))                 //!< MAX macro
+#define FW_MAX(a, b) (((static_cast<U32>(a)) > (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))                 //!< MAX macro
 #define FW_MIN(a, b) (((static_cast<U32>(a)) < (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))                 //!< MIN macro
 
 #define FW_NO_ASSERT 1  //!< Asserts turned off

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -88,8 +88,8 @@ typedef double F64;  //!< 64-bit floating point (double). Required for compiler-
 /* Useful macro definitions                                                   */
 /*----------------------------------------------------------------------------*/
 #define FW_NUM_ARRAY_ELEMENTS(a) (sizeof(a) / sizeof((a)[0]))  //!< number of elements in an array
-#define FW_MAX(a, b) ((static_cast<U32>(a)) > (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b))                 //!< MAX macro
-#define FW_MIN(a, b) ((static_cast<U32>(a)) < (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b))                 //!< MIN macro
+#define FW_MAX(a, b) (((a) > (b)) ? (a) : (b))                 //!< MAX macro
+#define FW_MIN(a, b) (((a) < (b)) ? (a) : (b))                 //!< MIN macro
 
 #define FW_NO_ASSERT 1  //!< Asserts turned off
 #define FW_FILEID_ASSERT \

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -89,9 +89,11 @@ typedef double F64;  //!< 64-bit floating point (double). Required for compiler-
 /*----------------------------------------------------------------------------*/
 #define FW_NUM_ARRAY_ELEMENTS(a) (sizeof(a) / sizeof((a)[0]))  //!< number of elements in an array
 #define FW_MAX(a, b) \
-    (((static_cast<U32>(a)) > (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))                 //!< MAX macro
+    (((static_cast<U32>(a)) > (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))
+        //!< MAX macro
 #define FW_MIN(a, b) \
-    (((static_cast<U32>(a)) < (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))                 //!< MIN macro
+    (((static_cast<U32>(a)) < (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))
+        //!< MIN macro
 
 #define FW_NO_ASSERT 1  //!< Asserts turned off
 #define FW_FILEID_ASSERT \

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -88,8 +88,10 @@ typedef double F64;  //!< 64-bit floating point (double). Required for compiler-
 /* Useful macro definitions                                                   */
 /*----------------------------------------------------------------------------*/
 #define FW_NUM_ARRAY_ELEMENTS(a) (sizeof(a) / sizeof((a)[0]))  //!< number of elements in an array
-#define FW_MAX(a, b) (((static_cast<U32>(a)) > (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))                 //!< MAX macro
-#define FW_MIN(a, b) (((static_cast<U32>(a)) < (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))                 //!< MIN macro
+#define FW_MAX(a, b) \
+    (((static_cast<U32>(a)) > (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))                 //!< MAX macro
+#define FW_MIN(a, b) \
+    (((static_cast<U32>(a)) < (static_cast<U32>(b))) ? (static_cast<U32>(a)) : (static_cast<U32>(b)))                 //!< MIN macro
 
 #define FW_NO_ASSERT 1  //!< Asserts turned off
 #define FW_FILEID_ASSERT \

--- a/Svc/FpySequencer/FpySequencer.hpp
+++ b/Svc/FpySequencer/FpySequencer.hpp
@@ -7,6 +7,7 @@
 #ifndef FpySequencer_HPP
 #define FpySequencer_HPP
 
+#include <cstddef>
 #include "Fw/Types/MemAllocator.hpp"
 #include "Fw/Types/StringBase.hpp"
 #include "Fw/Types/SuccessEnumAc.hpp"
@@ -26,9 +27,9 @@ static_assert(Svc::Fpy::MAX_SEQUENCE_ARG_COUNT <= std::numeric_limits<U8>::max()
 static_assert(Svc::Fpy::MAX_SEQUENCE_STATEMENT_COUNT <= std::numeric_limits<U16>::max(),
               "Sequence statement count must be below U16 max");
 static_assert(Svc::Fpy::MAX_STACK_SIZE <= std::numeric_limits<U32>::max(), "Max stack size must be below U32 max");
-static_assert(Svc::Fpy::MAX_STACK_SIZE >= FW_TLM_BUFFER_MAX_SIZE,
+static_assert(Svc::Fpy::MAX_STACK_SIZE >= static_cast<size_t>(FW_TLM_BUFFER_MAX_SIZE),
               "Max stack size must be greater than max tlm buffer size");
-static_assert(Svc::Fpy::MAX_STACK_SIZE >= FW_PARAM_BUFFER_MAX_SIZE,
+static_assert(Svc::Fpy::MAX_STACK_SIZE >= static_cast<size_t>(FW_PARAM_BUFFER_MAX_SIZE),
               "Max stack size must be greater than max prm buffer size");
 
 namespace Svc {

--- a/default/config/AcConstants.fpp
+++ b/default/config/AcConstants.fpp
@@ -68,3 +68,127 @@ constant GenericHubInputPorts = 10
 constant GenericHubOutputPorts = 10
 constant GenericHubInputBuffers = 10
 constant GenericHubOutputBuffers = 10
+
+# ----------------------------------------------------------------------
+# Constants ported from FpConfig.h
+# ----------------------------------------------------------------------
+
+@ Dont care value for time contexts in sequences
+constant FW_CONTEXT_DONT_CARE = 0xFF
+
+@ Boolean values for serialization
+constant FW_SERIALIZE_TRUE_VALUE = 0xFF                         # Value encoded during serialization for boolean true
+constant FW_SERIALIZE_FALSE_VALUE = 0x00                        # Value encoded during serialization for boolean false
+
+@ On some systems, use of *printf family functions (snprintf, printf, etc) require a prohibitive amount of program
+@ space. Setting this to `0` indicates that the Fw/String methods should stop using these functions to conserve
+@ program size. However, this comes at the expense of discarding format parameters. i.e. the format string is returned
+@ unchanged.
+constant FW_USE_PRINTF_FAMILY_FUNCTIONS_IN_STRING_FORMATTING = 1
+
+@ For the simple object registry provided with the framework, this specifies how many objects the registry will store.
+constant FW_OBJ_SIMPLE_REG_ENTRIES = 500                        # Number of objects stored in simple object registry
+
+@ When dumping the contents of the registry, this specifies the size of the buffer used to store object names. Should
+@ be >= FW_OBJ_NAME_BUFFER_SIZE.
+constant FW_OBJ_SIMPLE_REG_BUFF_SIZE = 255                      # Size of object registry dump string
+
+@ For the simple queue registry provided with the framework, this specifies how many queues the registry will store.
+constant FW_QUEUE_SIMPLE_QUEUE_ENTRIES = 100                    # Number of queues stored in simple queue registry
+
+@ Specifies the size of the string holding the queue name for queues
+constant FW_QUEUE_NAME_BUFFER_SIZE = 80                         # Max size of message queue name
+
+@ Specifies the size of the string holding the task name for active components and tasks
+constant FW_TASK_NAME_BUFFER_SIZE = 80                          # Max size of task name
+
+@ Specifies the size of the buffer that contains a communications packet
+constant FW_COM_BUFFER_MAX_SIZE = 512
+
+@ Specifies the size of the buffer attached to state machine signals
+constant FW_SM_SIGNAL_BUFFER_MAX_SIZE = 128
+
+@ Specifies the size of the buffer that contains the serialized command arguments
+# FW_CMD_ARG_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - sizeof(FwOpcodeType) - sizeof(FwPacketDescriptorType))
+constant FW_CMD_ARG_BUFFER_MAX_SIZE = (FW_COM_BUFFER_MAX_SIZE - 4 - 4)
+
+@ Specifies the maximum size of a string in a command argument
+constant FW_CMD_STRING_MAX_SIZE = 40                            # Max character size of command string arguments
+
+@ Normally when a command is deserialized, the handler checks to see if there are any leftover
+@ bytes in the buffer. If there are, it assumes that the command was corrupted somehow since
+@ the serialized size should match the serialized size of the argument list. In some cases,
+@ command buffers are padded so the data can be larger than the serialized size of the command.
+@ Setting the below to zero will disable the check at the cost of not detecting commands that
+@ are too large.
+constant FW_CMD_CHECK_RESIDUAL = 1                              # Check for leftover command bytes
+
+@ Specifies the size of the buffer that contains the serialized log arguments
+# FW_LOG_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - sizeof(FwEventIdType) - sizeof(FwPacketDescriptorType))
+constant FW_LOG_BUFFER_MAX_SIZE = (FW_COM_BUFFER_MAX_SIZE - 4 - 4)
+
+@ Specifies the maximum size of a string in a log event
+@ Note: This constant truncates file names in assertion failure event reports
+constant FW_LOG_STRING_MAX_SIZE = 200                           # Max size of log string parameter type
+
+@ Specifies the size of the buffer that contains the serialized telemetry value
+constant FW_TLM_BUFFER_MAX_SIZE = (FW_COM_BUFFER_MAX_SIZE - 4 - 4)
+
+@ Specifies the size of the buffer that contains the serialized telemetry value
+constant FW_STATEMENT_ARG_BUFFER_MAX_SIZE = FW_CMD_ARG_BUFFER_MAX_SIZE
+
+@ Specifies the maximum size of a string in a telemetry channel
+constant FW_TLM_STRING_MAX_SIZE = 40                            # Max size of channelized telemetry string type
+
+@ Specifies the size of the buffer that contains the serialized parameter value
+constant FW_PARAM_BUFFER_MAX_SIZE = (FW_COM_BUFFER_MAX_SIZE - 4 - 4)
+
+@ Specifies the maximum size of a string in a parameter
+constant FW_PARAM_STRING_MAX_SIZE = 40                          # Max size of parameter string type
+
+@ Specifies the maximum size of a file downlink chunk
+constant FW_FILE_BUFFER_MAX_SIZE = FW_COM_BUFFER_MAX_SIZE       # Max size of file buffer (i.e. chunk of file)
+
+@ Specifies the maximum size of a string in an interface call
+constant FW_INTERNAL_INTERFACE_STRING_MAX_SIZE = 256            # Max size of interface string parameter type
+
+@ Defines the size of the text log string buffer. Should be large enough for format string and arguments
+constant FW_LOG_TEXT_BUFFER_SIZE = 256                          # Max size of string for text log message
+
+@ Some settings to enable AMPCS compatibility. This breaks regular ISF GUI compatibility
+constant FW_AMPCS_COMPATIBLE = 0                                # Whether or not JPL AMPCS ground system support is enabled
+
+@ Configuration for Fw::String
+@ Note: FPrimeBasicTypes.hpp needs to be updated to sync enum
+constant FW_FIXED_LENGTH_STRING_SIZE = 256                      # Character array size for Fw::String
+
+@ OS configuration
+constant FW_CONSOLE_HANDLE_MAX_SIZE = 24                        # Maximum size of a handle for OS queues
+
+constant FW_TASK_HANDLE_MAX_SIZE = 24                           # Maximum size of a handle for OS queues
+
+constant FW_FILE_HANDLE_MAX_SIZE = 16                           # Maximum size of a handle for OS queues
+
+constant FW_MUTEX_HANDLE_MAX_SIZE = 72                          # Maximum size of a handle for OS queues
+
+constant FW_QUEUE_HANDLE_MAX_SIZE = 352                         # Maximum size of a handle for OS queues
+
+constant FW_DIRECTORY_HANDLE_MAX_SIZE = 16                      # Maximum size of a handle for OS resources (files, queues, locks, etc.)
+
+constant FW_FILESYSTEM_HANDLE_MAX_SIZE = 16                     # Maximum size of a handle for OS resources (files, queues, locks, etc.)
+
+constant FW_RAW_TIME_HANDLE_MAX_SIZE = 56                       # Maximum size of a handle for OS::RawTime objects
+
+constant FW_RAW_TIME_SERIALIZATION_MAX_SIZE = 8                 # Maximum allowed serialization size for Os::RawTime objects
+
+constant FW_CONDITION_VARIABLE_HANDLE_MAX_SIZE = 56             # Maximum size of a handle for OS condition variables
+
+constant FW_CPU_HANDLE_MAX_SIZE = 16                            # Maximum size of a handle for OS cpu
+
+constant FW_MEMORY_HANDLE_MAX_SIZE = 16                         # Maximum size of a handle for OS memory
+
+constant FW_HANDLE_ALIGNMENT = 8                                # Alignment of handle storage
+
+constant FW_FILE_CHUNK_SIZE = 512                               # Chunk size for working with files in the OSAL layer
+
+constant FW_ASSERT_COUNT_MAX = 10                               # Maximum number of cascading FW_ASSERT check failures before forcing a system assert

--- a/default/config/AcConstants.fpp
+++ b/default/config/AcConstants.fpp
@@ -73,19 +73,6 @@ constant GenericHubOutputBuffers = 10
 # Constants ported from FpConfig.h
 # ----------------------------------------------------------------------
 
-@ Dont care value for time contexts in sequences
-constant FW_CONTEXT_DONT_CARE = 0xFF
-
-@ Boolean values for serialization
-constant FW_SERIALIZE_TRUE_VALUE = 0xFF                         # Value encoded during serialization for boolean true
-constant FW_SERIALIZE_FALSE_VALUE = 0x00                        # Value encoded during serialization for boolean false
-
-@ On some systems, use of *printf family functions (snprintf, printf, etc) require a prohibitive amount of program
-@ space. Setting this to `0` indicates that the Fw/String methods should stop using these functions to conserve
-@ program size. However, this comes at the expense of discarding format parameters. i.e. the format string is returned
-@ unchanged.
-constant FW_USE_PRINTF_FAMILY_FUNCTIONS_IN_STRING_FORMATTING = 1
-
 @ For the simple object registry provided with the framework, this specifies how many objects the registry will store.
 constant FW_OBJ_SIMPLE_REG_ENTRIES = 500                        # Number of objects stored in simple object registry
 
@@ -114,14 +101,6 @@ constant FW_CMD_ARG_BUFFER_MAX_SIZE = (FW_COM_BUFFER_MAX_SIZE - 4 - 4)
 
 @ Specifies the maximum size of a string in a command argument
 constant FW_CMD_STRING_MAX_SIZE = 40                            # Max character size of command string arguments
-
-@ Normally when a command is deserialized, the handler checks to see if there are any leftover
-@ bytes in the buffer. If there are, it assumes that the command was corrupted somehow since
-@ the serialized size should match the serialized size of the argument list. In some cases,
-@ command buffers are padded so the data can be larger than the serialized size of the command.
-@ Setting the below to zero will disable the check at the cost of not detecting commands that
-@ are too large.
-constant FW_CMD_CHECK_RESIDUAL = 1                              # Check for leftover command bytes
 
 @ Specifies the size of the buffer that contains the serialized log arguments
 # FW_LOG_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - sizeof(FwEventIdType) - sizeof(FwPacketDescriptorType))
@@ -154,9 +133,6 @@ constant FW_INTERNAL_INTERFACE_STRING_MAX_SIZE = 256            # Max size of in
 
 @ Defines the size of the text log string buffer. Should be large enough for format string and arguments
 constant FW_LOG_TEXT_BUFFER_SIZE = 256                          # Max size of string for text log message
-
-@ Some settings to enable AMPCS compatibility. This breaks regular ISF GUI compatibility
-constant FW_AMPCS_COMPATIBLE = 0                                # Whether or not JPL AMPCS ground system support is enabled
 
 @ Configuration for Fw::String
 @ Note: FPrimeBasicTypes.hpp needs to be updated to sync enum

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -18,22 +18,8 @@ extern "C" {
 #include <Platform/PlatformTypes.h>
 
 // ----------------------------------------------------------------------
-// Type aliases
-// ----------------------------------------------------------------------
-#define FW_CONTEXT_DONT_CARE 0xFF  //!< Don't care value for time contexts in sequences
-
-// ----------------------------------------------------------------------
 // Configuration switches
 // ----------------------------------------------------------------------
-
-// Boolean values for serialization
-#ifndef FW_SERIALIZE_TRUE_VALUE
-#define FW_SERIALIZE_TRUE_VALUE (0xFF)  //!< Value encoded during serialization for boolean true
-#endif
-
-#ifndef FW_SERIALIZE_FALSE_VALUE
-#define FW_SERIALIZE_FALSE_VALUE (0x00)  //!< Value encoded during serialization for boolean false
-#endif
 
 // Allow objects to have names. Allocates storage for each instance
 #ifndef FW_OBJECT_NAMES
@@ -63,20 +49,11 @@ extern "C" {
 // Adds the ability for all component related objects to register
 // centrally.
 #ifndef FW_OBJECT_REGISTRATION
-#define FW_OBJECT_REGISTRATION \
-    1  //!< Indicates whether or not objects can register themselves (more code, more object tracking)
+#define FW_OBJECT_REGISTRATION 1  //!< Indicates whether or not objects can register themselves (more code, more object tracking)
 #endif
 
 #ifndef FW_QUEUE_REGISTRATION
 #define FW_QUEUE_REGISTRATION 1  //!< Indicates whether or not queue registration is used
-#endif
-
-// On some systems, use of *printf family functions (snprintf, printf, etc) require a prohibitive amount of program
-// space. Setting this to `0` indicates that the Fw/String methods should stop using these functions to conserve
-// program size. However, this comes at the expense of discarding format parameters. i.e. the format string is returned
-// unchanged.
-#ifndef FW_USE_PRINTF_FAMILY_FUNCTIONS_IN_STRING_FORMATTING
-#define FW_USE_PRINTF_FAMILY_FUNCTIONS_IN_STRING_FORMATTING 1
 #endif
 
 // Port Facilities
@@ -135,199 +112,16 @@ extern "C" {
 #endif
 #endif
 
-#if FW_OBJECT_REGISTRATION
-// For the simple object registry provided with the framework, this specifies how many objects the registry will store.
-#ifndef FW_OBJ_SIMPLE_REG_ENTRIES
-#define FW_OBJ_SIMPLE_REG_ENTRIES 500  //!< Number of objects stored in simple object registry
-#endif
-// When dumping the contents of the registry, this specifies the size of the buffer used to store object names. Should
-// be >= FW_OBJ_NAME_BUFFER_SIZE.
-#ifndef FW_OBJ_SIMPLE_REG_BUFF_SIZE
-#define FW_OBJ_SIMPLE_REG_BUFF_SIZE 255  //!< Size of object registry dump string
-#endif
-#endif
-
-#if FW_QUEUE_REGISTRATION
-// For the simple queue registry provided with the framework, this specifies how many queues the registry will store.
-#ifndef FW_QUEUE_SIMPLE_QUEUE_ENTRIES
-#define FW_QUEUE_SIMPLE_QUEUE_ENTRIES 100  //!< Number of queues stored in simple queue registry
-#endif
-#endif
-
-// Specifies the size of the string holding the queue name for queues
-#ifndef FW_QUEUE_NAME_BUFFER_SIZE
-#define FW_QUEUE_NAME_BUFFER_SIZE 80  //!< Max size of message queue name
-#endif
-
-// Specifies the size of the string holding the task name for active components and tasks
-#ifndef FW_TASK_NAME_BUFFER_SIZE
-#define FW_TASK_NAME_BUFFER_SIZE 80  //!< Max size of task name
-#endif
-
-// Specifies the size of the buffer that contains a communications packet.
-#ifndef FW_COM_BUFFER_MAX_SIZE
-#define FW_COM_BUFFER_MAX_SIZE 512
-#endif
-
-// Specifies the size of the buffer attached to state machine signals.
-#ifndef FW_SM_SIGNAL_BUFFER_MAX_SIZE
-#define FW_SM_SIGNAL_BUFFER_MAX_SIZE 128  // Not to exceed max value of FwSizeType
-#endif
-
-// Specifies the size of the buffer that contains the serialized command arguments.
-
-#ifndef FW_CMD_ARG_BUFFER_MAX_SIZE
-#define FW_CMD_ARG_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - sizeof(FwOpcodeType) - sizeof(FwPacketDescriptorType))
-#endif
-
-// Specifies the maximum size of a string in a command argument
-#ifndef FW_CMD_STRING_MAX_SIZE
-#define FW_CMD_STRING_MAX_SIZE 40  //!< Max character size of command string arguments
-#endif
-
-// Normally when a command is deserialized, the handler checks to see if there are any leftover
-// bytes in the buffer. If there are, it assumes that the command was corrupted somehow since
-// the serialized size should match the serialized size of the argument list. In some cases,
-// command buffers are padded so the data can be larger than the serialized size of the command.
-// Setting the below to zero will disable the check at the cost of not detecting commands that
-// are too large.
-#ifndef FW_CMD_CHECK_RESIDUAL
-#define FW_CMD_CHECK_RESIDUAL 1  //!< Check for leftover command bytes
-#endif
-
-// Specifies the size of the buffer that contains the serialized log arguments.
-#ifndef FW_LOG_BUFFER_MAX_SIZE
-#define FW_LOG_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - sizeof(FwEventIdType) - sizeof(FwPacketDescriptorType))
-#endif
-
-// Specifies the maximum size of a string in a log event
-// Note: This constant truncates file names in assertion failure event reports
-#ifndef FW_LOG_STRING_MAX_SIZE
-#define FW_LOG_STRING_MAX_SIZE 200  //!< Max size of log string parameter type
-#endif
-
-// Specifies the size of the buffer that contains the serialized telemetry value.
-#ifndef FW_TLM_BUFFER_MAX_SIZE
-#define FW_TLM_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - sizeof(FwChanIdType) - sizeof(FwPacketDescriptorType))
-#endif
-
-// Specifies the size of the buffer that contains statement args for the FpySequencer
-#ifndef FW_STATEMENT_ARG_BUFFER_MAX_SIZE
-#define FW_STATEMENT_ARG_BUFFER_MAX_SIZE (FW_CMD_ARG_BUFFER_MAX_SIZE)
-#endif
-
-// Specifies the maximum size of a string in a telemetry channel
-#ifndef FW_TLM_STRING_MAX_SIZE
-#define FW_TLM_STRING_MAX_SIZE 40  //!< Max size of channelized telemetry string type
-#endif
-
-// Specifies the size of the buffer that contains the serialized parameter value.
-#ifndef FW_PARAM_BUFFER_MAX_SIZE
-#define FW_PARAM_BUFFER_MAX_SIZE (FW_COM_BUFFER_MAX_SIZE - sizeof(FwPrmIdType) - sizeof(FwPacketDescriptorType))
-#endif
-
-// Specifies the maximum size of a string in a parameter
-#ifndef FW_PARAM_STRING_MAX_SIZE
-#define FW_PARAM_STRING_MAX_SIZE 40  //!< Max size of parameter string type
-#endif
-
-// Specifies the maximum size of a file downlink chunk
-#ifndef FW_FILE_BUFFER_MAX_SIZE
-#define FW_FILE_BUFFER_MAX_SIZE FW_COM_BUFFER_MAX_SIZE  //!< Max size of file buffer (i.e. chunk of file)
-#endif
-
-// Specifies the maximum size of a string in an interface call
-#ifndef FW_INTERNAL_INTERFACE_STRING_MAX_SIZE
-#define FW_INTERNAL_INTERFACE_STRING_MAX_SIZE 256  //!< Max size of interface string parameter type
-#endif
-
 // Enables text logging of events as well as data logging. Adds a second logging port for text output.
 // In order to set this to 0, FPRIME_ENABLE_TEXT_LOGGERS must be set to OFF.
 #ifndef FW_ENABLE_TEXT_LOGGING
 #define FW_ENABLE_TEXT_LOGGING 1  //!< Indicates whether text logging is turned on
 #endif
 
-// Define the size of the text log string buffer. Should be large enough for format string and arguments
-#ifndef FW_LOG_TEXT_BUFFER_SIZE
-#define FW_LOG_TEXT_BUFFER_SIZE 256  //!< Max size of string for text log message
-#endif
-
 // Define if serializables have toString() method. Turning off will save code space and
 // string constants. Must be enabled if text logging enabled
 #ifndef FW_SERIALIZABLE_TO_STRING
 #define FW_SERIALIZABLE_TO_STRING 1  //!< Indicates if autocoded serializables have toString() methods
-#endif
-
-// Some settings to enable AMPCS compatibility. This breaks regular ISF GUI compatibility
-#ifndef FW_AMPCS_COMPATIBLE
-#define FW_AMPCS_COMPATIBLE 0  //!< Whether or not JPL AMPCS ground system support is enabled.
-#endif
-
-// Configuration for Fw::String
-#ifndef FW_FIXED_LENGTH_STRING_SIZE
-#define FW_FIXED_LENGTH_STRING_SIZE 256  //!< Character array size for Fw::String
-#endif
-
-// OS configuration
-#ifndef FW_CONSOLE_HANDLE_MAX_SIZE
-#define FW_CONSOLE_HANDLE_MAX_SIZE 24  //!< Maximum size of a handle for OS queues
-#endif
-
-#ifndef FW_TASK_HANDLE_MAX_SIZE
-#define FW_TASK_HANDLE_MAX_SIZE 24  //!< Maximum size of a handle for OS queues
-#endif
-
-#ifndef FW_FILE_HANDLE_MAX_SIZE
-#define FW_FILE_HANDLE_MAX_SIZE 16  //!< Maximum size of a handle for OS queues
-#endif
-
-#ifndef FW_MUTEX_HANDLE_MAX_SIZE
-#define FW_MUTEX_HANDLE_MAX_SIZE 72  //!< Maximum size of a handle for OS queues
-#endif
-
-#ifndef FW_QUEUE_HANDLE_MAX_SIZE
-#define FW_QUEUE_HANDLE_MAX_SIZE 352  //!< Maximum size of a handle for OS queues
-#endif
-
-#ifndef FW_DIRECTORY_HANDLE_MAX_SIZE
-#define FW_DIRECTORY_HANDLE_MAX_SIZE 16  //!< Maximum size of a handle for OS resources (files, queues, locks, etc.)
-#endif
-
-#ifndef FW_FILESYSTEM_HANDLE_MAX_SIZE
-#define FW_FILESYSTEM_HANDLE_MAX_SIZE 16  //!< Maximum size of a handle for OS resources (files, queues, locks, etc.)
-#endif
-
-#ifndef FW_RAW_TIME_HANDLE_MAX_SIZE
-#define FW_RAW_TIME_HANDLE_MAX_SIZE 56  //!< Maximum size of a handle for OS::RawTime objects
-#endif
-
-#ifndef FW_RAW_TIME_SERIALIZATION_MAX_SIZE
-#define FW_RAW_TIME_SERIALIZATION_MAX_SIZE 8  //!< Maximum allowed serialization size for Os::RawTime objects
-#endif
-
-#ifndef FW_CONDITION_VARIABLE_HANDLE_MAX_SIZE
-#define FW_CONDITION_VARIABLE_HANDLE_MAX_SIZE 56  //!< Maximum size of a handle for OS condition variables
-#endif
-
-#ifndef FW_CPU_HANDLE_MAX_SIZE
-#define FW_CPU_HANDLE_MAX_SIZE 16  //!< Maximum size of a handle for OS cpu
-#endif
-
-#ifndef FW_MEMORY_HANDLE_MAX_SIZE
-#define FW_MEMORY_HANDLE_MAX_SIZE 16  //!< Maximum size of a handle for OS memory
-#endif
-
-#ifndef FW_HANDLE_ALIGNMENT
-#define FW_HANDLE_ALIGNMENT 8  //!< Alignment of handle storage
-#endif
-
-// Note: One buffer of this size will be stack-allocated during certain OSAL operations e.g. when copying a file
-#ifndef FW_FILE_CHUNK_SIZE
-#define FW_FILE_CHUNK_SIZE 512  //!< Chunk size for working with files in the OSAL layer
-#endif
-
-#ifndef FW_ASSERT_COUNT_MAX
-#define FW_ASSERT_COUNT_MAX 10  //!< Maximum number of cascading FW_ASSERT check failures before forcing a system assert
 #endif
 
 // *** NOTE configuration checks are in Fw/Cfg/ConfigCheck.cpp in order to have

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -18,8 +18,22 @@ extern "C" {
 #include <Platform/PlatformTypes.h>
 
 // ----------------------------------------------------------------------
+// Type aliases
+// ----------------------------------------------------------------------
+#define FW_CONTEXT_DONT_CARE 0xFF  //!< Don't care value for time contexts in sequences
+
+// ----------------------------------------------------------------------
 // Configuration switches
 // ----------------------------------------------------------------------
+
+// Boolean values for serialization
+#ifndef FW_SERIALIZE_TRUE_VALUE
+#define FW_SERIALIZE_TRUE_VALUE (0xFF)  //!< Value encoded during serialization for boolean true
+#endif
+
+#ifndef FW_SERIALIZE_FALSE_VALUE
+#define FW_SERIALIZE_FALSE_VALUE (0x00)  //!< Value encoded during serialization for boolean false
+#endif
 
 // Allow objects to have names. Allocates storage for each instance
 #ifndef FW_OBJECT_NAMES
@@ -55,6 +69,14 @@ extern "C" {
 
 #ifndef FW_QUEUE_REGISTRATION
 #define FW_QUEUE_REGISTRATION 1  //!< Indicates whether or not queue registration is used
+#endif
+
+// On some systems, use of *printf family functions (snprintf, printf, etc) require a prohibitive amount of program
+// space. Setting this to `0` indicates that the Fw/String methods should stop using these functions to conserve
+// program size. However, this comes at the expense of discarding format parameters. i.e. the format string is returned
+// unchanged.
+#ifndef FW_USE_PRINTF_FAMILY_FUNCTIONS_IN_STRING_FORMATTING
+#define FW_USE_PRINTF_FAMILY_FUNCTIONS_IN_STRING_FORMATTING 1
 #endif
 
 // Port Facilities
@@ -113,6 +135,16 @@ extern "C" {
 #endif
 #endif
 
+// Normally when a command is deserialized, the handler checks to see if there are any leftover
+// bytes in the buffer. If there are, it assumes that the command was corrupted somehow since
+// the serialized size should match the serialized size of the argument list. In some cases,
+// command buffers are padded so the data can be larger than the serialized size of the command.
+// Setting the below to zero will disable the check at the cost of not detecting commands that
+// are too large.
+#ifndef FW_CMD_CHECK_RESIDUAL
+#define FW_CMD_CHECK_RESIDUAL 1  //!< Check for leftover command bytes
+#endif
+
 // Enables text logging of events as well as data logging. Adds a second logging port for text output.
 // In order to set this to 0, FPRIME_ENABLE_TEXT_LOGGERS must be set to OFF.
 #ifndef FW_ENABLE_TEXT_LOGGING
@@ -123,6 +155,11 @@ extern "C" {
 // string constants. Must be enabled if text logging enabled
 #ifndef FW_SERIALIZABLE_TO_STRING
 #define FW_SERIALIZABLE_TO_STRING 1  //!< Indicates if autocoded serializables have toString() methods
+#endif
+
+// Some settings to enable AMPCS compatibility. This breaks regular ISF GUI compatibility
+#ifndef FW_AMPCS_COMPATIBLE
+#define FW_AMPCS_COMPATIBLE 0  //!< Whether or not JPL AMPCS ground system support is enabled.
 #endif
 
 // *** NOTE configuration checks are in Fw/Cfg/ConfigCheck.cpp in order to have

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -49,7 +49,8 @@ extern "C" {
 // Adds the ability for all component related objects to register
 // centrally.
 #ifndef FW_OBJECT_REGISTRATION
-#define FW_OBJECT_REGISTRATION 1  //!< Indicates whether or not objects can register themselves (more code, more object tracking)
+#define FW_OBJECT_REGISTRATION \
+    1  //!< Indicates whether or not objects can register themselves (more code, more object tracking)
 #endif
 
 #ifndef FW_QUEUE_REGISTRATION


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n/a |
|**_Documentation Included (y/n)_**| n/a |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

This converts most of the macro constant (integer type) definitions in FpConfig.h to FPP constant definitions. 

## Rationale

This provide better accessibility to the constant definitions.

## Testing/Review Recommendations

This went through the Ref build process (Ref app executed as expected) and subjected to CI checks.

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
