### PR TITLE
Print the task name when socket open/recv fails

### DIFF
--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -297,7 +297,7 @@ void SocketComponentHelper::reconnectLoop() {
             // Reopen Case 3: Keep trying to reconnect - NO reconnect
             // state change
             else {
-                Fw::Logger::log("[WARNING] Failed to open port with status %d and errno %d\n", status, errno);
+                Fw::Logger::log("[WARNING] %s failed to open port with status %d and errno %d\n", this->m_task.getName().toChar(), status, errno);
                 (void)Os::Task::delay(SOCKET_RETRY_INTERVAL);
             }
         } else {

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -220,7 +220,7 @@ void SocketComponentHelper::readLoop() {
             status = this->recv(data, size);
             if ((status != SOCK_SUCCESS) && (status != SOCK_INTERRUPTED_TRY_AGAIN) &&
                 (status != SOCK_NO_DATA_AVAILABLE)) {
-                Fw::Logger::log("[WARNING] Failed to recv from port with status %d and errno %d\n", status, errno);
+                Fw::Logger::log("[WARNING] %s failed to recv from port with status %d and errno %d\n", this->m_task.getName().toChar(), status, errno);
                 this->close();
                 buffer.setSize(0);
             } else {

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -220,7 +220,8 @@ void SocketComponentHelper::readLoop() {
             status = this->recv(data, size);
             if ((status != SOCK_SUCCESS) && (status != SOCK_INTERRUPTED_TRY_AGAIN) &&
                 (status != SOCK_NO_DATA_AVAILABLE)) {
-                Fw::Logger::log("[WARNING] %s failed to recv from port with status %d and errno %d\n", this->m_task.getName().toChar(), status, errno);
+                Fw::Logger::log("[WARNING] %s failed to recv from port with status %d and errno %d\n",
+                                this->m_task.getName().toChar(), status, errno);
                 this->close();
                 buffer.setSize(0);
             } else {
@@ -297,7 +298,8 @@ void SocketComponentHelper::reconnectLoop() {
             // Reopen Case 3: Keep trying to reconnect - NO reconnect
             // state change
             else {
-                Fw::Logger::log("[WARNING] %s failed to open port with status %d and errno %d\n", this->m_task.getName().toChar(), status, errno);
+                Fw::Logger::log("[WARNING] %s failed to open port with status %d and errno %d\n",
+                                this->m_task.getName().toChar(), status, errno);
                 (void)Os::Task::delay(SOCKET_RETRY_INTERVAL);
             }
         } else {

--- a/Os/Task.cpp
+++ b/Os/Task.cpp
@@ -174,6 +174,11 @@ bool Task::isCooperative() {
     return this->m_delegate.isCooperative();
 }
 
+TaskString Task::getName() {
+    Os::ScopeLock lock(this->m_lock);
+    return this->m_name;
+}
+
 FwTaskPriorityType Task::getPriority() {
     Os::ScopeLock lock(this->m_lock);
     return this->m_priority;

--- a/Os/Task.hpp
+++ b/Os/Task.hpp
@@ -346,7 +346,6 @@ class Task final : public TaskInterface {
     //! \return true if cooperative, false otherwise
     bool isCooperative() override;
 
-
     //! \brief get the task name
     TaskString getName();
 

--- a/Os/Task.hpp
+++ b/Os/Task.hpp
@@ -346,6 +346,10 @@ class Task final : public TaskInterface {
     //! \return true if cooperative, false otherwise
     bool isCooperative() override;
 
+
+    //! \brief get the task name
+    TaskString getName();
+
     //! \brief get the task priority
     FwTaskPriorityType getPriority();
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n  |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Add the name of the task the log when a socket recv or open fails.

## Rationale

Give users a hope of hunting down which socket driver isn't correctly configured.

## Testing/Review Recommendations

See if there are any other similar warnings that would also benefit from access to the instance/task name.

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A