### PR TITLE
Add undef to fix collission problem.

### DIFF
--- a/Drv/Ip/UdpSocket.hpp
+++ b/Drv/Ip/UdpSocket.hpp
@@ -21,7 +21,7 @@
 #include <inetLib.h>
 #include <socket.h>
 
-// Undefining these Vxworks-defined macros because
+// Undefine these Vxworks-defined macros because
 // they collide with member variables in F Prime.
 // These macros are defined somewhere in inetLib.h.
 #undef m_type

--- a/Drv/Ip/UdpSocket.hpp
+++ b/Drv/Ip/UdpSocket.hpp
@@ -20,6 +20,13 @@
 #ifdef TGT_OS_TYPE_VXWORKS
 #include <inetLib.h>
 #include <socket.h>
+
+// Undefining these Vxworks-defined macros because
+// they collide with member variables in F Prime.
+// These macros are defined somewhere in inetLib.h.
+#undef m_type
+#undef m_data
+
 #else
 #include <arpa/inet.h>
 #include <sys/socket.h>


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/4399 |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**|n  |

---
## Change Description

Undefined VxWorks macros that collides with names of member variables in core F Prime.

## Rationale

Collisions cause fsw build to fail. 

## Testing/Review Recommendations

Let CI Pass.
Run a VxWorks application that uses a UDP component.

## Future Work

Other VxWorks' macros could cause collision. Keep an eye out on it

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None