### PR TITLE
Remove redundant line from ActiveRateGroup SDD

### DIFF
--- a/Svc/ActiveRateGroup/docs/sdd.md
+++ b/Svc/ActiveRateGroup/docs/sdd.md
@@ -4,7 +4,6 @@
 
 `Svc::ActiveRateGroup` is an active component that drives a set of components connected to `Svc::Sched` output ports. 
 It contains an asynchronous input `Svc::Cycle` port. This port sends a message which wakes the component task. 
-It contains an asynchronous input `Svc::Cycle` port. This port sends a message which wakes the component task. 
 The task invokes each output port in order, passing an argument indicating the order. It tracks execution time and detects overruns.
 
 ## 2. Requirements


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Removed a duplicate line from the SDD.

## Rationale

Removes redundant content to keep the SDD accurate and consistent.

## Testing/Review Recommendations

N/A

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
