### PR TITLE
FpySequencer Add DUMP_STACK_TO_FILE command

### DIFF
--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -241,6 +241,37 @@ void FpySequencer::SET_FLAG_cmdHandler(FwOpcodeType opCode,  //!< The opcode
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }
 
+//! Handler for command DUMP_STACK_TO_FILE
+//!
+//! Writes the contents of the stack to a file. This command is only valid in the RUNNING.PAUSED state.
+void FpySequencer::DUMP_STACK_TO_FILE_cmdHandler(FwOpcodeType opCode,               //!< The opcode
+                                                 U32 cmdSeq,                        //!< The command sequence number
+                                                 const Fw::CmdStringArg& fileName  //!< The name of the output file
+) {
+    if (this->sequencer_getState() != State::RUNNING_PAUSED) {
+        this->log_WARNING_HI_InvalidCommand(static_cast<I32>(sequencer_getState()));
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
+    Os::File sequenceFile;
+    Os::File::Status status = sequenceFile.open(fileName.toChar(), Os::File::OPEN_WRITE);
+
+    if (status != Os::File::Status::OP_OK) {
+        this->log_WARNING_HI_FileOpenError(this->m_sequenceFilePath, static_cast<I32>(status));
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
+
+    FwSizeType writeSize = static_cast<FwSizeType>(this->m_runtime.stack.size);
+    status = sequenceFile.write(this->m_runtime.stack.bytes, writeSize);
+    if (status != Os::File::Status::OP_OK || writeSize != this->m_runtime.stack.size) {
+        this->log_WARNING_HI_FileWriteError(writeSize, fileName, static_cast<I32>(status));
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
+    this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
+    return;
+}
 //! Handler for input port checkTimers
 void FpySequencer::checkTimers_handler(FwIndexType portNum,  //!< The port number
                                        U32 context           //!< The call order
@@ -396,6 +427,7 @@ void FpySequencer::tlmWrite_handler(FwIndexType portNum,  //!< The port number
     this->tlmWrite_Debug_NextStatementOpcode(this->m_debug.nextStatementOpcode);
     this->tlmWrite_Debug_NextStatementReadSuccess(this->m_debug.nextStatementReadSuccess);
     this->tlmWrite_Debug_ReachedEndOfFile(this->m_debug.reachedEndOfFile);
+    this->tlmWrite_Debug_StackSize(this->m_debug.stackSize);
 }
 
 void FpySequencer::updateDebugTelemetryStruct() {
@@ -407,6 +439,7 @@ void FpySequencer::updateDebugTelemetryStruct() {
             this->m_debug.nextStatementReadSuccess = false;
             this->m_debug.nextStatementOpcode = 0;
             this->m_debug.nextCmdOpcode = 0;
+            this->m_debug.stackSize = this->m_runtime.stack.size;
             return;
         }
 
@@ -419,6 +452,7 @@ void FpySequencer::updateDebugTelemetryStruct() {
             this->m_debug.nextStatementReadSuccess = false;
             this->m_debug.nextStatementOpcode = nextStmt.get_opCode();
             this->m_debug.nextCmdOpcode = 0;
+            this->m_debug.stackSize = this->m_runtime.stack.size;
             return;
         }
 
@@ -428,6 +462,7 @@ void FpySequencer::updateDebugTelemetryStruct() {
             this->m_debug.nextStatementReadSuccess = true;
             this->m_debug.nextStatementOpcode = nextStmt.get_opCode();
             this->m_debug.nextCmdOpcode = directiveUnion.constCmd.get_opCode();
+            this->m_debug.stackSize = this->m_runtime.stack.size;
             return;
         }
 
@@ -435,6 +470,7 @@ void FpySequencer::updateDebugTelemetryStruct() {
         this->m_debug.nextStatementReadSuccess = true;
         this->m_debug.nextStatementOpcode = nextStmt.get_opCode();
         this->m_debug.nextCmdOpcode = 0;
+        this->m_debug.stackSize = this->m_runtime.stack.size;
         return;
     }
     // send some default tlm when we aren't in debug break
@@ -442,6 +478,7 @@ void FpySequencer::updateDebugTelemetryStruct() {
     this->m_debug.nextStatementReadSuccess = false;
     this->m_debug.nextStatementOpcode = 0;
     this->m_debug.nextCmdOpcode = 0;
+    this->m_debug.stackSize = 0;
 }
 
 void FpySequencer::parametersLoaded() {

--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -244,8 +244,8 @@ void FpySequencer::SET_FLAG_cmdHandler(FwOpcodeType opCode,  //!< The opcode
 //! Handler for command DUMP_STACK_TO_FILE
 //!
 //! Writes the contents of the stack to a file. This command is only valid in the RUNNING.PAUSED state.
-void FpySequencer::DUMP_STACK_TO_FILE_cmdHandler(FwOpcodeType opCode,               //!< The opcode
-                                                 U32 cmdSeq,                        //!< The command sequence number
+void FpySequencer::DUMP_STACK_TO_FILE_cmdHandler(FwOpcodeType opCode,              //!< The opcode
+                                                 U32 cmdSeq,                       //!< The command sequence number
                                                  const Fw::CmdStringArg& fileName  //!< The name of the output file
 ) {
     if (this->sequencer_getState() != State::RUNNING_PAUSED) {

--- a/Svc/FpySequencer/FpySequencer.hpp
+++ b/Svc/FpySequencer/FpySequencer.hpp
@@ -213,6 +213,13 @@ class FpySequencer : public FpySequencerComponentBase {
                              U32 cmdSeq,           //!< The command sequence number
                              Svc::Fpy::FlagId flag,
                              bool value) override;
+    //! Handler for command DUMP_STACK_TO_FILE
+    //!
+    //! Writes the contents of the stack to a file. This command is only valid in the RUNNING.PAUSED state.
+    void DUMP_STACK_TO_FILE_cmdHandler(FwOpcodeType opCode,              //!< The opcode
+                                       U32 cmdSeq,                       //!< The command sequence number
+                                       const Fw::CmdStringArg& fileName  //!< The name of the output file
+                                       ) override;
 
     // ----------------------------------------------------------------------
     // Functions to implement for internal state machine actions
@@ -646,6 +653,10 @@ class FpySequencer : public FpySequencerComponentBase {
         U8 nextStatementOpcode = 0;
         // if the next statement is a cmd directive, the opcode of that cmd
         FwOpcodeType nextCmdOpcode = 0;
+        // the size of the stack. store this separately from the real stack size
+        // so we can avoid changing this during runtime, only modify it during
+        // debug
+        Fpy::StackSizeType stackSize = 0;
     } m_debug;
 
     struct Telemetry {

--- a/Svc/FpySequencer/FpySequencerCommands.fppi
+++ b/Svc/FpySequencer/FpySequencerCommands.fppi
@@ -63,3 +63,9 @@ async command SET_FLAG(
     flag: Fpy.FlagId, value: bool
 ) \
     opcode 9 priority 7 assert
+
+@ Writes the contents of the stack to a file. This command is only valid in the RUNNING.PAUSED state.
+async command DUMP_STACK_TO_FILE(
+    fileName: string size FileNameStringSize @< The name of the output file
+) \
+    opcode 10 priority 7 assert

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -658,7 +658,7 @@ DirectiveError FpySequencer::op_isub() {
     // Underflow can only occur when the left operand is negative and the right operand is positive. It occurs when the
     // left (negative) operand is less than the minimum value plus the other (positive) operand. If the right operand
     // is negative or zero, underflow cannot occur.
-    else if ((rhs > 0) && (lhs < 0) && ((std::numeric_limits<I64>::min() - rhs) > lhs)) {
+    else if ((rhs > 0) && (lhs < 0) && ((std::numeric_limits<I64>::min() + rhs) > lhs)) {
         return DirectiveError::ARITHMETIC_UNDERFLOW;
     }
     this->m_runtime.stack.push(static_cast<I64>(lhs - rhs));

--- a/Svc/FpySequencer/FpySequencerEvents.fppi
+++ b/Svc/FpySequencer/FpySequencerEvents.fppi
@@ -13,6 +13,14 @@ event FileOpenError(
     severity warning high \
     format "File open error encountered while opening {}: {}"
 
+event FileWriteError(
+    writeSize: FwSizeType
+    filePath: string
+    errorCode: I32
+) \
+    severity warning high \
+    format "File write error encountered while writing {} bytes to {}: {}"
+
 event FileReadError(
     readStage: FileReadStage
     filePath: string

--- a/Svc/FpySequencer/FpySequencerTelemetry.fppi
+++ b/Svc/FpySequencer/FpySequencerTelemetry.fppi
@@ -33,29 +33,31 @@ telemetry SeqPath: string size FileNameStringSize update on change
 # debug telemetry
 # only valid in RUNNING.PAUSED state
 @ true if there are no statements remaining in the sequence file
-telemetry Debug_ReachedEndOfFile: bool
+telemetry Debug_ReachedEndOfFile: bool update on change
 @ true if we were able to deserialize the next statement successfully
-telemetry Debug_NextStatementReadSuccess: bool
+telemetry Debug_NextStatementReadSuccess: bool update on change
 @ the opcode of the next statement to dispatch.
 telemetry Debug_NextStatementOpcode: U8 update on change
 @ if the next statement is a cmd directive, the opcode of that cmd
 telemetry Debug_NextCmdOpcode: FwOpcodeType update on change
+@ the size of the stack in bytes
+telemetry Debug_StackSize: Fpy.StackSizeType update on change
 
 # breakpoint telemetry
 @ whether or not to break at the breakpoint index
-telemetry BreakpointInUse: bool
+telemetry BreakpointInUse: bool update on change
 @ the current breakpoint index. The sequence will break at this point 
 @ just before dispatching the directive at this index
 telemetry BreakpointIndex: U32 update on change
 @ whether or not to remove the breakpoint after breaking on it
-telemetry BreakOnlyOnceOnBreakpoint: bool
+telemetry BreakOnlyOnceOnBreakpoint: bool update on change
 @ whether or not to break before dispatching the next line,
 @ independent of what line it is.
 @ can be used in combination with breakpointIndex
-telemetry BreakBeforeNextLine: bool
+telemetry BreakBeforeNextLine: bool update on change
 
 @ value of prm STATEMENT_TIMEOUT_SECS
 telemetry PRM_STATEMENT_TIMEOUT_SECS: F32 update on change
 
 @ value of prm FLAG_DEFAULT_EXIT_ON_CMD_FAIL
-telemetry PRM_FLAG_DEFAULT_EXIT_ON_CMD_FAIL: bool
+telemetry PRM_FLAG_DEFAULT_EXIT_ON_CMD_FAIL: bool update on change

--- a/Svc/FpySequencer/docs/sdd.md
+++ b/Svc/FpySequencer/docs/sdd.md
@@ -144,6 +144,7 @@ The FpySequencer has a set of debugging commands which can be used to pause and 
 | CONTINUE | Continues automatic execution of the sequence after it has been paused. If a breakpoint is still set, execution may pause again. |
 | CLEAR_BREAKPOINT | Clears any set breakpoint, but does not continue executing the sequence. |
 | STEP | When paused, executes the next statement then returns to paused state. Not valid during automatic execution. |
+| DUMP_STACK_TO_FILE | Writes the contents of the stack to a file. Not valid during automatic execution. |
 
 ## Directives
 See `directives.md` for documentation on all directives.

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -1699,7 +1699,8 @@ TEST_F(FpySequencerTester, cmd_DUMP_STACK_TO_FILE) {
     dispatchCurrentMessages(cmp);
     ASSERT_CMD_RESPONSE_SIZE(1);
     // Should fail in IDLE state
-    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_DUMP_STACK_TO_FILE(), 0, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_DUMP_STACK_TO_FILE(), 0,
+                        Fw::CmdResponse::EXECUTION_ERROR);
 
     // Test STEP command in RUNNING_PAUSED state (should succeed)
     this->clearHistory();
@@ -1734,7 +1735,7 @@ TEST_F(FpySequencerTester, cmd_DUMP_STACK_TO_FILE) {
     ASSERT_EQ(bytes[0], 0x00);
     ASSERT_EQ(bytes[1], 0x11);
     ASSERT_EQ(bytes[2], 0x22);
-    
+
     removeFile("output.bin");
 }
 

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -1692,6 +1692,52 @@ TEST_F(FpySequencerTester, cmd_STEP) {
     ASSERT_EVENTS_SequenceDone_SIZE(1);
 }
 
+TEST_F(FpySequencerTester, cmd_DUMP_STACK_TO_FILE) {
+    // Test command in IDLE state (should fail)
+    this->tester_setState(State::IDLE);
+    sendCmd_DUMP_STACK_TO_FILE(0, 0, Fw::String("test"));
+    dispatchCurrentMessages(cmp);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    // Should fail in IDLE state
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_DUMP_STACK_TO_FILE(), 0, Fw::CmdResponse::EXECUTION_ERROR);
+
+    // Test STEP command in RUNNING_PAUSED state (should succeed)
+    this->clearHistory();
+    // Setup test sequence
+    allocMem();
+    add_PUSH_VAL<U8>(0x00);
+    add_PUSH_VAL<U8>(0x11);
+    add_PUSH_VAL<U8>(0x22);
+    writeAndRun();
+
+    // tell it to break before the end
+    tester_get_m_breakpoint_ptr()->breakpointInUse = true;
+    tester_get_m_breakpoint_ptr()->breakpointIndex = 3;
+
+    // run until we get to paused
+    dispatchUntilState(State::RUNNING_PAUSED);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 3);
+
+    sendCmd_DUMP_STACK_TO_FILE(0, 0, Fw::String("output.bin"));
+    dispatchCurrentMessages(cmp);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    // Should succeed in RUNNING_PAUSED state
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_DUMP_STACK_TO_FILE(), 0, Fw::CmdResponse::OK);
+
+    // assert that the file was created and has the right data
+    Os::File outputFile;
+    ASSERT_EQ(outputFile.open("output.bin", Os::FileInterface::Mode::OPEN_READ), Os::File::Status::OP_OK);
+    U8 bytes[3] = {};
+    FwSizeType size = sizeof(bytes);
+    ASSERT_EQ(outputFile.read(bytes, size), Os::File::Status::OP_OK);
+    ASSERT_EQ(size, sizeof(bytes));
+    ASSERT_EQ(bytes[0], 0x00);
+    ASSERT_EQ(bytes[1], 0x11);
+    ASSERT_EQ(bytes[2], 0x22);
+    
+    removeFile("output.bin");
+}
+
 TEST_F(FpySequencerTester, readHeader) {
     U8 seqBuf[Fpy::Header::SERIALIZED_SIZE] = {0};
     tester_get_m_sequenceBuffer_ptr()->setExtBuffer(seqBuf, sizeof(seqBuf));
@@ -2494,7 +2540,7 @@ TEST_F(FpySequencerTester, tlmWrite) {
     invoke_to_tlmWrite(0, 0);
     this->tester_doDispatch();
     // make sure that all tlm is written every call
-    ASSERT_TLM_SIZE(18);
+    ASSERT_TLM_SIZE(19);
 }
 
 TEST_F(FpySequencerTester, seqRunIn) {

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
@@ -290,6 +290,9 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
 
     //! Get the OPCODE_STEP value
     static FwOpcodeType get_OPCODE_STEP() { return FpySequencerComponentBase::OPCODE_STEP; }
+
+    //! Get the OPCODE_DUMP_STACK_TO_FILE value
+    static FwOpcodeType get_OPCODE_DUMP_STACK_TO_FILE() { return FpySequencerComponentBase::OPCODE_DUMP_STACK_TO_FILE; }
 };
 
 class FpySequencer_SequencerStateMachineTester {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4383  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Adds telemetry for the stack size, and a command to write the stack to a file. Both are valid in the PAUSED state and are useful for debugging the compiler or VM