### PR TITLE
Bump FPP to 3.1.0a2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Flask-Compress==1.15
 Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.3
 fprime-fpl-write-pic==1.0.3
-fprime-fpp==3.1.0a1
+fprime-fpp==3.1.0a2
 fprime-gds==4.0.2a7
 fprime-tools==4.0.2a1
 fprime-visual==1.0.2


### PR DESCRIPTION
Bumps FPP version to https://github.com/nasa/fpp/releases/tag/v3.1.0a2 which includes an important bug fix for interface resolution when composing interfaces.