### PR TITLE
Make Os::Queues use Fw::MemAllocator pattern for memory

### DIFF
--- a/FppTestProject/FppTest/component/active/test/ut/ActiveTestTester.cpp
+++ b/FppTestProject/FppTest/component/active/test/ut/ActiveTestTester.cpp
@@ -27,7 +27,9 @@ ActiveTestTester ::ActiveTestTester()
     this->component.registerExternalParameters(&this->paramTesterDelegate);
 }
 
-ActiveTestTester ::~ActiveTestTester() {}
+ActiveTestTester ::~ActiveTestTester() {
+    this->component.deinit();
+}
 
 void ActiveTestTester ::initComponents() {
     this->init();

--- a/FppTestProject/FppTest/component/queued/test/ut/QueuedTestTester.cpp
+++ b/FppTestProject/FppTest/component/queued/test/ut/QueuedTestTester.cpp
@@ -27,7 +27,9 @@ QueuedTestTester ::QueuedTestTester()
     this->component.registerExternalParameters(&this->paramTesterDelegate);
 }
 
-QueuedTestTester ::~QueuedTestTester() {}
+QueuedTestTester ::~QueuedTestTester() {
+    this->component.deinit();
+}
 
 void QueuedTestTester ::initComponents() {
     this->init();

--- a/FppTestProject/FppTest/dp/test/ut/DpTestTester.cpp
+++ b/FppTestProject/FppTest/dp/test/ut/DpTestTester.cpp
@@ -56,7 +56,9 @@ DpTestTester::DpTestTester()
     generateRandomString(this->stringRecordData);
 }
 
-DpTestTester::~DpTestTester() {}
+DpTestTester::~DpTestTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/FppTestProject/FppTest/state_machine/external_instance/test/ut/SmTestTester.cpp
+++ b/FppTestProject/FppTest/state_machine/external_instance/test/ut/SmTestTester.cpp
@@ -22,7 +22,9 @@ SmTestTester::SmTestTester() : SmTestGTestBase("SmTestTester", SmTestTester::MAX
     this->component.setIdBase(ID_BASE);
 }
 
-SmTestTester::~SmTestTester() {}
+SmTestTester::~SmTestTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/FppTestProject/FppTest/state_machine/internal_instance/choice/BasicTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/choice/BasicTester.cpp
@@ -26,7 +26,9 @@ BasicTester::BasicTester(const char* const compName)
       m_smChoiceBasic_action_b_history(),
       m_smChoiceBasic_guard_g() {}
 
-BasicTester::~BasicTester() {}
+BasicTester::~BasicTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Handler implementations for typed input ports

--- a/FppTestProject/FppTest/state_machine/internal_instance/choice/BasicU32Tester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/choice/BasicU32Tester.cpp
@@ -23,7 +23,9 @@ BasicU32Tester ::BasicU32Tester(const char* const compName)
       m_smChoiceBasicU32_action_b_history(),
       m_smChoiceBasicU32_guard_g() {}
 
-BasicU32Tester ::~BasicU32Tester() {}
+BasicU32Tester ::~BasicU32Tester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/choice/ChoiceToChoiceTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/choice/ChoiceToChoiceTester.cpp
@@ -23,7 +23,9 @@ ChoiceToChoiceTester ::ChoiceToChoiceTester(const char* const compName)
       m_smChoiceChoiceToChoice_guard_g1(),
       m_smChoiceChoiceToChoice_guard_g2() {}
 
-ChoiceToChoiceTester ::~ChoiceToChoiceTester() {}
+ChoiceToChoiceTester ::~ChoiceToChoiceTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/choice/ChoiceToStateTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/choice/ChoiceToStateTester.cpp
@@ -22,7 +22,9 @@ ChoiceToStateTester::ChoiceToStateTester(const char* const compName)
       m_smChoiceChoiceToState_actionHistory(),
       m_smChoiceChoiceToState_guard_g() {}
 
-ChoiceToStateTester::~ChoiceToStateTester() {}
+ChoiceToStateTester::~ChoiceToStateTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/choice/InputPairU16U32Tester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/choice/InputPairU16U32Tester.cpp
@@ -22,7 +22,9 @@ InputPairU16U32Tester ::InputPairU16U32Tester(const char* const compName)
       m_smChoiceInputPairU16U32_action_a_history(),
       m_smChoiceInputPairU16U32_guard_g() {}
 
-InputPairU16U32Tester ::~InputPairU16U32Tester() {}
+InputPairU16U32Tester ::~InputPairU16U32Tester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/choice/SequenceTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/choice/SequenceTester.cpp
@@ -24,7 +24,9 @@ SequenceTester ::SequenceTester(const char* const compName)
       m_smChoiceSequence_guard_g1(),
       m_smChoiceSequence_guard_g2() {}
 
-SequenceTester ::~SequenceTester() {}
+SequenceTester ::~SequenceTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/choice/SequenceU32Tester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/choice/SequenceU32Tester.cpp
@@ -24,7 +24,9 @@ SequenceU32Tester::SequenceU32Tester(const char* const compName)
       m_smChoiceSequenceU32_guard_g1(),
       m_smChoiceSequenceU32_guard_g2() {}
 
-SequenceU32Tester::~SequenceU32Tester() {}
+SequenceU32Tester::~SequenceU32Tester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/initial/BasicTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/initial/BasicTester.cpp
@@ -19,7 +19,9 @@ namespace SmInstanceInitial {
 BasicTester::BasicTester(const char* const compName)
     : BasicComponentBase(compName), m_basic1_action_a_history(), m_smInitialBasic1_action_a_history() {}
 
-BasicTester::~BasicTester() {}
+BasicTester::~BasicTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Handler implementations for typed input ports

--- a/FppTestProject/FppTest/state_machine/internal_instance/initial/ChoiceTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/initial/ChoiceTester.cpp
@@ -24,7 +24,9 @@ ChoiceTester::ChoiceTester(const char* const compName)
       m_choice_guard_g(),
       m_smInitialChoice_guard_g() {}
 
-ChoiceTester::~ChoiceTester() {}
+ChoiceTester::~ChoiceTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/initial/NestedTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/initial/NestedTester.cpp
@@ -19,7 +19,9 @@ namespace SmInstanceInitial {
 NestedTester::NestedTester(const char* const compName)
     : NestedComponentBase(compName), m_nested_action_a_history(), m_smInitialNested_action_a_history() {}
 
-NestedTester::~NestedTester() {}
+NestedTester::~NestedTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardStringTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardStringTester.cpp
@@ -23,7 +23,9 @@ BasicGuardStringTester ::BasicGuardStringTester(const char* const compName)
       m_smStateBasicGuardString_action_a_history(),
       m_smStateBasicGuardString_guard_g() {}
 
-BasicGuardStringTester ::~BasicGuardStringTester() {}
+BasicGuardStringTester ::~BasicGuardStringTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTestAbsTypeTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTestAbsTypeTester.cpp
@@ -23,7 +23,9 @@ BasicGuardTestAbsTypeTester::BasicGuardTestAbsTypeTester(const char* const compN
       m_smStateBasicGuardTestAbsType_action_a_history(),
       m_smStateBasicGuardTestAbsType_guard_g() {}
 
-BasicGuardTestAbsTypeTester::~BasicGuardTestAbsTypeTester() {}
+BasicGuardTestAbsTypeTester::~BasicGuardTestAbsTypeTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTestArrayTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTestArrayTester.cpp
@@ -22,7 +22,9 @@ BasicGuardTestArrayTester::BasicGuardTestArrayTester(const char* const compName)
       m_smStateBasicGuardTestArray_action_a_history(),
       m_smStateBasicGuardTestArray_guard_g() {}
 
-BasicGuardTestArrayTester::~BasicGuardTestArrayTester() {}
+BasicGuardTestArrayTester::~BasicGuardTestArrayTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTestEnumTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTestEnumTester.cpp
@@ -22,7 +22,9 @@ BasicGuardTestEnumTester::BasicGuardTestEnumTester(const char* const compName)
       m_smStateBasicGuardTestEnum_action_a_history(),
       m_smStateBasicGuardTestEnum_guard_g() {}
 
-BasicGuardTestEnumTester::~BasicGuardTestEnumTester() {}
+BasicGuardTestEnumTester::~BasicGuardTestEnumTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTestStructTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTestStructTester.cpp
@@ -22,7 +22,9 @@ BasicGuardTestStructTester::BasicGuardTestStructTester(const char* const compNam
       m_smStateBasicGuardTestStruct_action_a_history(),
       m_smStateBasicGuardTestStruct_guard_g() {}
 
-BasicGuardTestStructTester::~BasicGuardTestStructTester() {}
+BasicGuardTestStructTester::~BasicGuardTestStructTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardTester.cpp
@@ -20,7 +20,9 @@ namespace SmInstanceState {
 BasicGuardTester ::BasicGuardTester(const char* const compName)
     : BasicGuardComponentBase(compName), m_smStateBasicGuard_action_a_history(), m_smStateBasicGuard_guard_g() {}
 
-BasicGuardTester ::~BasicGuardTester() {}
+BasicGuardTester ::~BasicGuardTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardU32Tester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicGuardU32Tester.cpp
@@ -22,7 +22,9 @@ BasicGuardU32Tester::BasicGuardU32Tester(const char* const compName)
       m_smStateBasicGuardU32_action_a_history(),
       m_smStateBasicGuardU32_guard_g() {}
 
-BasicGuardU32Tester::~BasicGuardU32Tester() {}
+BasicGuardU32Tester::~BasicGuardU32Tester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicInternalTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicInternalTester.cpp
@@ -19,7 +19,9 @@ namespace SmInstanceState {
 BasicInternalTester::BasicInternalTester(const char* const compName)
     : BasicInternalComponentBase(compName), m_smStateBasicInternal_action_a_history() {}
 
-BasicInternalTester::~BasicInternalTester() {}
+BasicInternalTester::~BasicInternalTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicSelfTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicSelfTester.cpp
@@ -19,7 +19,9 @@ namespace SmInstanceState {
 BasicSelfTester::BasicSelfTester(const char* const compName)
     : BasicSelfComponentBase(compName), m_smStateBasicSelf_action_a_history() {}
 
-BasicSelfTester::~BasicSelfTester() {}
+BasicSelfTester::~BasicSelfTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicStringTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicStringTester.cpp
@@ -22,7 +22,9 @@ BasicStringTester ::BasicStringTester(const char* const compName)
       m_smStateBasicString_action_a_history(),
       m_smStateBasicString_action_b_history() {}
 
-BasicStringTester ::~BasicStringTester() {}
+BasicStringTester ::~BasicStringTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicTestAbsTypeTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicTestAbsTypeTester.cpp
@@ -21,7 +21,9 @@ BasicTestAbsTypeTester ::BasicTestAbsTypeTester(const char* const compName)
       m_smStateBasicTestAbsType_action_a_history(),
       m_smStateBasicTestAbsType_action_b_history() {}
 
-BasicTestAbsTypeTester ::~BasicTestAbsTypeTester() {}
+BasicTestAbsTypeTester ::~BasicTestAbsTypeTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicTestArrayTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicTestArrayTester.cpp
@@ -21,7 +21,9 @@ BasicTestArrayTester::BasicTestArrayTester(const char* const compName)
       m_smStateBasicTestArray_action_a_history(),
       m_smStateBasicTestArray_action_b_history() {}
 
-BasicTestArrayTester::~BasicTestArrayTester() {}
+BasicTestArrayTester::~BasicTestArrayTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicTestEnumTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicTestEnumTester.cpp
@@ -21,7 +21,9 @@ BasicTestEnumTester::BasicTestEnumTester(const char* const compName)
       m_smStateBasicTestEnum_action_a_history(),
       m_smStateBasicTestEnum_action_b_history() {}
 
-BasicTestEnumTester::~BasicTestEnumTester() {}
+BasicTestEnumTester::~BasicTestEnumTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicTestStructTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicTestStructTester.cpp
@@ -21,7 +21,9 @@ BasicTestStructTester::BasicTestStructTester(const char* const compName)
       m_smStateBasicTestStruct_action_a_history(),
       m_smStateBasicTestStruct_action_b_history() {}
 
-BasicTestStructTester::~BasicTestStructTester() {}
+BasicTestStructTester::~BasicTestStructTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicTester.cpp
@@ -19,7 +19,9 @@ namespace SmInstanceState {
 BasicTester ::BasicTester(const char* const compName)
     : BasicComponentBase(compName), m_basic1_action_a_history(), m_smStateBasic1_action_a_history() {}
 
-BasicTester ::~BasicTester() {}
+BasicTester ::~BasicTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Handler implementations for typed input ports

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/BasicU32Tester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/BasicU32Tester.cpp
@@ -19,7 +19,9 @@ namespace SmInstanceState {
 BasicU32Tester::BasicU32Tester(const char* const compName)
     : BasicU32ComponentBase(compName), m_smStateBasicU32_action_a_history(), m_smStateBasicU32_action_b_history() {}
 
-BasicU32Tester::~BasicU32Tester() {}
+BasicU32Tester::~BasicU32Tester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/InternalTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/InternalTester.cpp
@@ -19,7 +19,9 @@ namespace SmInstanceState {
 InternalTester::InternalTester(const char* const compName)
     : InternalComponentBase(compName), m_smStateInternal_action_a_history() {}
 
-InternalTester::~InternalTester() {}
+InternalTester::~InternalTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/PolymorphismTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/PolymorphismTester.cpp
@@ -18,7 +18,9 @@ namespace SmInstanceState {
 
 PolymorphismTester::PolymorphismTester(const char* const compName) : PolymorphismComponentBase(compName) {}
 
-PolymorphismTester::~PolymorphismTester() {}
+PolymorphismTester::~PolymorphismTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/StateToChildTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/StateToChildTester.cpp
@@ -19,7 +19,9 @@ namespace SmInstanceState {
 StateToChildTester::StateToChildTester(const char* const compName)
     : StateToChildComponentBase(compName), m_smStateStateToChild_actionHistory() {}
 
-StateToChildTester::~StateToChildTester() {}
+StateToChildTester::~StateToChildTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/StateToChoiceTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/StateToChoiceTester.cpp
@@ -20,7 +20,9 @@ namespace SmInstanceState {
 StateToChoiceTester::StateToChoiceTester(const char* const compName)
     : StateToChoiceComponentBase(compName), m_smStateStateToChoice_actionHistory(), m_smStateStateToChoice_guard_g() {}
 
-StateToChoiceTester::~StateToChoiceTester() {}
+StateToChoiceTester::~StateToChoiceTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/StateToSelfTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/StateToSelfTester.cpp
@@ -19,7 +19,9 @@ namespace SmInstanceState {
 StateToSelfTester::StateToSelfTester(const char* const compName)
     : StateToSelfComponentBase(compName), m_smStateStateToSelf_actionHistory() {}
 
-StateToSelfTester::~StateToSelfTester() {}
+StateToSelfTester::~StateToSelfTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/FppTestProject/FppTest/state_machine/internal_instance/state/StateToStateTester.cpp
+++ b/FppTestProject/FppTest/state_machine/internal_instance/state/StateToStateTester.cpp
@@ -19,7 +19,9 @@ namespace SmInstanceState {
 StateToStateTester::StateToStateTester(const char* const compName)
     : StateToStateComponentBase(compName), m_smStateStateToState_actionHistory() {}
 
-StateToStateTester::~StateToStateTester() {}
+StateToStateTester::~StateToStateTester() {
+    this->deinit();
+}
 
 // ----------------------------------------------------------------------
 // Implementations for internal state machine actions

--- a/Fw/Comp/QueuedComponentBase.cpp
+++ b/Fw/Comp/QueuedComponentBase.cpp
@@ -15,6 +15,10 @@ void QueuedComponentBase::init(FwEnumStoreType instance) {
     PassiveComponentBase::init(instance);
 }
 
+void QueuedComponentBase::deinit() {
+    this->m_queue.teardown();
+}
+
 #if FW_OBJECT_TO_STRING == 1
 const char* QueuedComponentBase::getToStringFormatString() {
     return "QueueComp: %s";

--- a/Fw/Comp/QueuedComponentBase.cpp
+++ b/Fw/Comp/QueuedComponentBase.cpp
@@ -28,7 +28,7 @@ Os::Queue::Queue::Status QueuedComponentBase::createQueue(FwSizeType depth, FwSi
 #else
     queueName.format("CompQ_%" PRI_FwSizeType, Os::Queue::getNumQueues());
 #endif
-    return this->m_queue.create(queueName, depth, msgSize);
+    return this->m_queue.create(this->getInstance(), queueName, depth, msgSize);
 }
 
 FwSizeType QueuedComponentBase::getNumMsgsDropped() {

--- a/Fw/Comp/QueuedComponentBase.hpp
+++ b/Fw/Comp/QueuedComponentBase.hpp
@@ -31,6 +31,7 @@ class QueuedComponentBase : public PassiveComponentBase {
     QueuedComponentBase(const char* name);  //!< Constructor
     virtual ~QueuedComponentBase();         //!< Destructor
     void init(FwEnumStoreType instance);    //!< initialization function
+    void deinit();                          //!< Allows de-initialization on teardown
     Os::Queue m_queue;                      //!< queue object for active component
     Os::Queue::Status createQueue(FwSizeType depth, FwSizeType msgSize);
     virtual MsgDispatchStatus doDispatch() = 0;  //!< method to dispatch a single message in the queue.

--- a/Fw/LanguageHelpers.hpp
+++ b/Fw/LanguageHelpers.hpp
@@ -10,9 +10,11 @@
 // ======================================================================
 #ifndef FW_TYPES_LANGUAGEHELPERS_HPP_
 #define FW_TYPES_LANGUAGEHELPERS_HPP_
-#include <Fw/ByteArray.hpp>
+#include "Fw/Types/Assert.hpp"
+#include "Fw/Types/ByteArray.hpp"
+#include <new>
 #include <type_traits>
-
+namespace Fw {
 //! \brief placement new for arrays
 //!
 //! C++ as a language does not guaranteed that placement new for a C++ array of length N will fit within a memory
@@ -36,7 +38,7 @@ T* arrayPlacementNew(Fw::ByteArray array, FwSizeType arraySize) {
     static_assert(std::is_trivially_constructible<T>::value, "Cannot use arrayPlacementNew for non-trivially constructible types");
     void* base_pointer = reinterpret_cast<void*>(array.bytes);
     FW_ASSERT(base_pointer != nullptr); // Confirm non-null
-    FW_ASSERT((array.bytes % alignof(T)) == 0); // Confirm alignment
+    FW_ASSERT((reinterpret_cast<std::uintptr_t>(base_pointer) % alignof(T)) == 0); // Confirm alignment
     FW_ASSERT(array.size >= (sizeof(T) * arraySize)); // Confirm size
     T* type_pointer = static_cast<T*>(base_pointer);
     for (FwSizeType index = 0; index < arraySize; index++) {
@@ -44,4 +46,5 @@ T* arrayPlacementNew(Fw::ByteArray array, FwSizeType arraySize) {
     }
     return type_pointer;
 }
+} // namespace Fw
 #endif

--- a/Fw/LanguageHelpers.hpp
+++ b/Fw/LanguageHelpers.hpp
@@ -48,4 +48,4 @@ T* arrayPlacementNew(Fw::ByteArray array, FwSizeType arraySize) {
     return type_pointer;
 }
 }  // namespace Fw
-#endif // FW_TYPES_LANGUAGE_HELPERS_HPP_
+#endif  // FW_TYPES_LANGUAGE_HELPERS_HPP_

--- a/Fw/LanguageHelpers.hpp
+++ b/Fw/LanguageHelpers.hpp
@@ -8,8 +8,8 @@
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
 // ======================================================================
-#ifndef FW_TYPES_LANGUAGEHELPERS_HPP_
-#define FW_TYPES_LANGUAGEHELPERS_HPP_
+#ifndef FW_TYPES_LANGUAGE_HELPERS_HPP_
+#define FW_TYPES_LANGUAGE_HELPERS_HPP_
 #include <new>
 #include <type_traits>
 #include "Fw/Types/Assert.hpp"
@@ -38,9 +38,9 @@ T* arrayPlacementNew(Fw::ByteArray array, FwSizeType arraySize) {
     static_assert(std::is_constructible<T>::value,
                   "Cannot use arrayPlacementNew on types without a default zero-argument constructor");
     void* base_pointer = reinterpret_cast<void*>(array.bytes);
-    FW_ASSERT(base_pointer != nullptr);                                             // Confirm non-null
-    FW_ASSERT((reinterpret_cast<std::uintptr_t>(base_pointer) % alignof(T)) == 0);  // Confirm alignment
-    FW_ASSERT(array.size >= (sizeof(T) * arraySize));                               // Confirm size
+    FW_ASSERT(base_pointer != nullptr);
+    FW_ASSERT((reinterpret_cast<PlatformPointerCastType>(base_pointer) % alignof(T)) == 0);
+    FW_ASSERT(array.size >= (sizeof(T) * arraySize));
     T* type_pointer = static_cast<T*>(base_pointer);
     for (FwSizeType index = 0; index < arraySize; index++) {
         new (&type_pointer[index]) T();
@@ -48,4 +48,4 @@ T* arrayPlacementNew(Fw::ByteArray array, FwSizeType arraySize) {
     return type_pointer;
 }
 }  // namespace Fw
-#endif
+#endif // FW_TYPES_LANGUAGE_HELPERS_HPP_

--- a/Fw/LanguageHelpers.hpp
+++ b/Fw/LanguageHelpers.hpp
@@ -10,10 +10,10 @@
 // ======================================================================
 #ifndef FW_TYPES_LANGUAGEHELPERS_HPP_
 #define FW_TYPES_LANGUAGEHELPERS_HPP_
-#include "Fw/Types/Assert.hpp"
-#include "Fw/Types/ByteArray.hpp"
 #include <new>
 #include <type_traits>
+#include "Fw/Types/Assert.hpp"
+#include "Fw/Types/ByteArray.hpp"
 namespace Fw {
 //! \brief placement new for arrays
 //!
@@ -35,16 +35,17 @@ namespace Fw {
 template <typename T>
 T* arrayPlacementNew(Fw::ByteArray array, FwSizeType arraySize) {
     static_assert(!std::is_array<T>::value, "Cannot use arrayPlacementNew new for arrays of arrays");
-    static_assert(std::is_trivially_constructible<T>::value, "Cannot use arrayPlacementNew for non-trivially constructible types");
+    static_assert(std::is_constructible<T>::value,
+                  "Cannot use arrayPlacementNew on types without a default zero-argument constructor");
     void* base_pointer = reinterpret_cast<void*>(array.bytes);
-    FW_ASSERT(base_pointer != nullptr); // Confirm non-null
-    FW_ASSERT((reinterpret_cast<std::uintptr_t>(base_pointer) % alignof(T)) == 0); // Confirm alignment
-    FW_ASSERT(array.size >= (sizeof(T) * arraySize)); // Confirm size
+    FW_ASSERT(base_pointer != nullptr);                                             // Confirm non-null
+    FW_ASSERT((reinterpret_cast<std::uintptr_t>(base_pointer) % alignof(T)) == 0);  // Confirm alignment
+    FW_ASSERT(array.size >= (sizeof(T) * arraySize));                               // Confirm size
     T* type_pointer = static_cast<T*>(base_pointer);
     for (FwSizeType index = 0; index < arraySize; index++) {
         new (&type_pointer[index]) T();
     }
     return type_pointer;
 }
-} // namespace Fw
+}  // namespace Fw
 #endif

--- a/Fw/LanguageHelpers.hpp
+++ b/Fw/LanguageHelpers.hpp
@@ -47,5 +47,24 @@ T* arrayPlacementNew(Fw::ByteArray array, FwSizeType arraySize) {
     }
     return type_pointer;
 }
+
+//! \brief placement delete for arrays
+//!
+//! This is the partner of tha above function that performs the destructor operation on every element of type T in the
+//! array. This assumes that all elements have been constructed.
+//!
+//! \warning this function cannot be used for arrays of arrays (i.e. T cannot be an array type).
+//!
+//! \tparam T the type of the array elements
+//! \param arrayPointer pointer to an array of type T
+//! \param arraySize the number of elements in the array
+template <typename T>
+void arrayPlacementDestruct(T* arrayPointer, FwSizeType arraySize) {
+    static_assert(!std::is_array<T>::value, "Cannot use arrayPlacementDestruct new for arrays of arrays");
+    FW_ASSERT(arrayPointer != nullptr);
+    for (FwSizeType index = 0; index < arraySize; index++) {
+        arrayPointer[index].~T();
+    }
+}
 }  // namespace Fw
 #endif  // FW_TYPES_LANGUAGE_HELPERS_HPP_

--- a/Fw/Types/LanguageHelpers.hpp
+++ b/Fw/Types/LanguageHelpers.hpp
@@ -1,0 +1,47 @@
+// ======================================================================
+// \title  LanguageHelpers.hpp
+// \author lestarch
+// \brief  hpp file for C++ language helper functions
+//
+// \copyright
+// Copyright (C) 2025 California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+// ======================================================================
+#ifndef FW_TYPES_LANGUAGEHELPERS_HPP_
+#define FW_TYPES_LANGUAGEHELPERS_HPP_
+#include <Fw/ByteArray.hpp>
+#include <type_traits>
+
+//! \brief placement new for arrays
+//!
+//! C++ as a language does not guaranteed that placement new for a C++ array of length N will fit within a memory
+//! region of size N *sizeof(T). Moreover, there are some compilers whose implementation of placement new for arrays
+//! do not guarantee this property.
+//!
+//! This function provides a helper for placement new for arrays that guarantees that the array will fit within the
+//! provided memory region. It checks that the provided memory region is large enough to hold the array (N * sizeof(T)
+//! and that the alignment of the provided memory region is sufficient for the type T. It also checks that the provided
+//! memory region is non-null.
+//!
+//! \warning this function cannot be used for arrays of arrays (i.e. T cannot be an array type).
+//!
+//! \tparam T the type of the array elements
+//! \param array the byte array to use for placement new (pair of bytes pointer and size)
+//! \param arraySize the number of elements in the array
+//! \return a pointer to the array of type T
+template <typename T>
+T* arrayPlacementNew(Fw::ByteArray array, FwSizeType arraySize) {
+    static_assert(!std::is_array<T>::value, "Cannot use arrayPlacementNew new for arrays of arrays");
+    static_assert(std::is_trivially_constructible<T>::value, "Cannot use arrayPlacementNew for non-trivially constructible types");
+    void* base_pointer = reinterpret_cast<void*>(array.bytes);
+    FW_ASSERT(base_pointer != nullptr); // Confirm non-null
+    FW_ASSERT((array.bytes % alignof(T)) == 0); // Confirm alignment
+    FW_ASSERT(array.size >= (sizeof(T) * arraySize)); // Confirm size
+    T* type_pointer = static_cast<T*>(base_pointer);
+    for (FwSizeType index = 0; index < arraySize; index++) {
+        new (&type_pointer[index]) T();
+    }
+    return type_pointer;
+}
+#endif

--- a/Fw/Types/MallocAllocator.hpp
+++ b/Fw/Types/MallocAllocator.hpp
@@ -33,7 +33,7 @@ class MallocAllocator : public MemAllocator {
     //! Allocate memory using malloc(). The identifier is unused and memory is never recoverable.
     //! malloc() guarantees alignment for any type and so does this allocator. It will not respect smaller alignments.
     //!
-    //! \param identifier the memory segment identifier (not used)
+    //! \param identifier the allocating entity identifier (not used)
     //! \param size the requested size (not changed)
     //! \param recoverable - flag to indicate the memory could be recoverable (always set to false)
     //! \param alignment - alignment requirement for the allocation. Default: maximum alignment defined by C++.

--- a/Fw/Types/MemAllocator.cpp
+++ b/Fw/Types/MemAllocator.cpp
@@ -64,7 +64,7 @@ MemAllocator& MemAllocatorRegistry::getAnAllocator(const MemoryAllocation::Memor
 
 MemAllocator& MemAllocatorRegistry::getDefaultAllocator() {
     static_assert(std::is_constructible<MemoryAllocation::DefaultMemoryAllocatorType>::value,
-              "DefaultMemoryAllocatorType must be constructible without arguments");
+                  "DefaultMemoryAllocatorType must be constructible without arguments");
     static MemoryAllocation::DefaultMemoryAllocatorType defaultAllocator;
     return defaultAllocator;
 }

--- a/Fw/Types/MemAllocator.cpp
+++ b/Fw/Types/MemAllocator.cpp
@@ -6,10 +6,10 @@
  */
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/MemAllocator.hpp>
-
+#include <config/MemoryAllocation.hpp>
+#include <type_traits>
+#include <stdio.h>
 namespace Fw {
-
-MemAllocatorRegistry* MemAllocatorRegistry::s_registry = nullptr;  //!< singleton registry
 
 MemAllocator::MemAllocator() {}
 
@@ -36,9 +36,8 @@ void* MemAllocator ::checkedAllocate(const FwEnumStoreType identifier, FwSizeTyp
     return this->checkedAllocate(identifier, size, unused, alignment);
 }
 
-MemAllocatorRegistry::MemAllocatorRegistry() {
-    // Register self as the singleton
-    MemAllocatorRegistry::s_registry = this;
+MemAllocatorRegistry::MemAllocatorRegistry() : m_defaultAllocator(MemAllocatorRegistry::getDefaultAllocator()) {
+    this->registerAllocator(MemoryAllocation::MemoryAllocatorType::SYSTEM, m_defaultAllocator);
 }
 
 void MemAllocatorRegistry::registerAllocator(const MemoryAllocation::MemoryAllocatorType type,
@@ -47,8 +46,8 @@ void MemAllocatorRegistry::registerAllocator(const MemoryAllocation::MemoryAlloc
 }
 
 MemAllocatorRegistry& MemAllocatorRegistry::getInstance() {
-    FW_ASSERT(s_registry != nullptr);
-    return *s_registry;
+    static MemAllocatorRegistry registry;
+    return registry;
 }
 
 MemAllocator& MemAllocatorRegistry::getAllocator(const MemoryAllocation::MemoryAllocatorType type) {
@@ -63,4 +62,12 @@ MemAllocator& MemAllocatorRegistry::getAnAllocator(const MemoryAllocation::Memor
     }
     return *this->m_allocators[type];
 }
+
+MemAllocator& MemAllocatorRegistry::getDefaultAllocator() {
+    static_assert(std::is_constructible<MemoryAllocation::DefaultMemoryAllocatorType>::value,
+              "DefaultMemoryAllocatorType must be constructible without arguments");
+    static MemoryAllocation::DefaultMemoryAllocatorType defaultAllocator;
+    return defaultAllocator;
+}
+
 } /* namespace Fw */

--- a/Fw/Types/MemAllocator.cpp
+++ b/Fw/Types/MemAllocator.cpp
@@ -8,7 +8,6 @@
 #include <Fw/Types/MemAllocator.hpp>
 #include <config/MemoryAllocation.hpp>
 #include <type_traits>
-#include <stdio.h>
 namespace Fw {
 
 MemAllocator::MemAllocator() {}

--- a/Fw/Types/MemAllocator.hpp
+++ b/Fw/Types/MemAllocator.hpp
@@ -132,11 +132,12 @@ class MemAllocator {
 };
 
 class MemAllocatorRegistry {
-  public:
+  private:
     // Constructor which will register itself as the singleton
     MemAllocatorRegistry();
     ~MemAllocatorRegistry() = default;
 
+  public:
     //! \brief get the singleton registry
     //!
     //! \return the singleton registry
@@ -169,11 +170,18 @@ class MemAllocatorRegistry {
     MemAllocator& getAnAllocator(const MemoryAllocation::MemoryAllocatorType type);
 
   private:
+    //! \brief get the default allocator
+    //!
+    //! Creates a single instance of the default allocator and returns a reference to it. This is done to ensure that
+    //! the default allocator is only created once and is available when ill-ordered static initialization occurs.
+    //!
+    //! \return the default allocator
+    static MemAllocator& getDefaultAllocator();
+
     //! Array of allocators for each type defaulted to nullptr
     MemAllocator* m_allocators[MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS] = {nullptr};
+    MemAllocator& m_defaultAllocator;  //!< default allocator
 
-    //! The singleton registry pointer
-    static MemAllocatorRegistry* s_registry;  //!< singleton registry
 };
 } /* namespace Fw */
 

--- a/Fw/Types/MemAllocator.hpp
+++ b/Fw/Types/MemAllocator.hpp
@@ -181,7 +181,6 @@ class MemAllocatorRegistry {
     //! Array of allocators for each type defaulted to nullptr
     MemAllocator* m_allocators[MemoryAllocation::MemoryAllocatorType::NUM_CONSTANTS] = {nullptr};
     MemAllocator& m_defaultAllocator;  //!< default allocator
-
 };
 } /* namespace Fw */
 

--- a/Fw/Types/MemAllocator.hpp
+++ b/Fw/Types/MemAllocator.hpp
@@ -55,7 +55,7 @@ class MemAllocator {
     //! identifier is a unique identifier for the allocating entity. This entity (e.g. a component) may call allocate
     //! multiple times with the same id, but no other entity in the system shall call allocate with that id.
     //!
-    //! \param identifier the memory segment identifier, each identifier is to be used in once single allocation
+    //! \param identifier - a unique identifier for the allocating entity
     //! \param size the requested size - changed to actual if different
     //! \param recoverable - flag to indicate the memory could be recoverable
     //! \param alignment - alignment requirement for the allocation. Default: maximum alignment defined by C++.
@@ -70,7 +70,7 @@ class MemAllocator {
     //! Deallocate memory previously allocated by allocate(). The pointer must be one returned by allocate() and the
     //! identifier must match the one used in the original allocate() call.
     //!
-    //! \param identifier the memory segment identifier, each identifier is to be used in once single allocation
+    //! \param identifier - a unique identifier for the allocating entity, must match the call to allocate()
     //! \param ptr the pointer to memory returned by allocate()
     virtual void deallocate(const FwEnumStoreType identifier, void* ptr) = 0;
 
@@ -80,7 +80,7 @@ class MemAllocator {
     //! by the underlying allocator but is not returned to the caller. This is for cases when the caller does not care
     //! about recoverability of memory.
     //!
-    //! \param identifier the memory segment identifier, each identifier is to be used in once single allocation
+    //! \param identifier - a unique identifier for the allocating entity
     //! \param size the requested size - changed to actual if different
     //! \param alignment - alignment requirement for the allocation. Default: maximum alignment defined by C++.
     //! \return the pointer to memory. Zero if unable to allocate
@@ -95,7 +95,7 @@ class MemAllocator {
     //!
     //! Allocations are checked using FW_ASSERT implying that an allocation failure results in a tripped assertion.
     //!
-    //! \param identifier the memory segment identifier, each identifier is to be used in once single allocation
+    //! \param identifier - a unique identifier for the allocating entity
     //! \param size the requested size, actual allocation will be at least this size
     //! \param recoverable - flag to indicate the memory could be recoverable
     //! \param alignment - alignment requirement for the allocation. Default: maximum alignment defined by C++.
@@ -114,7 +114,7 @@ class MemAllocator {
     //!
     //! Allocations are checked using FW_ASSERT implying that an allocation failure results in a tripped assertion.
     //!
-    //! \param identifier the memory segment identifier, each identifier is to be used in once single allocation
+    //! \param identifier - a unique identifier for the allocating entity
     //! \param size the requested size, actual allocation will be at least this size
     //! \param alignment - alignment requirement for the allocation. Default: maximum alignment defined by C++.
     //! \return the pointer to memory. Zero if unable to allocate

--- a/Os/Generic/PriorityQueue.cpp
+++ b/Os/Generic/PriorityQueue.cpp
@@ -2,11 +2,11 @@
 // \title Os/Generic/PriorityQueue.cpp
 // \brief priority queue implementation for Os::Queue
 // ======================================================================
-
-#include "PriorityQueue.hpp"
+#include "Fw/LanguageHelpers.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/MemAllocator.hpp"
 #include "config/MemoryAllocatorTypeEnumAc.hpp"
+#include "Os/Generic/PriorityQueue.hpp"
 #include <cstring>
 
 namespace Os {
@@ -40,67 +40,128 @@ void PriorityQueueHandle ::load_data(FwSizeType index, U8* destination, FwSizeTy
 }
 
 PriorityQueue::~PriorityQueue() {
-    delete[] this->m_handle.m_data;
-    delete[] this->m_handle.m_indices;
-    delete[] this->m_handle.m_sizes;
+    const FwEnumStoreType identifier = this->m_handle.m_id;
+    Fw::MemAllocator& allocator = Fw::MemAllocatorRegistry::getInstance().getAllocator(Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
+    if (this->m_handle.m_data != nullptr) {
+        allocator.deallocate(identifier, this->m_handle.m_data);
+        allocator.deallocate(identifier, this->m_handle.m_indices);
+        allocator.deallocate(identifier, this->m_handle.m_sizes);
+        this->m_handle.m_heap_pointer->~MaxHeap();
+        allocator.deallocate(identifier, this->m_handle.m_heap_pointer);
+    }
 }
 
-QueueInterface::Status PriorityQueue::create(const Fw::ConstStringBase& name,
+QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
+    const Fw::ConstStringBase& name,
                                              FwSizeType depth,
                                              FwSizeType messageSize) {
+    const FwEnumStoreType identifier = id;
+    QueueInterface::Status status = Os::QueueInterface::Status::OP_OK;                          
     // Ensure we are created exactly once
     FW_ASSERT(this->m_handle.m_indices == nullptr);
     FW_ASSERT(this->m_handle.m_sizes == nullptr);
     FW_ASSERT(this->m_handle.m_data == nullptr);
 
     // Get the memory allocator configured for priority queues
-    Fw::MemAllocator allocator = Fw::MemAllocatorRegistry::getInstance().getAllocator(Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
-
-
+    Fw::MemAllocator& allocator = Fw::MemAllocatorRegistry::getInstance().getAnAllocator(Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
 
     // Allocate indices list
-    
-    FwSizeType* indices = new (std::nothrow) FwSizeType[depth];
-    if (indices == nullptr) {
-        return QueueInterface::Status::ALLOCATION_FAILED;
-    }
-    // Allocate sizes list or clean-up
-    FwSizeType* sizes = new (std::nothrow) FwSizeType[depth];
-    if (sizes == nullptr) {
-        delete[] indices;
-        return QueueInterface::Status::ALLOCATION_FAILED;
-    }
-    // Allocate sizes list or clean-up
-    U8* data = new (std::nothrow) U8[depth * messageSize];
-    if (data == nullptr) {
-        delete[] indices;
-        delete[] sizes;
-        return QueueInterface::Status::ALLOCATION_FAILED;
-    }
-    // Allocate max heap or clean-up
-    bool created = this->m_handle.m_heap.create(depth);
-    if (not created) {
-        delete[] indices;
-        delete[] sizes;
-        delete[] data;
-        return QueueInterface::Status::ALLOCATION_FAILED;
-    }
-    // Assign initial indices and sizes
-    for (FwSizeType i = 0; i < depth; i++) {
-        indices[i] = i;
-        sizes[i] = 0;
-    }
-    // Set local tracking variables
-    this->m_handle.m_maxSize = messageSize;
-    this->m_handle.m_indices = indices;
-    this->m_handle.m_data = data;
-    this->m_handle.m_sizes = sizes;
-    this->m_handle.m_startIndex = 0;
-    this->m_handle.m_stopIndex = 0;
-    this->m_handle.m_depth = depth;
-    this->m_handle.m_highMark = 0;
+    void* allocation = nullptr;
+    FwSizeType size = 0;
+    FwSizeType* indices = nullptr;
+    FwSizeType* sizes = nullptr;
+    U8* data = nullptr;
 
-    return QueueInterface::Status::OP_OK;
+    // Allocate indicies list and construct it when valid
+    size = depth * sizeof(FwSizeType);
+    allocation = allocator.allocate(identifier, size, alignof(FwSizeType));
+    if (allocation == nullptr) {
+        status = QueueInterface::Status::ALLOCATION_FAILED;
+    }
+    else if (size < (depth * sizeof(FwSizeType))) {
+        allocator.deallocate(identifier, allocation);
+        status = QueueInterface::Status::ALLOCATION_FAILED;
+    }
+    else {
+        indices = Fw::arrayPlacementNew<FwSizeType>(Fw::ByteArray(static_cast<U8*>(allocation), size), depth);
+    }
+
+    // Allocate sizes list and construct it when valid
+    if (status == QueueInterface::Status::OP_OK) {
+        size = depth * sizeof(FwSizeType);
+        allocation = allocator.allocate(identifier, size, alignof(FwSizeType));
+        if (allocation == nullptr) {
+            allocator.deallocate(identifier, indices);
+            status = QueueInterface::Status::ALLOCATION_FAILED;
+        }
+        else if (size < (depth * sizeof(FwSizeType))) {
+            allocator.deallocate(identifier, indices);
+            allocator.deallocate(identifier, allocation);
+            status = QueueInterface::Status::ALLOCATION_FAILED;
+        }
+        else {
+            sizes = Fw::arrayPlacementNew<FwSizeType>(Fw::ByteArray(static_cast<U8*>(allocation), size), depth);
+        }
+    }
+    // Allocate data
+    if (status == QueueInterface::Status::OP_OK) {
+        size = depth * messageSize;
+        allocation = allocator.allocate(identifier, size, alignof(U8));
+        if (allocation == nullptr) {
+            allocator.deallocate(identifier, indices);
+            allocator.deallocate(identifier, sizes);
+            status = QueueInterface::Status::ALLOCATION_FAILED;
+        }
+        else if (size < (depth * sizeof(FwSizeType))) {
+            allocator.deallocate(identifier, indices);
+            allocator.deallocate(identifier, sizes);
+            allocator.deallocate(identifier, allocation);
+            status = QueueInterface::Status::ALLOCATION_FAILED;
+        }
+        else {
+            data = static_cast<U8*>(allocation);
+        }
+    }
+    // Allocate data for max heap
+    if (status == QueueInterface::Status::OP_OK) {
+        size = Types::MaxHeap::ELEMENT_SIZE * depth;
+        allocation = allocator.allocate(identifier, size, Types::MaxHeap::ALIGNMENT);
+        if (allocation == nullptr) {
+            allocator.deallocate(identifier, indices);
+            allocator.deallocate(identifier, sizes);
+            allocator.deallocate(identifier, data);
+            status = QueueInterface::Status::ALLOCATION_FAILED;
+        }
+        else if (size < (Types::MaxHeap::ELEMENT_SIZE * depth)) {
+            allocator.deallocate(identifier, indices);
+            allocator.deallocate(identifier, sizes);
+            allocator.deallocate(identifier, data);
+            allocator.deallocate(identifier, allocation);
+            status = QueueInterface::Status::ALLOCATION_FAILED;
+        }
+        else {
+            this->m_handle.m_heap.create(depth, Fw::ByteArray(static_cast<U8*>(allocation), size));
+        }
+    }
+    // Set up structures when all allocations succeeded
+    if (status == QueueInterface::Status::OP_OK) {
+        // Assign initial indices and sizes
+        for (FwSizeType i = 0; i < depth; i++) {
+            indices[i] = i;
+            sizes[i] = 0;
+        }
+        // Set local tracking variables
+        this->m_handle.m_id = id;
+        this->m_handle.m_maxSize = messageSize;
+        this->m_handle.m_indices = indices;
+        this->m_handle.m_data = data;
+        this->m_handle.m_sizes = sizes;
+        this->m_handle.m_startIndex = 0;
+        this->m_handle.m_stopIndex = 0;
+        this->m_handle.m_depth = depth;
+        this->m_handle.m_highMark = 0;
+    }
+    return status;
 }
 
 QueueInterface::Status PriorityQueue::send(const U8* buffer,

--- a/Os/Generic/PriorityQueue.cpp
+++ b/Os/Generic/PriorityQueue.cpp
@@ -99,7 +99,7 @@ QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
             allocator.deallocate(identifier, indices);
             allocator.deallocate(identifier, sizes);
             status = QueueInterface::Status::ALLOCATION_FAILED;
-        } else if (size < (depth * sizeof(FwSizeType))) {
+        } else if (size < (depth * messageSize)) {
             allocator.deallocate(identifier, indices);
             allocator.deallocate(identifier, sizes);
             allocator.deallocate(identifier, allocation);

--- a/Os/Generic/PriorityQueue.cpp
+++ b/Os/Generic/PriorityQueue.cpp
@@ -75,7 +75,7 @@ QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
     U8* data = nullptr;
     U8* heap_pointer = nullptr;
 
-    // Allocate indicies list and construct it when valid
+    // Allocate indices list and construct it when valid
     size = depth * sizeof(FwSizeType);
     allocation = allocator.allocate(identifier, size, alignof(FwSizeType));
     if (allocation == nullptr) {

--- a/Os/Generic/PriorityQueue.cpp
+++ b/Os/Generic/PriorityQueue.cpp
@@ -39,18 +39,7 @@ void PriorityQueueHandle ::load_data(FwSizeType index, U8* destination, FwSizeTy
     (void)::memcpy(destination, this->m_data + offset, static_cast<size_t>(size));
 }
 
-PriorityQueue::~PriorityQueue() {
-    const FwEnumStoreType identifier = this->m_handle.m_id;
-    Fw::MemAllocator& allocator = Fw::MemAllocatorRegistry::getInstance().getAnAllocator(
-        Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
-    if (this->m_handle.m_data != nullptr) {
-        allocator.deallocate(identifier, this->m_handle.m_data);
-        allocator.deallocate(identifier, this->m_handle.m_indices);
-        allocator.deallocate(identifier, this->m_handle.m_sizes);
-        this->m_handle.m_heap.~MaxHeap();
-        allocator.deallocate(identifier, this->m_handle.m_heap_pointer);
-    }
-}
+PriorityQueue::~PriorityQueue() {}
 
 QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
                                              const Fw::ConstStringBase& name,
@@ -159,6 +148,28 @@ QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
         this->m_handle.m_highMark = 0;
     }
     return status;
+}
+
+void PriorityQueue::teardown() {
+    this->teardownInternal();
+}
+
+void PriorityQueue::teardownInternal() {
+    if (this->m_handle.m_data != nullptr) {
+        const FwEnumStoreType identifier = this->m_handle.m_id;
+        Fw::MemAllocator& allocator = Fw::MemAllocatorRegistry::getInstance().getAnAllocator(
+            Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
+        allocator.deallocate(identifier, this->m_handle.m_data);
+        allocator.deallocate(identifier, this->m_handle.m_indices);
+        allocator.deallocate(identifier, this->m_handle.m_sizes);
+        this->m_handle.m_heap.~MaxHeap();
+        allocator.deallocate(identifier, this->m_handle.m_heap_pointer);
+
+        // Set these pointers to nullptr
+        this->m_handle.m_data = nullptr;
+        this->m_handle.m_indices = nullptr;
+        this->m_handle.m_sizes = nullptr;
+    }
 }
 
 QueueInterface::Status PriorityQueue::send(const U8* buffer,

--- a/Os/Generic/PriorityQueue.cpp
+++ b/Os/Generic/PriorityQueue.cpp
@@ -2,12 +2,12 @@
 // \title Os/Generic/PriorityQueue.cpp
 // \brief priority queue implementation for Os::Queue
 // ======================================================================
+#include "Os/Generic/PriorityQueue.hpp"
+#include <cstring>
 #include "Fw/LanguageHelpers.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/MemAllocator.hpp"
 #include "config/MemoryAllocatorTypeEnumAc.hpp"
-#include "Os/Generic/PriorityQueue.hpp"
-#include <cstring>
 
 namespace Os {
 namespace Generic {
@@ -41,29 +41,31 @@ void PriorityQueueHandle ::load_data(FwSizeType index, U8* destination, FwSizeTy
 
 PriorityQueue::~PriorityQueue() {
     const FwEnumStoreType identifier = this->m_handle.m_id;
-    Fw::MemAllocator& allocator = Fw::MemAllocatorRegistry::getInstance().getAllocator(Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
+    Fw::MemAllocator& allocator = Fw::MemAllocatorRegistry::getInstance().getAnAllocator(
+        Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
     if (this->m_handle.m_data != nullptr) {
         allocator.deallocate(identifier, this->m_handle.m_data);
         allocator.deallocate(identifier, this->m_handle.m_indices);
         allocator.deallocate(identifier, this->m_handle.m_sizes);
-        this->m_handle.m_heap_pointer->~MaxHeap();
+        this->m_handle.m_heap.~MaxHeap();
         allocator.deallocate(identifier, this->m_handle.m_heap_pointer);
     }
 }
 
 QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
-    const Fw::ConstStringBase& name,
+                                             const Fw::ConstStringBase& name,
                                              FwSizeType depth,
                                              FwSizeType messageSize) {
     const FwEnumStoreType identifier = id;
-    QueueInterface::Status status = Os::QueueInterface::Status::OP_OK;                          
+    QueueInterface::Status status = Os::QueueInterface::Status::OP_OK;
     // Ensure we are created exactly once
     FW_ASSERT(this->m_handle.m_indices == nullptr);
     FW_ASSERT(this->m_handle.m_sizes == nullptr);
     FW_ASSERT(this->m_handle.m_data == nullptr);
 
     // Get the memory allocator configured for priority queues
-    Fw::MemAllocator& allocator = Fw::MemAllocatorRegistry::getInstance().getAnAllocator(Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
+    Fw::MemAllocator& allocator = Fw::MemAllocatorRegistry::getInstance().getAnAllocator(
+        Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
 
     // Allocate indices list
     void* allocation = nullptr;
@@ -71,18 +73,17 @@ QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
     FwSizeType* indices = nullptr;
     FwSizeType* sizes = nullptr;
     U8* data = nullptr;
+    U8* heap_pointer = nullptr;
 
     // Allocate indicies list and construct it when valid
     size = depth * sizeof(FwSizeType);
     allocation = allocator.allocate(identifier, size, alignof(FwSizeType));
     if (allocation == nullptr) {
         status = QueueInterface::Status::ALLOCATION_FAILED;
-    }
-    else if (size < (depth * sizeof(FwSizeType))) {
+    } else if (size < (depth * sizeof(FwSizeType))) {
         allocator.deallocate(identifier, allocation);
         status = QueueInterface::Status::ALLOCATION_FAILED;
-    }
-    else {
+    } else {
         indices = Fw::arrayPlacementNew<FwSizeType>(Fw::ByteArray(static_cast<U8*>(allocation), size), depth);
     }
 
@@ -93,13 +94,11 @@ QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
         if (allocation == nullptr) {
             allocator.deallocate(identifier, indices);
             status = QueueInterface::Status::ALLOCATION_FAILED;
-        }
-        else if (size < (depth * sizeof(FwSizeType))) {
+        } else if (size < (depth * sizeof(FwSizeType))) {
             allocator.deallocate(identifier, indices);
             allocator.deallocate(identifier, allocation);
             status = QueueInterface::Status::ALLOCATION_FAILED;
-        }
-        else {
+        } else {
             sizes = Fw::arrayPlacementNew<FwSizeType>(Fw::ByteArray(static_cast<U8*>(allocation), size), depth);
         }
     }
@@ -111,14 +110,12 @@ QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
             allocator.deallocate(identifier, indices);
             allocator.deallocate(identifier, sizes);
             status = QueueInterface::Status::ALLOCATION_FAILED;
-        }
-        else if (size < (depth * sizeof(FwSizeType))) {
+        } else if (size < (depth * sizeof(FwSizeType))) {
             allocator.deallocate(identifier, indices);
             allocator.deallocate(identifier, sizes);
             allocator.deallocate(identifier, allocation);
             status = QueueInterface::Status::ALLOCATION_FAILED;
-        }
-        else {
+        } else {
             data = static_cast<U8*>(allocation);
         }
     }
@@ -131,15 +128,14 @@ QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
             allocator.deallocate(identifier, sizes);
             allocator.deallocate(identifier, data);
             status = QueueInterface::Status::ALLOCATION_FAILED;
-        }
-        else if (size < (Types::MaxHeap::ELEMENT_SIZE * depth)) {
+        } else if (size < (Types::MaxHeap::ELEMENT_SIZE * depth)) {
             allocator.deallocate(identifier, indices);
             allocator.deallocate(identifier, sizes);
             allocator.deallocate(identifier, data);
             allocator.deallocate(identifier, allocation);
             status = QueueInterface::Status::ALLOCATION_FAILED;
-        }
-        else {
+        } else {
+            heap_pointer = static_cast<U8*>(allocation);
             this->m_handle.m_heap.create(depth, Fw::ByteArray(static_cast<U8*>(allocation), size));
         }
     }
@@ -156,6 +152,7 @@ QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
         this->m_handle.m_indices = indices;
         this->m_handle.m_data = data;
         this->m_handle.m_sizes = sizes;
+        this->m_handle.m_heap_pointer = heap_pointer;
         this->m_handle.m_startIndex = 0;
         this->m_handle.m_stopIndex = 0;
         this->m_handle.m_depth = depth;

--- a/Os/Generic/PriorityQueue.cpp
+++ b/Os/Generic/PriorityQueue.cpp
@@ -4,9 +4,10 @@
 // ======================================================================
 
 #include "PriorityQueue.hpp"
-#include <Fw/Types/Assert.hpp>
+#include "Fw/Types/Assert.hpp"
+#include "Fw/Types/MemAllocator.hpp"
+#include "config/MemoryAllocatorTypeEnumAc.hpp"
 #include <cstring>
-#include <new>
 
 namespace Os {
 namespace Generic {
@@ -52,7 +53,13 @@ QueueInterface::Status PriorityQueue::create(const Fw::ConstStringBase& name,
     FW_ASSERT(this->m_handle.m_sizes == nullptr);
     FW_ASSERT(this->m_handle.m_data == nullptr);
 
+    // Get the memory allocator configured for priority queues
+    Fw::MemAllocator allocator = Fw::MemAllocatorRegistry::getInstance().getAllocator(Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
+
+
+
     // Allocate indices list
+    
     FwSizeType* indices = new (std::nothrow) FwSizeType[depth];
     if (indices == nullptr) {
         return QueueInterface::Status::ALLOCATION_FAILED;

--- a/Os/Generic/PriorityQueue.cpp
+++ b/Os/Generic/PriorityQueue.cpp
@@ -162,7 +162,7 @@ void PriorityQueue::teardownInternal() {
         allocator.deallocate(identifier, this->m_handle.m_data);
         allocator.deallocate(identifier, this->m_handle.m_indices);
         allocator.deallocate(identifier, this->m_handle.m_sizes);
-        this->m_handle.m_heap.~MaxHeap();
+        this->m_handle.m_heap.teardown();
         allocator.deallocate(identifier, this->m_handle.m_heap_pointer);
 
         // Set these pointers to nullptr

--- a/Os/Generic/PriorityQueue.hpp
+++ b/Os/Generic/PriorityQueue.hpp
@@ -20,7 +20,7 @@ namespace Generic {
 //! the data region and index list have queue depth number of entries.
 struct PriorityQueueHandle : public QueueHandle {
     Types::MaxHeap m_heap;            //!< MaxHeap data store for tracking priority
-    Types::MaxHeap* m_heap_pointer;   //!< Pointer to the MaxHeap data store
+    U8* m_heap_pointer;               //!< Pointer to the MaxHeap data store
     U8* m_data = nullptr;             //!< Pointer to data allocation
     FwSizeType* m_indices = nullptr;  //!< List of indices into data
     FwSizeType* m_sizes = nullptr;    //!< Size store for each method
@@ -32,7 +32,7 @@ struct PriorityQueueHandle : public QueueHandle {
     Os::Mutex m_data_lock;            //!< Lock against data manipulation
     Os::ConditionVariable m_full;     //!< Queue full condition variable to support blocking
     Os::ConditionVariable m_empty;    //!< Queue empty condition variable to support blocking
-    FwEnumStoreType m_id;              //!< Identifier for the queue, used for memory allocation
+    FwEnumStoreType m_id;             //!< Identifier for the queue, used for memory allocation
 
     //!\brief find an available index to store data from the list
     FwSizeType find_index();
@@ -83,7 +83,10 @@ class PriorityQueue : public Os::QueueInterface {
     //! \param depth: depth of queue in number of messages
     //! \param messageSize: size of an individual message
     //! \return: status of the creation
-    Status create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
+    Status create(FwEnumStoreType id,
+                  const Fw::ConstStringBase& name,
+                  FwSizeType depth,
+                  FwSizeType messageSize) override;
 
     //! \brief send a message into the queue
     //!

--- a/Os/Generic/PriorityQueue.hpp
+++ b/Os/Generic/PriorityQueue.hpp
@@ -88,6 +88,20 @@ class PriorityQueue : public Os::QueueInterface {
                   FwSizeType depth,
                   FwSizeType messageSize) override;
 
+    //! \brief teardown the queue
+    //!
+    //! Allow for queues to deallocate resources as part of system shutdown. This delegates to the underlying queue
+    //! implementation.
+    void teardown() override;
+
+    //! \brief teardown the queue
+    //!
+    //! Allow for queues to deallocate resources as part of system shutdown. This delegates to the underlying queue
+    //! implementation.
+    //!
+    //! Note: this is a helper to allow this to be called from the destructor.
+    void teardownInternal();
+
     //! \brief send a message into the queue
     //!
     //! Send a message into the queue, providing the message data, size, priority, and blocking type. When

--- a/Os/Generic/PriorityQueue.hpp
+++ b/Os/Generic/PriorityQueue.hpp
@@ -20,6 +20,7 @@ namespace Generic {
 //! the data region and index list have queue depth number of entries.
 struct PriorityQueueHandle : public QueueHandle {
     Types::MaxHeap m_heap;            //!< MaxHeap data store for tracking priority
+    Types::MaxHeap* m_heap_pointer;   //!< Pointer to the MaxHeap data store
     U8* m_data = nullptr;             //!< Pointer to data allocation
     FwSizeType* m_indices = nullptr;  //!< List of indices into data
     FwSizeType* m_sizes = nullptr;    //!< Size store for each method
@@ -31,6 +32,7 @@ struct PriorityQueueHandle : public QueueHandle {
     Os::Mutex m_data_lock;            //!< Lock against data manipulation
     Os::ConditionVariable m_full;     //!< Queue full condition variable to support blocking
     Os::ConditionVariable m_empty;    //!< Queue empty condition variable to support blocking
+    FwEnumStoreType m_id;              //!< Identifier for the queue, used for memory allocation
 
     //!\brief find an available index to store data from the list
     FwSizeType find_index();
@@ -74,13 +76,14 @@ class PriorityQueue : public Os::QueueInterface {
     //!
     //! Creates a queue ensuring sufficient storage to hold `depth` messages of `messageSize` size each.
     //!
-    //! \warning allocates memory on the heap
+    //! \warning allocates memory through the memory allocator registry
     //!
+    //! \param id: identifier for the queue, used for memory allocation
     //! \param name: name of queue
     //! \param depth: depth of queue in number of messages
     //! \param messageSize: size of an individual message
     //! \return: status of the creation
-    Status create(const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
+    Status create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
 
     //! \brief send a message into the queue
     //!

--- a/Os/Generic/Types/MaxHeap.cpp
+++ b/Os/Generic/Types/MaxHeap.cpp
@@ -29,7 +29,6 @@
 namespace Types {
 
 MaxHeap::MaxHeap() {
-    // Initialize the heap:
     this->m_capacity = 0;
     this->m_heap = nullptr;
     this->m_size = 0;
@@ -49,6 +48,15 @@ void MaxHeap::create(FwSizeType capacity, Fw::ByteArray heap_allocation) {
     FW_ASSERT(capacity < std::numeric_limits<FwSizeType>::max());
     this->m_heap = Fw::arrayPlacementNew<Node>(heap_allocation, capacity);
     this->m_capacity = capacity;
+}
+
+void MaxHeap::teardown() {
+    Fw::arrayPlacementDestruct<Node>(this->m_heap, this->m_capacity);
+    // Reset the capacity and heap so that the provider of memory
+    this->m_capacity = 0;
+    this->m_heap = nullptr;
+    this->m_size = 0;
+    this->m_order = 0;
 }
 
 bool MaxHeap::push(FwQueuePriorityType value, FwSizeType id) {

--- a/Os/Generic/Types/MaxHeap.cpp
+++ b/Os/Generic/Types/MaxHeap.cpp
@@ -51,7 +51,10 @@ void MaxHeap::create(FwSizeType capacity, Fw::ByteArray heap_allocation) {
 }
 
 void MaxHeap::teardown() {
-    Fw::arrayPlacementDestruct<Node>(this->m_heap, this->m_capacity);
+    // Only destroy the heap if it is still allocated
+    if (this->m_heap != null) {
+        Fw::arrayPlacementDestruct<Node>(this->m_heap, this->m_capacity);
+    }
     // Reset the capacity and heap so that the provider of memory
     this->m_capacity = 0;
     this->m_heap = nullptr;

--- a/Os/Generic/Types/MaxHeap.cpp
+++ b/Os/Generic/Types/MaxHeap.cpp
@@ -42,6 +42,8 @@ MaxHeap::~MaxHeap() {
 
 void MaxHeap::create(FwSizeType capacity, Fw::ByteArray heap_allocation) {
     FW_ASSERT(this->m_heap == nullptr);
+    FW_ASSERT(heap_allocation.size >= (capacity * sizeof(Node)));
+    FW_ASSERT(heap_allocation.bytes != nullptr);
     // Loop bounds will overflow if capacity set to the max allowable value
     FW_ASSERT(capacity < std::numeric_limits<FwSizeType>::max());
     this->m_heap = Fw::arrayPlacementNew<Node>(heap_allocation, capacity);

--- a/Os/Generic/Types/MaxHeap.cpp
+++ b/Os/Generic/Types/MaxHeap.cpp
@@ -17,9 +17,9 @@
 #include "Os/Generic/Types/MaxHeap.hpp"
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <Fw/Logger/Logger.hpp>
-#include "Fw/Types/Assert.hpp"
-#include "Fw/LanguageHelpers.hpp"
 #include <cstdio>
+#include "Fw/LanguageHelpers.hpp"
+#include "Fw/Types/Assert.hpp"
 
 // Macros for traversing the heap:
 #define LCHILD(x) (2 * x + 1)

--- a/Os/Generic/Types/MaxHeap.cpp
+++ b/Os/Generic/Types/MaxHeap.cpp
@@ -42,7 +42,8 @@ MaxHeap::~MaxHeap() {
 
 void MaxHeap::create(FwSizeType capacity, Fw::ByteArray heap_allocation) {
     FW_ASSERT(this->m_heap == nullptr);
-    FW_ASSERT(heap_allocation.size >= (capacity * sizeof(Node)));
+    FW_ASSERT(heap_allocation.size >= (capacity * sizeof(Node)), static_cast<FwAssertArgType>(capacity),
+              static_cast<FwAssertArgType>(heap_allocation.size));
     FW_ASSERT(heap_allocation.bytes != nullptr);
     // Loop bounds will overflow if capacity set to the max allowable value
     FW_ASSERT(capacity < std::numeric_limits<FwSizeType>::max());

--- a/Os/Generic/Types/MaxHeap.cpp
+++ b/Os/Generic/Types/MaxHeap.cpp
@@ -52,7 +52,7 @@ void MaxHeap::create(FwSizeType capacity, Fw::ByteArray heap_allocation) {
 
 void MaxHeap::teardown() {
     // Only destroy the heap if it is still allocated
-    if (this->m_heap != null) {
+    if (this->m_heap != nullptr) {
         Fw::arrayPlacementDestruct<Node>(this->m_heap, this->m_capacity);
     }
     // Reset the capacity and heap so that the provider of memory

--- a/Os/Generic/Types/MaxHeap.cpp
+++ b/Os/Generic/Types/MaxHeap.cpp
@@ -18,9 +18,8 @@
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <Fw/Logger/Logger.hpp>
 #include "Fw/Types/Assert.hpp"
-
+#include "Fw/LanguageHelpers.hpp"
 #include <cstdio>
-#include <new>
 
 // Macros for traversing the heap:
 #define LCHILD(x) (2 * x + 1)
@@ -38,20 +37,15 @@ MaxHeap::MaxHeap() {
 }
 
 MaxHeap::~MaxHeap() {
-    delete[] this->m_heap;
     this->m_heap = nullptr;
 }
 
-bool MaxHeap::create(FwSizeType capacity) {
+void MaxHeap::create(FwSizeType capacity, Fw::ByteArray heap_allocation) {
     FW_ASSERT(this->m_heap == nullptr);
     // Loop bounds will overflow if capacity set to the max allowable value
     FW_ASSERT(capacity < std::numeric_limits<FwSizeType>::max());
-    this->m_heap = new (std::nothrow) Node[capacity];
-    if (nullptr == this->m_heap) {
-        return false;
-    }
+    this->m_heap = Fw::arrayPlacementNew<Node>(heap_allocation, capacity);
     this->m_capacity = capacity;
-    return true;
 }
 
 bool MaxHeap::push(FwQueuePriorityType value, FwSizeType id) {

--- a/Os/Generic/Types/MaxHeap.hpp
+++ b/Os/Generic/Types/MaxHeap.hpp
@@ -45,6 +45,8 @@ class MaxHeap {
     //! \param heap_allocation the memory to use for the heap
     //!
     void create(FwSizeType capacity, Fw::ByteArray heap_allocation);
+    //! \brief MaxHeap teardown
+    void teardown();
     //! \brief Push an item onto the heap.
     //!
     //! The item will be put into the heap according to its value. The

--- a/Os/Generic/Types/MaxHeap.hpp
+++ b/Os/Generic/Types/MaxHeap.hpp
@@ -14,6 +14,7 @@
 #define UTILS_TYPES_MAX_HEAP_HPP
 
 #include <Fw/FPrimeBasicTypes.hpp>
+#include <Fw/Types/ByteArray.hpp>
 
 namespace Types {
 
@@ -39,12 +40,11 @@ class MaxHeap {
     ~MaxHeap();
     //! \brief MaxHeap creation
     //!
-    //! Create the max heap with a given maximum size
-    //! \warning allocates memory on the heap
-    //!
+    //! Create the max heap with a given capacity. Constructs heap elements in the provided memory.
     //! \param capacity the maximum number of elements to store in the heap
+    //! \param heap_allocation the memory to use for the heap
     //!
-    bool create(FwSizeType capacity);
+    void create(FwSizeType capacity, Fw::ByteArray heap_allocation);
     //! \brief Push an item onto the heap.
     //!
     //! The item will be put into the heap according to its value. The
@@ -105,6 +105,11 @@ class MaxHeap {
     FwSizeType m_size;      // the current size of the heap
     FwSizeType m_order;     // the current count of heap pushes
     FwSizeType m_capacity;  // the maximum capacity of the heap
+  public:
+    //! Exposes the ELEMENT_SIZE for pre-allocation
+    static constexpr FwSizeType ELEMENT_SIZE = sizeof(Node);
+    //! Exposes the ALIGNMENT for pre-allocation
+    static constexpr FwSizeType ALIGNMENT = alignof(Node);
 };
 
 }  // namespace Types

--- a/Os/Generic/Types/test/ut/MaxHeap/MaxHeapTest.cpp
+++ b/Os/Generic/Types/test/ut/MaxHeap/MaxHeapTest.cpp
@@ -5,17 +5,18 @@
 
 #define DEPTH 5
 #define DATA_SIZE 3
+#define BIG 100000
 
 TEST(Nominal, Creation) {
  
-    U8 heap_allocation[Types::MaxHeap::ELEMENT_SIZE * 1000000];
+    alignas(Types::MaxHeap::ALIGNMENT) U8 heap_allocation[Types::MaxHeap::ELEMENT_SIZE * BIG];
     {
         Types::MaxHeap heap;
         heap.create(0, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
     }
     {
         Types::MaxHeap heap;
-        heap.create(1000000, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
+        heap.create(BIG, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
     }
     {
         Types::MaxHeap heap;
@@ -33,7 +34,7 @@ TEST(Nominal, Creation) {
 
 TEST(Nominal, Empty) {
     bool ret;
-    U8 heap_allocation[Types::MaxHeap::ELEMENT_SIZE * DEPTH];
+    alignas(Types::MaxHeap::ALIGNMENT) U8 heap_allocation[Types::MaxHeap::ELEMENT_SIZE * DEPTH];
     Types::MaxHeap heap;
     heap.create(DEPTH, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
 
@@ -55,7 +56,7 @@ TEST(Nominal, Empty) {
 TEST(Nominal, PushPop) {
     printf("Creating heap.\n");
     bool ret;
-    U8 heap_allocation[Types::MaxHeap::ELEMENT_SIZE * DEPTH];
+    alignas(Types::MaxHeap::ALIGNMENT) U8 heap_allocation[Types::MaxHeap::ELEMENT_SIZE * DEPTH];
     Types::MaxHeap heap;
     heap.create(DEPTH, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
 

--- a/Os/Generic/Types/test/ut/MaxHeap/MaxHeapTest.cpp
+++ b/Os/Generic/Types/test/ut/MaxHeap/MaxHeapTest.cpp
@@ -8,7 +8,6 @@
 #define BIG 100000
 
 TEST(Nominal, Creation) {
- 
     alignas(Types::MaxHeap::ALIGNMENT) U8 heap_allocation[Types::MaxHeap::ELEMENT_SIZE * BIG];
     {
         Types::MaxHeap heap;

--- a/Os/Generic/Types/test/ut/MaxHeap/MaxHeapTest.cpp
+++ b/Os/Generic/Types/test/ut/MaxHeap/MaxHeapTest.cpp
@@ -7,39 +7,35 @@
 #define DATA_SIZE 3
 
 TEST(Nominal, Creation) {
-    bool ret;
+ 
+    U8 heap_allocation[Types::MaxHeap::ELEMENT_SIZE * 1000000];
     {
         Types::MaxHeap heap;
-        ret = heap.create(0);
-        ASSERT_TRUE(ret);
+        heap.create(0, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
     }
     {
         Types::MaxHeap heap;
-        ret = heap.create(1000000);
-        ASSERT_TRUE(ret);
+        heap.create(1000000, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
     }
     {
         Types::MaxHeap heap;
-        ret = heap.create(1);
-        ASSERT_TRUE(ret);
+        heap.create(1, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
     }
     {
         Types::MaxHeap heap;
-        ret = heap.create(DEPTH);
-        ASSERT_TRUE(ret);
+        heap.create(DEPTH, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
     }
     {
         Types::MaxHeap heap;
-        ret = heap.create(DEPTH);
-        ASSERT_TRUE(ret);
+        heap.create(DEPTH, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
     }
 }
 
 TEST(Nominal, Empty) {
     bool ret;
+    U8 heap_allocation[Types::MaxHeap::ELEMENT_SIZE * DEPTH];
     Types::MaxHeap heap;
-    ret = heap.create(DEPTH);
-    ASSERT_TRUE(ret);
+    heap.create(DEPTH, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
 
     FwQueuePriorityType value;
     FwSizeType id = 0;
@@ -59,9 +55,9 @@ TEST(Nominal, Empty) {
 TEST(Nominal, PushPop) {
     printf("Creating heap.\n");
     bool ret;
+    U8 heap_allocation[Types::MaxHeap::ELEMENT_SIZE * DEPTH];
     Types::MaxHeap heap;
-    ret = heap.create(DEPTH);
-    ASSERT_TRUE(ret);
+    heap.create(DEPTH, Fw::ByteArray(heap_allocation, sizeof(heap_allocation)));
 
     FwQueuePriorityType value;
     FwSizeType size;

--- a/Os/Queue.cpp
+++ b/Os/Queue.cpp
@@ -19,7 +19,7 @@ Queue::~Queue() {
     m_delegate.~QueueInterface();
 }
 
-QueueInterface::Status Queue ::create(const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) {
+QueueInterface::Status Queue ::create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) {
     FW_ASSERT(&this->m_delegate == reinterpret_cast<QueueInterface*>(&this->m_handle_storage[0]));
     FW_ASSERT(depth > 0);
     FW_ASSERT(messageSize > 0);
@@ -27,7 +27,7 @@ QueueInterface::Status Queue ::create(const Fw::ConstStringBase& name, FwSizeTyp
     if (this->m_depth > 0 || this->m_size > 0) {
         return QueueInterface::Status::ALREADY_CREATED;
     }
-    QueueInterface::Status status = this->m_delegate.create(name, depth, messageSize);
+    QueueInterface::Status status = this->m_delegate.create(id, name, depth, messageSize);
     if (status == QueueInterface::Status::OP_OK) {
         this->m_name = name;
         this->m_depth = depth;

--- a/Os/Queue.cpp
+++ b/Os/Queue.cpp
@@ -19,7 +19,10 @@ Queue::~Queue() {
     m_delegate.~QueueInterface();
 }
 
-QueueInterface::Status Queue ::create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) {
+QueueInterface::Status Queue ::create(FwEnumStoreType id,
+                                      const Fw::ConstStringBase& name,
+                                      FwSizeType depth,
+                                      FwSizeType messageSize) {
     FW_ASSERT(&this->m_delegate == reinterpret_cast<QueueInterface*>(&this->m_handle_storage[0]));
     FW_ASSERT(depth > 0);
     FW_ASSERT(messageSize > 0);

--- a/Os/Queue.cpp
+++ b/Os/Queue.cpp
@@ -46,6 +46,11 @@ QueueInterface::Status Queue ::create(FwEnumStoreType id,
     return status;
 }
 
+void Queue::teardown() {
+    FW_ASSERT(&this->m_delegate == reinterpret_cast<QueueInterface*>(&this->m_handle_storage[0]));
+    return this->m_delegate.teardown();
+}
+
 QueueInterface::Status Queue::send(const U8* buffer,
                                    FwSizeType size,
                                    FwQueuePriorityType priority,

--- a/Os/Queue.hpp
+++ b/Os/Queue.hpp
@@ -69,11 +69,12 @@ class QueueInterface {
     //! allocation is dependent on the underlying implementation and users should assume that resource allocation is
     //! possible.
     //!
+    //! \param id: identifier for the queue, used for memory allocation
     //! \param name: name of queue
     //! \param depth: depth of queue in number of messages
     //! \param messageSize: size of an individual message
     //! \return: status of the creation
-    virtual Status create(const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) = 0;
+    virtual Status create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) = 0;
 
     //! \brief send a message into the queue
     //!
@@ -179,7 +180,7 @@ class Queue final : public QueueInterface {
     //! \param depth: depth of queue in number of messages
     //! \param messageSize: size of an individual message
     //! \return: status of the creation
-    Status create(const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
+    Status create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
 
     //! \brief send a message into the queue through delegate
     //!

--- a/Os/Queue.hpp
+++ b/Os/Queue.hpp
@@ -74,7 +74,10 @@ class QueueInterface {
     //! \param depth: depth of queue in number of messages
     //! \param messageSize: size of an individual message
     //! \return: status of the creation
-    virtual Status create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) = 0;
+    virtual Status create(FwEnumStoreType id,
+                          const Fw::ConstStringBase& name,
+                          FwSizeType depth,
+                          FwSizeType messageSize) = 0;
 
     //! \brief send a message into the queue
     //!
@@ -180,7 +183,10 @@ class Queue final : public QueueInterface {
     //! \param depth: depth of queue in number of messages
     //! \param messageSize: size of an individual message
     //! \return: status of the creation
-    Status create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
+    Status create(FwEnumStoreType id,
+                  const Fw::ConstStringBase& name,
+                  FwSizeType depth,
+                  FwSizeType messageSize) override;
 
     //! \brief send a message into the queue through delegate
     //!

--- a/Os/Queue.hpp
+++ b/Os/Queue.hpp
@@ -79,6 +79,14 @@ class QueueInterface {
                           FwSizeType depth,
                           FwSizeType messageSize) = 0;
 
+    //! \brief teardown the queue
+    //!
+    //! Allow for queues to deallocate resources as part of system shutdown. This delegates to the underlying queue
+    //! implementation.
+    //!
+    //! Note: the default implementation does nothing.
+    virtual void teardown() {}
+
     //! \brief send a message into the queue
     //!
     //! Send a message into the queue, providing the message data, size, priority, and blocking type. When
@@ -187,6 +195,13 @@ class Queue final : public QueueInterface {
                   const Fw::ConstStringBase& name,
                   FwSizeType depth,
                   FwSizeType messageSize) override;
+
+    //! \brief teardown the queue
+    //!
+    //! Allow for queues to deallocate resources as part of system shutdown. This delegates to the underlying queue
+    //! implementation. 
+    //! implementation.
+    void teardown() override;
 
     //! \brief send a message into the queue through delegate
     //!

--- a/Os/Queue.hpp
+++ b/Os/Queue.hpp
@@ -199,7 +199,7 @@ class Queue final : public QueueInterface {
     //! \brief teardown the queue
     //!
     //! Allow for queues to deallocate resources as part of system shutdown. This delegates to the underlying queue
-    //! implementation. 
+    //! implementation.
     //! implementation.
     void teardown() override;
 

--- a/Os/Stub/Queue.cpp
+++ b/Os/Stub/Queue.cpp
@@ -8,7 +8,10 @@ namespace Os {
 namespace Stub {
 namespace Queue {
 
-QueueInterface::Status StubQueue::create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) {
+QueueInterface::Status StubQueue::create(FwEnumStoreType id,
+                                         const Fw::ConstStringBase& name,
+                                         FwSizeType depth,
+                                         FwSizeType messageSize) {
     return QueueInterface::Status::UNKNOWN_ERROR;
 }
 

--- a/Os/Stub/Queue.cpp
+++ b/Os/Stub/Queue.cpp
@@ -8,7 +8,7 @@ namespace Os {
 namespace Stub {
 namespace Queue {
 
-QueueInterface::Status StubQueue::create(const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) {
+QueueInterface::Status StubQueue::create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) {
     return QueueInterface::Status::UNKNOWN_ERROR;
 }
 

--- a/Os/Stub/Queue.hpp
+++ b/Os/Stub/Queue.hpp
@@ -38,7 +38,10 @@ class StubQueue : public QueueInterface {
     //! \param depth: depth of queue in number of messages
     //! \param messageSize: size of an individual message
     //! \return: status of the creation
-    Status create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
+    Status create(FwEnumStoreType id,
+                  const Fw::ConstStringBase& name,
+                  FwSizeType depth,
+                  FwSizeType messageSize) override;
 
     //! \brief send a message into the queue
     //!

--- a/Os/Stub/Queue.hpp
+++ b/Os/Stub/Queue.hpp
@@ -33,11 +33,12 @@ class StubQueue : public QueueInterface {
     //! \brief create queue storage
     //!
     //! Creates a queue ensuring sufficient storage to hold `depth` messages of `messageSize` size each.
+    //! \param id: identifier of queue
     //! \param name: name of queue
     //! \param depth: depth of queue in number of messages
     //! \param messageSize: size of an individual message
     //! \return: status of the creation
-    Status create(const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
+    Status create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
 
     //! \brief send a message into the queue
     //!

--- a/Os/Stub/test/Queue.cpp
+++ b/Os/Stub/test/Queue.cpp
@@ -32,7 +32,7 @@ InjectableStlQueue::~InjectableStlQueue() {
     StaticData::data.lastCalled = StaticData::LastFn::DESTRUCT_FN;
 }
 
-QueueInterface::Status InjectableStlQueue::create(const Fw::ConstStringBase& name,
+QueueInterface::Status InjectableStlQueue::create(FwEnumStoreType id, const Fw::ConstStringBase& name,
                                                   FwSizeType depth,
                                                   FwSizeType messageSize) {
     StaticData::data.lastCalled = StaticData::LastFn::CREATE_FN;

--- a/Os/Stub/test/Queue.cpp
+++ b/Os/Stub/test/Queue.cpp
@@ -32,7 +32,8 @@ InjectableStlQueue::~InjectableStlQueue() {
     StaticData::data.lastCalled = StaticData::LastFn::DESTRUCT_FN;
 }
 
-QueueInterface::Status InjectableStlQueue::create(FwEnumStoreType id, const Fw::ConstStringBase& name,
+QueueInterface::Status InjectableStlQueue::create(FwEnumStoreType id,
+                                                  const Fw::ConstStringBase& name,
                                                   FwSizeType depth,
                                                   FwSizeType messageSize) {
     StaticData::data.lastCalled = StaticData::LastFn::CREATE_FN;

--- a/Os/Stub/test/Queue.hpp
+++ b/Os/Stub/test/Queue.hpp
@@ -112,7 +112,10 @@ class InjectableStlQueue : public QueueInterface {
     //! \param depth: depth of queue in number of messages
     //! \param messageSize: size of an individual message
     //! \return: status of the creation
-    Status create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
+    Status create(FwEnumStoreType id,
+                  const Fw::ConstStringBase& name,
+                  FwSizeType depth,
+                  FwSizeType messageSize) override;
 
     //! \brief send a message into the queue
     //!

--- a/Os/Stub/test/Queue.hpp
+++ b/Os/Stub/test/Queue.hpp
@@ -107,11 +107,12 @@ class InjectableStlQueue : public QueueInterface {
     //! \brief create queue storage
     //!
     //! Creates a queue ensuring sufficient storage to hold `depth` messages of `messageSize` size each.
+    //! \param id: identifier of queue
     //! \param name: name of queue
     //! \param depth: depth of queue in number of messages
     //! \param messageSize: size of an individual message
     //! \return: status of the creation
-    Status create(const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
+    Status create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
 
     //! \brief send a message into the queue
     //!

--- a/Os/Stub/test/ut/StubQueueTests.cpp
+++ b/Os/Stub/test/ut/StubQueueTests.cpp
@@ -42,7 +42,7 @@ TEST(Interface, Create) {
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
                                   FW_MIN(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
     Os::Stub::Queue::Test::StaticData::data.createStatus = Os::QueueInterface::Status::INVALID_PRIORITY;
-    Os::QueueInterface::Status status = queue.create(name, depth, messageSize);
+    Os::QueueInterface::Status status = queue.create(0, name, depth, messageSize);
     ASSERT_EQ(Os::Stub::Queue::Test::StaticData::data.lastCalled, Os::Stub::Queue::Test::StaticData::CREATE_FN);
     ASSERT_EQ(Os::QueueInterface::Status::INVALID_PRIORITY, status);
     ASSERT_STREQ(name.toChar(), Os::Stub::Queue::Test::StaticData::data.name.toChar());
@@ -62,7 +62,7 @@ TEST(Interface, SendPointer) {
     const FwQueuePriorityType priority = STest::Random::lowerUpper(
         0, FW_MIN(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
     U8 buffer[messageSize];
-    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(name, depth, messageSize));
+    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     ASSERT_STREQ(name.toChar(), queue.getName().toChar());
     Os::Stub::Queue::Test::StaticData::data.sendStatus = Os::QueueInterface::Status::EMPTY;
     Os::QueueInterface::Status status =
@@ -93,7 +93,7 @@ TEST(Interface, SendBuffer) {
     Fw::String message = "hello";
     buffer.serializeFrom(message);
 
-    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(name, depth, messageSize));
+    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     Os::Stub::Queue::Test::StaticData::data.sendStatus = Os::QueueInterface::Status::UNKNOWN_ERROR;
     Os::QueueInterface::Status status = queue.send(buffer, priority, Os::QueueInterface::BlockingType::NONBLOCKING);
     ASSERT_EQ(Os::Stub::Queue::Test::StaticData::data.lastCalled, Os::Stub::Queue::Test::StaticData::SEND_FN);
@@ -123,7 +123,7 @@ TEST(Interface, ReceivePointer) {
     FwQueuePriorityType priority;
     U8 storage[size];
 
-    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(name, depth, size));
+    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, size));
     Os::Stub::Queue::Test::StaticData::data.receiveStatus = Os::QueueInterface::Status::FULL;
     Os::Stub::Queue::Test::StaticData::data.size = sizeOut;
     Os::Stub::Queue::Test::StaticData::data.priority = priorityOut;
@@ -159,7 +159,7 @@ TEST(Interface, ReceiveBuffer) {
     U8 storage[size];
     Fw::ExternalSerializeBuffer buffer(storage, sizeof storage);
 
-    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(name, depth, size));
+    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, size));
     Os::Stub::Queue::Test::StaticData::data.receiveStatus = Os::QueueInterface::Status::FULL;
     Os::Stub::Queue::Test::StaticData::data.size = sizeOut;
     Os::Stub::Queue::Test::StaticData::data.priority = priorityOut;
@@ -186,7 +186,7 @@ TEST(Interface, MessageCount) {
     const FwSizeType messages =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
                                   FW_MIN(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
-    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(name, depth, messageSize));
+    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     Os::Stub::Queue::Test::StaticData::data.messages = messages;
     ASSERT_EQ(queue.getMessagesAvailable(), messages);
 
@@ -201,7 +201,7 @@ TEST(Interface, MessageHighWaterMarkCount) {
     const FwSizeType highWater =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
                                   FW_MIN(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
-    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(name, depth, messageSize));
+    ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     Os::Stub::Queue::Test::StaticData::data.highWaterMark = highWater;
     ASSERT_EQ(queue.getMessageHighWaterMark(), highWater);
 

--- a/Os/test/ut/queue/CommonTests.cpp
+++ b/Os/test/ut/queue/CommonTests.cpp
@@ -165,13 +165,13 @@ TEST(InterfaceUninitialized, ReceiveBuffer) {
 TEST(InterfaceInvalid, CreateInvalidDepth) {
     Os::Queue queue;
     Fw::String name = "My queue";
-    ASSERT_DEATH_IF_SUPPORTED(queue.create(name, 0, 10), "Assert:.*Queue\\.cpp");
+    ASSERT_DEATH_IF_SUPPORTED(queue.create(0, name, 0, 10), "Assert:.*Queue\\.cpp");
 }
 
 TEST(InterfaceInvalid, CreateInvalidSize) {
     Os::Queue queue;
     Fw::String name = "My queue";
-    ASSERT_DEATH_IF_SUPPORTED(queue.create(name, 10, 0), "Assert:.*Queue\\.cpp");
+    ASSERT_DEATH_IF_SUPPORTED(queue.create(0, name, 10, 0), "Assert:.*Queue\\.cpp");
 }
 
 TEST(InterfaceInvalid, SendPointerNull) {

--- a/Os/test/ut/queue/CommonTests.cpp
+++ b/Os/test/ut/queue/CommonTests.cpp
@@ -136,6 +136,7 @@ TEST(InterfaceUninitialized, SendBuffer) {
 
     Os::QueueInterface::Status status = queue.send(buffer, priority, Os::QueueInterface::BlockingType::BLOCKING);
     ASSERT_EQ(Os::QueueInterface::Status::UNINITIALIZED, status);
+    queue.teardown();
 }
 
 TEST(InterfaceUninitialized, ReceivePointer) {
@@ -148,6 +149,7 @@ TEST(InterfaceUninitialized, ReceivePointer) {
     Os::QueueInterface::Status status =
         queue.receive(storage, sizeof storage, Os::QueueInterface::BlockingType::NONBLOCKING, size, priority);
     ASSERT_EQ(Os::QueueInterface::Status::UNINITIALIZED, status);
+    queue.teardown();
 }
 
 TEST(InterfaceUninitialized, ReceiveBuffer) {
@@ -160,18 +162,21 @@ TEST(InterfaceUninitialized, ReceiveBuffer) {
 
     Os::QueueInterface::Status status = queue.receive(buffer, Os::QueueInterface::BlockingType::NONBLOCKING, priority);
     ASSERT_EQ(Os::QueueInterface::Status::UNINITIALIZED, status);
+    queue.teardown();
 }
 
 TEST(InterfaceInvalid, CreateInvalidDepth) {
     Os::Queue queue;
     Fw::String name = "My queue";
     ASSERT_DEATH_IF_SUPPORTED(queue.create(0, name, 0, 10), "Assert:.*Queue\\.cpp");
+    queue.teardown();
 }
 
 TEST(InterfaceInvalid, CreateInvalidSize) {
     Os::Queue queue;
     Fw::String name = "My queue";
     ASSERT_DEATH_IF_SUPPORTED(queue.create(0, name, 10, 0), "Assert:.*Queue\\.cpp");
+    queue.teardown();
 }
 
 TEST(InterfaceInvalid, SendPointerNull) {
@@ -181,6 +186,7 @@ TEST(InterfaceInvalid, SendPointerNull) {
     const FwQueuePriorityType priority = 127;
     ASSERT_DEATH_IF_SUPPORTED(queue.send(nullptr, messageSize, priority, Os::QueueInterface::BlockingType::BLOCKING),
                               "Assert:.*Queue\\.cpp");
+    queue.teardown();
 }
 
 TEST(InterfaceInvalid, SendInvalidEnum) {
@@ -191,6 +197,7 @@ TEST(InterfaceInvalid, SendInvalidEnum) {
     Os::QueueInterface::BlockingType blockingType =
         static_cast<Os::QueueInterface::BlockingType>(Os::QueueInterface::BlockingType::BLOCKING + 1);
     ASSERT_DEATH_IF_SUPPORTED(queue.send(nullptr, messageSize, priority, blockingType), "Assert:.*Queue\\.cpp");
+    queue.teardown();
 }
 
 TEST(InterfaceInvalid, ReceivePointerNull) {
@@ -201,6 +208,7 @@ TEST(InterfaceInvalid, ReceivePointerNull) {
     ASSERT_DEATH_IF_SUPPORTED(
         queue.receive(nullptr, size, Os::QueueInterface::BlockingType::NONBLOCKING, size, priority),
         "Assert:.*Queue\\.cpp");
+    queue.teardown();
 }
 
 TEST(InterfaceInvalid, ReceiveInvalidEnum) {
@@ -211,6 +219,7 @@ TEST(InterfaceInvalid, ReceiveInvalidEnum) {
     Os::QueueInterface::BlockingType blockingType =
         static_cast<Os::QueueInterface::BlockingType>(Os::QueueInterface::BlockingType::BLOCKING + 1);
     ASSERT_DEATH_IF_SUPPORTED(queue.receive(nullptr, size, blockingType, size, priority), "Assert:.*Queue\\.cpp");
+    queue.teardown();
 }
 
 TEST(BasicRules, Create) {

--- a/Os/test/ut/queue/QueueRules.cpp
+++ b/Os/test/ut/queue/QueueRules.cpp
@@ -61,7 +61,7 @@ void Os::Test::Queue::Tester::Create::action(Os::Test::Queue::Tester& state  //!
     FwSizeType depth = STest::Random::lowerUpper(1, QUEUE_DEPTH_UPPER_BOUND);
     FwSizeType messageSize = STest::Random::lowerUpper(1, QUEUE_MESSAGE_SIZE_UPPER_BOUND);
     QueueInterface::Status status = state.shadow_create(depth, messageSize);
-    QueueInterface::Status test_status = state.queue.create(name, depth, messageSize);
+    QueueInterface::Status test_status = state.queue.create(0, name, depth, messageSize);
     ASSERT_EQ(status, created ? QueueInterface::Status::ALREADY_CREATED : QueueInterface::Status::OP_OK);
     ASSERT_EQ(status, test_status);
     ASSERT_EQ(name, state.queue.getName());

--- a/Os/test/ut/queue/RulesHeaders.hpp
+++ b/Os/test/ut/queue/RulesHeaders.hpp
@@ -27,7 +27,7 @@ struct Tester {
   public:
     //! Constructor
     Tester() = default;
-    virtual ~Tester() = default;
+    virtual ~Tester() { queue.teardown(); };
 
     struct QueueMessage {
         U8 data[QUEUE_MESSAGE_SIZE_UPPER_BOUND];

--- a/Ref/BlockDriver/test/ut/BlockDriverTester.cpp
+++ b/Ref/BlockDriver/test/ut/BlockDriverTester.cpp
@@ -18,7 +18,9 @@ BlockDriverTester ::BlockDriverTester()
     this->connectPorts();
 }
 
-BlockDriverTester ::~BlockDriverTester() {}
+BlockDriverTester ::~BlockDriverTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/Ref/SignalGen/test/ut/SignalGenTester.cpp
+++ b/Ref/SignalGen/test/ut/SignalGenTester.cpp
@@ -24,7 +24,9 @@ SignalGenTester ::SignalGenTester() : SignalGenGTestBase("Tester", MAX_HISTORY_S
     this->m_reqDpBuff.set(this->m_dpBuff, sizeof(this->m_dpBuff));
 }
 
-SignalGenTester ::~SignalGenTester() {}
+SignalGenTester ::~SignalGenTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/Ref/Top/RefTopology.cpp
+++ b/Ref/Top/RefTopology.cpp
@@ -21,9 +21,6 @@ using namespace Ref;
 // Instantiate a malloc allocator for cmdSeq buffer allocation
 Fw::MallocAllocator mallocator;
 
-// Instantiate a malloc allocator for cmdSeq buffer allocation
-Fw::MemAllocatorRegistry registry;
-
 // The reference topology divides the incoming clock signal (1Hz) into sub-signals: 1Hz, 1/2Hz, and 1/4Hz and
 // zero offset for all the dividers
 Svc::RateGroupDriver::DividerSet rateGroupDivisorsSet{{{1, 0}, {2, 0}, {4, 0}}};
@@ -61,7 +58,6 @@ void configureTopology() {
 // Public functions for use in main program are namespaced with deployment name Ref
 namespace Ref {
 void setupTopology(const TopologyState& state) {
-    registry.registerAllocator(Fw::MemoryAllocation::MemoryAllocatorType::SYSTEM, mallocator);
     // Autocoded initialization. Function provided by autocoder.
     initComponents(state);
     // Autocoded id setup. Function provided by autocoder.

--- a/Ref/Top/RefTopology.cpp
+++ b/Ref/Top/RefTopology.cpp
@@ -46,7 +46,7 @@ enum TopologyConstants {
  * desired, but is extracted here for clarity.
  */
 void configureTopology() {
-   // Rate group driver needs a divisor list
+    // Rate group driver needs a divisor list
     rateGroupDriverComp.configure(rateGroupDivisorsSet);
 
     // Rate groups require context arrays. Empty for Reference example.

--- a/Ref/Top/RefTopology.cpp
+++ b/Ref/Top/RefTopology.cpp
@@ -21,6 +21,9 @@ using namespace Ref;
 // Instantiate a malloc allocator for cmdSeq buffer allocation
 Fw::MallocAllocator mallocator;
 
+// Instantiate a malloc allocator for cmdSeq buffer allocation
+Fw::MemAllocatorRegistry registry;
+
 // The reference topology divides the incoming clock signal (1Hz) into sub-signals: 1Hz, 1/2Hz, and 1/4Hz and
 // zero offset for all the dividers
 Svc::RateGroupDriver::DividerSet rateGroupDivisorsSet{{{1, 0}, {2, 0}, {4, 0}}};
@@ -43,7 +46,7 @@ enum TopologyConstants {
  * desired, but is extracted here for clarity.
  */
 void configureTopology() {
-    // Rate group driver needs a divisor list
+   // Rate group driver needs a divisor list
     rateGroupDriverComp.configure(rateGroupDivisorsSet);
 
     // Rate groups require context arrays. Empty for Reference example.
@@ -58,6 +61,7 @@ void configureTopology() {
 // Public functions for use in main program are namespaced with deployment name Ref
 namespace Ref {
 void setupTopology(const TopologyState& state) {
+    registry.registerAllocator(Fw::MemoryAllocation::MemoryAllocatorType::SYSTEM, mallocator);
     // Autocoded initialization. Function provided by autocoder.
     initComponents(state);
     // Autocoded id setup. Function provided by autocoder.

--- a/Svc/ActivePhaser/test/ut/ActivePhaserTester.cpp
+++ b/Svc/ActivePhaser/test/ut/ActivePhaserTester.cpp
@@ -79,7 +79,9 @@ ActivePhaserTester ::ActivePhaserTester()
     this->connectPorts();
 }
 
-ActivePhaserTester ::~ActivePhaserTester() {}
+ActivePhaserTester ::~ActivePhaserTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Test helpers

--- a/Svc/ActiveRateGroup/test/ut/ActiveRateGroupTester.cpp
+++ b/Svc/ActiveRateGroup/test/ut/ActiveRateGroupTester.cpp
@@ -32,7 +32,9 @@ void ActiveRateGroupTester::clearPortCalls() {
     this->m_callOrder = 0;
 }
 
-ActiveRateGroupTester::~ActiveRateGroupTester() {}
+ActiveRateGroupTester::~ActiveRateGroupTester() {
+    this->m_impl.deinit();
+}
 
 void ActiveRateGroupTester::from_RateGroupMemberOut_handler(FwIndexType portNum, U32 context) {
     ASSERT_TRUE(portNum < static_cast<FwIndexType>(FW_NUM_ARRAY_ELEMENTS(m_impl.m_RateGroupMemberOut_OutputPort)));

--- a/Svc/ActiveTextLogger/test/ut/ActiveTextLoggerTester.cpp
+++ b/Svc/ActiveTextLogger/test/ut/ActiveTextLoggerTester.cpp
@@ -23,7 +23,9 @@ ActiveTextLoggerTester ::ActiveTextLoggerTester()
     this->connectPorts();
 }
 
-ActiveTextLoggerTester ::~ActiveTextLoggerTester() {}
+ActiveTextLoggerTester ::~ActiveTextLoggerTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.cpp
+++ b/Svc/BufferAccumulator/test/ut/BufferAccumulatorTester.cpp
@@ -55,6 +55,7 @@ BufferAccumulatorTester ::~BufferAccumulatorTester() {
         Fw::MallocAllocator buffAccumMallocator;
         this->component.deallocateQueue(buffAccumMallocator);
     }
+    this->component.deinit();
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/BufferLogger/test/ut/BufferLoggerTester.cpp
+++ b/Svc/BufferLogger/test/ut/BufferLoggerTester.cpp
@@ -43,7 +43,9 @@ BufferLoggerTester ::BufferLoggerTester(bool doInitLog)
     }
 }
 
-BufferLoggerTester ::~BufferLoggerTester() {}
+BufferLoggerTester ::~BufferLoggerTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.cpp
+++ b/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.cpp
@@ -22,7 +22,9 @@ namespace Svc {
 CommandDispatcherTester::CommandDispatcherTester(Svc::CommandDispatcherImpl& inst)
     : CommandDispatcherGTestBase("testerbase", 100), m_impl(inst) {}
 
-CommandDispatcherTester::~CommandDispatcherTester() {}
+CommandDispatcherTester::~CommandDispatcherTester() {
+    this->m_impl.deinit();
+}
 
 void CommandDispatcherTester::from_compCmdSend_handler(FwIndexType portNum,
                                                        FwOpcodeType opCode,

--- a/Svc/CmdSequencer/test/ut/CmdSequencerTester.cpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerTester.cpp
@@ -38,6 +38,7 @@ CmdSequencerTester ::CmdSequencerTester(const SequenceFiles::File::Format::t a_f
 
 CmdSequencerTester ::~CmdSequencerTester() {
     this->component.deallocateBuffer(this->mallocator);
+    this->component.deinit();
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/ComAggregator/test/ut/ComAggregatorTester.cpp
+++ b/Svc/ComAggregator/test/ut/ComAggregatorTester.cpp
@@ -21,7 +21,9 @@ ComAggregatorTester ::ComAggregatorTester()
     this->connectPorts();
 }
 
-ComAggregatorTester ::~ComAggregatorTester() {}
+ComAggregatorTester ::~ComAggregatorTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/Svc/ComLogger/test/ut/ComLoggerTester.cpp
+++ b/Svc/ComLogger/test/ut/ComLoggerTester.cpp
@@ -28,7 +28,9 @@ ComLoggerTester ::ComLoggerTester(const char* const compName, bool standardCLIni
     (void)standardCLInit;
 }
 
-ComLoggerTester ::~ComLoggerTester() {}
+ComLoggerTester ::~ComLoggerTester() {
+    this->comLogger.deinit();
+}
 
 void ComLoggerTester ::connectPorts() {
     comLogger.set_cmdRegOut_OutputPort(0, this->get_from_cmdRegOut(0));

--- a/Svc/ComQueue/test/ut/ComQueueTester.cpp
+++ b/Svc/ComQueue/test/ut/ComQueueTester.cpp
@@ -24,7 +24,9 @@ ComQueueTester ::ComQueueTester() : ComQueueGTestBase("Tester", MAX_HISTORY_SIZE
     this->connectPorts();
 }
 
-ComQueueTester ::~ComQueueTester() {}
+ComQueueTester ::~ComQueueTester() {
+    this->component.deinit();
+}
 
 void ComQueueTester ::dispatchAll() {
     while (this->component.m_queue.getMessagesAvailable() > 0) {

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
@@ -26,7 +26,9 @@ DpCatalogTester ::DpCatalogTester()
     this->connectPorts();
 }
 
-DpCatalogTester ::~DpCatalogTester() {}
+DpCatalogTester ::~DpCatalogTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/Svc/DpManager/test/ut/DpManagerTester.cpp
+++ b/Svc/DpManager/test/ut/DpManagerTester.cpp
@@ -18,7 +18,9 @@ DpManagerTester ::DpManagerTester()
     this->connectPorts();
 }
 
-DpManagerTester ::~DpManagerTester() {}
+DpManagerTester ::~DpManagerTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Handlers for typed from ports

--- a/Svc/DpWriter/test/ut/DpWriterTester.cpp
+++ b/Svc/DpWriter/test/ut/DpWriterTester.cpp
@@ -23,7 +23,9 @@ DpWriterTester ::DpWriterTester()
     Os::Stub::File::Test::StaticData::data.pointer = 0;
 }
 
-DpWriterTester ::~DpWriterTester() {}
+DpWriterTester ::~DpWriterTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Handlers for typed from ports

--- a/Svc/EventManager/test/ut/EventManagerTester.cpp
+++ b/Svc/EventManager/test/ut/EventManagerTester.cpp
@@ -25,7 +25,9 @@ EventManagerTester::EventManagerTester(Svc::EventManager& inst)
       m_receivedPacket(false),
       m_receivedFatalEvent(false) {}
 
-EventManagerTester::~EventManagerTester() {}
+EventManagerTester::~EventManagerTester() {
+    this->m_impl.deinit();
+}
 
 void EventManagerTester::from_PktSend_handler(const FwIndexType portNum,  //!< The port number
                                               Fw::ComBuffer& data,        //!< Buffer containing packet data

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -46,7 +46,7 @@ void FileDownlink ::configure(U32 timeout, U32 cooldown, U32 cycleTime, U32 file
     this->m_configured = true;
 
     Os::Queue::Status stat =
-        m_fileQueue.create(Os::QueueString("fileDownlinkQueue"), static_cast<FwSizeType>(fileQueueDepth),
+        m_fileQueue.create(this->getInstance(), Os::QueueString("fileDownlinkQueue"), static_cast<FwSizeType>(fileQueueDepth),
                            static_cast<FwSizeType>(sizeof(struct FileEntry)));
     FW_ASSERT(stat == Os::Queue::OP_OK, static_cast<FwAssertArgType>(stat));
 }

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -46,8 +46,8 @@ void FileDownlink ::configure(U32 timeout, U32 cooldown, U32 cycleTime, U32 file
     this->m_configured = true;
 
     Os::Queue::Status stat =
-        m_fileQueue.create(this->getInstance(), Os::QueueString("fileDownlinkQueue"), static_cast<FwSizeType>(fileQueueDepth),
-                           static_cast<FwSizeType>(sizeof(struct FileEntry)));
+        m_fileQueue.create(this->getInstance(), Os::QueueString("fileDownlinkQueue"),
+                           static_cast<FwSizeType>(fileQueueDepth), static_cast<FwSizeType>(sizeof(struct FileEntry)));
     FW_ASSERT(stat == Os::Queue::OP_OK, static_cast<FwAssertArgType>(stat));
 }
 

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -51,6 +51,11 @@ void FileDownlink ::configure(U32 timeout, U32 cooldown, U32 cycleTime, U32 file
     FW_ASSERT(stat == Os::Queue::OP_OK, static_cast<FwAssertArgType>(stat));
 }
 
+void FileDownlink ::deinit() {
+    this->m_fileQueue.teardown();
+    FileDownlinkComponentBase::deinit();
+}
+
 void FileDownlink ::preamble() {
     FW_ASSERT(this->m_configured == true);
 }

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -229,6 +229,9 @@ class FileDownlink final : public FileDownlinkComponentBase {
                    U32 fileQueueDepth  //!< Max number of items in file downlink queue
     );
 
+    //! Cleans up file queue before dispatching to underlying component
+    void deinit();
+
     //! Start FileDownlink component
     //! The component must be configured with configure() before starting.
     //!

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -39,6 +39,7 @@ FileDownlinkTester ::~FileDownlinkTester() {
     for (U32 i = 0; i < buffers_index; i++) {
         delete[] buffers[i];
     }
+    this->component.deinit();
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -31,7 +31,9 @@ FileManagerTester ::FileManagerTester() : FileManagerGTestBase("Tester", MAX_HIS
     this->initComponents();
 }
 
-FileManagerTester ::~FileManagerTester() {}
+FileManagerTester ::~FileManagerTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/Svc/FileUplink/test/ut/FileUplinkTester.cpp
+++ b/Svc/FileUplink/test/ut/FileUplinkTester.cpp
@@ -37,6 +37,7 @@ FileUplinkTester ::FileUplinkTester()
 
 FileUplinkTester ::~FileUplinkTester() {
     this->component.m_file.osFile.close();
+    this->component.deinit();
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
@@ -23,7 +23,9 @@ FpySequencerTester ::FpySequencerTester()
     clearSeq();
 }
 
-FpySequencerTester ::~FpySequencerTester() {}
+FpySequencerTester ::~FpySequencerTester() {
+    this->component.deinit();
+}
 
 // dispatches events from the queue until the cmp reaches the given state
 void FpySequencerTester::dispatchUntilState(State state, U32 bound) {

--- a/Svc/Health/test/ut/HealthTester.cpp
+++ b/Svc/Health/test/ut/HealthTester.cpp
@@ -33,7 +33,9 @@ HealthTester ::HealthTester() : HealthGTestBase("Tester", MAX_HISTORY_SIZE), com
     this->initComponents();
 }
 
-HealthTester ::~HealthTester() {}
+HealthTester ::~HealthTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Handlers for typed from ports

--- a/Svc/PrmDb/test/ut/PrmDbTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.cpp
@@ -1341,7 +1341,9 @@ PrmDbTester::PrmDbTester(Svc::PrmDbImpl& inst) : PrmDbGTestBase("testerbase", 10
     PrmDbTester::PrmDbTestFile::setTester(this);
 }
 
-PrmDbTester::~PrmDbTester() {}
+PrmDbTester::~PrmDbTester() {
+    this->m_impl.deinit();
+}
 
 void PrmDbTester ::from_pingOut_handler(const FwIndexType portNum, U32 key) {
     this->pushFromPortEntry_pingOut(key);

--- a/Svc/SeqDispatcher/test/ut/SeqDispatcherTester.cpp
+++ b/Svc/SeqDispatcher/test/ut/SeqDispatcherTester.cpp
@@ -18,7 +18,9 @@ SeqDispatcherTester ::SeqDispatcherTester()
     this->initComponents();
 }
 
-SeqDispatcherTester ::~SeqDispatcherTester() {}
+SeqDispatcherTester ::~SeqDispatcherTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/Svc/TlmChan/test/ut/TlmChanTester.cpp
+++ b/Svc/TlmChan/test/ut/TlmChanTester.cpp
@@ -30,7 +30,9 @@ TlmChanTester ::TlmChanTester()
     this->connectPorts();
 }
 
-TlmChanTester ::~TlmChanTester() {}
+TlmChanTester ::~TlmChanTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
+++ b/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
@@ -28,7 +28,9 @@ TlmPacketizerTester ::TlmPacketizerTester()
     this->connectPorts();
 }
 
-TlmPacketizerTester ::~TlmPacketizerTester() {}
+TlmPacketizerTester ::~TlmPacketizerTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests

--- a/default/config/CMakeLists.txt
+++ b/default/config/CMakeLists.txt
@@ -12,6 +12,7 @@ register_fprime_config(
         "${CMAKE_CURRENT_LIST_DIR}/FpConstants.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/FpySequencerCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/MemoryAllocation.fpp"
+        "${CMAKE_CURRENT_LIST_DIR}/MemoryAllocation.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/PlatformCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/PolyDbCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/VersionCfg.fpp"

--- a/default/config/MemoryAllocation.hpp
+++ b/default/config/MemoryAllocation.hpp
@@ -14,7 +14,7 @@
 namespace Fw {
 namespace MemoryAllocation {
 using DefaultMemoryAllocatorType = Fw::MallocAllocator;
-} // namespace MemoryAllocation
-} // namespace Fw
+}  // namespace MemoryAllocation
+}  // namespace Fw
 
-#endif // CONFIG_MEMORY_ALLOCATION_HPP
+#endif  // CONFIG_MEMORY_ALLOCATION_HPP

--- a/default/config/MemoryAllocation.hpp
+++ b/default/config/MemoryAllocation.hpp
@@ -1,0 +1,20 @@
+// ======================================================================
+// \title  config/MemoryAllocation.hpp
+// \author lestarch
+// \brief  hpp file for memory allocation configuration
+//
+// \copyright
+// Copyright 2024, by the California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+// ======================================================================
+#ifndef CONFIG_MEMORY_ALLOCATION_HPP
+#define CONFIG_MEMORY_ALLOCATION_HPP
+#include <Fw/Types/MallocAllocator.hpp>
+namespace Fw {
+namespace MemoryAllocation {
+using DefaultMemoryAllocatorType = Fw::MallocAllocator;
+} // namespace MemoryAllocation
+} // namespace Fw
+
+#endif // CONFIG_MEMORY_ALLOCATION_HPP

--- a/default/config/PlatformCfg.fpp
+++ b/default/config/PlatformCfg.fpp
@@ -15,7 +15,7 @@ constant FW_FILE_HANDLE_MAX_SIZE = 16
 constant FW_MUTEX_HANDLE_MAX_SIZE = 72
 
 @ Maximum size of a handle for Os::Queue
-constant FW_QUEUE_HANDLE_MAX_SIZE = 352
+constant FW_QUEUE_HANDLE_MAX_SIZE = 368
 
 @ Maximum size of a handle for Os::Directory
 constant FW_DIRECTORY_HANDLE_MAX_SIZE = 16


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Fix #4039 

Makes queues use registry memory for allocations.

## Rationale

Raw `new`/`malloc` are difficult.

## Testing/Review Recommendations

CI

## Future Work

Other uses of new/malloc in framework

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Autocomplete