### PR TITLE
Remove virtual methods from final classes

### DIFF
--- a/Svc/Health/HealthComponentImpl.hpp
+++ b/Svc/Health/HealthComponentImpl.hpp
@@ -82,7 +82,7 @@ class HealthImpl final : public HealthComponentBase {
     //!  \brief additional checks function
     //!
     //!  Does additional checks based on the platform
-    virtual void doOtherChecks();
+    void doOtherChecks();
 
   private:
     //!  \brief ping return handler

--- a/Svc/TlmChan/TlmChan.hpp
+++ b/Svc/TlmChan/TlmChan.hpp
@@ -28,7 +28,7 @@ class TlmChan final : public TlmChanComponentBase {
 
   protected:
     // can be overridden for alternate algorithms
-    virtual FwChanIdType doHash(FwChanIdType id);
+    FwChanIdType doHash(FwChanIdType id);
 
   private:
     // Port functions


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Remove `virtual` modifier on methods inside final classes

## Rationale

I recently upgraded to LLVM 21 and clang now errors from this.
