### PR TITLE
Restrict core C and DH when turning off text loggers

### DIFF
--- a/Svc/Subtopologies/CdhCore/CMakeLists.txt
+++ b/Svc/Subtopologies/CdhCore/CMakeLists.txt
@@ -1,3 +1,7 @@
+
+if (NOT FPRIME_ENABLE_TEXT_LOGGERS)
+    return()
+endif()
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/CdhCoreConfig/")
 
 register_fprime_module(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Fixes #4432