### PR TITLE
Bump FPP with unified tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Flask-Compress==1.15
 Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.3
 fprime-fpl-write-pic==1.0.3
-fprime-fpp==3.1.0a2
+fprime-fpp==3.1.0a3
 fprime-gds==4.0.2a7
 fprime-tools==4.0.2a1
 fprime-visual==1.0.2


### PR DESCRIPTION
This PR bumps FPP the new alpha release which unifies the FPP executable tools into a single binary. It greatly decreases the package size so we now only need a single pip package rather than a package for each FPP tool.
