### PR TITLE
Add alignment to memory allocator

### DIFF
--- a/Fw/Types/MallocAllocator.cpp
+++ b/Fw/Types/MallocAllocator.cpp
@@ -7,13 +7,16 @@
  * ALL RIGHTS RESERVED.  United States Government Sponsorship
  * acknowledged.
  */
-#include <Fw/Types/MallocAllocator.hpp>
 #include <Fw/Types/Assert.hpp>
+#include <Fw/Types/MallocAllocator.hpp>
 #include <cstdlib>
 
 namespace Fw {
 
-void* MallocAllocator::allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable, FwSizeType alignment) {
+void* MallocAllocator::allocate(const FwEnumStoreType identifier,
+                                FwSizeType& size,
+                                bool& recoverable,
+                                FwSizeType alignment) {
     // don't use identifier
     // heap memory is never recoverable
     recoverable = false;

--- a/Fw/Types/MallocAllocator.cpp
+++ b/Fw/Types/MallocAllocator.cpp
@@ -1,5 +1,4 @@
 /**
- * \file
  * \author T. Canham
  * \brief Implementation of malloc based allocator
  *
@@ -7,22 +6,18 @@
  * Copyright 2009-2016, by the California Institute of Technology.
  * ALL RIGHTS RESERVED.  United States Government Sponsorship
  * acknowledged.
- *
  */
-
 #include <Fw/Types/MallocAllocator.hpp>
+#include <Fw/Types/Assert.hpp>
 #include <cstdlib>
 
 namespace Fw {
 
-MallocAllocator::MallocAllocator() {}
-
-MallocAllocator::~MallocAllocator() {}
-
-void* MallocAllocator::allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable) {
+void* MallocAllocator::allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable, FwSizeType alignment) {
     // don't use identifier
     // heap memory is never recoverable
     recoverable = false;
+    FW_ASSERT(size < std::numeric_limits<size_t>::max());
     void* mem = ::malloc(static_cast<size_t>(size));
     if (nullptr == mem) {
         size = 0;  // set to zero if can't get memory
@@ -33,5 +28,4 @@ void* MallocAllocator::allocate(const FwEnumStoreType identifier, FwSizeType& si
 void MallocAllocator::deallocate(const FwEnumStoreType identifier, void* ptr) {
     ::free(ptr);
 }
-
 } /* namespace Fw */

--- a/Fw/Types/MallocAllocator.hpp
+++ b/Fw/Types/MallocAllocator.hpp
@@ -37,7 +37,10 @@ class MallocAllocator : public MemAllocator {
     //! \param recoverable - flag to indicate the memory could be recoverable (always set to false)
     //! \param alignment - alignment requirement for the allocation. Default: maximum alignment defined by C++.
     //! \return the pointer to memory. Zero if unable to allocate.
-    void* allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable, FwSizeType alignment=alignof(std::max_align_t)) override;
+    void* allocate(const FwEnumStoreType identifier,
+                   FwSizeType& size,
+                   bool& recoverable,
+                   FwSizeType alignment = alignof(std::max_align_t)) override;
     //! Deallocate memory
     //!
     //! Deallocate memory previously allocated by allocate() using free(). The identifier is unused but should still

--- a/Fw/Types/MallocAllocator.hpp
+++ b/Fw/Types/MallocAllocator.hpp
@@ -17,33 +17,35 @@
 
 namespace Fw {
 
-/*!
- *
- * This class is an implementation of the MemAllocator base class.
- * It uses the heap as the memory source.
- *
- * Since it is heap space, the identifier is unused, and memory is never recoverable.
- *
- */
-
+//! \brief malloc based memory allocator
+//!
+//! This class implements a memory allocator that uses malloc/free to allocate memory and deallocate memory. malloc()
+//! guarantees alignment for any type and thus does this allocator. It will not respect smaller alignments.
+//!
+//! Since this directs to heap space, the identifier is unused and memory is never recoverable.
 class MallocAllocator : public MemAllocator {
   public:
-    MallocAllocator();
-    virtual ~MallocAllocator();
+    MallocAllocator() = default;
+    virtual ~MallocAllocator() = default;
+
     //! Allocate memory
-    /*!
-     * \param identifier the memory segment identifier (not used)
-     * \param size the requested size (not changed)
-     * \param recoverable - flag to indicate the memory could be recoverable (always set to false)
-     * \return the pointer to memory. Zero if unable to allocate.
-     */
-    void* allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable);
+    //!
+    //! Allocate memory using malloc(). The identifier is unused and memory is never recoverable.
+    //!
+    //! \param identifier the memory segment identifier (not used)
+    //! \param size the requested size (not changed)
+    //! \param recoverable - flag to indicate the memory could be recoverable (always set to false)
+    //! \param alignment - alignment requirement for the allocation. Default: maximum alignment defined by C++.
+    //! \return the pointer to memory. Zero if unable to allocate.
+    void* allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable, FwSizeType alignment=alignof(std::max_align_t)) override;
     //! Deallocate memory
-    /*!
-     * \param identifier the memory segment identifier (not used)
-     * \param ptr the pointer to memory returned by allocate()
-     */
-    void deallocate(const FwEnumStoreType identifier, void* ptr);
+    //!
+    //! Deallocate memory previously allocated by allocate() using free(). The identifier is unused but should still
+    //! match the original call.
+    //!
+    //! \param identifier the memory segment identifier (not used)
+    //! \param ptr the pointer to memory returned by allocate()
+    void deallocate(const FwEnumStoreType identifier, void* ptr) override;
 };
 
 } /* namespace Fw */

--- a/Fw/Types/MallocAllocator.hpp
+++ b/Fw/Types/MallocAllocator.hpp
@@ -31,6 +31,7 @@ class MallocAllocator : public MemAllocator {
     //! Allocate memory
     //!
     //! Allocate memory using malloc(). The identifier is unused and memory is never recoverable.
+    //! malloc() guarantees alignment for any type and so does this allocator. It will not respect smaller alignments.
     //!
     //! \param identifier the memory segment identifier (not used)
     //! \param size the requested size (not changed)

--- a/Fw/Types/MemAllocator.cpp
+++ b/Fw/Types/MemAllocator.cpp
@@ -4,24 +4,24 @@
  * ALL RIGHTS RESERVED.  United States Government Sponsorship
  * acknowledged.
  */
-#include <Fw/Types/MemAllocator.hpp>
 #include <Fw/Types/Assert.hpp>
+#include <Fw/Types/MemAllocator.hpp>
 
 namespace Fw {
 
-MemAllocatorRegistry* MemAllocatorRegistry::s_registry = nullptr; //!< singleton registry
+MemAllocatorRegistry* MemAllocatorRegistry::s_registry = nullptr;  //!< singleton registry
 
 MemAllocator::MemAllocator() {}
 
 MemAllocator::~MemAllocator() {}
-
 
 MemAllocatorRegistry::MemAllocatorRegistry() {
     // Register self as the singleton
     MemAllocatorRegistry::s_registry = this;
 }
 
-void MemAllocatorRegistry::registerAllocator(const MemoryAllocation::MemoryAllocatorType type, MemAllocator& allocator) {
+void MemAllocatorRegistry::registerAllocator(const MemoryAllocation::MemoryAllocatorType type,
+                                             MemAllocator& allocator) {
     this->m_allocators[type] = &allocator;
 }
 

--- a/Fw/Types/MemAllocator.cpp
+++ b/Fw/Types/MemAllocator.cpp
@@ -21,8 +21,7 @@ MemAllocatorRegistry::MemAllocatorRegistry() {
     MemAllocatorRegistry::s_registry = this;
 }
 
-void MemAllocatorRegistry::registerAllocator(const MemoryAllocation::MemoryAllocatorType::T type, MemAllocator& allocator) {
-    FW_ASSERT(type.e < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
+void MemAllocatorRegistry::registerAllocator(const MemoryAllocation::MemoryAllocatorType type, MemAllocator& allocator) {
     this->m_allocators[type] = &allocator;
 }
 
@@ -31,14 +30,12 @@ MemAllocatorRegistry& MemAllocatorRegistry::getInstance() {
     return *s_registry;
 }
 
-MemAllocator& MemAllocatorRegistry::getAllocator(const MemoryAllocation::MemoryAllocatorType::T type) {
-    FW_ASSERT(type.e < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
+MemAllocator& MemAllocatorRegistry::getAllocator(const MemoryAllocation::MemoryAllocatorType type) {
     FW_ASSERT(this->m_allocators[type] != nullptr, static_cast<FwAssertArgType>(type));
     return *this->m_allocators[type];
 }
 
-MemAllocator& MemAllocatorRegistry::getAnAllocator(const MemoryAllocation::MemoryAllocatorType::T type) {
-    FW_ASSERT(type.e < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
+MemAllocator& MemAllocatorRegistry::getAnAllocator(const MemoryAllocation::MemoryAllocatorType type) {
     // If the allocator is not registered, return the SYSTEM allocator
     if (this->m_allocators[type] == nullptr) {
         return this->getAllocator(MemoryAllocation::MemoryAllocatorType::SYSTEM);

--- a/Fw/Types/MemAllocator.cpp
+++ b/Fw/Types/MemAllocator.cpp
@@ -9,6 +9,8 @@
 
 namespace Fw {
 
+MemAllocatorRegistry* MemAllocatorRegistry::s_registry = nullptr; //!< singleton registry
+
 MemAllocator::MemAllocator() {}
 
 MemAllocator::~MemAllocator() {}

--- a/Fw/Types/MemAllocator.cpp
+++ b/Fw/Types/MemAllocator.cpp
@@ -22,7 +22,7 @@ MemAllocatorRegistry::MemAllocatorRegistry() {
 }
 
 void MemAllocatorRegistry::registerAllocator(const MemoryAllocation::MemoryAllocatorType::T type, MemAllocator& allocator) {
-    FW_ASSERT(type < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
+    FW_ASSERT(type.e < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
     this->m_allocators[type] = &allocator;
 }
 
@@ -32,13 +32,13 @@ MemAllocatorRegistry& MemAllocatorRegistry::getInstance() {
 }
 
 MemAllocator& MemAllocatorRegistry::getAllocator(const MemoryAllocation::MemoryAllocatorType::T type) {
-    FW_ASSERT(type < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
+    FW_ASSERT(type.e < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
     FW_ASSERT(this->m_allocators[type] != nullptr, static_cast<FwAssertArgType>(type));
     return *this->m_allocators[type];
 }
 
 MemAllocator& MemAllocatorRegistry::getAnAllocator(const MemoryAllocation::MemoryAllocatorType::T type) {
-    FW_ASSERT(type < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
+    FW_ASSERT(type.e < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
     // If the allocator is not registered, return the SYSTEM allocator
     if (this->m_allocators[type] == nullptr) {
         return this->getAllocator(MemoryAllocation::MemoryAllocatorType::SYSTEM);

--- a/Fw/Types/MemAllocator.cpp
+++ b/Fw/Types/MemAllocator.cpp
@@ -1,16 +1,11 @@
 /**
- * \file
- * \author
- * \brief
- *
  * \copyright
  * Copyright 2009-2016, by the California Institute of Technology.
  * ALL RIGHTS RESERVED.  United States Government Sponsorship
  * acknowledged.
- *
  */
-
 #include <Fw/Types/MemAllocator.hpp>
+#include <Fw/Types/Assert.hpp>
 
 namespace Fw {
 
@@ -18,4 +13,34 @@ MemAllocator::MemAllocator() {}
 
 MemAllocator::~MemAllocator() {}
 
+
+MemAllocatorRegistry::MemAllocatorRegistry() {
+    // Register self as the singleton
+    MemAllocatorRegistry::s_registry = this;
+}
+
+void MemAllocatorRegistry::registerAllocator(const MemoryAllocation::MemoryAllocatorType::T type, MemAllocator& allocator) {
+    FW_ASSERT(type < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
+    this->m_allocators[type] = &allocator;
+}
+
+MemAllocatorRegistry& MemAllocatorRegistry::getInstance() {
+    FW_ASSERT(s_registry != nullptr);
+    return *s_registry;
+}
+
+MemAllocator& MemAllocatorRegistry::getAllocator(const MemoryAllocation::MemoryAllocatorType::T type) {
+    FW_ASSERT(type < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
+    FW_ASSERT(this->m_allocators[type] != nullptr, static_cast<FwAssertArgType>(type));
+    return *this->m_allocators[type];
+}
+
+MemAllocator& MemAllocatorRegistry::getAnAllocator(const MemoryAllocation::MemoryAllocatorType::T type) {
+    FW_ASSERT(type < MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS, static_cast<FwAssertArgType>(type));
+    // If the allocator is not registered, return the SYSTEM allocator
+    if (this->m_allocators[type] == nullptr) {
+        return this->getAllocator(MemoryAllocation::MemoryAllocatorType::SYSTEM);
+    }
+    return *this->m_allocators[type];
+}
 } /* namespace Fw */

--- a/Fw/Types/MemAllocator.hpp
+++ b/Fw/Types/MemAllocator.hpp
@@ -100,7 +100,7 @@ class MemAllocatorRegistry {
     //!
     //! \param type the type of allocator
     //! \param allocator the allocator. The registry does not take ownership of the allocator.
-    void registerAllocator(const MemoryAllocation::MemoryAllocatorType::T type, MemAllocator& allocator);
+    void registerAllocator(const MemoryAllocation::MemoryAllocatorType type, MemAllocator& allocator);
 
     //! Get an allocator for a type
     //!
@@ -108,7 +108,7 @@ class MemAllocatorRegistry {
     //! been registered.
     //!
     //! \param type the type of allocator
-    MemAllocator& getAllocator(const MemoryAllocation::MemoryAllocatorType::T type);
+    MemAllocator& getAllocator(const MemoryAllocation::MemoryAllocatorType type);
 
     //! Get an allocator for a type with default
     //!
@@ -116,7 +116,7 @@ class MemAllocatorRegistry {
     //! registered to MemoryAllocatorType::SYSTEM. It is an error if SYSTEM has not been registered.
     //!
     //! \param type the type of allocator
-    MemAllocator& getAnAllocator(const MemoryAllocation::MemoryAllocatorType::T type);
+    MemAllocator& getAnAllocator(const MemoryAllocation::MemoryAllocatorType type);
   private:
     //! Array of allocators for each type defaulted to nullptr
     MemAllocator* m_allocators[MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS] = {nullptr};

--- a/Fw/Types/MemAllocator.hpp
+++ b/Fw/Types/MemAllocator.hpp
@@ -20,7 +20,6 @@
 #include <config/MemoryAllocatorTypeEnumAc.hpp>
 #include <cstddef>
 
-
 namespace Fw {
 
 //! \brief Memory Allocation base class
@@ -61,7 +60,10 @@ class MemAllocator {
     //! \param recoverable - flag to indicate the memory could be recoverable
     //! \param alignment - alignment requirement for the allocation. Default: maximum alignment defined by C++.
     //! \return the pointer to memory. Zero if unable to allocate
-    virtual void* allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable, FwSizeType alignment=alignof(std::max_align_t)) = 0;
+    virtual void* allocate(const FwEnumStoreType identifier,
+                           FwSizeType& size,
+                           bool& recoverable,
+                           FwSizeType alignment = alignof(std::max_align_t)) = 0;
 
     //! Deallocate memory
     //!
@@ -117,12 +119,13 @@ class MemAllocatorRegistry {
     //!
     //! \param type the type of allocator
     MemAllocator& getAnAllocator(const MemoryAllocation::MemoryAllocatorType type);
+
   private:
     //! Array of allocators for each type defaulted to nullptr
     MemAllocator* m_allocators[MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS] = {nullptr};
 
     //! The singleton registry pointer
-    static MemAllocatorRegistry* s_registry; //!< singleton registry
+    static MemAllocatorRegistry* s_registry;  //!< singleton registry
 };
 } /* namespace Fw */
 

--- a/Fw/Types/MemAllocator.hpp
+++ b/Fw/Types/MemAllocator.hpp
@@ -35,7 +35,7 @@ namespace Fw {
 //! \warning implementors providing derived classes that tie an identifier to a specific memory segment should use
 //! bump pointer or other implementation to handle multiple calls to allocate() with the same identifier.
 //!
-//! \warning alignment must be respected in allocation calls, but may be larger than than requested.
+//! \warning alignment must be respected in allocation calls, but may be larger than requested.
 //!
 //! The size is the requested size of the memory. If the allocator cannot return the requested amount, it should return
 //! the actual amount and users should check.

--- a/Fw/Types/MemAllocator.hpp
+++ b/Fw/Types/MemAllocator.hpp
@@ -17,47 +17,59 @@
 #define TYPES_MEMALLOCATOR_HPP_
 
 #include <Fw/FPrimeBasicTypes.hpp>
+#include <config/MemoryAllocatorTypeEnumAc.hpp>
+#include <cstddef>
 
-/*!
- *
- * This class is a pure virtual base class for memory allocators in Fprime.
- * The intent is to provide derived classes the get memory from different sources.
- * The base class can be passed to classes so the allocator can be selected at the
- * system level, and different allocators can be used by different components as
- * appropriate.
- *
- * The identifier can be used to look up a pre-allocated buffer by ID in an
- * embedded system. Identifiers may be used only in a single call to an invocation.
- * Some implementations of MemAllocator discard the identifier but components using
- * the MemAllocator interface should not depend on the identifier to be discarded.
- *
- * The size is the requested size of the memory. If the allocator cannot return the
- * requested amount, it should return the actual amount and users should check.
- *
- * The recoverable flag is intended to be used in embedded environments where
- * memory can survive a processor reset and data can be recovered. The component
- * using the allocator can then use the data. Any integrity checks are up to the
- * user of the memory.
- *
- */
 
 namespace Fw {
 
+//! \brief Memory Allocation base class
+//!
+//! This class is a pure virtual base class for memory allocators in F Prime. The intent is to provide derived classes
+//! that allocate memory from different sources. The base class can be passed to classes so the allocator can be
+//! selected at the system level, and different allocators can be used by different components as appropriate.
+//!
+//! The identifier can be used to look up a pre-allocated buffer by ID in an embedded system. There is no guarantee
+//! that an identifier is unique across multiple calls to allocate(). It is intended to be unique to a given entity.
+//!
+//! \warning implementors providing derived classes that tie an identifier to a specific memory segment should use
+//! bump pointer or other implementation to handle multiple calls to allocate() with the same identifier.
+//!
+//! \warning alignment must be respected in allocation calls, but may be larger than than requested.
+//!
+//! The size is the requested size of the memory. If the allocator cannot return the requested amount, it should return
+//! the actual amount and users should check.
+//!
+//! The recoverable flag is intended to be used in embedded environments where memory can survive a processor reset and
+//! data can be recovered. The component using the allocator can then use the data. Any integrity checks are up to the
+//! user of the memory.
+//!
 class MemAllocator {
   public:
     //! Allocate memory
-    /*!
-     * \param identifier the memory segment identifier, each identifier is to be used in once single allocation
-     * \param size the requested size - changed to actual if different
-     * \param recoverable - flag to indicate the memory could be recoverable
-     * \return the pointer to memory. Zero if unable to allocate
-     */
-    virtual void* allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable) = 0;
+    //!
+    //! Allows allocation of memory of a given size and alignment. The actual returned memory size may be smaller than
+    //! the requested size. The alignment of the memory is guaranteed to be at least as large as the requested
+    //! alignment but may be larger. The recoverable flag indicates if the memory is recoverable (i.e. non-volatile)
+    //! and thus may be valid without initialization.
+    //!
+    //! identifier is a unique identifier for the allocating entity. This entity (e.g. a component) may call allocate
+    //! multiple times with the same id, but no other entity in the system shall call allocate with that id.
+    //!
+    //! \param identifier the memory segment identifier, each identifier is to be used in once single allocation
+    //! \param size the requested size - changed to actual if different
+    //! \param recoverable - flag to indicate the memory could be recoverable
+    //! \param alignment - alignment requirement for the allocation. Default: maximum alignment defined by C++.
+    //! \return the pointer to memory. Zero if unable to allocate
+    virtual void* allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable, FwSizeType alignment=alignof(std::max_align_t)) = 0;
+
     //! Deallocate memory
-    /*!
-     * \param identifier the memory segment identifier, each identifier is to be used in once single allocation
-     * \param ptr the pointer to memory returned by allocate()
-     */
+    //!
+    //! Deallocate memory previously allocated by allocate(). The pointer must be one returned by allocate() and the
+    //! identifier must match the one used in the original allocate() call.
+    //!
+    //! \param identifier the memory segment identifier, each identifier is to be used in once single allocation
+    //! \param ptr the pointer to memory returned by allocate()
     virtual void deallocate(const FwEnumStoreType identifier, void* ptr) = 0;
 
   protected:
@@ -69,6 +81,49 @@ class MemAllocator {
     MemAllocator(MemAllocator*);  //!< disable
 };
 
+class MemAllocatorRegistry {
+  public:
+    // Constructor which will register itself as the singleton
+    MemAllocatorRegistry();
+    ~MemAllocatorRegistry() = default;
+
+    //! \brief get the singleton registry
+    //!
+    //! \return the singleton registry
+    static MemAllocatorRegistry& getInstance();
+
+    //! \brief register an allocator for the given type
+    //!
+    //! This will register an allocator for the given type. If the allocator is already registered it will overwrite.
+    //!
+    //! \warning allocator must remain valid for duration of the program.
+    //!
+    //! \param type the type of allocator
+    //! \param allocator the allocator. The registry does not take ownership of the allocator.
+    void registerAllocator(const MemoryAllocation::MemoryAllocatorType::T type, MemAllocator& allocator);
+
+    //! Get an allocator for a type
+    //!
+    //! Return the memory allocator for the given type. It is an error to request an allocator for a type that has not
+    //! been registered.
+    //!
+    //! \param type the type of allocator
+    MemAllocator& getAllocator(const MemoryAllocation::MemoryAllocatorType::T type);
+
+    //! Get an allocator for a type with default
+    //!
+    //! Return the memory allocator for the given type. If the type has not been registered, then return the allocator
+    //! registered to MemoryAllocatorType::SYSTEM. It is an error if SYSTEM has not been registered.
+    //!
+    //! \param type the type of allocator
+    MemAllocator& getAnAllocator(const MemoryAllocation::MemoryAllocatorType::T type);
+  private:
+    //! Array of allocators for each type defaulted to nullptr
+    MemAllocator* m_allocators[MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS] = {nullptr};
+
+    //! The singleton registry pointer
+    static MemAllocatorRegistry* s_registry; //!< singleton registry
+};
 } /* namespace Fw */
 
 #endif /* TYPES_MEMALLOCATOR_HPP_ */

--- a/Fw/Types/MmapAllocator.cpp
+++ b/Fw/Types/MmapAllocator.cpp
@@ -21,7 +21,7 @@ MmapAllocator::MmapAllocator() : m_length(0) {}
 
 MmapAllocator::~MmapAllocator() {}
 
-void* MmapAllocator::allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable) {
+void* MmapAllocator::allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable, FwSizeType alignment) {
     void* addr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     if (addr == MAP_FAILED) {
         size = 0;

--- a/Fw/Types/MmapAllocator.cpp
+++ b/Fw/Types/MmapAllocator.cpp
@@ -21,7 +21,10 @@ MmapAllocator::MmapAllocator() : m_length(0) {}
 
 MmapAllocator::~MmapAllocator() {}
 
-void* MmapAllocator::allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable, FwSizeType alignment) {
+void* MmapAllocator::allocate(const FwEnumStoreType identifier,
+                              FwSizeType& size,
+                              bool& recoverable,
+                              FwSizeType alignment) {
     void* addr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     if (addr == MAP_FAILED) {
         size = 0;

--- a/Fw/Types/MmapAllocator.hpp
+++ b/Fw/Types/MmapAllocator.hpp
@@ -31,12 +31,12 @@ class MmapAllocator : public MemAllocator {
     //! \param identifier: identifier to use with allocation
     //! \param size: size of memory to be allocated
     //! \param recoverable: (output) is this memory recoverable after a reset. Always false for mmap.
-    void* allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable);
+    void* allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable, FwSizeType alignment=alignof(std::max_align_t)) override;
 
     //! Deallocation of memory using the mmap allocator
     //! \param identifier: identifier used at allocation
     //! \param ptr: pointer to memory being deallocated
-    void deallocate(const FwEnumStoreType identifier, void* ptr);
+    void deallocate(const FwEnumStoreType identifier, void* ptr) override;
 
   private:
     FwSizeType m_length;

--- a/Fw/Types/MmapAllocator.hpp
+++ b/Fw/Types/MmapAllocator.hpp
@@ -31,7 +31,10 @@ class MmapAllocator : public MemAllocator {
     //! \param identifier: identifier to use with allocation
     //! \param size: size of memory to be allocated
     //! \param recoverable: (output) is this memory recoverable after a reset. Always false for mmap.
-    void* allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable, FwSizeType alignment=alignof(std::max_align_t)) override;
+    void* allocate(const FwEnumStoreType identifier,
+                   FwSizeType& size,
+                   bool& recoverable,
+                   FwSizeType alignment = alignof(std::max_align_t)) override;
 
     //! Deallocation of memory using the mmap allocator
     //! \param identifier: identifier used at allocation

--- a/Fw/Types/MmapAllocator.hpp
+++ b/Fw/Types/MmapAllocator.hpp
@@ -31,6 +31,8 @@ class MmapAllocator : public MemAllocator {
     //! \param identifier: identifier to use with allocation
     //! \param size: size of memory to be allocated
     //! \param recoverable: (output) is this memory recoverable after a reset. Always false for mmap.
+    //! \param alignment - alignment requirement for the allocation. Default: maximum alignment defined by C++.
+    //! \return the pointer to memory. Zero if unable to allocate
     void* allocate(const FwEnumStoreType identifier,
                    FwSizeType& size,
                    bool& recoverable,

--- a/Svc/BufferManager/test/ut/BufferManagerTester.cpp
+++ b/Svc/BufferManager/test/ut/BufferManagerTester.cpp
@@ -42,7 +42,7 @@ class TestAllocator : public Fw::MemAllocator {
      * \param recoverable - flag to indicate the memory could be recoverable (always set to false)
      * \return the pointer to memory. Zero if unable to allocate.
      */
-    void* allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable) {
+    void* allocate(const FwEnumStoreType identifier, FwSizeType& size, bool& recoverable, FwSizeType alignment) {
         this->m_reqId = identifier;
         this->m_reqSize = size;
         this->m_mem = this->m_alloc.allocate(identifier, size, recoverable);

--- a/default/config/CMakeLists.txt
+++ b/default/config/CMakeLists.txt
@@ -10,6 +10,7 @@ register_fprime_config(
         "${CMAKE_CURRENT_LIST_DIR}/ComCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/FpConfig.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/FpySequencerCfg.fpp"
+        "${CMAKE_CURRENT_LIST_DIR}/MemoryAllocation.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/PolyDbCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/VersionCfg.fpp"
     HEADERS

--- a/default/config/MemoryAllocation.fpp
+++ b/default/config/MemoryAllocation.fpp
@@ -1,0 +1,13 @@
+module Fw {
+module MemoryAllocation {
+    @ Enumeration of the registered memory allocators provided by Fw::MemAllocatorRegistry. This allows system
+    @ designers to enumerate the memory functions in their system and configure the Fw::MemAllocatorRegistry to delegate
+    @ to the appropriate allocator. 
+    enum MemoryAllocatorType {
+        CUSTOM_ALLOCATOR_1 @< SAMPLE: sample allocator subsystem
+        # Below this line are required allocators
+        SYSTEM @< REQUIRED: required for allocation for memory using a standard system allocator (i.e. the default)
+        OS_GENERIC_PRIORITY_QUEUE @< REQUIRED: required for Os::Queue memory allocation when using queues that allocate memory
+    }
+}
+}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| y  |

---
## Change Description

Adds memory alignment to our allocate functions.

## Rationale

Fixes #4318.

## Testing/Review Recommendations

CI for the win.

## Future Work

Replace new/malloc with the MemAllocator pattern.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Some autocomplete.