### PR TITLE
Make timevalue and timeintervalvalue dict types

### DIFF
--- a/Fw/Time/Time.fpp
+++ b/Fw/Time/Time.fpp
@@ -1,7 +1,7 @@
 module Fw {
   
   @ Data structure for Time 
-  struct TimeValue {
+  dictionary struct TimeValue {
     timeBase: TimeBase  @< basis of time (defined by system)
     timeContext: FwTimeContextStoreType  @< user settable value. Could be reboot count, node, etc
     seconds: U32  @< seconds portion of Time
@@ -16,7 +16,7 @@ module Fw {
   )
 
   @ Data structure for Time Interval
-  struct TimeIntervalValue {
+  dictionary struct TimeIntervalValue {
     seconds: U32  @< seconds portion of TimeInterval
     useconds: U32  @< microseconds portion of TimeInterval
   }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4574  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

* Two line change: make TimeValue and TimeIntervalValue dictionary types

## Rationale

This allows ground based tools to access these types
