### PR TITLE
FpySequencer Add push tlm val and time dir

### DIFF
--- a/Svc/FpySequencer/FpySequencer.hpp
+++ b/Svc/FpySequencer/FpySequencer.hpp
@@ -616,6 +616,8 @@ class FpySequencer : public FpySequencerComponentBase {
 
     // sends a signal based on a signal id
     void sendSignal(Signal signal);
+
+    // dispatches a command, returns whether successful or not
     Fw::Success sendCmd(FwOpcodeType opcode, const U8* argBuf, FwSizeType argBufSize);
 
     // pops a value off of the top of the stack

--- a/Svc/FpySequencer/FpySequencer.hpp
+++ b/Svc/FpySequencer/FpySequencer.hpp
@@ -25,7 +25,7 @@ static_assert(Svc::Fpy::MAX_SEQUENCE_ARG_COUNT <= std::numeric_limits<U8>::max()
               "Sequence arg count must be below U8 max");
 static_assert(Svc::Fpy::MAX_SEQUENCE_STATEMENT_COUNT <= std::numeric_limits<U16>::max(),
               "Sequence statement count must be below U16 max");
-static_assert(Svc::Fpy::MAX_STACK_SIZE <= std::numeric_limits<U32>::max(), "Max stack size must be below U32 max");
+static_assert(Svc::Fpy::MAX_STACK_SIZE <= std::numeric_limits<Svc::Fpy::StackSizeType>::max(), "Max stack size must be below Svc::Fpy::StackSizeType max");
 static_assert(Svc::Fpy::MAX_STACK_SIZE >= FW_TLM_BUFFER_MAX_SIZE,
               "Max stack size must be greater than max tlm buffer size");
 static_assert(Svc::Fpy::MAX_STACK_SIZE >= FW_PARAM_BUFFER_MAX_SIZE,
@@ -48,6 +48,7 @@ class FpySequencer : public FpySequencerComponentBase {
         FpySequencer_IfDirective ifDirective;
         FpySequencer_NoOpDirective noOp;
         FpySequencer_StoreTlmValDirective storeTlmVal;
+        FpySequencer_PushTlmValAndTimeDirective pushTlmValAndTime;
         FpySequencer_StorePrmDirective storePrm;
         FpySequencer_ConstCmdDirective constCmd;
         FpySequencer_StackOpDirective stackOp;
@@ -410,6 +411,10 @@ class FpySequencer : public FpySequencerComponentBase {
     void directive_storeTlmVal_internalInterfaceHandler(
         const Svc::FpySequencer_StoreTlmValDirective& directive) override;
 
+    //! Internal interface handler for directive_pushTlmValAndTime
+    void directive_pushTlmValAndTime_internalInterfaceHandler(
+        const Svc::FpySequencer_PushTlmValAndTimeDirective& directive) override;
+
     //! Internal interface handler for directive_storePrm
     void directive_storePrm_internalInterfaceHandler(const Svc::FpySequencer_StorePrmDirective& directive) override;
 
@@ -639,6 +644,7 @@ class FpySequencer : public FpySequencerComponentBase {
     Signal if_directiveHandler(const FpySequencer_IfDirective& directive, DirectiveError& error);
     Signal noOp_directiveHandler(const FpySequencer_NoOpDirective& directive, DirectiveError& error);
     Signal storeTlmVal_directiveHandler(const FpySequencer_StoreTlmValDirective& directive, DirectiveError& error);
+    Signal pushTlmValAndTime_directiveHandler(const FpySequencer_PushTlmValAndTimeDirective& directive, DirectiveError& error);
     Signal storePrm_directiveHandler(const FpySequencer_StorePrmDirective& directive, DirectiveError& error);
     Signal constCmd_directiveHandler(const FpySequencer_ConstCmdDirective& directive, DirectiveError& error);
     Signal stackOp_directiveHandler(const FpySequencer_StackOpDirective& directive, DirectiveError& error);

--- a/Svc/FpySequencer/FpySequencer.hpp
+++ b/Svc/FpySequencer/FpySequencer.hpp
@@ -25,7 +25,8 @@ static_assert(Svc::Fpy::MAX_SEQUENCE_ARG_COUNT <= std::numeric_limits<U8>::max()
               "Sequence arg count must be below U8 max");
 static_assert(Svc::Fpy::MAX_SEQUENCE_STATEMENT_COUNT <= std::numeric_limits<U16>::max(),
               "Sequence statement count must be below U16 max");
-static_assert(Svc::Fpy::MAX_STACK_SIZE <= std::numeric_limits<Svc::Fpy::StackSizeType>::max(), "Max stack size must be below Svc::Fpy::StackSizeType max");
+static_assert(Svc::Fpy::MAX_STACK_SIZE <= std::numeric_limits<Svc::Fpy::StackSizeType>::max(),
+              "Max stack size must be below Svc::Fpy::StackSizeType max");
 static_assert(Svc::Fpy::MAX_STACK_SIZE >= FW_TLM_BUFFER_MAX_SIZE,
               "Max stack size must be greater than max tlm buffer size");
 static_assert(Svc::Fpy::MAX_STACK_SIZE >= FW_PARAM_BUFFER_MAX_SIZE,
@@ -644,7 +645,8 @@ class FpySequencer : public FpySequencerComponentBase {
     Signal if_directiveHandler(const FpySequencer_IfDirective& directive, DirectiveError& error);
     Signal noOp_directiveHandler(const FpySequencer_NoOpDirective& directive, DirectiveError& error);
     Signal storeTlmVal_directiveHandler(const FpySequencer_StoreTlmValDirective& directive, DirectiveError& error);
-    Signal pushTlmValAndTime_directiveHandler(const FpySequencer_PushTlmValAndTimeDirective& directive, DirectiveError& error);
+    Signal pushTlmValAndTime_directiveHandler(const FpySequencer_PushTlmValAndTimeDirective& directive,
+                                              DirectiveError& error);
     Signal storePrm_directiveHandler(const FpySequencer_StorePrmDirective& directive, DirectiveError& error);
     Signal constCmd_directiveHandler(const FpySequencer_ConstCmdDirective& directive, DirectiveError& error);
     Signal stackOp_directiveHandler(const FpySequencer_StackOpDirective& directive, DirectiveError& error);

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -451,9 +451,7 @@ Signal FpySequencer::pushTlmValAndTime_directiveHandler(const FpySequencer_PushT
     FW_ASSERT(stat == Fw::SerializeStatus::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(stat));
 
     // check that our stack won't overflow if we put both val and time on it
-    // cast to u64 first so that we don't get u32 overflow
-    if (static_cast<U64>(this->m_runtime.stackSize) + tlmValue.getBuffLength() + timeEsb.getBuffLength() >
-        Fpy::MAX_STACK_SIZE) {
+    if (Fpy::MAX_STACK_SIZE - tlmValue.getBuffLength() - timeEsb.getBuffLength() < this->m_runtime.stackSize) {
         error = DirectiveError::STACK_OVERFLOW;
         return Signal::stmtResponse_failure;
     }

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -237,6 +237,14 @@ void FpySequencer::directive_storeTlmVal_internalInterfaceHandler(
     handleDirectiveErrorCode(Fpy::DirectiveId::STORE_TLM_VAL, error);
 }
 
+//! Internal interface handler for directive_pushTlmValAndTime
+void FpySequencer::directive_pushTlmValAndTime_internalInterfaceHandler(
+    const Svc::FpySequencer_PushTlmValAndTimeDirective& directive) {
+    DirectiveError error = DirectiveError::NO_ERROR;
+    this->sendSignal(this->pushTlmValAndTime_directiveHandler(directive, error));
+    handleDirectiveErrorCode(Fpy::DirectiveId::PUSH_TLM_VAL_AND_TIME, error);
+}
+
 //! Internal interface handler for directive_storePrm
 void FpySequencer::directive_storePrm_internalInterfaceHandler(const Svc::FpySequencer_StorePrmDirective& directive) {
     DirectiveError error = DirectiveError::NO_ERROR;
@@ -415,6 +423,47 @@ Signal FpySequencer::storeTlmVal_directiveHandler(const FpySequencer_StoreTlmVal
     }
 
     memcpy(this->m_runtime.stack + stackOffset, tlmValue.getBuffAddr(), tlmValue.getBuffLength());
+    return Signal::stmtResponse_success;
+}
+
+Signal FpySequencer::pushTlmValAndTime_directiveHandler(const FpySequencer_PushTlmValAndTimeDirective& directive,
+                                                        DirectiveError& error) {
+    if (!this->isConnected_getTlmChan_OutputPort(0)) {
+        error = DirectiveError::TLM_GET_NOT_CONNECTED;
+        return Signal::stmtResponse_failure;
+    }
+
+    Fw::Time tlmTime;
+    Fw::TlmBuffer tlmValue;
+    Fw::TlmValid valid = this->getTlmChan_out(0, directive.get_chanId(), tlmTime, tlmValue);
+
+    if (valid != Fw::TlmValid::VALID) {
+        // could not find this tlm chan
+        error = DirectiveError::TLM_CHAN_NOT_FOUND;
+        return Signal::stmtResponse_failure;
+    }
+
+    U8 tlmTimeBuf[Fw::Time::SERIALIZED_SIZE];
+    Fw::ExternalSerializeBuffer timeEsb(tlmTimeBuf, Fw::Time::SERIALIZED_SIZE);
+    Fw::SerializeStatus stat = timeEsb.serializeFrom(tlmTime);
+
+    // coding error if this failed, we should have enough space
+    FW_ASSERT(stat == Fw::SerializeStatus::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(stat));
+
+    // check that our stack won't overflow if we put both val and time on it
+    // cast to u64 first so that we don't get u32 overflow
+    if (static_cast<U64>(this->m_runtime.stackSize) + tlmValue.getBuffLength() + timeEsb.getBuffLength() >
+        Fpy::MAX_STACK_SIZE) {
+        error = DirectiveError::STACK_OVERFLOW;
+        return Signal::stmtResponse_failure;
+    }
+
+    // push tlm to end of stack
+    memcpy(this->m_runtime.stack + this->m_runtime.stackSize, tlmValue.getBuffAddr(), tlmValue.getBuffLength());
+    this->m_runtime.stackSize += static_cast<Fpy::StackSizeType>(tlmValue.getBuffLength());
+    // now push time to end of stack
+    memcpy(this->m_runtime.stack + this->m_runtime.stackSize, timeEsb.getBuffAddr(), timeEsb.getBuffLength());
+    this->m_runtime.stackSize += static_cast<Fpy::StackSizeType>(timeEsb.getBuffLength());
     return Signal::stmtResponse_success;
 }
 

--- a/Svc/FpySequencer/FpySequencerDirectives.fppi
+++ b/Svc/FpySequencer/FpySequencerDirectives.fppi
@@ -38,6 +38,13 @@ struct StoreTlmValDirective {
     lvarOffset: Fpy.StackSizeType
 }
 
+@ pushes a tlm buffer to the stack, and then pushes the time 
+@ of the tlm meas to the stack
+struct PushTlmValAndTimeDirective {
+    @ the tlm channel id to get the time and value of
+    chanId: FwChanIdType
+}
+
 @ stores a prm buffer in the lvar array
 struct StorePrmDirective {
     @ the param id to get the value of
@@ -117,6 +124,8 @@ internal port directive_if(directive: IfDirective) priority 6 assert
 internal port directive_noOp(directive: NoOpDirective) priority 6 assert
 
 internal port directive_storeTlmVal(directive: StoreTlmValDirective) priority 6 assert
+
+internal port directive_pushTlmValAndTime(directive: PushTlmValAndTimeDirective) priority 6 assert
 
 internal port directive_storePrm(directive: StorePrmDirective) priority 6 assert
 

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -126,6 +126,16 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
             }
             break;
         }
+        case Fpy::DirectiveId::PUSH_TLM_VAL_AND_TIME: {
+            new (&deserializedDirective.pushTlmValAndTime) FpySequencer_PushTlmValAndTimeDirective();
+            status = argBuf.deserializeTo(deserializedDirective.pushTlmValAndTime);
+            if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getBuffLeft() != 0) {
+                this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
+                                                               argBuf.getBuffLeft(), argBuf.getBuffLength());
+                return Fw::Success::FAILURE;
+            }
+            break;
+        }
         case Fpy::DirectiveId::STORE_PRM: {
             new (&deserializedDirective.storePrm) FpySequencer_StorePrmDirective();
             status = argBuf.deserializeTo(deserializedDirective.storePrm);
@@ -378,6 +388,10 @@ void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy:
         }
         case Fpy::DirectiveId::STORE_TLM_VAL: {
             this->directive_storeTlmVal_internalInterfaceInvoke(directive.storeTlmVal);
+            return;
+        }
+        case Fpy::DirectiveId::PUSH_TLM_VAL_AND_TIME: {
+            this->directive_pushTlmValAndTime_internalInterfaceInvoke(directive.pushTlmValAndTime);
             return;
         }
         case Fpy::DirectiveId::STORE_PRM: {

--- a/Svc/FpySequencer/FpySequencerTypes.fpp
+++ b/Svc/FpySequencer/FpySequencerTypes.fpp
@@ -93,6 +93,7 @@ module Svc {
             DISCARD = 64
             MEMCMP = 65
             STACK_CMD = 66
+            PUSH_TLM_VAL_AND_TIME = 67
         }
 
         struct Header {

--- a/Svc/FpySequencer/docs/sdd.md
+++ b/Svc/FpySequencer/docs/sdd.md
@@ -28,7 +28,7 @@ The FpySequencer has a set of debugging commands which can be used to pause and 
 
 ## Directives
 | Opcode | Name | Description |
-|---| |------|-------------|
+|---|------|-------------|
 | 1 | WAIT_REL | Sleeps for a time duration relative to the current time |
 | 2 | WAIT_ABS | Sleeps until an absolute time is reached |
 | 4 | GOTO | Sets the index of the next statement to be executed |
@@ -37,33 +37,61 @@ The FpySequencer has a set of debugging commands which can be used to pause and 
 | 7 | STORE_TLM_VAL | Stores a telemetry buffer in the lvar array |
 | 8 | STORE_PRM | Stores a parameter buffer in the lvar array |
 | 9 | CONST_CMD | Dispatches a command with constant arguments |
-| 15 | OR | Pops two bytes off the stack. If either one is != 0, pushes 1 to stack, otherwise 0 |
-| 16 | AND | Pops two bytes off the stack. If both are != 0, pushes 1 to stack, otherwise 0 |
-| 17 | IEQ | Pops two 8-byte integers off the stack. If they are bitwise equal, pushes 1 to stack, otherwise 0 |
-| 18 | INE | Pops two 8-byte integers off the stack. If they are not bitwise equal, pushes 1 to stack, otherwise 0 | 
-| 19 | ULT | Pops two 8-byte unsigned integers off the stack. If the second < first, pushes 1 to stack, otherwise 0 |
-| 20 | ULE | Pops two 8-byte unsigned integers off the stack. If the second <= first, pushes 1 to stack, otherwise 0 |
-| 21 | UGT | Pops two 8-byte unsigned integers off the stack. If the second > first, pushes 1 to stack, otherwise 0 |
-| 22 | UGE | Pops two 8-byte unsigned integers off the stack. If the second >= first, pushes 1 to stack, otherwise 0 |
-| 23 | SLT | Pops two 8-byte signed integers off the stack. If the second < first, pushes 1 to stack, otherwise 0 |
-| 24 | SLE | Pops two 8-byte signed integers off the stack. If the second <= first, pushes 1 to stack, otherwise 0 |
-| 25 | SGT | Pops two 8-byte signed integers off the stack. If the second > first, pushes 1 to stack, otherwise 0 |
-| 26 | SGE | Pops two 8-byte signed integers off the stack. If the second >= first, pushes 1 to stack, otherwise 0 |
-| 27 | FEQ | Pops two 8-byte floats off the stack. If neither is NaN and they are otherwise equal, pushes 1 to stack, otherwise 0 |
-| 28 | FNE | Pops two 8-byte floats off the stack. If neither is NaN and they are otherwise not equal , pushes 1 to stack, otherwise 0 |
-| 29 | FLT | Pops two 8-byte floats off the stack. If neither is NaN and the second < first, pushes 1 to stack, otherwise 0 |
-| 30 | FLE | Pops two 8-byte floats off the stack. If neither is NaN and the second <= first, pushes 1 to stack, otherwise 0 |
-| 31 | FGT | Pops two 8-byte floats off the stack. If neither is NaN and the second > first, pushes 1 to stack, otherwise 0 |
-| 32 | FGE | Pops two 8-byte floats off the stack. If neither is NaN and the second >= first, pushes 1 to stack, otherwise 0 |
-| 33 | NOT | Pops a byte off the stack. If it is != 0, push 0 to stack, otherwise 1 |
-| 34 | FPEXT | Pops a 4-byte float off the stack, cast it to an 8-byte float and push to the stack |
-| 35 | FPTRUNC | Pops an 8-byte float off the stack, cast it to a 4-byte float and push to the stack |
-| 36 | FPTOSI | Pops an 8-byte float off the stack, cast it to a signed 8-byte integer and push to the stack |
-| 37 | FPTOUI | Pops an 8-byte float off the stack, cast it to an unsigned 8-byte integer and push to the stack |
-| 38 | SITOFP | Pops a signed 8-byte integer off the stack, cast it to an 8-byte float and push to the stack |
-| 39 | UITOFP | Pops an unsigned 8-byte integer off the stack, cast it to an 8-byte float and push to the stack |
-| 40 | EXIT | Pops a byte off the stack. If the byte != 0, end sequence as if it had finished nominally, otherwise end as if a command had failed |
-| 41 | ALLOCATE | Pushes a hard-coded count of 0-bytes to the stack |
-| 42 | STORE | Pops a hard-coded number of bytes off the stack, and writes them to the local variable array at a hard-coded offset |
-| 43 | LOAD | Reads a hard-coded number of bytes from the local variable array at a specific offset, and pushes them to the stack |
-| 44 | PUSH_VAL | Pushes a constant array of bytes to the stack |
+| 10 | OR | Pops two bytes off the stack. If either one is != 0, pushes 1 to stack, otherwise 0 |
+| 11 | AND | Pops two bytes off the stack. If both are != 0, pushes 1 to stack, otherwise 0 |
+| 12 | IEQ | Pops two 8-byte integers off the stack. If they are bitwise equal, pushes 1 to stack, otherwise 0 |
+| 13 | INE | Pops two 8-byte integers off the stack. If they are not bitwise equal, pushes 1 to stack, otherwise 0 | 
+| 14 | ULT | Pops two 8-byte unsigned integers off the stack. If the second < first, pushes 1 to stack, otherwise 0 |
+| 15 | ULE | Pops two 8-byte unsigned integers off the stack. If the second <= first, pushes 1 to stack, otherwise 0 |
+| 16 | UGT | Pops two 8-byte unsigned integers off the stack. If the second > first, pushes 1 to stack, otherwise 0 |
+| 17 | UGE | Pops two 8-byte unsigned integers off the stack. If the second >= first, pushes 1 to stack, otherwise 0 |
+| 18 | SLT | Pops two 8-byte signed integers off the stack. If the second < first, pushes 1 to stack, otherwise 0 |
+| 19 | SLE | Pops two 8-byte signed integers off the stack. If the second <= first, pushes 1 to stack, otherwise 0 |
+| 20 | SGT | Pops two 8-byte signed integers off the stack. If the second > first, pushes 1 to stack, otherwise 0 |
+| 21 | SGE | Pops two 8-byte signed integers off the stack. If the second >= first, pushes 1 to stack, otherwise 0 |
+| 22 | FEQ | Pops two 8-byte floats off the stack. If neither is NaN and they are otherwise equal, pushes 1 to stack, otherwise 0 |
+| 23 | FNE | Pops two 8-byte floats off the stack. If neither is NaN and they are otherwise not equal , pushes 1 to stack, otherwise 0 |
+| 24 | FLT | Pops two 8-byte floats off the stack. If neither is NaN and the second < first, pushes 1 to stack, otherwise 0 |
+| 25 | FLE | Pops two 8-byte floats off the stack. If neither is NaN and the second <= first, pushes 1 to stack, otherwise 0 |
+| 26 | FGT | Pops two 8-byte floats off the stack. If neither is NaN and the second > first, pushes 1 to stack, otherwise 0 |
+| 27 | FGE | Pops two 8-byte floats off the stack. If neither is NaN and the second >= first, pushes 1 to stack, otherwise 0 |
+| 28 | NOT | Pops a byte off the stack. If it is != 0, push 0 to stack, otherwise 1 |
+| 29 | FPTOSI | Pops an 8-byte float off the stack, cast it to a signed 8-byte integer and push to the stack |
+| 30 | FPTOUI | Pops an 8-byte float off the stack, cast it to an unsigned 8-byte integer and push to the stack |
+| 31 | SITOFP | Pops a signed 8-byte integer off the stack, cast it to an 8-byte float and push to the stack |
+| 32 | UITOFP | Pops an unsigned 8-byte integer off the stack, cast it to an 8-byte float and push to the stack |
+| 33 | IADD | Pops two 8-byte integers off the stack. Adds them and pushes the result to stack |
+| 34 | ISUB | Pops two 8-byte integers off the stack. Subtracts them and pushes the result to stack |
+| 35 | IMUL | Pops two 8-byte integers off the stack. Multiplies them and pushes the result to stack |
+| 36 | UDIV | Pops two 8-byte unsigned integers off the stack. Divides them and pushes the result to stack |
+| 37 | SDIV | Pops two 8-byte signed integers off the stack. Divides them and pushes the result to stack |
+| 38 | UMOD | Pops two 8-byte unsigned integers off the stack. Computes modulo and pushes the result to stack |
+| 39 | SMOD | Pops two 8-byte signed integers off the stack. Computes modulo and pushes the result to stack |
+| 40 | FADD | Pops two 8-byte floats off the stack. Adds them and pushes the result to stack |
+| 41 | FSUB | Pops two 8-byte floats off the stack. Subtracts them and pushes the result to stack |
+| 42 | FMUL | Pops two 8-byte floats off the stack. Multiplies them and pushes the result to stack |
+| 43 | FDIV | Pops two 8-byte floats off the stack. Divides them and pushes the result to stack |
+| 44 | FLOAT_FLOOR_DIV | Pops two 8-byte floats off the stack. Performs floor division and pushes the result to stack |
+| 45 | FPOW | Pops two 8-byte floats off the stack. Computes power and pushes the result to stack |
+| 46 | FLOG | Pops two 8-byte floats off the stack. Computes logarithm and pushes the result to stack |
+| 47 | FMOD | Pops two 8-byte floats off the stack. Computes modulo and pushes the result to stack |
+| 48 | FPEXT | Pops a 4-byte float off the stack, cast it to an 8-byte float and push to the stack |
+| 49 | FPTRUNC | Pops an 8-byte float off the stack, cast it to a 4-byte float and push to the stack |
+| 50 | SIEXT_8_64 | Sign extends an 8-bit integer to 64 bits |
+| 51 | SIEXT_16_64 | Sign extends a 16-bit integer to 64 bits |
+| 52 | SIEXT_32_64 | Sign extends a 32-bit integer to 64 bits |
+| 53 | ZIEXT_8_64 | Zero extends an 8-bit integer to 64 bits |
+| 54 | ZIEXT_16_64 | Zero extends a 16-bit integer to 64 bits |
+| 55 | ZIEXT_32_64 | Zero extends a 32-bit integer to 64 bits |
+| 56 | ITRUNC_64_8 | Truncates a 64-bit integer to 8 bits |
+| 57 | ITRUNC_64_16 | Truncates a 64-bit integer to 16 bits |
+| 58 | ITRUNC_64_32 | Truncates a 64-bit integer to 32 bits |
+| 59 | EXIT | Pops a byte off the stack. If the byte != 0, end sequence as if it had finished nominally, otherwise end as if a command had failed |
+| 60 | ALLOCATE | Pushes a hard-coded count of 0-bytes to the stack |
+| 61 | STORE | Pops a hard-coded number of bytes off the stack, and writes them to the local variable array at a hard-coded offset |
+| 62 | LOAD | Reads a hard-coded number of bytes from the local variable array at a specific offset, and pushes them to the stack |
+| 63 | PUSH_VAL | Pushes a constant array of bytes to the stack |
+| 64 | DISCARD | Discards bytes from the top of the stack |
+| 65 | MEMCMP | Compares two memory regions on the stack |
+| 66 | STACK_CMD | Dispatches a command with arguments from the stack |
+| 67 | PUSH_TLM_VAL_AND_TIME | Gets a telemetry channel and pushes its value, and then its time, onto the stack |

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
@@ -172,6 +172,16 @@ void FpySequencerTester::add_STORE_TLM_VAL(FpySequencer_StoreTlmValDirective dir
     addDirective(Fpy::DirectiveId::STORE_TLM_VAL, buf);
 }
 
+void FpySequencerTester::add_PUSH_TLM_VAL_AND_TIME(FwChanIdType id) {
+    add_PUSH_TLM_VAL_AND_TIME(FpySequencer_PushTlmValAndTimeDirective(id));
+}
+
+void FpySequencerTester::add_PUSH_TLM_VAL_AND_TIME(FpySequencer_PushTlmValAndTimeDirective dir) {
+    Fw::StatementArgBuffer buf;
+    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
+    addDirective(Fpy::DirectiveId::PUSH_TLM_VAL_AND_TIME, buf);
+}
+
 void FpySequencerTester::add_STORE_PRM(FwPrmIdType id, Fpy::StackSizeType lvarOffset) {
     add_STORE_PRM(FpySequencer_StorePrmDirective(id, lvarOffset));
 }
@@ -353,6 +363,12 @@ Signal FpySequencerTester::tester_storePrm_directiveHandler(const FpySequencer_S
 Signal FpySequencerTester::tester_storeTlmVal_directiveHandler(const FpySequencer_StoreTlmValDirective& directive,
                                                                DirectiveError& err) {
     return this->cmp.storeTlmVal_directiveHandler(directive, err);
+}
+
+Signal FpySequencerTester::tester_pushTlmValAndTime_directiveHandler(
+    const FpySequencer_PushTlmValAndTimeDirective& directive,
+    DirectiveError& err) {
+    return this->cmp.pushTlmValAndTime_directiveHandler(directive, err);
 }
 
 Signal FpySequencerTester::tester_exit_directiveHandler(const FpySequencer_ExitDirective& directive,

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
@@ -145,7 +145,8 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     Signal tester_if_directiveHandler(const FpySequencer_IfDirective& directive, DirectiveError& err);
     Signal tester_storePrm_directiveHandler(const FpySequencer_StorePrmDirective& directive, DirectiveError& err);
     Signal tester_storeTlmVal_directiveHandler(const FpySequencer_StoreTlmValDirective& directive, DirectiveError& err);
-    Signal tester_pushTlmValAndTime_directiveHandler(const FpySequencer_PushTlmValAndTimeDirective& directive, DirectiveError& err);
+    Signal tester_pushTlmValAndTime_directiveHandler(const FpySequencer_PushTlmValAndTimeDirective& directive,
+                                                     DirectiveError& err);
     Signal tester_exit_directiveHandler(const FpySequencer_ExitDirective& directive, DirectiveError& err);
     Signal tester_constCmd_directiveHandler(const FpySequencer_ConstCmdDirective& directive, DirectiveError& err);
     Signal tester_stackOp_directiveHandler(const FpySequencer_StackOpDirective& directive, DirectiveError& err);

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
@@ -91,6 +91,8 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     void add_NO_OP();
     void add_STORE_TLM_VAL(FwChanIdType id, Fpy::StackSizeType lvarOffset);
     void add_STORE_TLM_VAL(FpySequencer_StoreTlmValDirective dir);
+    void add_PUSH_TLM_VAL_AND_TIME(FwChanIdType id);
+    void add_PUSH_TLM_VAL_AND_TIME(FpySequencer_PushTlmValAndTimeDirective dir);
     void add_STORE_PRM(FwPrmIdType id, Fpy::StackSizeType lvarOffset);
     void add_STORE_PRM(FpySequencer_StorePrmDirective dir);
     void add_CONST_CMD(FwOpcodeType opcode);
@@ -143,6 +145,7 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     Signal tester_if_directiveHandler(const FpySequencer_IfDirective& directive, DirectiveError& err);
     Signal tester_storePrm_directiveHandler(const FpySequencer_StorePrmDirective& directive, DirectiveError& err);
     Signal tester_storeTlmVal_directiveHandler(const FpySequencer_StoreTlmValDirective& directive, DirectiveError& err);
+    Signal tester_pushTlmValAndTime_directiveHandler(const FpySequencer_PushTlmValAndTimeDirective& directive, DirectiveError& err);
     Signal tester_exit_directiveHandler(const FpySequencer_ExitDirective& directive, DirectiveError& err);
     Signal tester_constCmd_directiveHandler(const FpySequencer_ConstCmdDirective& directive, DirectiveError& err);
     Signal tester_stackOp_directiveHandler(const FpySequencer_StackOpDirective& directive, DirectiveError& err);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4218  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

This PR adds a PUSH_TLM_VAL_AND_TIME directive, which takes in one hardcoded argument, the tlm channel, and pushes the value of the tlm chan and the time to the stack.

Also updates the sdd with the latest directives.

## Rationale

This is needed for situations in which the time a telemetry measurement was made is important.



## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Used for generating updated sdd.md with all the directives.
