### PR TITLE
Remove Timeout from `Svc::FileDownlink`

### DIFF
--- a/Svc/FileDownlink/Events.fppi
+++ b/Svc/FileDownlink/Events.fppi
@@ -34,15 +34,6 @@ event DownlinkCanceled(
   format "Canceled downlink of file {} to file {}"
 
 @ The File Downlink component has detected a timeout. Downlink has been canceled.
-event DownlinkTimeout(
-                       sourceFileName: string size 100 @< The source filename
-                       destFileName: string size 100 @< The destination file name
-                     ) \
-  severity warning high \
-  id 0x04 \
-  format "Timeout occurred during downlink of file {} to file {}. Downlink has been canceled."
-
-@ The File Downlink component has detected a timeout. Downlink has been canceled.
 event DownlinkPartialWarning(
                               startOffset: U32 @< Starting file offset in bytes
                               length: U32 @< Number of bytes to downlink

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -39,8 +39,7 @@ FileDownlink ::FileDownlink(const char* const name)
       m_curEntry(),
       m_cntxId(0) {}
 
-void FileDownlink ::configure(U32 timeout, U32 cooldown, U32 cycleTime, U32 fileQueueDepth) {
-    this->m_timeout = timeout;
+void FileDownlink ::configure(U32 cooldown, U32 cycleTime, U32 fileQueueDepth) {
     this->m_cooldown = cooldown;
     this->m_cycleTime = cycleTime;
     this->m_configured = true;
@@ -93,16 +92,7 @@ void FileDownlink ::Run_handler(const FwIndexType portNum, U32 context) {
             break;
         }
         case Mode::WAIT: {
-            // If current timeout is too-high and we are waiting for a packet, issue a timeout
-            if (this->m_curTimer >= this->m_timeout) {
-                this->m_curTimer = 0;
-                this->log_WARNING_HI_DownlinkTimeout(this->m_file.getSourceName(), this->m_file.getDestName());
-                this->enterCooldown();
-                this->sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK
-                                                                          : SendFileStatus::STATUS_ERROR);
-            } else {  // Otherwise update the current counter
-                this->m_curTimer += m_cycleTime;
-            }
+            this->m_curTimer += m_cycleTime;
             break;
         }
         default:

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -223,8 +223,7 @@ class FileDownlink final : public FileDownlinkComponentBase {
 
     //! Configure FileDownlink component
     //!
-    void configure(U32 timeout,        //!< Timeout threshold (milliseconds) while in WAIT state
-                   U32 cooldown,       //!< Cooldown (in ms) between finishing a downlink and starting the next file.
+    void configure(U32 cooldown,       //!< Cooldown (in ms) between finishing a downlink and starting the next file.
                    U32 cycleTime,      //!< Rate at which we are running
                    U32 fileQueueDepth  //!< Max number of items in file downlink queue
     );

--- a/Svc/FileDownlink/docs/sdd.md
+++ b/Svc/FileDownlink/docs/sdd.md
@@ -65,10 +65,8 @@ Name | Type | Kind | Purpose
 at component instantiation time:
 
 * *downlinkPacketSize*: The size of the packets to use on downlink.
-* *timeout*: Max amount of time in ms to wait for a buffer return before aborting downlink
 * *cooldown*: The amount of time in ms to wait in a cooldown state before starting next downlink.
-* *cycle time*: Frequency in ms of clock pulses sent to `Run` port, used for timing timeouts and
-  cooldown.
+* *cycle time*: Frequency in ms of clock pulses sent to `Run` port, used for cooldown.
 * *file queue depth*: The maximum number of files that can be held in the internal file downlink
   queue. Attempting to dispatch a SendFile command or port call while the queue is full will result
   in a busy error response.
@@ -123,7 +121,3 @@ Checklist |
 [Design](Checklist/design.xlsx) |
 [Code](Checklist/code.xlsx) |
 [Unit Test](Checklist/unit_test.xls) |
-
-## 6 Unit Testing
-
-TODO

--- a/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
@@ -29,11 +29,6 @@ TEST(FileDownlink, DownlinkPartial) {
     tester.downlinkPartial();
 }
 
-TEST(FileDownlink, DownlinkTimeout) {
-    Svc::FileDownlinkTester tester;
-    tester.timeout();
-}
-
 TEST(FileDownlink, SendFilePort) {
     Svc::FileDownlinkTester tester;
     tester.sendFilePort();

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
@@ -102,10 +102,6 @@ class FileDownlinkTester : public FileDownlinkGTestBase {
     //!
     void downlinkPartial();
 
-    //! Timeout
-    //!
-    void timeout();
-
     //! sendFilePort
     //! Test downlinking a file via a port
     //!

--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -15,7 +15,6 @@ module FileHandling {
     {
         phase Fpp.ToCpp.Phases.configComponents """
         FileHandling::fileDownlink.configure(
-            FileHandlingConfig::DownlinkConfig::timeout,
             FileHandlingConfig::DownlinkConfig::cooldown,
             FileHandlingConfig::DownlinkConfig::cycleTime,
             FileHandlingConfig::DownlinkConfig::fileQueueDepth

--- a/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
@@ -25,7 +25,6 @@ module FileHandlingConfig {
 
     # File downlink configuration constants
     module DownlinkConfig {
-        constant timeout        = 1000         # File downlink timeout in ms
         constant cooldown       = 1000         # File downlink cooldown in ms  
         constant cycleTime      = 1000         # File downlink cycle time in ms
         constant fileQueueDepth = 10           # File downlink queue depth


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4550 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y  |
|**_Generative AI was used in this contribution (y/n)_**| y  |

---
## Change Description

`Svc.FileDownlink` has a buffer ownership bug that causes a buffer to be owned by multiple owners. This can cause unknown file downlink corruption.

The fix has to be for timeout to wait for buffer return, which undermines the need for a timeout at all.  Thus we remove the timeout.

