### PR TITLE
Adjust task priorities to fit within supported platforms' priority ranges

### DIFF
--- a/Os/Task.hpp
+++ b/Os/Task.hpp
@@ -34,8 +34,18 @@ class TaskHandle {};
 
 class TaskInterface {
   public:
+    //! Sentinel value to use a default value for the task argument to which this is supplied.
+    //!
+    //! Implementations of TaskInterface::start() should make a special case to use some default value that is
+    //! valid for the target platform.
     static constexpr FwSizeType TASK_DEFAULT = std::numeric_limits<FwSizeType>::max();
+
+    //! Sentinel value to use a default priority for the task.
+    //!
+    //! Implementations of TaskInterface::start() should make a special case to use some default task priority
+    //! that is valid for the target platform.
     static constexpr FwTaskPriorityType TASK_PRIORITY_DEFAULT = std::numeric_limits<FwTaskPriorityType>::max();
+
     enum Status {
         OP_OK,             //!< message sent/received okay
         INVALID_HANDLE,    //!< Task handle invalid

--- a/Ref/Top/RefTopology.cpp
+++ b/Ref/Top/RefTopology.cpp
@@ -32,7 +32,7 @@ U32 rateGroup2Context[Svc::ActiveRateGroup::CONNECTION_COUNT_MAX] = {};
 U32 rateGroup3Context[Svc::ActiveRateGroup::CONNECTION_COUNT_MAX] = {};
 
 enum TopologyConstants {
-    COMM_PRIORITY = 100,
+    COMM_PRIORITY = 23,
 };
 
 /**

--- a/Ref/Top/RefTopology.cpp
+++ b/Ref/Top/RefTopology.cpp
@@ -32,7 +32,7 @@ U32 rateGroup2Context[Svc::ActiveRateGroup::CONNECTION_COUNT_MAX] = {};
 U32 rateGroup3Context[Svc::ActiveRateGroup::CONNECTION_COUNT_MAX] = {};
 
 enum TopologyConstants {
-    COMM_PRIORITY = 23,
+    COMM_PRIORITY = 34,
 };
 
 /**

--- a/Ref/Top/instances.fpp
+++ b/Ref/Top/instances.fpp
@@ -29,39 +29,39 @@ module Ref {
   instance blockDrv: Ref.BlockDriver base id 0x10000000 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
-    priority 140
+    priority 47
 
   instance rateGroup1Comp: Svc.ActiveRateGroup base id 0x10001000 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
-    priority 120
+    priority 43
 
   instance rateGroup2Comp: Svc.ActiveRateGroup base id 0x10002000 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
-    priority 119
+    priority 42
 
   instance rateGroup3Comp: Svc.ActiveRateGroup base id 0x10003000 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
-    priority 118
+    priority 41
 
   instance pingRcvr: Ref.PingReceiver base id 0x10004000 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
-    priority 100
+    priority 23
 
   instance typeDemo: Ref.TypeDemo base id 0x10005000
 
   instance cmdSeq: Svc.CmdSequencer base id 0x10006000 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
-    priority 97
+    priority 20
 
   instance dpDemo: Ref.DpDemo base id 0x0A10 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
-    priority 96
+    priority 19
 
   # ----------------------------------------------------------------------
   # Queued component instances

--- a/Svc/Subtopologies/CdhCore/CdhCoreConfig/CdhCoreConfig.fpp
+++ b/Svc/Subtopologies/CdhCore/CdhCoreConfig/CdhCoreConfig.fpp
@@ -17,7 +17,7 @@ module CdhCoreConfig {
     }
 
     module Priorities {
-        constant cmdDisp     = 25
+        constant cmdDisp     = 35
         constant $health     = 24
         constant events      = 23
         constant tlmSend     = 22

--- a/Svc/Subtopologies/CdhCore/CdhCoreConfig/CdhCoreConfig.fpp
+++ b/Svc/Subtopologies/CdhCore/CdhCoreConfig/CdhCoreConfig.fpp
@@ -17,10 +17,10 @@ module CdhCoreConfig {
     }
 
     module Priorities {
-        constant cmdDisp     = 102
-        constant $health     = 101
-        constant events      = 100
-        constant tlmSend     = 99
+        constant cmdDisp     = 25
+        constant $health     = 24
+        constant events      = 23
+        constant tlmSend     = 22
 
     }
 }

--- a/Svc/Subtopologies/ComCcsds/ComCcsdsConfig/ComCcsdsConfig.fpp
+++ b/Svc/Subtopologies/ComCcsds/ComCcsdsConfig/ComCcsdsConfig.fpp
@@ -13,8 +13,8 @@ module ComCcsdsConfig {
     }
 
     module Priorities {
-        constant comQueue   = 24
-        constant aggregator = 23
+        constant aggregator = 30
+        constant comQueue   = 29
     }
 
     # Queue configuration constants

--- a/Svc/Subtopologies/ComCcsds/ComCcsdsConfig/ComCcsdsConfig.fpp
+++ b/Svc/Subtopologies/ComCcsds/ComCcsdsConfig/ComCcsdsConfig.fpp
@@ -13,8 +13,8 @@ module ComCcsdsConfig {
     }
 
     module Priorities {
-        constant comQueue   = 101
-        constant aggregator = 100
+        constant comQueue   = 24
+        constant aggregator = 23
     }
 
     # Queue configuration constants

--- a/Svc/Subtopologies/ComFprime/ComFprimeConfig/ComFprimeConfig.fpp
+++ b/Svc/Subtopologies/ComFprime/ComFprimeConfig/ComFprimeConfig.fpp
@@ -11,7 +11,7 @@ module ComFprimeConfig {
     }
 
     module Priorities {
-        constant comQueue   = 24
+        constant comQueue   = 29
     }
 
     # Queue configuration constants

--- a/Svc/Subtopologies/ComFprime/ComFprimeConfig/ComFprimeConfig.fpp
+++ b/Svc/Subtopologies/ComFprime/ComFprimeConfig/ComFprimeConfig.fpp
@@ -11,7 +11,7 @@ module ComFprimeConfig {
     }
 
     module Priorities {
-        constant comQueue   = 101
+        constant comQueue   = 24
     }
 
     # Queue configuration constants

--- a/Svc/Subtopologies/ComLoggerTee/ComLoggerTeeConfig/ComLoggerTeeConfig.fpp
+++ b/Svc/Subtopologies/ComLoggerTee/ComLoggerTeeConfig/ComLoggerTeeConfig.fpp
@@ -9,6 +9,6 @@ module ComLoggerTeeConfig {
     }
 
     module Priorities {
-        constant comLog = 95
+        constant comLog = 18
     }
 }

--- a/Svc/Subtopologies/DataProducts/DataProductsConfig/DataProductsConfig.fpp
+++ b/Svc/Subtopologies/DataProducts/DataProductsConfig/DataProductsConfig.fpp
@@ -18,10 +18,10 @@ module DataProductsConfig {
     }
 
     module Priorities {
-        constant dpCat    = 101
-        constant dpMgr  = 100
-        constant dpWriter   = 99
-        constant dpBufferManager  = 98
+        constant dpCat    = 24
+        constant dpMgr  = 23
+        constant dpWriter   = 22
+        constant dpBufferManager  = 21
     }
 
     # Buffer management constants

--- a/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
@@ -17,10 +17,10 @@ module FileHandlingConfig {
     }
 
     module Priorities {
-        constant fileUplink    = 101
-        constant fileDownlink  = 100
-        constant fileManager   = 99
-        constant prmDb         = 98
+        constant fileUplink    = 24
+        constant fileDownlink  = 23
+        constant fileManager   = 22
+        constant prmDb         = 21
     }
 
     # File downlink configuration constants


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3985 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Adjusted all task priorities throughout the framework so that they fit within the most-restrictive task priority range among supported platforms, which was determined to be Darwin's [15,47]. See the linked issue for that analysis. Within the fprime repository, this resulted in changes in framework-provided subtopologies and in the Ref project.

Priority changes in the fprime-tools repository are handled in [fprime-tools PR #292](https://github.com/nasa/fprime-tools/pull/292).

In-code documentation was added to clarify the intended meaning of constant `Os::Task::TASK_PRIORITY_DEFAULT`, as well as `Os::Task::TASK_DEFAULT` which follows the same pattern. The meaning has implications for derived classes' implementations which are not immediately obvious.

## Rationale

Previous task priorities were out of the valid range for the Linux and Darwin platforms, clamping tasks to the maximum priority and preventing differentiation of priority between some threads. Accordingly, priority clamp warnings were being (correctly) produced to the Logger when starting F Prime.

## Testing/Review Recommendations

No unit tests were added. The changes were verified by running the CI Integration tests and visually inspecting that the priority clamp warnings are no longer produced in the log. We should repeat this verification a final time before merging.

## Future Work

This pull request does not include documentation for recommendations on task priority. A style guide update to keep newly-added or modified threads in the framework within Darwin's range could help to prevent future code changes from reintroducing the priority clamping and provide guidance to users for their own threads.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None.
