### PR TITLE
Update Spi component to return a status on device access

### DIFF
--- a/Drv/Interfaces/Spi.fpp
+++ b/Drv/Interfaces/Spi.fpp
@@ -1,5 +1,9 @@
 module Drv {
     interface Spi {
+        @ Port to perform a synchronous write/read operation over the SPI bus
+        guarded input port SpiWriteRead: Drv.SpiWriteRead
+
+        @ TODO Mark SpiReadWrite as deprecated because it does not return a status, and indicate when it will be removed from FPrime
         @ Port to perform a synchronous read/write operation over the SPI bus
         sync input port SpiReadWrite: Drv.SpiReadWrite
     }

--- a/Drv/Interfaces/Spi.fpp
+++ b/Drv/Interfaces/Spi.fpp
@@ -3,7 +3,7 @@ module Drv {
         @ Port to perform a synchronous write/read operation over the SPI bus
         guarded input port SpiWriteRead: Drv.SpiWriteRead
 
-        @ TODO Mark SpiReadWrite as deprecated because it does not return a status, and indicate when it will be removed from FPrime
+        @ DEPRECATED Use SpiWriteRead port instead (same operation with a return value)
         @ Port to perform a synchronous read/write operation over the SPI bus
         sync input port SpiReadWrite: Drv.SpiReadWrite
     }

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -34,18 +34,18 @@ namespace Drv {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-// @TODO: SpiReadWrite is deprecated.  Just call the other function and throw away the status
+// @ DEPRECATED: Use SpiWriteRead port instead (same operation with a return value)
 void LinuxSpiDriverComponentImpl::SpiReadWrite_handler(const FwIndexType portNum,
                                                        Fw::Buffer& writeBuffer,
                                                        Fw::Buffer& readBuffer) {
-    (void) SpiWriteRead_handler(portNum,
-                                writeBuffer,
-                                readBuffer);
+    (void)SpiWriteRead_handler(portNum, writeBuffer, readBuffer);
 }
 
 SpiStatus LinuxSpiDriverComponentImpl::SpiWriteRead_handler(const FwIndexType portNum,
                                                             Fw::Buffer& writeBuffer,
                                                             Fw::Buffer& readBuffer) {
+    FW_ASSERT(writeBuffer != nullptr);
+    FW_ASSERT(readBuffer  != nullptr);
     FW_ASSERT(writeBuffer.getSize() == readBuffer.getSize());
 
     if (this->m_fd == -1) {
@@ -73,11 +73,12 @@ SpiStatus LinuxSpiDriverComponentImpl::SpiWriteRead_handler(const FwIndexType po
 
     if (stat < 1) {
         this->log_WARNING_HI_SPI_WriteError(this->m_device, this->m_select, stat);
+        return SpiStatus::SPI_OTHER_ERR;
     }
     this->m_bytes += readBuffer.getSize();
     this->tlmWrite_SPI_Bytes(this->m_bytes);
 
-    return SpiStatus::SPI_OK;  // @TODO: catch errors.
+    return SpiStatus::SPI_OK;
 }
 
 bool LinuxSpiDriverComponentImpl::open(FwIndexType device, FwIndexType select, SpiFrequency clock, SpiMode spiMode) {

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -44,8 +44,8 @@ void LinuxSpiDriverComponentImpl::SpiReadWrite_handler(const FwIndexType portNum
 SpiStatus LinuxSpiDriverComponentImpl::SpiWriteRead_handler(const FwIndexType portNum,
                                                             Fw::Buffer& writeBuffer,
                                                             Fw::Buffer& readBuffer) {
-    FW_ASSERT(writeBuffer != nullptr);
-    FW_ASSERT(readBuffer  != nullptr);
+    FW_ASSERT(writeBuffer.isValid());
+    FW_ASSERT(readBuffer.isValid());
     FW_ASSERT(writeBuffer.getSize() == readBuffer.getSize());
 
     if (this->m_fd == -1) {

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -38,12 +38,16 @@ namespace Drv {
 void LinuxSpiDriverComponentImpl::SpiReadWrite_handler(const FwIndexType portNum,
                                                        Fw::Buffer& writeBuffer,
                                                        Fw::Buffer& readBuffer) {
+    FW_ASSERT(portNum >= 0, static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(writeBuffer.isValid());
+    FW_ASSERT(readBuffer.isValid());
     (void)SpiWriteRead_handler(portNum, writeBuffer, readBuffer);
 }
 
 SpiStatus LinuxSpiDriverComponentImpl::SpiWriteRead_handler(const FwIndexType portNum,
                                                             Fw::Buffer& writeBuffer,
                                                             Fw::Buffer& readBuffer) {
+    FW_ASSERT(portNum >= 0, static_cast<FwAssertArgType>(portNum));
     FW_ASSERT(writeBuffer.isValid());
     FW_ASSERT(readBuffer.isValid());
     FW_ASSERT(writeBuffer.getSize() == readBuffer.getSize());

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -34,13 +34,22 @@ namespace Drv {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
+// @TODO: SpiReadWrite is deprecated.  Just call the other function and throw away the status
 void LinuxSpiDriverComponentImpl::SpiReadWrite_handler(const FwIndexType portNum,
                                                        Fw::Buffer& writeBuffer,
                                                        Fw::Buffer& readBuffer) {
+    (void) SpiWriteRead_handler(portNum,
+                                writeBuffer,
+                                readBuffer);
+}
+
+SpiStatus LinuxSpiDriverComponentImpl::SpiWriteRead_handler(const FwIndexType portNum,
+                                                            Fw::Buffer& writeBuffer,
+                                                            Fw::Buffer& readBuffer) {
     FW_ASSERT(writeBuffer.getSize() == readBuffer.getSize());
 
     if (this->m_fd == -1) {
-        return;
+        return SpiStatus::SPI_OPEN_ERR;
     }
 
     spi_ioc_transfer tr;
@@ -67,6 +76,8 @@ void LinuxSpiDriverComponentImpl::SpiReadWrite_handler(const FwIndexType portNum
     }
     this->m_bytes += readBuffer.getSize();
     this->tlmWrite_SPI_Bytes(this->m_bytes);
+
+    return SpiStatus::SPI_OK;  // @TODO: catch errors.
 }
 
 bool LinuxSpiDriverComponentImpl::open(FwIndexType device, FwIndexType select, SpiFrequency clock, SpiMode spiMode) {

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
@@ -76,6 +76,13 @@ class LinuxSpiDriverComponentImpl final : public LinuxSpiDriverComponentBase {
     // Handler implementations for user-defined typed input ports
     // ----------------------------------------------------------------------
 
+    //! Handler implementation for SpiWriteRead
+    //!
+    SpiStatus SpiWriteRead_handler(const FwIndexType portNum, /*!< The port number*/
+                                   Fw::Buffer& WriteBuffer,
+                                   Fw::Buffer& readBuffer);
+
+    // TODO: Mark SpiReadWrite as deprecated
     //! Handler implementation for SpiReadWrite
     //!
     void SpiReadWrite_handler(const FwIndexType portNum, /*!< The port number*/

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.hpp
@@ -82,7 +82,7 @@ class LinuxSpiDriverComponentImpl final : public LinuxSpiDriverComponentBase {
                                    Fw::Buffer& WriteBuffer,
                                    Fw::Buffer& readBuffer);
 
-    // TODO: Mark SpiReadWrite as deprecated
+    // @ DEPRECATED: Use SpiWriteRead port instead (same operation with a return value)
     //! Handler implementation for SpiReadWrite
     //!
     void SpiReadWrite_handler(const FwIndexType portNum, /*!< The port number*/

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImplStub.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImplStub.cpp
@@ -23,6 +23,13 @@ bool LinuxSpiDriverComponentImpl::open(FwIndexType device, FwIndexType select, S
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
+SpiStatus LinuxSpiDriverComponentImpl::SpiWriteRead_handler(const FwIndexType portNum,
+                                                            Fw::Buffer& WriteBuffer,
+                                                            Fw::Buffer& readBuffer) {
+    return SpiStatus::SPI_OK;
+}
+
+// TODO: Mark SpiReadWrite as deprecated
 void LinuxSpiDriverComponentImpl::SpiReadWrite_handler(const FwIndexType portNum,
                                                        Fw::Buffer& WriteBuffer,
                                                        Fw::Buffer& readBuffer) {}

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImplStub.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImplStub.cpp
@@ -29,7 +29,7 @@ SpiStatus LinuxSpiDriverComponentImpl::SpiWriteRead_handler(const FwIndexType po
     return SpiStatus::SPI_OK;
 }
 
-// TODO: Mark SpiReadWrite as deprecated
+// @ DEPRECATED: Use SpiWriteRead port instead (same operation with a return value)
 void LinuxSpiDriverComponentImpl::SpiReadWrite_handler(const FwIndexType portNum,
                                                        Fw::Buffer& WriteBuffer,
                                                        Fw::Buffer& readBuffer) {}

--- a/Drv/Ports/SpiDriverPorts.fpp
+++ b/Drv/Ports/SpiDriverPorts.fpp
@@ -1,8 +1,30 @@
 module Drv {
 
+  @ TODO: Update description: Serial Peripheral Interface Write a set of bytes then read a set of bytes
+  @ TODO: Why is no chip select required?  Or SPI mode?  Is FPrime always presumed to be the slave?
+  port SpiWriteRead(
+                     ref writeBuffer: Fw.Buffer
+                     ref readBuffer:  Fw.Buffer
+                   ) -> Drv.SpiStatus
+
+  @ TODO Mark SpiReadWrite as deprecated because it does not return a status, and indicate when it will be removed from FPrime
   port SpiReadWrite(
                      ref writeBuffer: Fw.Buffer
-                     ref readBuffer: Fw.Buffer
+                     ref readBuffer:  Fw.Buffer
                    )
 
 }
+
+module Drv {
+
+  enum SpiStatus : U8 {
+    SPI_OK           = 0 @< Transaction okay
+    SPI_OPEN_ERR     = 1 @< SPI driver failed to open device
+    SPI_CONFIG_ERR   = 2 @< SPI read failed
+    SPI_MISMATCH_ERR = 3 @< SPI read failed
+    SPI_WRITE_ERR    = 4 @< SPI write failed
+    SPI_OTHER_ERR    = 5 @< Other errors that do not fit
+  }
+
+}
+

--- a/Drv/Ports/SpiDriverPorts.fpp
+++ b/Drv/Ports/SpiDriverPorts.fpp
@@ -1,13 +1,11 @@
 module Drv {
 
-  @ TODO: Update description: Serial Peripheral Interface Write a set of bytes then read a set of bytes
-  @ TODO: Why is no chip select required?  Or SPI mode?  Is FPrime always presumed to be the slave?
   port SpiWriteRead(
                      ref writeBuffer: Fw.Buffer
                      ref readBuffer:  Fw.Buffer
                    ) -> Drv.SpiStatus
 
-  @ TODO Mark SpiReadWrite as deprecated because it does not return a status, and indicate when it will be removed from FPrime
+  @ DEPRECATED: Use SpiWriteRead port instead (same operation with a return value)
   port SpiReadWrite(
                      ref writeBuffer: Fw.Buffer
                      ref readBuffer:  Fw.Buffer


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4140 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

1. Add enum `SpiStatus` to include values for each error already noted in `Events.fppi`
2. Convert Spi access port from "sync" to "guarded", consistent with I2C port. (In `Drv/Interfaces/Spi.fpp`)

## Rationale

This would bring it in line with other similar drivers like I2C.

## Testing/Review Recommendations

Unit Test is currently broken.  Should be fixed to do one or several of:
* At least not run all the other UTs, as reported in [Issue #4405](https://github.com/nasa/fprime/issues/4405)
* Run on any supported platform, possibly just a subset of tests.
* Run only on a linux development workstation.
* Require specific hardware to run.

## Future Work

[Issue #4470](https://github.com/nasa/fprime/issues/4470) captures more work to go on this component, including
1. Fix / create Unit Test
2. Add docs/sdd.md
3. Add SpiStatus to other existing function

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A