### PR TITLE
[Rate Groups and Timeliness] RateGroups Docs Enhancements

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -499,6 +499,7 @@ PORTOUT
 PORTSELECTOR
 ppandian
 pregen
+prescaler
 prioritization
 PRIORITYQUEUE
 prm


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| None |
|**_Changed Files (y/n)_**|  [fprime/docs/user-manual/rate-groups.md](https://github.com/nasa/fprime/blob/devel/docs/user-manual/design-patterns/rate-group.md) |
| **_Requested Changes_** | A detailed Clock prescaler example algorithm using components from the `Svc` core module. |

---
## Change Description

### The First Change:
I am completely new to F-Prime, but I've some good experience in embedded systems design in general. I was reading the [RateGroups and Timeliness](https://fprime.jpl.nasa.gov/latest/docs/user-manual/design-patterns/rate-group/) documentation when I stepped into a grammatical error, and I've corrected it in this PR.

### The Second Change:
At the first glance, I didn't understand what does it mean to provide a clock divider until I looked for the code. That's why I've added this example.

This change involves an example for the algorithms that could be used to implement a Virtual Clock Prescaler (And, I believe there is more). The example simplifies the operations of Cycling and Sampling performed by the core routine `Svc::RateGroupDriver::CycleIn_handler(...)`. 

## Rationale

I believe this example would be a great add to this page; as it also describes the core algorithm used here to design the `RateGroupDriver` components around the System base component. It may immerse the reader, who might be new to F`-prime, into the core quickly, in addition to providing a good example to the RateGroups-Drivers pattern. Let me know if there are requested changes.

## Future Work

I think referencing more details from the core on the specialized implementation documentation pages would be a good rigorous change, unless these algorithms shall carry breaking future changes. What do you think about that? Also, another thing, maybe examining whether there are other clock prescaler algorithms?
