### PR TITLE
Add queue flush commands to com queue

### DIFF
--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -137,7 +137,7 @@ void ComQueue ::FLUSH_QUEUE_cmdHandler(FwOpcodeType opCode,
                                        Svc::QueueType queueType,
                                        FwIndexType indexType) {
     // Acquire the queue that we need to drain
-    FwIndexType queueIndex = (queueType == QueueType::COM_QUEUE) ? indexType : indexType + COM_PORT_COUNT;
+    FwIndexType queueIndex = (queueType == QueueType::COM_QUEUE) ? indexType : static_cast<FwIndexType>(indexType + COM_PORT_COUNT);
     this->drainQueue(queueIndex);
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }
@@ -327,7 +327,7 @@ void ComQueue::drainQueue(FwIndexType index) {
             // Dequeueing is reading the whole persisted Fw::Buffer object from the queue's storage.
             Fw::Buffer buffer;
             status = queue.dequeue(reinterpret_cast<U8*>(&buffer), sizeof(buffer));
-            this->bufferReturnOut_out(index - COM_PORT_COUNT, buffer);
+            this->bufferReturnOut_out(static_cast<FwIndexType>(index - COM_PORT_COUNT), buffer);
         }
     }
 }

--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -135,10 +135,10 @@ void ComQueue::configure(QueueConfigurationTable queueConfig,
 void ComQueue ::FLUSH_QUEUE_cmdHandler(FwOpcodeType opCode,
                                        U32 cmdSeq,
                                        Svc::QueueType queueType,
-                                       FwIndexType indexType) {
+                                       FwIndexType index) {
     // Acquire the queue that we need to drain
     FwIndexType queueIndex =
-        (queueType == QueueType::COM_QUEUE) ? indexType : static_cast<FwIndexType>(indexType + COM_PORT_COUNT);
+        (queueType == QueueType::COM_QUEUE) ? index : static_cast<FwIndexType>(index + COM_PORT_COUNT);
     this->drainQueue(queueIndex);
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }

--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -132,10 +132,7 @@ void ComQueue::configure(QueueConfigurationTable queueConfig,
 // Handler implementations for commands
 // ----------------------------------------------------------------------
 
-void ComQueue ::FLUSH_QUEUE_cmdHandler(FwOpcodeType opCode,
-                                       U32 cmdSeq,
-                                       Svc::QueueType queueType,
-                                       FwIndexType index) {
+void ComQueue ::FLUSH_QUEUE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, Svc::QueueType queueType, FwIndexType index) {
     // Acquire the queue that we need to drain
     FwIndexType queueIndex =
         (queueType == QueueType::COM_QUEUE) ? index : static_cast<FwIndexType>(index + COM_PORT_COUNT);

--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -127,6 +127,28 @@ void ComQueue::configure(QueueConfigurationTable queueConfig,
     FW_ASSERT(allocationOffset == totalAllocation, static_cast<FwAssertArgType>(allocationOffset),
               static_cast<FwAssertArgType>(totalAllocation));
 }
+
+// ----------------------------------------------------------------------
+// Handler implementations for commands
+// ----------------------------------------------------------------------
+
+void ComQueue ::FLUSH_QUEUE_cmdHandler(FwOpcodeType opCode,
+                                       U32 cmdSeq,
+                                       Svc::QueueType queueType,
+                                       FwIndexType indexType) {
+    // Acquire the queue that we need to drain
+    FwIndexType queueIndex = (queueType == QueueType::COM_QUEUE) ? indexType : indexType + COM_PORT_COUNT;
+    this->drainQueue(queueIndex);
+    this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
+}
+
+void ComQueue ::FLUSH_ALL_QUEUES_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
+    for (FwIndexType i = 0; i < TOTAL_PORT_COUNT; i++) {
+        this->drainQueue(i);
+    }
+    this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
+}
+
 // ----------------------------------------------------------------------
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
@@ -285,6 +307,29 @@ void ComQueue::sendBuffer(Fw::Buffer& buffer, FwIndexType queueIndex) {
     this->dataOut_out(0, buffer, context);
     // Set state to WAITING for the status to come back
     this->m_state = WAITING;
+}
+
+void ComQueue::drainQueue(FwIndexType index) {
+    FW_ASSERT(index >= 0 && index < TOTAL_PORT_COUNT, static_cast<FwAssertArgType>(index));
+    Types::Queue& queue = this->m_queues[index];
+
+    // Read all messages from the queue and discard them
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    const FwSizeType available = queue.getQueueSize();
+    for (FwSizeType i = 0; (i < available) && (status == Fw::FW_SERIALIZE_OK); i++) {
+        if (index < COM_PORT_COUNT) {
+            // Dequeueing is reading the whole persisted Fw::ComBuffer object from the queue's storage.
+            // thus it takes an address to the object to fill and the size of the actual object
+            Fw::ComBuffer comBuffer;
+            status = queue.dequeue(reinterpret_cast<U8*>(&comBuffer), sizeof(comBuffer));
+        } else {
+            // For buffer queues, if the buffer requires ownership return, return it via the bufferReturnOut port
+            // Dequeueing is reading the whole persisted Fw::Buffer object from the queue's storage.
+            Fw::Buffer buffer;
+            status = queue.dequeue(reinterpret_cast<U8*>(&buffer), sizeof(buffer));
+            this->bufferReturnOut_out(index - COM_PORT_COUNT, buffer);
+        }
+    }
 }
 
 void ComQueue::processQueue() {

--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -137,7 +137,8 @@ void ComQueue ::FLUSH_QUEUE_cmdHandler(FwOpcodeType opCode,
                                        Svc::QueueType queueType,
                                        FwIndexType indexType) {
     // Acquire the queue that we need to drain
-    FwIndexType queueIndex = (queueType == QueueType::COM_QUEUE) ? indexType : static_cast<FwIndexType>(indexType + COM_PORT_COUNT);
+    FwIndexType queueIndex =
+        (queueType == QueueType::COM_QUEUE) ? indexType : static_cast<FwIndexType>(indexType + COM_PORT_COUNT);
     this->drainQueue(queueIndex);
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }

--- a/Svc/ComQueue/ComQueue.fpp
+++ b/Svc/ComQueue/ComQueue.fpp
@@ -8,7 +8,6 @@ module Svc {
     @ Array of queue depths for Fw::Buffer types
     array BuffQueueDepth = [ComQueueBufferPorts] U32
 
-
     @ Component used to queue buffer types
     active component ComQueue {
 
@@ -37,6 +36,14 @@ module Svc {
       @ Port for scheduling telemetry output
       async input port run: Svc.Sched drop
 
+      @ Flush a specific queue. This will discard all queued data in the specified queue removing it from eventual
+      @ downlink. Buffers requiring ownership return will be returned via the bufferReturnOut port.
+      async command FLUSH_QUEUE(queueType: QueueType @< The Queue data type
+                                indexType: FwIndexType @< The index of the queue (within the supplied type) to flush
+                               )
+      @ Flush all queues. This will discard all queued data removing it from eventual downlink. Buffers requiring
+      @ ownership return will be returned via the bufferReturnOut port.
+      async command FLUSH_ALL_QUEUES()
       # ----------------------------------------------------------------------
       # Special ports
       # ----------------------------------------------------------------------
@@ -52,6 +59,15 @@ module Svc {
 
       @ Port for emitting telemetry
       telemetry port Tlm
+
+      @ Command receive port
+      command recv port CmdDisp
+
+      @ Command registration port
+      command reg port CmdReg
+
+      @ Command response port
+      command resp port CmdStatus
 
       # ----------------------------------------------------------------------
       # Events

--- a/Svc/ComQueue/ComQueue.hpp
+++ b/Svc/ComQueue/ComQueue.hpp
@@ -124,6 +124,29 @@ class ComQueue final : public ComQueueComponentBase {
 
   private:
     // ----------------------------------------------------------------------
+    // Handler implementations for commands
+    // ----------------------------------------------------------------------
+
+    //! Handler implementation for command FLUSH_QUEUE
+    //!
+    //! Flush a specific queue. This will discard all queued data in the specified queue removing it from eventual
+    //! downlink. Buffers requiring ownership return will be returned via the bufferReturnOut port.
+    void FLUSH_QUEUE_cmdHandler(FwOpcodeType opCode,       //!< The opcode
+                                U32 cmdSeq,                //!< The command sequence number
+                                Svc::QueueType queueType,  //!< The Queue data type
+                                FwIndexType indexType  //!< The index of the queue (within the supplied type) to flush
+                                ) override;
+
+    //! Handler implementation for command FLUSH_ALL_QUEUES
+    //!
+    //! Flush all queues. This will discard all queued data removing it from eventual downlink. Buffers requiring
+    //! ownership return will be returned via the bufferReturnOut port.
+    void FLUSH_ALL_QUEUES_cmdHandler(FwOpcodeType opCode,  //!< The opcode
+                                     U32 cmdSeq            //!< The command sequence number
+                                     ) override;
+
+  private:
+    // ----------------------------------------------------------------------
     // Handler implementations for user-defined typed input ports
     // ----------------------------------------------------------------------
 
@@ -190,6 +213,9 @@ class ComQueue final : public ComQueueComponentBase {
     //!
     void sendBuffer(Fw::Buffer& buffer,     //!< Reference to buffer to send
                     FwIndexType queueIndex  //!< Index of the queue emitting the message
+    );
+
+    void drainQueue(FwIndexType queueNum  //!< Index of the queue to drain
     );
 
     //! Process the queues to select the next priority message

--- a/Svc/ComQueue/docs/sdd.md
+++ b/Svc/ComQueue/docs/sdd.md
@@ -33,6 +33,8 @@ Queued messages from the highest priority source port are serviced first and a r
 | SVC-COMQUEUE-008 | `Svc::ComQueue` shall implement a round robin approach to balance between ports of the same priority.                                   | Allows projects to balance between a set of queues of similar priority. | Unit Test           |
 | SVC-COMQUEUE-009 | `Svc::ComQueue` shall keep track and throttle queue overflow events per port.                                                           | Prevents a flood of queue overflow events.                              | Unit test           | 
 | SVC-COMQUEUE-010 | `Svc::ComQueue` shall return ownership of incoming buffers once they have been enqueued.                                                | Memory management                                                       | Unit test           | 
+| SVC-COMQUEUE-011 | `Svc::ComQueue` shall provide a command to flush queued items.      | Queue management              | Unit test           | 
+
 
 ## 4. Design
 The diagram below shows the `Svc::ComQueue` component.
@@ -138,15 +140,23 @@ The `run` port handler does the following:
 |----------------|---------------------------------------------------------------------------------|
 | QueueOverflow  | WARNING_HI event triggered when a queue can no longer hold the incoming message |
 
-### 4.8 Helper Functions
+### 4.8 Commands
 
-#### 4.8.1 sendComBuffer
+| Name             | Description                                                                                     |
+|------------------|-------------------------------------------------------------------------------------------------|
+| FLUSH_QUEUE      | Flushes all queued items from the specified queue type and index, returning ownership of any buffers.      |
+| FLUSH_ALL_QUEUES | Flushes all queued items from all queues, returning ownership of any buffers. |
+
+
+### 4.9 Helper Functions
+
+#### 4.9.1 sendComBuffer
 Stores the com buffer message, sends the com buffer message on the output port, and then sets the send state to waiting.
 
-#### 4.8.2 sendBuffer
+#### 4.9.2 sendBuffer
 Stores the buffer message, sends the buffer message on the output port, and then sets the send state to waiting.
 
-#### 4.8.3 processQueue
+#### 4.9.3 processQueue
 In a bounded loop that is constrained by the total size of the queue that contains both 
 buffer and com buffer data, do:
 

--- a/Svc/ComQueue/test/ut/ComQueueTestMain.cpp
+++ b/Svc/ComQueue/test/ut/ComQueueTestMain.cpp
@@ -9,6 +9,16 @@ TEST(Nominal, Send) {
     tester.testQueueSend();
 }
 
+TEST(Nominal, Flush) {
+    Svc::ComQueueTester tester;
+    tester.testQueueFlush();
+}
+
+TEST(Nominal, FlushAll) {
+    Svc::ComQueueTester tester;
+    tester.testQueueFlushAll();
+}
+
 TEST(Nominal, Pause) {
     Svc::ComQueueTester tester;
     tester.testQueuePause();

--- a/Svc/ComQueue/test/ut/ComQueueTester.cpp
+++ b/Svc/ComQueue/test/ut/ComQueueTester.cpp
@@ -123,7 +123,7 @@ void ComQueueTester ::testQueueFlush() {
         ASSERT_from_bufferReturnOut(portNum, buffer);
         ASSERT_from_dataOut_SIZE(0);
     }
-    this->emitOne(); // Ensure that nothing is emitted
+    this->emitOne();  // Ensure that nothing is emitted
     ASSERT_from_bufferReturnOut_SIZE(ComQueue::BUFFER_PORT_COUNT);
     clearFromPortHistory();
     component.cleanup();
@@ -148,7 +148,7 @@ void ComQueueTester ::testQueueFlushAll() {
     // Flush everything ensuring nothing is sent
     this->sendCmd_FLUSH_ALL_QUEUES(0, 0);
     this->dispatchAll();
-    this->emitOne(); // Ensure that nothing is emitted
+    this->emitOne();  // Ensure that nothing is emitted
     ASSERT_from_dataOut_SIZE(0);
     // Check that all buffers are returned (by count)
     ASSERT_from_bufferReturnOut_SIZE(ComQueue::BUFFER_PORT_COUNT);

--- a/Svc/ComQueue/test/ut/ComQueueTester.cpp
+++ b/Svc/ComQueue/test/ut/ComQueueTester.cpp
@@ -123,6 +123,7 @@ void ComQueueTester ::testQueueFlush() {
         ASSERT_from_bufferReturnOut(portNum, buffer);
         ASSERT_from_dataOut_SIZE(0);
     }
+    this->emitOne(); // Ensure that nothing is emitted
     ASSERT_from_bufferReturnOut_SIZE(ComQueue::BUFFER_PORT_COUNT);
     clearFromPortHistory();
     component.cleanup();
@@ -147,6 +148,7 @@ void ComQueueTester ::testQueueFlushAll() {
     // Flush everything ensuring nothing is sent
     this->sendCmd_FLUSH_ALL_QUEUES(0, 0);
     this->dispatchAll();
+    this->emitOne(); // Ensure that nothing is emitted
     ASSERT_from_dataOut_SIZE(0);
     // Check that all buffers are returned (by count)
     ASSERT_from_bufferReturnOut_SIZE(ComQueue::BUFFER_PORT_COUNT);

--- a/Svc/ComQueue/test/ut/ComQueueTester.cpp
+++ b/Svc/ComQueue/test/ut/ComQueueTester.cpp
@@ -101,6 +101,65 @@ void ComQueueTester ::testQueueSend() {
     component.cleanup();
 }
 
+void ComQueueTester ::testQueueFlush() {
+    U8 data[BUFFER_LENGTH] = BUFFER_DATA;
+    Fw::ComBuffer comBuffer(&data[0], sizeof(data));
+    Fw::Buffer buffer(&data[0], sizeof(data));
+    configure();
+
+    // Iterate over queues dispatch and flush each
+    for (FwIndexType portNum = 0; portNum < ComQueue::COM_PORT_COUNT; portNum++) {
+        invoke_to_comPacketQueueIn(portNum, comBuffer, 0);
+        this->sendCmd_FLUSH_QUEUE(0, 0, QueueType::COM_QUEUE, portNum);
+        this->dispatchAll();
+        ASSERT_from_dataOut_SIZE(0);
+    }
+    clearFromPortHistory();
+    // Similar for buffer queues but the buffer should be returned
+    for (FwIndexType portNum = 0; portNum < ComQueue::BUFFER_PORT_COUNT; portNum++) {
+        invoke_to_bufferQueueIn(portNum, buffer);
+        this->sendCmd_FLUSH_QUEUE(0, 0, QueueType::BUFFER_QUEUE, portNum);
+        this->dispatchAll();
+        ASSERT_from_bufferReturnOut(portNum, buffer);
+        ASSERT_from_dataOut_SIZE(0);
+    }
+    ASSERT_from_bufferReturnOut_SIZE(ComQueue::BUFFER_PORT_COUNT);
+    clearFromPortHistory();
+    component.cleanup();
+}
+
+void ComQueueTester ::testQueueFlushAll() {
+    U8 data[BUFFER_LENGTH] = BUFFER_DATA;
+    Fw::ComBuffer comBuffer(&data[0], sizeof(data));
+    Fw::Buffer buffer(&data[0], sizeof(data));
+    configure();
+
+    // Iterate over queues and queue a message to each
+    for (FwIndexType portNum = 0; portNum < ComQueue::COM_PORT_COUNT; portNum++) {
+        invoke_to_comPacketQueueIn(portNum, comBuffer, 0);
+        this->dispatchAll();
+    }
+    // Same with buffer queues
+    for (FwIndexType portNum = 0; portNum < ComQueue::BUFFER_PORT_COUNT; portNum++) {
+        invoke_to_bufferQueueIn(portNum, buffer);
+        this->dispatchAll();
+    }
+    // Flush everything ensuring nothing is sent
+    this->sendCmd_FLUSH_ALL_QUEUES(0, 0);
+    this->dispatchAll();
+    ASSERT_from_dataOut_SIZE(0);
+    // Check that all buffers are returned (by count)
+    ASSERT_from_bufferReturnOut_SIZE(ComQueue::BUFFER_PORT_COUNT);
+
+    // Check that each buffer returned is the expected one. Although, the order isn't guaranteed, the set should match
+    // since the implementation is in queue order. This thus makes an easy "did we get them all" check.
+    for (FwIndexType portNum = 0; portNum < ComQueue::BUFFER_PORT_COUNT; portNum++) {
+        ASSERT_from_bufferReturnOut(portNum, buffer);
+    }
+    clearFromPortHistory();
+    component.cleanup();
+}
+
 void ComQueueTester ::testQueuePause() {
     U8 data[BUFFER_LENGTH] = BUFFER_DATA;
     Fw::ComBuffer comBuffer(&data[0], sizeof(data));

--- a/Svc/ComQueue/test/ut/ComQueueTester.hpp
+++ b/Svc/ComQueue/test/ut/ComQueueTester.hpp
@@ -65,6 +65,10 @@ class ComQueueTester : public ComQueueGTestBase {
 
     void testQueueSend();
 
+    void testQueueFlush();
+
+    void testQueueFlushAll();
+
     void testQueuePause();
 
     void testPrioritySend();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4551  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Adds `FLUSH_QUEUE` and `FLUSH_ALL_QUEUES` commands to `Svc::ComQueue`.

## Rationale

Gives operators the ability to clean out commands.

## Testing/Review Recommendations

UTs.

## Future Work

N/A.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI autocomplete.