### PR TITLE
Added missing undef for m_len in VxWorks collision fix

### DIFF
--- a/Drv/Ip/UdpSocket.hpp
+++ b/Drv/Ip/UdpSocket.hpp
@@ -26,6 +26,7 @@
 // These macros are defined somewhere in inetLib.h.
 #undef m_type
 #undef m_data
+#undef m_len
 
 #else
 #include <arpa/inet.h>


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4519  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Added missing `#undef m_len` that was not included in #4399 

cc: @LeStarch @kevin-f-ortega 

## Rationale

<!-- A rationale for this change. e.g. fixes bug, or most projects need XYZ feature. -->

## Testing/Review Recommendations

<!-- Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality. -->

## Future Work

<!-- Note any additional work that will be done relating to this issue. -->

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). -->
