### PR TITLE
Fix compiler options in Ref build

### DIFF
--- a/Ref/CMakeLists.txt
+++ b/Ref/CMakeLists.txt
@@ -12,10 +12,7 @@ cmake_policy(SET CMP0048 NEW)
 cmake_minimum_required(VERSION 3.26)
 project(Ref VERSION 1.0.0 LANGUAGES C CXX)
 
-# Find the fprime package and include the core codebase
-set(FPRIME_INCLUDE_FRAMEWORK_CODE ON)
-find_package(FPrime REQUIRED PATHS "${CMAKE_CURRENT_LIST_DIR}/..")
-
+# Add compile options used by all build modules
 add_compile_options(
     $<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>
     -Wall
@@ -28,6 +25,10 @@ add_compile_options(
     -Wshadow
     -pedantic
 )
+
+# Find the fprime package and include the core codebase
+set(FPRIME_INCLUDE_FRAMEWORK_CODE ON)
+find_package(FPrime REQUIRED PATHS "${CMAKE_CURRENT_LIST_DIR}/..")
 
 # Add subdirectories for the Ref project specific components
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PingReceiver/")


### PR DESCRIPTION
CMake directives were out of order, causing core F Prime code to be compiled with default compiler options. I noticed this when running the tracing script submitted in https://github.com/nasa/fpp/pull/871. The build was showing symptoms of running with default compiler options (complaining about warnings that are turned off, not converting warnings to errors).
