### PR TITLE
Enclose macros iss4375

### DIFF
--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -19,13 +19,13 @@
 // Passing the __LINE__ argument at the end of the function ensures that
 // the FW_ASSERT_NO_FIRST_ARG macro will never have an empty variadic variable
 #if FW_ASSERT_LEVEL == FW_FILEID_ASSERT && defined ASSERT_FILE_ID
-#define FILE_NAME_ARG U32
+#define FILE_NAME_ARG (U32)
 #define FW_ASSERT(...)                            \
     ((void)((FW_ASSERT_FIRST_ARG(__VA_ARGS__, 0)) \
                 ? (0)                             \
                 : (Fw::SwAssert(ASSERT_FILE_ID, FW_ASSERT_NO_FIRST_ARG(__VA_ARGS__, __LINE__)))))
 #elif FW_ASSERT_LEVEL == FW_FILEID_ASSERT && !defined ASSERT_FILE_ID
-#define FILE_NAME_ARG U32
+#define FILE_NAME_ARG (U32)
 #define FW_ASSERT(...)                            \
     ((void)((FW_ASSERT_FIRST_ARG(__VA_ARGS__, 0)) \
                 ? (0)                             \

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -96,8 +96,8 @@ typedef double F64;  //!< 64-bit floating point (double). Required for compiler-
     (2)  //!< File ID used - requires -DASSERT_FILE_ID=somevalue to be set on the compile command line
 #define FW_FILENAME_ASSERT (3)  //!< Uses the file path in the assert - image stores filenames
 #define FW_RELATIVE_PATH_ASSERT \
-    (4)  //!< Uses a relative file path (within fprime/fprime library) for assert. - requires -DASSERT_RELATIVE_PATH=path
-       //!< to be set on the compile command line
+    (4)  //!< Uses a relative file path (within fprime/fprime library) for assert.
+         //!< Requires -DASSERT_RELATIVE_PATH=path to be set on the compile command line
 
 #ifdef __cplusplus
 }

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -91,12 +91,12 @@ typedef double F64;  //!< 64-bit floating point (double). Required for compiler-
 #define FW_MAX(a, b) (((a) > (b)) ? (a) : (b))                 //!< MAX macro
 #define FW_MIN(a, b) (((a) < (b)) ? (a) : (b))                 //!< MIN macro
 
-#define FW_NO_ASSERT 1  //!< Asserts turned off
+#define FW_NO_ASSERT (1)  //!< Asserts turned off
 #define FW_FILEID_ASSERT \
-    2  //!< File ID used - requires -DASSERT_FILE_ID=somevalue to be set on the compile command line
-#define FW_FILENAME_ASSERT 3  //!< Uses the file path in the assert - image stores filenames
+    (2)  //!< File ID used - requires -DASSERT_FILE_ID=somevalue to be set on the compile command line
+#define FW_FILENAME_ASSERT (3)  //!< Uses the file path in the assert - image stores filenames
 #define FW_RELATIVE_PATH_ASSERT \
-    4  //!< Uses a relative file path (within fprime/fprime library) for assert. - requires -DASSERT_RELATIVE_PATH=path
+    (4)  //!< Uses a relative file path (within fprime/fprime library) for assert. - requires -DASSERT_RELATIVE_PATH=path
        //!< to be set on the compile command line
 
 #ifdef __cplusplus

--- a/Utils/Hash/libcrc/lib_crc.c
+++ b/Utils/Hash/libcrc/lib_crc.c
@@ -62,12 +62,12 @@
     *                                                                   *
     \*******************************************************************/
 
-#define                 P_16        0xA001
-#define                 P_32        0xEDB88320L
-#define                 P_CCITT     0x1021
-#define                 P_DNP       0xA6BC
-#define                 P_KERMIT    0x8408
-#define                 P_SICK      0x8005
+#define                 P_16        (0xA001)
+#define                 P_32        (0xEDB88320L)
+#define                 P_CCITT     (0x1021)
+#define                 P_DNP       (0xA6BC)
+#define                 P_KERMIT    (0x8408)
+#define                 P_SICK      (0x8005)
 
 
 

--- a/Utils/Hash/libcrc/lib_crc.h
+++ b/Utils/Hash/libcrc/lib_crc.h
@@ -59,8 +59,8 @@ extern "C" {
 
 
 
-#define CRC_FALSE           0
-#define CRC_TRUE            1
+#define CRC_FALSE           (0)
+#define CRC_TRUE            (1)
 
 
 

--- a/default/config/FPrimeNumericalConfig.h
+++ b/default/config/FPrimeNumericalConfig.h
@@ -26,10 +26,10 @@
 extern "C" {
 #endif
 
-#define FW_HAS_64_BIT 1                   //!< Architecture supports 64 bit integers
-#define FW_HAS_32_BIT 1                   //!< Architecture supports 32 bit integers
-#define FW_HAS_16_BIT 1                   //!< Architecture supports 16 bit integers
-#define SKIP_FLOAT_IEEE_754_COMPLIANCE 0  //!<  Check IEEE 754 compliance of floating point arithmetic
+#define FW_HAS_64_BIT (1)                   //!< Architecture supports 64 bit integers
+#define FW_HAS_32_BIT (1)                   //!< Architecture supports 32 bit integers
+#define FW_HAS_16_BIT (1)                   //!< Architecture supports 16 bit integers
+#define SKIP_FLOAT_IEEE_754_COMPLIANCE (0)  //!<  Check IEEE 754 compliance of floating point arithmetic
 
 #ifdef __cplusplus
 }

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -24,15 +24,15 @@ extern "C" {
 // Allow objects to have names. Allocates storage for each instance
 #ifndef FW_OBJECT_NAMES
 #define FW_OBJECT_NAMES \
-    1  //!< Indicates whether or not object names are stored (more memory, can be used for tracking objects)
+    (1)  //!< Indicates whether or not object names are stored (more memory, can be used for tracking objects)
 #endif
 
 // To reduce binary size, FW_OPTIONAL_NAME(<string>) can be used to substitute strings with an empty string
 // when running with FW_OBJECT_NAMES disabled
 #if FW_OBJECT_NAMES == 1
-#define FW_OPTIONAL_NAME(name) name
+#define FW_OPTIONAL_NAME(name) (name)
 #else
-#define FW_OPTIONAL_NAME(name) ""
+#define FW_OPTIONAL_NAME(name) ("")
 #endif
 
 // Add methods to query an object about its name. Can be overridden by derived classes
@@ -40,21 +40,21 @@ extern "C" {
 #if FW_OBJECT_NAMES == 1
 #ifndef FW_OBJECT_TO_STRING
 #define FW_OBJECT_TO_STRING \
-    1  //!< Indicates whether or not generated objects have toString() methods to dump internals (more code)
+    (1)  //!< Indicates whether or not generated objects have toString() methods to dump internals (more code)
 #endif
 #else
-#define FW_OBJECT_TO_STRING 0
+#define FW_OBJECT_TO_STRING (0)
 #endif
 
 // Adds the ability for all component related objects to register
 // centrally.
 #ifndef FW_OBJECT_REGISTRATION
 #define FW_OBJECT_REGISTRATION \
-    1  //!< Indicates whether or not objects can register themselves (more code, more object tracking)
+    (1)  //!< Indicates whether or not objects can register themselves (more code, more object tracking)
 #endif
 
 #ifndef FW_QUEUE_REGISTRATION
-#define FW_QUEUE_REGISTRATION 1  //!< Indicates whether or not queue registration is used
+#define FW_QUEUE_REGISTRATION (1)  //!< Indicates whether or not queue registration is used
 #endif
 
 // On some systems, use of *printf family functions (snprintf, printf, etc) require a prohibitive amount of program
@@ -62,20 +62,20 @@ extern "C" {
 // program size. However, this comes at the expense of discarding format parameters. i.e. the format string is returned
 // unchanged.
 #ifndef FW_USE_PRINTF_FAMILY_FUNCTIONS_IN_STRING_FORMATTING
-#define FW_USE_PRINTF_FAMILY_FUNCTIONS_IN_STRING_FORMATTING 1
+#define FW_USE_PRINTF_FAMILY_FUNCTIONS_IN_STRING_FORMATTING (1)
 #endif
 
 // Port Facilities
 
 // This allows tracing calls through ports for debugging
 #ifndef FW_PORT_TRACING
-#define FW_PORT_TRACING 1  //!< Indicates whether port calls are traced (more code, more visibility into execution)
+#define FW_PORT_TRACING (1)  //!< Indicates whether port calls are traced (more code, more visibility into execution)
 #endif
 
 // This generates code to connect to serialized ports
 #ifndef FW_PORT_SERIALIZATION
 #define FW_PORT_SERIALIZATION \
-    1  //!< Indicates whether there is code in ports to serialize the call (more code, but ability to serialize
+    (1)  //!< Indicates whether there is code in ports to serialize the call (more code, but ability to serialize
        //!< calls for multi-note systems)
 #endif
 
@@ -89,14 +89,14 @@ extern "C" {
 
 #ifndef FW_SERIALIZATION_TYPE_ID
 #define FW_SERIALIZATION_TYPE_ID \
-    0  //!< Indicates if type id is stored when type is serialized. (More storage, but more type safety)
+    (0)  //!< Indicates if type id is stored when type is serialized. (More storage, but more type safety)
 #endif
 
 // Number of bytes to use for serialization IDs. More
 // bytes is more storage, but greater number of IDs
 #if FW_SERIALIZATION_TYPE_ID
 #ifndef FW_SERIALIZATION_TYPE_ID_BYTES
-#define FW_SERIALIZATION_TYPE_ID_BYTES 4  //!< Number of bytes used to represent type id - more bytes, more ids
+#define FW_SERIALIZATION_TYPE_ID_BYTES (4)  //!< Number of bytes used to represent type id - more bytes, more ids
 #endif
 #endif
 
@@ -108,7 +108,7 @@ extern "C" {
 //
 // Note: users who want alternate asserts should set assert level to FW_NO_ASSERT and define FW_ASSERT in this header
 #ifndef FW_ASSERT_LEVEL
-#define FW_ASSERT_LEVEL FW_FILENAME_ASSERT  //!< Defines the type of assert used
+#define FW_ASSERT_LEVEL (FW_FILENAME_ASSERT)  //!< Defines the type of assert used
 #endif
 
 // Adjust various configuration parameters in the architecture. Some of the above enables may disable some of the values
@@ -117,7 +117,7 @@ extern "C" {
 #if FW_OBJECT_NAMES
 #ifndef FW_OBJ_NAME_BUFFER_SIZE
 #define FW_OBJ_NAME_BUFFER_SIZE \
-    80  //!< Size of object name (if object names enabled). AC Limits to 80, truncation occurs above 80.
+    (80)  //!< Size of object name (if object names enabled). AC Limits to 80, truncation occurs above 80.
 #endif
 #endif
 
@@ -128,30 +128,30 @@ extern "C" {
 // Setting the below to zero will disable the check at the cost of not detecting commands that
 // are too large.
 #ifndef FW_CMD_CHECK_RESIDUAL
-#define FW_CMD_CHECK_RESIDUAL 1  //!< Check for leftover command bytes
+#define FW_CMD_CHECK_RESIDUAL (1)  //!< Check for leftover command bytes
 #endif
 
 // Enables text logging of events as well as data logging. Adds a second logging port for text output.
 // In order to set this to 0, FPRIME_ENABLE_TEXT_LOGGERS must be set to OFF.
 #ifndef FW_ENABLE_TEXT_LOGGING
-#define FW_ENABLE_TEXT_LOGGING 1  //!< Indicates whether text logging is turned on
+#define FW_ENABLE_TEXT_LOGGING (1)  //!< Indicates whether text logging is turned on
 #endif
 
 // Define if serializables have toString() method. Turning off will save code space and
 // string constants. Must be enabled if text logging enabled
 #ifndef FW_SERIALIZABLE_TO_STRING
-#define FW_SERIALIZABLE_TO_STRING 1  //!< Indicates if autocoded serializables have toString() methods
+#define FW_SERIALIZABLE_TO_STRING (1)  //!< Indicates if autocoded serializables have toString() methods
 #endif
 
 // Some settings to enable AMPCS compatibility. This breaks regular ISF GUI compatibility
 #ifndef FW_AMPCS_COMPATIBLE
-#define FW_AMPCS_COMPATIBLE 0  //!< Whether or not JPL AMPCS ground system support is enabled.
+#define FW_AMPCS_COMPATIBLE (0)  //!< Whether or not JPL AMPCS ground system support is enabled.
 #endif
 
 // Posix thread names are limited to 16 characters, this can lead to collisions. In the event of a
 // collision, set this to 0.
 #ifndef POSIX_THREADS_ENABLE_NAMES
-#define POSIX_THREADS_ENABLE_NAMES 1  //!< Enable/Disable assigning names to threads
+#define POSIX_THREADS_ENABLE_NAMES (1)  //!< Enable/Disable assigning names to threads
 #endif
 
 // *** NOTE configuration checks are in Fw/Cfg/ConfigCheck.cpp in order to have

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -76,7 +76,7 @@ extern "C" {
 #ifndef FW_PORT_SERIALIZATION
 #define FW_PORT_SERIALIZATION \
     (1)  //!< Indicates whether there is code in ports to serialize the call (more code, but ability to serialize
-       //!< calls for multi-note systems)
+         //!< calls for multi-note systems)
 #endif
 
 // Component Facilities


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4375 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Enclosed macro definitions inside parentheses as a defensive coding practice.
Fix #4375 

## Rationale

Static analysis findings.

## Testing/Review Recommendations

As the update ought not to result in a functional change, I just re-built the code and will trust to the CI checks returning expected results.
```
fprime-util purge
fprime-util generate --ut -DCMAKE_CXX_CLANG_TIDY=clang-tidy
fprime-util build --all --ut -j8
```

## Future Work

More files will be done in a separate PR, to keep things reviewable.  This first batch was files with the largest number of simple occurrences.  The next set will be many files with few changes each.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
