### PR TITLE
Refactor FrameAccumulator not to assert on incorrect size_out

### DIFF
--- a/Svc/FrameAccumulator/FrameAccumulator.cpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.cpp
@@ -118,17 +118,16 @@ void FrameAccumulator ::processRing() {
                   static_cast<FwAssertArgType>(m_inRing.get_allocated_size()), static_cast<FwAssertArgType>(remaining));
         // On successful detection, consume data from the ring buffer and place it into an allocated frame
         if (status == FrameDetector::FRAME_DETECTED) {
-            // size_out must be set to the size of the buffer and must fit within the existing data
+            // size_out must be set (non-zero) and must fit within the remaining data. Otherwise would mean
+            // a coding error in the detector (returned FRAME_DETECTED without proper validation)
             FW_ASSERT(size_out != 0);
             FW_ASSERT(size_out <= remaining, static_cast<FwAssertArgType>(size_out),
                       static_cast<FwAssertArgType>(remaining));
-            // check for overflow before casting down to U32
-            FW_ASSERT(size_out <= std::numeric_limits<U32>::max());
-            Fw::Buffer buffer = this->bufferAllocate_out(0, static_cast<U32>(size_out));
+            Fw::Buffer buffer = this->allocate_out(0, size_out);
             if (buffer.isValid()) {
                 // Copy data out of ring buffer into the allocated buffer
                 Fw::SerializeStatus serialize_status = this->m_inRing.peek(buffer.getData(), size_out);
-                buffer.setSize(static_cast<Fw::Buffer::SizeType>(size_out));
+                buffer.setSize(size_out);
                 FW_ASSERT(serialize_status == Fw::SerializeStatus::FW_SERIALIZE_OK);
                 // Consume (rotate) the data from the ring buffer
                 serialize_status = this->m_inRing.rotate(size_out);
@@ -146,13 +145,24 @@ void FrameAccumulator ::processRing() {
         }
         // More data needed
         else if (status == FrameDetector::MORE_DATA_NEEDED) {
-            // size_out can never be larger than the capacity of the ring. Otherwise all uplink will fail.
-            FW_ASSERT(size_out < m_inRing.get_capacity(), static_cast<FwAssertArgType>(size_out));
-            // Detection should report "more is needed" and set size_out to something larger than available data
-            FW_ASSERT(size_out > remaining, static_cast<FwAssertArgType>(size_out),
-                      static_cast<FwAssertArgType>(remaining));
-            // Break out of loop: suspend detection until we receive another buffer
-            break;
+            if (size_out > ringCapacity) {
+                // Detector reports a size_out larger than the ring capacity. We can not accumulate enough
+                // data to hold the entire frame. Log a warning and discard a byte to effectively drop the frame.
+                this->log_WARNING_HI_FrameDetectionSizeError(size_out);
+                // Discard a single byte of data and start again
+                (void)this->m_inRing.rotate(1);
+                FW_ASSERT(m_inRing.get_allocated_size() == remaining - 1,
+                          static_cast<FwAssertArgType>(m_inRing.get_allocated_size()),
+                          static_cast<FwAssertArgType>(remaining));
+            } else {
+                // size_out can never be larger than the capacity of the ring. Otherwise all uplink will fail.
+                FW_ASSERT(size_out <= m_inRing.get_capacity(), static_cast<FwAssertArgType>(size_out));
+                // Detection should report "more is needed" and set size_out to something larger than available data
+                FW_ASSERT(size_out > remaining, static_cast<FwAssertArgType>(size_out),
+                          static_cast<FwAssertArgType>(remaining));
+                // Break out of loop: suspend detection until we receive another buffer
+                break;
+            }
         }
         // No frame was detected or an unknown status was received
         else {
@@ -170,7 +180,7 @@ void FrameAccumulator ::dataReturnIn_handler(FwIndexType portNum,
                                              const ComCfg::FrameContext& context) {
     // Frame buffer ownership is returned to the component. Component had allocated with a buffer manager,
     // so we return it to the buffer manager for deallocation
-    this->bufferDeallocate_out(0, fwBuffer);
+    this->deallocate_out(0, fwBuffer);
 }
 
 }  // namespace Svc

--- a/Svc/FrameAccumulator/FrameAccumulator.cpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.cpp
@@ -123,7 +123,7 @@ void FrameAccumulator ::processRing() {
             FW_ASSERT(size_out != 0);
             FW_ASSERT(size_out <= remaining, static_cast<FwAssertArgType>(size_out),
                       static_cast<FwAssertArgType>(remaining));
-            Fw::Buffer buffer = this->allocate_out(0, size_out);
+            Fw::Buffer buffer = this->bufferAllocate_out(0, size_out);
             if (buffer.isValid()) {
                 // Copy data out of ring buffer into the allocated buffer
                 Fw::SerializeStatus serialize_status = this->m_inRing.peek(buffer.getData(), size_out);
@@ -180,7 +180,7 @@ void FrameAccumulator ::dataReturnIn_handler(FwIndexType portNum,
                                              const ComCfg::FrameContext& context) {
     // Frame buffer ownership is returned to the component. Component had allocated with a buffer manager,
     // so we return it to the buffer manager for deallocation
-    this->deallocate_out(0, fwBuffer);
+    this->bufferDeallocate_out(0, fwBuffer);
 }
 
 }  // namespace Svc

--- a/Svc/FrameAccumulator/FrameAccumulator.cpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.cpp
@@ -146,7 +146,7 @@ void FrameAccumulator ::processRing() {
         // More data needed
         else if (status == FrameDetector::MORE_DATA_NEEDED) {
             if (size_out > ringCapacity) {
-                // Detector reports a size_out larger than the ring capacity. We can not accumulate enough
+                // Detector reports a size_out larger than the ring capacity. We cannot accumulate enough
                 // data to hold the entire frame. Log a warning and discard a byte to effectively drop the frame.
                 this->log_WARNING_HI_FrameDetectionSizeError(size_out);
                 // Discard a single byte of data and start again

--- a/Svc/FrameAccumulator/FrameAccumulator.cpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.cpp
@@ -116,10 +116,23 @@ void FrameAccumulator ::processRing() {
         // Detect must not consume data in the ring buffer
         FW_ASSERT(m_inRing.get_allocated_size() == remaining,
                   static_cast<FwAssertArgType>(m_inRing.get_allocated_size()), static_cast<FwAssertArgType>(remaining));
+
+        // Drop frames that are too large to handle (can't fit in the accumulation circular buffer)
+        if (size_out > ringCapacity) {
+            // Detector reports a size_out larger than the accumulation buffer capacity, we will never be able
+            // to process it. Log a warning and discard a byte, then keep iterating to look for a new frame
+            this->log_WARNING_HI_FrameDetectionSizeError(size_out);
+            // Discard a single byte of data and start again
+            (void)this->m_inRing.rotate(1);
+            FW_ASSERT(m_inRing.get_allocated_size() == remaining - 1,
+                      static_cast<FwAssertArgType>(m_inRing.get_allocated_size()),
+                      static_cast<FwAssertArgType>(remaining));
+            continue;
+        }
+
         // On successful detection, consume data from the ring buffer and place it into an allocated frame
         if (status == FrameDetector::FRAME_DETECTED) {
-            // size_out must be set (non-zero) and must fit within the remaining data. Otherwise would mean
-            // a coding error in the detector (returned FRAME_DETECTED without proper validation)
+            // size_out must be set (non-zero) and must fit within the remaining data
             FW_ASSERT(size_out != 0);
             FW_ASSERT(size_out <= remaining, static_cast<FwAssertArgType>(size_out),
                       static_cast<FwAssertArgType>(remaining));
@@ -145,24 +158,11 @@ void FrameAccumulator ::processRing() {
         }
         // More data needed
         else if (status == FrameDetector::MORE_DATA_NEEDED) {
-            if (size_out > ringCapacity) {
-                // Detector reports a size_out larger than the ring capacity. We cannot accumulate enough
-                // data to hold the entire frame. Log a warning and discard a byte to effectively drop the frame.
-                this->log_WARNING_HI_FrameDetectionSizeError(size_out);
-                // Discard a single byte of data and start again
-                (void)this->m_inRing.rotate(1);
-                FW_ASSERT(m_inRing.get_allocated_size() == remaining - 1,
-                          static_cast<FwAssertArgType>(m_inRing.get_allocated_size()),
-                          static_cast<FwAssertArgType>(remaining));
-            } else {
-                // size_out can never be larger than the capacity of the ring. Otherwise all uplink will fail.
-                FW_ASSERT(size_out <= m_inRing.get_capacity(), static_cast<FwAssertArgType>(size_out));
-                // Detection should report "more is needed" and set size_out to something larger than available data
-                FW_ASSERT(size_out > remaining, static_cast<FwAssertArgType>(size_out),
-                          static_cast<FwAssertArgType>(remaining));
-                // Break out of loop: suspend detection until we receive another buffer
-                break;
-            }
+            // Detection should report "more is needed" and set size_out to something larger than available data
+            FW_ASSERT(size_out > remaining, static_cast<FwAssertArgType>(size_out),
+                      static_cast<FwAssertArgType>(remaining));
+            // Break out of loop: suspend detection until we receive another buffer
+            break;
         }
         // No frame was detected or an unknown status was received
         else {

--- a/Svc/FrameAccumulator/FrameAccumulator.fpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.fpp
@@ -7,8 +7,11 @@ module Svc {
         # ----------------------------------------------------------------------
         import Svc.FrameAccumulator
 
-        @ Enables buffer allocation and deallocation
-        import Svc.BufferAllocation
+        @ Port for deallocating buffers holding extracted frames
+        output port bufferDeallocate: Fw.BufferSend
+
+        @ Port for allocating buffer to hold extracted frame
+        output port bufferAllocate: Fw.BufferGet
 
         @ An error occurred while deserializing a packet
         event NoBufferAvailable \

--- a/Svc/FrameAccumulator/FrameAccumulator.fpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.fpp
@@ -5,19 +5,19 @@ module Svc {
         # ----------------------------------------------------------------------
         # FrameAccumulator interface
         # ----------------------------------------------------------------------
-        import FrameAccumulator
+        import Svc.FrameAccumulator
 
-        @ Port for deallocating buffers holding extracted frames
-        output port bufferDeallocate: Fw.BufferSend
-
-        @ Port for allocating buffer to hold extracted frame
-        output port bufferAllocate: Fw.BufferGet
+        @ Enables buffer allocation and deallocation
+        import Svc.BufferAllocation
 
         @ An error occurred while deserializing a packet
         event NoBufferAvailable \
             severity warning high \
             format "Could not allocate a valid buffer to fit the detected frame"
 
+        event FrameDetectionSizeError(size_out: FwSizeType) \
+            severity warning high \
+            format "Reported size_out={} exceeds available data"
 
         ###############################################################################
         # Standard AC Ports for Events 
@@ -25,11 +25,8 @@ module Svc {
         @ Port for requesting the current time
         time get port timeCaller
 
-        @ Port for sending textual representation of events
-        text event port logTextOut
-
-        @ Port for sending events to downlink
-        event port logOut
+        @ Ports for logging events
+        import Fw.Event
 
     }
 }

--- a/Svc/FrameAccumulator/FrameAccumulator.fpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.fpp
@@ -18,9 +18,11 @@ module Svc {
             severity warning high \
             format "Could not allocate a valid buffer to fit the detected frame"
 
+        @ A frame was detected whose size exceeds the internal accumulation buffer
+        @ capacity. No choice but to drop the frame.
         event FrameDetectionSizeError(size_out: FwSizeType) \
             severity warning high \
-            format "Reported size_out={} exceeds available data"
+            format "Reported size_out={} exceeds accumulation buffer capacity"
 
         ###############################################################################
         # Standard AC Ports for Events 

--- a/Svc/FrameAccumulator/docs/sdd.md
+++ b/Svc/FrameAccumulator/docs/sdd.md
@@ -22,6 +22,9 @@ The `Svc::FrameAccumulator` receives `Fw::Buffer` objects on its `dataIn` input 
 - `FRAME_DETECTED`: indicates there is a frame at the current head of the circular buffer. The `Svc::FrameAccumulator` allocates a new `Fw::Buffer` object to hold the frame, copies the detected frame from the circular buffer into the new `Fw::Buffer` object, and emits the new `Fw::Buffer` object (containing the frame) on its `dataOut` output port. The `Svc::FrameAccumulator` then rotates the circular buffer to remove the data that was just extracted, and deallocates the original `Fw::Buffer` that was received on the `dataIn` input port.
 - `MORE_DATA_NEEDED`: indicates that more data is needed to determine whether there is a valid frame. The `Svc::FrameAccumulator` deallocates the original `Fw::Buffer` that was received on the `dataIn` input port and halts execution, effectively waiting for the next `Fw::Buffer` to be received on the `dataIn` input port.
 
+> [!NOTE]
+> If the `Svc::FrameDetector` reports a `size_out` that is larger than the capacity of the internal accumulation buffer, the frame will cannot be processed. The `Svc::FrameAccumulator` logs a warning event, and continues searching for a new frame.
+
 
 ```mermaid
 sequenceDiagram

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTestMain.cpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTestMain.cpp
@@ -47,6 +47,11 @@ TEST(FrameAccumulator, testBufferReturnDeallocation) {
     tester.testBufferReturnDeallocation();
 }
 
+TEST(FrameAccumulator, testDetectionErrorHandling) {
+    Svc::FrameAccumulatorTester tester;
+    tester.testDetectionErrorHandling();
+}
+
 int main(int argc, char** argv) {
     STest::Random::seed();
     ::testing::InitGoogleTest(&argc, argv);

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
@@ -155,9 +155,34 @@ void FrameAccumulatorTester ::testBufferReturnDeallocation() {
     Fw::Buffer buffer(data, sizeof(data));
     ComCfg::FrameContext context;
     this->invoke_to_dataReturnIn(0, buffer, context);
-    ASSERT_from_bufferDeallocate_SIZE(1);  // incoming buffer should be deallocated
-    ASSERT_EQ(this->fromPortHistory_bufferDeallocate->at(0).fwBuffer.getData(), data);
-    ASSERT_EQ(this->fromPortHistory_bufferDeallocate->at(0).fwBuffer.getSize(), sizeof(data));
+    ASSERT_from_deallocate_SIZE(1);  // incoming buffer should be deallocated
+    ASSERT_EQ(this->fromPortHistory_deallocate->at(0).fwBuffer.getData(), data);
+    ASSERT_EQ(this->fromPortHistory_deallocate->at(0).fwBuffer.getSize(), sizeof(data));
+}
+
+void FrameAccumulatorTester ::testDetectionErrorHandling() {
+    FwSizeType too_large_size = this->component.m_inRing.get_capacity() + 1;
+    // Using buffer_size=1 to simplify test since otherwise Accumulator will loop `buffer_size` times
+    Fw::Buffer::SizeType buffer_size = 1;
+    U8 data[buffer_size];
+    Fw::Buffer buffer(data, buffer_size);
+    ComCfg::FrameContext context;
+
+    // Too large size reported by detector should crash if returning FRAME_DETECTED
+    this->mockDetector.set_next_result(FrameDetector::Status::FRAME_DETECTED, too_large_size);
+    ASSERT_DEATH(this->invoke_to_dataIn(0, buffer, context), "");
+
+    this->clearHistory();
+
+    // Too large size reported by detector should emit event and continue if returning MORE_DATA_NEEDED
+    this->mockDetector.set_next_result(FrameDetector::Status::MORE_DATA_NEEDED, too_large_size);
+    this->invoke_to_dataIn(0, buffer, context);
+    // Checks
+    ASSERT_from_dataReturnOut_SIZE(1);                         // input buffer ownership was returned
+    ASSERT_from_dataOut_SIZE(0);                               // No frame was sent out
+    ASSERT_EVENTS_SIZE(1);                                     // One event should be logged:
+    ASSERT_EVENTS_FrameDetectionSizeError_SIZE(1);             // FrameDetectionSizeError
+    ASSERT_EVENTS_FrameDetectionSizeError(0, too_large_size);  // with expected size_out
 }
 
 // ----------------------------------------------------------------------
@@ -202,8 +227,8 @@ void FrameAccumulatorTester ::mockAccumulateFullFrame(U32& frame_size, U32& buff
 // ----------------------------------------------------------------------
 // Port handler overrides
 // ----------------------------------------------------------------------
-Fw::Buffer FrameAccumulatorTester ::from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) {
-    this->pushFromPortEntry_bufferAllocate(size);
+Fw::Buffer FrameAccumulatorTester ::from_allocate_handler(FwIndexType portNum, FwSizeType size) {
+    this->pushFromPortEntry_allocate(size);
     this->m_buffer.setData(this->m_buffer_slot);
     this->m_buffer.setSize(size);
     ::memset(this->m_buffer.getData(), 0, size);

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
@@ -155,9 +155,9 @@ void FrameAccumulatorTester ::testBufferReturnDeallocation() {
     Fw::Buffer buffer(data, sizeof(data));
     ComCfg::FrameContext context;
     this->invoke_to_dataReturnIn(0, buffer, context);
-    ASSERT_from_deallocate_SIZE(1);  // incoming buffer should be deallocated
-    ASSERT_EQ(this->fromPortHistory_deallocate->at(0).fwBuffer.getData(), data);
-    ASSERT_EQ(this->fromPortHistory_deallocate->at(0).fwBuffer.getSize(), sizeof(data));
+    ASSERT_from_bufferDeallocate_SIZE(1);  // incoming buffer should be deallocated
+    ASSERT_EQ(this->fromPortHistory_bufferDeallocate->at(0).fwBuffer.getData(), data);
+    ASSERT_EQ(this->fromPortHistory_bufferDeallocate->at(0).fwBuffer.getSize(), sizeof(data));
 }
 
 void FrameAccumulatorTester ::testDetectionErrorHandling() {
@@ -227,8 +227,8 @@ void FrameAccumulatorTester ::mockAccumulateFullFrame(U32& frame_size, U32& buff
 // ----------------------------------------------------------------------
 // Port handler overrides
 // ----------------------------------------------------------------------
-Fw::Buffer FrameAccumulatorTester ::from_allocate_handler(FwIndexType portNum, FwSizeType size) {
-    this->pushFromPortEntry_allocate(size);
+Fw::Buffer FrameAccumulatorTester ::from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) {
+    this->pushFromPortEntry_bufferAllocate(size);
     this->m_buffer.setData(this->m_buffer_slot);
     this->m_buffer.setSize(size);
     ::memset(this->m_buffer.getData(), 0, size);

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
@@ -168,14 +168,32 @@ void FrameAccumulatorTester ::testDetectionErrorHandling() {
     Fw::Buffer buffer(data, buffer_size);
     ComCfg::FrameContext context;
 
-    // Too large size reported by detector should crash if returning FRAME_DETECTED
+    // Too large size reported by detector should emit event and continue
     this->mockDetector.set_next_result(FrameDetector::Status::FRAME_DETECTED, too_large_size);
-    ASSERT_DEATH(this->invoke_to_dataIn(0, buffer, context), "");
+    this->invoke_to_dataIn(0, buffer, context);
+    // Checks
+    ASSERT_from_dataReturnOut_SIZE(1);                         // input buffer ownership was returned
+    ASSERT_from_dataOut_SIZE(0);                               // No frame was sent out
+    ASSERT_EVENTS_SIZE(1);                                     // One event should be logged:
+    ASSERT_EVENTS_FrameDetectionSizeError_SIZE(1);             // FrameDetectionSizeError
+    ASSERT_EVENTS_FrameDetectionSizeError(0, too_large_size);  // with expected size_out
 
     this->clearHistory();
 
-    // Too large size reported by detector should emit event and continue if returning MORE_DATA_NEEDED
+    // Too large size reported by detector should emit event and continue
     this->mockDetector.set_next_result(FrameDetector::Status::MORE_DATA_NEEDED, too_large_size);
+    this->invoke_to_dataIn(0, buffer, context);
+    // Checks
+    ASSERT_from_dataReturnOut_SIZE(1);                         // input buffer ownership was returned
+    ASSERT_from_dataOut_SIZE(0);                               // No frame was sent out
+    ASSERT_EVENTS_SIZE(1);                                     // One event should be logged:
+    ASSERT_EVENTS_FrameDetectionSizeError_SIZE(1);             // FrameDetectionSizeError
+    ASSERT_EVENTS_FrameDetectionSizeError(0, too_large_size);  // with expected size_out
+
+    this->clearHistory();
+
+    // Too large size reported by detector should emit event and continue
+    this->mockDetector.set_next_result(FrameDetector::Status::NO_FRAME_DETECTED, too_large_size);
     this->invoke_to_dataIn(0, buffer, context);
     // Checks
     ASSERT_from_dataReturnOut_SIZE(1);                         // input buffer ownership was returned

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.hpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.hpp
@@ -66,6 +66,9 @@ class FrameAccumulatorTester : public FrameAccumulatorGTestBase {
     //! Test returning ownership of a buffer
     void testBufferReturnDeallocation();
 
+    //! Test handling of errors from the FrameDetector (too large size_out)
+    void testDetectionErrorHandling();
+
   private:
     // ----------------------------------------------------------------------
     // Helper functions
@@ -87,7 +90,7 @@ class FrameAccumulatorTester : public FrameAccumulatorGTestBase {
     // Port handler overrides
     // ----------------------------------------------------------------------
     //! Overriding bufferAllocate handler to be able to request a buffer in component tests
-    Fw::Buffer from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) override;
+    Fw::Buffer from_allocate_handler(FwIndexType portNum, FwSizeType size) override;
 
   private:
     // ----------------------------------------------------------------------

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.hpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.hpp
@@ -90,7 +90,7 @@ class FrameAccumulatorTester : public FrameAccumulatorGTestBase {
     // Port handler overrides
     // ----------------------------------------------------------------------
     //! Overriding bufferAllocate handler to be able to request a buffer in component tests
-    Fw::Buffer from_allocate_handler(FwIndexType portNum, FwSizeType size) override;
+    Fw::Buffer from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) override;
 
   private:
     // ----------------------------------------------------------------------


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4320  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n/a |
|**_Generative AI was used in this contribution (y/n)_**|  No |

---
## Change Description

Fix #4320

Putting in draft for now cause the cognitive complexity of all these if-else is becoming quite high and I'm trying to see if I can make it more readable somehow.

