### PR TITLE
Change FPP enums to smallest representation

### DIFF
--- a/Drv/ByteStreamDriverModel/ByteStreamDriverModel.fpp
+++ b/Drv/ByteStreamDriverModel/ByteStreamDriverModel.fpp
@@ -1,7 +1,7 @@
 module Drv {
 
     @ Status returned by the send call
-    enum ByteStreamStatus {
+    enum ByteStreamStatus : U8 {
         OP_OK         @< Operation worked as expected
         SEND_RETRY    @< Data send should be retried
         RECV_NO_DATA  @< Receive worked, but there was no data 

--- a/Drv/Ports/GpioDriverPorts.fpp
+++ b/Drv/Ports/GpioDriverPorts.fpp
@@ -1,5 +1,5 @@
 module Drv {
-  enum GpioStatus {
+  enum GpioStatus : U8 {
     OP_OK @< Operation succeeded
     NOT_OPENED @< Pin was never opened
     INVALID_MODE @< Operation not permitted with current configuration

--- a/Drv/Ports/I2cDriverPorts.fpp
+++ b/Drv/Ports/I2cDriverPorts.fpp
@@ -11,7 +11,7 @@ module Drv {
 
 module Drv {
 
-  enum I2cStatus {
+  enum I2cStatus : U8 {
     I2C_OK = 0 @< Transaction okay
     I2C_ADDRESS_ERR = 1 @< I2C address invalid
     I2C_WRITE_ERR = 2 @< I2C write failed

--- a/Fpp/ToCpp.fpp
+++ b/Fpp/ToCpp.fpp
@@ -2,7 +2,7 @@ module Fpp {
 
   module ToCpp {
 
-    enum Phases {
+    enum Phases : U8 {
       configConstants
       configObjects
       instances

--- a/Fw/Cmd/Cmd.fpp
+++ b/Fw/Cmd/Cmd.fpp
@@ -15,7 +15,7 @@ module Fw {
           )
 
   @ Enum representing a command response
-  enum CmdResponse {
+  enum CmdResponse : U8 {
     OK = 0 @< Command successfully executed
     INVALID_OPCODE = 1 @< Invalid opcode dispatched
     VALIDATION_ERROR = 2 @< Command failed validation

--- a/Fw/Log/Log.fpp
+++ b/Fw/Log/Log.fpp
@@ -4,7 +4,7 @@ module Fw {
   type TextLogString
 
   @ Enum representing event severity
-  enum LogSeverity {
+  enum LogSeverity : U8 {
     FATAL = 1 @< A fatal non-recoverable event
     WARNING_HI = 2 @< A serious but recoverable event
     WARNING_LO = 3 @< A less serious but recoverable event

--- a/Fw/Prm/Prm.fpp
+++ b/Fw/Prm/Prm.fpp
@@ -3,7 +3,7 @@ module Fw {
   type ParamBuffer
 
   @ Enum representing parameter validity
-  enum ParamValid {
+  enum ParamValid : U8 {
     UNINIT = 0
     VALID = 1
     INVALID = 2

--- a/Fw/Tlm/Tlm.fpp
+++ b/Fw/Tlm/Tlm.fpp
@@ -2,7 +2,7 @@ module Fw {
 
   type TlmBuffer
 
-  enum TlmValid {
+  enum TlmValid : U8 {
     VALID = 0
     INVALID = 1
   }

--- a/Os/Models/Directory.fpp
+++ b/Os/Models/Directory.fpp
@@ -5,7 +5,7 @@
 
 module Os {
 @ FPP shadow-enum representing Os::Directory::Status
-enum DirectoryStatus {
+enum DirectoryStatus : U8 {
     OP_OK,          @<  Operation was successful
     DOESNT_EXIST,   @<  Directory doesn't exist
     NO_PERMISSION,  @<  No permission to read directory
@@ -19,7 +19,7 @@ enum DirectoryStatus {
     OTHER_ERROR,    @<  A catch-all for other errors. Have to look in implementation-specific code
 }
 
-enum DirectoryOpenMode {
+enum DirectoryOpenMode : U8 {
     READ,               @<  Error if directory doesn't exist
     CREATE_IF_MISSING,  @<  Create directory if it doesn't exist
     CREATE_EXCLUSIVE,   @<  Create directory and error if it already exists

--- a/Os/Models/File.fpp
+++ b/Os/Models/File.fpp
@@ -5,7 +5,7 @@
 
 module Os {
 @ FPP shadow-enum representing Os::File::Status
-enum FileStatus {
+enum FileStatus : U8 {
     OP_OK,            @< Operation was successful
     DOESNT_EXIST,     @< File doesn't exist (for read)
     NO_SPACE,         @< No space left
@@ -20,7 +20,7 @@ enum FileStatus {
     OTHER_ERROR,      @< A catch-all for other errors. Have to look in implementation-specific code
 }
 @ FPP shadow-enum representing Os::File::Mode
-enum FileMode {
+enum FileMode : U8 {
     OPEN_NO_MODE,     @< File mode not yet selected
     OPEN_READ,        @< Open file for reading
     OPEN_CREATE,      @< Open file for writing and truncates file if it exists, ie same flags as creat()

--- a/Os/Models/FileSystem.fpp
+++ b/Os/Models/FileSystem.fpp
@@ -5,7 +5,7 @@
 
 module Os {
 @ FPP shadow-enum representing Os::FileSystem::Status
-enum FileSystemStatus {
+enum FileSystemStatus : U8 {
         OP_OK,            @<  Operation was successful
         ALREADY_EXISTS,   @<  File already exists
         NO_SPACE,         @<  No space left

--- a/Os/Models/Generic.fpp
+++ b/Os/Models/Generic.fpp
@@ -5,7 +5,7 @@
 
 module Os {
 @ FPP shadow-enum representing Os::Generic::Status
-enum GenericStatus {
+enum GenericStatus : U8 {
     OP_OK, @< operation okay
     ERROR, @< error return value
 }

--- a/Os/Models/Mutex.fpp
+++ b/Os/Models/Mutex.fpp
@@ -5,7 +5,7 @@
 
 module Os {
     @ FPP shadow-enum representing Os::Mutex::Status
-    enum MutexStatus {
+    enum MutexStatus : U8 {
         OP_OK,          @< Operation was successful
         ERROR_BUSY,     @< Mutex is busy
         ERROR_DEADLOCK, @< Deadlock condition detected

--- a/Os/Models/Queue.fpp
+++ b/Os/Models/Queue.fpp
@@ -5,7 +5,7 @@
 
 module Os {
     @ FPP shadow-enum representing Os::Queue::Status
-    enum QueueStatus {
+    enum QueueStatus : U8 {
         OP_OK,             @<  message sent/received okay
         ALREADY_CREATED,   @<  creating an already created queue
         EMPTY,             @<  If non-blocking, all the messages have been drained.
@@ -21,7 +21,7 @@ module Os {
     }
 
     @ FPP shadow-enum representing Os::Queue::BlockingType
-    enum QueueBlockingType {
+    enum QueueBlockingType : U8 {
         BLOCKING,    @< Message will block until space is available
         NONBLOCKING  @< Message will return with status when space is unavailable
     }

--- a/Os/Models/RawTime.fpp
+++ b/Os/Models/RawTime.fpp
@@ -6,7 +6,7 @@
 module Os {
 
     @ FPP shadow-enum representing Os::RawTime::Status
-    enum RawTimeStatus {
+    enum RawTimeStatus : U8 {
         OP_OK,          @< Operation was successful
         OP_OVERFLOW,    @< Operation result caused an overflow
         INVALID_PARAMS, @< Parameters invalid for current platform

--- a/Os/Models/Task.fpp
+++ b/Os/Models/Task.fpp
@@ -5,7 +5,7 @@
 
 module Os {
 @ FPP shadow-enum representing Os::Task::Status
-enum TaskStatus {
+enum TaskStatus : U8 {
     OP_OK,             @< message sent/received okay
     INVALID_HANDLE,    @< Task handle invalid
     INVALID_PARAMS,    @< started task with invalid parameters

--- a/Svc/BufferAccumulator/Commands.fppi
+++ b/Svc/BufferAccumulator/Commands.fppi
@@ -1,4 +1,4 @@
-enum OpState {
+enum OpState : U8 {
   ACCUMULATE = 0
   DRAIN = 1
 }
@@ -9,7 +9,7 @@ async command BA_SetMode(
                         ) \
   opcode 0x00
 
-enum BlockMode {
+enum BlockMode : U8 {
   NOBLOCK = 0
   BLOCK = 1
 }

--- a/Svc/BufferLogger/Commands.fppi
+++ b/Svc/BufferLogger/Commands.fppi
@@ -8,7 +8,7 @@ async command BL_OpenFile(
 async command BL_CloseFile \
   opcode 0x01
 
-enum LogState {
+enum LogState : U8 {
   LOGGING_ON = 0
   LOGGING_OFF = 1
 }

--- a/Svc/CmdSequencer/CmdSequencer.fpp
+++ b/Svc/CmdSequencer/CmdSequencer.fpp
@@ -8,19 +8,19 @@ module Svc {
     # ----------------------------------------------------------------------
 
     @ The sequencer mode
-    enum SeqMode {
+    enum SeqMode : U8 {
       STEP = 0
       AUTO = 1
     }
 
     @ Sequencer blocking state
-    enum BlockState {
+    enum BlockState : U8 {
         BLOCK = 0
         NO_BLOCK = 1
     }
 
     @ The stage of the file read operation
-    enum FileReadStage {
+    enum FileReadStage : U8 {
       READ_HEADER
       READ_HEADER_SIZE
       DESER_SIZE

--- a/Svc/ComQueue/ComQueue.fpp
+++ b/Svc/ComQueue/ComQueue.fpp
@@ -1,6 +1,6 @@
 module Svc {
     @ An enumeration of queue data types
-    enum QueueType { COM_QUEUE, BUFFER_QUEUE }
+    enum QueueType : U8 { COM_QUEUE, BUFFER_QUEUE }
 
     @ Array of queue depths for Fw::Com types
     array ComQueueDepth = [ComQueueComPorts] U32

--- a/Svc/DpCatalog/DpCatalog.fpp
+++ b/Svc/DpCatalog/DpCatalog.fpp
@@ -7,7 +7,7 @@ module Svc {
   # data product
 
   @ Header validation error
-  enum DpHdrField {
+  enum DpHdrField : U8 {
     DESCRIPTOR,
     ID,
     PRIORITY,

--- a/Svc/EventManager/EventManager.fpp
+++ b/Svc/EventManager/EventManager.fpp
@@ -9,7 +9,7 @@ module Svc {
 
     @ Severity level for event filtering
     @ Similar to Fw::LogSeverity, but no FATAL event
-    enum FilterSeverity {
+    enum FilterSeverity : U8 {
       WARNING_HI = 0 @< Filter WARNING_HI events
       WARNING_LO = 1 @< Filter WARNING_LO events
       COMMAND = 2 @< Filter COMMAND events
@@ -21,7 +21,7 @@ module Svc {
     # TODO: Consider replacing this enum with Fw::Enabled
     # However, the sense of 0 and 1 are reversed
     @ Enabled and disabled state
-    enum Enabled {
+    enum Enabled : U8 {
       ENABLED = 0 @< Enabled state
       DISABLED = 1 @< Disabled state
     }

--- a/Svc/FileDownlinkPorts/FileDownlinkPorts.fpp
+++ b/Svc/FileDownlinkPorts/FileDownlinkPorts.fpp
@@ -1,7 +1,7 @@
 module Svc {
 
   @ Send file status enum
-  enum SendFileStatus {
+  enum SendFileStatus : U8 {
     STATUS_OK
     STATUS_ERROR
     STATUS_INVALID

--- a/Svc/FpySequencer/FpySequencer.fpp
+++ b/Svc/FpySequencer/FpySequencer.fpp
@@ -2,18 +2,18 @@ module Svc {
     @ Dispatches command sequences to available command sequencers
     active component FpySequencer {
 
-        enum BlockState {
+        enum BlockState : U8 {
             BLOCK
             NO_BLOCK
         }
 
-        enum GoalState {
+        enum GoalState : U8 {
             RUNNING
             VALID
             IDLE
         }
 
-        enum FileReadStage {
+        enum FileReadStage : U8 {
             HEADER
             BODY
             FOOTER

--- a/Svc/FpySequencer/FpySequencerDirectives.fppi
+++ b/Svc/FpySequencer/FpySequencerDirectives.fppi
@@ -176,7 +176,7 @@ internal port directive_setFlag(directive: SetFlagDirective) priority 6 assert
 
 internal port directive_getFlag(directive: GetFlagDirective) priority 6 assert
 
-enum DirectiveErrorCode {
+enum DirectiveErrorCode : U8 {
     NO_ERROR
     STMT_OUT_OF_BOUNDS
     TLM_GET_NOT_CONNECTED

--- a/Svc/PolyIf/PolyIf.fpp
+++ b/Svc/PolyIf/PolyIf.fpp
@@ -1,7 +1,7 @@
 module Svc {
 
   @ An enumeration for measurement status
-  enum MeasurementStatus {
+  enum MeasurementStatus : U8 {
     OK = 0 @< Measurement was good
     FAILURE = 1 @< Failure to retrieve measurement
     STALE = 2 @< Measurement is stale

--- a/Svc/Ports/VersionPorts/VersionPorts.fpp
+++ b/Svc/Ports/VersionPorts/VersionPorts.fpp
@@ -7,7 +7,7 @@
 module Svc{
     
     @ An enumeration for version status
-    enum VersionStatus {
+    enum VersionStatus : U8 {
         OK = 0 @< Version was good
         FAILURE = 1 @< Failure to get version
     }

--- a/Svc/PrmDb/PrmDb.fpp
+++ b/Svc/PrmDb/PrmDb.fpp
@@ -8,13 +8,13 @@ module Svc {
     # ----------------------------------------------------------------------
 
     @ Parameter DB type
-    enum PrmDbType {
+    enum PrmDbType : U8 {
       DB_ACTIVE,
       DB_STAGING
     }
 
     @ State of parameter DB file load operations
-    enum PrmDbFileLoadState {
+    enum PrmDbFileLoadState : U8 {
         IDLE,
         LOADING_FILE_UPDATES,
         FILE_UPDATES_STAGED,
@@ -22,7 +22,7 @@ module Svc {
 
 
     @ Parameter read error
-    enum PrmReadError {
+    enum PrmReadError : U8 {
       OPEN
       DELIMITER
       DELIMITER_SIZE
@@ -37,7 +37,7 @@ module Svc {
     }
 
     @ Parameter write error
-    enum PrmWriteError {
+    enum PrmWriteError : U8 {
       OPEN
       DELIMITER
       DELIMITER_SIZE

--- a/Svc/SeqDispatcher/SeqDispatcher.fpp
+++ b/Svc/SeqDispatcher/SeqDispatcher.fpp
@@ -2,7 +2,7 @@ module Svc {
     @ Dispatches command sequences to available command sequencers
     active component SeqDispatcher {
 
-        enum CmdSequencerState {
+        enum CmdSequencerState : U8 {
             AVAILABLE = 0
             RUNNING_SEQUENCE_BLOCK = 1
             RUNNING_SEQUENCE_NO_BLOCK = 2

--- a/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
+++ b/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
@@ -1,12 +1,12 @@
 module ComCcsds {
 
     # ComPacket Queue enum for queue types
-    enum Ports_ComPacketQueue {
+    enum Ports_ComPacketQueue : U8 {
         EVENTS,
         TELEMETRY 
     }
 
-    enum Ports_ComBufferQueue {
+    enum Ports_ComBufferQueue : U8 {
         FILE
     }
 

--- a/Svc/Subtopologies/ComFprime/ComFprime.fpp
+++ b/Svc/Subtopologies/ComFprime/ComFprime.fpp
@@ -1,11 +1,11 @@
 module ComFprime {
 
-    enum Ports_ComPacketQueue {
+    enum Ports_ComPacketQueue : U8 {
         EVENTS,
         TELEMETRY,
     };
 
-    enum Ports_ComBufferQueue {
+    enum Ports_ComBufferQueue : U8 {
         FILE
     };
 

--- a/Svc/SystemResources/SystemResources.fpp
+++ b/Svc/SystemResources/SystemResources.fpp
@@ -1,6 +1,6 @@
 module Svc {
 
-  enum SystemResourceEnabled {
+  enum SystemResourceEnabled : U8 {
     DISABLED = 0
     ENABLED = 1
   }

--- a/Svc/Version/Version.fpp
+++ b/Svc/Version/Version.fpp
@@ -1,14 +1,14 @@
 module Svc {
     
     @ Tracks versions for project, framework and user defined versions etc
-    enum VersionEnabled {
+    enum VersionEnabled : U8 {
         DISABLED = 0 @< verbosity disabled
         ENABLED = 1 @< verbosity enabled
     }
     
    
     @ An enumeration for Version Type
-    enum VersionType {
+    enum VersionType : U8 {
         PROJECT = 0 @< project version
         FRAMEWORK = 1 @< framework version
         LIBRARY = 2 @< library version

--- a/default/config/MemoryAllocation.fpp
+++ b/default/config/MemoryAllocation.fpp
@@ -3,7 +3,7 @@ module MemoryAllocation {
     @ Enumeration of the registered memory allocators provided by Fw::MemAllocatorRegistry. This allows system
     @ designers to enumerate the memory functions in their system and configure the Fw::MemAllocatorRegistry to delegate
     @ to the appropriate allocator. 
-    enum MemoryAllocatorType {
+    enum MemoryAllocatorType : U8 {
         CUSTOM_ALLOCATOR_1 @< SAMPLE: sample allocator subsystem
         # Below this line are required allocators
         SYSTEM @< REQUIRED: required for allocation for memory using a standard system allocator (i.e. the default)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3921 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

For all FPP enums in the framework, set the representing type to the minimum width integer that can represent the enum's member constants, if representing type was not already specified.

## Rationale

Most enums in the framework only have a few member values that could all fit in U8 but had no representing type specified, resulting in the default I32 representation and unused bytes in the serialized representation.

## Testing/Review Recommendations

No tests were updated.

Note: I didn't modify FppTestProject since it is exercising the range of features in FPP, including enum serialized width, and this is not part of framework code affecting user projects. I also didn't modify the Ref project for similar reasons; enums here do not affect users of the framework.

## Future Work

A style guide update to specify enums' representing type to the smallest type possible could help minimize the framework's footprint in downlink/uplink data bandwidth.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None.