### PR TITLE
Specify dictionary types as required by GDS

### DIFF
--- a/Ref/fprime-gds.yml
+++ b/Ref/fprime-gds.yml
@@ -1,3 +1,2 @@
 command-line-options:
-  scid: 0x0044 
   framing-selection: space-packet-space-data-link

--- a/default/config/ComCfg.fpp
+++ b/default/config/ComCfg.fpp
@@ -3,21 +3,22 @@
 # ======================================================================
 
 @ The width of packet descriptors when they are serialized by the framework
-type FwPacketDescriptorType = U16
+dictionary type FwPacketDescriptorType = U16
 constant SIZE_OF_FwPacketDescriptorType = 2  @< Size of FwPacketDescriptorType in bytes
 
 module ComCfg {
 
-    # Needed in dictionary:
-    # - spacecraftId
-    # - TmFrameFixedSize
-    # - potentially APID enum ?
-    constant SpacecraftId = 0x0044    # Spacecraft ID (10 bits)
-    constant TmFrameFixedSize = 1024  # Needs to be at least COM_BUFFER_MAX_SIZE + (2 * SpacePacketHeaderSize) + 1
+    @ Spacecraft ID (10 bits) for CCSDS Data Link layer
+    dictionary constant SpacecraftId = 0x0044
+    
+    @ Fixed size of CCSDS TM frames
+    dictionary constant TmFrameFixedSize = 1024  # Needs to be at least COM_BUFFER_MAX_SIZE + (2 * SpacePacketHeaderSize) + 1
+
+    @ Aggregation buffer for ComAggregator component
     constant AggregationSize = TmFrameFixedSize - 6 - 6 - 1 - 2  # 2 header (6) + 1 idle byte + 2 trailer bytes
 
     @ APIDs are 11 bits in the Space Packet protocol, so we use U16. Max value 7FF
-    enum Apid : FwPacketDescriptorType {
+    dictionary enum Apid : FwPacketDescriptorType {
         # APIDs prefixed with FW are reserved for F Prime and need to be present
         # in the enumeration. Their values can be changed
         FW_PACKET_COMMAND        = 0x0000  @< Command packet type - incoming

--- a/default/config/FpConfig.fpp
+++ b/default/config/FpConfig.fpp
@@ -51,7 +51,7 @@ type FwTaskIdType = PlatformTaskIdType
 ####
 
 @ The type of a telemetry channel identifier
-type FwChanIdType = FwIdType
+dictionary type FwChanIdType = FwIdType
 constant SIZE_OF_FwChanIdType = SIZE_OF_FwIdType  @< Size of FwChanIdType in bytes
 
 @ The type of a data product identifier
@@ -61,11 +61,11 @@ type FwDpIdType = FwIdType
 type FwDpPriorityType = U32
 
 @ The type of an event identifier
-type FwEventIdType = FwIdType
+dictionary type FwEventIdType = FwIdType
 constant SIZE_OF_FwEventIdType = SIZE_OF_FwIdType  @< Size of FwEventIdType in bytes
 
 @ The type of a command opcode
-type FwOpcodeType = FwIdType
+dictionary type FwOpcodeType = FwIdType
 constant SIZE_OF_FwOpcodeType = SIZE_OF_FwIdType  @< Size of FwOpcodeType in bytes
 
 @ The type of a parameter identifier
@@ -73,10 +73,10 @@ type FwPrmIdType = FwIdType
 constant SIZE_OF_FwPrmIdType = SIZE_OF_FwIdType  @< Size of FwPrmIdType in bytes
 
 @ The type used to serialize a size value
-type FwSizeStoreType = U16
+dictionary type FwSizeStoreType = U16
 
 @ The type used to serialize a time context value
-type FwTimeContextStoreType = U8
+dictionary type FwTimeContextStoreType = U8
 
 @ The type of a telemetry packet identifier
 type FwTlmPacketizeIdType = U16
@@ -92,9 +92,10 @@ type FwEnumStoreType = I32
 type FwTimeBaseStoreType = U16
 
 @ Define enumeration for Time base types
-enum TimeBase : FwTimeBaseStoreType {
+dictionary enum TimeBase : FwTimeBaseStoreType {
     TB_NONE = 0              @< No time base has been established (Required)
     TB_PROC_TIME = 1         @< Indicates time is processor cycle time. Not tied to external time
     TB_WORKSTATION_TIME = 2  @< Time as reported on workstation where software is running. For testing. (Required)
+    TB_SC_TIME = 3,          @< Time as reported by the spacecraft clock.
     TB_DONT_CARE = 0xFFFF    @< Don't care value for sequences. If FwTimeBaseStoreType is changed, value should be changed (Required)
 } default TB_NONE;

--- a/default/config/FpConstants.fpp
+++ b/default/config/FpConstants.fpp
@@ -80,7 +80,7 @@ constant FW_ASSERT_COUNT_MAX = 10
 constant FW_CONTEXT_DONT_CARE = 0xFF
 
 @ Value encoded during serialization for boolean true
-constant FW_SERIALIZE_TRUE_VALUE = 0xFF
+dictionary constant FW_SERIALIZE_TRUE_VALUE = 0xFF
 
 @ Value encoded during serialization for boolean false
-constant FW_SERIALIZE_FALSE_VALUE = 0x00
+dictionary constant FW_SERIALIZE_FALSE_VALUE = 0x00

--- a/docs/user-manual/gds/gds-test-api-guide.md
+++ b/docs/user-manual/gds/gds-test-api-guide.md
@@ -375,7 +375,7 @@ The TimeType serializable stores timestamp information for both events and telem
 > Math operations between TimeType objects of different time_bases or time_context will return a TimeType with the same base and context as the left operand.
 
 ```python
-from fprime.common.models.serialize.time_type import TimeType
+from fprime_gds.common.models.serialize.time_type import TimeType
 
 t0 = TimeType() # 0.0 seconds
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.3
 fprime-fpl-write-pic==1.0.3
 fprime-fpp==3.1.0a10
-fprime-gds==4.0.2a10
+fprime-gds==4.0.2a11
 fprime-tools==4.0.2a1
 fprime-visual==1.0.2
 gcovr==8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ fprime-fpl-layout==1.0.3
 fprime-fpl-write-pic==1.0.3
 fprime-fpp==3.1.0a10
 fprime-gds==4.0.2a11
-fprime-tools==4.0.2a1
+fprime-tools==4.0.2a2
 fprime-visual==1.0.2
 gcovr==8.2
 idna==3.10


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Following up on past work to define the `dictionary` specifier (https://github.com/nasa/fpp/issues/762) and GDS configurability (https://github.com/nasa/fprime-gds/pull/262) - tying all that up in this PR

<!-- A description of the changes contained in the PR. -->


## Future Work

- [x] Merge https://github.com/nasa/fprime-tools/pull/296

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

No
