### PR TITLE
Clean up FpySequencer directives

### DIFF
--- a/Svc/FpySequencer/FpySequencer.hpp
+++ b/Svc/FpySequencer/FpySequencer.hpp
@@ -786,9 +786,9 @@ class FpySequencer : public FpySequencerComponentBase {
     DirectiveError op_fptosi();
     DirectiveError op_sitofp();
     DirectiveError op_uitofp();
-    DirectiveError op_iadd();
-    DirectiveError op_isub();
-    DirectiveError op_imul();
+    DirectiveError op_add();
+    DirectiveError op_sub();
+    DirectiveError op_mul();
     DirectiveError op_udiv();
     DirectiveError op_sdiv();
     DirectiveError op_umod();

--- a/Svc/FpySequencer/FpySequencer.hpp
+++ b/Svc/FpySequencer/FpySequencer.hpp
@@ -69,7 +69,6 @@ class FpySequencer : public FpySequencerComponentBase {
         FpySequencer_GetFlagDirective getFlag;
         FpySequencer_GetFieldDirective getField;
         FpySequencer_PeekDirective peek;
-        FpySequencer_AssertDirective assert;
         FpySequencer_StoreDirective store;
 
         DirectiveUnion() {}
@@ -544,9 +543,6 @@ class FpySequencer : public FpySequencerComponentBase {
     //! Internal interface handler for directive_peek
     void directive_peek_internalInterfaceHandler(const Svc::FpySequencer_PeekDirective& directive) override;
 
-    //! Internal interface handler for directive_assert
-    void directive_assert_internalInterfaceHandler(const Svc::FpySequencer_AssertDirective& directive) override;
-
     //! Internal interface handler for directive_store
     void directive_store_internalInterfaceHandler(const Svc::FpySequencer_StoreDirective& directive) override;
 
@@ -818,7 +814,6 @@ class FpySequencer : public FpySequencerComponentBase {
     Signal getFlag_directiveHandler(const FpySequencer_GetFlagDirective& directive, DirectiveError& error);
     Signal getField_directiveHandler(const FpySequencer_GetFieldDirective& directive, DirectiveError& error);
     Signal peek_directiveHandler(const FpySequencer_PeekDirective& directive, DirectiveError& error);
-    Signal assert_directiveHandler(const FpySequencer_AssertDirective& directive, DirectiveError& error);
     Signal store_directiveHandler(const FpySequencer_StoreDirective& directive, DirectiveError& error);
 };
 

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -615,7 +615,7 @@ DirectiveError FpySequencer::op_uitofp() {
     this->m_runtime.stack.push(static_cast<F64>(this->m_runtime.stack.pop<U64>()));
     return DirectiveError::NO_ERROR;
 }
-DirectiveError FpySequencer::op_iadd() {
+DirectiveError FpySequencer::op_add() {
     if (this->m_runtime.stack.size < sizeof(I64) * 2) {
         return DirectiveError::STACK_ACCESS_OUT_OF_BOUNDS;
     }
@@ -635,7 +635,7 @@ DirectiveError FpySequencer::op_iadd() {
     this->m_runtime.stack.push(static_cast<I64>(lhs + rhs));
     return DirectiveError::NO_ERROR;
 }
-DirectiveError FpySequencer::op_isub() {
+DirectiveError FpySequencer::op_sub() {
     if (this->m_runtime.stack.size < sizeof(I64) * 2) {
         return DirectiveError::STACK_ACCESS_OUT_OF_BOUNDS;
     }
@@ -657,7 +657,7 @@ DirectiveError FpySequencer::op_isub() {
     this->m_runtime.stack.push(static_cast<I64>(lhs - rhs));
     return DirectiveError::NO_ERROR;
 }
-DirectiveError FpySequencer::op_imul() {
+DirectiveError FpySequencer::op_mul() {
     if (this->m_runtime.stack.size < sizeof(I64) * 2) {
         return DirectiveError::STACK_ACCESS_OUT_OF_BOUNDS;
     }
@@ -967,14 +967,14 @@ Signal FpySequencer::stackOp_directiveHandler(const FpySequencer_StackOpDirectiv
         case Fpy::DirectiveId::UITOFP:
             error = this->op_uitofp();
             break;
-        case Fpy::DirectiveId::IADD:
-            error = this->op_iadd();
+        case Fpy::DirectiveId::ADD:
+            error = this->op_add();
             break;
-        case Fpy::DirectiveId::ISUB:
-            error = this->op_isub();
+        case Fpy::DirectiveId::SUB:
+            error = this->op_sub();
             break;
-        case Fpy::DirectiveId::IMUL:
-            error = this->op_imul();
+        case Fpy::DirectiveId::MUL:
+            error = this->op_mul();
             break;
         case Fpy::DirectiveId::UDIV:
             error = this->op_udiv();

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -235,13 +235,6 @@ void FpySequencer::directive_peek_internalInterfaceHandler(const Svc::FpySequenc
     handleDirectiveErrorCode(Fpy::DirectiveId::PEEK, error);
 }
 
-//! Internal interface handler for directive_assert
-void FpySequencer::directive_assert_internalInterfaceHandler(const Svc::FpySequencer_AssertDirective& directive) {
-    DirectiveError error = DirectiveError::NO_ERROR;
-    this->sendSignal(this->assert_directiveHandler(directive, error));
-    handleDirectiveErrorCode(Fpy::DirectiveId::ASSERT, error);
-}
-
 //! Internal interface handler for directive_store
 void FpySequencer::directive_store_internalInterfaceHandler(const Svc::FpySequencer_StoreDirective& directive) {
     DirectiveError error = DirectiveError::NO_ERROR;
@@ -789,15 +782,6 @@ DirectiveError FpySequencer::op_fdiv() {
     this->m_runtime.stack.push(static_cast<F64>(lhs / rhs));
     return DirectiveError::NO_ERROR;
 }
-DirectiveError FpySequencer::op_float_floor_div() {
-    if (this->m_runtime.stack.size < sizeof(F64) * 2) {
-        return DirectiveError::STACK_ACCESS_OUT_OF_BOUNDS;
-    }
-    F64 rhs = this->m_runtime.stack.pop<F64>();
-    F64 lhs = this->m_runtime.stack.pop<F64>();
-    this->m_runtime.stack.push(static_cast<F64>(floor(lhs / rhs)));
-    return DirectiveError::NO_ERROR;
-}
 DirectiveError FpySequencer::op_fpow() {
     if (this->m_runtime.stack.size < sizeof(F64) * 2) {
         return DirectiveError::STACK_ACCESS_OUT_OF_BOUNDS;
@@ -1015,9 +999,6 @@ Signal FpySequencer::stackOp_directiveHandler(const FpySequencer_StackOpDirectiv
             break;
         case Fpy::DirectiveId::FDIV:
             error = this->op_fdiv();
-            break;
-        case Fpy::DirectiveId::FLOAT_FLOOR_DIV:
-            error = this->op_float_floor_div();
             break;
         case Fpy::DirectiveId::FPOW:
             error = this->op_fpow();
@@ -1319,26 +1300,6 @@ Signal FpySequencer::peek_directiveHandler(const FpySequencer_PeekDirective& dir
     U8* src = this->m_runtime.stack.top() - offset - byteCount;
     this->m_runtime.stack.push(src, byteCount);
     return Signal::stmtResponse_success;
-}
-
-Signal FpySequencer::assert_directiveHandler(const FpySequencer_AssertDirective& directive, DirectiveError& error) {
-    if (this->m_runtime.stack.size < sizeof(U8) * 2) {
-        error = DirectiveError::STACK_ACCESS_OUT_OF_BOUNDS;
-        return Signal::stmtResponse_failure;
-    }
-    U8 errorCode = this->m_runtime.stack.pop<U8>();
-    U8 condition = this->m_runtime.stack.pop<U8>();
-
-    if (condition != 0) {
-        // proceed to next instruction
-        return Signal::stmtResponse_success;
-    }
-
-    // otherwise, kill the sequence here
-    // raise the user defined error code as an event
-    this->log_WARNING_HI_SequenceAsserted(this->m_sequenceFilePath, errorCode);
-    error = DirectiveError::ASSERTION_FAILURE;
-    return Signal::stmtResponse_failure;
 }
 
 Signal FpySequencer::store_directiveHandler(const FpySequencer_StoreDirective& directive, DirectiveError& error) {

--- a/Svc/FpySequencer/FpySequencerDirectives.fppi
+++ b/Svc/FpySequencer/FpySequencerDirectives.fppi
@@ -146,13 +146,6 @@ struct PeekDirective {
     _empty: U8
 }
 
-@ asserts that a condition is true, raise an error code if not
-struct AssertDirective {
-    # pops two U8s off the stack
-    # condition and error code
-    _empty: U8
-}
-
 @ stores bytes from the top of the stack into a memory location, determined by the stack
 struct StoreDirective {
     # pops an Fpy.StackSizeType offset off of stack
@@ -205,7 +198,5 @@ internal port directive_getFlag(directive: GetFlagDirective) priority 6 assert
 internal port directive_getField(directive: GetFieldDirective) priority 6 assert
 
 internal port directive_peek(directive: PeekDirective) priority 6 assert
-
-internal port directive_assert(directive: AssertDirective) priority 6 assert
 
 internal port directive_store(directive: StoreDirective) priority 6 assert

--- a/Svc/FpySequencer/FpySequencerEvents.fppi
+++ b/Svc/FpySequencer/FpySequencerEvents.fppi
@@ -95,13 +95,6 @@ event SequenceExitedWithError(
     severity warning high \
     format "Sequence {} exited with error code {}"
 
-event SequenceAsserted(
-    filePath: string
-    errorCode: U8
-) \
-    severity warning high \
-    format "Sequence {} failed an assertion with error code {}"
-
 event UnknownSequencerDirective(
     $opcode: U8
     stmtIdx: U32

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -213,9 +213,9 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         case Fpy::DirectiveId::FPTOUI:
         case Fpy::DirectiveId::SITOFP:
         case Fpy::DirectiveId::UITOFP:
-        case Fpy::DirectiveId::IADD:
-        case Fpy::DirectiveId::ISUB:
-        case Fpy::DirectiveId::IMUL:
+        case Fpy::DirectiveId::ADD:
+        case Fpy::DirectiveId::SUB:
+        case Fpy::DirectiveId::MUL:
         case Fpy::DirectiveId::UDIV:
         case Fpy::DirectiveId::SDIV:
         case Fpy::DirectiveId::UMOD:
@@ -487,9 +487,9 @@ void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy:
         case Fpy::DirectiveId::FPTOUI:
         case Fpy::DirectiveId::SITOFP:
         case Fpy::DirectiveId::UITOFP:
-        case Fpy::DirectiveId::IADD:
-        case Fpy::DirectiveId::ISUB:
-        case Fpy::DirectiveId::IMUL:
+        case Fpy::DirectiveId::ADD:
+        case Fpy::DirectiveId::SUB:
+        case Fpy::DirectiveId::MUL:
         case Fpy::DirectiveId::UDIV:
         case Fpy::DirectiveId::SDIV:
         case Fpy::DirectiveId::UMOD:

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -224,7 +224,6 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
         case Fpy::DirectiveId::FSUB:
         case Fpy::DirectiveId::FMUL:
         case Fpy::DirectiveId::FDIV:
-        case Fpy::DirectiveId::FLOAT_FLOOR_DIV:
         case Fpy::DirectiveId::FPOW:
         case Fpy::DirectiveId::FLOG:
         case Fpy::DirectiveId::FMOD:
@@ -398,16 +397,6 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
             }
             break;
         }
-        case Fpy::DirectiveId::ASSERT: {
-            new (&deserializedDirective.assert) FpySequencer_AssertDirective();
-            if (argBuf.getBuffLeft() != 0) {
-                this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(),
-                                                               Fw::SerializeStatus::FW_DESERIALIZE_SIZE_MISMATCH,
-                                                               argBuf.getBuffLeft(), argBuf.getBuffLength());
-                return Fw::Success::FAILURE;
-            }
-            break;
-        }
         case Fpy::DirectiveId::STORE: {
             new (&deserializedDirective.store) FpySequencer_StoreDirective();
             status = argBuf.deserializeTo(deserializedDirective.store);
@@ -509,7 +498,6 @@ void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy:
         case Fpy::DirectiveId::FSUB:
         case Fpy::DirectiveId::FMUL:
         case Fpy::DirectiveId::FDIV:
-        case Fpy::DirectiveId::FLOAT_FLOOR_DIV:
         case Fpy::DirectiveId::FPOW:
         case Fpy::DirectiveId::FLOG:
         case Fpy::DirectiveId::FMOD:
@@ -575,10 +563,6 @@ void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy:
         }
         case Fpy::DirectiveId::PEEK: {
             this->directive_peek_internalInterfaceInvoke(directive.peek);
-            return;
-        }
-        case Fpy::DirectiveId::ASSERT: {
-            this->directive_assert_internalInterfaceInvoke(directive.assert);
             return;
         }
         case Fpy::DirectiveId::STORE: {

--- a/Svc/FpySequencer/FpySequencerTypes.fpp
+++ b/Svc/FpySequencer/FpySequencerTypes.fpp
@@ -62,9 +62,9 @@ module Svc {
             SITOFP = 30
             UITOFP = 31
             # integer arithmetic
-            IADD = 32
-            ISUB = 33
-            IMUL = 34
+            ADD = 32
+            SUB = 33
+            MUL = 34
             UDIV = 35
             SDIV = 36
             UMOD = 37

--- a/Svc/FpySequencer/FpySequencerTypes.fpp
+++ b/Svc/FpySequencer/FpySequencerTypes.fpp
@@ -21,97 +21,95 @@ module Svc {
             INVALID = 0
             WAIT_REL = 1
             WAIT_ABS = 2
-            GOTO = 4
-            IF = 5
-            NO_OP = 6
-            PUSH_TLM_VAL = 7
-            PUSH_PRM = 8
-            CONST_CMD = 9
+            GOTO = 3
+            IF = 4
+            NO_OP = 5
+            PUSH_TLM_VAL = 6
+            PUSH_PRM = 7
+            CONST_CMD = 8
             # stack op directives
             # all of these are handled at the CPP level by one StackOpDirective to save boilerplate
             # you MUST keep them all in between OR and ITRUNC_64_32 inclusive
             # boolean ops
-            OR = 10
-            AND = 11
+            OR = 9
+            AND = 10
             # integer equalities
-            IEQ = 12
-            INE = 13
+            IEQ = 11
+            INE = 12
             # unsigned integer inequalities
-            ULT = 14
-            ULE = 15
-            UGT = 16
-            UGE = 17
+            ULT = 13
+            ULE = 14
+            UGT = 15
+            UGE = 16
             # signed integer inequalities
-            SLT = 18
-            SLE = 19
-            SGT = 20
-            SGE = 21
+            SLT = 17
+            SLE = 18
+            SGT = 19
+            SGE = 20
             # floating point equalities
-            FEQ = 22
-            FNE = 23
+            FEQ = 21
+            FNE = 22
             # floating point inequalities
-            FLT = 24
-            FLE = 25
-            FGT = 26
-            FGE = 27
-            NOT = 28
+            FLT = 23
+            FLE = 24
+            FGT = 25
+            FGE = 26
+            NOT = 27
             # floating point conversion to signed/unsigned integer,
             # and vice versa
-            FPTOSI = 29
-            FPTOUI = 30
-            SITOFP = 31
-            UITOFP = 32
+            FPTOSI = 28
+            FPTOUI = 29
+            SITOFP = 30
+            UITOFP = 31
             # integer arithmetic
-            IADD = 33
-            ISUB = 34
-            IMUL = 35
-            UDIV = 36
-            SDIV = 37
-            UMOD = 38
-            SMOD = 39
+            IADD = 32
+            ISUB = 33
+            IMUL = 34
+            UDIV = 35
+            SDIV = 36
+            UMOD = 37
+            SMOD = 38
             # float arithmetic
-            FADD = 40
-            FSUB = 41
-            FMUL = 42
-            FDIV = 43
-            FLOAT_FLOOR_DIV = 44
-            FPOW = 45
-            FLOG = 46
-            FMOD = 47
+            FADD = 39
+            FSUB = 40
+            FMUL = 41
+            FDIV = 42
+            FPOW = 43
+            FLOG = 44
+            FMOD = 45
             # floating point bitwidth conversions
-            FPEXT = 48
-            FPTRUNC = 49
+            FPEXT = 46
+            FPTRUNC = 47
             # integer bitwidth conversions
             # signed integer extend
-            SIEXT_8_64 = 50
-            SIEXT_16_64 = 51
-            SIEXT_32_64 = 52
+            SIEXT_8_64 = 48
+            SIEXT_16_64 = 49
+            SIEXT_32_64 = 50
             # zero (unsigned) integer extend
-            ZIEXT_8_64 = 53
-            ZIEXT_16_64 = 54
-            ZIEXT_32_64 = 55
+            ZIEXT_8_64 = 51
+            ZIEXT_16_64 = 52
+            ZIEXT_32_64 = 53
             # integer truncate
-            ITRUNC_64_8 = 56
-            ITRUNC_64_16 = 57
-            ITRUNC_64_32 = 58
+            ITRUNC_64_8 = 54
+            ITRUNC_64_16 = 55
+            ITRUNC_64_32 = 56
             # end stack op dirs
 
-            EXIT = 59
-            ALLOCATE = 60
-            STORE_CONST_OFFSET = 61
-            LOAD = 62
-            PUSH_VAL = 63
-            DISCARD = 64
-            MEMCMP = 65
-            STACK_CMD = 66
-            PUSH_TLM_VAL_AND_TIME = 67
-            PUSH_TIME = 68
-            SET_FLAG = 69
-            GET_FLAG = 70
-            GET_FIELD = 71
-            PEEK = 72
-            ASSERT = 73
-            STORE = 74
+            EXIT = 57
+            ALLOCATE = 58
+            STORE_CONST_OFFSET = 59
+            LOAD = 60
+            PUSH_VAL = 61
+            DISCARD = 62
+            MEMCMP = 63
+            STACK_CMD = 64
+            PUSH_TLM_VAL_AND_TIME = 65
+            PUSH_TIME = 66
+            SET_FLAG = 67
+            GET_FLAG = 68
+            GET_FIELD = 69
+            PEEK = 70
+            STORE = 71
         }
 
         enum DirectiveErrorCode : U8 {
@@ -127,10 +125,9 @@ module Svc {
             STACK_OVERFLOW = 9
             DOMAIN_ERROR = 10
             FLAG_IDX_OUT_OF_BOUNDS = 11
-            ASSERTION_FAILURE = 12
-            ARRAY_OUT_OF_BOUNDS = 13
-            ARITHMETIC_OVERFLOW = 14
-            ARITHMETIC_UNDERFLOW = 15
+            ARRAY_OUT_OF_BOUNDS = 12
+            ARITHMETIC_OVERFLOW = 13
+            ARITHMETIC_UNDERFLOW = 14
         }
 
         struct Header {

--- a/Svc/FpySequencer/docs/directives.md
+++ b/Svc/FpySequencer/docs/directives.md
@@ -32,7 +32,7 @@ Sleeps until an absolute time.
 
 **Requirement:** FPY-SEQ-008
 
-## GOTO (4)
+## GOTO (3)
 Sets the index of the next directive to execute.
 | Arg Name | Arg Type | Source     | Description |
 |----------|----------|------------|-------------|
@@ -44,7 +44,7 @@ Sets the index of the next directive to execute.
 
 **Requirement:**  FPY-SEQ-017
 
-## IF (5)
+## IF (4)
 Pops a byte off the stack. If the byte is not 0, proceed to the next directive, otherwise goto a hardcoded directive index.
  
 | Arg Name             | Arg Type | Source     | Description |
@@ -58,7 +58,7 @@ Pops a byte off the stack. If the byte is not 0, proceed to the next directive, 
 
 **Requirement:** FPY-SEQ-001
 
-## NO_OP (6)
+## NO_OP (5)
 Does nothing.
 
 | Arg Name             | Arg Type | Source     | Description |
@@ -71,7 +71,7 @@ Does nothing.
 
 **Requirement:**  FPY-SEQ-018
 
-## PUSH_TLM_VAL (7)
+## PUSH_TLM_VAL (6)
 Pushes a telemetry value buffer to the stack.
 | Arg Name     | Arg Type | Source     | Description |
 |--------------|----------|------------|-------------|
@@ -83,7 +83,7 @@ Pushes a telemetry value buffer to the stack.
 
 **Requirement:**  FPY-SEQ-003
 
-## PUSH_PRM (8)
+## PUSH_PRM (7)
 Pushes a parameter buffer to the stack.
 | Arg Name     | Arg Type | Source     | Description |
 |--------------|----------|------------|-------------|
@@ -95,7 +95,7 @@ Pushes a parameter buffer to the stack.
 
 **Requirement:**  FPY-SEQ-004
 
-## CONST_CMD (9)
+## CONST_CMD (8)
 Runs a command with a constant opcode and a constant byte array of arguments.
 | Arg Name   | Arg Type | Source     | Description |
 |------------|----------|------------|-------------|
@@ -108,7 +108,7 @@ Runs a command with a constant opcode and a constant byte array of arguments.
 
 **Requirement:**  FPY-SEQ-007, FPY-SEQ-008
 
-## OR (10)
+## OR (9)
 Performs an `or` between two booleans, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -121,7 +121,7 @@ Performs an `or` between two booleans, pushes result to stack.
 
 **Requirement:**  FPY-SEQ-002
 
-## AND (11)
+## AND (10)
 Performs an `and` between two booleans, pushes result to stack.
 
 | Arg Name | Arg Type | Source | Description |
@@ -135,7 +135,7 @@ Performs an `and` between two booleans, pushes result to stack.
 
 **Requirement:**  FPY-SEQ-002
 
-## IEQ (12)
+## IEQ (11)
 Compares two integers for equality, pushes result to stack. Doesn't differentiate between signed and unsigned.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -148,7 +148,7 @@ Compares two integers for equality, pushes result to stack. Doesn't differentiat
 
 **Requirement:**  FPY-SEQ-002
 
-## INE (13)
+## INE (12)
 Compares two integers for inequality, pushes result to stack. Doesn't differentiate between signed and unsigned.
 
 | Arg Name | Arg Type | Source | Description |
@@ -162,7 +162,7 @@ Compares two integers for inequality, pushes result to stack. Doesn't differenti
 
 **Requirement:**  FPY-SEQ-002
 
-## ULT (14)
+## ULT (13)
 Performs an unsigned less than comparison on two unsigned integers, pushes result to stack
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -175,7 +175,7 @@ Performs an unsigned less than comparison on two unsigned integers, pushes resul
 
 **Requirement:**  FPY-SEQ-002
 
-## ULE (15)
+## ULE (14)
 Performs an unsigned less than or equal to comparison on two unsigned integers, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -188,7 +188,7 @@ Performs an unsigned less than or equal to comparison on two unsigned integers, 
 
 **Requirement:**  FPY-SEQ-002
 
-## UGT (16)
+## UGT (15)
 Performs an unsigned greater than comparison on two unsigned integers, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -201,7 +201,7 @@ Performs an unsigned greater than comparison on two unsigned integers, pushes re
 
 **Requirement:**  FPY-SEQ-002
 
-## UGE (17)
+## UGE (16)
 Performs an unsigned greater than or equal to comparison on two unsigned integers, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -214,7 +214,7 @@ Performs an unsigned greater than or equal to comparison on two unsigned integer
 
 **Requirement:**  FPY-SEQ-002
 
-## SLT (18)
+## SLT (17)
 Performs a signed less than comparison on two signed integers, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -227,7 +227,7 @@ Performs a signed less than comparison on two signed integers, pushes result to 
 
 **Requirement:**  FPY-SEQ-002
 
-## SLE (19)
+## SLE (18)
 Performs a signed less than or equal to comparison on two signed integers, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -240,7 +240,7 @@ Performs a signed less than or equal to comparison on two signed integers, pushe
 
 **Requirement:**  FPY-SEQ-002
 
-## SGT (20)
+## SGT (19)
 Performs a signed greater than comparison on two signed integers, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -253,7 +253,7 @@ Performs a signed greater than comparison on two signed integers, pushes result 
 
 **Requirement:**  FPY-SEQ-002
 
-## SGE (21)
+## SGE (20)
 Performs a signed greater than or equal to comparison on two signed integers, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -266,7 +266,7 @@ Performs a signed greater than or equal to comparison on two signed integers, pu
 
 **Requirement:**  FPY-SEQ-002
 
-## FEQ (22)
+## FEQ (21)
 Compares two floats for equality, pushes result to stack. If neither is NaN and they are otherwise equal, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -279,7 +279,7 @@ Compares two floats for equality, pushes result to stack. If neither is NaN and 
 
 **Requirement:**  FPY-SEQ-002
 
-## FNE (23)
+## FNE (22)
 Compares two floats for inequality, pushes result to stack. If either is NaN or they are not equal, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -292,7 +292,7 @@ Compares two floats for inequality, pushes result to stack. If either is NaN or 
 
 **Requirement:**  FPY-SEQ-002
 
-## FLT (24)
+## FLT (23)
 Performs a less than comparison on two floats, pushes result to stack. If neither is NaN and the second < first, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -305,7 +305,7 @@ Performs a less than comparison on two floats, pushes result to stack. If neithe
 
 **Requirement:**  FPY-SEQ-002
 
-## FLE (25)
+## FLE (24)
 Performs a less than or equal to comparison on two floats, pushes result to stack. If neither is NaN and the second <= first, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -318,7 +318,7 @@ Performs a less than or equal to comparison on two floats, pushes result to stac
 
 **Requirement:**  FPY-SEQ-002
 
-## FGT (26)
+## FGT (25)
 Performs a greater than comparison on two floats, pushes result to stack. If neither is NaN and the second > first, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -331,7 +331,7 @@ Performs a greater than comparison on two floats, pushes result to stack. If nei
 
 **Requirement:**  FPY-SEQ-002
 
-## FGE (27)
+## FGE (26)
 Performs a greater than or equal to comparison on two floats, pushes result to stack. If neither is NaN and the second >= first, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -344,7 +344,7 @@ Performs a greater than or equal to comparison on two floats, pushes result to s
 
 **Requirement:**  FPY-SEQ-002
 
-## NOT (28)
+## NOT (27)
 Performs a boolean not operation on a boolean, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -356,7 +356,7 @@ Performs a boolean not operation on a boolean, pushes result to stack.
 
 **Requirement:**  FPY-SEQ-002
 
-## FPTOSI (29)
+## FPTOSI (28)
 Converts a float to a signed integer, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -368,7 +368,7 @@ Converts a float to a signed integer, pushes result to stack.
 
 **Requirement:**  FPY-SEQ-015
 
-## FPTOUI (30)
+## FPTOUI (29)
 Converts a float to an unsigned integer, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -380,7 +380,7 @@ Converts a float to an unsigned integer, pushes result to stack.
 
 **Requirement:**  FPY-SEQ-015
 
-## SITOFP (31)
+## SITOFP (30)
 Converts a signed integer to a float, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -393,7 +393,7 @@ Converts a signed integer to a float, pushes result to stack.
 **Requirement:**  FPY-SEQ-015
 
 
-## UITOFP (32)
+## UITOFP (31)
 Converts an unsigned integer to a float, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -405,7 +405,7 @@ Converts an unsigned integer to a float, pushes result to stack.
 
 **Requirement:**  FPY-SEQ-015
 
-## ADD (33)
+## ADD (32)
 Performs integer addition, pushes result to stack. Integers are handled with 2's complement representation.
 
 | Arg Name | Arg Type | Source | Description |
@@ -419,7 +419,7 @@ Performs integer addition, pushes result to stack. Integers are handled with 2's
 
 **Requirement:**  FPY-SEQ-002
 
-## SUB (34)
+## SUB (33)
 Performs integer subtraction, pushes result to stack. Integers are handled with 2's complement representation.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -432,7 +432,7 @@ Performs integer subtraction, pushes result to stack. Integers are handled with 
 
 **Requirement:**  FPY-SEQ-002
 
-## MUL (35)
+## MUL (34)
 Performs integer multiplication, pushes result to stack.  Integers are handled with 2's complement representation.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -445,7 +445,7 @@ Performs integer multiplication, pushes result to stack.  Integers are handled w
 
 **Requirement:**  FPY-SEQ-002
 
-## UDIV (36)
+## UDIV (35)
 Performs unsigned integer division, pushes result to stack. A divisor of 0 will result in DOMAIN_ERROR.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -458,7 +458,7 @@ Performs unsigned integer division, pushes result to stack. A divisor of 0 will 
 
 **Requirement:**  FPY-SEQ-002
 
-## SDIV (37)
+## SDIV (36)
 Performs signed integer division, pushes result to stack. A divisor of 0 will result in DOMAIN_ERROR.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -471,7 +471,7 @@ Performs signed integer division, pushes result to stack. A divisor of 0 will re
 
 **Requirement:**  FPY-SEQ-002
 
-## UMOD (38)
+## UMOD (37)
 Performs unsigned integer modulo, pushes result to stack. A 0 divisor (rhs) will result in DOMAIN_ERROR.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -484,7 +484,7 @@ Performs unsigned integer modulo, pushes result to stack. A 0 divisor (rhs) will
 
 **Requirement:**  FPY-SEQ-002
 
-## SMOD (39)
+## SMOD (38)
 Performs signed integer modulo, pushes result to stack. A 0 divisor (rhs) will result in DOMAIN_ERROR.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -497,7 +497,7 @@ Performs signed integer modulo, pushes result to stack. A 0 divisor (rhs) will r
 
 **Requirement:**  FPY-SEQ-002
 
-## FADD (40)
+## FADD (39)
 Performs float addition, pushes result to stack. NaN, and infinity are handled consistently with C++ addition.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -510,7 +510,7 @@ Performs float addition, pushes result to stack. NaN, and infinity are handled c
 
 **Requirement:**  FPY-SEQ-002
 
-## FSUB (41)
+## FSUB (40)
 Performs float subtraction, pushes result to stack. NaN, and infinity are handled consistently with C++ subtraction.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -523,7 +523,7 @@ Performs float subtraction, pushes result to stack. NaN, and infinity are handle
 
 **Requirement:**  FPY-SEQ-002
 
-## FMUL (42)
+## FMUL (41)
 Performs float multiplication, pushes result to stack. NaN, and infinity are handled consistently with C++ multiplication.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -536,7 +536,7 @@ Performs float multiplication, pushes result to stack. NaN, and infinity are han
 
 **Requirement:**  FPY-SEQ-002
 
-## FDIV (43)
+## FDIV (42)
 Performs float division, pushes result to stack. Zero divisors, NaN, and infinity are handled consistently with C++ division.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -549,7 +549,7 @@ Performs float division, pushes result to stack. Zero divisors, NaN, and infinit
 
 **Requirement:**  FPY-SEQ-002
 
-## FPOW (45)
+## FPOW (43)
 Performs float exponentiation, pushes result to stack. NaN and infinity values are handled consistently with C++ `std::pow`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -562,7 +562,7 @@ Performs float exponentiation, pushes result to stack. NaN and infinity values a
 
 **Requirement:**  FPY-SEQ-002
 
-## FLOG (46)
+## FLOG (44)
 Performs float logarithm, pushes result to stack. Negatives yield a DOMAIN_ERROR, NaN and infinity values are handled consistently with C++ `std::log`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -574,7 +574,7 @@ Performs float logarithm, pushes result to stack. Negatives yield a DOMAIN_ERROR
 
 **Requirement:**  FPY-SEQ-002
 
-## FMOD (47)
+## FMOD (45)
 Performs float modulo, pushes result to stack. A 0 divisor (rhs) will result in a DOMAIN_ERROR. A NaN will produce a NaN result or infinity as either argument yields NaN.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -587,7 +587,7 @@ Performs float modulo, pushes result to stack. A 0 divisor (rhs) will result in 
 
 **Requirement:**  FPY-SEQ-002
 
-## FPTRUNC (49)
+## FPTRUNC (47)
 Truncates a 64-bit float to a 32-bit float, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -599,7 +599,7 @@ Truncates a 64-bit float to a 32-bit float, pushes result to stack.
 
 **Requirement:**  FPY-SEQ-002
 
-## FPEXT (48)
+## FPEXT (46)
 Extends a 32-bit float to a 64-bit float, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -611,7 +611,7 @@ Extends a 32-bit float to a 64-bit float, pushes result to stack.
 
 **Requirement:**  FPY-SEQ-002
 
-## SIEXT_8_64 (50)
+## SIEXT_8_64 (48)
 Sign-extends an 8-bit integer to a 64-bit integer, pushes result to stack.  Integers are handled with 2's complement representation.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -623,7 +623,7 @@ Sign-extends an 8-bit integer to a 64-bit integer, pushes result to stack.  Inte
 
 **Requirement:** FPY-SEQ-015
 
-## SIEXT_16_64 (51)
+## SIEXT_16_64 (49)
 Sign-extends a 16-bit integer to a 64-bit integer, pushes result to stack. Integers are handled with 2's complement representation.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -635,7 +635,7 @@ Sign-extends a 16-bit integer to a 64-bit integer, pushes result to stack. Integ
 
 **Requirement:** FPY-SEQ-015
 
-## SIEXT_32_64 (52)
+## SIEXT_32_64 (50)
 Sign-extends a 32-bit integer to a 64-bit integer, pushes result to stack. Integers are handled with 2's complement representation.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -647,7 +647,7 @@ Sign-extends a 32-bit integer to a 64-bit integer, pushes result to stack. Integ
 
 **Requirement:** FPY-SEQ-015
 
-## ZIEXT_8_64 (53)
+## ZIEXT_8_64 (51)
 Zero-extends an 8-bit integer to a 64-bit integer, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -659,7 +659,7 @@ Zero-extends an 8-bit integer to a 64-bit integer, pushes result to stack.
 
 **Requirement:**  FPY-SEQ-015
 
-## ZIEXT_16_64 (54)
+## ZIEXT_16_64 (52)
 Zero-extends a 16-bit integer to a 64-bit integer, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -671,7 +671,7 @@ Zero-extends a 16-bit integer to a 64-bit integer, pushes result to stack.
 
 **Requirement:**  FPY-SEQ-015
 
-## ZIEXT_32_64 (55)
+## ZIEXT_32_64 (53)
 Zero-extends a 32-bit integer to a 64-bit integer, pushes result to stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -683,7 +683,7 @@ Zero-extends a 32-bit integer to a 64-bit integer, pushes result to stack.
 
 **Requirement:**  FPY-SEQ-015
 
-## ITRUNC_64_8 (56)
+## ITRUNC_64_8 (54)
 Truncates a 64-bit integer to an 8-bit integer, pushes result to stack. Integers are handled with 2's complement representation.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -695,7 +695,7 @@ Truncates a 64-bit integer to an 8-bit integer, pushes result to stack. Integers
 
 **Requirement:**  FPY-SEQ-015
 
-## ITRUNC_64_16 (57)
+## ITRUNC_64_16 (55)
 Truncates a 64-bit integer to a 16-bit integer, pushes result to stack. Integers are handled with 2's complement representation.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -707,7 +707,7 @@ Truncates a 64-bit integer to a 16-bit integer, pushes result to stack. Integers
 
 **Requirement:** FPY-SEQ-015
 
-## ITRUNC_64_32 (58)
+## ITRUNC_64_32 (56)
 Truncates a 64-bit integer to a 32-bit integer, pushes result to stack. Integers are handled with 2's complement representation.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -719,7 +719,7 @@ Truncates a 64-bit integer to a 32-bit integer, pushes result to stack. Integers
 
 **Requirement:**  FPY-SEQ-015
 
-## EXIT (59)
+## EXIT (57)
 Pops a byte off the stack. If the byte == 0, end sequence as if it had finished nominally, otherwise exit the sequence and raise an event with an error code.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -731,7 +731,7 @@ Pops a byte off the stack. If the byte == 0, end sequence as if it had finished 
 
 **Requirement:**  FPY-SEQ-016
 
-## ALLOCATE (60)
+## ALLOCATE (58)
 Pushes a hard-coded count of 0x00-bytes to the stack.
 | Arg Name | Arg Type | Source     | Description |
 |----------|----------|------------|-------------|
@@ -743,7 +743,7 @@ Pushes a hard-coded count of 0x00-bytes to the stack.
 
 **Requirement:**  FPY-SEQ-009, FPY-SEQ-010
 
-## STORE_CONST_OFFSET (61)
+## STORE_CONST_OFFSET (59)
 Pops a hard-coded number of bytes off the stack, and writes them to the local variable array at a hard-coded offset.
 | Arg Name    | Arg Type | Source     | Description |
 |-------------|----------|------------|-------------|
@@ -753,7 +753,7 @@ Pops a hard-coded number of bytes off the stack, and writes them to the local va
 
 **Requirement:**  FPY-SEQ-009, FPY-SEQ-010
 
-## LOAD (62)
+## LOAD (60)
 Reads a hard-coded number of bytes from the local variable array at a specific offset, and pushes them to the stack.
 | Arg Name    | Arg Type | Source     | Description |
 |-------------|----------|------------|-------------|
@@ -766,7 +766,7 @@ Reads a hard-coded number of bytes from the local variable array at a specific o
 
 **Requirement:** FPY-SEQ-009, FPY-SEQ-010
 
-## PUSH_VAL (63)
+## PUSH_VAL (61)
 Pushes a constant array of bytes to the stack.
 | Arg Name | Arg Type | Source     | Description |
 |----------|----------|------------|-------------|
@@ -778,7 +778,7 @@ Pushes a constant array of bytes to the stack.
 
 **Requirement:**  FPY-SEQ-009, FPY-SEQ-010
 
-## DISCARD (64)
+## DISCARD (62)
 Discards bytes from the top of the stack.
 | Arg Name | Arg Type | Source     | Description |
 |----------|----------|------------|-------------|
@@ -786,7 +786,7 @@ Discards bytes from the top of the stack.
 
 **Requirement:**  FPY-SEQ-009, FPY-SEQ-010
 
-## MEMCMP (65)
+## MEMCMP (63)
 
 Pops 2x `size` bytes off the stack.  Compares the first `size` bytes to the second `size` bytes with a byte-for-byte comparison pushing a boolean true when equal and false when unequal.
 
@@ -800,7 +800,7 @@ Pops 2x `size` bytes off the stack.  Compares the first `size` bytes to the seco
 
 **Requirement:** FPY-SEQ-019
 
-## STACK_CMD (66)
+## STACK_CMD (64)
 Dispatches a command with arguments from the stack.
 | Arg Name  | Arg Type | Source     | Description |
 |-----------|----------|------------|-------------|
@@ -812,7 +812,7 @@ Dispatches a command with arguments from the stack.
 
 **Requirement:**  FPY-SEQ-010
 
-## PUSH_TLM_VAL_AND_TIME (67)
+## PUSH_TLM_VAL_AND_TIME (65)
 Gets a telemetry channel and pushes its value, and then its time, onto the stack.
 | Arg Name     | Arg Type | Source     | Description |
 |--------------|----------|------------|-------------|
@@ -825,7 +825,7 @@ Gets a telemetry channel and pushes its value, and then its time, onto the stack
 
 **Requirement:**  FPY-SEQ-010
 
-## PUSH_TIME (68)
+## PUSH_TIME (66)
 Pushes the current time, from the `timeCaller` port, to the stack.
 | Stack Result Type | Description |
 | ------------------|-------------|
@@ -833,7 +833,7 @@ Pushes the current time, from the `timeCaller` port, to the stack.
 
 **Requirement:**  FPY-SEQ-010
 
-## SET_FLAG (69)
+## SET_FLAG (67)
 Pops a bool off the stack, and sets a command sequencer flag from the value.
 
 | Arg Name | Arg Type | Source | Description |
@@ -847,7 +847,7 @@ Pops a bool off the stack, and sets a command sequencer flag from the value.
 
 **Requirement:**  FPY-SEQ-020
 
-## GET_FLAG (70)
+## GET_FLAG (68)
 Gets a command sequencer flag and pushes its value as a U8 to the stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -859,7 +859,7 @@ Gets a command sequencer flag and pushes its value as a U8 to the stack.
 
 **Requirement:**  FPY-SEQ-020
 
-## GET_FIELD (71)
+## GET_FIELD (69)
 Pops an offset (StackSizeType) off the stack. Takes a hard-coded number of bytes from top of stack, and then inside of that a second array of hard-coded number of bytes. The second array is offset by the value previously popped off the stack, with offset 0 meaning the second array starts furthest down the stack. Leaves only the second array of bytes, deleting the surrounding bytes.
 
 | Arg Name | Arg Type | Source | Description |
@@ -874,7 +874,7 @@ Pops an offset (StackSizeType) off the stack. Takes a hard-coded number of bytes
 
 **Requirement:**  FPY-SEQ-019
 
-## PEEK (72)
+## PEEK (70)
 Pops a StackSizeType `offset` off the stack, then a StackSizeType `byteCount`. Let `top` be the top of the stack. Takes the region starting at `top - offset - byteCount` and going to `top - offset`, and pushes this region to the top of the stack.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -887,7 +887,7 @@ Pops a StackSizeType `offset` off the stack, then a StackSizeType `byteCount`. L
 
 **Requirement:**  FPY-SEQ-009
 
-## STORE (74)
+## STORE (71)
 Pops an offset (StackSizeType) off the stack. Pops a hardcoded number of bytes from the top of the stack, and moves them to the start of the lvar array plus the offset previously popped off the stack.
 | Arg Name    | Arg Type | Source     | Description |
 |-------------|----------|------------|-------------|

--- a/Svc/FpySequencer/docs/directives.md
+++ b/Svc/FpySequencer/docs/directives.md
@@ -678,13 +678,6 @@ Pops a StackSizeType `offset` off the stack, then a StackSizeType `byteCount`. L
 | ------------------|-------------|
 | bytes | The peeked bytes |
 
-## ASSERT (73)
-Pops one byte for a condition and one byte for an error code off the stack. If condition is false, raise the error code as an event.
-| Arg Name | Arg Type | Source | Description |
-|----------|----------|--------|-------------|
-| error_code | U8 | stack | Error code to exit with if assertion fails |
-| condition | bool | stack | Condition to assert |
-
 ## STORE (74)
 Pops an offset (StackSizeType) off the stack. Pops a hardcoded number of bytes from the top of the stack, and moves them to the start of the lvar array plus the offset previously popped off the stack.
 | Arg Name    | Arg Type | Source     | Description |

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -892,13 +892,6 @@ TEST_F(FpySequencerTester, fdiv) {
     ASSERT_EQ(tester_pop<F64>(), 123.0);
 }
 
-TEST_F(FpySequencerTester, float_floor_div) {
-    tester_push<F64>(246.8);
-    tester_push<F64>(2.0);
-    ASSERT_EQ(tester_op_float_floor_div(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_pop<F64>(), 123.0);
-}
-
 TEST_F(FpySequencerTester, fpow) {
     tester_push<F64>(3.0);
     tester_push<F64>(2.0);
@@ -1137,31 +1130,6 @@ TEST_F(FpySequencerTester, getField) {
     tester_get_m_runtime_ptr()->stack.size = 0;
     directive = FpySequencer_GetFieldDirective(0, 0);
     result = tester_getField_directiveHandler(directive, err);
-    ASSERT_EQ(result, Signal::stmtResponse_failure);
-    ASSERT_EQ(err, DirectiveError::STACK_ACCESS_OUT_OF_BOUNDS);
-}
-
-TEST_F(FpySequencerTester, assert) {
-    FpySequencer_AssertDirective directive;
-    tester_push<U8>(1);  // True condition
-    tester_push<U8>(0);  // 0 error code
-    DirectiveError err = DirectiveError::NO_ERROR;
-    Signal result = tester_assert_directiveHandler(directive, err);
-    ASSERT_EQ(result, Signal::stmtResponse_success);
-    ASSERT_EQ(err, DirectiveError::NO_ERROR);
-
-    // Test false assertion
-    tester_push<U8>(0);
-    tester_push<U8>(123);  // 123 error code
-    result = tester_assert_directiveHandler(directive, err);
-    ASSERT_EQ(result, Signal::stmtResponse_failure);
-    ASSERT_EQ(err, DirectiveError::ASSERTION_FAILURE);
-    ASSERT_EVENTS_SequenceAsserted_SIZE(1);
-    ASSERT_EVENTS_SequenceAsserted(0, tester_get_m_sequenceFilePath().toChar(), 123);
-
-    // Test stack underflow
-    tester_get_m_runtime_ptr()->stack.size = 0;
-    result = tester_assert_directiveHandler(directive, err);
     ASSERT_EQ(result, Signal::stmtResponse_failure);
     ASSERT_EQ(err, DirectiveError::STACK_ACCESS_OUT_OF_BOUNDS);
 }
@@ -2283,26 +2251,6 @@ TEST_F(FpySequencerTester, deserialize_getField) {
     result = tester_deserializeDirective(seq.get_statements()[0], actual);
     ASSERT_EQ(result, Fw::Success::FAILURE);
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
-}
-
-TEST_F(FpySequencerTester, deserialize_assert) {
-    FpySequencer::DirectiveUnion actual;
-    FpySequencer_AssertDirective dir;
-    add_ASSERT();
-    Fw::Success result = tester_deserializeDirective(seq.get_statements()[0], actual);
-    ASSERT_EQ(result, Fw::Success::SUCCESS);
-    ASSERT_EQ(actual.assert, dir);
-    // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serializeFrom(123);
-    result = tester_deserializeDirective(seq.get_statements()[0], actual);
-    ASSERT_EQ(result, Fw::Success::FAILURE);
-    ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
-    this->clearHistory();
-    // clear args, make sure it succeeds
-    seq.get_statements()[0].get_argBuf().resetSer();
-    result = tester_deserializeDirective(seq.get_statements()[0], actual);
-    ASSERT_EQ(result, Fw::Success::SUCCESS);
-    ASSERT_EVENTS_DirectiveDeserializeError_SIZE(0);
 }
 
 TEST_F(FpySequencerTester, deserialize_store) {

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -815,24 +815,24 @@ TEST_F(FpySequencerTester, uitofp) {
     ASSERT_EQ(expected, tester_pop<F64>());
 }
 
-TEST_F(FpySequencerTester, iadd) {
+TEST_F(FpySequencerTester, add) {
     tester_push<I64>(100);
     tester_push<I64>(23);
-    ASSERT_EQ(tester_op_iadd(), DirectiveError::NO_ERROR);
+    ASSERT_EQ(tester_op_add(), DirectiveError::NO_ERROR);
     ASSERT_EQ(tester_pop<I64>(), 123);
 }
 
-TEST_F(FpySequencerTester, isub) {
+TEST_F(FpySequencerTester, sub) {
     tester_push<I64>(150);
     tester_push<I64>(27);
-    ASSERT_EQ(tester_op_isub(), DirectiveError::NO_ERROR);
+    ASSERT_EQ(tester_op_sub(), DirectiveError::NO_ERROR);
     ASSERT_EQ(tester_pop<I64>(), 123);
 }
 
-TEST_F(FpySequencerTester, imul) {
+TEST_F(FpySequencerTester, mul) {
     tester_push<I64>(41);
     tester_push<I64>(3);
-    ASSERT_EQ(tester_op_imul(), DirectiveError::NO_ERROR);
+    ASSERT_EQ(tester_op_mul(), DirectiveError::NO_ERROR);
     ASSERT_EQ(tester_pop<I64>(), 123);
 }
 

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
@@ -643,14 +643,14 @@ DirectiveError FpySequencerTester::tester_op_sitofp() {
 DirectiveError FpySequencerTester::tester_op_uitofp() {
     return this->cmp.op_uitofp();
 }
-DirectiveError FpySequencerTester::tester_op_iadd() {
-    return this->cmp.op_iadd();
+DirectiveError FpySequencerTester::tester_op_add() {
+    return this->cmp.op_add();
 }
-DirectiveError FpySequencerTester::tester_op_isub() {
-    return this->cmp.op_isub();
+DirectiveError FpySequencerTester::tester_op_sub() {
+    return this->cmp.op_sub();
 }
-DirectiveError FpySequencerTester::tester_op_imul() {
-    return this->cmp.op_imul();
+DirectiveError FpySequencerTester::tester_op_mul() {
+    return this->cmp.op_mul();
 }
 DirectiveError FpySequencerTester::tester_op_udiv() {
     return this->cmp.op_udiv();

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
@@ -315,15 +315,6 @@ void FpySequencerTester::add_PEEK(const FpySequencer_PeekDirective dir) {
     addDirective(Fpy::DirectiveId::PEEK, buf);
 }
 
-void FpySequencerTester::add_ASSERT() {
-    add_ASSERT(FpySequencer_AssertDirective());
-}
-
-void FpySequencerTester::add_ASSERT(const FpySequencer_AssertDirective dir) {
-    Fw::StatementArgBuffer buf;
-    addDirective(Fpy::DirectiveId::ASSERT, buf);
-}
-
 void FpySequencerTester::add_STORE(const Fpy::StackSizeType size) {
     add_STORE(FpySequencer_StoreDirective(size));
 }
@@ -476,11 +467,6 @@ Signal FpySequencerTester::tester_getField_directiveHandler(const FpySequencer_G
 Signal FpySequencerTester::tester_peek_directiveHandler(const FpySequencer_PeekDirective& directive,
                                                         DirectiveError& err) {
     return this->cmp.peek_directiveHandler(directive, err);
-}
-
-Signal FpySequencerTester::tester_assert_directiveHandler(const FpySequencer_AssertDirective& directive,
-                                                          DirectiveError& err) {
-    return this->cmp.assert_directiveHandler(directive, err);
 }
 
 Signal FpySequencerTester::tester_store_directiveHandler(const FpySequencer_StoreDirective& directive,
@@ -689,9 +675,6 @@ DirectiveError FpySequencerTester::tester_op_fmul() {
 }
 DirectiveError FpySequencerTester::tester_op_fdiv() {
     return this->cmp.op_fdiv();
-}
-DirectiveError FpySequencerTester::tester_op_float_floor_div() {
-    return this->cmp.op_float_floor_div();
 }
 DirectiveError FpySequencerTester::tester_op_fpow() {
     return this->cmp.op_fpow();

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
@@ -195,9 +195,9 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     DirectiveError tester_op_fptosi();
     DirectiveError tester_op_sitofp();
     DirectiveError tester_op_uitofp();
-    DirectiveError tester_op_iadd();
-    DirectiveError tester_op_isub();
-    DirectiveError tester_op_imul();
+    DirectiveError tester_op_add();
+    DirectiveError tester_op_sub();
+    DirectiveError tester_op_mul();
     DirectiveError tester_op_udiv();
     DirectiveError tester_op_sdiv();
     DirectiveError tester_op_umod();

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
@@ -120,8 +120,6 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     void add_GET_FIELD(FpySequencer_GetFieldDirective dir);
     void add_PEEK();
     void add_PEEK(FpySequencer_PeekDirective dir);
-    void add_ASSERT();
-    void add_ASSERT(FpySequencer_AssertDirective dir);
     void add_STORE(Fpy::StackSizeType size);
     void add_STORE(FpySequencer_StoreDirective dir);
     template <typename T>
@@ -170,7 +168,6 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     Signal tester_getFlag_directiveHandler(const FpySequencer_GetFlagDirective& directive, DirectiveError& err);
     Signal tester_getField_directiveHandler(const FpySequencer_GetFieldDirective& directive, DirectiveError& err);
     Signal tester_peek_directiveHandler(const FpySequencer_PeekDirective& directive, DirectiveError& err);
-    Signal tester_assert_directiveHandler(const FpySequencer_AssertDirective& directive, DirectiveError& err);
     Signal tester_store_directiveHandler(const FpySequencer_StoreDirective& directive, DirectiveError& err);
     Signal tester_pushTime_directiveHandler(const FpySequencer_PushTimeDirective& directive, DirectiveError& err);
     DirectiveError tester_op_or();
@@ -209,7 +206,6 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     DirectiveError tester_op_fsub();
     DirectiveError tester_op_fmul();
     DirectiveError tester_op_fdiv();
-    DirectiveError tester_op_float_floor_div();
     DirectiveError tester_op_fpow();
     DirectiveError tester_op_flog();
     DirectiveError tester_op_fmod();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4394  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

* Remove the ASSERT and FLOAT_FLOOR_DIV directives, which can be replaced with combinations of other dirs.
* Rename IADD to ADD, ISUB to SUB and IMUL to MUL
## Rationale
This keeps the bytecode simple and consistent with other bytecodes.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Updated docs, renamed bytecode ops
