### PR TITLE
Use correct enum size when generating tlm packet structures

### DIFF
--- a/.github/workflows/build-test-rpi.yml
+++ b/.github/workflows/build-test-rpi.yml
@@ -58,6 +58,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         sparse-checkout: 'requirements.txt'
+        sparse-checkout-cone-mode: false
     - name: "Setup environment"
       run: |
         python -m venv venv

--- a/.github/workflows/cookiecutters-test.yml
+++ b/.github/workflows/cookiecutters-test.yml
@@ -26,12 +26,14 @@ jobs:
     uses: ./.github/workflows/reusable-get-pr-branch.yml
     with:
       target_repository: nasa/fprime-tools
+      default_target_ref: v3.6.1
 
   get-bootstrap-branch:
     name: "Get fprime-bootstrap target branch"
     uses: ./.github/workflows/reusable-get-pr-branch.yml
     with:
       target_repository: nasa/fprime-bootstrap
+      default_target_ref: v1.4.0
 
   # -------- Install target versions of the cookiecutter templates and validate -------
   Validate:

--- a/.github/workflows/ext-build-hello-world.yml
+++ b/.github/workflows/ext-build-hello-world.yml
@@ -20,6 +20,7 @@ jobs:
     uses: ./.github/workflows/reusable-get-pr-branch.yml
     with:
       target_repository: fprime-community/fprime-tutorial-hello-world
+      default_target_ref: v3.6.0
 
   run:
     needs: get-branch

--- a/.github/workflows/ext-build-led-blinker.yml
+++ b/.github/workflows/ext-build-led-blinker.yml
@@ -20,6 +20,7 @@ jobs:
     uses: ./.github/workflows/reusable-get-pr-branch.yml
     with:
       target_repository: fprime-community/fprime-workshop-led-blinker
+      default_target_ref: v3.6.0
 
   run:
     needs: get-branch

--- a/.github/workflows/ext-build-math-comp.yml
+++ b/.github/workflows/ext-build-math-comp.yml
@@ -20,6 +20,7 @@ jobs:
     uses: ./.github/workflows/reusable-get-pr-branch.yml
     with:
       target_repository: fprime-community/fprime-tutorial-math-component
+      default_target_ref: v3.6.0
 
   run:
     needs: get-branch

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -24,6 +24,7 @@ jobs:
     uses: ./.github/workflows/reusable-get-pr-branch.yml
     with:
       target_repository: fprime-community/fprime-workshop-led-blinker
+      default_target_ref: v3.6.0
 
   cross-compilation:
     name: "Cross Compilation"
@@ -74,6 +75,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           sparse-checkout: 'requirements.txt'
+          sparse-checkout-cone-mode: false
       - name: "Setup environment"
         run: |
           python -m venv venv

--- a/Autocoders/Python/bin/tlm_packet_gen.py
+++ b/Autocoders/Python/bin/tlm_packet_gen.py
@@ -224,14 +224,11 @@ class TlmPacketParser(object):
                     if self.verbose:
                         print("Processing Channel %s" % channel_name)
                     chan_type = chan.get_type()
-                    # if channel is enum
-                    if type(chan_type) == type(tuple()):
-                        chan_size = 4
                     # if channel type is string
                     #                    elif chan_type == "string":
                     #                        chan_size = int(chan.get_size()) + 2 # FIXME: buffer size storage size magic number - needs to be turned into a constant
                     # if channel is serializable
-                    elif chan_type in self.size_dict:
+                    if chan_type in self.size_dict:
                         chan_size = self.size_dict[chan_type]
                     else:
                         chan_size = self.get_type_size(chan_type, chan.get_size())
@@ -506,10 +503,7 @@ class TlmPacketParser(object):
                 member_comment,
                 _,
             ) in serializable_model.get_members():
-                # if enumeration
-                if type(member_type) == type(tuple()):
-                    type_size = 4  # Fixme: can we put this in a constant somewhere?
-                elif (
+                if (
                     member_type in self.size_dict.keys()
                 ):  # See if it is a registered type
                     type_size = self.size_dict[member_type]
@@ -536,9 +530,9 @@ class TlmPacketParser(object):
             enum_file = search_for_file("Enumeration", enum_file)
             enum_model = XmlEnumParser.XmlEnumParser(enum_file)
             enum_type = enum_model.get_namespace() + "::" + enum_model.get_name()
-            self.add_type_size(
-                enum_type, 4
-            )  # Fixme: can we put this in a constant somewhere?
+            serialize_type = enum_model.get_serialize_type()
+            enum_size = self.get_type_size(serialize_type, None)
+            self.add_type_size(enum_type, enum_size)
 
     def process_array_files(self, array_file_list):
         for array_file in array_file_list:
@@ -552,9 +546,7 @@ class TlmPacketParser(object):
             array_size = int(array_model.get_size())
             elem_type = array_model.get_type()
             elem_type_size = None
-            if type(elem_type) == type(tuple()):
-                elem_type_size = 4  # Fixme: can we put this in a constant somewhere?
-            elif elem_type in self.size_dict.keys():  # See if it is a registered type
+            if elem_type in self.size_dict.keys():  # See if it is a registered type
                 elem_type_size = self.size_dict[elem_type]
             else:
                 elem_type_size = self.get_type_size(elem_type, 1)  # Fixme: strings?


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4261 |
|**_Has Unit Tests (y/n)_**| no new unit tests |
|**_Documentation Included (y/n)_**| no new documentation |
|**_Generative AI was used in this contribution (y/n)_**| no |

---
## Change Description

This PR modifies the `tlm_packet_gen.py` autocoder to pull in the correct size of each enum type when generating `PacketsAc.cpp`.

## Rationale

Prior to this change, the autocoder assumes a hardcoded 4-byte length for each enum channel, even though `TopologyAppDictionary.xml` and `TopologyDictionary.json` files are generated with the proper enum length. This leads to a discrepancy, where a GDS using the above Dictionary files will have a different packet definition than the fprime deployment is using to generate telemetry packets.

This change brings the fprime telemetry packet generation process into consistency with the Dictionary files, at least where enum lengths are concerned.

## Notes

The primary fix is to the `process_enum_files()` function, which is modified to grab the `serialize_type` from the parsed XML via `enum_model`, then evaluate that string (likely 'U8', 'U16', etc) using `get_type_size()`, rather than assuming a hardcoded 4-byte length.

A secondary fix is to remove what I believe to be dead code in other parts of the file. It looks like a past version of the autocoder stored enum types in a tuple rather than a string, so there are 3 instances (processing typical channels, processing structs/serializables, and processing arrays) where the type was being checked against `type(tuple())` and in `True` cases, the type was assumed to be an enum with size of 4 bytes. Since enum types are currently stored as strings, these 3 hardcoded `if` statements never resolve `True`, so their hardcoded values don't really matter. But I've removed them for clarity.

## Testing/Review Recommendations

I've confirmed the following:

- Tested successfully on internal deployment:
  - The enum length disparity is resolved. `fprime-gds` now happily displays packetized 1-byte, 2-byte, and 4-byte enum channels
  - Other tlm channel types work properly:
    - Numeric values (U8, U16, U32, etc)
    - Integer arrays (U8, U16, U32)
    - Enum arrays (U8, U16, U32)
    - Structs/serializables packed with integers, enums (U8, U16, U32), and strings
    - Strings
- Ref deployment compiles, seems to work correctly via fprime-gds, and passes unit tests

## Future Work

There are some other hardcoded and possible out-of-date assumptions in this autocoder script that could be looked at, but it seems the autocoder was rewritten for F Prime 4.0, so there may be no need to improve this script further.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
