### PR TITLE
Mark SwAssert declarations as noinline

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -434,6 +434,7 @@ ncsl
 newtio
 nmsgs
 NOBLOCK
+noinline
 NOLINT
 NOLINTNEXTLINE
 noparent

--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -63,19 +63,36 @@
 #endif
 #endif
 
+#ifndef NOINLINE
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+#if __has_attribute(noinline)
+#define NOINLINE __attribute__((noinline))
+#else
+#define NOINLINE
+#endif
+#endif
+
 namespace Fw {
 //! Assert with no arguments
-I8 SwAssert(FILE_NAME_ARG file, FwSizeType lineNo) CLANG_ANALYZER_NORETURN;
+I8 SwAssert(FILE_NAME_ARG file, FwSizeType lineNo) NOINLINE CLANG_ANALYZER_NORETURN;
 
 //! Assert with one argument
-I8 SwAssert(FILE_NAME_ARG file, FwAssertArgType arg1, FwSizeType lineNo) CLANG_ANALYZER_NORETURN;
+I8 SwAssert(FILE_NAME_ARG file, FwAssertArgType arg1, FwSizeType lineNo) NOINLINE CLANG_ANALYZER_NORETURN;
 
 //! Assert with two arguments
-I8 SwAssert(FILE_NAME_ARG file, FwAssertArgType arg1, FwAssertArgType arg2, FwSizeType lineNo) CLANG_ANALYZER_NORETURN;
+I8 SwAssert(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwSizeType lineNo) NOINLINE CLANG_ANALYZER_NORETURN;
 
 //! Assert with three arguments
-I8 SwAssert(FILE_NAME_ARG file, FwAssertArgType arg1, FwAssertArgType arg2, FwAssertArgType arg3, FwSizeType lineNo)
-    CLANG_ANALYZER_NORETURN;
+I8 SwAssert(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwSizeType lineNo) NOINLINE CLANG_ANALYZER_NORETURN;
 
 //! Assert with four arguments
 I8 SwAssert(FILE_NAME_ARG file,
@@ -83,7 +100,7 @@ I8 SwAssert(FILE_NAME_ARG file,
             FwAssertArgType arg2,
             FwAssertArgType arg3,
             FwAssertArgType arg4,
-            FwSizeType lineNo) CLANG_ANALYZER_NORETURN;
+            FwSizeType lineNo) NOINLINE CLANG_ANALYZER_NORETURN;
 
 //! Assert with five arguments
 I8 SwAssert(FILE_NAME_ARG file,
@@ -92,7 +109,7 @@ I8 SwAssert(FILE_NAME_ARG file,
             FwAssertArgType arg3,
             FwAssertArgType arg4,
             FwAssertArgType arg5,
-            FwSizeType lineNo) CLANG_ANALYZER_NORETURN;
+            FwSizeType lineNo) NOINLINE CLANG_ANALYZER_NORETURN;
 
 //! Assert with six arguments
 I8 SwAssert(FILE_NAME_ARG file,
@@ -102,7 +119,7 @@ I8 SwAssert(FILE_NAME_ARG file,
             FwAssertArgType arg4,
             FwAssertArgType arg5,
             FwAssertArgType arg6,
-            FwSizeType lineNo) CLANG_ANALYZER_NORETURN;
+            FwSizeType lineNo) NOINLINE CLANG_ANALYZER_NORETURN;
 }  // namespace Fw
 
 // Base class for declaring an assert hook

--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -63,6 +63,9 @@
 #endif
 #endif
 
+// Define NOINLINE as __attribute__((noinline)) if that attribute is available.
+// Marking assertion functions as NOINLINE can reduce code size without sacrificing performance
+// in the common case that the function is not called.
 #ifndef NOINLINE
 #ifndef __has_attribute
 #define __has_attribute(x) 0


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Mark `SwAssert` functions with `__attribute__((noinline))` where available.

## Rationale

Without this change, a compiler using LTO may inline the zeros that are inserted as additional parameters for the call to defaultSwAssert. This increases code size to optimize for the off-nominal condition where an assertion is tripped.

In my testing, this single change reduces my largest deployment's code size by 11%.

## Testing/Review Recommendations

I only tested this on a clang compiler where the noinline attribute was available. It may be worth testing on other compilers.

## Future Work

None.