### PR TITLE
Little Endian Serialization

### DIFF
--- a/FppTestProject/FppTest/state_machine/internal/harness/TestAbsType.hpp
+++ b/FppTestProject/FppTest/state_machine/internal/harness/TestAbsType.hpp
@@ -49,7 +49,7 @@ struct TestAbsType final : public Fw::Serializable {
     //! Serialize function
     //! \return Status
     Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& sbb, //!< The serialize buffer base
-        Fw::Endianness mode = Fw::Serialization::BIG
+        Fw::Endianness mode = Fw::Endianness::BIG
     ) const final {
         return sbb.serializeFrom(this->m_data, mode);
     }
@@ -57,7 +57,7 @@ struct TestAbsType final : public Fw::Serializable {
     //! Deserialize method
     //! \return status
     Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& sbb, //!< The serialize buffer base
-        Fw::Endianness mode = Fw::Serialization::BIG
+        Fw::Endianness mode = Fw::Endianness::BIG
                                         ) final {
         return sbb.deserializeTo(this->m_data, mode);
     }

--- a/FppTestProject/FppTest/state_machine/internal/harness/TestAbsType.hpp
+++ b/FppTestProject/FppTest/state_machine/internal/harness/TestAbsType.hpp
@@ -49,7 +49,7 @@ struct TestAbsType final : public Fw::Serializable {
     //! Serialize function
     //! \return Status
     Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& sbb, //!< The serialize buffer base
-        Fw::Serialization::Endianness mode = Fw::Serialization::BIG
+        Fw::Endianness mode = Fw::Serialization::BIG
     ) const final {
         return sbb.serializeFrom(this->m_data, mode);
     }
@@ -57,7 +57,7 @@ struct TestAbsType final : public Fw::Serializable {
     //! Deserialize method
     //! \return status
     Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& sbb, //!< The serialize buffer base
-        Fw::Serialization::Endianness mode = Fw::Serialization::BIG
+        Fw::Endianness mode = Fw::Serialization::BIG
                                         ) final {
         return sbb.deserializeTo(this->m_data, mode);
     }

--- a/FppTestProject/FppTest/state_machine/internal/harness/TestAbsType.hpp
+++ b/FppTestProject/FppTest/state_machine/internal/harness/TestAbsType.hpp
@@ -48,17 +48,15 @@ struct TestAbsType final : public Fw::Serializable {
 
     //! Serialize function
     //! \return Status
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& sbb, //!< The serialize buffer base
-        Fw::Endianness mode = Fw::Endianness::BIG
-    ) const final {
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& sbb,  //!< The serialize buffer base
+                                    Fw::Endianness mode = Fw::Endianness::BIG) const final {
         return sbb.serializeFrom(this->m_data, mode);
     }
 
     //! Deserialize method
     //! \return status
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& sbb, //!< The serialize buffer base
-        Fw::Endianness mode = Fw::Endianness::BIG
-                                        ) final {
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& sbb,  //!< The serialize buffer base
+                                        Fw::Endianness mode = Fw::Endianness::BIG) final {
         return sbb.deserializeTo(this->m_data, mode);
     }
 

--- a/FppTestProject/FppTest/state_machine/internal/harness/TestAbsType.hpp
+++ b/FppTestProject/FppTest/state_machine/internal/harness/TestAbsType.hpp
@@ -48,16 +48,18 @@ struct TestAbsType final : public Fw::Serializable {
 
     //! Serialize function
     //! \return Status
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& sbb  //!< The serialize buffer base
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& sbb, //!< The serialize buffer base
+        Fw::Serialization::Endianness mode = Fw::Serialization::BIG
     ) const final {
-        return sbb.serializeFrom(this->m_data);
+        return sbb.serializeFrom(this->m_data, mode);
     }
 
     //! Deserialize method
     //! \return status
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& sbb  //!< The serialize buffer base
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& sbb, //!< The serialize buffer base
+        Fw::Serialization::Endianness mode = Fw::Serialization::BIG
                                         ) final {
-        return sbb.deserializeTo(this->m_data);
+        return sbb.deserializeTo(this->m_data, mode);
     }
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/Fw/Buffer/Buffer.cpp
+++ b/Fw/Buffer/Buffer.cpp
@@ -113,7 +113,7 @@ Fw::ExternalSerializeBufferWithMemberCopy Buffer::getDeserializer() {
     }
 }
 
-Fw::SerializeStatus Buffer::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+Fw::SerializeStatus Buffer::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode) const {
     Fw::SerializeStatus stat;
 #if FW_SERIALIZATION_TYPE_ID
     stat = buffer.serializeFrom(static_cast<U32>(Buffer::TYPE_ID));
@@ -136,7 +136,7 @@ Fw::SerializeStatus Buffer::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Ser
     return stat;
 }
 
-Fw::SerializeStatus Buffer::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+Fw::SerializeStatus Buffer::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode) {
     Fw::SerializeStatus stat;
 
 #if FW_SERIALIZATION_TYPE_ID

--- a/Fw/Buffer/Buffer.cpp
+++ b/Fw/Buffer/Buffer.cpp
@@ -113,7 +113,7 @@ Fw::ExternalSerializeBufferWithMemberCopy Buffer::getDeserializer() {
     }
 }
 
-Fw::SerializeStatus Buffer::serializeTo(Fw::SerializeBufferBase& buffer) const {
+Fw::SerializeStatus Buffer::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
     Fw::SerializeStatus stat;
 #if FW_SERIALIZATION_TYPE_ID
     stat = buffer.serializeFrom(static_cast<U32>(Buffer::TYPE_ID));
@@ -121,22 +121,22 @@ Fw::SerializeStatus Buffer::serializeTo(Fw::SerializeBufferBase& buffer) const {
         return stat;
     }
 #endif
-    stat = buffer.serializeFrom(reinterpret_cast<PlatformPointerCastType>(this->m_bufferData));
+    stat = buffer.serializeFrom(reinterpret_cast<PlatformPointerCastType>(this->m_bufferData), mode);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
-    stat = buffer.serializeFrom(this->m_size);
+    stat = buffer.serializeFrom(this->m_size, mode);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
-    stat = buffer.serializeFrom(this->m_context);
+    stat = buffer.serializeFrom(this->m_context, mode);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
     return stat;
 }
 
-Fw::SerializeStatus Buffer::deserializeFrom(Fw::SerializeBufferBase& buffer) {
+Fw::SerializeStatus Buffer::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
     Fw::SerializeStatus stat;
 
 #if FW_SERIALIZATION_TYPE_ID
@@ -152,17 +152,17 @@ Fw::SerializeStatus Buffer::deserializeFrom(Fw::SerializeBufferBase& buffer) {
     }
 #endif
     PlatformPointerCastType pointer;
-    stat = buffer.deserializeTo(pointer);
+    stat = buffer.deserializeTo(pointer, mode);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
     this->m_bufferData = reinterpret_cast<U8*>(pointer);
 
-    stat = buffer.deserializeTo(this->m_size);
+    stat = buffer.deserializeTo(this->m_size, mode);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
-    stat = buffer.deserializeTo(this->m_context);
+    stat = buffer.deserializeTo(this->m_context, mode);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }

--- a/Fw/Buffer/Buffer.hpp
+++ b/Fw/Buffer/Buffer.hpp
@@ -125,7 +125,7 @@ class Buffer : public Fw::Serializable {
     //! or the serialize buffer base representation and serialize from that.
     //! \param serialBuffer: serialize buffer to write data into
     //! \return: status of serialization
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& serialBuffer, Fw::Endianness mode = Fw::Serialization::BIG) const;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& serialBuffer, Fw::Endianness mode = Fw::Endianness::BIG) const;
 
     //! Deserializes this buffer from a SerializeBufferBase
     //!
@@ -135,7 +135,7 @@ class Buffer : public Fw::Serializable {
     //! or the serialize buffer base representation and deserialize from that.
     //! \param buffer: serialize buffer to read data into
     //! \return: status of serialization
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG);
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG);
 
     // ----------------------------------------------------------------------
     // Accessor functions

--- a/Fw/Buffer/Buffer.hpp
+++ b/Fw/Buffer/Buffer.hpp
@@ -125,7 +125,7 @@ class Buffer : public Fw::Serializable {
     //! or the serialize buffer base representation and serialize from that.
     //! \param serialBuffer: serialize buffer to write data into
     //! \return: status of serialization
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& serialBuffer) const;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& serialBuffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const;
 
     //! Deserializes this buffer from a SerializeBufferBase
     //!
@@ -135,7 +135,7 @@ class Buffer : public Fw::Serializable {
     //! or the serialize buffer base representation and deserialize from that.
     //! \param buffer: serialize buffer to read data into
     //! \return: status of serialization
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer);
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG);
 
     // ----------------------------------------------------------------------
     // Accessor functions

--- a/Fw/Buffer/Buffer.hpp
+++ b/Fw/Buffer/Buffer.hpp
@@ -125,7 +125,8 @@ class Buffer : public Fw::Serializable {
     //! or the serialize buffer base representation and serialize from that.
     //! \param serialBuffer: serialize buffer to write data into
     //! \return: status of serialization
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& serialBuffer, Fw::Endianness mode = Fw::Endianness::BIG) const;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& serialBuffer,
+                                    Fw::Endianness mode = Fw::Endianness::BIG) const;
 
     //! Deserializes this buffer from a SerializeBufferBase
     //!

--- a/Fw/Buffer/Buffer.hpp
+++ b/Fw/Buffer/Buffer.hpp
@@ -125,7 +125,7 @@ class Buffer : public Fw::Serializable {
     //! or the serialize buffer base representation and serialize from that.
     //! \param serialBuffer: serialize buffer to write data into
     //! \return: status of serialization
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& serialBuffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& serialBuffer, Fw::Endianness mode = Fw::Serialization::BIG) const;
 
     //! Deserializes this buffer from a SerializeBufferBase
     //!
@@ -135,7 +135,7 @@ class Buffer : public Fw::Serializable {
     //! or the serialize buffer base representation and deserialize from that.
     //! \param buffer: serialize buffer to read data into
     //! \return: status of serialization
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG);
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG);
 
     // ----------------------------------------------------------------------
     // Accessor functions

--- a/Fw/Buffer/docs/sdd.md
+++ b/Fw/Buffer/docs/sdd.md
@@ -73,8 +73,12 @@ managed by the caller and only affects the data of the underlying buffer.
 U32 my_data = 10001;
 U8  my_byte = 2;
 auto sb = my_fw_buffer.getSerializer();
+// Defaults to big-endian
 sb.serializeFrom(my_data);
 sb.serializeFrom(my_byte);
+// Or for little-endian
+sb.serializeFrom(my_data, Fw::Serialization::LITTLE);
+sb.serializeFrom(my_byte, Fw::Serialization::LITTLE);
 ```
 
 **Deserializing from `Fw::Buffer`**
@@ -82,6 +86,10 @@ sb.serializeFrom(my_byte);
 U32 my_data = 0;
 U8  my_byte = 0;
 auto sb = my_fw_buffer.getDeserializer();
+// Defaults to big-endian
 sb.deserializeTo(my_data);
 sb.deserializeTo(my_byte);
+// Or for little-endian
+sb.deserializeTo(my_data, Fw::Serialization::LITTLE);
+sb.deserializeTo(my_byte, Fw::Serialization::LITTLE);
 ```

--- a/Fw/Buffer/docs/sdd.md
+++ b/Fw/Buffer/docs/sdd.md
@@ -77,8 +77,8 @@ auto sb = my_fw_buffer.getSerializer();
 sb.serializeFrom(my_data);
 sb.serializeFrom(my_byte);
 // Or for little-endian
-sb.serializeFrom(my_data, Fw::Serialization::LITTLE);
-sb.serializeFrom(my_byte, Fw::Serialization::LITTLE);
+sb.serializeFrom(my_data, Fw::Endianness::LITTLE);
+sb.serializeFrom(my_byte, Fw::Endianness::LITTLE);
 ```
 
 **Deserializing from `Fw::Buffer`**
@@ -90,6 +90,6 @@ auto sb = my_fw_buffer.getDeserializer();
 sb.deserializeTo(my_data);
 sb.deserializeTo(my_byte);
 // Or for little-endian
-sb.deserializeTo(my_data, Fw::Serialization::LITTLE);
-sb.deserializeTo(my_byte, Fw::Serialization::LITTLE);
+sb.deserializeTo(my_data, Fw::Endianness::LITTLE);
+sb.deserializeTo(my_byte, Fw::Endianness::LITTLE);
 ```

--- a/Fw/Cmd/CmdPacket.cpp
+++ b/Fw/Cmd/CmdPacket.cpp
@@ -18,13 +18,13 @@ CmdPacket::CmdPacket() : m_opcode(0) {
 CmdPacket::~CmdPacket() {}
 
 // New serialization interface methods
-SerializeStatus CmdPacket::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+SerializeStatus CmdPacket::serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode) const {
     // Shouldn't be called, no use case for serializing CmdPackets in FSW (currently)
     FW_ASSERT(0);
     return FW_SERIALIZE_OK;  // for compiler
 }
 
-SerializeStatus CmdPacket::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+SerializeStatus CmdPacket::deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode) {
     SerializeStatus stat = ComPacket::deserializeBase(buffer);
     if (stat != FW_SERIALIZE_OK) {
         return stat;

--- a/Fw/Cmd/CmdPacket.cpp
+++ b/Fw/Cmd/CmdPacket.cpp
@@ -18,13 +18,13 @@ CmdPacket::CmdPacket() : m_opcode(0) {
 CmdPacket::~CmdPacket() {}
 
 // New serialization interface methods
-SerializeStatus CmdPacket::serializeTo(SerializeBufferBase& buffer) const {
+SerializeStatus CmdPacket::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
     // Shouldn't be called, no use case for serializing CmdPackets in FSW (currently)
     FW_ASSERT(0);
     return FW_SERIALIZE_OK;  // for compiler
 }
 
-SerializeStatus CmdPacket::deserializeFrom(SerializeBufferBase& buffer) {
+SerializeStatus CmdPacket::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
     SerializeStatus stat = ComPacket::deserializeBase(buffer);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
@@ -35,7 +35,7 @@ SerializeStatus CmdPacket::deserializeFrom(SerializeBufferBase& buffer) {
         return FW_DESERIALIZE_TYPE_MISMATCH;
     }
 
-    stat = buffer.deserializeTo(this->m_opcode);
+    stat = buffer.deserializeTo(this->m_opcode, mode);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }

--- a/Fw/Cmd/CmdPacket.hpp
+++ b/Fw/Cmd/CmdPacket.hpp
@@ -19,8 +19,8 @@ class CmdPacket : public ComPacket {
     virtual ~CmdPacket();
 
     // New serialization interface methods
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const;
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG);
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const;
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG);
 
     FwOpcodeType getOpCode() const;
     CmdArgBuffer& getArgBuffer();

--- a/Fw/Cmd/CmdPacket.hpp
+++ b/Fw/Cmd/CmdPacket.hpp
@@ -19,8 +19,8 @@ class CmdPacket : public ComPacket {
     virtual ~CmdPacket();
 
     // New serialization interface methods
-    SerializeStatus serializeTo(SerializeBufferBase& buffer) const;
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer);
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const;
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG);
 
     FwOpcodeType getOpCode() const;
     CmdArgBuffer& getArgBuffer();

--- a/Fw/Cmd/CmdPacket.hpp
+++ b/Fw/Cmd/CmdPacket.hpp
@@ -19,8 +19,8 @@ class CmdPacket : public ComPacket {
     virtual ~CmdPacket();
 
     // New serialization interface methods
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const;
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG);
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const;
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG);
 
     FwOpcodeType getOpCode() const;
     CmdArgBuffer& getArgBuffer();

--- a/Fw/Log/AmpcsEvrLogPacket.hpp
+++ b/Fw/Log/AmpcsEvrLogPacket.hpp
@@ -23,8 +23,8 @@ class AmpcsEvrLogPacket : public ComPacket {
     AmpcsEvrLogPacket();
     virtual ~AmpcsEvrLogPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer) const;  //!< serialize contents
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer);
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const;  //!< serialize contents
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG);
 
     void setTaskName(U8* taskName, U8 len);
     void setId(U32 eventID);

--- a/Fw/Log/AmpcsEvrLogPacket.hpp
+++ b/Fw/Log/AmpcsEvrLogPacket.hpp
@@ -23,8 +23,8 @@ class AmpcsEvrLogPacket : public ComPacket {
     AmpcsEvrLogPacket();
     virtual ~AmpcsEvrLogPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const;  //!< serialize contents
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG);
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const;  //!< serialize contents
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG);
 
     void setTaskName(U8* taskName, U8 len);
     void setId(U32 eventID);

--- a/Fw/Log/AmpcsEvrLogPacket.hpp
+++ b/Fw/Log/AmpcsEvrLogPacket.hpp
@@ -23,7 +23,8 @@ class AmpcsEvrLogPacket : public ComPacket {
     AmpcsEvrLogPacket();
     virtual ~AmpcsEvrLogPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const;  //!< serialize contents
+    SerializeStatus serializeTo(SerializeBufferBase& buffer,
+                                Fw::Endianness mode = Fw::Endianness::BIG) const;  //!< serialize contents
     SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG);
 
     void setTaskName(U8* taskName, U8 len);

--- a/Fw/Log/AmpcsEvrLogPacket.hpp
+++ b/Fw/Log/AmpcsEvrLogPacket.hpp
@@ -23,8 +23,8 @@ class AmpcsEvrLogPacket : public ComPacket {
     AmpcsEvrLogPacket();
     virtual ~AmpcsEvrLogPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const;  //!< serialize contents
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG);
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const;  //!< serialize contents
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG);
 
     void setTaskName(U8* taskName, U8 len);
     void setId(U32 eventID);

--- a/Fw/Log/LogPacket.cpp
+++ b/Fw/Log/LogPacket.cpp
@@ -16,18 +16,18 @@ LogPacket::LogPacket() : m_id(0) {
 
 LogPacket::~LogPacket() {}
 
-SerializeStatus LogPacket::serializeTo(SerializeBufferBase& buffer) const {
+SerializeStatus LogPacket::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
     SerializeStatus stat = ComPacket::serializeBase(buffer);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
 
-    stat = buffer.serializeFrom(this->m_id);
+    stat = buffer.serializeFrom(this->m_id, mode);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
 
-    stat = buffer.serializeFrom(this->m_timeTag);
+    stat = buffer.serializeFrom(this->m_timeTag, mode);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
@@ -37,18 +37,18 @@ SerializeStatus LogPacket::serializeTo(SerializeBufferBase& buffer) const {
                                 Fw::Serialization::OMIT_LENGTH);
 }
 
-SerializeStatus LogPacket::deserializeFrom(SerializeBufferBase& buffer) {
+SerializeStatus LogPacket::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
     SerializeStatus stat = deserializeBase(buffer);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
 
-    stat = buffer.deserializeTo(this->m_id);
+    stat = buffer.deserializeTo(this->m_id, mode);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
 
-    stat = buffer.deserializeTo(this->m_timeTag);
+    stat = buffer.deserializeTo(this->m_timeTag, mode);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }

--- a/Fw/Log/LogPacket.cpp
+++ b/Fw/Log/LogPacket.cpp
@@ -16,7 +16,7 @@ LogPacket::LogPacket() : m_id(0) {
 
 LogPacket::~LogPacket() {}
 
-SerializeStatus LogPacket::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+SerializeStatus LogPacket::serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode) const {
     SerializeStatus stat = ComPacket::serializeBase(buffer);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
@@ -37,7 +37,7 @@ SerializeStatus LogPacket::serializeTo(SerializeBufferBase& buffer, Fw::Serializ
                                 Fw::Serialization::OMIT_LENGTH);
 }
 
-SerializeStatus LogPacket::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+SerializeStatus LogPacket::deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode) {
     SerializeStatus stat = deserializeBase(buffer);
     if (stat != FW_SERIALIZE_OK) {
         return stat;

--- a/Fw/Log/LogPacket.hpp
+++ b/Fw/Log/LogPacket.hpp
@@ -19,8 +19,8 @@ class LogPacket : public ComPacket {
     LogPacket();
     virtual ~LogPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer) const override;  //!< serialize contents
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer) override;
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;  //!< serialize contents
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
 
     void setId(FwEventIdType id);
     void setLogBuffer(const LogBuffer& buffer);

--- a/Fw/Log/LogPacket.hpp
+++ b/Fw/Log/LogPacket.hpp
@@ -19,8 +19,8 @@ class LogPacket : public ComPacket {
     LogPacket();
     virtual ~LogPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;  //!< serialize contents
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;  //!< serialize contents
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
 
     void setId(FwEventIdType id);
     void setLogBuffer(const LogBuffer& buffer);

--- a/Fw/Log/LogPacket.hpp
+++ b/Fw/Log/LogPacket.hpp
@@ -19,7 +19,8 @@ class LogPacket : public ComPacket {
     LogPacket();
     virtual ~LogPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;  //!< serialize contents
+    SerializeStatus serializeTo(SerializeBufferBase& buffer,
+                                Fw::Endianness mode = Fw::Endianness::BIG) const override;  //!< serialize contents
     SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
 
     void setId(FwEventIdType id);

--- a/Fw/Log/LogPacket.hpp
+++ b/Fw/Log/LogPacket.hpp
@@ -19,8 +19,8 @@ class LogPacket : public ComPacket {
     LogPacket();
     virtual ~LogPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;  //!< serialize contents
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;  //!< serialize contents
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
 
     void setId(FwEventIdType id);
     void setLogBuffer(const LogBuffer& buffer);

--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -77,12 +77,12 @@ bool Time::operator<=(const Time& other) const {
     return ((LT == c) or (EQ == c));
 }
 
-SerializeStatus Time::serializeTo(SerializeBufferBase& buffer) const {
-    return this->m_val.serializeTo(buffer);
+SerializeStatus Time::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+    return this->m_val.serializeTo(buffer, mode);
 }
 
-SerializeStatus Time::deserializeFrom(SerializeBufferBase& buffer) {
-    return this->m_val.deserializeFrom(buffer);
+SerializeStatus Time::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+    return this->m_val.deserializeFrom(buffer, mode);
 }
 
 U32 Time::getSeconds() const {

--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -77,11 +77,11 @@ bool Time::operator<=(const Time& other) const {
     return ((LT == c) or (EQ == c));
 }
 
-SerializeStatus Time::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+SerializeStatus Time::serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode) const {
     return this->m_val.serializeTo(buffer, mode);
 }
 
-SerializeStatus Time::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+SerializeStatus Time::deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode) {
     return this->m_val.deserializeFrom(buffer, mode);
 }
 

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -37,7 +37,7 @@ class Time : public Serializable {
         const;  // !< Time base of time. This is project specific and is meant for indicating different sources of time
     FwTimeContextStoreType getContext() const;  // !< get the context value
     SerializeStatus serializeTo(SerializeBufferBase& buffer,
-                                Fw::Endianness mode) const override;  // !< Serialize method
+                                Fw::Endianness mode = Fw::Endianness::BIG) const override;  // !< Serialize method
     SerializeStatus deserializeFrom(SerializeBufferBase& buffer,
                                     Fw::Endianness mode) override;  // !< Deserialize method
     bool operator==(const Time& other) const;

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -35,9 +35,11 @@ class Time : public Serializable {
     U32 getUSeconds() const;  // !< Gets microseconds part of time
     TimeBase getTimeBase()
         const;  // !< Time base of time. This is project specific and is meant for indicating different sources of time
-    FwTimeContextStoreType getContext() const;                                // !< get the context value
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode) const override;  // !< Serialize method
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode) override;    // !< Deserialize method
+    FwTimeContextStoreType getContext() const;  // !< get the context value
+    SerializeStatus serializeTo(SerializeBufferBase& buffer,
+                                Fw::Endianness mode) const override;  // !< Serialize method
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer,
+                                    Fw::Endianness mode) override;  // !< Deserialize method
     bool operator==(const Time& other) const;
     bool operator!=(const Time& other) const;
     bool operator>(const Time& other) const;

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -36,8 +36,8 @@ class Time : public Serializable {
     TimeBase getTimeBase()
         const;  // !< Time base of time. This is project specific and is meant for indicating different sources of time
     FwTimeContextStoreType getContext() const;                                // !< get the context value
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const override;  // !< Serialize method
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) override;    // !< Deserialize method
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode) const override;  // !< Serialize method
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode) override;    // !< Deserialize method
     bool operator==(const Time& other) const;
     bool operator!=(const Time& other) const;
     bool operator>(const Time& other) const;

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -39,7 +39,7 @@ class Time : public Serializable {
     SerializeStatus serializeTo(SerializeBufferBase& buffer,
                                 Fw::Endianness mode = Fw::Endianness::BIG) const override;  // !< Serialize method
     SerializeStatus deserializeFrom(SerializeBufferBase& buffer,
-                                    Fw::Endianness mode) override;  // !< Deserialize method
+                                    Fw::Endianness mode = Fw::Endianness::BIG) override;  // !< Deserialize method
     bool operator==(const Time& other) const;
     bool operator!=(const Time& other) const;
     bool operator>(const Time& other) const;

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -36,8 +36,8 @@ class Time : public Serializable {
     TimeBase getTimeBase()
         const;  // !< Time base of time. This is project specific and is meant for indicating different sources of time
     FwTimeContextStoreType getContext() const;                                // !< get the context value
-    SerializeStatus serializeTo(SerializeBufferBase& buffer) const override;  // !< Serialize method
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer) override;    // !< Deserialize method
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const override;  // !< Serialize method
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) override;    // !< Deserialize method
     bool operator==(const Time& other) const;
     bool operator!=(const Time& other) const;
     bool operator>(const Time& other) const;

--- a/Fw/Time/TimeInterval.cpp
+++ b/Fw/Time/TimeInterval.cpp
@@ -53,14 +53,14 @@ bool TimeInterval::operator<=(const TimeInterval& other) const {
     return ((LT == c) or (EQ == c));
 }
 
-SerializeStatus TimeInterval::serializeTo(SerializeBufferBase& buffer) const {
+SerializeStatus TimeInterval::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
     // Use TimeIntervalValue's built-in serialization
-    return this->m_val.serializeTo(buffer);
+    return this->m_val.serializeTo(buffer, mode);
 }
 
-SerializeStatus TimeInterval::deserializeFrom(SerializeBufferBase& buffer) {
+SerializeStatus TimeInterval::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
     // Use TimeIntervalValue's built-in deserialization
-    return this->m_val.deserializeFrom(buffer);
+    return this->m_val.deserializeFrom(buffer, mode);
 }
 
 U32 TimeInterval::getSeconds() const {

--- a/Fw/Time/TimeInterval.cpp
+++ b/Fw/Time/TimeInterval.cpp
@@ -53,12 +53,12 @@ bool TimeInterval::operator<=(const TimeInterval& other) const {
     return ((LT == c) or (EQ == c));
 }
 
-SerializeStatus TimeInterval::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+SerializeStatus TimeInterval::serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode) const {
     // Use TimeIntervalValue's built-in serialization
     return this->m_val.serializeTo(buffer, mode);
 }
 
-SerializeStatus TimeInterval::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+SerializeStatus TimeInterval::deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode) {
     // Use TimeIntervalValue's built-in deserialization
     return this->m_val.deserializeFrom(buffer, mode);
 }

--- a/Fw/Time/TimeInterval.hpp
+++ b/Fw/Time/TimeInterval.hpp
@@ -30,8 +30,8 @@ class TimeInterval : public Serializable {
     U32 getSeconds() const;                            // !< Gets seconds part of time
     U32 getUSeconds() const;                           // !< Gets microseconds part of time
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;  // !< Serialize method
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;    // !< Deserialize method
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;  // !< Serialize method
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;    // !< Deserialize method
     void add(U32 seconds, U32 mseconds);  // !< Add seconds and microseconds to existing time interval
     bool operator==(const TimeInterval& other) const;
     bool operator!=(const TimeInterval& other) const;

--- a/Fw/Time/TimeInterval.hpp
+++ b/Fw/Time/TimeInterval.hpp
@@ -30,8 +30,8 @@ class TimeInterval : public Serializable {
     U32 getSeconds() const;                            // !< Gets seconds part of time
     U32 getUSeconds() const;                           // !< Gets microseconds part of time
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer) const override;  // !< Serialize method
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer) override;    // !< Deserialize method
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;  // !< Serialize method
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;    // !< Deserialize method
     void add(U32 seconds, U32 mseconds);  // !< Add seconds and microseconds to existing time interval
     bool operator==(const TimeInterval& other) const;
     bool operator!=(const TimeInterval& other) const;

--- a/Fw/Time/TimeInterval.hpp
+++ b/Fw/Time/TimeInterval.hpp
@@ -30,8 +30,8 @@ class TimeInterval : public Serializable {
     U32 getSeconds() const;                            // !< Gets seconds part of time
     U32 getUSeconds() const;                           // !< Gets microseconds part of time
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;  // !< Serialize method
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;    // !< Deserialize method
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;  // !< Serialize method
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;    // !< Deserialize method
     void add(U32 seconds, U32 mseconds);  // !< Add seconds and microseconds to existing time interval
     bool operator==(const TimeInterval& other) const;
     bool operator!=(const TimeInterval& other) const;

--- a/Fw/Time/TimeInterval.hpp
+++ b/Fw/Time/TimeInterval.hpp
@@ -30,8 +30,10 @@ class TimeInterval : public Serializable {
     U32 getSeconds() const;                            // !< Gets seconds part of time
     U32 getUSeconds() const;                           // !< Gets microseconds part of time
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;  // !< Serialize method
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;    // !< Deserialize method
+    SerializeStatus serializeTo(SerializeBufferBase& buffer,
+                                Fw::Endianness mode = Fw::Endianness::BIG) const override;  // !< Serialize method
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer,
+                                    Fw::Endianness mode = Fw::Endianness::BIG) override;  // !< Deserialize method
     void add(U32 seconds, U32 mseconds);  // !< Add seconds and microseconds to existing time interval
     bool operator==(const TimeInterval& other) const;
     bool operator!=(const TimeInterval& other) const;

--- a/Fw/Tlm/TlmPacket.cpp
+++ b/Fw/Tlm/TlmPacket.cpp
@@ -125,7 +125,7 @@ SerializeStatus TlmPacket::extractValue(FwChanIdType& id, Time& timeTag, TlmBuff
     return Fw::FW_SERIALIZE_OK;
 }
 
-SerializeStatus TlmPacket::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+SerializeStatus TlmPacket::serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode) const {
     // serialize the number of packets
     SerializeStatus stat = buffer.serializeFrom(this->m_numEntries, mode);
     if (stat != Fw::FW_SERIALIZE_OK) {
@@ -136,7 +136,7 @@ SerializeStatus TlmPacket::serializeTo(SerializeBufferBase& buffer, Fw::Serializ
                                 Fw::Serialization::OMIT_LENGTH);
 }
 
-SerializeStatus TlmPacket::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+SerializeStatus TlmPacket::deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode) {
     // deserialize the number of packets
     SerializeStatus stat = buffer.deserializeTo(this->m_numEntries, mode);
     if (stat != Fw::FW_SERIALIZE_OK) {

--- a/Fw/Tlm/TlmPacket.cpp
+++ b/Fw/Tlm/TlmPacket.cpp
@@ -125,9 +125,9 @@ SerializeStatus TlmPacket::extractValue(FwChanIdType& id, Time& timeTag, TlmBuff
     return Fw::FW_SERIALIZE_OK;
 }
 
-SerializeStatus TlmPacket::serializeTo(SerializeBufferBase& buffer) const {
+SerializeStatus TlmPacket::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
     // serialize the number of packets
-    SerializeStatus stat = buffer.serializeFrom(this->m_numEntries);
+    SerializeStatus stat = buffer.serializeFrom(this->m_numEntries, mode);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
@@ -136,9 +136,9 @@ SerializeStatus TlmPacket::serializeTo(SerializeBufferBase& buffer) const {
                                 Fw::Serialization::OMIT_LENGTH);
 }
 
-SerializeStatus TlmPacket::deserializeFrom(SerializeBufferBase& buffer) {
+SerializeStatus TlmPacket::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
     // deserialize the number of packets
-    SerializeStatus stat = buffer.deserializeTo(this->m_numEntries);
+    SerializeStatus stat = buffer.deserializeTo(this->m_numEntries, mode);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }

--- a/Fw/Tlm/TlmPacket.hpp
+++ b/Fw/Tlm/TlmPacket.hpp
@@ -22,8 +22,8 @@ class TlmPacket : public ComPacket {
     //! Destructor
     virtual ~TlmPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer) const override;  //!< serialize contents
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer) override;
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;  //!< serialize contents
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
     //! Add telemetry value to buffer.
     SerializeStatus addValue(FwChanIdType id, Time& timeTag, TlmBuffer& buffer);
     //! extract telemetry value - since there are potentially multiple channel values in the packet,

--- a/Fw/Tlm/TlmPacket.hpp
+++ b/Fw/Tlm/TlmPacket.hpp
@@ -22,8 +22,8 @@ class TlmPacket : public ComPacket {
     //! Destructor
     virtual ~TlmPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;  //!< serialize contents
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;  //!< serialize contents
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
     //! Add telemetry value to buffer.
     SerializeStatus addValue(FwChanIdType id, Time& timeTag, TlmBuffer& buffer);
     //! extract telemetry value - since there are potentially multiple channel values in the packet,

--- a/Fw/Tlm/TlmPacket.hpp
+++ b/Fw/Tlm/TlmPacket.hpp
@@ -22,7 +22,8 @@ class TlmPacket : public ComPacket {
     //! Destructor
     virtual ~TlmPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;  //!< serialize contents
+    SerializeStatus serializeTo(SerializeBufferBase& buffer,
+                                Fw::Endianness mode = Fw::Endianness::BIG) const override;  //!< serialize contents
     SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
     //! Add telemetry value to buffer.
     SerializeStatus addValue(FwChanIdType id, Time& timeTag, TlmBuffer& buffer);

--- a/Fw/Tlm/TlmPacket.hpp
+++ b/Fw/Tlm/TlmPacket.hpp
@@ -22,8 +22,8 @@ class TlmPacket : public ComPacket {
     //! Destructor
     virtual ~TlmPacket();
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;  //!< serialize contents
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;  //!< serialize contents
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
     //! Add telemetry value to buffer.
     SerializeStatus addValue(FwChanIdType id, Time& timeTag, TlmBuffer& buffer);
     //! extract telemetry value - since there are potentially multiple channel values in the packet,

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -480,7 +480,7 @@ bool PolyType::operator<=(const PolyType& other) const {
     return (this->operator<(other)) || (this->operator==(other));
 }
 
-SerializeStatus PolyType::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+SerializeStatus PolyType::serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode) const {
     // store type
     SerializeStatus stat = buffer.serializeFrom(static_cast<FwEnumStoreType>(this->m_dataType), mode);
     if (stat != FW_SERIALIZE_OK) {
@@ -539,7 +539,7 @@ SerializeStatus PolyType::serializeTo(SerializeBufferBase& buffer, Fw::Serializa
     return stat;
 }
 
-SerializeStatus PolyType::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+SerializeStatus PolyType::deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode) {
     // get type
     FwEnumStoreType des;
     SerializeStatus stat = buffer.deserializeTo(des, mode);

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -480,9 +480,9 @@ bool PolyType::operator<=(const PolyType& other) const {
     return (this->operator<(other)) || (this->operator==(other));
 }
 
-SerializeStatus PolyType::serializeTo(SerializeBufferBase& buffer) const {
+SerializeStatus PolyType::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
     // store type
-    SerializeStatus stat = buffer.serializeFrom(static_cast<FwEnumStoreType>(this->m_dataType));
+    SerializeStatus stat = buffer.serializeFrom(static_cast<FwEnumStoreType>(this->m_dataType), mode);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
@@ -490,46 +490,46 @@ SerializeStatus PolyType::serializeTo(SerializeBufferBase& buffer) const {
     // switch on type
     switch (this->m_dataType) {
         case TYPE_U8:
-            stat = buffer.serializeFrom(this->m_val.u8Val);
+            stat = buffer.serializeFrom(this->m_val.u8Val, mode);
             break;
         case TYPE_I8:
-            stat = buffer.serializeFrom(this->m_val.i8Val);
+            stat = buffer.serializeFrom(this->m_val.i8Val, mode);
             break;
 #if FW_HAS_16_BIT
         case TYPE_U16:
-            stat = buffer.serializeFrom(this->m_val.u16Val);
+            stat = buffer.serializeFrom(this->m_val.u16Val, mode);
             break;
         case TYPE_I16:
-            stat = buffer.serializeFrom(this->m_val.i16Val);
+            stat = buffer.serializeFrom(this->m_val.i16Val, mode);
             break;
 #endif
 #if FW_HAS_32_BIT
         case TYPE_U32:
-            stat = buffer.serializeFrom(this->m_val.u32Val);
+            stat = buffer.serializeFrom(this->m_val.u32Val, mode);
             break;
         case TYPE_I32:
-            stat = buffer.serializeFrom(this->m_val.i32Val);
+            stat = buffer.serializeFrom(this->m_val.i32Val, mode);
             break;
 #endif
 #if FW_HAS_64_BIT
         case TYPE_U64:
-            stat = buffer.serializeFrom(this->m_val.u64Val);
+            stat = buffer.serializeFrom(this->m_val.u64Val, mode);
             break;
         case TYPE_I64:
-            stat = buffer.serializeFrom(this->m_val.i64Val);
+            stat = buffer.serializeFrom(this->m_val.i64Val, mode);
             break;
 #endif
         case TYPE_F64:
-            stat = buffer.serializeFrom(this->m_val.f64Val);
+            stat = buffer.serializeFrom(this->m_val.f64Val, mode);
             break;
         case TYPE_F32:
-            stat = buffer.serializeFrom(this->m_val.f32Val);
+            stat = buffer.serializeFrom(this->m_val.f32Val, mode);
             break;
         case TYPE_BOOL:
-            stat = buffer.serializeFrom(this->m_val.boolVal);
+            stat = buffer.serializeFrom(this->m_val.boolVal, mode);
             break;
         case TYPE_PTR:
-            stat = buffer.serializeFrom(this->m_val.ptrVal);
+            stat = buffer.serializeFrom(this->m_val.ptrVal, mode);
             break;
         default:
             stat = FW_SERIALIZE_FORMAT_ERROR;
@@ -539,10 +539,10 @@ SerializeStatus PolyType::serializeTo(SerializeBufferBase& buffer) const {
     return stat;
 }
 
-SerializeStatus PolyType::deserializeFrom(SerializeBufferBase& buffer) {
+SerializeStatus PolyType::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
     // get type
     FwEnumStoreType des;
-    SerializeStatus stat = buffer.deserializeTo(des);
+    SerializeStatus stat = buffer.deserializeTo(des, mode);
 
     if (stat != FW_SERIALIZE_OK) {
         return stat;
@@ -551,35 +551,35 @@ SerializeStatus PolyType::deserializeFrom(SerializeBufferBase& buffer) {
         // switch on type
         switch (this->m_dataType) {
             case TYPE_U8:
-                return buffer.deserializeTo(this->m_val.u8Val);
+                return buffer.deserializeTo(this->m_val.u8Val, mode);
             case TYPE_I8:
-                return buffer.deserializeTo(this->m_val.i8Val);
+                return buffer.deserializeTo(this->m_val.i8Val, mode);
 #if FW_HAS_16_BIT
             case TYPE_U16:
-                return buffer.deserializeTo(this->m_val.u16Val);
+                return buffer.deserializeTo(this->m_val.u16Val, mode);
             case TYPE_I16:
-                return buffer.deserializeTo(this->m_val.i16Val);
+                return buffer.deserializeTo(this->m_val.i16Val, mode);
 #endif
 #if FW_HAS_32_BIT
             case TYPE_U32:
-                return buffer.deserializeTo(this->m_val.u32Val);
+                return buffer.deserializeTo(this->m_val.u32Val, mode);
             case TYPE_I32:
-                return buffer.deserializeTo(this->m_val.i32Val);
+                return buffer.deserializeTo(this->m_val.i32Val, mode);
 #endif
 #if FW_HAS_64_BIT
             case TYPE_U64:
-                return buffer.deserializeTo(this->m_val.u64Val);
+                return buffer.deserializeTo(this->m_val.u64Val, mode);
             case TYPE_I64:
-                return buffer.deserializeTo(this->m_val.i64Val);
+                return buffer.deserializeTo(this->m_val.i64Val, mode);
 #endif
             case TYPE_F64:
-                return buffer.deserializeTo(this->m_val.f64Val);
+                return buffer.deserializeTo(this->m_val.f64Val, mode);
             case TYPE_F32:
-                return buffer.deserializeTo(this->m_val.f32Val);
+                return buffer.deserializeTo(this->m_val.f32Val, mode);
             case TYPE_BOOL:
-                return buffer.deserializeTo(this->m_val.boolVal);
+                return buffer.deserializeTo(this->m_val.boolVal, mode);
             case TYPE_PTR:
-                return buffer.deserializeTo(this->m_val.ptrVal);
+                return buffer.deserializeTo(this->m_val.ptrVal, mode);
             default:
                 return FW_DESERIALIZE_FORMAT_ERROR;
         }

--- a/Fw/Types/PolyType.hpp
+++ b/Fw/Types/PolyType.hpp
@@ -103,8 +103,8 @@ class PolyType : public Serializable {
     bool operator==(const PolyType& other) const;  //!< PolyType operator==
     bool operator!=(const PolyType& other) const;  //!< PolyType operator!=
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;  //!< Serialize function
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;    //!< Deserialize function
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;  //!< Serialize function
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;    //!< Deserialize function
 
   private:
     typedef enum {

--- a/Fw/Types/PolyType.hpp
+++ b/Fw/Types/PolyType.hpp
@@ -103,8 +103,8 @@ class PolyType : public Serializable {
     bool operator==(const PolyType& other) const;  //!< PolyType operator==
     bool operator!=(const PolyType& other) const;  //!< PolyType operator!=
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;  //!< Serialize function
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;    //!< Deserialize function
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;  //!< Serialize function
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;    //!< Deserialize function
 
   private:
     typedef enum {

--- a/Fw/Types/PolyType.hpp
+++ b/Fw/Types/PolyType.hpp
@@ -103,8 +103,8 @@ class PolyType : public Serializable {
     bool operator==(const PolyType& other) const;  //!< PolyType operator==
     bool operator!=(const PolyType& other) const;  //!< PolyType operator!=
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer) const override;  //!< Serialize function
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer) override;    //!< Deserialize function
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;  //!< Serialize function
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;    //!< Deserialize function
 
   private:
     typedef enum {

--- a/Fw/Types/PolyType.hpp
+++ b/Fw/Types/PolyType.hpp
@@ -103,8 +103,10 @@ class PolyType : public Serializable {
     bool operator==(const PolyType& other) const;  //!< PolyType operator==
     bool operator!=(const PolyType& other) const;  //!< PolyType operator!=
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;  //!< Serialize function
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;    //!< Deserialize function
+    SerializeStatus serializeTo(SerializeBufferBase& buffer,
+                                Fw::Endianness mode = Fw::Endianness::BIG) const override;  //!< Serialize function
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer,
+                                    Fw::Endianness mode = Fw::Endianness::BIG) override;  //!< Deserialize function
 
   private:
     typedef enum {

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -224,11 +224,16 @@ SerializeStatus SerializeBufferBase::serializeFrom(const void* val, Endianness m
     return this->serializeFrom(reinterpret_cast<PlatformPointerCastType>(val), mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, Serializable::SizeType length, Endianness endianMode) {
+SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff,
+                                                   Serializable::SizeType length,
+                                                   Endianness endianMode) {
     return this->serializeFrom(buff, static_cast<FwSizeType>(length), Serialization::INCLUDE_LENGTH, endianMode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, FwSizeType length, Serialization::t lengthMode, Endianness endianMode) { // First serialize length
+SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff,
+                                                   FwSizeType length,
+                                                   Serialization::t lengthMode,
+                                                   Endianness endianMode) {  // First serialize length
     SerializeStatus stat;
     if (lengthMode == Serialization::INCLUDE_LENGTH) {
         stat = this->serializeFrom(static_cast<FwSizeStoreType>(length), endianMode);
@@ -332,12 +337,12 @@ SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Endianness mode) {
         case Endianness::BIG:
             // MSB first
             val = static_cast<U16>(((this->getBuffAddr()[this->m_deserLoc + 1]) << 0) |
-                           ((this->getBuffAddr()[this->m_deserLoc + 0]) << 8));
+                                   ((this->getBuffAddr()[this->m_deserLoc + 0]) << 8));
             break;
         case Endianness::LITTLE:
             // LSB first
             val = static_cast<U16>(((this->getBuffAddr()[this->m_deserLoc + 0]) << 0) |
-                           ((this->getBuffAddr()[this->m_deserLoc + 1]) << 8));
+                                   ((this->getBuffAddr()[this->m_deserLoc + 1]) << 8));
             break;
         default:
             FW_ASSERT(false);
@@ -370,16 +375,16 @@ SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Endianness mode) {
         case Endianness::BIG:
             // MSB first
             val = (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 0) |
-                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8) |
-                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16) |
-                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
+                  (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8) |
+                  (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16) |
+                  (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
             break;
         case Endianness::LITTLE:
             // LSB first
             val = (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 0) |
-                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 8) |
-                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 16) |
-                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 24);
+                  (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 8) |
+                  (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 16) |
+                  (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 24);
             break;
         default:
             FW_ASSERT(false);
@@ -414,24 +419,24 @@ SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Endianness mode) {
         case Endianness::BIG:
             // MSB first
             val = (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 0) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 16) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 24) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 32) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 40) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 16) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 24) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 32) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 40) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
             break;
         case Endianness::LITTLE:
             // LSB first
             val = (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 0) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 8) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 16) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 24) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 32) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 40) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 48) |
-                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 56);
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 8) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 16) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 24) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 32) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 40) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 48) |
+                  (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 56);
             break;
         default:
             FW_ASSERT(false);
@@ -514,7 +519,10 @@ SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeT
     return status;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeType& length, Serialization::t lengthMode, Endianness endianMode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U8* buff,
+                                                   Serializable::SizeType& length,
+                                                   Serialization::t lengthMode,
+                                                   Endianness endianMode) {
     FW_ASSERT(this->getBuffAddr());
 
     if (lengthMode == Serialization::INCLUDE_LENGTH) {
@@ -698,8 +706,7 @@ SerializeStatus SerializeBufferBase::copyRawOffset(SerializeBufferBase& dest, Se
     }
 
     // otherwise, serialize bytes to destination without writing length
-    SerializeStatus stat =
-        dest.serializeFrom(&this->getBuffAddr()[this->m_deserLoc], size, Serialization::OMIT_LENGTH);
+    SerializeStatus stat = dest.serializeFrom(&this->getBuffAddr()[this->m_deserLoc], size, Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         this->m_deserLoc += size;
     }

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -216,12 +216,12 @@ SerializeStatus SerializeBufferBase::serializeFrom(bool val, Fw::Serialization::
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const void* val) {
+SerializeStatus SerializeBufferBase::serializeFrom(const void* val, Fw::Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(void*)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
 
-    return this->serializeFrom(reinterpret_cast<PlatformPointerCastType>(val));
+    return this->serializeFrom(reinterpret_cast<PlatformPointerCastType>(val), mode);
 }
 
 SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, Serializable::SizeType length) {
@@ -329,27 +329,32 @@ SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Fw::Serialization::
     }
     // read from current location
     FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    val = static_cast<U16>(((this->getBuffAddr()[this->m_deserLoc + 1]) << 0) |
+    switch (mode) {
+        case Serialization::BIG:
+            // MSB first
+            val = static_cast<U16>(((this->getBuffAddr()[this->m_deserLoc + 1]) << 0) |
                            ((this->getBuffAddr()[this->m_deserLoc + 0]) << 8));
+            break;
+        case Serialization::LITTLE:
+            // LSB first
+            val = static_cast<U16>(((this->getBuffAddr()[this->m_deserLoc + 0]) << 0) |
+                           ((this->getBuffAddr()[this->m_deserLoc + 1]) << 8));
+            break;
+        default:
+            FW_ASSERT(false);
+            break;
+    }
     this->m_deserLoc += static_cast<Serializable::SizeType>(sizeof(val));
     return FW_SERIALIZE_OK;
 }
 
 SerializeStatus SerializeBufferBase::deserializeTo(I16& val, Fw::Serialization::Endianness mode) {
-    // check for room
-    if (this->getBuffLength() == this->m_deserLoc) {
-        return FW_DESERIALIZE_BUFFER_EMPTY;
-    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
-        return FW_DESERIALIZE_SIZE_MISMATCH;
+    U16 unsignVal;
+    SerializeStatus res = deserializeTo(unsignVal, mode);
+    if (res == SerializeStatus::FW_SERIALIZE_OK) {
+        val = static_cast<I16>(unsignVal);
     }
-    // read from current location
-    FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    val = static_cast<I16>(((this->getBuffAddr()[this->m_deserLoc + 1]) << 0) |
-                           ((this->getBuffAddr()[this->m_deserLoc + 0]) << 8));
-    this->m_deserLoc += static_cast<Serializable::SizeType>(sizeof(val));
-    return FW_SERIALIZE_OK;
+    return res;
 }
 #endif
 #if FW_HAS_32_BIT == 1
@@ -362,31 +367,36 @@ SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Fw::Serialization::
     }
     // read from current location
     FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    val = (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 0) |
-          (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8) |
-          (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16) |
-          (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
+    switch (mode) {
+        case Serialization::BIG:
+            // MSB first
+            val = (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 0) |
+                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8) |
+                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16) |
+                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
+            break;
+        case Serialization::LITTLE:
+            // LSB first
+            val = (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 0) |
+                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 8) |
+                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 16) |
+                (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 24);
+            break;
+        default:
+            FW_ASSERT(false);
+            break;
+    }
     this->m_deserLoc += static_cast<Serializable::SizeType>(sizeof(val));
     return FW_SERIALIZE_OK;
 }
 
 SerializeStatus SerializeBufferBase::deserializeTo(I32& val, Fw::Serialization::Endianness mode) {
-    // check for room
-    if (this->getBuffLength() == this->m_deserLoc) {
-        return FW_DESERIALIZE_BUFFER_EMPTY;
-    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
-        return FW_DESERIALIZE_SIZE_MISMATCH;
+    U32 unsignVal;
+    SerializeStatus res = deserializeTo(unsignVal, mode);
+    if (res == SerializeStatus::FW_SERIALIZE_OK) {
+        val = static_cast<I32>(unsignVal);
     }
-    // read from current location
-    FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    val = (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 0) |
-          (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8) |
-          (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16) |
-          (static_cast<I32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
-    this->m_deserLoc += static_cast<Serializable::SizeType>(sizeof(val));
-    return FW_SERIALIZE_OK;
+    return res;
 }
 #endif
 
@@ -401,47 +411,51 @@ SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Fw::Serialization::
     }
     // read from current location
     FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    val = (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 0) |
-          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8) |
-          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 16) |
-          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 24) |
-          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 32) |
-          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 40) |
-          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48) |
-          (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
-
+    switch (mode) {
+        case Serialization::BIG:
+            // MSB first
+            val = (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 0) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 16) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 24) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 32) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 40) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
+            break;
+        case Serialization::LITTLE:
+            // LSB first
+            val = (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 0) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 8) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 16) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 24) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 32) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 40) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 48) |
+                (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 56);
+            break;
+        default:
+            FW_ASSERT(false);
+            break;
+    }
     this->m_deserLoc += static_cast<Serializable::SizeType>(sizeof(val));
     return FW_SERIALIZE_OK;
 }
 
 SerializeStatus SerializeBufferBase::deserializeTo(I64& val, Fw::Serialization::Endianness mode) {
-    // check for room
-    if (this->getBuffLength() == this->m_deserLoc) {
-        return FW_DESERIALIZE_BUFFER_EMPTY;
-    } else if (this->getBuffLength() - this->m_deserLoc < static_cast<Serializable::SizeType>(sizeof(val))) {
-        return FW_DESERIALIZE_SIZE_MISMATCH;
+    U64 unsignVal;
+    SerializeStatus res = deserializeTo(unsignVal, mode);
+    if (res == SerializeStatus::FW_SERIALIZE_OK) {
+        val = static_cast<I64>(unsignVal);
     }
-    // read from current location
-    FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    val = (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 0) |
-          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8) |
-          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 5]) << 16) |
-          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 4]) << 24) |
-          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 3]) << 32) |
-          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 2]) << 40) |
-          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48) |
-          (static_cast<I64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
-    this->m_deserLoc += static_cast<Serializable::SizeType>(sizeof(val));
-    return FW_SERIALIZE_OK;
+    return res;
 }
 #endif
 
 SerializeStatus SerializeBufferBase::deserializeTo(F64& val, Fw::Serialization::Endianness mode) {
     // deserialize as 64-bit int to handle endianness
     U64 tempVal;
-    SerializeStatus stat = this->deserializeTo(tempVal);
+    SerializeStatus stat = this->deserializeTo(tempVal, mode);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
@@ -475,7 +489,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(bool& val, Fw::Serialization:
 SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Fw::Serialization::Endianness mode) {
     // Deserialize as pointer cast, then convert to void*
     PlatformPointerCastType pointerCastVal = 0;
-    const SerializeStatus stat = this->deserializeTo(pointerCastVal);
+    const SerializeStatus stat = this->deserializeTo(pointerCastVal, mode);
     if (stat == FW_SERIALIZE_OK) {
         val = reinterpret_cast<void*>(pointerCastVal);
     }
@@ -485,7 +499,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Fw::Serialization
 SerializeStatus SerializeBufferBase::deserializeTo(F32& val, Fw::Serialization::Endianness mode) {
     // deserialize as 64-bit int to handle endianness
     U32 tempVal;
-    SerializeStatus stat = this->deserializeTo(tempVal);
+    SerializeStatus stat = this->deserializeTo(tempVal, mode);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
@@ -536,7 +550,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeT
 }
 
 SerializeStatus SerializeBufferBase::deserializeTo(Serializable& val, Fw::Serialization::Endianness mode) {
-    return val.deserializeFrom(*this);
+    return val.deserializeFrom(*this, mode);
 }
 
 SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Fw::Serialization::Endianness mode) {
@@ -545,7 +559,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Fw:
 
     FwSizeStoreType storedLength;
 
-    stat = this->deserializeTo(storedLength);
+    stat = this->deserializeTo(storedLength, mode);
 
     if (stat != FW_SERIALIZE_OK) {
         return stat;
@@ -573,7 +587,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Fw:
 
 SerializeStatus SerializeBufferBase::deserializeSize(FwSizeType& size, Serialization::Endianness mode) {
     FwSizeStoreType storedSize = 0;
-    Fw::SerializeStatus status = this->deserializeTo(storedSize);
+    Fw::SerializeStatus status = this->deserializeTo(storedSize, mode);
     if (status == FW_SERIALIZE_OK) {
         size = static_cast<FwSizeType>(storedSize);
     }

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -61,7 +61,7 @@ SerializeBufferBase& SerializeBufferBase::operator=(const SerializeBufferBase& s
 
 // serialization routines
 
-SerializeStatus SerializeBufferBase::serializeFrom(U8 val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U8 val, Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -73,12 +73,12 @@ SerializeStatus SerializeBufferBase::serializeFrom(U8 val, Serialization::Endian
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I8 val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I8 val, Endianness mode) {
     return serializeFrom(static_cast<U8>(val), mode);
 }
 
 #if FW_HAS_16_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U16 val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U16 val, Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -103,12 +103,12 @@ SerializeStatus SerializeBufferBase::serializeFrom(U16 val, Serialization::Endia
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I16 val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I16 val, Endianness mode) {
     return serializeFrom(static_cast<U16>(val), mode);
 }
 #endif
 #if FW_HAS_32_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U32 val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U32 val, Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -137,13 +137,13 @@ SerializeStatus SerializeBufferBase::serializeFrom(U32 val, Serialization::Endia
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I32 val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I32 val, Endianness mode) {
     return serializeFrom(static_cast<U32>(val), mode);
 }
 #endif
 
 #if FW_HAS_64_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -180,26 +180,26 @@ SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Serialization::Endia
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I64 val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I64 val, Endianness mode) {
     return serializeFrom(static_cast<U64>(val), mode);
 }
 #endif
 
-SerializeStatus SerializeBufferBase::serializeFrom(F64 val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(F64 val, Endianness mode) {
     // floating point values need to be byte-swapped as well, so copy to U64 and use that routine
     U64 u64Val;
     (void)memcpy(&u64Val, &val, sizeof(val));
     return this->serializeFrom(u64Val, mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(F32 val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(F32 val, Endianness mode) {
     // floating point values need to be byte-swapped as well, so copy to U32 and use that routine
     U32 u32Val;
     (void)memcpy(&u32Val, &val, sizeof(val));
     return this->serializeFrom(u32Val, mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(bool val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(bool val, Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(U8)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -216,7 +216,7 @@ SerializeStatus SerializeBufferBase::serializeFrom(bool val, Serialization::Endi
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const void* val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(const void* val, Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(void*)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -224,11 +224,11 @@ SerializeStatus SerializeBufferBase::serializeFrom(const void* val, Serializatio
     return this->serializeFrom(reinterpret_cast<PlatformPointerCastType>(val), mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, Serializable::SizeType length, Serialization::Endianness endianMode) {
+SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, Serializable::SizeType length, Endianness endianMode) {
     return this->serializeFrom(buff, static_cast<FwSizeType>(length), Serialization::INCLUDE_LENGTH, endianMode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, FwSizeType length, Serialization::t lengthMode, Serialization::Endianness endianMode) { // First serialize length
+SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, FwSizeType length, Serialization::t lengthMode, Endianness endianMode) { // First serialize length
     SerializeStatus stat;
     if (lengthMode == Serialization::INCLUDE_LENGTH) {
         stat = this->serializeFrom(static_cast<FwSizeStoreType>(length), endianMode);
@@ -250,11 +250,11 @@ SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, FwSizeType le
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const Serializable& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(const Serializable& val, Endianness mode) {
     return val.serializeTo(*this, mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& val, Endianness mode) {
     Serializable::SizeType size = val.getBuffLength();
     if (this->m_serLoc + size + static_cast<Serializable::SizeType>(sizeof(FwSizeStoreType)) >
         this->getBuffCapacity()) {
@@ -277,7 +277,7 @@ SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& va
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size, Endianness mode) {
     SerializeStatus status = FW_SERIALIZE_OK;
     if ((size < std::numeric_limits<FwSizeStoreType>::min()) || (size > std::numeric_limits<FwSizeStoreType>::max())) {
         status = FW_SERIALIZE_FORMAT_ERROR;
@@ -290,7 +290,7 @@ SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size, Serial
 
 // deserialization routines
 
-SerializeStatus SerializeBufferBase::deserializeTo(U8& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U8& val, Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -304,7 +304,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U8& val, Serialization::Endia
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I8& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I8& val, Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -319,7 +319,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I8& val, Serialization::Endia
 }
 
 #if FW_HAS_16_BIT == 1
-SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -347,7 +347,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Serialization::Endi
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I16& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I16& val, Endianness mode) {
     U16 unsignVal;
     SerializeStatus res = deserializeTo(unsignVal, mode);
     if (res == SerializeStatus::FW_SERIALIZE_OK) {
@@ -357,7 +357,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I16& val, Serialization::Endi
 }
 #endif
 #if FW_HAS_32_BIT == 1
-SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -389,7 +389,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Serialization::Endi
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I32& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I32& val, Endianness mode) {
     U32 unsignVal;
     SerializeStatus res = deserializeTo(unsignVal, mode);
     if (res == SerializeStatus::FW_SERIALIZE_OK) {
@@ -401,7 +401,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I32& val, Serialization::Endi
 
 #if FW_HAS_64_BIT == 1
 
-SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -441,7 +441,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Serialization::Endi
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I64& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I64& val, Endianness mode) {
     U64 unsignVal;
     SerializeStatus res = deserializeTo(unsignVal, mode);
     if (res == SerializeStatus::FW_SERIALIZE_OK) {
@@ -451,7 +451,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I64& val, Serialization::Endi
 }
 #endif
 
-SerializeStatus SerializeBufferBase::deserializeTo(F64& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(F64& val, Endianness mode) {
     // deserialize as 64-bit int to handle endianness
     U64 tempVal;
     SerializeStatus stat = this->deserializeTo(tempVal, mode);
@@ -464,7 +464,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(F64& val, Serialization::Endi
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(bool& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(bool& val, Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -485,7 +485,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(bool& val, Serialization::End
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Endianness mode) {
     // Deserialize as pointer cast, then convert to void*
     PlatformPointerCastType pointerCastVal = 0;
     const SerializeStatus stat = this->deserializeTo(pointerCastVal, mode);
@@ -495,7 +495,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Serialization::En
     return stat;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(F32& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(F32& val, Endianness mode) {
     // deserialize as 64-bit int to handle endianness
     U32 tempVal;
     SerializeStatus stat = this->deserializeTo(tempVal, mode);
@@ -507,14 +507,14 @@ SerializeStatus SerializeBufferBase::deserializeTo(F32& val, Serialization::Endi
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeType& length, Serialization::Endianness endianMode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeType& length, Endianness endianMode) {
     FwSizeType length_in_out = static_cast<FwSizeType>(length);
     SerializeStatus status = this->deserializeTo(buff, length_in_out, Serialization::INCLUDE_LENGTH, endianMode);
     length = static_cast<Serializable::SizeType>(length_in_out);
     return status;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeType& length, Serialization::t lengthMode, Serialization::Endianness endianMode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeType& length, Serialization::t lengthMode, Endianness endianMode) {
     FW_ASSERT(this->getBuffAddr());
 
     if (lengthMode == Serialization::INCLUDE_LENGTH) {
@@ -548,11 +548,11 @@ SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeT
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(Serializable& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(Serializable& val, Endianness mode) {
     return val.deserializeFrom(*this, mode);
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Endianness mode) {
     FW_ASSERT(val.getBuffAddr());
     SerializeStatus stat = FW_SERIALIZE_OK;
 
@@ -584,7 +584,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Ser
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeSize(FwSizeType& size, Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeSize(FwSizeType& size, Endianness mode) {
     FwSizeStoreType storedSize = 0;
     Fw::SerializeStatus status = this->deserializeTo(storedSize, mode);
     if (status == FW_SERIALIZE_OK) {

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -61,7 +61,7 @@ SerializeBufferBase& SerializeBufferBase::operator=(const SerializeBufferBase& s
 
 // serialization routines
 
-SerializeStatus SerializeBufferBase::serializeFrom(U8 val) {
+SerializeStatus SerializeBufferBase::serializeFrom(U8 val, Fw::Serialization::Endianess mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -73,131 +73,133 @@ SerializeStatus SerializeBufferBase::serializeFrom(U8 val) {
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I8 val) {
-    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-        return FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    FW_ASSERT(this->getBuffAddr());
-    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val);
-    this->m_serLoc += static_cast<Serializable::SizeType>(sizeof(val));
-    this->m_deserLoc = 0;
-    return FW_SERIALIZE_OK;
+SerializeStatus SerializeBufferBase::serializeFrom(I8 val, Fw::Serialization::Endianess mode) {
+    return serializeFrom(static_cast<U8>(val), mode);
 }
 
 #if FW_HAS_16_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U16 val) {
+SerializeStatus SerializeBufferBase::serializeFrom(U16 val, Fw::Serialization::Endianess mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
     FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 8);
-    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val);
+    switch (mode) {
+        case Serialization::BIG:
+            // MSB first
+            this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 8);
+            this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val);
+            break;
+        case Serialization::LITTLE:
+            // LSB first
+            this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val);
+            this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 8);
+            break;
+        default:
+            FW_ASSERT(false);
+            break;
+    }
     this->m_serLoc += static_cast<Serializable::SizeType>(sizeof(val));
     this->m_deserLoc = 0;
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I16 val) {
-    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-        return FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 8);
-    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val);
-    this->m_serLoc += static_cast<Serializable::SizeType>(sizeof(val));
-    this->m_deserLoc = 0;
-    return FW_SERIALIZE_OK;
+SerializeStatus SerializeBufferBase::serializeFrom(I16 val, Fw::Serialization::Endianess mode) {
+    return serializeFrom(static_cast<U16>(val), mode);
 }
 #endif
 #if FW_HAS_32_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U32 val) {
+SerializeStatus SerializeBufferBase::serializeFrom(U32 val, Fw::Serialization::Endianess mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
     FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 24);
-    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 16);
-    this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 8);
-    this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val);
+    switch (mode) {
+        case Serialization::BIG:
+            // MSB first
+            this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 24);
+            this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 16);
+            this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 8);
+            this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val);
+            break;
+        case Serialization::LITTLE:
+            // LSB first
+            this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val);
+            this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 8);
+            this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 16);
+            this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val >> 24);
+            break;
+        default:
+            FW_ASSERT(false);
+            break;
+    }
     this->m_serLoc += static_cast<Serializable::SizeType>(sizeof(val));
     this->m_deserLoc = 0;
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I32 val) {
-    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-        return FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 24);
-    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 16);
-    this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 8);
-    this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val);
-    this->m_serLoc += static_cast<Serializable::SizeType>(sizeof(val));
-    this->m_deserLoc = 0;
-    return FW_SERIALIZE_OK;
+SerializeStatus SerializeBufferBase::serializeFrom(I32 val, Fw::Serialization::Endianess mode) {
+    return serializeFrom(static_cast<U32>(val), mode);
 }
 #endif
 
 #if FW_HAS_64_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U64 val) {
+SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Fw::Serialization::Endianess mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
     FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 56);
-    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 48);
-    this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 40);
-    this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val >> 32);
-    this->getBuffAddr()[this->m_serLoc + 4] = static_cast<U8>(val >> 24);
-    this->getBuffAddr()[this->m_serLoc + 5] = static_cast<U8>(val >> 16);
-    this->getBuffAddr()[this->m_serLoc + 6] = static_cast<U8>(val >> 8);
-    this->getBuffAddr()[this->m_serLoc + 7] = static_cast<U8>(val);
+    switch (mode) {
+        case Serialization::BIG:
+            // MSB first
+            this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 56);
+            this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 48);
+            this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 40);
+            this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val >> 32);
+            this->getBuffAddr()[this->m_serLoc + 4] = static_cast<U8>(val >> 24);
+            this->getBuffAddr()[this->m_serLoc + 5] = static_cast<U8>(val >> 16);
+            this->getBuffAddr()[this->m_serLoc + 6] = static_cast<U8>(val >> 8);
+            this->getBuffAddr()[this->m_serLoc + 7] = static_cast<U8>(val);
+            break;
+        case Serialization::LITTLE:
+            // LSB first
+            this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val);
+            this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 8);
+            this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 16);
+            this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val >> 24);
+            this->getBuffAddr()[this->m_serLoc + 4] = static_cast<U8>(val >> 32);
+            this->getBuffAddr()[this->m_serLoc + 5] = static_cast<U8>(val >> 40);
+            this->getBuffAddr()[this->m_serLoc + 6] = static_cast<U8>(val >> 48);
+            this->getBuffAddr()[this->m_serLoc + 7] = static_cast<U8>(val >> 56);
+            break;
+        default:
+            FW_ASSERT(false);
+            break;
+    }
     this->m_serLoc += static_cast<Serializable::SizeType>(sizeof(val));
     this->m_deserLoc = 0;
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I64 val) {
-    if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
-        return FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    FW_ASSERT(this->getBuffAddr());
-    // MSB first
-    this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 56);
-    this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 48);
-    this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 40);
-    this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val >> 32);
-    this->getBuffAddr()[this->m_serLoc + 4] = static_cast<U8>(val >> 24);
-    this->getBuffAddr()[this->m_serLoc + 5] = static_cast<U8>(val >> 16);
-    this->getBuffAddr()[this->m_serLoc + 6] = static_cast<U8>(val >> 8);
-    this->getBuffAddr()[this->m_serLoc + 7] = static_cast<U8>(val);
-    this->m_serLoc += static_cast<Serializable::SizeType>(sizeof(val));
-    this->m_deserLoc = 0;
-    return FW_SERIALIZE_OK;
+SerializeStatus SerializeBufferBase::serializeFrom(I64 val, Fw::Serialization::Endianess mode) {
+    return serializeFrom(static_cast<U64>(val), mode);
 }
 #endif
 
-SerializeStatus SerializeBufferBase::serializeFrom(F64 val) {
+SerializeStatus SerializeBufferBase::serializeFrom(F64 val, Fw::Serialization::Endianess mode) {
     // floating point values need to be byte-swapped as well, so copy to U64 and use that routine
     U64 u64Val;
     (void)memcpy(&u64Val, &val, sizeof(val));
-    return this->serializeFrom(u64Val);
+    return this->serializeFrom(u64Val, mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(F32 val) {
+SerializeStatus SerializeBufferBase::serializeFrom(F32 val, Fw::Serialization::Endianess mode) {
     // floating point values need to be byte-swapped as well, so copy to U32 and use that routine
     U32 u32Val;
     (void)memcpy(&u32Val, &val, sizeof(val));
-    return this->serializeFrom(u32Val);
+    return this->serializeFrom(u32Val, mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(bool val) {
+SerializeStatus SerializeBufferBase::serializeFrom(bool val, Fw::Serialization::Endianess mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(U8)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -249,8 +251,8 @@ SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, FwSizeType le
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const Serializable& val) {
-    return val.serializeTo(*this);
+SerializeStatus SerializeBufferBase::serializeFrom(const Serializable& val, Fw::Serialization::Endianess mode) {
+    return val.serializeTo(*this, mode);
 }
 
 SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& val) {
@@ -276,7 +278,7 @@ SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& va
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size) {
+SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size, Fw::Serialization::Endianess mode) {
     SerializeStatus status = FW_SERIALIZE_OK;
     if ((size < std::numeric_limits<FwSizeStoreType>::min()) || (size > std::numeric_limits<FwSizeStoreType>::max())) {
         status = FW_SERIALIZE_FORMAT_ERROR;

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -289,7 +289,7 @@ SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size) {
 
 // deserialization routines
 
-SerializeStatus SerializeBufferBase::deserializeTo(U8& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(U8& val, Fw::Serialization::Endianess mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -303,7 +303,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U8& val) {
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I8& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(I8& val, Fw::Serialization::Endianess mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -318,7 +318,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I8& val) {
 }
 
 #if FW_HAS_16_BIT == 1
-SerializeStatus SerializeBufferBase::deserializeTo(U16& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Fw::Serialization::Endianess mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -334,7 +334,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U16& val) {
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I16& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(I16& val, Fw::Serialization::Endianess mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -351,7 +351,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I16& val) {
 }
 #endif
 #if FW_HAS_32_BIT == 1
-SerializeStatus SerializeBufferBase::deserializeTo(U32& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Fw::Serialization::Endianess mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -369,7 +369,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U32& val) {
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I32& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(I32& val, Fw::Serialization::Endianess mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -390,7 +390,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I32& val) {
 
 #if FW_HAS_64_BIT == 1
 
-SerializeStatus SerializeBufferBase::deserializeTo(U64& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Fw::Serialization::Endianess mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -413,7 +413,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U64& val) {
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I64& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(I64& val, Fw::Serialization::Endianess mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -436,7 +436,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I64& val) {
 }
 #endif
 
-SerializeStatus SerializeBufferBase::deserializeTo(F64& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(F64& val, Fw::Serialization::Endianess mode) {
     // deserialize as 64-bit int to handle endianness
     U64 tempVal;
     SerializeStatus stat = this->deserializeTo(tempVal);
@@ -449,7 +449,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(F64& val) {
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(bool& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(bool& val, Fw::Serialization::Endianess mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -470,7 +470,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(bool& val) {
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(void*& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Fw::Serialization::Endianess mode) {
     // Deserialize as pointer cast, then convert to void*
     PlatformPointerCastType pointerCastVal = 0;
     const SerializeStatus stat = this->deserializeTo(pointerCastVal);
@@ -480,7 +480,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(void*& val) {
     return stat;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(F32& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(F32& val, Fw::Serialization::Endianess mode) {
     // deserialize as 64-bit int to handle endianness
     U32 tempVal;
     SerializeStatus stat = this->deserializeTo(tempVal);
@@ -533,11 +533,11 @@ SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeT
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(Serializable& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(Serializable& val, Fw::Serialization::Endianess mode) {
     return val.deserializeFrom(*this);
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val) {
+SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Fw::Serialization::Endianess mode) {
     FW_ASSERT(val.getBuffAddr());
     SerializeStatus stat = FW_SERIALIZE_OK;
 
@@ -569,7 +569,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val) {
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeSize(FwSizeType& size) {
+SerializeStatus SerializeBufferBase::deserializeSize(FwSizeType& size, Serialization::Endianess mode) {
     FwSizeStoreType storedSize = 0;
     Fw::SerializeStatus status = this->deserializeTo(storedSize);
     if (status == FW_SERIALIZE_OK) {
@@ -889,7 +889,7 @@ SerializeStatus SerializeBufferBase::deserialize(U8* buff, FwSizeType& length) {
     return this->deserializeTo(buff, length, Serialization::INCLUDE_LENGTH);
 }
 
-SerializeStatus SerializeBufferBase::deserialize(U8* buff, FwSizeType& length, Serialization::t mode) {
+SerializeStatus SerializeBufferBase::deserialize(U8* buff, FwSizeType& length, Fw::Serialization::t mode) {
     return this->deserializeTo(buff, length, mode);
 }
 

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -61,7 +61,7 @@ SerializeBufferBase& SerializeBufferBase::operator=(const SerializeBufferBase& s
 
 // serialization routines
 
-SerializeStatus SerializeBufferBase::serializeFrom(U8 val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U8 val, Fw::Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -73,12 +73,12 @@ SerializeStatus SerializeBufferBase::serializeFrom(U8 val, Fw::Serialization::En
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I8 val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I8 val, Fw::Serialization::Endianness mode) {
     return serializeFrom(static_cast<U8>(val), mode);
 }
 
 #if FW_HAS_16_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U16 val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U16 val, Fw::Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -103,12 +103,12 @@ SerializeStatus SerializeBufferBase::serializeFrom(U16 val, Fw::Serialization::E
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I16 val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I16 val, Fw::Serialization::Endianness mode) {
     return serializeFrom(static_cast<U16>(val), mode);
 }
 #endif
 #if FW_HAS_32_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U32 val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U32 val, Fw::Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -137,13 +137,13 @@ SerializeStatus SerializeBufferBase::serializeFrom(U32 val, Fw::Serialization::E
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I32 val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I32 val, Fw::Serialization::Endianness mode) {
     return serializeFrom(static_cast<U32>(val), mode);
 }
 #endif
 
 #if FW_HAS_64_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Fw::Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -180,26 +180,26 @@ SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Fw::Serialization::E
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I64 val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I64 val, Fw::Serialization::Endianness mode) {
     return serializeFrom(static_cast<U64>(val), mode);
 }
 #endif
 
-SerializeStatus SerializeBufferBase::serializeFrom(F64 val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(F64 val, Fw::Serialization::Endianness mode) {
     // floating point values need to be byte-swapped as well, so copy to U64 and use that routine
     U64 u64Val;
     (void)memcpy(&u64Val, &val, sizeof(val));
     return this->serializeFrom(u64Val, mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(F32 val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(F32 val, Fw::Serialization::Endianness mode) {
     // floating point values need to be byte-swapped as well, so copy to U32 and use that routine
     U32 u32Val;
     (void)memcpy(&u32Val, &val, sizeof(val));
     return this->serializeFrom(u32Val, mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(bool val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(bool val, Fw::Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(U8)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -251,11 +251,11 @@ SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, FwSizeType le
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const Serializable& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(const Serializable& val, Fw::Serialization::Endianness mode) {
     return val.serializeTo(*this, mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& val) {
+SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& val, Fw::Serialization::Endianness mode) {
     Serializable::SizeType size = val.getBuffLength();
     if (this->m_serLoc + size + static_cast<Serializable::SizeType>(sizeof(FwSizeStoreType)) >
         this->getBuffCapacity()) {
@@ -263,7 +263,7 @@ SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& va
     }
 
     // First, serialize size
-    SerializeStatus stat = this->serializeFrom(static_cast<FwSizeStoreType>(size));
+    SerializeStatus stat = this->serializeFrom(static_cast<FwSizeStoreType>(size), mode);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
@@ -278,7 +278,7 @@ SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& va
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size, Fw::Serialization::Endianness mode) {
     SerializeStatus status = FW_SERIALIZE_OK;
     if ((size < std::numeric_limits<FwSizeStoreType>::min()) || (size > std::numeric_limits<FwSizeStoreType>::max())) {
         status = FW_SERIALIZE_FORMAT_ERROR;
@@ -291,7 +291,7 @@ SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size, Fw::Se
 
 // deserialization routines
 
-SerializeStatus SerializeBufferBase::deserializeTo(U8& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U8& val, Fw::Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -305,7 +305,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U8& val, Fw::Serialization::E
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I8& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I8& val, Fw::Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -320,7 +320,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I8& val, Fw::Serialization::E
 }
 
 #if FW_HAS_16_BIT == 1
-SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Fw::Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -336,7 +336,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Fw::Serialization::
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I16& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I16& val, Fw::Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -353,7 +353,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I16& val, Fw::Serialization::
 }
 #endif
 #if FW_HAS_32_BIT == 1
-SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Fw::Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -371,7 +371,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Fw::Serialization::
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I32& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I32& val, Fw::Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -392,7 +392,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I32& val, Fw::Serialization::
 
 #if FW_HAS_64_BIT == 1
 
-SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Fw::Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -415,7 +415,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Fw::Serialization::
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I64& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I64& val, Fw::Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -438,7 +438,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I64& val, Fw::Serialization::
 }
 #endif
 
-SerializeStatus SerializeBufferBase::deserializeTo(F64& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(F64& val, Fw::Serialization::Endianness mode) {
     // deserialize as 64-bit int to handle endianness
     U64 tempVal;
     SerializeStatus stat = this->deserializeTo(tempVal);
@@ -451,7 +451,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(F64& val, Fw::Serialization::
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(bool& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(bool& val, Fw::Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -472,7 +472,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(bool& val, Fw::Serialization:
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Fw::Serialization::Endianness mode) {
     // Deserialize as pointer cast, then convert to void*
     PlatformPointerCastType pointerCastVal = 0;
     const SerializeStatus stat = this->deserializeTo(pointerCastVal);
@@ -482,7 +482,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Fw::Serialization
     return stat;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(F32& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(F32& val, Fw::Serialization::Endianness mode) {
     // deserialize as 64-bit int to handle endianness
     U32 tempVal;
     SerializeStatus stat = this->deserializeTo(tempVal);
@@ -535,11 +535,11 @@ SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeT
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(Serializable& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(Serializable& val, Fw::Serialization::Endianness mode) {
     return val.deserializeFrom(*this);
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Fw::Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Fw::Serialization::Endianness mode) {
     FW_ASSERT(val.getBuffAddr());
     SerializeStatus stat = FW_SERIALIZE_OK;
 
@@ -571,7 +571,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Fw:
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeSize(FwSizeType& size, Serialization::Endianess mode) {
+SerializeStatus SerializeBufferBase::deserializeSize(FwSizeType& size, Serialization::Endianness mode) {
     FwSizeStoreType storedSize = 0;
     Fw::SerializeStatus status = this->deserializeTo(storedSize);
     if (status == FW_SERIALIZE_OK) {

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -84,12 +84,12 @@ SerializeStatus SerializeBufferBase::serializeFrom(U16 val, Endianness mode) {
     }
     FW_ASSERT(this->getBuffAddr());
     switch (mode) {
-        case Serialization::BIG:
+        case Endianness::BIG:
             // MSB first
             this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 8);
             this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val);
             break;
-        case Serialization::LITTLE:
+        case Endianness::LITTLE:
             // LSB first
             this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val);
             this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 8);
@@ -114,14 +114,14 @@ SerializeStatus SerializeBufferBase::serializeFrom(U32 val, Endianness mode) {
     }
     FW_ASSERT(this->getBuffAddr());
     switch (mode) {
-        case Serialization::BIG:
+        case Endianness::BIG:
             // MSB first
             this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 24);
             this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 16);
             this->getBuffAddr()[this->m_serLoc + 2] = static_cast<U8>(val >> 8);
             this->getBuffAddr()[this->m_serLoc + 3] = static_cast<U8>(val);
             break;
-        case Serialization::LITTLE:
+        case Endianness::LITTLE:
             // LSB first
             this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val);
             this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 8);
@@ -149,7 +149,7 @@ SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Endianness mode) {
     }
     FW_ASSERT(this->getBuffAddr());
     switch (mode) {
-        case Serialization::BIG:
+        case Endianness::BIG:
             // MSB first
             this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val >> 56);
             this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 48);
@@ -160,7 +160,7 @@ SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Endianness mode) {
             this->getBuffAddr()[this->m_serLoc + 6] = static_cast<U8>(val >> 8);
             this->getBuffAddr()[this->m_serLoc + 7] = static_cast<U8>(val);
             break;
-        case Serialization::LITTLE:
+        case Endianness::LITTLE:
             // LSB first
             this->getBuffAddr()[this->m_serLoc + 0] = static_cast<U8>(val);
             this->getBuffAddr()[this->m_serLoc + 1] = static_cast<U8>(val >> 8);
@@ -329,12 +329,12 @@ SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Endianness mode) {
     // read from current location
     FW_ASSERT(this->getBuffAddr());
     switch (mode) {
-        case Serialization::BIG:
+        case Endianness::BIG:
             // MSB first
             val = static_cast<U16>(((this->getBuffAddr()[this->m_deserLoc + 1]) << 0) |
                            ((this->getBuffAddr()[this->m_deserLoc + 0]) << 8));
             break;
-        case Serialization::LITTLE:
+        case Endianness::LITTLE:
             // LSB first
             val = static_cast<U16>(((this->getBuffAddr()[this->m_deserLoc + 0]) << 0) |
                            ((this->getBuffAddr()[this->m_deserLoc + 1]) << 8));
@@ -367,14 +367,14 @@ SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Endianness mode) {
     // read from current location
     FW_ASSERT(this->getBuffAddr());
     switch (mode) {
-        case Serialization::BIG:
+        case Endianness::BIG:
             // MSB first
             val = (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 3]) << 0) |
                 (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 2]) << 8) |
                 (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 16) |
                 (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 24);
             break;
-        case Serialization::LITTLE:
+        case Endianness::LITTLE:
             // LSB first
             val = (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 0]) << 0) |
                 (static_cast<U32>(this->getBuffAddr()[this->m_deserLoc + 1]) << 8) |
@@ -411,7 +411,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Endianness mode) {
     // read from current location
     FW_ASSERT(this->getBuffAddr());
     switch (mode) {
-        case Serialization::BIG:
+        case Endianness::BIG:
             // MSB first
             val = (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 7]) << 0) |
                 (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 6]) << 8) |
@@ -422,7 +422,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Endianness mode) {
                 (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 48) |
                 (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 56);
             break;
-        case Serialization::LITTLE:
+        case Endianness::LITTLE:
             // LSB first
             val = (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 0]) << 0) |
                 (static_cast<U64>(this->getBuffAddr()[this->m_deserLoc + 1]) << 8) |

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -61,7 +61,7 @@ SerializeBufferBase& SerializeBufferBase::operator=(const SerializeBufferBase& s
 
 // serialization routines
 
-SerializeStatus SerializeBufferBase::serializeFrom(U8 val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U8 val, Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -73,12 +73,12 @@ SerializeStatus SerializeBufferBase::serializeFrom(U8 val, Fw::Serialization::En
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I8 val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I8 val, Serialization::Endianness mode) {
     return serializeFrom(static_cast<U8>(val), mode);
 }
 
 #if FW_HAS_16_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U16 val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U16 val, Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -103,12 +103,12 @@ SerializeStatus SerializeBufferBase::serializeFrom(U16 val, Fw::Serialization::E
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I16 val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I16 val, Serialization::Endianness mode) {
     return serializeFrom(static_cast<U16>(val), mode);
 }
 #endif
 #if FW_HAS_32_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U32 val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U32 val, Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -137,13 +137,13 @@ SerializeStatus SerializeBufferBase::serializeFrom(U32 val, Fw::Serialization::E
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I32 val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I32 val, Serialization::Endianness mode) {
     return serializeFrom(static_cast<U32>(val), mode);
 }
 #endif
 
 #if FW_HAS_64_BIT == 1
-SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(val)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -180,26 +180,26 @@ SerializeStatus SerializeBufferBase::serializeFrom(U64 val, Fw::Serialization::E
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(I64 val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(I64 val, Serialization::Endianness mode) {
     return serializeFrom(static_cast<U64>(val), mode);
 }
 #endif
 
-SerializeStatus SerializeBufferBase::serializeFrom(F64 val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(F64 val, Serialization::Endianness mode) {
     // floating point values need to be byte-swapped as well, so copy to U64 and use that routine
     U64 u64Val;
     (void)memcpy(&u64Val, &val, sizeof(val));
     return this->serializeFrom(u64Val, mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(F32 val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(F32 val, Serialization::Endianness mode) {
     // floating point values need to be byte-swapped as well, so copy to U32 and use that routine
     U32 u32Val;
     (void)memcpy(&u32Val, &val, sizeof(val));
     return this->serializeFrom(u32Val, mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(bool val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(bool val, Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(U8)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -216,7 +216,7 @@ SerializeStatus SerializeBufferBase::serializeFrom(bool val, Fw::Serialization::
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const void* val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(const void* val, Serialization::Endianness mode) {
     if (this->m_serLoc + static_cast<Serializable::SizeType>(sizeof(void*)) - 1 >= this->getBuffCapacity()) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
@@ -224,15 +224,14 @@ SerializeStatus SerializeBufferBase::serializeFrom(const void* val, Fw::Serializ
     return this->serializeFrom(reinterpret_cast<PlatformPointerCastType>(val), mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, Serializable::SizeType length) {
-    return this->serializeFrom(buff, static_cast<FwSizeType>(length), Serialization::INCLUDE_LENGTH);
+SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, Serializable::SizeType length, Serialization::Endianness endianMode) {
+    return this->serializeFrom(buff, static_cast<FwSizeType>(length), Serialization::INCLUDE_LENGTH, endianMode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, FwSizeType length, Fw::Serialization::t mode) {
-    // First serialize length
+SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, FwSizeType length, Serialization::t lengthMode, Serialization::Endianness endianMode) { // First serialize length
     SerializeStatus stat;
-    if (mode == Serialization::INCLUDE_LENGTH) {
-        stat = this->serializeFrom(static_cast<FwSizeStoreType>(length));
+    if (lengthMode == Serialization::INCLUDE_LENGTH) {
+        stat = this->serializeFrom(static_cast<FwSizeStoreType>(length), endianMode);
         if (stat != FW_SERIALIZE_OK) {
             return stat;
         }
@@ -251,11 +250,11 @@ SerializeStatus SerializeBufferBase::serializeFrom(const U8* buff, FwSizeType le
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const Serializable& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(const Serializable& val, Serialization::Endianness mode) {
     return val.serializeTo(*this, mode);
 }
 
-SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& val, Serialization::Endianness mode) {
     Serializable::SizeType size = val.getBuffLength();
     if (this->m_serLoc + size + static_cast<Serializable::SizeType>(sizeof(FwSizeStoreType)) >
         this->getBuffCapacity()) {
@@ -278,20 +277,20 @@ SerializeStatus SerializeBufferBase::serializeFrom(const SerializeBufferBase& va
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::serializeSize(const FwSizeType size, Serialization::Endianness mode) {
     SerializeStatus status = FW_SERIALIZE_OK;
     if ((size < std::numeric_limits<FwSizeStoreType>::min()) || (size > std::numeric_limits<FwSizeStoreType>::max())) {
         status = FW_SERIALIZE_FORMAT_ERROR;
     }
     if (status == FW_SERIALIZE_OK) {
-        status = this->serializeFrom(static_cast<FwSizeStoreType>(size));
+        status = this->serializeFrom(static_cast<FwSizeStoreType>(size), mode);
     }
     return status;
 }
 
 // deserialization routines
 
-SerializeStatus SerializeBufferBase::deserializeTo(U8& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U8& val, Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -305,7 +304,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U8& val, Fw::Serialization::E
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I8& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I8& val, Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -320,7 +319,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I8& val, Fw::Serialization::E
 }
 
 #if FW_HAS_16_BIT == 1
-SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -348,7 +347,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U16& val, Fw::Serialization::
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I16& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I16& val, Serialization::Endianness mode) {
     U16 unsignVal;
     SerializeStatus res = deserializeTo(unsignVal, mode);
     if (res == SerializeStatus::FW_SERIALIZE_OK) {
@@ -358,7 +357,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I16& val, Fw::Serialization::
 }
 #endif
 #if FW_HAS_32_BIT == 1
-SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -390,7 +389,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U32& val, Fw::Serialization::
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I32& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I32& val, Serialization::Endianness mode) {
     U32 unsignVal;
     SerializeStatus res = deserializeTo(unsignVal, mode);
     if (res == SerializeStatus::FW_SERIALIZE_OK) {
@@ -402,7 +401,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I32& val, Fw::Serialization::
 
 #if FW_HAS_64_BIT == 1
 
-SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -442,7 +441,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(U64& val, Fw::Serialization::
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(I64& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(I64& val, Serialization::Endianness mode) {
     U64 unsignVal;
     SerializeStatus res = deserializeTo(unsignVal, mode);
     if (res == SerializeStatus::FW_SERIALIZE_OK) {
@@ -452,7 +451,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(I64& val, Fw::Serialization::
 }
 #endif
 
-SerializeStatus SerializeBufferBase::deserializeTo(F64& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(F64& val, Serialization::Endianness mode) {
     // deserialize as 64-bit int to handle endianness
     U64 tempVal;
     SerializeStatus stat = this->deserializeTo(tempVal, mode);
@@ -465,7 +464,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(F64& val, Fw::Serialization::
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(bool& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(bool& val, Serialization::Endianness mode) {
     // check for room
     if (this->getBuffLength() == this->m_deserLoc) {
         return FW_DESERIALIZE_BUFFER_EMPTY;
@@ -486,7 +485,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(bool& val, Fw::Serialization:
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Serialization::Endianness mode) {
     // Deserialize as pointer cast, then convert to void*
     PlatformPointerCastType pointerCastVal = 0;
     const SerializeStatus stat = this->deserializeTo(pointerCastVal, mode);
@@ -496,7 +495,7 @@ SerializeStatus SerializeBufferBase::deserializeTo(void*& val, Fw::Serialization
     return stat;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(F32& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(F32& val, Serialization::Endianness mode) {
     // deserialize as 64-bit int to handle endianness
     U32 tempVal;
     SerializeStatus stat = this->deserializeTo(tempVal, mode);
@@ -508,20 +507,20 @@ SerializeStatus SerializeBufferBase::deserializeTo(F32& val, Fw::Serialization::
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeType& length) {
+SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeType& length, Serialization::Endianness endianMode) {
     FwSizeType length_in_out = static_cast<FwSizeType>(length);
-    SerializeStatus status = this->deserializeTo(buff, length_in_out, Serialization::INCLUDE_LENGTH);
+    SerializeStatus status = this->deserializeTo(buff, length_in_out, Serialization::INCLUDE_LENGTH, endianMode);
     length = static_cast<Serializable::SizeType>(length_in_out);
     return status;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeType& length, Serialization::t mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeType& length, Serialization::t lengthMode, Serialization::Endianness endianMode) {
     FW_ASSERT(this->getBuffAddr());
 
-    if (mode == Serialization::INCLUDE_LENGTH) {
+    if (lengthMode == Serialization::INCLUDE_LENGTH) {
         FwSizeStoreType storedLength;
 
-        SerializeStatus stat = this->deserializeTo(storedLength);
+        SerializeStatus stat = this->deserializeTo(storedLength, endianMode);
 
         if (stat != FW_SERIALIZE_OK) {
             return stat;
@@ -549,11 +548,11 @@ SerializeStatus SerializeBufferBase::deserializeTo(U8* buff, Serializable::SizeT
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(Serializable& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(Serializable& val, Serialization::Endianness mode) {
     return val.deserializeFrom(*this, mode);
 }
 
-SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Fw::Serialization::Endianness mode) {
+SerializeStatus SerializeBufferBase::deserializeTo(SerializeBufferBase& val, Serialization::Endianness mode) {
     FW_ASSERT(val.getBuffAddr());
     SerializeStatus stat = FW_SERIALIZE_OK;
 
@@ -700,7 +699,7 @@ SerializeStatus SerializeBufferBase::copyRawOffset(SerializeBufferBase& dest, Se
 
     // otherwise, serialize bytes to destination without writing length
     SerializeStatus stat =
-        dest.serializeFrom(&this->getBuffAddr()[this->m_deserLoc], size, Fw::Serialization::OMIT_LENGTH);
+        dest.serializeFrom(&this->getBuffAddr()[this->m_deserLoc], size, Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         this->m_deserLoc += size;
     }
@@ -905,7 +904,7 @@ SerializeStatus SerializeBufferBase::deserialize(U8* buff, FwSizeType& length) {
     return this->deserializeTo(buff, length, Serialization::INCLUDE_LENGTH);
 }
 
-SerializeStatus SerializeBufferBase::deserialize(U8* buff, FwSizeType& length, Fw::Serialization::t mode) {
+SerializeStatus SerializeBufferBase::deserialize(U8* buff, FwSizeType& length, Serialization::t mode) {
     return this->deserializeTo(buff, length, mode);
 }
 

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -65,6 +65,11 @@ class Serialization {
         INCLUDE_LENGTH,  //!< Include length as first token in serialization
         OMIT_LENGTH      //!< Omit length from serialization
     };
+
+    enum Endianess {
+        BIG,   //!< Include length as first token in serialization
+        LITTLE //!< Omit length from serialization
+    };
 };
 
 class SerializeBufferBase {
@@ -123,27 +128,27 @@ class SerializeBufferBase {
 
     // Deserialization for built-in types
 
-    SerializeStatus deserializeTo(U8& val);  //!< deserialize 8-bit unsigned int
-    SerializeStatus deserializeTo(I8& val);  //!< deserialize 8-bit signed int
+    SerializeStatus deserializeTo(U8& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 8-bit unsigned int
+    SerializeStatus deserializeTo(I8& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 8-bit signed int
 
 #if FW_HAS_16_BIT == 1
-    SerializeStatus deserializeTo(U16& val);  //!< deserialize 16-bit unsigned int
-    SerializeStatus deserializeTo(I16& val);  //!< deserialize 16-bit signed int
+    SerializeStatus deserializeTo(U16& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 16-bit unsigned int
+    SerializeStatus deserializeTo(I16& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 16-bit signed int
 #endif
 
 #if FW_HAS_32_BIT == 1
-    SerializeStatus deserializeTo(U32& val);  //!< deserialize 32-bit unsigned int
-    SerializeStatus deserializeTo(I32& val);  //!< deserialize 32-bit signed int
+    SerializeStatus deserializeTo(U32& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 32-bit unsigned int
+    SerializeStatus deserializeTo(I32& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 32-bit signed int
 #endif
 #if FW_HAS_64_BIT == 1
-    SerializeStatus deserializeTo(U64& val);  //!< deserialize 64-bit unsigned int
-    SerializeStatus deserializeTo(I64& val);  //!< deserialize 64-bit signed int
+    SerializeStatus deserializeTo(U64& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 64-bit unsigned int
+    SerializeStatus deserializeTo(I64& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 64-bit signed int
 #endif
-    SerializeStatus deserializeTo(F32& val);   //!< deserialize 32-bit floating point
-    SerializeStatus deserializeTo(F64& val);   //!< deserialize 64-bit floating point
-    SerializeStatus deserializeTo(bool& val);  //!< deserialize boolean
+    SerializeStatus deserializeTo(F32& val, Serialization::Endianess mode = Serialization::BIG);   //!< deserialize 32-bit floating point
+    SerializeStatus deserializeTo(F64& val, Serialization::Endianess mode = Serialization::BIG);   //!< deserialize 64-bit floating point
+    SerializeStatus deserializeTo(bool& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize boolean
 
-    SerializeStatus deserializeTo(void*& val);  //!< deserialize point value (careful, pointer value only, not contents)
+    SerializeStatus deserializeTo(void*& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize point value (careful, pointer value only, not contents)
 
     SerializeStatus deserializeTo(U8* buff, FwSizeType& length);  //!< deserialize data buffer
 
@@ -156,11 +161,11 @@ class SerializeBufferBase {
     //! \return status of serialization
     SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Serialization::t mode);
 
-    SerializeStatus deserializeTo(Serializable& val);  //!< deserialize an object derived from serializable base class
+    SerializeStatus deserializeTo(Serializable& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize an object derived from serializable base class
 
-    SerializeStatus deserializeTo(SerializeBufferBase& val);  //!< serialize a serialized buffer
+    SerializeStatus deserializeTo(SerializeBufferBase& val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize a serialized buffer
 
-    SerializeStatus deserializeSize(FwSizeType& size);  //!< deserialize a size value
+    SerializeStatus deserializeSize(FwSizeType& size, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize a size value
 
     // ----------------------------------------------------------------------
     // Serialization methods

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -29,7 +29,7 @@ class Serialization {
         OMIT_LENGTH      //!< Omit length from serialization
     };
 
-    enum Endianess {
+    enum Endianness {
         BIG,   //!< Include length as first token in serialization
         LITTLE //!< Omit length from serialization
     };
@@ -41,9 +41,9 @@ class Serializable {
     using SizeType = FwSizeType;
 
   public:
-    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, Serialization::Endianess mode = Serialization::BIG) const = 0;  //!< serialize contents to buffer
+    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, Serialization::Endianness mode = Serialization::BIG) const = 0;  //!< serialize contents to buffer
 
-    virtual SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Serialization::Endianess mode = Serialization::BIG) = 0;  //!< deserialize contents from buffer
+    virtual SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Serialization::Endianness mode = Serialization::BIG) = 0;  //!< deserialize contents from buffer
 
     // ----------------------------------------------------------------------
     // Legacy methods for backward compatibility
@@ -83,24 +83,24 @@ class SerializeBufferBase {
 
     // Serialization for built-in types
 
-    SerializeStatus serializeFrom(U8 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 8-bit unsigned int
-    SerializeStatus serializeFrom(I8 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 8-bit signed int
+    SerializeStatus serializeFrom(U8 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 8-bit unsigned int
+    SerializeStatus serializeFrom(I8 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 8-bit signed int
 
 #if FW_HAS_16_BIT == 1
-    SerializeStatus serializeFrom(U16 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 16-bit unsigned int
-    SerializeStatus serializeFrom(I16 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 16-bit signed int
+    SerializeStatus serializeFrom(U16 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 16-bit unsigned int
+    SerializeStatus serializeFrom(I16 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 16-bit signed int
 #endif
 #if FW_HAS_32_BIT == 1
-    SerializeStatus serializeFrom(U32 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 32-bit unsigned int
-    SerializeStatus serializeFrom(I32 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 32-bit signed int
+    SerializeStatus serializeFrom(U32 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 32-bit unsigned int
+    SerializeStatus serializeFrom(I32 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 32-bit signed int
 #endif
 #if FW_HAS_64_BIT == 1
-    SerializeStatus serializeFrom(U64 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 64-bit unsigned int
-    SerializeStatus serializeFrom(I64 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 64-bit signed int
+    SerializeStatus serializeFrom(U64 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 64-bit unsigned int
+    SerializeStatus serializeFrom(I64 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 64-bit signed int
 #endif
-    SerializeStatus serializeFrom(F32 val, Serialization::Endianess mode = Serialization::BIG);   //!< serialize 32-bit floating point
-    SerializeStatus serializeFrom(F64 val, Serialization::Endianess mode = Serialization::BIG);   //!< serialize 64-bit floating point
-    SerializeStatus serializeFrom(bool val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize boolean
+    SerializeStatus serializeFrom(F32 val, Serialization::Endianness mode = Serialization::BIG);   //!< serialize 32-bit floating point
+    SerializeStatus serializeFrom(F64 val, Serialization::Endianness mode = Serialization::BIG);   //!< serialize 64-bit floating point
+    SerializeStatus serializeFrom(bool val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize boolean
 
     SerializeStatus serializeFrom(
         const void* val);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
@@ -119,36 +119,36 @@ class SerializeBufferBase {
     //! \return status of serialization
     SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Serialization::t mode);
 
-    SerializeStatus serializeFrom(const SerializeBufferBase& val);  //!< serialize a serialized buffer
+    SerializeStatus serializeFrom(const SerializeBufferBase& val, Fw::Serialization::Endianness mode = Fw::Serialization::BIG);  //!< serialize a serialized buffer
 
     SerializeStatus serializeFrom(
-        const Serializable& val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize an object derived from serializable base class
+        const Serializable& val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize an object derived from serializable base class
 
-    SerializeStatus serializeSize(const FwSizeType size, Serialization::Endianess mode = Serialization::BIG);  //!< serialize a size value
+    SerializeStatus serializeSize(const FwSizeType size, Serialization::Endianness mode = Serialization::BIG);  //!< serialize a size value
 
     // Deserialization for built-in types
 
-    SerializeStatus deserializeTo(U8& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 8-bit unsigned int
-    SerializeStatus deserializeTo(I8& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 8-bit signed int
+    SerializeStatus deserializeTo(U8& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 8-bit unsigned int
+    SerializeStatus deserializeTo(I8& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 8-bit signed int
 
 #if FW_HAS_16_BIT == 1
-    SerializeStatus deserializeTo(U16& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 16-bit unsigned int
-    SerializeStatus deserializeTo(I16& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 16-bit signed int
+    SerializeStatus deserializeTo(U16& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 16-bit unsigned int
+    SerializeStatus deserializeTo(I16& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 16-bit signed int
 #endif
 
 #if FW_HAS_32_BIT == 1
-    SerializeStatus deserializeTo(U32& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 32-bit unsigned int
-    SerializeStatus deserializeTo(I32& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 32-bit signed int
+    SerializeStatus deserializeTo(U32& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 32-bit unsigned int
+    SerializeStatus deserializeTo(I32& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 32-bit signed int
 #endif
 #if FW_HAS_64_BIT == 1
-    SerializeStatus deserializeTo(U64& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 64-bit unsigned int
-    SerializeStatus deserializeTo(I64& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize 64-bit signed int
+    SerializeStatus deserializeTo(U64& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 64-bit unsigned int
+    SerializeStatus deserializeTo(I64& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 64-bit signed int
 #endif
-    SerializeStatus deserializeTo(F32& val, Serialization::Endianess mode = Serialization::BIG);   //!< deserialize 32-bit floating point
-    SerializeStatus deserializeTo(F64& val, Serialization::Endianess mode = Serialization::BIG);   //!< deserialize 64-bit floating point
-    SerializeStatus deserializeTo(bool& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize boolean
+    SerializeStatus deserializeTo(F32& val, Serialization::Endianness mode = Serialization::BIG);   //!< deserialize 32-bit floating point
+    SerializeStatus deserializeTo(F64& val, Serialization::Endianness mode = Serialization::BIG);   //!< deserialize 64-bit floating point
+    SerializeStatus deserializeTo(bool& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize boolean
 
-    SerializeStatus deserializeTo(void*& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize point value (careful, pointer value only, not contents)
+    SerializeStatus deserializeTo(void*& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize point value (careful, pointer value only, not contents)
 
     SerializeStatus deserializeTo(U8* buff, FwSizeType& length);  //!< deserialize data buffer
 
@@ -161,11 +161,11 @@ class SerializeBufferBase {
     //! \return status of serialization
     SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Serialization::t mode);
 
-    SerializeStatus deserializeTo(Serializable& val, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize an object derived from serializable base class
+    SerializeStatus deserializeTo(Serializable& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize an object derived from serializable base class
 
-    SerializeStatus deserializeTo(SerializeBufferBase& val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize a serialized buffer
+    SerializeStatus deserializeTo(SerializeBufferBase& val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize a serialized buffer
 
-    SerializeStatus deserializeSize(FwSizeType& size, Serialization::Endianess mode = Serialization::BIG);  //!< deserialize a size value
+    SerializeStatus deserializeSize(FwSizeType& size, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize a size value
 
     // ----------------------------------------------------------------------
     // Serialization methods

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -27,12 +27,11 @@ struct Serialization {
         INCLUDE_LENGTH,  //!< Include length as first token in serialization
         OMIT_LENGTH      //!< Omit length from serialization
     };
-
 };
 
 enum class Endianness {
-    BIG,   //!< Big endian serialization
-    LITTLE //!< Little endian serialization
+    BIG,    //!< Big endian serialization
+    LITTLE  //!< Little endian serialization
 };
 
 class Serializable {
@@ -41,9 +40,12 @@ class Serializable {
     using SizeType = FwSizeType;
 
   public:
-    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, Endianness mode = Endianness::BIG) const = 0;  //!< serialize contents to buffer
+    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer,
+                                        Endianness mode = Endianness::BIG) const = 0;  //!< serialize contents to buffer
 
-    virtual SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Endianness mode = Endianness::BIG) = 0;  //!< deserialize contents from buffer
+    virtual SerializeStatus deserializeFrom(
+        SerializeBufferBase& buffer,
+        Endianness mode = Endianness::BIG) = 0;  //!< deserialize contents from buffer
 
     // ----------------------------------------------------------------------
     // Legacy methods for backward compatibility
@@ -102,8 +104,9 @@ class SerializeBufferBase {
     SerializeStatus serializeFrom(F64 val, Endianness mode = Endianness::BIG);   //!< serialize 64-bit floating point
     SerializeStatus serializeFrom(bool val, Endianness mode = Endianness::BIG);  //!< serialize boolean
 
-    SerializeStatus serializeFrom(
-        const void* val, Endianness mode = Endianness::BIG);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
+    SerializeStatus serializeFrom(const void* val,
+                                  Endianness mode = Endianness::BIG);  //!< serialize pointer (careful, only pointer
+                                                                       //!< value, not contents are serialized)
 
     //! serialize data buffer
     SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Endianness endianMode = Endianness::BIG);
@@ -117,14 +120,20 @@ class SerializeBufferBase {
     //! \param length: length of data to serialize
     //! \param mode: serialization type
     //! \return status of serialization
-    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Serialization::t lengthMode, Endianness endianMode = Endianness::BIG);
+    SerializeStatus serializeFrom(const U8* buff,
+                                  FwSizeType length,
+                                  Serialization::t lengthMode,
+                                  Endianness endianMode = Endianness::BIG);
 
-    SerializeStatus serializeFrom(const SerializeBufferBase& val, Endianness mode = Endianness::BIG);  //!< serialize a serialized buffer
+    SerializeStatus serializeFrom(const SerializeBufferBase& val,
+                                  Endianness mode = Endianness::BIG);  //!< serialize a serialized buffer
 
     SerializeStatus serializeFrom(
-        const Serializable& val, Endianness mode = Endianness::BIG);  //!< serialize an object derived from serializable base class
+        const Serializable& val,
+        Endianness mode = Endianness::BIG);  //!< serialize an object derived from serializable base class
 
-    SerializeStatus serializeSize(const FwSizeType size, Endianness mode = Endianness::BIG);  //!< serialize a size value
+    SerializeStatus serializeSize(const FwSizeType size,
+                                  Endianness mode = Endianness::BIG);  //!< serialize a size value
 
     // Deserialization for built-in types
 
@@ -148,9 +157,13 @@ class SerializeBufferBase {
     SerializeStatus deserializeTo(F64& val, Endianness mode = Endianness::BIG);   //!< deserialize 64-bit floating point
     SerializeStatus deserializeTo(bool& val, Endianness mode = Endianness::BIG);  //!< deserialize boolean
 
-    SerializeStatus deserializeTo(void*& val, Endianness mode = Endianness::BIG);  //!< deserialize point value (careful, pointer value only, not contents)
+    SerializeStatus deserializeTo(
+        void*& val,
+        Endianness mode = Endianness::BIG);  //!< deserialize point value (careful, pointer value only, not contents)
 
-    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Endianness endianMode = Endianness::BIG);  //!< deserialize data buffer
+    SerializeStatus deserializeTo(U8* buff,
+                                  FwSizeType& length,
+                                  Endianness endianMode = Endianness::BIG);  //!< deserialize data buffer
 
     //! \brief deserialize a byte buffer of a given length
     //!
@@ -159,11 +172,17 @@ class SerializeBufferBase {
     //! \param length: length of the buffer, updated with the actual deserialized length
     //! \param mode: deserialization type
     //! \return status of serialization
-    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Serialization::t lengthMode, Endianness endianMode = Endianness::BIG);
+    SerializeStatus deserializeTo(U8* buff,
+                                  FwSizeType& length,
+                                  Serialization::t lengthMode,
+                                  Endianness endianMode = Endianness::BIG);
 
-    SerializeStatus deserializeTo(Serializable& val, Endianness mode = Endianness::BIG);  //!< deserialize an object derived from serializable base class
+    SerializeStatus deserializeTo(
+        Serializable& val,
+        Endianness mode = Endianness::BIG);  //!< deserialize an object derived from serializable base class
 
-    SerializeStatus deserializeTo(SerializeBufferBase& val, Endianness mode = Endianness::BIG);  //!< serialize a serialized buffer
+    SerializeStatus deserializeTo(SerializeBufferBase& val,
+                                  Endianness mode = Endianness::BIG);  //!< serialize a serialized buffer
 
     SerializeStatus deserializeSize(FwSizeType& size, Endianness mode = Endianness::BIG);  //!< deserialize a size value
 

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -22,17 +22,17 @@ typedef enum {
 } SerializeStatus;
 class SerializeBufferBase;  //!< forward declaration
 
-class Serialization {
-  public:
+struct Serialization {
     enum t {
         INCLUDE_LENGTH,  //!< Include length as first token in serialization
         OMIT_LENGTH      //!< Omit length from serialization
     };
 
-    enum Endianness {
-        BIG,   //!< Include length as first token in serialization
-        LITTLE //!< Omit length from serialization
-    };
+};
+
+enum class Endianness {
+    BIG,   //!< Big endian serialization
+    LITTLE //!< Little endian serialization
 };
 
 class Serializable {
@@ -41,9 +41,9 @@ class Serializable {
     using SizeType = FwSizeType;
 
   public:
-    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, Serialization::Endianness mode = Serialization::BIG) const = 0;  //!< serialize contents to buffer
+    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, Endianness mode = Serialization::BIG) const = 0;  //!< serialize contents to buffer
 
-    virtual SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Serialization::Endianness mode = Serialization::BIG) = 0;  //!< deserialize contents from buffer
+    virtual SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Endianness mode = Serialization::BIG) = 0;  //!< deserialize contents from buffer
 
     // ----------------------------------------------------------------------
     // Legacy methods for backward compatibility
@@ -83,30 +83,30 @@ class SerializeBufferBase {
 
     // Serialization for built-in types
 
-    SerializeStatus serializeFrom(U8 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 8-bit unsigned int
-    SerializeStatus serializeFrom(I8 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 8-bit signed int
+    SerializeStatus serializeFrom(U8 val, Endianness mode = Serialization::BIG);  //!< serialize 8-bit unsigned int
+    SerializeStatus serializeFrom(I8 val, Endianness mode = Serialization::BIG);  //!< serialize 8-bit signed int
 
 #if FW_HAS_16_BIT == 1
-    SerializeStatus serializeFrom(U16 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 16-bit unsigned int
-    SerializeStatus serializeFrom(I16 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 16-bit signed int
+    SerializeStatus serializeFrom(U16 val, Endianness mode = Serialization::BIG);  //!< serialize 16-bit unsigned int
+    SerializeStatus serializeFrom(I16 val, Endianness mode = Serialization::BIG);  //!< serialize 16-bit signed int
 #endif
 #if FW_HAS_32_BIT == 1
-    SerializeStatus serializeFrom(U32 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 32-bit unsigned int
-    SerializeStatus serializeFrom(I32 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 32-bit signed int
+    SerializeStatus serializeFrom(U32 val, Endianness mode = Serialization::BIG);  //!< serialize 32-bit unsigned int
+    SerializeStatus serializeFrom(I32 val, Endianness mode = Serialization::BIG);  //!< serialize 32-bit signed int
 #endif
 #if FW_HAS_64_BIT == 1
-    SerializeStatus serializeFrom(U64 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 64-bit unsigned int
-    SerializeStatus serializeFrom(I64 val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize 64-bit signed int
+    SerializeStatus serializeFrom(U64 val, Endianness mode = Serialization::BIG);  //!< serialize 64-bit unsigned int
+    SerializeStatus serializeFrom(I64 val, Endianness mode = Serialization::BIG);  //!< serialize 64-bit signed int
 #endif
-    SerializeStatus serializeFrom(F32 val, Serialization::Endianness mode = Serialization::BIG);   //!< serialize 32-bit floating point
-    SerializeStatus serializeFrom(F64 val, Serialization::Endianness mode = Serialization::BIG);   //!< serialize 64-bit floating point
-    SerializeStatus serializeFrom(bool val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize boolean
+    SerializeStatus serializeFrom(F32 val, Endianness mode = Serialization::BIG);   //!< serialize 32-bit floating point
+    SerializeStatus serializeFrom(F64 val, Endianness mode = Serialization::BIG);   //!< serialize 64-bit floating point
+    SerializeStatus serializeFrom(bool val, Endianness mode = Serialization::BIG);  //!< serialize boolean
 
     SerializeStatus serializeFrom(
-        const void* val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
+        const void* val, Endianness mode = Serialization::BIG);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
 
     //! serialize data buffer
-    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Serialization::Endianness endianMode = Serialization::BIG);
+    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Endianness endianMode = Serialization::BIG);
 
     //! \brief serialize a byte buffer of a given length
     //!
@@ -117,40 +117,40 @@ class SerializeBufferBase {
     //! \param length: length of data to serialize
     //! \param mode: serialization type
     //! \return status of serialization
-    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Serialization::t lengthMode, Serialization::Endianness endianMode = Serialization::BIG);
+    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Serialization::t lengthMode, Endianness endianMode = Serialization::BIG);
 
-    SerializeStatus serializeFrom(const SerializeBufferBase& val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize a serialized buffer
+    SerializeStatus serializeFrom(const SerializeBufferBase& val, Endianness mode = Serialization::BIG);  //!< serialize a serialized buffer
 
     SerializeStatus serializeFrom(
-        const Serializable& val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize an object derived from serializable base class
+        const Serializable& val, Endianness mode = Serialization::BIG);  //!< serialize an object derived from serializable base class
 
-    SerializeStatus serializeSize(const FwSizeType size, Serialization::Endianness mode = Serialization::BIG);  //!< serialize a size value
+    SerializeStatus serializeSize(const FwSizeType size, Endianness mode = Serialization::BIG);  //!< serialize a size value
 
     // Deserialization for built-in types
 
-    SerializeStatus deserializeTo(U8& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 8-bit unsigned int
-    SerializeStatus deserializeTo(I8& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 8-bit signed int
+    SerializeStatus deserializeTo(U8& val, Endianness mode = Serialization::BIG);  //!< deserialize 8-bit unsigned int
+    SerializeStatus deserializeTo(I8& val, Endianness mode = Serialization::BIG);  //!< deserialize 8-bit signed int
 
 #if FW_HAS_16_BIT == 1
-    SerializeStatus deserializeTo(U16& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 16-bit unsigned int
-    SerializeStatus deserializeTo(I16& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 16-bit signed int
+    SerializeStatus deserializeTo(U16& val, Endianness mode = Serialization::BIG);  //!< deserialize 16-bit unsigned int
+    SerializeStatus deserializeTo(I16& val, Endianness mode = Serialization::BIG);  //!< deserialize 16-bit signed int
 #endif
 
 #if FW_HAS_32_BIT == 1
-    SerializeStatus deserializeTo(U32& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 32-bit unsigned int
-    SerializeStatus deserializeTo(I32& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 32-bit signed int
+    SerializeStatus deserializeTo(U32& val, Endianness mode = Serialization::BIG);  //!< deserialize 32-bit unsigned int
+    SerializeStatus deserializeTo(I32& val, Endianness mode = Serialization::BIG);  //!< deserialize 32-bit signed int
 #endif
 #if FW_HAS_64_BIT == 1
-    SerializeStatus deserializeTo(U64& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 64-bit unsigned int
-    SerializeStatus deserializeTo(I64& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize 64-bit signed int
+    SerializeStatus deserializeTo(U64& val, Endianness mode = Serialization::BIG);  //!< deserialize 64-bit unsigned int
+    SerializeStatus deserializeTo(I64& val, Endianness mode = Serialization::BIG);  //!< deserialize 64-bit signed int
 #endif
-    SerializeStatus deserializeTo(F32& val, Serialization::Endianness mode = Serialization::BIG);   //!< deserialize 32-bit floating point
-    SerializeStatus deserializeTo(F64& val, Serialization::Endianness mode = Serialization::BIG);   //!< deserialize 64-bit floating point
-    SerializeStatus deserializeTo(bool& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize boolean
+    SerializeStatus deserializeTo(F32& val, Endianness mode = Serialization::BIG);   //!< deserialize 32-bit floating point
+    SerializeStatus deserializeTo(F64& val, Endianness mode = Serialization::BIG);   //!< deserialize 64-bit floating point
+    SerializeStatus deserializeTo(bool& val, Endianness mode = Serialization::BIG);  //!< deserialize boolean
 
-    SerializeStatus deserializeTo(void*& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize point value (careful, pointer value only, not contents)
+    SerializeStatus deserializeTo(void*& val, Endianness mode = Serialization::BIG);  //!< deserialize point value (careful, pointer value only, not contents)
 
-    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Serialization::Endianness endianMode = Serialization::BIG);  //!< deserialize data buffer
+    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Endianness endianMode = Serialization::BIG);  //!< deserialize data buffer
 
     //! \brief deserialize a byte buffer of a given length
     //!
@@ -159,13 +159,13 @@ class SerializeBufferBase {
     //! \param length: length of the buffer, updated with the actual deserialized length
     //! \param mode: deserialization type
     //! \return status of serialization
-    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Serialization::t lengthMode, Serialization::Endianness endianMode = Serialization::BIG);
+    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Serialization::t lengthMode, Endianness endianMode = Serialization::BIG);
 
-    SerializeStatus deserializeTo(Serializable& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize an object derived from serializable base class
+    SerializeStatus deserializeTo(Serializable& val, Endianness mode = Serialization::BIG);  //!< deserialize an object derived from serializable base class
 
-    SerializeStatus deserializeTo(SerializeBufferBase& val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize a serialized buffer
+    SerializeStatus deserializeTo(SerializeBufferBase& val, Endianness mode = Serialization::BIG);  //!< serialize a serialized buffer
 
-    SerializeStatus deserializeSize(FwSizeType& size, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize a size value
+    SerializeStatus deserializeSize(FwSizeType& size, Endianness mode = Serialization::BIG);  //!< deserialize a size value
 
     // ----------------------------------------------------------------------
     // Serialization methods

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -22,15 +22,28 @@ typedef enum {
 } SerializeStatus;
 class SerializeBufferBase;  //!< forward declaration
 
+class Serialization {
+  public:
+    enum t {
+        INCLUDE_LENGTH,  //!< Include length as first token in serialization
+        OMIT_LENGTH      //!< Omit length from serialization
+    };
+
+    enum Endianess {
+        BIG,   //!< Include length as first token in serialization
+        LITTLE //!< Omit length from serialization
+    };
+};
+
 class Serializable {
   public:
     // Size type for backwards compatibility
     using SizeType = FwSizeType;
 
   public:
-    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer) const = 0;  //!< serialize contents to buffer
+    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, Serialization::Endianess mode = Serialization::BIG) const = 0;  //!< serialize contents to buffer
 
-    virtual SerializeStatus deserializeFrom(SerializeBufferBase& buffer) = 0;  //!< deserialize contents from buffer
+    virtual SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Serialization::Endianess mode = Serialization::BIG) = 0;  //!< deserialize contents from buffer
 
     // ----------------------------------------------------------------------
     // Legacy methods for backward compatibility
@@ -59,19 +72,6 @@ class Serializable {
     virtual ~Serializable();  //!< destructor
 };
 
-class Serialization {
-  public:
-    enum t {
-        INCLUDE_LENGTH,  //!< Include length as first token in serialization
-        OMIT_LENGTH      //!< Omit length from serialization
-    };
-
-    enum Endianess {
-        BIG,   //!< Include length as first token in serialization
-        LITTLE //!< Omit length from serialization
-    };
-};
-
 class SerializeBufferBase {
     friend class SerializeBufferBaseTester;
 
@@ -83,24 +83,24 @@ class SerializeBufferBase {
 
     // Serialization for built-in types
 
-    SerializeStatus serializeFrom(U8 val);  //!< serialize 8-bit unsigned int
-    SerializeStatus serializeFrom(I8 val);  //!< serialize 8-bit signed int
+    SerializeStatus serializeFrom(U8 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 8-bit unsigned int
+    SerializeStatus serializeFrom(I8 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 8-bit signed int
 
 #if FW_HAS_16_BIT == 1
-    SerializeStatus serializeFrom(U16 val);  //!< serialize 16-bit unsigned int
-    SerializeStatus serializeFrom(I16 val);  //!< serialize 16-bit signed int
+    SerializeStatus serializeFrom(U16 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 16-bit unsigned int
+    SerializeStatus serializeFrom(I16 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 16-bit signed int
 #endif
 #if FW_HAS_32_BIT == 1
-    SerializeStatus serializeFrom(U32 val);  //!< serialize 32-bit unsigned int
-    SerializeStatus serializeFrom(I32 val);  //!< serialize 32-bit signed int
+    SerializeStatus serializeFrom(U32 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 32-bit unsigned int
+    SerializeStatus serializeFrom(I32 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 32-bit signed int
 #endif
 #if FW_HAS_64_BIT == 1
-    SerializeStatus serializeFrom(U64 val);  //!< serialize 64-bit unsigned int
-    SerializeStatus serializeFrom(I64 val);  //!< serialize 64-bit signed int
+    SerializeStatus serializeFrom(U64 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 64-bit unsigned int
+    SerializeStatus serializeFrom(I64 val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize 64-bit signed int
 #endif
-    SerializeStatus serializeFrom(F32 val);   //!< serialize 32-bit floating point
-    SerializeStatus serializeFrom(F64 val);   //!< serialize 64-bit floating point
-    SerializeStatus serializeFrom(bool val);  //!< serialize boolean
+    SerializeStatus serializeFrom(F32 val, Serialization::Endianess mode = Serialization::BIG);   //!< serialize 32-bit floating point
+    SerializeStatus serializeFrom(F64 val, Serialization::Endianess mode = Serialization::BIG);   //!< serialize 64-bit floating point
+    SerializeStatus serializeFrom(bool val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize boolean
 
     SerializeStatus serializeFrom(
         const void* val);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
@@ -122,9 +122,9 @@ class SerializeBufferBase {
     SerializeStatus serializeFrom(const SerializeBufferBase& val);  //!< serialize a serialized buffer
 
     SerializeStatus serializeFrom(
-        const Serializable& val);  //!< serialize an object derived from serializable base class
+        const Serializable& val, Serialization::Endianess mode = Serialization::BIG);  //!< serialize an object derived from serializable base class
 
-    SerializeStatus serializeSize(const FwSizeType size);  //!< serialize a size value
+    SerializeStatus serializeSize(const FwSizeType size, Serialization::Endianess mode = Serialization::BIG);  //!< serialize a size value
 
     // Deserialization for built-in types
 

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -103,7 +103,7 @@ class SerializeBufferBase {
     SerializeStatus serializeFrom(bool val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize boolean
 
     SerializeStatus serializeFrom(
-        const void* val);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
+        const void* val, Fw::Serialization::Endianness mode = Fw::Serialization::BIG);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
 
     //! serialize data buffer
     SerializeStatus serializeFrom(const U8* buff, FwSizeType length);

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -103,10 +103,10 @@ class SerializeBufferBase {
     SerializeStatus serializeFrom(bool val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize boolean
 
     SerializeStatus serializeFrom(
-        const void* val, Fw::Serialization::Endianness mode = Fw::Serialization::BIG);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
+        const void* val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
 
     //! serialize data buffer
-    SerializeStatus serializeFrom(const U8* buff, FwSizeType length);
+    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Serialization::Endianness endianMode = Serialization::BIG);
 
     //! \brief serialize a byte buffer of a given length
     //!
@@ -117,9 +117,9 @@ class SerializeBufferBase {
     //! \param length: length of data to serialize
     //! \param mode: serialization type
     //! \return status of serialization
-    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Serialization::t mode);
+    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Serialization::t lengthMode, Serialization::Endianness endianMode = Serialization::BIG);
 
-    SerializeStatus serializeFrom(const SerializeBufferBase& val, Fw::Serialization::Endianness mode = Fw::Serialization::BIG);  //!< serialize a serialized buffer
+    SerializeStatus serializeFrom(const SerializeBufferBase& val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize a serialized buffer
 
     SerializeStatus serializeFrom(
         const Serializable& val, Serialization::Endianness mode = Serialization::BIG);  //!< serialize an object derived from serializable base class
@@ -150,7 +150,7 @@ class SerializeBufferBase {
 
     SerializeStatus deserializeTo(void*& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize point value (careful, pointer value only, not contents)
 
-    SerializeStatus deserializeTo(U8* buff, FwSizeType& length);  //!< deserialize data buffer
+    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Serialization::Endianness endianMode = Serialization::BIG);  //!< deserialize data buffer
 
     //! \brief deserialize a byte buffer of a given length
     //!
@@ -159,7 +159,7 @@ class SerializeBufferBase {
     //! \param length: length of the buffer, updated with the actual deserialized length
     //! \param mode: deserialization type
     //! \return status of serialization
-    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Serialization::t mode);
+    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Serialization::t lengthMode, Serialization::Endianness endianMode = Serialization::BIG);
 
     SerializeStatus deserializeTo(Serializable& val, Serialization::Endianness mode = Serialization::BIG);  //!< deserialize an object derived from serializable base class
 

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -41,9 +41,9 @@ class Serializable {
     using SizeType = FwSizeType;
 
   public:
-    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, Endianness mode = Serialization::BIG) const = 0;  //!< serialize contents to buffer
+    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, Endianness mode = Endianness::BIG) const = 0;  //!< serialize contents to buffer
 
-    virtual SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Endianness mode = Serialization::BIG) = 0;  //!< deserialize contents from buffer
+    virtual SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Endianness mode = Endianness::BIG) = 0;  //!< deserialize contents from buffer
 
     // ----------------------------------------------------------------------
     // Legacy methods for backward compatibility
@@ -83,30 +83,30 @@ class SerializeBufferBase {
 
     // Serialization for built-in types
 
-    SerializeStatus serializeFrom(U8 val, Endianness mode = Serialization::BIG);  //!< serialize 8-bit unsigned int
-    SerializeStatus serializeFrom(I8 val, Endianness mode = Serialization::BIG);  //!< serialize 8-bit signed int
+    SerializeStatus serializeFrom(U8 val, Endianness mode = Endianness::BIG);  //!< serialize 8-bit unsigned int
+    SerializeStatus serializeFrom(I8 val, Endianness mode = Endianness::BIG);  //!< serialize 8-bit signed int
 
 #if FW_HAS_16_BIT == 1
-    SerializeStatus serializeFrom(U16 val, Endianness mode = Serialization::BIG);  //!< serialize 16-bit unsigned int
-    SerializeStatus serializeFrom(I16 val, Endianness mode = Serialization::BIG);  //!< serialize 16-bit signed int
+    SerializeStatus serializeFrom(U16 val, Endianness mode = Endianness::BIG);  //!< serialize 16-bit unsigned int
+    SerializeStatus serializeFrom(I16 val, Endianness mode = Endianness::BIG);  //!< serialize 16-bit signed int
 #endif
 #if FW_HAS_32_BIT == 1
-    SerializeStatus serializeFrom(U32 val, Endianness mode = Serialization::BIG);  //!< serialize 32-bit unsigned int
-    SerializeStatus serializeFrom(I32 val, Endianness mode = Serialization::BIG);  //!< serialize 32-bit signed int
+    SerializeStatus serializeFrom(U32 val, Endianness mode = Endianness::BIG);  //!< serialize 32-bit unsigned int
+    SerializeStatus serializeFrom(I32 val, Endianness mode = Endianness::BIG);  //!< serialize 32-bit signed int
 #endif
 #if FW_HAS_64_BIT == 1
-    SerializeStatus serializeFrom(U64 val, Endianness mode = Serialization::BIG);  //!< serialize 64-bit unsigned int
-    SerializeStatus serializeFrom(I64 val, Endianness mode = Serialization::BIG);  //!< serialize 64-bit signed int
+    SerializeStatus serializeFrom(U64 val, Endianness mode = Endianness::BIG);  //!< serialize 64-bit unsigned int
+    SerializeStatus serializeFrom(I64 val, Endianness mode = Endianness::BIG);  //!< serialize 64-bit signed int
 #endif
-    SerializeStatus serializeFrom(F32 val, Endianness mode = Serialization::BIG);   //!< serialize 32-bit floating point
-    SerializeStatus serializeFrom(F64 val, Endianness mode = Serialization::BIG);   //!< serialize 64-bit floating point
-    SerializeStatus serializeFrom(bool val, Endianness mode = Serialization::BIG);  //!< serialize boolean
+    SerializeStatus serializeFrom(F32 val, Endianness mode = Endianness::BIG);   //!< serialize 32-bit floating point
+    SerializeStatus serializeFrom(F64 val, Endianness mode = Endianness::BIG);   //!< serialize 64-bit floating point
+    SerializeStatus serializeFrom(bool val, Endianness mode = Endianness::BIG);  //!< serialize boolean
 
     SerializeStatus serializeFrom(
-        const void* val, Endianness mode = Serialization::BIG);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
+        const void* val, Endianness mode = Endianness::BIG);  //!< serialize pointer (careful, only pointer value, not contents are serialized)
 
     //! serialize data buffer
-    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Endianness endianMode = Serialization::BIG);
+    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Endianness endianMode = Endianness::BIG);
 
     //! \brief serialize a byte buffer of a given length
     //!
@@ -117,40 +117,40 @@ class SerializeBufferBase {
     //! \param length: length of data to serialize
     //! \param mode: serialization type
     //! \return status of serialization
-    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Serialization::t lengthMode, Endianness endianMode = Serialization::BIG);
+    SerializeStatus serializeFrom(const U8* buff, FwSizeType length, Serialization::t lengthMode, Endianness endianMode = Endianness::BIG);
 
-    SerializeStatus serializeFrom(const SerializeBufferBase& val, Endianness mode = Serialization::BIG);  //!< serialize a serialized buffer
+    SerializeStatus serializeFrom(const SerializeBufferBase& val, Endianness mode = Endianness::BIG);  //!< serialize a serialized buffer
 
     SerializeStatus serializeFrom(
-        const Serializable& val, Endianness mode = Serialization::BIG);  //!< serialize an object derived from serializable base class
+        const Serializable& val, Endianness mode = Endianness::BIG);  //!< serialize an object derived from serializable base class
 
-    SerializeStatus serializeSize(const FwSizeType size, Endianness mode = Serialization::BIG);  //!< serialize a size value
+    SerializeStatus serializeSize(const FwSizeType size, Endianness mode = Endianness::BIG);  //!< serialize a size value
 
     // Deserialization for built-in types
 
-    SerializeStatus deserializeTo(U8& val, Endianness mode = Serialization::BIG);  //!< deserialize 8-bit unsigned int
-    SerializeStatus deserializeTo(I8& val, Endianness mode = Serialization::BIG);  //!< deserialize 8-bit signed int
+    SerializeStatus deserializeTo(U8& val, Endianness mode = Endianness::BIG);  //!< deserialize 8-bit unsigned int
+    SerializeStatus deserializeTo(I8& val, Endianness mode = Endianness::BIG);  //!< deserialize 8-bit signed int
 
 #if FW_HAS_16_BIT == 1
-    SerializeStatus deserializeTo(U16& val, Endianness mode = Serialization::BIG);  //!< deserialize 16-bit unsigned int
-    SerializeStatus deserializeTo(I16& val, Endianness mode = Serialization::BIG);  //!< deserialize 16-bit signed int
+    SerializeStatus deserializeTo(U16& val, Endianness mode = Endianness::BIG);  //!< deserialize 16-bit unsigned int
+    SerializeStatus deserializeTo(I16& val, Endianness mode = Endianness::BIG);  //!< deserialize 16-bit signed int
 #endif
 
 #if FW_HAS_32_BIT == 1
-    SerializeStatus deserializeTo(U32& val, Endianness mode = Serialization::BIG);  //!< deserialize 32-bit unsigned int
-    SerializeStatus deserializeTo(I32& val, Endianness mode = Serialization::BIG);  //!< deserialize 32-bit signed int
+    SerializeStatus deserializeTo(U32& val, Endianness mode = Endianness::BIG);  //!< deserialize 32-bit unsigned int
+    SerializeStatus deserializeTo(I32& val, Endianness mode = Endianness::BIG);  //!< deserialize 32-bit signed int
 #endif
 #if FW_HAS_64_BIT == 1
-    SerializeStatus deserializeTo(U64& val, Endianness mode = Serialization::BIG);  //!< deserialize 64-bit unsigned int
-    SerializeStatus deserializeTo(I64& val, Endianness mode = Serialization::BIG);  //!< deserialize 64-bit signed int
+    SerializeStatus deserializeTo(U64& val, Endianness mode = Endianness::BIG);  //!< deserialize 64-bit unsigned int
+    SerializeStatus deserializeTo(I64& val, Endianness mode = Endianness::BIG);  //!< deserialize 64-bit signed int
 #endif
-    SerializeStatus deserializeTo(F32& val, Endianness mode = Serialization::BIG);   //!< deserialize 32-bit floating point
-    SerializeStatus deserializeTo(F64& val, Endianness mode = Serialization::BIG);   //!< deserialize 64-bit floating point
-    SerializeStatus deserializeTo(bool& val, Endianness mode = Serialization::BIG);  //!< deserialize boolean
+    SerializeStatus deserializeTo(F32& val, Endianness mode = Endianness::BIG);   //!< deserialize 32-bit floating point
+    SerializeStatus deserializeTo(F64& val, Endianness mode = Endianness::BIG);   //!< deserialize 64-bit floating point
+    SerializeStatus deserializeTo(bool& val, Endianness mode = Endianness::BIG);  //!< deserialize boolean
 
-    SerializeStatus deserializeTo(void*& val, Endianness mode = Serialization::BIG);  //!< deserialize point value (careful, pointer value only, not contents)
+    SerializeStatus deserializeTo(void*& val, Endianness mode = Endianness::BIG);  //!< deserialize point value (careful, pointer value only, not contents)
 
-    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Endianness endianMode = Serialization::BIG);  //!< deserialize data buffer
+    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Endianness endianMode = Endianness::BIG);  //!< deserialize data buffer
 
     //! \brief deserialize a byte buffer of a given length
     //!
@@ -159,13 +159,13 @@ class SerializeBufferBase {
     //! \param length: length of the buffer, updated with the actual deserialized length
     //! \param mode: deserialization type
     //! \return status of serialization
-    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Serialization::t lengthMode, Endianness endianMode = Serialization::BIG);
+    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Serialization::t lengthMode, Endianness endianMode = Endianness::BIG);
 
-    SerializeStatus deserializeTo(Serializable& val, Endianness mode = Serialization::BIG);  //!< deserialize an object derived from serializable base class
+    SerializeStatus deserializeTo(Serializable& val, Endianness mode = Endianness::BIG);  //!< deserialize an object derived from serializable base class
 
-    SerializeStatus deserializeTo(SerializeBufferBase& val, Endianness mode = Serialization::BIG);  //!< serialize a serialized buffer
+    SerializeStatus deserializeTo(SerializeBufferBase& val, Endianness mode = Endianness::BIG);  //!< serialize a serialized buffer
 
-    SerializeStatus deserializeSize(FwSizeType& size, Endianness mode = Serialization::BIG);  //!< deserialize a size value
+    SerializeStatus deserializeSize(FwSizeType& size, Endianness mode = Endianness::BIG);  //!< deserialize a size value
 
     // ----------------------------------------------------------------------
     // Serialization methods

--- a/Fw/Types/StringBase.cpp
+++ b/Fw/Types/StringBase.cpp
@@ -139,17 +139,17 @@ StringBase::SizeType StringBase::serializedTruncatedSize(FwSizeType maxLength) c
     return static_cast<SizeType>(sizeof(FwSizeStoreType)) + static_cast<SizeType>(FW_MIN(this->length(), maxLength));
 }
 
-SerializeStatus StringBase::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+SerializeStatus StringBase::serializeTo(SerializeBufferBase& buffer, Fw::Endianness mode) const {
     return buffer.serializeFrom(reinterpret_cast<const U8*>(this->toChar()), this->length());
 }
 
-SerializeStatus StringBase::serializeTo(SerializeBufferBase& buffer, SizeType maxLength, Fw::Serialization::Endianness mode) const {
+SerializeStatus StringBase::serializeTo(SerializeBufferBase& buffer, SizeType maxLength, Fw::Endianness mode) const {
     const FwSizeType len = FW_MIN(maxLength, this->length());
     // Serialize length and then bytes
     return buffer.serializeFrom(reinterpret_cast<const U8*>(this->toChar()), len, Serialization::INCLUDE_LENGTH);
 }
 
-SerializeStatus StringBase::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+SerializeStatus StringBase::deserializeFrom(SerializeBufferBase& buffer, Fw::Endianness mode) {
     // Get the max size of the deserialized string
     const SizeType maxSize = this->maxLength();
     // Initial estimate of actual size is max size

--- a/Fw/Types/StringBase.cpp
+++ b/Fw/Types/StringBase.cpp
@@ -139,17 +139,17 @@ StringBase::SizeType StringBase::serializedTruncatedSize(FwSizeType maxLength) c
     return static_cast<SizeType>(sizeof(FwSizeStoreType)) + static_cast<SizeType>(FW_MIN(this->length(), maxLength));
 }
 
-SerializeStatus StringBase::serializeTo(SerializeBufferBase& buffer) const {
+SerializeStatus StringBase::serializeTo(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
     return buffer.serializeFrom(reinterpret_cast<const U8*>(this->toChar()), this->length());
 }
 
-SerializeStatus StringBase::serializeTo(SerializeBufferBase& buffer, SizeType maxLength) const {
+SerializeStatus StringBase::serializeTo(SerializeBufferBase& buffer, SizeType maxLength, Fw::Serialization::Endianness mode) const {
     const FwSizeType len = FW_MIN(maxLength, this->length());
     // Serialize length and then bytes
     return buffer.serializeFrom(reinterpret_cast<const U8*>(this->toChar()), len, Serialization::INCLUDE_LENGTH);
 }
 
-SerializeStatus StringBase::deserializeFrom(SerializeBufferBase& buffer) {
+SerializeStatus StringBase::deserializeFrom(SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
     // Get the max size of the deserialized string
     const SizeType maxSize = this->maxLength();
     // Initial estimate of actual size is max size

--- a/Fw/Types/StringBase.hpp
+++ b/Fw/Types/StringBase.hpp
@@ -66,9 +66,9 @@ class StringBase : public Serializable {
     FormatStatus format(const CHAR* formatString, ...);            //!< write formatted string to buffer
     FormatStatus vformat(const CHAR* formatString, va_list args);  //!< write formatted string to buffer using va_list
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Serialization::Endianess mode = Serialization::BIG) const override;
-    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, SizeType maxLen, Serialization::Endianess mode = Serialization::BIG) const;
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Serialization::Endianess mode = Serialization::BIG) override;
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Serialization::Endianness mode = Serialization::BIG) const override;
+    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, SizeType maxLen, Serialization::Endianness mode = Serialization::BIG) const;
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Serialization::Endianness mode = Serialization::BIG) override;
 
     DEPRECATED(SerializeStatus serialize(SerializeBufferBase& buffer) const,
                "Use serializeTo(SerializeBufferBase& buffer) instead") {

--- a/Fw/Types/StringBase.hpp
+++ b/Fw/Types/StringBase.hpp
@@ -66,9 +66,9 @@ class StringBase : public Serializable {
     FormatStatus format(const CHAR* formatString, ...);            //!< write formatted string to buffer
     FormatStatus vformat(const CHAR* formatString, va_list args);  //!< write formatted string to buffer using va_list
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Serialization::Endianness mode = Serialization::BIG) const override;
-    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, SizeType maxLen, Serialization::Endianness mode = Serialization::BIG) const;
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Serialization::Endianness mode = Serialization::BIG) override;
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Endianness mode = Serialization::BIG) const override;
+    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, SizeType maxLen, Endianness mode = Serialization::BIG) const;
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Endianness mode = Serialization::BIG) override;
 
     DEPRECATED(SerializeStatus serialize(SerializeBufferBase& buffer) const,
                "Use serializeTo(SerializeBufferBase& buffer) instead") {

--- a/Fw/Types/StringBase.hpp
+++ b/Fw/Types/StringBase.hpp
@@ -67,7 +67,9 @@ class StringBase : public Serializable {
     FormatStatus vformat(const CHAR* formatString, va_list args);  //!< write formatted string to buffer using va_list
 
     SerializeStatus serializeTo(SerializeBufferBase& buffer, Endianness mode = Endianness::BIG) const override;
-    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, SizeType maxLen, Endianness mode = Endianness::BIG) const;
+    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer,
+                                        SizeType maxLen,
+                                        Endianness mode = Endianness::BIG) const;
     SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Endianness mode = Endianness::BIG) override;
 
     DEPRECATED(SerializeStatus serialize(SerializeBufferBase& buffer) const,

--- a/Fw/Types/StringBase.hpp
+++ b/Fw/Types/StringBase.hpp
@@ -66,9 +66,9 @@ class StringBase : public Serializable {
     FormatStatus format(const CHAR* formatString, ...);            //!< write formatted string to buffer
     FormatStatus vformat(const CHAR* formatString, va_list args);  //!< write formatted string to buffer using va_list
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer, Endianness mode = Serialization::BIG) const override;
-    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, SizeType maxLen, Endianness mode = Serialization::BIG) const;
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Endianness mode = Serialization::BIG) override;
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Endianness mode = Endianness::BIG) const override;
+    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, SizeType maxLen, Endianness mode = Endianness::BIG) const;
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Endianness mode = Endianness::BIG) override;
 
     DEPRECATED(SerializeStatus serialize(SerializeBufferBase& buffer) const,
                "Use serializeTo(SerializeBufferBase& buffer) instead") {

--- a/Fw/Types/StringBase.hpp
+++ b/Fw/Types/StringBase.hpp
@@ -66,9 +66,9 @@ class StringBase : public Serializable {
     FormatStatus format(const CHAR* formatString, ...);            //!< write formatted string to buffer
     FormatStatus vformat(const CHAR* formatString, va_list args);  //!< write formatted string to buffer using va_list
 
-    SerializeStatus serializeTo(SerializeBufferBase& buffer) const override;
-    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, SizeType maxLen) const;
-    SerializeStatus deserializeFrom(SerializeBufferBase& buffer) override;
+    SerializeStatus serializeTo(SerializeBufferBase& buffer, Serialization::Endianess mode = Serialization::BIG) const override;
+    virtual SerializeStatus serializeTo(SerializeBufferBase& buffer, SizeType maxLen, Serialization::Endianess mode = Serialization::BIG) const;
+    SerializeStatus deserializeFrom(SerializeBufferBase& buffer, Serialization::Endianess mode = Serialization::BIG) override;
 
     DEPRECATED(SerializeStatus serialize(SerializeBufferBase& buffer) const,
                "Use serializeTo(SerializeBufferBase& buffer) instead") {

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -129,6 +129,27 @@ TEST(SerializationTest, Serialization1) {
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 2);
 
 #if DEBUG_VERBOSE
+    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", i8t1, i8t2, stat1, stat2);
+    printf("U16 Little-Endian Test\n");
+#endif
+
+    u16t1 = 0xABCD;
+    u16t2 = 0;
+
+    // Test shorts
+
+    buff.resetSer();
+    stat1 = buff.serializeFrom(u16t1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 2);
+    ASSERT_EQ(0xCD, ptr[0]);
+    ASSERT_EQ(0xAB, ptr[1]);
+    stat2 = buff.deserializeTo(u16t2, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u16t1, u16t2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 2);
+
+#if DEBUG_VERBOSE
     printf("Val: in: %d out: %d stat1: %d stat2: %d\n", u16t1, u16t2, stat1, stat2);
     printf("I16 test\n");
 #endif
@@ -162,6 +183,39 @@ TEST(SerializationTest, Serialization1) {
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 2);
 
 #if DEBUG_VERBOSE
+    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", u16t1, u16t2, stat1, stat2);
+    printf("I16 Little-Endian test\n");
+#endif
+
+    i16t1 = static_cast<I16>(0xABCD);
+    i16t2 = 0;
+
+    buff.resetSer();
+    stat1 = buff.serializeFrom(i16t1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 2);
+    // 2s complement
+    ASSERT_EQ(0xCD, ptr[0]);
+    ASSERT_EQ(0xAB, ptr[1]);
+    stat2 = buff.deserializeTo(i16t2, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i16t1, i16t2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 2);
+
+    // double check negative number
+    i16t1 = -1000;
+    i16t2 = 0;
+
+    buff.resetSer();
+    stat1 = buff.serializeFrom(i16t1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 2);
+    stat2 = buff.deserializeTo(i16t2, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i16t1, i16t2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 2);
+
+#if DEBUG_VERBOSE
     printf("Val: in: %d out: %d stat1: %d stat2: %d\n", i16t1, i16t2, stat1, stat2);
 
     printf("U32 Test\n");
@@ -181,6 +235,30 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(0xEF, ptr[2]);
     ASSERT_EQ(0x12, ptr[3]);
     stat2 = buff.deserializeTo(u32t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u32t1, u32t2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
+
+#if DEBUG_VERBOSE
+    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", i16t1, i16t2, stat1, stat2);
+
+    printf("U32 Little-Endian Test\n");
+#endif
+
+    u32t1 = 0xABCDEF12;
+    u32t2 = 0;
+
+    // Test ints
+
+    buff.resetSer();
+    stat1 = buff.serializeFrom(u32t1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
+    ASSERT_EQ(0x12, ptr[0]);
+    ASSERT_EQ(0xEF, ptr[1]);
+    ASSERT_EQ(0xCD, ptr[2]);
+    ASSERT_EQ(0xAB, ptr[3]);
+    stat2 = buff.deserializeTo(u32t2, Fw::Serialization::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u32t1, u32t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
@@ -220,6 +298,40 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(i32t1, i32t2);
 
 #if DEBUG_VERBOSE
+    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", u32t1, u32t2, stat1, stat2);
+    printf("I32 Little-Endian Test\n");
+#endif
+
+    i32t1 = 0xABCDEF12;
+    i32t2 = 0;
+
+    buff.resetSer();
+    stat1 = buff.serializeFrom(i32t1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
+    ASSERT_EQ(0x12, ptr[0]);
+    ASSERT_EQ(0xEF, ptr[1]);
+    ASSERT_EQ(0xCD, ptr[2]);
+    ASSERT_EQ(0xAB, ptr[3]);
+    stat2 = buff.deserializeTo(i32t2, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
+    ASSERT_EQ(i32t1, i32t2);
+
+    // double check negative number
+    i32t1 = -1000000;
+    i32t2 = 0;
+
+    buff.resetSer();
+    stat1 = buff.serializeFrom(i32t1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
+    stat2 = buff.deserializeTo(i32t2, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
+    ASSERT_EQ(i32t1, i32t2);
+
+#if DEBUG_VERBOSE
     printf("Val: in: %d out: %d stat1: %d stat2: %d\n", i32t1, i32t2, stat1, stat2);
 
     printf("U64 Test\n");
@@ -243,6 +355,35 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(0xCD, ptr[6]);
     ASSERT_EQ(0xEF, ptr[7]);
     stat2 = buff.deserializeTo(u64t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u64t1, u64t2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
+
+#if DEBUG_VERBOSE
+    printf("Val: in: %d out: %d stat1: %d stat2: %d\n", i32t1, i32t2, stat1, stat2);
+
+    printf("U64 Little-Endian Test\n");
+#endif
+
+    u64t1 = 0x0123456789ABCDEF;
+    u64t2 = 0;
+
+    // Test ints
+
+    buff.resetSer();
+    ASSERT_EQ(0x23, ptr[1]);
+    stat1 = buff.serializeFrom(u64t1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
+    ASSERT_EQ(0xEF, ptr[0]);
+    ASSERT_EQ(0xCD, ptr[1]);
+    ASSERT_EQ(0xAB, ptr[2]);
+    ASSERT_EQ(0x89, ptr[3]);
+    ASSERT_EQ(0x67, ptr[4]);
+    ASSERT_EQ(0x45, ptr[5]);
+    ASSERT_EQ(0x23, ptr[6]);
+    ASSERT_EQ(0x01, ptr[7]);
+    stat2 = buff.deserializeTo(u64t2, Fw::Serialization::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u64t1, u64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
@@ -286,6 +427,44 @@ TEST(SerializationTest, Serialization1) {
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
 
 #if DEBUG_VERBOSE
+    printf("Val: in: %lld out: %lld stat1: %d stat2: %d\n", u64t1, u64t2, stat1, stat2);
+    printf("I64 Little-Endian Test\n");
+#endif
+
+    i64t1 = 0x0123456789ABCDEF;
+    i64t2 = 0;
+
+    buff.resetSer();
+    stat1 = buff.serializeFrom(i64t1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
+    ASSERT_EQ(0xEF, ptr[0]);
+    ASSERT_EQ(0xCD, ptr[1]);
+    ASSERT_EQ(0xAB, ptr[2]);
+    ASSERT_EQ(0x89, ptr[3]);
+    ASSERT_EQ(0x67, ptr[4]);
+    ASSERT_EQ(0x45, ptr[5]);
+    ASSERT_EQ(0x23, ptr[6]);
+    ASSERT_EQ(0x01, ptr[7]);
+    stat2 = buff.deserializeTo(i64t2, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i64t1, i64t2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
+
+    // double check negative number
+    i64t1 = -1000000000000;
+    i64t2 = 0;
+
+    buff.resetSer();
+    stat1 = buff.serializeFrom(i64t1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
+    stat2 = buff.deserializeTo(i64t2, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(i64t1, i64t2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
+
+#if DEBUG_VERBOSE
     printf("Val: in: %lld out: %lld stat1: %d stat2: %d\n", i64t1, i64t2, stat1, stat2);
 
     printf("F32 Test\n");
@@ -305,6 +484,30 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(0x70, ptr[2]);
     ASSERT_EQ(0xA4, ptr[3]);
     stat2 = buff.deserializeTo(f32t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_FLOAT_EQ(f32t1, f32t2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
+
+#if DEBUG_VERBOSE
+    printf("Val: in: %lld out: %lld stat1: %d stat2: %d\n", i64t1, i64t2, stat1, stat2);
+
+    printf("F32 Little-Endian Test\n");
+#endif
+
+    f32t1 = -1.23;
+    f32t2 = 0;
+
+    // Test ints
+
+    buff.resetSer();
+    stat1 = buff.serializeFrom(f32t1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
+    ASSERT_EQ(0xA4, ptr[0]);
+    ASSERT_EQ(0x70, ptr[1]);
+    ASSERT_EQ(0x9D, ptr[2]);
+    ASSERT_EQ(0xBF, ptr[3]);
+    stat2 = buff.deserializeTo(f32t2, Fw::Serialization::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_FLOAT_EQ(f32t1, f32t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
@@ -330,6 +533,31 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(0x8B, ptr[6]);
     ASSERT_EQ(0xA6, ptr[7]);
     stat2 = buff.deserializeTo(f64t2);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_DOUBLE_EQ(f64t1, f64t2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
+
+#if DEBUG_VERBOSE
+    printf("Val: in: %f out: %f stat1: %d stat2: %d\n", f32t1, f32t2, stat1, stat2);
+    printf("F64 Little-Endian Test\n");
+#endif
+
+    f64t1 = 100.232145345346534;
+    f64t2 = 0;
+
+    buff.resetSer();
+    stat1 = buff.serializeFrom(f64t1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
+    ASSERT_EQ(0xA6, ptr[0]);
+    ASSERT_EQ(0x8B, ptr[1]);
+    ASSERT_EQ(0x26, ptr[2]);
+    ASSERT_EQ(0x78, ptr[3]);
+    ASSERT_EQ(0xDB, ptr[4]);
+    ASSERT_EQ(0x0E, ptr[5]);
+    ASSERT_EQ(0x59, ptr[6]);
+    ASSERT_EQ(0x40, ptr[7]);
+    stat2 = buff.deserializeTo(f64t2, Fw::Serialization::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_DOUBLE_EQ(f64t1, f64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
@@ -367,9 +595,25 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(ptrt1, ptrt2);
 
 #if DEBUG_VERBOSE
-    printf("Val: in: %p out: %p stat1: %d stat2: %d\n", ptrt1, ptrt2, stat1, stat2);
+    printf("Val: in: %s out: %s stat1: %d stat2: %d\n", boolt1 ? "TRUE" : "FALSE", boolt2 ? "TRUE" : "FALSE", stat1,
+           stat2);
+    printf("Pointer Little-Endian Test\n");
+#endif
 
-    printf("Skip deserialization Tests\n");
+    u32Var = 0;
+    ptrt1 = &u32Var;
+    ptrt2 = nullptr;
+
+    buff.resetSer();
+    stat1 = buff.serializeFrom(ptrt1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    stat2 = buff.deserializeTo(ptrt2, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(ptrt1, ptrt2);
+
+#if DEBUG_VERBOSE
+    printf("Val: in: %p out: %p stat1: %d stat2: %d\n", ptrt1, ptrt2, stat1, stat2);
+    printf("Size Test\n");
 #endif
 
     // Test sizes
@@ -384,10 +628,28 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u64t1, u64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, sizeof(FwSizeStoreType));
+    
+#if DEBUG_VERBOSE
+    printf("Val: in: %p out: %p stat1: %d stat2: %d\n", ptrt1, ptrt2, stat1, stat2);
+    printf("Size Little-Endian Test\n");
+#endif
+
+    // Test sizes
+
+    size1 = std::numeric_limits<FwSizeStoreType>::max();
+    size2 = 0;
+
+    buff.resetSer();
+    stat1 = buff.serializeSize(size1, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
+    stat2 = buff.deserializeSize(size2, Fw::Serialization::LITTLE);
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
+    ASSERT_EQ(u64t1, u64t2);
+    Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, sizeof(FwSizeStoreType));
 
 #if DEBUG_VERBOSE
     printf("Val: in: %" PRI_FwSizeType " out: %" PRI_FwSizeType " stat1: %d stat2: %d\n", size1, size2, stat1, stat2);
-    printf("Size Test\n");
+    printf("Skip deserialization Tests\n");
 #endif
 
     // Test skipping:
@@ -626,20 +888,20 @@ struct TestStruct {
 class MySerializable : public Fw::Serializable {
   public:
     Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override {
-        buffer.serializeFrom(m_testStruct.m_u32);
-        buffer.serializeFrom(m_testStruct.m_u16);
-        buffer.serializeFrom(m_testStruct.m_u8);
-        buffer.serializeFrom(m_testStruct.m_f32);
+        buffer.serializeFrom(m_testStruct.m_u32, mode);
+        buffer.serializeFrom(m_testStruct.m_u16, mode);
+        buffer.serializeFrom(m_testStruct.m_u8, mode);
+        buffer.serializeFrom(m_testStruct.m_f32, mode);
         buffer.serializeFrom(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
         return Fw::FW_SERIALIZE_OK;
     }
 
     Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override {
         buffer.serializeFrom(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
-        buffer.serializeFrom(m_testStruct.m_f32);
-        buffer.serializeFrom(m_testStruct.m_u8);
-        buffer.serializeFrom(m_testStruct.m_u16);
-        buffer.serializeFrom(m_testStruct.m_u32);
+        buffer.serializeFrom(m_testStruct.m_f32, mode);
+        buffer.serializeFrom(m_testStruct.m_u8, mode);
+        buffer.serializeFrom(m_testStruct.m_u16, mode);
+        buffer.serializeFrom(m_testStruct.m_u32, mode);
         return Fw::FW_SERIALIZE_OK;
     }
 

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -625,7 +625,7 @@ struct TestStruct {
 
 class MySerializable : public Fw::Serializable {
   public:
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer) const override {
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override {
         buffer.serializeFrom(m_testStruct.m_u32);
         buffer.serializeFrom(m_testStruct.m_u16);
         buffer.serializeFrom(m_testStruct.m_u8);
@@ -634,7 +634,7 @@ class MySerializable : public Fw::Serializable {
         return Fw::FW_SERIALIZE_OK;
     }
 
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer) override {
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override {
         buffer.serializeFrom(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
         buffer.serializeFrom(m_testStruct.m_f32);
         buffer.serializeFrom(m_testStruct.m_u8);

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -628,7 +628,7 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u64t1, u64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, sizeof(FwSizeStoreType));
-    
+
 #if DEBUG_VERBOSE
     printf("Val: in: %p out: %p stat1: %d stat2: %d\n", ptrt1, ptrt2, stat1, stat2);
     printf("Size Little-Endian Test\n");
@@ -887,7 +887,8 @@ struct TestStruct {
 
 class MySerializable : public Fw::Serializable {
   public:
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override {
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer,
+                                    Fw::Endianness mode = Fw::Endianness::BIG) const override {
         buffer.serializeFrom(m_testStruct.m_u32, mode);
         buffer.serializeFrom(m_testStruct.m_u16, mode);
         buffer.serializeFrom(m_testStruct.m_u8, mode);
@@ -896,7 +897,8 @@ class MySerializable : public Fw::Serializable {
         return Fw::FW_SERIALIZE_OK;
     }
 
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override {
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer,
+                                        Fw::Endianness mode = Fw::Endianness::BIG) override {
         buffer.serializeFrom(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
         buffer.serializeFrom(m_testStruct.m_f32, mode);
         buffer.serializeFrom(m_testStruct.m_u8, mode);

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -887,7 +887,7 @@ struct TestStruct {
 
 class MySerializable : public Fw::Serializable {
   public:
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override {
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override {
         buffer.serializeFrom(m_testStruct.m_u32, mode);
         buffer.serializeFrom(m_testStruct.m_u16, mode);
         buffer.serializeFrom(m_testStruct.m_u8, mode);
@@ -896,7 +896,7 @@ class MySerializable : public Fw::Serializable {
         return Fw::FW_SERIALIZE_OK;
     }
 
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override {
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override {
         buffer.serializeFrom(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
         buffer.serializeFrom(m_testStruct.m_f32, mode);
         buffer.serializeFrom(m_testStruct.m_u8, mode);

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -139,12 +139,12 @@ TEST(SerializationTest, Serialization1) {
     // Test shorts
 
     buff.resetSer();
-    stat1 = buff.serializeFrom(u16t1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(u16t1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 2);
     ASSERT_EQ(0xCD, ptr[0]);
     ASSERT_EQ(0xAB, ptr[1]);
-    stat2 = buff.deserializeTo(u16t2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(u16t2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u16t1, u16t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 2);
@@ -191,13 +191,13 @@ TEST(SerializationTest, Serialization1) {
     i16t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serializeFrom(i16t1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(i16t1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 2);
     // 2s complement
     ASSERT_EQ(0xCD, ptr[0]);
     ASSERT_EQ(0xAB, ptr[1]);
-    stat2 = buff.deserializeTo(i16t2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(i16t2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i16t1, i16t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 2);
@@ -207,10 +207,10 @@ TEST(SerializationTest, Serialization1) {
     i16t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serializeFrom(i16t1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(i16t1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 2);
-    stat2 = buff.deserializeTo(i16t2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(i16t2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i16t1, i16t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 2);
@@ -251,14 +251,14 @@ TEST(SerializationTest, Serialization1) {
     // Test ints
 
     buff.resetSer();
-    stat1 = buff.serializeFrom(u32t1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(u32t1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
     ASSERT_EQ(0x12, ptr[0]);
     ASSERT_EQ(0xEF, ptr[1]);
     ASSERT_EQ(0xCD, ptr[2]);
     ASSERT_EQ(0xAB, ptr[3]);
-    stat2 = buff.deserializeTo(u32t2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(u32t2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u32t1, u32t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
@@ -306,14 +306,14 @@ TEST(SerializationTest, Serialization1) {
     i32t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serializeFrom(i32t1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(i32t1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
     ASSERT_EQ(0x12, ptr[0]);
     ASSERT_EQ(0xEF, ptr[1]);
     ASSERT_EQ(0xCD, ptr[2]);
     ASSERT_EQ(0xAB, ptr[3]);
-    stat2 = buff.deserializeTo(i32t2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(i32t2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
     ASSERT_EQ(i32t1, i32t2);
@@ -323,10 +323,10 @@ TEST(SerializationTest, Serialization1) {
     i32t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serializeFrom(i32t1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(i32t1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
-    stat2 = buff.deserializeTo(i32t2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(i32t2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
     ASSERT_EQ(i32t1, i32t2);
@@ -372,7 +372,7 @@ TEST(SerializationTest, Serialization1) {
 
     buff.resetSer();
     ASSERT_EQ(0x23, ptr[1]);
-    stat1 = buff.serializeFrom(u64t1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(u64t1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
     ASSERT_EQ(0xEF, ptr[0]);
@@ -383,7 +383,7 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(0x45, ptr[5]);
     ASSERT_EQ(0x23, ptr[6]);
     ASSERT_EQ(0x01, ptr[7]);
-    stat2 = buff.deserializeTo(u64t2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(u64t2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u64t1, u64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
@@ -435,7 +435,7 @@ TEST(SerializationTest, Serialization1) {
     i64t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serializeFrom(i64t1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(i64t1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
     ASSERT_EQ(0xEF, ptr[0]);
@@ -446,7 +446,7 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(0x45, ptr[5]);
     ASSERT_EQ(0x23, ptr[6]);
     ASSERT_EQ(0x01, ptr[7]);
-    stat2 = buff.deserializeTo(i64t2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(i64t2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i64t1, i64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
@@ -456,10 +456,10 @@ TEST(SerializationTest, Serialization1) {
     i64t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serializeFrom(i64t1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(i64t1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
-    stat2 = buff.deserializeTo(i64t2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(i64t2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(i64t1, i64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
@@ -500,14 +500,14 @@ TEST(SerializationTest, Serialization1) {
     // Test ints
 
     buff.resetSer();
-    stat1 = buff.serializeFrom(f32t1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(f32t1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 4);
     ASSERT_EQ(0xA4, ptr[0]);
     ASSERT_EQ(0x70, ptr[1]);
     ASSERT_EQ(0x9D, ptr[2]);
     ASSERT_EQ(0xBF, ptr[3]);
-    stat2 = buff.deserializeTo(f32t2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(f32t2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_FLOAT_EQ(f32t1, f32t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 4);
@@ -546,7 +546,7 @@ TEST(SerializationTest, Serialization1) {
     f64t2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serializeFrom(f64t1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(f64t1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
     Fw::SerializeBufferBaseTester::verifySerLocEq(buff, 8);
     ASSERT_EQ(0xA6, ptr[0]);
@@ -557,7 +557,7 @@ TEST(SerializationTest, Serialization1) {
     ASSERT_EQ(0x0E, ptr[5]);
     ASSERT_EQ(0x59, ptr[6]);
     ASSERT_EQ(0x40, ptr[7]);
-    stat2 = buff.deserializeTo(f64t2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(f64t2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_DOUBLE_EQ(f64t1, f64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, 8);
@@ -605,9 +605,9 @@ TEST(SerializationTest, Serialization1) {
     ptrt2 = nullptr;
 
     buff.resetSer();
-    stat1 = buff.serializeFrom(ptrt1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeFrom(ptrt1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat2 = buff.deserializeTo(ptrt2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeTo(ptrt2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(ptrt1, ptrt2);
 
@@ -640,9 +640,9 @@ TEST(SerializationTest, Serialization1) {
     size2 = 0;
 
     buff.resetSer();
-    stat1 = buff.serializeSize(size1, Fw::Serialization::LITTLE);
+    stat1 = buff.serializeSize(size1, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat1);
-    stat2 = buff.deserializeSize(size2, Fw::Serialization::LITTLE);
+    stat2 = buff.deserializeSize(size2, Fw::Endianness::LITTLE);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat2);
     ASSERT_EQ(u64t1, u64t2);
     Fw::SerializeBufferBaseTester::verifyDeserLocEq(buff, sizeof(FwSizeStoreType));
@@ -887,7 +887,7 @@ struct TestStruct {
 
 class MySerializable : public Fw::Serializable {
   public:
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override {
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override {
         buffer.serializeFrom(m_testStruct.m_u32, mode);
         buffer.serializeFrom(m_testStruct.m_u16, mode);
         buffer.serializeFrom(m_testStruct.m_u8, mode);
@@ -896,7 +896,7 @@ class MySerializable : public Fw::Serializable {
         return Fw::FW_SERIALIZE_OK;
     }
 
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override {
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override {
         buffer.serializeFrom(m_testStruct.m_buff, sizeof(m_testStruct.m_buff));
         buffer.serializeFrom(m_testStruct.m_f32, mode);
         buffer.serializeFrom(m_testStruct.m_u8, mode);

--- a/Os/Posix/RawTime.cpp
+++ b/Os/Posix/RawTime.cpp
@@ -44,7 +44,7 @@ PosixRawTime::Status PosixRawTime::getTimeInterval(const Os::RawTime& other, Fw:
     return Status::OP_OK;
 }
 
-Fw::SerializeStatus PosixRawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+Fw::SerializeStatus PosixRawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode) const {
     static_assert(PosixRawTime::SERIALIZED_SIZE >= 2 * sizeof(U32),
                   "PosixRawTime implementation requires at least 2*sizeof(U32) serialization size");
     Fw::SerializeStatus status = buffer.serializeFrom(static_cast<U32>(this->m_handle.m_timespec.tv_sec), mode);
@@ -54,7 +54,7 @@ Fw::SerializeStatus PosixRawTime::serializeTo(Fw::SerializeBufferBase& buffer, F
     return buffer.serializeFrom(static_cast<U32>(this->m_handle.m_timespec.tv_nsec), mode);
 }
 
-Fw::SerializeStatus PosixRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+Fw::SerializeStatus PosixRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode) {
     static_assert(PosixRawTime::SERIALIZED_SIZE >= 2 * sizeof(U32),
                   "PosixRawTime implementation requires at least 2*sizeof(U32) serialization size");
     U32 sec = 0;

--- a/Os/Posix/RawTime.cpp
+++ b/Os/Posix/RawTime.cpp
@@ -44,26 +44,26 @@ PosixRawTime::Status PosixRawTime::getTimeInterval(const Os::RawTime& other, Fw:
     return Status::OP_OK;
 }
 
-Fw::SerializeStatus PosixRawTime::serializeTo(Fw::SerializeBufferBase& buffer) const {
+Fw::SerializeStatus PosixRawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
     static_assert(PosixRawTime::SERIALIZED_SIZE >= 2 * sizeof(U32),
                   "PosixRawTime implementation requires at least 2*sizeof(U32) serialization size");
-    Fw::SerializeStatus status = buffer.serializeFrom(static_cast<U32>(this->m_handle.m_timespec.tv_sec));
+    Fw::SerializeStatus status = buffer.serializeFrom(static_cast<U32>(this->m_handle.m_timespec.tv_sec), mode);
     if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
         return status;
     }
-    return buffer.serializeFrom(static_cast<U32>(this->m_handle.m_timespec.tv_nsec));
+    return buffer.serializeFrom(static_cast<U32>(this->m_handle.m_timespec.tv_nsec), mode);
 }
 
-Fw::SerializeStatus PosixRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer) {
+Fw::SerializeStatus PosixRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
     static_assert(PosixRawTime::SERIALIZED_SIZE >= 2 * sizeof(U32),
                   "PosixRawTime implementation requires at least 2*sizeof(U32) serialization size");
     U32 sec = 0;
     U32 nsec = 0;
-    Fw::SerializeStatus status = buffer.deserializeTo(sec);
+    Fw::SerializeStatus status = buffer.deserializeTo(sec, mode);
     if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
         return status;
     }
-    status = buffer.deserializeTo(nsec);
+    status = buffer.deserializeTo(nsec, mode);
     if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
         return status;
     }

--- a/Os/Posix/RawTime.hpp
+++ b/Os/Posix/RawTime.hpp
@@ -65,7 +65,8 @@ class PosixRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer,
+                                    Fw::Endianness mode = Fw::Endianness::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -79,7 +80,8 @@ class PosixRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer,
+                                        Fw::Endianness mode = Fw::Endianness::BIG) override;
 
   private:
     //! Handle for PosixRawTime

--- a/Os/Posix/RawTime.hpp
+++ b/Os/Posix/RawTime.hpp
@@ -65,7 +65,7 @@ class PosixRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -79,7 +79,7 @@ class PosixRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
 
   private:
     //! Handle for PosixRawTime

--- a/Os/Posix/RawTime.hpp
+++ b/Os/Posix/RawTime.hpp
@@ -65,7 +65,7 @@ class PosixRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -79,7 +79,7 @@ class PosixRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
 
   private:
     //! Handle for PosixRawTime

--- a/Os/Posix/RawTime.hpp
+++ b/Os/Posix/RawTime.hpp
@@ -65,7 +65,7 @@ class PosixRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -79,7 +79,7 @@ class PosixRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
 
   private:
     //! Handle for PosixRawTime

--- a/Os/RawTime.cpp
+++ b/Os/RawTime.cpp
@@ -43,14 +43,14 @@ RawTime::Status RawTime::getTimeInterval(const Os::RawTime& other, Fw::TimeInter
     return this->m_delegate.getTimeInterval(other, result);
 }
 
-Fw::SerializeStatus RawTime::serializeTo(Fw::SerializeBufferBase& buffer) const {
+Fw::SerializeStatus RawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
     FW_ASSERT(&this->m_delegate == reinterpret_cast<const RawTimeInterface*>(&this->m_handle_storage[0]));
-    return this->m_delegate.serializeTo(buffer);
+    return this->m_delegate.serializeTo(buffer, mode);
 }
 
-Fw::SerializeStatus RawTime::deserializeFrom(Fw::SerializeBufferBase& buffer) {
+Fw::SerializeStatus RawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
     FW_ASSERT(&this->m_delegate == reinterpret_cast<const RawTimeInterface*>(&this->m_handle_storage[0]));
-    return this->m_delegate.deserializeFrom(buffer);
+    return this->m_delegate.deserializeFrom(buffer, mode);
 }
 
 RawTime::Status RawTime::getDiffUsec(const RawTime& other, U32& result) const {

--- a/Os/RawTime.cpp
+++ b/Os/RawTime.cpp
@@ -43,12 +43,12 @@ RawTime::Status RawTime::getTimeInterval(const Os::RawTime& other, Fw::TimeInter
     return this->m_delegate.getTimeInterval(other, result);
 }
 
-Fw::SerializeStatus RawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+Fw::SerializeStatus RawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode) const {
     FW_ASSERT(&this->m_delegate == reinterpret_cast<const RawTimeInterface*>(&this->m_handle_storage[0]));
     return this->m_delegate.serializeTo(buffer, mode);
 }
 
-Fw::SerializeStatus RawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+Fw::SerializeStatus RawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode) {
     FW_ASSERT(&this->m_delegate == reinterpret_cast<const RawTimeInterface*>(&this->m_handle_storage[0]));
     return this->m_delegate.deserializeFrom(buffer, mode);
 }

--- a/Os/RawTime.hpp
+++ b/Os/RawTime.hpp
@@ -77,7 +77,7 @@ class RawTimeInterface : public Fw::Serializable {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    virtual Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const = 0;
+    virtual Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const = 0;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -91,7 +91,7 @@ class RawTimeInterface : public Fw::Serializable {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    virtual Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) = 0;
+    virtual Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) = 0;
 };
 
 class RawTime final : public RawTimeInterface {
@@ -143,7 +143,7 @@ class RawTime final : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -157,7 +157,7 @@ class RawTime final : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
 
     // ------------------------------------------------------------
     // Common functions built on top of OS-specific functions

--- a/Os/RawTime.hpp
+++ b/Os/RawTime.hpp
@@ -77,7 +77,7 @@ class RawTimeInterface : public Fw::Serializable {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    virtual Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const = 0;
+    virtual Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const = 0;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -91,7 +91,7 @@ class RawTimeInterface : public Fw::Serializable {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    virtual Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) = 0;
+    virtual Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) = 0;
 };
 
 class RawTime final : public RawTimeInterface {
@@ -143,7 +143,7 @@ class RawTime final : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -157,7 +157,7 @@ class RawTime final : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
 
     // ------------------------------------------------------------
     // Common functions built on top of OS-specific functions

--- a/Os/RawTime.hpp
+++ b/Os/RawTime.hpp
@@ -77,7 +77,8 @@ class RawTimeInterface : public Fw::Serializable {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    virtual Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const = 0;
+    virtual Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer,
+                                            Fw::Endianness mode = Fw::Endianness::BIG) const = 0;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -91,7 +92,8 @@ class RawTimeInterface : public Fw::Serializable {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    virtual Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) = 0;
+    virtual Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer,
+                                                Fw::Endianness mode = Fw::Endianness::BIG) = 0;
 };
 
 class RawTime final : public RawTimeInterface {
@@ -143,7 +145,8 @@ class RawTime final : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer,
+                                    Fw::Endianness mode = Fw::Endianness::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -157,7 +160,8 @@ class RawTime final : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer,
+                                        Fw::Endianness mode = Fw::Endianness::BIG) override;
 
     // ------------------------------------------------------------
     // Common functions built on top of OS-specific functions

--- a/Os/RawTime.hpp
+++ b/Os/RawTime.hpp
@@ -77,7 +77,7 @@ class RawTimeInterface : public Fw::Serializable {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    virtual Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer) const = 0;
+    virtual Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const = 0;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -91,7 +91,7 @@ class RawTimeInterface : public Fw::Serializable {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    virtual Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer) = 0;
+    virtual Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) = 0;
 };
 
 class RawTime final : public RawTimeInterface {
@@ -143,7 +143,7 @@ class RawTime final : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -157,7 +157,7 @@ class RawTime final : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
 
     // ------------------------------------------------------------
     // Common functions built on top of OS-specific functions

--- a/Os/Stub/RawTime.cpp
+++ b/Os/Stub/RawTime.cpp
@@ -21,11 +21,11 @@ StubRawTime::Status StubRawTime::getTimeInterval(const Os::RawTime& other, Fw::T
     return Status::OP_OK;
 }
 
-Fw::SerializeStatus StubRawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+Fw::SerializeStatus StubRawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode) const {
     return Fw::FW_SERIALIZE_OK;
 }
 
-Fw::SerializeStatus StubRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+Fw::SerializeStatus StubRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode) {
     return Fw::FW_SERIALIZE_OK;
 }
 

--- a/Os/Stub/RawTime.cpp
+++ b/Os/Stub/RawTime.cpp
@@ -21,11 +21,11 @@ StubRawTime::Status StubRawTime::getTimeInterval(const Os::RawTime& other, Fw::T
     return Status::OP_OK;
 }
 
-Fw::SerializeStatus StubRawTime::serializeTo(Fw::SerializeBufferBase& buffer) const {
+Fw::SerializeStatus StubRawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
     return Fw::FW_SERIALIZE_OK;
 }
 
-Fw::SerializeStatus StubRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer) {
+Fw::SerializeStatus StubRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
     return Fw::FW_SERIALIZE_OK;
 }
 

--- a/Os/Stub/RawTime.hpp
+++ b/Os/Stub/RawTime.hpp
@@ -64,7 +64,7 @@ class StubRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -78,7 +78,7 @@ class StubRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
 
   private:
     //! Handle for StubRawTime

--- a/Os/Stub/RawTime.hpp
+++ b/Os/Stub/RawTime.hpp
@@ -64,7 +64,7 @@ class StubRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -78,7 +78,7 @@ class StubRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
 
   private:
     //! Handle for StubRawTime

--- a/Os/Stub/RawTime.hpp
+++ b/Os/Stub/RawTime.hpp
@@ -64,7 +64,7 @@ class StubRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -78,7 +78,7 @@ class StubRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
 
   private:
     //! Handle for StubRawTime

--- a/Os/Stub/RawTime.hpp
+++ b/Os/Stub/RawTime.hpp
@@ -64,7 +64,8 @@ class StubRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to serialize the contents into.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer,
+                                    Fw::Endianness mode = Fw::Endianness::BIG) const override;
 
     //! \brief Deserialize the contents of the RawTimeInterface object from a buffer.
     //!
@@ -78,7 +79,8 @@ class StubRawTime : public RawTimeInterface {
     //!
     //! \param buffer The buffer to deserialize the contents from.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer,
+                                        Fw::Endianness mode = Fw::Endianness::BIG) override;
 
   private:
     //! Handle for StubRawTime

--- a/Os/Stub/test/RawTime.cpp
+++ b/Os/Stub/test/RawTime.cpp
@@ -38,12 +38,12 @@ TestRawTime::Status TestRawTime::getTimeInterval(const Os::RawTime& other, Fw::T
     return Status::OP_OK;
 }
 
-Fw::SerializeStatus TestRawTime::serializeTo(Fw::SerializeBufferBase& buffer) const {
+Fw::SerializeStatus TestRawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
     StaticData::data.lastCalled = StaticData::LastFn::SERIALIZE_FN;
     return Fw::FW_SERIALIZE_OK;
 }
 
-Fw::SerializeStatus TestRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer) {
+Fw::SerializeStatus TestRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
     StaticData::data.lastCalled = StaticData::LastFn::DESERIALIZE_FN;
     return Fw::FW_SERIALIZE_OK;
 }

--- a/Os/Stub/test/RawTime.cpp
+++ b/Os/Stub/test/RawTime.cpp
@@ -38,12 +38,12 @@ TestRawTime::Status TestRawTime::getTimeInterval(const Os::RawTime& other, Fw::T
     return Status::OP_OK;
 }
 
-Fw::SerializeStatus TestRawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) const {
+Fw::SerializeStatus TestRawTime::serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode) const {
     StaticData::data.lastCalled = StaticData::LastFn::SERIALIZE_FN;
     return Fw::FW_SERIALIZE_OK;
 }
 
-Fw::SerializeStatus TestRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode) {
+Fw::SerializeStatus TestRawTime::deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode) {
     StaticData::data.lastCalled = StaticData::LastFn::DESERIALIZE_FN;
     return Fw::FW_SERIALIZE_OK;
 }

--- a/Os/Stub/test/RawTime.hpp
+++ b/Os/Stub/test/RawTime.hpp
@@ -67,8 +67,8 @@ class TestRawTime : public RawTimeInterface {
     // ------------------------------------------------------------
     Status now() override;
     Status getTimeInterval(const Os::RawTime& other, Fw::TimeInterval& interval) const override;
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
 
   private:
     //! Handle for TestRawTime

--- a/Os/Stub/test/RawTime.hpp
+++ b/Os/Stub/test/RawTime.hpp
@@ -67,8 +67,8 @@ class TestRawTime : public RawTimeInterface {
     // ------------------------------------------------------------
     Status now() override;
     Status getTimeInterval(const Os::RawTime& other, Fw::TimeInterval& interval) const override;
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer) const override;
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer) override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
 
   private:
     //! Handle for TestRawTime

--- a/Os/Stub/test/RawTime.hpp
+++ b/Os/Stub/test/RawTime.hpp
@@ -67,8 +67,10 @@ class TestRawTime : public RawTimeInterface {
     // ------------------------------------------------------------
     Status now() override;
     Status getTimeInterval(const Os::RawTime& other, Fw::TimeInterval& interval) const override;
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override;
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer,
+                                    Fw::Endianness mode = Fw::Endianness::BIG) const override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer,
+                                        Fw::Endianness mode = Fw::Endianness::BIG) override;
 
   private:
     //! Handle for TestRawTime

--- a/Os/Stub/test/RawTime.hpp
+++ b/Os/Stub/test/RawTime.hpp
@@ -67,8 +67,8 @@ class TestRawTime : public RawTimeInterface {
     // ------------------------------------------------------------
     Status now() override;
     Status getTimeInterval(const Os::RawTime& other, Fw::TimeInterval& interval) const override;
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override;
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override;
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override;
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override;
 
   private:
     //! Handle for TestRawTime

--- a/Svc/OsTime/test/RawTimeTester/RawTimeTester.hpp
+++ b/Svc/OsTime/test/RawTimeTester/RawTimeTester.hpp
@@ -48,12 +48,12 @@ class RawTimeTester : public Os::RawTimeInterface {
         return OP_OK;
     }
 
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer) const override {
-        return buffer.serializeFrom(m_handle.t);
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override {
+        return buffer.serializeFrom(m_handle.t, mode);
     }
 
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer) override {
-        return buffer.deserializeTo(m_handle.t);
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override {
+        return buffer.deserializeTo(m_handle.t, mode);
     }
 
     static void setNowTime(const Fw::Time&& t) { s_now_time = t; }

--- a/Svc/OsTime/test/RawTimeTester/RawTimeTester.hpp
+++ b/Svc/OsTime/test/RawTimeTester/RawTimeTester.hpp
@@ -48,11 +48,13 @@ class RawTimeTester : public Os::RawTimeInterface {
         return OP_OK;
     }
 
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override {
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer,
+                                    Fw::Endianness mode = Fw::Endianness::BIG) const override {
         return buffer.serializeFrom(m_handle.t, mode);
     }
 
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override {
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer,
+                                        Fw::Endianness mode = Fw::Endianness::BIG) override {
         return buffer.deserializeTo(m_handle.t, mode);
     }
 

--- a/Svc/OsTime/test/RawTimeTester/RawTimeTester.hpp
+++ b/Svc/OsTime/test/RawTimeTester/RawTimeTester.hpp
@@ -48,11 +48,11 @@ class RawTimeTester : public Os::RawTimeInterface {
         return OP_OK;
     }
 
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override {
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) const override {
         return buffer.serializeFrom(m_handle.t, mode);
     }
 
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override {
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Endianness::BIG) override {
         return buffer.deserializeTo(m_handle.t, mode);
     }
 

--- a/Svc/OsTime/test/RawTimeTester/RawTimeTester.hpp
+++ b/Svc/OsTime/test/RawTimeTester/RawTimeTester.hpp
@@ -48,11 +48,11 @@ class RawTimeTester : public Os::RawTimeInterface {
         return OP_OK;
     }
 
-    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) const override {
+    Fw::SerializeStatus serializeTo(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) const override {
         return buffer.serializeFrom(m_handle.t, mode);
     }
 
-    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Serialization::Endianness mode = Fw::Serialization::BIG) override {
+    Fw::SerializeStatus deserializeFrom(Fw::SerializeBufferBase& buffer, Fw::Endianness mode = Fw::Serialization::BIG) override {
         return buffer.deserializeTo(m_handle.t, mode);
     }
 

--- a/docs/user-manual/framework/dynamic-memory.md
+++ b/docs/user-manual/framework/dynamic-memory.md
@@ -72,10 +72,16 @@ object which you can then call `.serializeFrom()` or `.deserializeTo()` on.
 ```c++
 U32 my_value = 123;
 Fw::Buffer my_buffer = ...;
+// Defaults to big-endian
 my_buffer.getSerializer().serializeFrom(mv_value);
+// Or for little-endian
+my_buffer.getSerializer().serializeFrom(mv_value, Fw::Serialization::LITTLE);
 
 U32 my_value_again = 0;
+// Defaults to big-endian
 my_buffer.getDeserializer().deserializeTo(mv_value_again);
+// Or for little-endian
+my_buffer.getDeserializer().deserializeTo(mv_value_again, Fw::Serialization::LITTLE);
 ```
 > [!NOTE]
 > To use this method types must inherit from `Fw::Serializable` or be basic types.

--- a/docs/user-manual/framework/dynamic-memory.md
+++ b/docs/user-manual/framework/dynamic-memory.md
@@ -75,13 +75,13 @@ Fw::Buffer my_buffer = ...;
 // Defaults to big-endian
 my_buffer.getSerializer().serializeFrom(mv_value);
 // Or for little-endian
-my_buffer.getSerializer().serializeFrom(mv_value, Fw::Serialization::LITTLE);
+my_buffer.getSerializer().serializeFrom(mv_value, Fw::Endianness::LITTLE);
 
 U32 my_value_again = 0;
 // Defaults to big-endian
 my_buffer.getDeserializer().deserializeTo(mv_value_again);
 // Or for little-endian
-my_buffer.getDeserializer().deserializeTo(mv_value_again, Fw::Serialization::LITTLE);
+my_buffer.getDeserializer().deserializeTo(mv_value_again, Fw::Endianness::LITTLE);
 ```
 > [!NOTE]
 > To use this method types must inherit from `Fw::Serializable` or be basic types.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Flask-Compress==1.15
 Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.3
 fprime-fpl-write-pic==1.0.3
-fprime-fpp==3.1.0a3-6-gad5acea80
+fprime-fpp==3.1.0a4
 fprime-gds==4.0.2a7
 fprime-tools==4.0.2a1
 fprime-visual==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Flask-Compress==1.15
 Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.3
 fprime-fpl-write-pic==1.0.3
-fprime-fpp==v3.1.0a3-2-gb5e4c7b23
+fprime-fpp==v3.1.0a3-4-g877d2eb7a
 fprime-gds==4.0.2a7
 fprime-tools==4.0.2a1
 fprime-visual==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Flask-Compress==1.15
 Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.3
 fprime-fpl-write-pic==1.0.3
-fprime-fpp==3.1.0a3
+fprime-fpp==v3.1.0a2-7-g1c284ccee
 fprime-gds==4.0.2a7
 fprime-tools==4.0.2a1
 fprime-visual==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Flask-Compress==1.15
 Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.3
 fprime-fpl-write-pic==1.0.3
-fprime-fpp==v3.1.0a3-4-g877d2eb7a
+fprime-fpp==3.1.0a3-6-gad5acea80
 fprime-gds==4.0.2a7
 fprime-tools==4.0.2a1
 fprime-visual==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Flask-Compress==1.15
 Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.3
 fprime-fpl-write-pic==1.0.3
-fprime-fpp==v3.1.0a2-7-g1c284ccee
+fprime-fpp==v3.1.0a3-2-gb5e4c7b23
 fprime-gds==4.0.2a7
 fprime-tools==4.0.2a1
 fprime-visual==1.0.2


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/4182 |
|**_Has Unit Tests (y/n)_**|  y |
|**_Documentation Included (y/n)_**| y  |
|**_Generative AI was used in this contribution (y/n)_**| n  |

---
## Change Description

Adds Little Endian serialization of fpp data types

## Rationale

Autocoded serialization of complex fpp data types enables easy interfacing w/ external byte level streams/packets. Unfortunately some devices require little endian serialization, making fpp serialization not useful for these applications without these modification.

## Testing/Review Recommendations

* Verify that all types with little-endian switched behavior make sense (mostly the swap on pointer types)
* Ensure calling of Unsigned Ser/Des functions from Signed Ser/Des functions agrees with library guarantees (I believe my implementation is closer to the verbiage in rule 1b of the Serialization of FPP Values section of the Writing-C-Plus-Plus-Implementations page of the User Guide).

Requires my accompanying PR against FPP
https://github.com/nasa/fpp/pull/842