### PR TITLE
Fix O_SYNC on systems without the definition

### DIFF
--- a/Os/Posix/File.cpp
+++ b/Os/Posix/File.cpp
@@ -29,6 +29,14 @@ namespace File {
 #define USER_FLAGS (0)
 #endif
 
+// O_SYNC is not defined on every system. This will set up the SYNC_FLAGS variable to be O_SYNC when defined and
+// (0) when not defined. This allows OPEN_SYNC_WRITE to fall-back to OPEN_WRITE on those systems.
+#if defined(O_SYNC)
+#define SYNC_FLAGS O_SYNC
+#else
+#define SYNC_FLAGS (0)
+#endif
+
 // Create constants for the max limits of the signed types
 // These constants are used for comparisons with complementary unsigned types to avoid sign-compare warning
 using UnsignedOffT = std::make_unsigned<off_t>::type;
@@ -83,7 +91,7 @@ PosixFile::Status PosixFile::open(const char* filepath,
             mode_flags = O_WRONLY | O_CREAT;
             break;
         case OPEN_SYNC_WRITE:
-            mode_flags = O_WRONLY | O_CREAT | O_SYNC;
+            mode_flags = O_WRONLY | O_CREAT | SYNC_FLAGS;
             break;
         case OPEN_CREATE:
             mode_flags =


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

This change allows systems not defining `O_SYNC` to compile `Os::Posix::File`.  This is done by moving it to a predefined `SYNC_FLAGS` definition.  On systems without the definition, this is set to `(0)` 

## Rationale

`O_SYNC` is not available in all posix implementations.  Completely disabling `OPEN_SYNC` in F Prime would push the error up the stack.  This just reduces the call to a raw open in that case.

## Testing/Review Recommendations

CI

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Autocomplete.