### PR TITLE
Add File Dispatcher port to CmdSequencer

### DIFF
--- a/Svc/CmdSequencer/CmdSequencer.fpp
+++ b/Svc/CmdSequencer/CmdSequencer.fpp
@@ -79,6 +79,9 @@ module Svc {
     @ Port for requests to run sequences
     async input port seqRunIn: Svc.CmdSeqIn
 
+    @ Port for file dispatches to run sequences
+    async input port seqDispatchIn: Svc.FileDispatch
+
     @ Port for sending sequence commands
     output port comCmdOut: Fw.Com
 

--- a/Svc/CmdSequencer/CmdSequencerImpl.cpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.cpp
@@ -133,7 +133,7 @@ void CmdSequencerComponentImpl::CS_VALIDATE_cmdHandler(FwOpcodeType opCode,
 }
 
 //! Handler for input port seqRunIn
-void CmdSequencerComponentImpl::seqRunIn_handler(FwIndexType portNum, const Fw::StringBase& filename) {
+void CmdSequencerComponentImpl::doSequenceRun(const Fw::StringBase& filename) {
     if (!this->requireRunMode(STOPPED)) {
         this->seqDone_out(0, 0, 0, Fw::CmdResponse::EXECUTION_ERROR);
         return;
@@ -168,6 +168,14 @@ void CmdSequencerComponentImpl::seqRunIn_handler(FwIndexType portNum, const Fw::
     }
 
     this->log_ACTIVITY_HI_CS_PortSequenceStarted(this->m_sequence->getLogFileName());
+}
+
+void CmdSequencerComponentImpl::seqRunIn_handler(FwIndexType portNum, const Fw::StringBase& filename) {
+    this->doSequenceRun(filename);
+}
+
+void CmdSequencerComponentImpl::seqDispatchIn_handler(FwIndexType portNum, Fw::StringBase& file_name) {
+    this->doSequenceRun(file_name);
 }
 
 void CmdSequencerComponentImpl ::seqCancelIn_handler(const FwIndexType portNum) {

--- a/Svc/CmdSequencer/CmdSequencerImpl.hpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.hpp
@@ -511,27 +511,34 @@ class CmdSequencerComponentImpl final : public CmdSequencerComponentBase {
                                FwOpcodeType opcode,             //!< The command opcode
                                U32 cmdSeq,                      //!< The command sequence number
                                const Fw::CmdResponse& response  //!< The command response
-    );
+                               ) override;
 
     //! Handler for input port schedIn
     void schedIn_handler(FwIndexType portNum,  //!< The port number
                          U32 order             //!< The call order
-    );
+                         ) override;
 
     //! Handler for input port seqRunIn
     void seqRunIn_handler(FwIndexType portNum,            //!< The port number
                           const Fw::StringBase& filename  //!< The sequence file
-    );
+                          ) override;
+
+    //! Handler implementation for seqDispatchIn
+    //!
+    //! Port for file dispatches to run sequences
+    void seqDispatchIn_handler(FwIndexType portNum,       //!< The port number
+                               Fw::StringBase& file_name  //!< The file to dispatch
+                               ) override;
 
     //! Handler for ping port
     void pingIn_handler(FwIndexType portNum,  //!< The port number
                         U32 key               //!< Value to return to pinger
-    );
+                        ) override;
 
     //! Handler implementation for seqCancelIn
     //!
     void seqCancelIn_handler(const FwIndexType portNum /*!< The port number*/
-    );
+                             ) override;
 
   private:
     // ----------------------------------------------------------------------
@@ -542,46 +549,46 @@ class CmdSequencerComponentImpl final : public CmdSequencerComponentBase {
     //! Set the run mode to AUTO.
     void CS_AUTO_cmdHandler(FwOpcodeType opcode,  //!< The opcode
                             U32 cmdSeq            //!< The command sequence number
-    );
+                            ) override;
 
     //! Handler for command CS_CANCEL
     //! Validate a command sequence file
     void CS_CANCEL_cmdHandler(FwOpcodeType opCode,  //!< The opcode
                               U32 cmdSeq            //!< The command sequence number
-    );
+                              ) override;
 
     //! Handler for command CS_MANUAL
     //! Set the run mode to MANUAL.
     void CS_MANUAL_cmdHandler(FwOpcodeType opcode,  //!< The opcode
                               U32 cmdSeq            //!< The command sequence number
-    );
+                              ) override;
 
     //! Handler for command CS_RUN
     void CS_RUN_cmdHandler(FwOpcodeType opCode,               //!< The opcode
                            U32 cmdSeq,                        //!< The command sequence number
                            const Fw::CmdStringArg& fileName,  //!< The file name
                            Svc::CmdSequencer_BlockState block /*!< Return command status when complete or not*/
-    );
+                           ) override;
 
     //! Handler for command CS_START
     //! Start running a command sequence
     void CS_START_cmdHandler(FwOpcodeType opcode,  //!< The opcode
                              U32 cmdSeq            //!< The command sequence number
-    );
+                             ) override;
 
     //! Handler for command CS_STEP
     //! Perform one step in a command sequence.
     //! Valid only if SequenceRunner is in MANUAL run mode.
     void CS_STEP_cmdHandler(FwOpcodeType opcode,  //!< The opcode
                             U32 cmdSeq            //!< The command sequence number
-    );
+                            ) override;
 
     //! Handler for command CS_VALIDATE
     //! Run a command sequence file
     void CS_VALIDATE_cmdHandler(FwOpcodeType opCode,              //!< The opcode
                                 U32 cmdSeq,                       //!< The command sequence number
                                 const Fw::CmdStringArg& fileName  //!< The name of the sequence file
-    );
+                                ) override;
 
     //! Implementation for CS_JOIN command handler
     //! Wait for sequences that are running to finish.
@@ -589,7 +596,7 @@ class CmdSequencerComponentImpl final : public CmdSequencerComponentBase {
     //! then wait for them to finish before allowing more seq run request.
     void CS_JOIN_WAIT_cmdHandler(const FwOpcodeType opCode, /*!< The opcode*/
                                  const U32 cmdSeq           /*!< The command sequence number*/
-    );
+                                 ) override;
 
   private:
     // ----------------------------------------------------------------------
@@ -639,6 +646,9 @@ class CmdSequencerComponentImpl final : public CmdSequencerComponentBase {
     //! Set command timeout timer
     void setCmdTimeout(const Fw::Time& currentTime  //!< The current time
     );
+
+    //! Sequence run helper
+    void doSequenceRun(const Fw::StringBase& fileName);
 
   private:
     // ----------------------------------------------------------------------

--- a/Svc/CmdSequencer/test/ut/CmdSequencerMain.cpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerMain.cpp
@@ -53,6 +53,11 @@ TEST(Immediate, AutoByPort) {
     tester.AutoByPort();
 }
 
+TEST(Immediate, AutoByFileDispatcherPort) {
+    Svc::Immediate::CmdSequencerTester tester;
+    tester.AutoByFileDispatcherPort();
+}
+
 TEST(Immediate, AutoByPortAMPCS) {
     Svc::Immediate::CmdSequencerTester tester(Svc::SequenceFiles::File::Format::AMPCS);
     tester.AutoByPort();

--- a/Svc/CmdSequencer/test/ut/CmdSequencerTester.cpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerTester.cpp
@@ -482,11 +482,11 @@ void CmdSequencerTester ::runSequenceByPortCall(const char* const fileName) {
     ASSERT_EVENTS_SIZE(2);
     ASSERT_EVENTS_CS_SequenceLoaded(0, fileName);
     ASSERT_EVENTS_CS_PortSequenceStarted(0, fileName);
+}
 
-    // reset
-    this->clearHistory();
-
-    // Invoke the seqDispatch port
+void CmdSequencerTester ::runSequenceByFileDispatcherPortCall(const char* const fileName) {
+    // Invoke the seqRun port
+    Fw::String fArg(fileName);
     this->invoke_to_seqDispatchIn(0, fArg);
     this->clearAndDispatch();
     // Assert no command response
@@ -496,6 +496,7 @@ void CmdSequencerTester ::runSequenceByPortCall(const char* const fileName) {
     ASSERT_EVENTS_CS_SequenceLoaded(0, fileName);
     ASSERT_EVENTS_CS_PortSequenceStarted(0, fileName);
 }
+
 
 void CmdSequencerTester ::runLoadedSequence() {
     // Invoke the port

--- a/Svc/CmdSequencer/test/ut/CmdSequencerTester.cpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerTester.cpp
@@ -497,7 +497,6 @@ void CmdSequencerTester ::runSequenceByFileDispatcherPortCall(const char* const 
     ASSERT_EVENTS_CS_PortSequenceStarted(0, fileName);
 }
 
-
 void CmdSequencerTester ::runLoadedSequence() {
     // Invoke the port
     Fw::String fArg("");
@@ -596,9 +595,9 @@ void CmdSequencerTester ::stepSequence(const U32 cmdSeq) {
 }
 
 void CmdSequencerTester::textLogIn(FwEventIdType id,                //!< The event ID
-    const Fw::Time& timeTag,         //!< The time
-    const Fw::LogSeverity severity,  //!< The severity
-    const Fw::TextLogString& text    //!< The event string
+                                   const Fw::Time& timeTag,         //!< The time
+                                   const Fw::LogSeverity severity,  //!< The severity
+                                   const Fw::TextLogString& text    //!< The event string
 ) {
     TextLogEntry e = {id, timeTag, severity, text};
 
@@ -635,6 +634,5 @@ DirectoryInterface* DirectoryInterface::getDelegate(DirectoryHandleStorage& alig
     return Os::Delegate::makeDelegate<DirectoryInterface, Os::Posix::Directory::PosixDirectory>(
         aligned_placement_new_memory);
 }
-
 
 }  // namespace Os

--- a/Svc/CmdSequencer/test/ut/CmdSequencerTester.cpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerTester.cpp
@@ -391,6 +391,9 @@ void CmdSequencerTester ::connectPorts() {
     // seqRunIn
     this->connect_to_seqRunIn(0, this->component.get_seqRunIn_InputPort(0));
 
+    // fileDispatch
+    this->connect_to_seqDispatchIn(0, this->component.get_seqDispatchIn_InputPort(0));
+
     // timeCaller
     this->component.set_timeCaller_OutputPort(0, this->get_from_timeCaller(0));
 
@@ -469,9 +472,22 @@ void CmdSequencerTester ::runSequence(const U32 cmdSeq, const char* const fileNa
 }
 
 void CmdSequencerTester ::runSequenceByPortCall(const char* const fileName) {
-    // Invoke the port
+    // Invoke the seqRun port
     Fw::String fArg(fileName);
     this->invoke_to_seqRunIn(0, fArg);
+    this->clearAndDispatch();
+    // Assert no command response
+    ASSERT_CMD_RESPONSE_SIZE(0);
+    // Assert events
+    ASSERT_EVENTS_SIZE(2);
+    ASSERT_EVENTS_CS_SequenceLoaded(0, fileName);
+    ASSERT_EVENTS_CS_PortSequenceStarted(0, fileName);
+
+    // reset
+    this->clearHistory();
+
+    // Invoke the seqDispatch port
+    this->invoke_to_seqDispatchIn(0, fArg);
     this->clearAndDispatch();
     // Assert no command response
     ASSERT_CMD_RESPONSE_SIZE(0);
@@ -577,6 +593,17 @@ void CmdSequencerTester ::stepSequence(const U32 cmdSeq) {
     ASSERT_CMD_RESPONSE_SIZE(1);
     ASSERT_CMD_RESPONSE(0, CmdSequencerComponentBase::OPCODE_CS_STEP, cmdSeq, Fw::CmdResponse(Fw::CmdResponse::OK));
 }
+
+void CmdSequencerTester::textLogIn(FwEventIdType id,                //!< The event ID
+    const Fw::Time& timeTag,         //!< The time
+    const Fw::LogSeverity severity,  //!< The severity
+    const Fw::TextLogString& text    //!< The event string
+) {
+    TextLogEntry e = {id, timeTag, severity, text};
+
+    printTextLogHistoryEntry(e, stdout);
+}
+
 }  // namespace Svc
 
 namespace Os {
@@ -607,5 +634,6 @@ DirectoryInterface* DirectoryInterface::getDelegate(DirectoryHandleStorage& alig
     return Os::Delegate::makeDelegate<DirectoryInterface, Os::Posix::Directory::PosixDirectory>(
         aligned_placement_new_memory);
 }
+
 
 }  // namespace Os

--- a/Svc/CmdSequencer/test/ut/CmdSequencerTester.hpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerTester.hpp
@@ -374,6 +374,14 @@ class CmdSequencerTester : public CmdSequencerGTestBase {
 
     //! Open/Read interceptor
     Interceptor interceptor;
+
+    void textLogIn(FwEventIdType id,                //!< The event ID
+        const Fw::Time& timeTag,         //!< The time
+        const Fw::LogSeverity severity,  //!< The severity
+        const Fw::TextLogString& text    //!< The event string
+        ) override;
+
+
 };
 
 }  // namespace Svc

--- a/Svc/CmdSequencer/test/ut/CmdSequencerTester.hpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerTester.hpp
@@ -334,6 +334,10 @@ class CmdSequencerTester : public CmdSequencerGTestBase {
     void runSequenceByPortCall(const char* const fileName  //!< The file name
     );
 
+    //! Run a sequence by the file dispatcher port call
+    void runSequenceByFileDispatcherPortCall(const char* const fileName  //!< The file name
+    );
+
     //! Send a step command
     void stepSequence(const U32 cmdSeq  //!< The command sequence number
     );

--- a/Svc/CmdSequencer/test/ut/CmdSequencerTester.hpp
+++ b/Svc/CmdSequencer/test/ut/CmdSequencerTester.hpp
@@ -185,20 +185,20 @@ class CmdSequencerTester : public CmdSequencerGTestBase {
                               FwOpcodeType opCode,             //!< Command Op Code
                               U32 cmdSeq,                      //!< Command Sequence
                               const Fw::CmdResponse& response  //!< The command response argument
-    );
+                              ) override;
 
     //! Handler for from_comCmdOut
     //!
     void from_comCmdOut_handler(const FwIndexType portNum,  //!< The port number
                                 Fw::ComBuffer& data,        //!< Buffer containing packet data
                                 U32 context                 //!< Call context value; meaning chosen by user
-    );
+                                ) override;
 
     //! Handler for from_pingOut
     //!
     void from_pingOut_handler(const FwIndexType portNum,  //!< The port number
                               U32 key                     //!< Value to return to pinger
-    );
+                              ) override;
 
 #if VERBOSE
   protected:
@@ -380,12 +380,10 @@ class CmdSequencerTester : public CmdSequencerGTestBase {
     Interceptor interceptor;
 
     void textLogIn(FwEventIdType id,                //!< The event ID
-        const Fw::Time& timeTag,         //!< The time
-        const Fw::LogSeverity severity,  //!< The severity
-        const Fw::TextLogString& text    //!< The event string
-        ) override;
-
-
+                   const Fw::Time& timeTag,         //!< The time
+                   const Fw::LogSeverity severity,  //!< The severity
+                   const Fw::TextLogString& text    //!< The event string
+                   ) override;
 };
 
 }  // namespace Svc

--- a/Svc/CmdSequencer/test/ut/Immediate.cpp
+++ b/Svc/CmdSequencer/test/ut/Immediate.cpp
@@ -43,6 +43,14 @@ void CmdSequencerTester ::AutoByPort() {
     this->parameterizedAutoByPort(file, numCommands, bound);
 }
 
+void CmdSequencerTester ::AutoByFileDispatcherPort() {
+    const U32 numRecords = 5;
+    const U32 numCommands = numRecords;
+    const U32 bound = numCommands;
+    SequenceFiles::ImmediateFile file(numRecords, this->format);
+    this->parameterizedAutoByFileDispatchPort(file, numCommands, bound);
+}
+
 void CmdSequencerTester ::Cancel() {
     const U32 numRecords = 5;
     const U32 numCommands = numRecords;

--- a/Svc/CmdSequencer/test/ut/Immediate.hpp
+++ b/Svc/CmdSequencer/test/ut/Immediate.hpp
@@ -64,6 +64,9 @@ class CmdSequencerTester : public ImmediateBase::CmdSequencerTester {
     //! Run an automatic sequence through a port call
     void AutoByPort();
 
+    //! Run an automatic sequence through a port call
+    void AutoByFileDispatcherPort();
+
     //! Send invalid manual commands while a sequence is running
     void InvalidManualCommands();
 

--- a/Svc/CmdSequencer/test/ut/ImmediateBase.cpp
+++ b/Svc/CmdSequencer/test/ut/ImmediateBase.cpp
@@ -72,6 +72,25 @@ void CmdSequencerTester ::parameterizedAutoByPort(SequenceFiles::File& file, con
     ASSERT_from_seqDone(0, 0U, 0U, Fw::CmdResponse(Fw::CmdResponse::OK));
 }
 
+void CmdSequencerTester ::parameterizedAutoByFileDispatchPort(SequenceFiles::File& file, const U32 numCommands, const U32 bound) {
+    // Set the time
+    Fw::Time testTime(TimeBase::TB_WORKSTATION_TIME, 1, 1);
+    this->setTestTime(testTime);
+    // Write the file
+    const char* const fileName = file.getName().toChar();
+    file.write();
+    // Validate the file
+    this->validateFile(0, fileName);
+    // Run the sequence by port call
+    this->runSequenceByFileDispatcherPortCall(fileName);
+    // Execute commands
+    this->executeCommandsAuto(fileName, numCommands, bound, CmdExecMode::NO_NEW_SEQUENCE);
+    // Check for command complete on seqDone
+    ASSERT_from_seqDone_SIZE(1);
+    ASSERT_from_seqDone(0, 0U, 0U, Fw::CmdResponse(Fw::CmdResponse::OK));
+}
+
+
 void CmdSequencerTester ::parameterizedInvalidManualCommands(SequenceFiles::File& file) {
     // Set the time
     Fw::Time testTime(TimeBase::TB_WORKSTATION_TIME, 1, 1);

--- a/Svc/CmdSequencer/test/ut/ImmediateBase.cpp
+++ b/Svc/CmdSequencer/test/ut/ImmediateBase.cpp
@@ -72,7 +72,9 @@ void CmdSequencerTester ::parameterizedAutoByPort(SequenceFiles::File& file, con
     ASSERT_from_seqDone(0, 0U, 0U, Fw::CmdResponse(Fw::CmdResponse::OK));
 }
 
-void CmdSequencerTester ::parameterizedAutoByFileDispatchPort(SequenceFiles::File& file, const U32 numCommands, const U32 bound) {
+void CmdSequencerTester ::parameterizedAutoByFileDispatchPort(SequenceFiles::File& file,
+                                                              const U32 numCommands,
+                                                              const U32 bound) {
     // Set the time
     Fw::Time testTime(TimeBase::TB_WORKSTATION_TIME, 1, 1);
     this->setTestTime(testTime);
@@ -89,7 +91,6 @@ void CmdSequencerTester ::parameterizedAutoByFileDispatchPort(SequenceFiles::Fil
     ASSERT_from_seqDone_SIZE(1);
     ASSERT_from_seqDone(0, 0U, 0U, Fw::CmdResponse(Fw::CmdResponse::OK));
 }
-
 
 void CmdSequencerTester ::parameterizedInvalidManualCommands(SequenceFiles::File& file) {
     // Set the time

--- a/Svc/CmdSequencer/test/ut/ImmediateBase.hpp
+++ b/Svc/CmdSequencer/test/ut/ImmediateBase.hpp
@@ -46,6 +46,12 @@ class CmdSequencerTester : public Svc::CmdSequencerTester {
                                  const U32 bound             //!< The number of commands to execute
     );
 
+    //! Run an automatic sequence by file dispatch port call
+    void parameterizedAutoByFileDispatchPort(SequenceFiles::File& file,  //!< The file
+        const U32 numCommands,      //!< The number of commands in the sequence
+        const U32 bound             //!< The number of commands to execute
+    );
+
     //! Send invalid manual commands while a sequence is running
     void parameterizedInvalidManualCommands(SequenceFiles::File& file  //!< The file
     );

--- a/Svc/CmdSequencer/test/ut/ImmediateBase.hpp
+++ b/Svc/CmdSequencer/test/ut/ImmediateBase.hpp
@@ -48,8 +48,8 @@ class CmdSequencerTester : public Svc::CmdSequencerTester {
 
     //! Run an automatic sequence by file dispatch port call
     void parameterizedAutoByFileDispatchPort(SequenceFiles::File& file,  //!< The file
-        const U32 numCommands,      //!< The number of commands in the sequence
-        const U32 bound             //!< The number of commands to execute
+                                             const U32 numCommands,      //!< The number of commands in the sequence
+                                             const U32 bound             //!< The number of commands to execute
     );
 
     //! Send invalid manual commands while a sequence is running


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/4444 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Adds a file dispatcher port to allow automatic dispatching of sequences by Svc/FileDispatcher.

## Rationale

Allows sequences to be run immediately after uplink without operator intervention.

## Testing/Review Recommendations

Added additional unit test. 

## Future Work

There will be a Ref topology addition to demonstrate its usage.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

