### PR TITLE
Fix for PosixFileTest UT failure

### DIFF
--- a/Os/test/ut/file/FileRules.cpp
+++ b/Os/test/ut/file/FileRules.cpp
@@ -272,6 +272,13 @@ void Os::Test::FileTest::Tester::OpenBaseRule::action(Os::Test::FileTest::Tester
     printf("--> Rule: %s mode %d\n", this->getName(), this->m_mode);
     // Initial variables used for this test
     std::shared_ptr<const std::string> filename = state.get_filename(this->m_random);
+    // When randomly generating filenames, some seeds can result in duplicate filenames
+    // Continue generating until unique, unless this is an overwrite test
+    if (this->m_random && !this->m_overwrite) {
+        while (state.exists(*filename)) {
+            filename = state.get_filename(this->m_random);
+        }
+    }
 
     // Ensure initial and shadow states synchronized
     state.assert_file_consistent();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4151 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

The seed value 906639 (see #4151) creates a test suite where there is an `OpenFileCreate` rule and the randomly-generated filename collides with a previously-created file. This causes the file `open` call to fail with status `Os::Status::FILE_EXISTS` which fails the UT.

This change adds a short snippet to `Os::Test::FileTest::Tester::OpenBaseRule::action` to ensure that this collision cannot happen by re-generating the filename until it is unique when filenames are random and this is not an overwrite test.

## Rationale

PosixFileTest UTs were failing previously.

## Testing/Review Recommendations

Seed value 906639 caused the failure, replace the call to `STest::Random::seed` in main inside `Os/Posix/test/ut/PosixFileTests.cpp` with `STest::Random::SeedValue::set(906639)` and run the PosixFileTest UTs.

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
