### PR TITLE
Add missing argument description to Os::RawTime

### DIFF
--- a/Os/Posix/RawTime.hpp
+++ b/Os/Posix/RawTime.hpp
@@ -64,6 +64,7 @@ class PosixRawTime : public RawTimeInterface {
     //! that value in its config/ folder.
     //!
     //! \param buffer The buffer to serialize the contents into.
+    //! \param mode Endianness to use when serializing to buffer.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
     Fw::SerializeStatus serializeTo(Fw::SerialBufferBase& buffer,
                                     Fw::Endianness mode = Fw::Endianness::BIG) const override;
@@ -79,6 +80,7 @@ class PosixRawTime : public RawTimeInterface {
     //! that value in its config/ folder.
     //!
     //! \param buffer The buffer to deserialize the contents from.
+    //! \param mode Endianness to use when deserializing from the buffer.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
     Fw::SerializeStatus deserializeFrom(Fw::SerialBufferBase& buffer,
                                         Fw::Endianness mode = Fw::Endianness::BIG) override;

--- a/Os/RawTime.hpp
+++ b/Os/RawTime.hpp
@@ -76,6 +76,7 @@ class RawTimeInterface : public Fw::Serializable {
     //! that value in its config/ folder.
     //!
     //! \param buffer The buffer to serialize the contents into.
+    //! \param mode Endianness to use when serializing to buffer.
     //! \return Fw::SerializeStatus indicating the result of the serialization.
     virtual Fw::SerializeStatus serializeTo(Fw::SerialBufferBase& buffer,
                                             Fw::Endianness mode = Fw::Endianness::BIG) const = 0;
@@ -91,6 +92,7 @@ class RawTimeInterface : public Fw::Serializable {
     //! that value in its config/ folder.
     //!
     //! \param buffer The buffer to deserialize the contents from.
+    //! \param mode Endianness to use when deserializing from the buffer.
     //! \return Fw::SerializeStatus indicating the result of the deserialization.
     virtual Fw::SerializeStatus deserializeFrom(Fw::SerialBufferBase& buffer,
                                                 Fw::Endianness mode = Fw::Endianness::BIG) = 0;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/4460 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Added missing description of argument

## Rationale

Useful documentation

## Testing/Review Recommendations

Proof read comment

## Future Work

Keep comments up to date

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Helped create a more concise and informative description for the argument
