### PR TITLE
Prevent infinite loop in FileTest unique filename generation

### DIFF
--- a/Os/test/ut/file/FileRules.cpp
+++ b/Os/test/ut/file/FileRules.cpp
@@ -274,9 +274,15 @@ void Os::Test::FileTest::Tester::OpenBaseRule::action(Os::Test::FileTest::Tester
     std::shared_ptr<const std::string> filename = state.get_filename(this->m_random);
     // When randomly generating filenames, some seeds can result in duplicate filenames
     // Continue generating until unique, unless this is an overwrite test
+    constexpr U32 MAX_FILENAME_ATTEMPTS = 100000;
+    U32 attempts = 0;
     if (this->m_random && !this->m_overwrite) {
         while (state.exists(*filename)) {
             filename = state.get_filename(this->m_random);
+            attempts++;
+            ASSERT_LT(attempts, MAX_FILENAME_ATTEMPTS)
+                << "Failed to generate unique filename after " << attempts << " attempts. "
+                << "Consider expanding the filename generation in get_filename().";
         }
     }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4411 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Add an iteration limit to the `OpenBaseRule::action()` method in `Os/test/ut/file/FileRules.cpp`. The while loop that generates unique filenames now fails with a clear assertion after 100,000 attempts instead of potentially looping forever.

## Rationale

When `get_filename()` cannot produce unique names (e.g., limited filename space in custom file system implementations), the existing unbounded while loop causes unit tests to hang indefinitely. This makes debugging difficult since there's no indication of what went wrong.

## Testing/Review Recommendations

  - All existing `PosixFileTest` and `StubFileTest` tests pass
  - The limit of 100,000 is consistent with `DEPTH_BOUND` in `Os/test/ut/queue/RulesHeaders.hpp`
  - The fix is defensive—normal test execution won't approach this limit
  
## Future Work

NA

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). -->
