### PR TITLE
NonASCII characters removed

### DIFF
--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -118,7 +118,7 @@ extern "C" {
 //   1. FW_NO_ASSERT: assertions are compiled out, side effects are kept
 //   2. FW_FILEID_ASSERT: asserts report a file CRC and line number
 //   3. FW_FILENAME_ASSERT: asserts report a file path (__FILE__) and line number
-//   4. FW_RELATIVE_PATH_ASSERT: asserts report a relative path within F´ or F´ library and line number
+//   4. FW_RELATIVE_PATH_ASSERT: asserts report a relative path within F' or F' library and line number
 //
 // Note: users who want alternate asserts should set assert level to FW_NO_ASSERT and define FW_ASSERT in this header
 #ifndef FW_ASSERT_LEVEL


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| 4297 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Converted non-ASCII prime symbol (or smart-quote?) to an ASCII single-quote in a comment.

## Rationale

Non-ASCII characters are allowed in C++11, but confuse the SonarQube static analysis tool.

## Testing/Review Recommendations

No testing for a change in a comment.
@kevin-f-ortega @LeStarch @thomas-bc

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
