### PR TITLE
Update CI to use latest macOS intel runners

### DIFF
--- a/.github/workflows/pip-check.yml
+++ b/.github/workflows/pip-check.yml
@@ -6,10 +6,10 @@ name: Python Dependency Check
 on:
   push:
     paths:
-      - 'requirements.txt'
+      - "requirements.txt"
   pull_request:
     paths:
-      - 'requirements.txt'
+      - "requirements.txt"
 # Cancel in-progress runs if a newer run is started on a given PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -21,8 +21,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        # macos-13 is the last Intel-family runner; macos-latest is ARM
-        runner: [macos-13, macos-latest, ubuntu-22.04, ubuntu-latest]
+        # Purposefully test on both ARM and Intel macOS (macos-latest is ARM)
+        runner: [macos-15-intel, macos-latest, ubuntu-22.04, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description
 
`macos-13` GitHub runner will be retired on December 4th 2025. Upgrading prior to that.
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

<!-- A description of the changes contained in the PR. -->

## Rationale

<!-- A rationale for this change. e.g. fixes bug, or most projects need XYZ feature. -->

## Testing/Review Recommendations

<!-- Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality. -->

## Future Work

<!-- Note any additional work that will be done relating to this issue. -->

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). -->
