### PR TITLE
Switch to FPP enum for time comparisons

### DIFF
--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -52,29 +52,29 @@ Time& Time::operator=(const Time& other) {
 }
 
 bool Time::operator==(const Time& other) const {
-    return (Time::compare(*this, other) == EQ);
+    return (Time::compare(*this, other) == TimeComparison::EQ);
 }
 
 bool Time::operator!=(const Time& other) const {
-    return (Time::compare(*this, other) != EQ);
+    return (Time::compare(*this, other) != TimeComparison::EQ);
 }
 
 bool Time::operator>(const Time& other) const {
-    return (Time::compare(*this, other) == GT);
+    return (Time::compare(*this, other) == TimeComparison::GT);
 }
 
 bool Time::operator<(const Time& other) const {
-    return (Time::compare(*this, other) == LT);
+    return (Time::compare(*this, other) == TimeComparison::LT);
 }
 
 bool Time::operator>=(const Time& other) const {
-    Time::Comparison c = Time::compare(*this, other);
-    return ((GT == c) or (EQ == c));
+    TimeComparison c = Time::compare(*this, other);
+    return ((TimeComparison::GT == c) or (TimeComparison::EQ == c));
 }
 
 bool Time::operator<=(const Time& other) const {
-    Time::Comparison c = Time::compare(*this, other);
-    return ((LT == c) or (EQ == c));
+    TimeComparison c = Time::compare(*this, other);
+    return ((TimeComparison::LT == c) or (TimeComparison::EQ == c));
 }
 
 SerializeStatus Time::serializeTo(SerialBufferBase& buffer, Fw::Endianness mode) const {
@@ -106,9 +106,9 @@ Time Time ::zero(TimeBase timeBase) {
     return time;
 }
 
-Time::Comparison Time ::compare(const Time& time1, const Time& time2) {
+TimeComparison Time ::compare(const Time& time1, const Time& time2) {
     if (time1.getTimeBase() != time2.getTimeBase()) {
-        return INCOMPARABLE;
+        return TimeComparison::INCOMPARABLE;
     }
 
     // Do not compare time context
@@ -119,15 +119,15 @@ Time::Comparison Time ::compare(const Time& time1, const Time& time2) {
     const U32 us2 = time2.getUSeconds();
 
     if (s1 < s2) {
-        return LT;
+        return TimeComparison::LT;
     } else if (s1 > s2) {
-        return GT;
+        return TimeComparison::GT;
     } else if (us1 < us2) {
-        return LT;
+        return TimeComparison::LT;
     } else if (us1 > us2) {
-        return GT;
+        return TimeComparison::GT;
     } else {
-        return EQ;
+        return TimeComparison::EQ;
     }
 }
 

--- a/Fw/Time/Time.fpp
+++ b/Fw/Time/Time.fpp
@@ -28,7 +28,7 @@ module Fw {
     ref timeInterval: Fw.TimeInterval @< Reference to TimeInterval object
   )
 
-  enum TimeComparison {
+  dictionary enum TimeComparison {
     LT = -1
     EQ = 0
     GT = 1

--- a/Fw/Time/Time.fpp
+++ b/Fw/Time/Time.fpp
@@ -28,4 +28,11 @@ module Fw {
     ref timeInterval: Fw.TimeInterval @< Reference to TimeInterval object
   )
 
+  enum TimeComparison {
+    LT = -1
+    EQ = 0
+    GT = 1
+    INCOMPARABLE = 2
+  }
+
 }

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -3,6 +3,7 @@
 
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <Fw/Time/TimeValueSerializableAc.hpp>
+#include <Fw/Time/TimeComparisonEnumAc.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/Serializable.hpp>
 #include <config/TimeBaseEnumAc.hpp>
@@ -50,14 +51,13 @@ class Time : public Serializable {
 
     // Static methods:
     //! The type of a comparison result
-    typedef enum { LT = -1, EQ = 0, GT = 1, INCOMPARABLE = 2 } Comparison;
 
     //! \return time zero
     static Time zero(TimeBase timeBase = TimeBase::TB_NONE);
 
     //! Compare two times
     //! \return The result
-    static Comparison compare(const Time& time1,  //!< Time 1
+    static TimeComparison compare(const Time& time1,  //!< Time 1
                               const Time& time2   //!< Time 2
     );
 

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -2,8 +2,8 @@
 #define FW_TIME_HPP
 
 #include <Fw/FPrimeBasicTypes.hpp>
-#include <Fw/Time/TimeValueSerializableAc.hpp>
 #include <Fw/Time/TimeComparisonEnumAc.hpp>
+#include <Fw/Time/TimeValueSerializableAc.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/Serializable.hpp>
 #include <config/TimeBaseEnumAc.hpp>
@@ -58,7 +58,7 @@ class Time : public Serializable {
     //! Compare two times
     //! \return The result
     static TimeComparison compare(const Time& time1,  //!< Time 1
-                              const Time& time2   //!< Time 2
+                                  const Time& time2   //!< Time 2
     );
 
     //! Add two times

--- a/Svc/CmdSequencer/CmdSequencerImpl.hpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.hpp
@@ -445,7 +445,7 @@ class CmdSequencerComponentImpl final : public CmdSequencerComponentBase {
         ) {
             if (this->m_state == CLEAR) {
                 return false;
-            } else if (Fw::Time::compare(this->expirationTime, time) == Fw::Time::GT) {
+            } else if (Fw::Time::compare(this->expirationTime, time) == Fw::TimeComparison::GT) {
                 return false;
             }
             return true;

--- a/Svc/TlmChan/TlmChan.cpp
+++ b/Svc/TlmChan/TlmChan.cpp
@@ -93,14 +93,14 @@ Fw::TlmValid TlmChan::TlmGet_handler(FwIndexType portNum, FwChanIdType id, Fw::T
     }
 
     if (activeEntry && inactiveEntry) {
-        Fw::Time::Comparison cmp = Fw::Time::compare(inactiveEntry->lastUpdate, activeEntry->lastUpdate);
+        Fw::TimeComparison cmp = Fw::Time::compare(inactiveEntry->lastUpdate, activeEntry->lastUpdate);
         // two entries. grab the one with the most recent time tag
-        if (cmp == Fw::Time::Comparison::GT) {
+        if (cmp == Fw::TimeComparison::GT) {
             // inactive entry is more recent
             val = inactiveEntry->buffer;
             timeTag = inactiveEntry->lastUpdate;
             return Fw::TlmValid::VALID;
-        } else if (cmp != Fw::Time::Comparison::INCOMPARABLE) {
+        } else if (cmp != Fw::TimeComparison::INCOMPARABLE) {
             // active entry is more recent, or they are equal
             val = activeEntry->buffer;
             timeTag = activeEntry->lastUpdate;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4560 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

* Switch to using an Fpp enum instead of a CPP enum for TimeComparison results
## Rationale

* This allows the time comparison result to be used in Fpy
## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None