### PR TITLE
Add component send only (configSend, open) test

### DIFF
--- a/Drv/Udp/test/ut/UdpTestMain.cpp
+++ b/Drv/Udp/test/ut/UdpTestMain.cpp
@@ -9,6 +9,11 @@ TEST(Nominal, UdpBasicMessaging) {
     tester.test_basic_messaging();
 }
 
+TEST(Nominal, UdpBasicUnidirectionalMessaging) {
+    Drv::UdpTester tester;
+    tester.test_basic_unidirectional_messaging();
+}
+
 TEST(Nominal, UdpBasicReceiveThread) {
     Drv::UdpTester tester;
     tester.test_receive_thread();
@@ -17,6 +22,11 @@ TEST(Nominal, UdpBasicReceiveThread) {
 TEST(Reconnect, UdpMultiMessaging) {
     Drv::UdpTester tester;
     tester.test_multiple_messaging();
+}
+
+TEST(Reconnect, UdpMultiUnidirectionalMessaging) {
+    Drv::UdpTester tester;
+    tester.test_multiple_unidirectional_messaging();
 }
 
 TEST(Reconnect, UdpReceiveThreadReconnect) {

--- a/Drv/Udp/test/ut/UdpTester.hpp
+++ b/Drv/Udp/test/ut/UdpTester.hpp
@@ -57,6 +57,15 @@ class UdpTester : public UdpGTestBase {
     //!
     void test_multiple_messaging();
 
+
+    //! Test basic messaging in unidirectional mode
+    //!
+    void test_basic_unidirectional_messaging();
+
+    //! Test basic reconnection behavior in unidirectional mode
+    //!
+    void test_multiple_unidirectional_messaging();
+
     //! Test receive via thread
     //!
     void test_receive_thread();
@@ -69,7 +78,7 @@ class UdpTester : public UdpGTestBase {
     void test_buffer_deallocation();
 
     // Helpers
-    void test_with_loop(U32 iterations, bool recv_thread = false);
+    void test_with_loop(U32 iterations, bool recv_thread = false, bool send_only = false);
 
     bool wait_on_change(Drv::IpSocket& socket, bool open, U32 iterations);
 

--- a/Drv/Udp/test/ut/UdpTester.hpp
+++ b/Drv/Udp/test/ut/UdpTester.hpp
@@ -57,7 +57,6 @@ class UdpTester : public UdpGTestBase {
     //!
     void test_multiple_messaging();
 
-
     //! Test basic messaging in unidirectional mode
     //!
     void test_basic_unidirectional_messaging();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Adds tests that demonstrate Udp in send only configuration.  This is done by configuring send, and then calling open without recv or a recv thread.

## Rationale

Some users use the Udp component in send mode.  This verifies that workflow.

## Testing/Review Recommendations

UTs

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Autocomplete