### PR TITLE
Prevent divide-by-zero in PosixFileSystem::_getFreeSpace

### DIFF
--- a/Os/Posix/FileSystem.cpp
+++ b/Os/Posix/FileSystem.cpp
@@ -82,6 +82,11 @@ PosixFileSystem::Status PosixFileSystem::_getFreeSpace(const char* path,
     const FwSizeType free_blocks = static_cast<FwSizeType>(fsStat.f_bfree);
     const FwSizeType total_blocks = static_cast<FwSizeType>(fsStat.f_blocks);
 
+    // Guard against divide-by-zero if filesystem reports invalid block size
+    if (block_size == 0) {
+        return OTHER_ERROR;
+    }
+
     // Check for overflow in multiplication
     if (free_blocks > (std::numeric_limits<FwSizeType>::max() / block_size) ||
         total_blocks > (std::numeric_limits<FwSizeType>::max() / block_size)) {


### PR DESCRIPTION
|    |    |
|:---|:---|
|**_Related Issue(s)_**| Fixes #4500 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Add a guard to check for zero `block_size` before performing division operations in `Os::Posix::FileSystem::PosixFileSystem::_getFreeSpace`. Returns `OTHER_ERROR` if the filesystem reports an invalid (zero) fragment size.

## Rationale

Static analysis (CodeSonar) identified a potential divide-by-zero vulnerability. The overflow check at lines 91-92 divides by `block_size` without first verifying it is non-zero. While `f_frsize` should never be zero on a properly functioning filesystem, this defensive guard ensures robustness against edge cases and satisfies static analysis requirements.

## Testing/Review Recommendations

- The edge case can't be triggered without mocking `statvfs` to simulate some radiation-induced memory corruption (changing f_frsize from 0x1000 to 0 in a bit flip)
- CI should verify compilation with strict warnings (`-Wall -Wextra -Werror`)
- Review that `OTHER_ERROR` is the appropriate status for invalid filesystem response
