### PR TITLE
Switch to U64 Logger Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ RemoteSystemsTempFiles
 *.stackdump
 Dict
 *.core
+*.swp
 
 **/coverage/
 *.gcov

--- a/Fw/Logger/test/ut/LoggerRules.cpp
+++ b/Fw/Logger/test/ut/LoggerRules.cpp
@@ -65,51 +65,51 @@ void LogGood::action(MockLogging::FakeLogger& truth) {
             correct = "No args";
             break;
         case 1:
-            Fw::Logger::log("One arg: %llu", ra[0]);
-            correct.format("One arg: %llu", ra[0]);
+            Fw::Logger::log("One arg: " PRI_U64, ra[0]);
+            correct.format("One arg: " PRI_U64, ra[0]);
             break;
         case 2:
-            Fw::Logger::log("Two arg: %llu  %llu", ra[0], ra[1]);
-            correct.format("Two arg: %llu  %llu", ra[0], ra[1]);
+            Fw::Logger::log("Two arg: " PRI_U64 "  " PRI_U64, ra[0], ra[1]);
+            correct.format("Two arg: " PRI_U64 "  " PRI_U64, ra[0], ra[1]);
             break;
         case 3:
-            Fw::Logger::log("Three arg: %llu  %llu  %llu", ra[0], ra[1], ra[2]);
-            correct.format("Three arg: %llu  %llu  %llu", ra[0], ra[1], ra[2]);
+            Fw::Logger::log("Three arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2]);
+            correct.format("Three arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2]);
             break;
         case 4:
-            Fw::Logger::log("Four arg: %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3]);
-            correct.format("Four arg: %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3]);
+            Fw::Logger::log("Four arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3]);
+            correct.format("Four arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3]);
             break;
         case 5:
-            Fw::Logger::log("Five arg: %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4]);
-            correct.format("Five arg: %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4]);
+            Fw::Logger::log("Five arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
+            correct.format("Five arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
             break;
         case 6:
-            Fw::Logger::log("Six arg: %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
-            correct.format("Six arg: %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            Fw::Logger::log("Six arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            correct.format("Six arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
             break;
         case 7:
-            Fw::Logger::log("Seven arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
+            Fw::Logger::log("Seven arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
                             ra[6]);
-            correct.format("Seven arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
+            correct.format("Seven arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
                            ra[6]);
             break;
         case 8:
-            Fw::Logger::log("Eight arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4],
+            Fw::Logger::log("Eight arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
                             ra[5], ra[6], ra[7]);
-            correct.format("Eight arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4],
+            correct.format("Eight arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
                            ra[5], ra[6], ra[7]);
             break;
         case 9:
-            Fw::Logger::log("Nine arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4],
+            Fw::Logger::log("Nine arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
                             ra[5], ra[6], ra[7], ra[8]);
-            correct.format("Nine arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4],
+            correct.format("Nine arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
                            ra[5], ra[6], ra[7], ra[8]);
             break;
         case 10:
-            Fw::Logger::log("Ten arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3],
+            Fw::Logger::log("Ten arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3],
                             ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
-            correct.format("Ten arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3],
+            correct.format("Ten arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3],
                            ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
             break;
 
@@ -165,34 +165,34 @@ void LogBad::action(MockLogging::FakeLogger& truth) {
             Fw::Logger::log("No args");
             break;
         case 1:
-            Fw::Logger::log("One arg: %llu", ra[0]);
+            Fw::Logger::log("One arg: " PRI_U64, ra[0]);
             break;
         case 2:
-            Fw::Logger::log("Two arg: %llu", ra[0], ra[1]);
+            Fw::Logger::log("Two arg: " PRI_U64, ra[0], ra[1]);
             break;
         case 3:
-            Fw::Logger::log("Three arg: %llu", ra[0], ra[1], ra[2]);
+            Fw::Logger::log("Three arg: " PRI_U64, ra[0], ra[1], ra[2]);
             break;
         case 4:
-            Fw::Logger::log("Four arg: %llu", ra[0], ra[1], ra[2], ra[3]);
+            Fw::Logger::log("Four arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3]);
             break;
         case 5:
-            Fw::Logger::log("Five arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4]);
+            Fw::Logger::log("Five arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
             break;
         case 6:
-            Fw::Logger::log("Six arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            Fw::Logger::log("Six arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
             break;
         case 7:
-            Fw::Logger::log("Seven arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6]);
+            Fw::Logger::log("Seven arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6]);
             break;
         case 8:
-            Fw::Logger::log("Eight arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7]);
+            Fw::Logger::log("Eight arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7]);
             break;
         case 9:
-            Fw::Logger::log("Nine arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8]);
+            Fw::Logger::log("Nine arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8]);
             break;
         case 10:
-            Fw::Logger::log("Ten arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
+            Fw::Logger::log("Ten arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
             break;
         default:
             ASSERT_EQ(0, 1);

--- a/Fw/Logger/test/ut/LoggerRules.cpp
+++ b/Fw/Logger/test/ut/LoggerRules.cpp
@@ -65,51 +65,51 @@ void LogGood::action(MockLogging::FakeLogger& truth) {
             correct = "No args";
             break;
         case 1:
-            Fw::Logger::log("One arg: " PRI_U64, ra[0]);
-            correct.format("One arg: " PRI_U64, ra[0]);
+            Fw::Logger::log("One arg: %" PRI_U64, ra[0]);
+            correct.format("One arg: %" PRI_U64, ra[0]);
             break;
         case 2:
-            Fw::Logger::log("Two arg: " PRI_U64 "  " PRI_U64, ra[0], ra[1]);
-            correct.format("Two arg: " PRI_U64 "  " PRI_U64, ra[0], ra[1]);
+            Fw::Logger::log("Two arg: %" PRI_U64 "  %" PRI_U64, ra[0], ra[1]);
+            correct.format("Two arg: %" PRI_U64 "  %" PRI_U64, ra[0], ra[1]);
             break;
         case 3:
-            Fw::Logger::log("Three arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2]);
-            correct.format("Three arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2]);
+            Fw::Logger::log("Three arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2]);
+            correct.format("Three arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2]);
             break;
         case 4:
-            Fw::Logger::log("Four arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3]);
-            correct.format("Four arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3]);
+            Fw::Logger::log("Four arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3]);
+            correct.format("Four arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3]);
             break;
         case 5:
-            Fw::Logger::log("Five arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
-            correct.format("Five arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
+            Fw::Logger::log("Five arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
+            correct.format("Five arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
             break;
         case 6:
-            Fw::Logger::log("Six arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
-            correct.format("Six arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            Fw::Logger::log("Six arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            correct.format("Six arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
             break;
         case 7:
-            Fw::Logger::log("Seven arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
+            Fw::Logger::log("Seven arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
                             ra[6]);
-            correct.format("Seven arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
+            correct.format("Seven arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
                            ra[6]);
             break;
         case 8:
-            Fw::Logger::log("Eight arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
+            Fw::Logger::log("Eight arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
                             ra[5], ra[6], ra[7]);
-            correct.format("Eight arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
+            correct.format("Eight arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
                            ra[5], ra[6], ra[7]);
             break;
         case 9:
-            Fw::Logger::log("Nine arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
+            Fw::Logger::log("Nine arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
                             ra[5], ra[6], ra[7], ra[8]);
-            correct.format("Nine arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
+            correct.format("Nine arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
                            ra[5], ra[6], ra[7], ra[8]);
             break;
         case 10:
-            Fw::Logger::log("Ten arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3],
+            Fw::Logger::log("Ten arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3],
                             ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
-            correct.format("Ten arg: " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64 "  " PRI_U64, ra[0], ra[1], ra[2], ra[3],
+            correct.format("Ten arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3],
                            ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
             break;
 
@@ -165,34 +165,34 @@ void LogBad::action(MockLogging::FakeLogger& truth) {
             Fw::Logger::log("No args");
             break;
         case 1:
-            Fw::Logger::log("One arg: " PRI_U64, ra[0]);
+            Fw::Logger::log("One arg: %" PRI_U64 " %" PRI_U64, ra[0]);
             break;
         case 2:
-            Fw::Logger::log("Two arg: " PRI_U64, ra[0], ra[1]);
+            Fw::Logger::log("Two arg: %" PRI_U64 " %" PRI_U64, ra[0], ra[1]);
             break;
         case 3:
-            Fw::Logger::log("Three arg: " PRI_U64, ra[0], ra[1], ra[2]);
+            Fw::Logger::log("Three arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2]);
             break;
         case 4:
-            Fw::Logger::log("Four arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3]);
+            Fw::Logger::log("Four arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3]);
             break;
         case 5:
-            Fw::Logger::log("Five arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
+            Fw::Logger::log("Five arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
             break;
         case 6:
-            Fw::Logger::log("Six arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            Fw::Logger::log("Six arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
             break;
         case 7:
-            Fw::Logger::log("Seven arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6]);
+            Fw::Logger::log("Seven arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6]);
             break;
         case 8:
-            Fw::Logger::log("Eight arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7]);
+            Fw::Logger::log("Eight arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7]);
             break;
         case 9:
-            Fw::Logger::log("Nine arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8]);
+            Fw::Logger::log("Nine arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8]);
             break;
         case 10:
-            Fw::Logger::log("Ten arg: " PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
+            Fw::Logger::log("Ten arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
             break;
         default:
             ASSERT_EQ(0, 1);

--- a/Fw/Logger/test/ut/LoggerRules.cpp
+++ b/Fw/Logger/test/ut/LoggerRules.cpp
@@ -46,7 +46,6 @@ bool LogGood::precondition(const MockLogging::FakeLogger& truth) {
     return truth.s_current != nullptr;
 }
 
-
 U64 randomU64() {
     return static_cast<U64>(STest::Pick::lowerUpper(0, 0xffffffff)) << 32 | STest::Pick::lowerUpper(0, 0xffffffff);
 }
@@ -77,40 +76,53 @@ void LogGood::action(MockLogging::FakeLogger& truth) {
             correct.format("Three arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2]);
             break;
         case 4:
-            Fw::Logger::log("Four arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3]);
+            Fw::Logger::log("Four arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2],
+                            ra[3]);
             correct.format("Four arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3]);
             break;
         case 5:
-            Fw::Logger::log("Five arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
-            correct.format("Five arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
+            Fw::Logger::log("Five arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1],
+                            ra[2], ra[3], ra[4]);
+            correct.format("Five arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1],
+                           ra[2], ra[3], ra[4]);
             break;
         case 6:
-            Fw::Logger::log("Six arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
-            correct.format("Six arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            Fw::Logger::log("Six arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64,
+                            ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            correct.format("Six arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64,
+                           ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
             break;
         case 7:
-            Fw::Logger::log("Seven arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
-                            ra[6]);
-            correct.format("Seven arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
-                           ra[6]);
+            Fw::Logger::log("Seven arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64
+                            "  %" PRI_U64,
+                            ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6]);
+            correct.format("Seven arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64
+                           "  %" PRI_U64,
+                           ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6]);
             break;
         case 8:
-            Fw::Logger::log("Eight arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
-                            ra[5], ra[6], ra[7]);
-            correct.format("Eight arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
-                           ra[5], ra[6], ra[7]);
+            Fw::Logger::log("Eight arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64
+                            "  %" PRI_U64 "  %" PRI_U64,
+                            ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7]);
+            correct.format("Eight arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64
+                           "  %" PRI_U64 "  %" PRI_U64,
+                           ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7]);
             break;
         case 9:
-            Fw::Logger::log("Nine arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
-                            ra[5], ra[6], ra[7], ra[8]);
-            correct.format("Nine arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4],
-                           ra[5], ra[6], ra[7], ra[8]);
+            Fw::Logger::log("Nine arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64
+                            "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64,
+                            ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8]);
+            correct.format("Nine arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64
+                           "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64,
+                           ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8]);
             break;
         case 10:
-            Fw::Logger::log("Ten arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3],
-                            ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
-            correct.format("Ten arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64, ra[0], ra[1], ra[2], ra[3],
-                           ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
+            Fw::Logger::log("Ten arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64
+                            "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64,
+                            ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
+            correct.format("Ten arg: %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64
+                           "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64 "  %" PRI_U64,
+                           ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
             break;
 
         default:
@@ -177,22 +189,32 @@ void LogBad::action(MockLogging::FakeLogger& truth) {
             Fw::Logger::log("Four arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3]);
             break;
         case 5:
-            Fw::Logger::log("Five arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4]);
+            Fw::Logger::log("Five arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1],
+                            ra[2], ra[3], ra[4]);
             break;
         case 6:
-            Fw::Logger::log("Six arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            Fw::Logger::log("Six arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64,
+                            ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
             break;
         case 7:
-            Fw::Logger::log("Seven arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6]);
+            Fw::Logger::log("Seven arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64
+                            " %" PRI_U64,
+                            ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6]);
             break;
         case 8:
-            Fw::Logger::log("Eight arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7]);
+            Fw::Logger::log("Eight arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64
+                            " %" PRI_U64 " %" PRI_U64,
+                            ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7]);
             break;
         case 9:
-            Fw::Logger::log("Nine arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8]);
+            Fw::Logger::log("Nine arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64
+                            " %" PRI_U64 " %" PRI_U64 " %" PRI_U64,
+                            ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8]);
             break;
         case 10:
-            Fw::Logger::log("Ten arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64, ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
+            Fw::Logger::log("Ten arg: %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64
+                            " %" PRI_U64 " %" PRI_U64 " %" PRI_U64 " %" PRI_U64,
+                            ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
             break;
         default:
             ASSERT_EQ(0, 1);

--- a/Fw/Logger/test/ut/LoggerRules.cpp
+++ b/Fw/Logger/test/ut/LoggerRules.cpp
@@ -46,12 +46,17 @@ bool LogGood::precondition(const MockLogging::FakeLogger& truth) {
     return truth.s_current != nullptr;
 }
 
+
+U64 randomU64() {
+    return static_cast<U64>(STest::Pick::lowerUpper(0, 0xffffffff)) << 32 | STest::Pick::lowerUpper(0, 0xffffffff);
+}
+
 // Log valid messages
 void LogGood::action(MockLogging::FakeLogger& truth) {
     U32 random = STest::Pick::lowerUpper(0, 10);
-    U32 ra[10];
+    U64 ra[10];
     for (int i = 0; i < 10; ++i) {
-        ra[i] = STest::Pick::lowerUpper(0, 0xffffffff);
+        ra[i] = randomU64();
     }
     Fw::String correct;
     switch (random) {
@@ -60,51 +65,51 @@ void LogGood::action(MockLogging::FakeLogger& truth) {
             correct = "No args";
             break;
         case 1:
-            Fw::Logger::log("One arg: %lu", ra[0]);
-            correct.format("One arg: %lu", ra[0]);
+            Fw::Logger::log("One arg: %llu", ra[0]);
+            correct.format("One arg: %llu", ra[0]);
             break;
         case 2:
-            Fw::Logger::log("Two arg: %lu  %lu", ra[0], ra[1]);
-            correct.format("Two arg: %lu  %lu", ra[0], ra[1]);
+            Fw::Logger::log("Two arg: %llu  %llu", ra[0], ra[1]);
+            correct.format("Two arg: %llu  %llu", ra[0], ra[1]);
             break;
         case 3:
-            Fw::Logger::log("Three arg: %lu  %lu  %lu", ra[0], ra[1], ra[2]);
-            correct.format("Three arg: %lu  %lu  %lu", ra[0], ra[1], ra[2]);
+            Fw::Logger::log("Three arg: %llu  %llu  %llu", ra[0], ra[1], ra[2]);
+            correct.format("Three arg: %llu  %llu  %llu", ra[0], ra[1], ra[2]);
             break;
         case 4:
-            Fw::Logger::log("Four arg: %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3]);
-            correct.format("Four arg: %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3]);
+            Fw::Logger::log("Four arg: %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3]);
+            correct.format("Four arg: %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3]);
             break;
         case 5:
-            Fw::Logger::log("Five arg: %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3], ra[4]);
-            correct.format("Five arg: %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3], ra[4]);
+            Fw::Logger::log("Five arg: %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4]);
+            correct.format("Five arg: %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4]);
             break;
         case 6:
-            Fw::Logger::log("Six arg: %lu  %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
-            correct.format("Six arg: %lu  %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            Fw::Logger::log("Six arg: %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            correct.format("Six arg: %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
             break;
         case 7:
-            Fw::Logger::log("Seven arg: %lu  %lu  %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
+            Fw::Logger::log("Seven arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
                             ra[6]);
-            correct.format("Seven arg: %lu  %lu  %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
+            correct.format("Seven arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
                            ra[6]);
             break;
         case 8:
-            Fw::Logger::log("Eight arg: %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3], ra[4],
+            Fw::Logger::log("Eight arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4],
                             ra[5], ra[6], ra[7]);
-            correct.format("Eight arg: %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3], ra[4],
+            correct.format("Eight arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4],
                            ra[5], ra[6], ra[7]);
             break;
         case 9:
-            Fw::Logger::log("Nine arg: %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3], ra[4],
+            Fw::Logger::log("Nine arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4],
                             ra[5], ra[6], ra[7], ra[8]);
-            correct.format("Nine arg: %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3], ra[4],
+            correct.format("Nine arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3], ra[4],
                            ra[5], ra[6], ra[7], ra[8]);
             break;
         case 10:
-            Fw::Logger::log("Ten arg: %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3],
+            Fw::Logger::log("Ten arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3],
                             ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
-            correct.format("Ten arg: %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu  %lu", ra[0], ra[1], ra[2], ra[3],
+            correct.format("Ten arg: %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu  %llu", ra[0], ra[1], ra[2], ra[3],
                            ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
             break;
 
@@ -150,9 +155,9 @@ bool LogBad::precondition(const MockLogging::FakeLogger& truth) {
 // Log valid messages
 void LogBad::action(MockLogging::FakeLogger& truth) {
     U32 random = STest::Pick::lowerUpper(0, 10);
-    U32 ra[10];
+    U64 ra[10];
     for (int i = 0; i < 10; ++i) {
-        ra[i] = STest::Pick::lowerUpper(0, 0xffffffff);
+        ra[i] = randomU64();
     }
 
     switch (random) {
@@ -160,34 +165,34 @@ void LogBad::action(MockLogging::FakeLogger& truth) {
             Fw::Logger::log("No args");
             break;
         case 1:
-            Fw::Logger::log("One arg: %lu", ra[0]);
+            Fw::Logger::log("One arg: %llu", ra[0]);
             break;
         case 2:
-            Fw::Logger::log("Two arg: %lu", ra[0], ra[1]);
+            Fw::Logger::log("Two arg: %llu", ra[0], ra[1]);
             break;
         case 3:
-            Fw::Logger::log("Three arg: %lu", ra[0], ra[1], ra[2]);
+            Fw::Logger::log("Three arg: %llu", ra[0], ra[1], ra[2]);
             break;
         case 4:
-            Fw::Logger::log("Four arg: %lu", ra[0], ra[1], ra[2], ra[3]);
+            Fw::Logger::log("Four arg: %llu", ra[0], ra[1], ra[2], ra[3]);
             break;
         case 5:
-            Fw::Logger::log("Five arg: %lu", ra[0], ra[1], ra[2], ra[3], ra[4]);
+            Fw::Logger::log("Five arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4]);
             break;
         case 6:
-            Fw::Logger::log("Six arg: %lu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
+            Fw::Logger::log("Six arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5]);
             break;
         case 7:
-            Fw::Logger::log("Seven arg: %lu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6]);
+            Fw::Logger::log("Seven arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6]);
             break;
         case 8:
-            Fw::Logger::log("Eight arg: %lu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7]);
+            Fw::Logger::log("Eight arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7]);
             break;
         case 9:
-            Fw::Logger::log("Nine arg: %lu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8]);
+            Fw::Logger::log("Nine arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8]);
             break;
         case 10:
-            Fw::Logger::log("Ten arg: %lu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
+            Fw::Logger::log("Ten arg: %llu", ra[0], ra[1], ra[2], ra[3], ra[4], ra[5], ra[6], ra[7], ra[8], ra[9]);
             break;
         default:
             ASSERT_EQ(0, 1);

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,3 +64,4 @@ urllib3==2.5.0
 Werkzeug==3.0.6
 zipp==3.19.1
 zstandard==0.23.0
+pip


### PR DESCRIPTION

| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  y |
|**_Documentation Included (y/n)_**| N/A |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

* add pip to the requirements.txt (fprime depends on the python pip module, which causes issues when installed requirements using another python package manager e.g. uv)
* add `*.swp` to gitignore to prevent vim swapfiles from marking the repo as dirty
* Switch the LoggerTests to U64 `%llu` since `unsinged long`s are 64 bits wide on aarch64 linux and variadic args break w/ the old code @ 7 args


## Rationale

I would like the unit tests to pass on my aarch64 linux machine, and I believe that U64 + `llu` should behave correctly on all systems.

## Testing/Review Recommendations

If a locked version of pip is required I am happy to modify the requirements.txt line

It would be good to get to the bottom of the behavior I saw with the old unit test; however, I suspect it is a case of the non-type safety of va_list + slightly different register layouts/contents between the two calls to vformat.

An integer width safe logger would be a nice feature, but seems unlikely to achieve through va_list.
