### PR TITLE
ComAggregator updates

### DIFF
--- a/Svc/ComAggregator/ComAggregator.cpp
+++ b/Svc/ComAggregator/ComAggregator.cpp
@@ -65,7 +65,7 @@ void ComAggregator ::timeout_handler(FwIndexType portNum, U32 context) {
 // ----------------------------------------------------------------------
 
 void ComAggregator ::Svc_AggregationMachine_action_doClear(SmId smId, Svc_AggregationMachine::Signal signal) {
-    this->m_allow_timeout = true; // Allow timeout messages in FILL state
+    this->m_allow_timeout = true;  // Allow timeout messages in FILL state
     this->m_frameSerializer.resetSer();
     this->m_frameBuffer.setSize(sizeof(this->m_frameBufferStore));
     if (this->m_held.get_data().isValid()) {
@@ -93,7 +93,7 @@ void ComAggregator ::Svc_AggregationMachine_action_doSend(SmId smId, Svc_Aggrega
     if (this->m_frameSerializer.getSize() > 0) {
         this->m_bufferState = Fw::Buffer::OwnershipState::NOT_OWNED;
         this->m_frameBuffer.setSize(this->m_frameSerializer.getSize());
-        this->m_allow_timeout = false; // Timeout messages should be discarded in WAIT_STATUS state
+        this->m_allow_timeout = false;  // Timeout messages should be discarded in WAIT_STATUS state
         this->dataOut_out(0, this->m_frameBuffer, this->m_lastContext);
     }
 }

--- a/Svc/ComAggregator/ComAggregator.cpp
+++ b/Svc/ComAggregator/ComAggregator.cpp
@@ -119,7 +119,15 @@ bool ComAggregator ::Svc_AggregationMachine_guard_isFull(SmId smId,
                                                          const Svc::ComDataContextPair& value) const {
     FW_ASSERT(value.get_data().getSize() <= ComCfg::AggregationSize);
     const FwSizeType remaining = this->m_frameSerializer.getCapacity() - this->m_frameSerializer.getSize();
-    return (remaining <= value.get_data().getSize());
+    return (remaining < value.get_data().getSize());
+}
+
+bool ComAggregator ::Svc_AggregationMachine_guard_willFill(SmId smId,
+                                                           Svc_AggregationMachine::Signal signal,
+                                                           const Svc::ComDataContextPair& value) const {
+    FW_ASSERT(value.get_data().getSize() <= ComCfg::AggregationSize);
+    const FwSizeType remaining = this->m_frameSerializer.getCapacity() - this->m_frameSerializer.getSize();
+    return (remaining == value.get_data().getSize());
 }
 
 bool ComAggregator ::Svc_AggregationMachine_guard_isNotEmpty(SmId smId, Svc_AggregationMachine::Signal signal) const {

--- a/Svc/ComAggregator/ComAggregator.cpp
+++ b/Svc/ComAggregator/ComAggregator.cpp
@@ -16,7 +16,8 @@ ComAggregator ::ComAggregator(const char* const compName)
     : ComAggregatorComponentBase(compName),
       m_bufferState(Fw::Buffer::OwnershipState::OWNED),
       m_frameBuffer(m_frameBufferStore, sizeof(m_frameBufferStore)),
-      m_frameSerializer(m_frameBuffer.getSerializer()) {}
+      m_frameSerializer(m_frameBuffer.getSerializer()),
+      m_allow_timeout(false) {}
 
 ComAggregator ::~ComAggregator() {}
 
@@ -44,7 +45,19 @@ void ComAggregator ::dataReturnIn_handler(FwIndexType portNum, Fw::Buffer& data,
 }
 
 void ComAggregator ::timeout_handler(FwIndexType portNum, U32 context) {
-    this->aggregationMachine_sendSignal_timeout();
+    // Timeout is ignored in WAIT_STATUS state. However, the queue may not process timeout messages until the wait
+    // status is returned because the port chain may be synchronous and downstream components (radio, retry, etc) may
+    // take a long time to complete the transmission of data. This can cause the queue to overflow with messages that
+    // will soon be discarded.
+    //
+    // Therefore, to fix the risk of queue overflow we only queue timeout messages when they would be processed by the
+    // state machine (i.e. in the FILL state). Otherwise, these messages are not queued.
+    //
+    // Behaviorally, this solution will work exactly like the naive implementation with an infinite queue depth, but
+    // prevents queue overflow when using finite queues.
+    if (this->m_allow_timeout) {
+        this->aggregationMachine_sendSignal_timeout();
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -52,6 +65,7 @@ void ComAggregator ::timeout_handler(FwIndexType portNum, U32 context) {
 // ----------------------------------------------------------------------
 
 void ComAggregator ::Svc_AggregationMachine_action_doClear(SmId smId, Svc_AggregationMachine::Signal signal) {
+    this->m_allow_timeout = true; // Allow timeout messages in FILL state
     this->m_frameSerializer.resetSer();
     this->m_frameBuffer.setSize(sizeof(this->m_frameBufferStore));
     if (this->m_held.get_data().isValid()) {
@@ -79,6 +93,7 @@ void ComAggregator ::Svc_AggregationMachine_action_doSend(SmId smId, Svc_Aggrega
     if (this->m_frameSerializer.getSize() > 0) {
         this->m_bufferState = Fw::Buffer::OwnershipState::NOT_OWNED;
         this->m_frameBuffer.setSize(this->m_frameSerializer.getSize());
+        this->m_allow_timeout = false; // Timeout messages should be discarded in WAIT_STATUS state
         this->dataOut_out(0, this->m_frameBuffer, this->m_lastContext);
     }
 }

--- a/Svc/ComAggregator/ComAggregator.hpp
+++ b/Svc/ComAggregator/ComAggregator.hpp
@@ -116,6 +116,14 @@ class ComAggregator final : public ComAggregatorComponentBase {
                                              const Svc::ComDataContextPair& value    //!< The value
     ) const override;
 
+    //! Implementation for guard willFill of state machine Svc_AggregationMachine
+    //!
+    //! Check if the incoming buffer will exactly fill the aggregation buffer
+    bool Svc_AggregationMachine_guard_willFill(SmId smId,                              //!< The state machine id
+                                               Svc_AggregationMachine::Signal signal,  //!< The signal
+                                               const Svc::ComDataContextPair& value    //!< The value
+    ) const override;
+
     //! Implementation for guard isNotEmpty of state machine Svc_AggregationMachine
     //!
     //! Check if not empty

--- a/Svc/ComAggregator/ComAggregator.hpp
+++ b/Svc/ComAggregator/ComAggregator.hpp
@@ -139,7 +139,7 @@ class ComAggregator final : public ComAggregatorComponentBase {
     Fw::ExternalSerializeBufferWithMemberCopy m_frameSerializer;  //!< Serializer for m_frameBuffer
     ComCfg::FrameContext m_lastContext;                           //!< Context for the current frame
 
-    Svc::ComDataContextPair m_held;  //!< Held data while waiting for send
+    Svc::ComDataContextPair m_held;     //!< Held data while waiting for send
     std::atomic<bool> m_allow_timeout;  //!< Whether status has been received
 };
 

--- a/Svc/ComAggregator/ComAggregator.hpp
+++ b/Svc/ComAggregator/ComAggregator.hpp
@@ -7,6 +7,7 @@
 #ifndef Svc_ComAggregator_HPP
 #define Svc_ComAggregator_HPP
 
+#include <atomic>
 #include "Os/Mutex.hpp"
 #include "Svc/ComAggregator/ComAggregatorComponentAc.hpp"
 
@@ -139,6 +140,7 @@ class ComAggregator final : public ComAggregatorComponentBase {
     ComCfg::FrameContext m_lastContext;                           //!< Context for the current frame
 
     Svc::ComDataContextPair m_held;  //!< Held data while waiting for send
+    std::atomic<bool> m_allow_timeout;  //!< Whether status has been received
 };
 
 }  // namespace Svc

--- a/Svc/ComAggregator/test/ut/ComAggregatorTestMain.cpp
+++ b/Svc/ComAggregator/test/ut/ComAggregatorTestMain.cpp
@@ -5,6 +5,7 @@
 // ======================================================================
 
 #include "ComAggregatorTester.hpp"
+#include "STest/Random/Random.hpp"
 
 TEST(Nominal, Initial) {
     Svc::ComAggregatorTester tester;
@@ -45,6 +46,16 @@ TEST(OffNominal, TimeoutEmpty) {
     tester.test_full();
 }
 
+TEST(OffNominal, TimeoutOverflowPrevention) {
+    Svc::ComAggregatorTester tester;
+    tester.test_initial();
+    tester.test_fill_multi();
+    tester.test_timeout_overflow_prevention();
+    // Now ensure normal operation resumes
+    tester.test_fill_multi();
+    tester.test_timeout();
+}
+
 TEST(Nominal, HoldWhileWaiting) {
     Svc::ComAggregatorTester tester;
     tester.test_initial();
@@ -64,6 +75,7 @@ TEST(Nominal, Clear) {
 }
 
 int main(int argc, char** argv) {
+    STest::Random::seed();
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/Svc/ComAggregator/test/ut/ComAggregatorTestMain.cpp
+++ b/Svc/ComAggregator/test/ut/ComAggregatorTestMain.cpp
@@ -31,6 +31,13 @@ TEST(Nominal, Full) {
     tester.test_full();
 }
 
+TEST(Nominal, ExactlyFull) {
+    Svc::ComAggregatorTester tester;
+    tester.test_initial();
+    tester.test_fill_multi();
+    tester.test_exactly_full();
+}
+
 TEST(Nominal, Timeout) {
     Svc::ComAggregatorTester tester;
     tester.test_initial();

--- a/Svc/ComAggregator/test/ut/ComAggregatorTester.cpp
+++ b/Svc/ComAggregator/test/ut/ComAggregatorTester.cpp
@@ -80,9 +80,9 @@ void ComAggregatorTester ::test_initial() {
 Fw::Buffer ComAggregatorTester ::test_fill(bool expect_hold) {
     // Precondition: initial has run
     const FwSizeType ORIGINAL_LENGTH = this->component.m_frameSerializer.getSize();
-    // Maximum size we can fill while respecting the expect_hold flag
-    const FwSizeType MAX_FILL = ComCfg::AggregationSize - ORIGINAL_LENGTH -
-                                ((expect_hold || ORIGINAL_LENGTH == ComCfg::AggregationSize) ? 0 : 1);
+    // Maximum size we can fill
+    const FwSizeType MAX_FILL =
+        ComCfg::AggregationSize - ORIGINAL_LENGTH - ((ORIGINAL_LENGTH == ComCfg::AggregationSize) ? 0 : 1);
     if (MAX_FILL == 0) {
         // Nothing to fill
         return Fw::Buffer();
@@ -99,7 +99,6 @@ Fw::Buffer ComAggregatorTester ::test_fill(bool expect_hold) {
     if (expect_hold) {
         EXPECT_EQ(ORIGINAL_LENGTH, this->component.m_frameSerializer.getSize());
     } else {
-        printf("DEBUG: ORIGINAL_LENGTH=%lu, BUFFER_LENGTH=%u\n", ORIGINAL_LENGTH, BUFFER_LENGTH);
         EXPECT_EQ(ORIGINAL_LENGTH + BUFFER_LENGTH, this->component.m_frameSerializer.getSize());
         this->validate_buffer_aggregated(buffer, context);
     }
@@ -152,6 +151,47 @@ void ComAggregatorTester ::test_full() {
               Svc::ComAggregatorComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);  // Dispatch the state machine
     // Validate that the new buffer has been aggregated
     this->validate_buffer_aggregated(buffer, context);
+    this->clearHistory();
+}
+
+//! Tests exactly full operation
+void ComAggregatorTester ::test_exactly_full() {
+    // Precondition: fill has run
+    // Chose a buffer that will be too large to fit but still will fit after being aggregated
+    const FwSizeType ORIGINAL_LENGTH = this->component.m_frameSerializer.getSize();
+    const U32 BUFFER_LENGTH = static_cast<U32>(ComCfg::AggregationSize - ORIGINAL_LENGTH);
+    Fw::Buffer buffer = fill_buffer(BUFFER_LENGTH);
+    ComCfg::FrameContext context;
+
+    // Send the overflow buffer and ensure the current aggregation comes out
+    this->invoke_to_dataIn(0, buffer, context);
+    ASSERT_EQ(this->dispatchOne(this->component),
+              Svc::ComAggregatorComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);  // Dispatch the state machine
+    ASSERT_from_dataOut_SIZE(1);
+    // First validate the sent buffer was aggregated correctly. This also updates the shadow aggregation.
+    this->validate_buffer_aggregated(buffer, context);
+    // Now validate that the sent buffer matches the shadow aggregation.
+    this->validate_aggregation(this->fromPortHistory_dataOut->at(0).data);
+    // Invoke some number of failures
+    for (U32 i = 0; i < STest::Pick::lowerUpper(1, 5); i++) {
+        Fw::Success bad = Fw::Success::FAILURE;
+        this->invoke_to_comStatusIn(0, bad);
+        ASSERT_EQ(this->dispatchOne(this->component),
+                  Svc::ComAggregatorComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);  // Dispatch the state machine
+        // Should be no change
+        this->validate_aggregation(this->component.m_frameBuffer);
+        ASSERT_from_dataOut_SIZE(1);
+    }
+    // Const cast is safe as data is not altered
+    this->invoke_to_dataReturnIn(0, const_cast<Fw::Buffer&>(this->fromPortHistory_dataOut->at(0).data),
+                                 this->fromPortHistory_dataOut->at(0).context);
+    Fw::Success good = Fw::Success::SUCCESS;
+    this->invoke_to_comStatusIn(0, good);
+    this->m_aggregation.clear();
+    ASSERT_EQ(this->dispatchOne(this->component),
+              Svc::ComAggregatorComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);  // Dispatch the state machine
+    // Validate that there is no data aggregated
+    ASSERT_EQ(this->component.m_frameSerializer.getSize(), 0);
     this->clearHistory();
 }
 

--- a/Svc/ComAggregator/test/ut/ComAggregatorTester.cpp
+++ b/Svc/ComAggregator/test/ut/ComAggregatorTester.cpp
@@ -33,7 +33,7 @@ Fw::Buffer ComAggregatorTester ::fill_buffer(U32 size) {
     for (U32 i = 0; i < size; i++) {
         data[i] = static_cast<U8>(STest::Pick::lowerUpper(0, 255));
     }
-    Fw::Buffer buffer(data, size);
+    Fw::Buffer buffer(data, static_cast<FwSizeType>(size));
     return buffer;
 }
 
@@ -72,29 +72,38 @@ void ComAggregatorTester ::test_initial() {
     this->invoke_to_comStatusIn(0, good);
     ASSERT_EQ(this->dispatchOne(this->component),
               Svc::ComAggregatorComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);  // Dispatch the state machine
+    // Ensure we dispatched all messages
+    ASSERT_EQ(this->component.m_queue.getMessagesAvailable(), 0);
 }
 
 //! Tests fill operation
 Fw::Buffer ComAggregatorTester ::test_fill(bool expect_hold) {
     // Precondition: initial has run
     const FwSizeType ORIGINAL_LENGTH = this->component.m_frameSerializer.getSize();
-    if (ORIGINAL_LENGTH == ComCfg::AggregationSize) {
+    // Maximum size we can fill while respecting the expect_hold flag
+    const FwSizeType MAX_FILL = ComCfg::AggregationSize - ORIGINAL_LENGTH -
+                                ((expect_hold || ORIGINAL_LENGTH == ComCfg::AggregationSize) ? 0 : 1);
+    if (MAX_FILL == 0) {
         // Nothing to fill
         return Fw::Buffer();
     }
-    const U32 BUFFER_LENGTH = STest::Pick::lowerUpper(1, static_cast<U32>(ComCfg::AggregationSize - ORIGINAL_LENGTH));
+    // Allow a full buffer only in the case where we expect to hold
+    const U32 BUFFER_LENGTH = STest::Pick::lowerUpper(1, static_cast<U32>(MAX_FILL));
     Fw::Buffer buffer = fill_buffer(BUFFER_LENGTH);
     ComCfg::FrameContext context;
-
+    EXPECT_EQ(this->component.m_queue.getMessagesAvailable(), 0);
     this->invoke_to_dataIn(0, buffer, context);
     EXPECT_EQ(this->dispatchOne(this->component),
               Svc::ComAggregatorComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);  // Dispatch the state machine
+    EXPECT_EQ(this->component.m_queue.getMessagesAvailable(), 0);
     if (expect_hold) {
         EXPECT_EQ(ORIGINAL_LENGTH, this->component.m_frameSerializer.getSize());
     } else {
+        printf("DEBUG: ORIGINAL_LENGTH=%lu, BUFFER_LENGTH=%u\n", ORIGINAL_LENGTH, BUFFER_LENGTH);
         EXPECT_EQ(ORIGINAL_LENGTH + BUFFER_LENGTH, this->component.m_frameSerializer.getSize());
         this->validate_buffer_aggregated(buffer, context);
     }
+    EXPECT_EQ(this->component.m_queue.getMessagesAvailable(), 0);
     this->clearHistory();
     return buffer;
 }
@@ -165,6 +174,45 @@ void ComAggregatorTester ::test_timeout() {
         this->validate_aggregation(this->component.m_frameBuffer);
         ASSERT_from_dataOut_SIZE(1);
     }
+    // Const cast is safe as data is not altered
+    this->invoke_to_dataReturnIn(0, const_cast<Fw::Buffer&>(this->fromPortHistory_dataOut->at(0).data),
+                                 this->fromPortHistory_dataOut->at(0).context);
+    Fw::Success good = Fw::Success::SUCCESS;
+    this->invoke_to_comStatusIn(0, good);
+    this->m_aggregation.clear();
+    ASSERT_EQ(this->dispatchOne(this->component),
+              Svc::ComAggregatorComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);  // Dispatch the state machine
+    this->clearHistory();
+}
+
+//! Tests timeout operation
+void ComAggregatorTester ::test_timeout_overflow_prevention() {
+    ASSERT_EQ(this->component.m_queue.getMessagesAvailable(), 0);
+    // Precondition: fill has run
+    this->invoke_to_timeout(0, 0);
+    ASSERT_EQ(this->dispatchOne(this->component),
+              Svc::ComAggregatorComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);  // Dispatch the state machine
+    ASSERT_from_dataOut_SIZE(1);
+    this->validate_aggregation(this->fromPortHistory_dataOut->at(0).data);
+    // Invoke some number of failure status. These prevent the timeout from being prematurely enabled.
+    for (U32 i = 0; i < STest::Pick::lowerUpper(1, 5); i++) {
+        Fw::Success bad = Fw::Success::FAILURE;
+        this->invoke_to_comStatusIn(0, bad);
+        ASSERT_EQ(this->dispatchOne(this->component),
+                  Svc::ComAggregatorComponentBase::MsgDispatchStatus::MSG_DISPATCH_OK);  // Dispatch the state machine
+        // Should be no change
+        this->validate_aggregation(this->component.m_frameBuffer);
+        ASSERT_from_dataOut_SIZE(1);
+    }
+    // Now invoke enough extra timeouts to overflow the queue if they were all queued
+    for (U32 i = 0; i < STest::Pick::lowerUpper(1, TEST_INSTANCE_QUEUE_DEPTH) + TEST_INSTANCE_QUEUE_DEPTH; i++) {
+        // These timeouts should be dropped
+        this->invoke_to_timeout(0, 0);
+        // Should be no change
+        this->validate_aggregation(this->component.m_frameBuffer);
+        ASSERT_from_dataOut_SIZE(1);
+    }
+
     // Const cast is safe as data is not altered
     this->invoke_to_dataReturnIn(0, const_cast<Fw::Buffer&>(this->fromPortHistory_dataOut->at(0).data),
                                  this->fromPortHistory_dataOut->at(0).context);

--- a/Svc/ComAggregator/test/ut/ComAggregatorTester.hpp
+++ b/Svc/ComAggregator/test/ut/ComAggregatorTester.hpp
@@ -59,6 +59,9 @@ class ComAggregatorTester final : public ComAggregatorGTestBase {
     //! Tests timeout operation
     void test_timeout();
 
+    //! Tests timeout operation
+    void test_timeout_overflow_prevention();
+
     //! Tests timeout operation sends no empty buffer
     void test_timeout_zero();
 

--- a/Svc/ComAggregator/test/ut/ComAggregatorTester.hpp
+++ b/Svc/ComAggregator/test/ut/ComAggregatorTester.hpp
@@ -56,6 +56,9 @@ class ComAggregatorTester final : public ComAggregatorGTestBase {
     //! Tests full operation
     void test_full();
 
+    //! Tests exactly full operation
+    void test_exactly_full();
+
     //! Tests timeout operation
     void test_timeout();
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Flask-Compress==1.15
 Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.3
 fprime-fpl-write-pic==1.0.3
-fprime-fpp==3.1.0a8
+fprime-fpp==3.1.0a9
 fprime-gds==4.0.2a9
 fprime-tools==4.0.2a1
 fprime-visual==1.0.2


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

This fixes two major oversights in ComAggregator:

1. Repeated timeout can trigger a queue-overflow assertion when the time spent sending the com buffer greatly exceeds the timeout interval. This can happen in the following (synchronous) scenarios:
  1.  Long retry intervals
  2. Long transmission times
2. A buffer will be held when it would exactly fit in the aggregation buffer. 

## Rationale

Both of these issues need to be fixed.

## Testing/Review Recommendations

Unit-tests!

## Future Work

None for these dimensions.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Autocomplete.