### PR TITLE
Add CRC checks to Svc.PrmDb

### DIFF
--- a/Os/Stub/test/File.cpp
+++ b/Os/Stub/test/File.cpp
@@ -59,6 +59,7 @@ FileInterface::Status TestFile::open(const char* filepath, Mode open_mode, Overw
     StaticData::data.openOverwrite = overwrite;
     StaticData::data.lastCalled = StaticData::OPEN_FN;
     StaticData::data.pointer = 0;
+    StaticData::data.positionResult = StaticData::data.pointer;
     return StaticData::data.openStatus;
 }
 
@@ -89,6 +90,9 @@ FileInterface::Status TestFile::seek(FwSignedSizeType offset, SeekType seekType)
     StaticData::data.seekOffset = offset;
     StaticData::data.seekType = seekType;
     StaticData::data.lastCalled = StaticData::SEEK_FN;
+    StaticData::data.pointer = offset;
+    StaticData::data.positionResult = StaticData::data.pointer;
+
     return StaticData::data.seekStatus;
 }
 
@@ -107,6 +111,7 @@ FileInterface::Status TestFile::read(U8* buffer, FwSizeType& size, WaitType wait
         size = FW_MIN(size, StaticData::data.readResultSize - StaticData::data.pointer);
         (void)::memcpy(buffer, StaticData::data.readResult + StaticData::data.pointer, static_cast<size_t>(size));
         StaticData::data.pointer += size;
+        StaticData::data.positionResult = StaticData::data.pointer;
     } else {
         size = StaticData::data.readSizeResult;
     }
@@ -123,6 +128,7 @@ FileInterface::Status TestFile::write(const U8* buffer, FwSizeType& size, WaitTy
         size = FW_MIN(size, StaticData::data.writeResultSize - StaticData::data.pointer);
         (void)::memcpy(StaticData::data.writeResult + StaticData::data.pointer, buffer, static_cast<size_t>(size));
         StaticData::data.pointer += size;
+        StaticData::data.positionResult = StaticData::data.pointer;
     } else {
         size = StaticData::data.writeSizeResult;
     }

--- a/Svc/PrmDb/PrmDb.fpp
+++ b/Svc/PrmDb/PrmDb.fpp
@@ -53,6 +53,9 @@ module Svc {
       PARAMETER_VALUE_SIZE
       CRC_PLACE
       CRC_REAL
+      CURR_POSITION
+      SEEK_ZERO
+      SEEK_POSITION
     }
 
     # ----------------------------------------------------------------------

--- a/Svc/PrmDb/PrmDb.fpp
+++ b/Svc/PrmDb/PrmDb.fpp
@@ -34,6 +34,10 @@ module Svc {
       PARAMETER_ID_SIZE
       PARAMETER_VALUE
       PARAMETER_VALUE_SIZE
+      CRC
+      CRC_SIZE
+      CRC_BUFFER
+      SEEK_ZERO
     }
 
     @ Parameter write error
@@ -47,6 +51,8 @@ module Svc {
       PARAMETER_ID_SIZE
       PARAMETER_VALUE
       PARAMETER_VALUE_SIZE
+      CRC_PLACE
+      CRC_REAL
     }
 
     # ----------------------------------------------------------------------

--- a/Svc/PrmDb/PrmDbEventDict.fppi
+++ b/Svc/PrmDb/PrmDbEventDict.fppi
@@ -107,3 +107,13 @@ event PrmDbFileLoadInvalidAction(
     severity warning low \
     id 11 \
     format "Invalid action during parameter file load. Current state: {}, Action (Invalid for current state): {}."
+
+
+@ parameter file failed CRC
+event PrmFileBadCrc(
+                       readCrc: U32  @< The read CRC
+                       compCrc: U32  @< The computed CRC
+                        ) \
+    severity warning high \
+    id 12 \
+    format "Parameter file failed CRC. Read: 0x{x} Computed: 0x{x}"

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -317,7 +317,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
         return;
     }
 
-    // Restore pointer to end of paramFile
+    // Restore pointer to previously saved location
     stat = paramFile.seek(static_cast<FwSignedSizeType>(currPosInParamFile), Os::File::SeekType::ABSOLUTE);
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::SEEK_POSITION, 0, stat);

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -122,7 +122,23 @@ void PrmDbImpl::pingIn_handler(FwIndexType portNum, U32 key) {
     this->pingOut_out(0, key);
 }
 
+
 U32 PrmDbImpl::computeCrc(U32 crc, const BYTE* buff, FwSizeType size) {
+    // Note: The crc parameter accepts any U32 value as valid input.
+    // This is correct behavior for CRC32 accumulation functions where:
+    // - Initial CRC values are typically 0x00000000 or 0xFFFFFFFF
+    // - Intermediate CRC values (from prior computeCrc calls) can be any U32 value
+
+    // Check for null pointer before dereferencing
+    if (buff == nullptr) {
+        // Return the input CRC unchanged if buffer is null
+        return crc;
+    }
+
+    // Check for zero size to avoid unnecessary processing
+    if (size == 0) {
+        return crc;
+    }
     for (FwSizeType byte = 0; byte < size; byte++) {
         crc = static_cast<U32>(update_crc_32(crc, static_cast<char>(buff[byte])));
     }
@@ -277,6 +293,8 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
 
     this->unLock();
 
+    printf("CINDY FIXME CRC FINAL = %u\n", crc);
+
     // save current location of pointer in paramFile
     FwSizeType currPosInParamFile;
 
@@ -288,7 +306,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     }
 
     // seek to beginning and write CRC value
-    paramFile.seek(0, Os::File::SeekType::ABSOLUTE);
+    stat = paramFile.seek(0, Os::File::SeekType::ABSOLUTE);
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::SEEK_ZERO, 0, stat);
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
@@ -303,7 +321,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     }
 
     // Restore pointer to end of paramFile
-    paramFile.seek(static_cast<FwSignedSizeType>(currPosInParamFile), Os::File::SeekType::ABSOLUTE);
+    stat = paramFile.seek(static_cast<FwSignedSizeType>(currPosInParamFile), Os::File::SeekType::ABSOLUTE);
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::SEEK_POSITION, 0, stat);
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
@@ -409,26 +427,18 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
     }
 
     if (readSize != sizeof(fileCrc)) {
-        this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC_SIZE, static_cast<I32>(readSize), stat);
+        this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC_SIZE, static_cast<I32>(0), static_cast<I32>(readSize));
         return PrmLoadStatus::ERROR;
     }
 
     readSize = PRMDB_CRC_BUFFER_SIZE;
-    FwSizeType crcChunk = 0;
     U32 crc = 0xFFFFFFFF;
     // read into CRC buffer for checking
 
-    while (readSize != 0) {
-        readSize = PRMDB_CRC_BUFFER_SIZE;
-        Os::File::Status fStat = paramFile.read(this->m_crcBuffer, readSize, Os::File::NO_WAIT);
-        if (fStat != Os::File::OP_OK) {
-            this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC_BUFFER, static_cast<I32>(crcChunk), fStat);
-            return PrmLoadStatus::ERROR;
-        }
-
-        crc = this->computeCrc(crc, this->m_crcBuffer, readSize);
-
-        crcChunk++;
+    Os::File::Status status = paramFile.calculateCrc(crc);
+    if (status != Os::File::OP_OK) {
+        this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC_BUFFER, static_cast<I32>(0), status);
+        return PrmLoadStatus::ERROR;
     }
 
     if (fileCrc != crc) {
@@ -567,6 +577,9 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
             this->log_WARNING_HI_PrmDbFull(parameterId);
         }
         recordNumTotal++;
+        // CINDY FIXME
+        //printf("DEBUG: Completed record %u\n", recordNumTotal-1);
+
     }
 
     this->log_ACTIVITY_HI_PrmFileLoadComplete(dbString, recordNumTotal, recordNumAdded, recordNumUpdated);

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -293,8 +293,6 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
 
     this->unLock();
 
-    printf("CINDY FIXME CRC FINAL = %u\n", crc);
-
     // save current location of pointer in paramFile
     FwSizeType currPosInParamFile;
 
@@ -577,9 +575,6 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
             this->log_WARNING_HI_PrmDbFull(parameterId);
         }
         recordNumTotal++;
-        // CINDY FIXME
-        //printf("DEBUG: Completed record %u\n", recordNumTotal-1);
-
     }
 
     this->log_ACTIVITY_HI_PrmFileLoadComplete(dbString, recordNumTotal, recordNumAdded, recordNumUpdated);

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -9,6 +9,9 @@
 #include <Svc/PrmDb/PrmDbImpl.hpp>
 
 #include <Os/File.hpp>
+extern "C" {
+#include <Utils/Hash/libcrc/lib_crc.h>
+}
 
 #include <cstdio>
 #include <cstring>
@@ -119,6 +122,14 @@ void PrmDbImpl::pingIn_handler(FwIndexType portNum, U32 key) {
     this->pingOut_out(0, key);
 }
 
+// CINDY FIXME. what do I change NATIVE_UINT_TYPE  to for size?
+U32 PrmDbImpl::computeCrc(U32 crc, const U8* buff, FwSizeType size) {
+    for (FwSizeType byte = 0; byte < size; byte++) {
+        crc = static_cast<U32>(update_crc_32(crc, static_cast<char>(buff[byte])));
+    }   
+    return crc;
+}       
+
 void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     // Reject PRM_SAVE_FILE command during non-idle file load states
     if (m_state != PrmDbFileLoadState::IDLE) {
@@ -139,6 +150,18 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
         return;
     }
 
+    // write placeholder for the CRC
+    U32 crc = 0xFFFFFFFF;
+    FwSizeType writeSize = static_cast<FwSizeType>(sizeof(crc));
+    stat = paramFile.write(reinterpret_cast<const U8*>(&crc), writeSize, Os::File::WaitType::WAIT);
+
+    if (stat != Os::File::OP_OK) {
+        this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::CRC_PLACE,0,stat);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
+
+
     this->lock();
     t_dbStruct* db = getDbPtr(PrmDbType::DB_ACTIVE);
     FW_ASSERT(db != nullptr);
@@ -151,7 +174,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
         if (db[entry].used) {
             // write delimiter
             static const U8 delim = PRMDB_ENTRY_DELIMITER;
-            FwSizeType writeSize = static_cast<FwSizeType>(sizeof(delim));
+            writeSize = static_cast<FwSizeType>(sizeof(delim));
             stat = paramFile.write(&delim, writeSize, Os::File::WaitType::WAIT);
             if (stat != Os::File::OP_OK) {
                 this->unLock();
@@ -166,6 +189,10 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
                 this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
                 return;
             }
+
+            // add delimiter to CRC
+            crc = this->computeCrc(crc, &delim, sizeof(delim));
+
             // serialize record size = id field + data
             U32 recordSize = static_cast<U32>(sizeof(FwPrmIdType) + db[entry].val.getSize());
 
@@ -191,6 +218,8 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
                 this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
                 return;
             }
+
+            crc = this->computeCrc(crc, buff.getBuffAddr(), writeSize);
 
             // reset buffer
             buff.resetSer();
@@ -218,6 +247,9 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
                 return;
             }
 
+            // add to CRC
+            crc = this->computeCrc(crc,buff.getBuffAddr(),writeSize);
+
             // write serialized parameter value
 
             writeSize = static_cast<FwSizeType>(db[entry].val.getSize());
@@ -236,11 +268,27 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
                 this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
                 return;
             }
+
+            // add serialized value to crc
+            crc = this->computeCrc(crc, db[entry].val.getBuffAddr(),writeSize);
+
             numRecords++;
         }  // end if record in use
     }  // end for each record
 
     this->unLock();
+
+    // seek to beginning and write CRC value
+    paramFile.seek(0, Os::File::SeekType::ABSOLUTE);
+    writeSize = static_cast<FwSizeType>(sizeof(crc));
+    stat = paramFile.write(reinterpret_cast<const U8*>(&crc), writeSize, Os::File::WaitType::WAIT);
+    if (stat != Os::File::OP_OK) {
+        this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::CRC_REAL, 0, stat);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
+
+
     this->log_ACTIVITY_HI_PrmFileSaveComplete(numRecords);
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }
@@ -326,8 +374,61 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
     Os::File::Status stat = paramFile.open(fileName.toChar(), Os::File::OPEN_READ);
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_PrmFileReadError(PrmReadError::OPEN, 0, stat);
-        return PrmLoadStatus::ERROR;
+        return  PrmLoadStatus::ERROR;
     }
+    //===========================================================================
+    // read CRC from beginning of file
+    U32 fileCrc;
+    FwSizeType readSize = static_cast<FwSizeType>(sizeof(fileCrc));
+
+    stat = paramFile.read(reinterpret_cast<U8*>(&fileCrc), readSize);
+    if (stat != Os::File::OP_OK) {
+        this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC,  static_cast<I32>(0), stat);
+        return  PrmLoadStatus::ERROR;
+
+    }
+
+    if (readSize != sizeof(fileCrc)) {
+        this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC_SIZE, static_cast<I32>(readSize), stat);
+        return  PrmLoadStatus::ERROR;
+
+    }
+
+    readSize = PRMDB_CRC_BUFFER_SIZE;
+    FwSizeType crcChunk = 0;
+    U32 crc = 0xFFFFFFFF;
+    // read into CRC buffer for checking
+
+    while (readSize != 0) {
+        // CINDY FIXME determine which one works
+        //readSize = static_cast<FwSizeType>(PRMDB_CRC_BUFFER_SIZE);
+        readSize = PRMDB_CRC_BUFFER_SIZE;
+        Os::File::Status fStat = paramFile.read(this->m_crcBuffer, readSize, Os::File::NO_WAIT);
+        if (fStat != Os::File::OP_OK) {
+            this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC_BUFFER, static_cast<I32>(crcChunk), fStat);
+            return  PrmLoadStatus::ERROR;
+
+        }
+
+        crc = this->computeCrc(crc, this->m_crcBuffer, readSize);
+
+        crcChunk++;
+    }
+
+    if (fileCrc != crc) {
+        this->log_WARNING_HI_PrmFileBadCrc(fileCrc, crc);
+        return  PrmLoadStatus::ERROR;
+
+    }
+
+
+    // seek back to just after CRC
+    stat = paramFile.seek(sizeof(fileCrc), Os::File::SeekType::ABSOLUTE);
+    if (stat != Os::File::OP_OK) {
+        this->log_WARNING_HI_PrmFileReadError(PrmReadError::SEEK_ZERO, 0, stat);
+        return  PrmLoadStatus::ERROR;
+    }
+    //===========================================================================
 
     WorkingBuffer buff;
 
@@ -337,7 +438,7 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
 
     for (FwSizeType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
         U8 delimiter;
-        FwSizeType readSize = static_cast<FwSizeType>(sizeof(delimiter));
+        readSize = static_cast<FwSizeType>(sizeof(delimiter));
 
         // read delimiter
         Os::File::Status fStat = paramFile.read(&delimiter, readSize, Os::File::WaitType::WAIT);

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -428,7 +428,6 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
         return PrmLoadStatus::ERROR;
     }
 
-    readSize = PRMDB_CRC_BUFFER_SIZE;
     U32 crc = 0xFFFFFFFF;
     // read into CRC buffer for checking
 

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -282,11 +282,6 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     FwSizeType currPosInParamFile;
 
     stat = paramFile.position(currPosInParamFile);
-    if (stat != Os::File::OP_OK) {
-        printf("CINDY FIXME: If we do it this way, make an EVR");
-        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
-        return;
-    }
 
     // seek to beginning and write CRC value
     paramFile.seek(0, Os::File::SeekType::ABSOLUTE);
@@ -412,8 +407,6 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
     // read into CRC buffer for checking
 
     while (readSize != 0) {
-        // CINDY FIXME determine which one works
-        //readSize = static_cast<FwSizeType>(PRMDB_CRC_BUFFER_SIZE);
         readSize = PRMDB_CRC_BUFFER_SIZE;
         Os::File::Status fStat = paramFile.read(this->m_crcBuffer, readSize, Os::File::NO_WAIT);
         if (fStat != Os::File::OP_OK) {

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -122,7 +122,6 @@ void PrmDbImpl::pingIn_handler(FwIndexType portNum, U32 key) {
     this->pingOut_out(0, key);
 }
 
-
 U32 PrmDbImpl::computeCrc(U32 crc, const BYTE* buff, FwSizeType size) {
     // Note: The crc parameter accepts any U32 value as valid input.
     // This is correct behavior for CRC32 accumulation functions where:

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -122,8 +122,7 @@ void PrmDbImpl::pingIn_handler(FwIndexType portNum, U32 key) {
     this->pingOut_out(0, key);
 }
 
-// CINDY FIXME. what do I change NATIVE_UINT_TYPE  to for size?
-U32 PrmDbImpl::computeCrc(U32 crc, const U8* buff, FwSizeType size) {
+U32 PrmDbImpl::computeCrc(U32 crc, const BYTE* buff, FwSizeType size) {
     for (FwSizeType byte = 0; byte < size; byte++) {
         crc = static_cast<U32>(update_crc_32(crc, static_cast<char>(buff[byte])));
     }   
@@ -219,6 +218,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
                 return;
             }
 
+            // add recordSize to CRC
             crc = this->computeCrc(crc, buff.getBuffAddr(), writeSize);
 
             // reset buffer
@@ -247,7 +247,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
                 return;
             }
 
-            // add to CRC
+            // add parameter ID to CRC
             crc = this->computeCrc(crc,buff.getBuffAddr(),writeSize);
 
             // write serialized parameter value
@@ -269,7 +269,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
                 return;
             }
 
-            // add serialized value to crc
+            // add serialized parameter value to crc
             crc = this->computeCrc(crc, db[entry].val.getBuffAddr(),writeSize);
 
             numRecords++;
@@ -277,6 +277,16 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     }  // end for each record
 
     this->unLock();
+
+    // save current location of pointer in paramFile
+    FwSizeType currPosInParamFile;
+
+    stat = paramFile.position(currPosInParamFile);
+    if (stat != Os::File::OP_OK) {
+        printf("CINDY FIXME: If we do it this way, make an EVR");
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
 
     // seek to beginning and write CRC value
     paramFile.seek(0, Os::File::SeekType::ABSOLUTE);
@@ -288,6 +298,8 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
         return;
     }
 
+    // Restore pointer to end of paramFile
+    paramFile.seek(static_cast<FwSignedSizeType>(currPosInParamFile), Os::File::SeekType::ABSOLUTE);
 
     this->log_ACTIVITY_HI_PrmFileSaveComplete(numRecords);
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -282,9 +282,20 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     FwSizeType currPosInParamFile;
 
     stat = paramFile.position(currPosInParamFile);
+    if (stat != Os::File::OP_OK) {
+        this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::CURR_POSITION, 0, stat);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
+    
 
     // seek to beginning and write CRC value
     paramFile.seek(0, Os::File::SeekType::ABSOLUTE);
+    if (stat != Os::File::OP_OK) {
+        this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::SEEK_ZERO, 0, stat);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
     writeSize = static_cast<FwSizeType>(sizeof(crc));
     stat = paramFile.write(reinterpret_cast<const U8*>(&crc), writeSize, Os::File::WaitType::WAIT);
     if (stat != Os::File::OP_OK) {
@@ -295,6 +306,11 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
 
     // Restore pointer to end of paramFile
     paramFile.seek(static_cast<FwSignedSizeType>(currPosInParamFile), Os::File::SeekType::ABSOLUTE);
+    if (stat != Os::File::OP_OK) {
+        this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::SEEK_POSITION, 0, stat);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
 
     this->log_ACTIVITY_HI_PrmFileSaveComplete(numRecords);
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -125,9 +125,9 @@ void PrmDbImpl::pingIn_handler(FwIndexType portNum, U32 key) {
 U32 PrmDbImpl::computeCrc(U32 crc, const BYTE* buff, FwSizeType size) {
     for (FwSizeType byte = 0; byte < size; byte++) {
         crc = static_cast<U32>(update_crc_32(crc, static_cast<char>(buff[byte])));
-    }   
+    }
     return crc;
-}       
+}
 
 void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     // Reject PRM_SAVE_FILE command during non-idle file load states
@@ -155,11 +155,10 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     stat = paramFile.write(reinterpret_cast<const U8*>(&crc), writeSize, Os::File::WaitType::WAIT);
 
     if (stat != Os::File::OP_OK) {
-        this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::CRC_PLACE,0,stat);
+        this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::CRC_PLACE, 0, stat);
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
         return;
     }
-
 
     this->lock();
     t_dbStruct* db = getDbPtr(PrmDbType::DB_ACTIVE);
@@ -248,7 +247,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
             }
 
             // add parameter ID to CRC
-            crc = this->computeCrc(crc,buff.getBuffAddr(),writeSize);
+            crc = this->computeCrc(crc, buff.getBuffAddr(), writeSize);
 
             // write serialized parameter value
 
@@ -270,7 +269,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
             }
 
             // add serialized parameter value to crc
-            crc = this->computeCrc(crc, db[entry].val.getBuffAddr(),writeSize);
+            crc = this->computeCrc(crc, db[entry].val.getBuffAddr(), writeSize);
 
             numRecords++;
         }  // end if record in use
@@ -287,7 +286,6 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
         return;
     }
-    
 
     // seek to beginning and write CRC value
     paramFile.seek(0, Os::File::SeekType::ABSOLUTE);
@@ -397,7 +395,7 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
     Os::File::Status stat = paramFile.open(fileName.toChar(), Os::File::OPEN_READ);
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_PrmFileReadError(PrmReadError::OPEN, 0, stat);
-        return  PrmLoadStatus::ERROR;
+        return PrmLoadStatus::ERROR;
     }
     //===========================================================================
     // read CRC from beginning of file
@@ -406,15 +404,13 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
 
     stat = paramFile.read(reinterpret_cast<U8*>(&fileCrc), readSize);
     if (stat != Os::File::OP_OK) {
-        this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC,  static_cast<I32>(0), stat);
-        return  PrmLoadStatus::ERROR;
-
+        this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC, static_cast<I32>(0), stat);
+        return PrmLoadStatus::ERROR;
     }
 
     if (readSize != sizeof(fileCrc)) {
         this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC_SIZE, static_cast<I32>(readSize), stat);
-        return  PrmLoadStatus::ERROR;
-
+        return PrmLoadStatus::ERROR;
     }
 
     readSize = PRMDB_CRC_BUFFER_SIZE;
@@ -427,8 +423,7 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
         Os::File::Status fStat = paramFile.read(this->m_crcBuffer, readSize, Os::File::NO_WAIT);
         if (fStat != Os::File::OP_OK) {
             this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC_BUFFER, static_cast<I32>(crcChunk), fStat);
-            return  PrmLoadStatus::ERROR;
-
+            return PrmLoadStatus::ERROR;
         }
 
         crc = this->computeCrc(crc, this->m_crcBuffer, readSize);
@@ -438,16 +433,14 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
 
     if (fileCrc != crc) {
         this->log_WARNING_HI_PrmFileBadCrc(fileCrc, crc);
-        return  PrmLoadStatus::ERROR;
-
+        return PrmLoadStatus::ERROR;
     }
-
 
     // seek back to just after CRC
     stat = paramFile.seek(sizeof(fileCrc), Os::File::SeekType::ABSOLUTE);
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_PrmFileReadError(PrmReadError::SEEK_ZERO, 0, stat);
-        return  PrmLoadStatus::ERROR;
+        return PrmLoadStatus::ERROR;
     }
     //===========================================================================
 

--- a/Svc/PrmDb/PrmDbImpl.hpp
+++ b/Svc/PrmDb/PrmDbImpl.hpp
@@ -103,10 +103,10 @@ class PrmDbImpl final : public PrmDbComponentBase {
         }
     };
 
-   U8 m_crcBuffer[PRMDB_CRC_BUFFER_SIZE]; //!< working buffer for computing CRC
+    U8 m_crcBuffer[PRMDB_CRC_BUFFER_SIZE];  //!< working buffer for computing CRC
 
-   // helper to compute CRC over a buffer
-   U32 computeCrc(U32 crc, const BYTE* buff, FwSizeType size);
+    // helper to compute CRC over a buffer
+    U32 computeCrc(U32 crc, const BYTE* buff, FwSizeType size);
 
     // Pointers to the active and staging databases
     // These point to the actual storage arrays below

--- a/Svc/PrmDb/PrmDbImpl.hpp
+++ b/Svc/PrmDb/PrmDbImpl.hpp
@@ -103,8 +103,6 @@ class PrmDbImpl final : public PrmDbComponentBase {
         }
     };
 
-    U8 m_crcBuffer[PRMDB_CRC_BUFFER_SIZE];  //!< working buffer for computing CRC
-
     // helper to compute CRC over a buffer
     U32 computeCrc(U32 crc, const BYTE* buff, FwSizeType size);
 

--- a/Svc/PrmDb/PrmDbImpl.hpp
+++ b/Svc/PrmDb/PrmDbImpl.hpp
@@ -103,6 +103,12 @@ class PrmDbImpl final : public PrmDbComponentBase {
         }
     };
 
+   U8 m_crcBuffer[PRMDB_CRC_BUFFER_SIZE]; //!< working buffer for computing CRC
+
+   // helper to compute CRC over a buffer
+   // CINDY FIXME check type for size is correct
+   U32 computeCrc(U32 crc, const U8* buff, FwSizeType size);
+
     // Pointers to the active and staging databases
     // These point to the actual storage arrays below
     // The active database is the ONLY one used for getting parameters

--- a/Svc/PrmDb/PrmDbImpl.hpp
+++ b/Svc/PrmDb/PrmDbImpl.hpp
@@ -106,8 +106,7 @@ class PrmDbImpl final : public PrmDbComponentBase {
    U8 m_crcBuffer[PRMDB_CRC_BUFFER_SIZE]; //!< working buffer for computing CRC
 
    // helper to compute CRC over a buffer
-   // CINDY FIXME check type for size is correct
-   U32 computeCrc(U32 crc, const U8* buff, FwSizeType size);
+   U32 computeCrc(U32 crc, const BYTE* buff, FwSizeType size);
 
     // Pointers to the active and staging databases
     // These point to the actual storage arrays below

--- a/Svc/PrmDb/test/ut/PrmDbTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.cpp
@@ -401,7 +401,7 @@ void PrmDbTester::runFileReadError() {
                 FAIL() << "Reached unknown case";
         }
 
-        FwSizeType ya = 0;    
+        FwSizeType ya = 0;
         // Loop through various field reads
         for (FwSizeType j = 0; j < 6; j++) {
             clearEvents();
@@ -416,7 +416,7 @@ void PrmDbTester::runFileReadError() {
                 case 1:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                     ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::CRC_BUFFER, 0, this->m_status);
-                    ya++; 
+                    ya++;
                     break;
                 case 2:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
@@ -448,9 +448,9 @@ void PrmDbTester::runFileReadError() {
         this->m_impl.readParamFile();
         ASSERT_EVENTS_SIZE(1);
         switch (i) {
-             case 0: 
+            case 0:
                 ASSERT_EVENTS_PrmFileBadCrc_SIZE(1);
-                // Parameter read error caused by adding one to the expected read 
+                // Parameter read error caused by adding one to the expected read
                 ASSERT_EVENTS_PrmFileBadCrc(0, 0x33d79cd4, 0xc180712b);
                 xa++;
                 break;
@@ -1339,7 +1339,7 @@ Os::File::Status PrmDbTester::PrmDbTestFile::read(U8* buffer, FwSizeType& size, 
                 status = s_tester->m_status;
                 break;
             case FILE_SIZE_ERROR:
-                if (size != 0) {  
+                if (size != 0) {
                     size += 1;
                 }
                 break;

--- a/Svc/PrmDb/test/ut/PrmDbTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.cpp
@@ -356,24 +356,29 @@ void PrmDbTester::runFileReadError() {
     for (FwSizeType i = 0; i < 5; i++) {
         clearEvents();
         this->m_waits = i + za;
+        printf("DEBUG: FILE_SIZE_ERROR case %d: m_waits=%d\n", static_cast<I32>(i), static_cast<I32>(i + za));
         this->m_impl.readParamFile();
         ASSERT_EVENTS_SIZE(1);
         switch (i) {
             case 0:
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
-                ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::CRC_SIZE, sizeof(U32) + 1, 0);
+                ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::CRC_SIZE, 0, sizeof(U32) + 1);
                 za++;
                 break;
             case 1:
+                printf("CINDY FIXME 1\n");
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                 ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER_SIZE, 0, sizeof(U8) + 1);
-                za++;
                 break;
             case 2:
+                printf("CINDY FIXME 2\n");
+
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                 ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::RECORD_SIZE_SIZE, 0, sizeof(U32) + 1);
                 break;
             case 3:
+                printf("CINDY FIXME 3\n");
+
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                 ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::PARAMETER_ID_SIZE, 0, sizeof(FwPrmIdType) + 1);
                 break;
@@ -416,17 +421,24 @@ void PrmDbTester::runFileReadError() {
                 case 1:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                     ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::CRC_BUFFER, 0, this->m_status);
-                    ya++;
+                    // CINDY FIXMEya++;
                     break;
                 case 2:
+                    printf("CINDY FIXME 4\n");
+
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                     ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER, 0, this->m_status);
+                    // CINDY FIXMEya++;
                     break;
                 case 3:
+                    printf("CINDY FIXME 5\n");
+
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                     ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::RECORD_SIZE, 0, this->m_status);
                     break;
                 case 4:
+                    printf("CINDY FIXME 6\n");
+
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                     ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::PARAMETER_ID, 0, this->m_status);
                     break;
@@ -445,20 +457,28 @@ void PrmDbTester::runFileReadError() {
     for (FwSizeType i = 0; i < 3; i++) {
         clearEvents();
         this->m_waits = i + xa;
+        // CINDY FIXME
+        printf("DEBUG: FILE_DATA_ERROR case %d: m_waits=%d\n", static_cast<I32>(i), static_cast<I32>(i + xa + 1));
         this->m_impl.readParamFile();
         ASSERT_EVENTS_SIZE(1);
         switch (i) {
             case 0:
+                printf("CINDY FIXME 7\n");
+
                 ASSERT_EVENTS_PrmFileBadCrc_SIZE(1);
                 // Parameter read error caused by adding one to the expected read
                 ASSERT_EVENTS_PrmFileBadCrc(0, 0x33d79cd4, 0xc180712b);
+                printf("CINDY FIXME 8\n");
+
                 xa++;
                 break;
             case 1:
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                 // Parameter read error caused by adding one to the expected read
                 ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER_VALUE, 0, PRMDB_ENTRY_DELIMITER + 1);
-                xa++;
+                // CINDY FIXMExa++;
+                printf("CINDY FIXME 9\n");
+
                 break;
             case 2: {
                 // Data in this test is corrupted by adding 1 to the first data byte read. Since data is stored in
@@ -1334,6 +1354,9 @@ Os::File::Status PrmDbTester::PrmDbTestFile::read(U8* buffer, FwSizeType& size, 
     EXPECT_NE(s_tester, nullptr);
     Os::File::Status status = this->Os::Stub::File::Test::TestFile::read(buffer, size, wait);
     if (s_tester->m_waits == 0) {
+        // CINDY FIXME
+        printf("DEBUG READ: m_waits=%d, size=%d, errorType=%d\n", static_cast<I32>(s_tester->m_waits),
+               static_cast<I32>(size), static_cast<I32>(s_tester->m_errorType));
         switch (s_tester->m_errorType) {
             case FILE_STATUS_ERROR:
                 status = s_tester->m_status;

--- a/Svc/PrmDb/test/ut/PrmDbTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.cpp
@@ -366,19 +366,14 @@ void PrmDbTester::runFileReadError() {
                 za++;
                 break;
             case 1:
-                printf("CINDY FIXME 1\n");
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                 ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER_SIZE, 0, sizeof(U8) + 1);
                 break;
             case 2:
-                printf("CINDY FIXME 2\n");
-
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                 ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::RECORD_SIZE_SIZE, 0, sizeof(U32) + 1);
                 break;
             case 3:
-                printf("CINDY FIXME 3\n");
-
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                 ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::PARAMETER_ID_SIZE, 0, sizeof(FwPrmIdType) + 1);
                 break;
@@ -421,24 +416,16 @@ void PrmDbTester::runFileReadError() {
                 case 1:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                     ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::CRC_BUFFER, 0, this->m_status);
-                    // CINDY FIXMEya++;
                     break;
                 case 2:
-                    printf("CINDY FIXME 4\n");
-
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                     ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER, 0, this->m_status);
-                    // CINDY FIXMEya++;
                     break;
                 case 3:
-                    printf("CINDY FIXME 5\n");
-
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                     ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::RECORD_SIZE, 0, this->m_status);
                     break;
                 case 4:
-                    printf("CINDY FIXME 6\n");
-
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                     ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::PARAMETER_ID, 0, this->m_status);
                     break;
@@ -457,28 +444,19 @@ void PrmDbTester::runFileReadError() {
     for (FwSizeType i = 0; i < 3; i++) {
         clearEvents();
         this->m_waits = i + xa;
-        // CINDY FIXME
-        printf("DEBUG: FILE_DATA_ERROR case %d: m_waits=%d\n", static_cast<I32>(i), static_cast<I32>(i + xa + 1));
         this->m_impl.readParamFile();
         ASSERT_EVENTS_SIZE(1);
         switch (i) {
             case 0:
-                printf("CINDY FIXME 7\n");
-
                 ASSERT_EVENTS_PrmFileBadCrc_SIZE(1);
                 // Parameter read error caused by adding one to the expected read
                 ASSERT_EVENTS_PrmFileBadCrc(0, 0x33d79cd4, 0xc180712b);
-                printf("CINDY FIXME 8\n");
-
                 xa++;
                 break;
             case 1:
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                 // Parameter read error caused by adding one to the expected read
                 ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER_VALUE, 0, PRMDB_ENTRY_DELIMITER + 1);
-                // CINDY FIXMExa++;
-                printf("CINDY FIXME 9\n");
-
                 break;
             case 2: {
                 // Data in this test is corrupted by adding 1 to the first data byte read. Since data is stored in
@@ -1354,9 +1332,6 @@ Os::File::Status PrmDbTester::PrmDbTestFile::read(U8* buffer, FwSizeType& size, 
     EXPECT_NE(s_tester, nullptr);
     Os::File::Status status = this->Os::Stub::File::Test::TestFile::read(buffer, size, wait);
     if (s_tester->m_waits == 0) {
-        // CINDY FIXME
-        printf("DEBUG READ: m_waits=%d, size=%d, errorType=%d\n", static_cast<I32>(s_tester->m_waits),
-               static_cast<I32>(size), static_cast<I32>(s_tester->m_errorType));
         switch (s_tester->m_errorType) {
             case FILE_STATUS_ERROR:
                 status = s_tester->m_status;

--- a/Svc/PrmDb/test/ut/PrmDbTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.cpp
@@ -351,25 +351,33 @@ void PrmDbTester::runFileReadError() {
     // Loop through all size errors testing each
     Os::Stub::File::Test::StaticData::setNextStatus(Os::File::OP_OK);
     this->m_errorType = FILE_SIZE_ERROR;
-    for (FwSizeType i = 0; i < 4; i++) {
+
+    FwSizeType za = 0;
+    for (FwSizeType i = 0; i < 5; i++) {
         clearEvents();
-        this->m_waits = i;
+        this->m_waits = i + za;
         this->m_impl.readParamFile();
         ASSERT_EVENTS_SIZE(1);
         switch (i) {
             case 0:
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
-                ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER_SIZE, 0, sizeof(U8) + 1);
+                ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::CRC_SIZE, sizeof(U32) + 1, 0);
+                za++;
                 break;
             case 1:
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
-                ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::RECORD_SIZE_SIZE, 0, sizeof(U32) + 1);
+                ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER_SIZE, 0, sizeof(U8) + 1);
+                za++;
                 break;
             case 2:
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
-                ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::PARAMETER_ID_SIZE, 0, sizeof(FwPrmIdType) + 1);
+                ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::RECORD_SIZE_SIZE, 0, sizeof(U32) + 1);
                 break;
             case 3:
+                ASSERT_EVENTS_PrmFileReadError_SIZE(1);
+                ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::PARAMETER_ID_SIZE, 0, sizeof(FwPrmIdType) + 1);
+                break;
+            case 4:
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                 ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::PARAMETER_VALUE_SIZE, 0, sizeof(U32) + 1);
                 break;
@@ -377,6 +385,7 @@ void PrmDbTester::runFileReadError() {
                 FAIL() << "Reached unknown case";
         }
     }
+
     // Loop through failure statuses
     for (FwSizeType i = 0; i < 2; i++) {
         this->m_errorType = FILE_STATUS_ERROR;
@@ -391,26 +400,37 @@ void PrmDbTester::runFileReadError() {
             default:
                 FAIL() << "Reached unknown case";
         }
+
+        FwSizeType ya = 0;    
         // Loop through various field reads
-        for (FwSizeType j = 0; j < 4; j++) {
+        for (FwSizeType j = 0; j < 6; j++) {
             clearEvents();
-            this->m_waits = j;
+            this->m_waits = j + ya;
             this->m_impl.readParamFile();
             ASSERT_EVENTS_SIZE(1);
             switch (j) {
                 case 0:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
-                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER, 0, this->m_status);
+                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::CRC, 0, this->m_status);
                     break;
                 case 1:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
-                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::RECORD_SIZE, 0, this->m_status);
+                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::CRC_BUFFER, 0, this->m_status);
+                    ya++; 
                     break;
                 case 2:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
-                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::PARAMETER_ID, 0, this->m_status);
+                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER, 0, this->m_status);
                     break;
                 case 3:
+                    ASSERT_EVENTS_PrmFileReadError_SIZE(1);
+                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::RECORD_SIZE, 0, this->m_status);
+                    break;
+                case 4:
+                    ASSERT_EVENTS_PrmFileReadError_SIZE(1);
+                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::PARAMETER_ID, 0, this->m_status);
+                    break;
+                case 5:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                     ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::PARAMETER_VALUE, 0, this->m_status);
                     break;
@@ -419,19 +439,28 @@ void PrmDbTester::runFileReadError() {
             }
         }
     }
+
+    FwSizeType xa = 0;
     this->m_errorType = FILE_DATA_ERROR;
-    for (FwSizeType i = 0; i < 2; i++) {
+    for (FwSizeType i = 0; i < 3; i++) {
         clearEvents();
-        this->m_waits = i;
+        this->m_waits = i + xa;
         this->m_impl.readParamFile();
         ASSERT_EVENTS_SIZE(1);
         switch (i) {
-            case 0:
+             case 0: 
+                ASSERT_EVENTS_PrmFileBadCrc_SIZE(1);
+                // Parameter read error caused by adding one to the expected read 
+                ASSERT_EVENTS_PrmFileBadCrc(0, 0x33d79cd4, 0xc180712b);
+                xa++;
+                break;
+            case 1:
                 ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                 // Parameter read error caused by adding one to the expected read
                 ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER_VALUE, 0, PRMDB_ENTRY_DELIMITER + 1);
+                xa++;
                 break;
-            case 1: {
+            case 2: {
                 // Data in this test is corrupted by adding 1 to the first data byte read. Since data is stored in
                 // big-endian format the highest order byte of the record size (U32) must have one added to it.
                 // Expected result of '8' inherited from original design of test.
@@ -468,13 +497,15 @@ void PrmDbTester::runFileWriteError() {
 
     this->runNominalPopulate();
 
+    FwSizeType zb = 0;
+
     // Loop through all size errors testing each
     Os::Stub::File::Test::StaticData::setNextStatus(Os::File::OP_OK);
     this->m_errorType = FILE_SIZE_ERROR;
     for (FwSizeType i = 0; i < 4; i++) {
         clearEvents();
         this->clearHistory();
-        this->m_waits = i;
+        this->m_waits = i + zb;
         this->sendCmd_PRM_SAVE_FILE(0, 12);
         stat = this->m_impl.doDispatch();
         ASSERT_EQ(stat, Fw::QueuedComponentBase::MSG_DISPATCH_OK);
@@ -483,6 +514,7 @@ void PrmDbTester::runFileWriteError() {
             case 0:
                 ASSERT_EVENTS_PrmFileWriteError_SIZE(1);
                 ASSERT_EVENTS_PrmFileWriteError(0, PrmWriteError::DELIMITER_SIZE, 0, sizeof(U8) + 1);
+                zb++;
                 break;
             case 1:
                 ASSERT_EVENTS_PrmFileWriteError_SIZE(1);
@@ -518,7 +550,7 @@ void PrmDbTester::runFileWriteError() {
                 FAIL() << "Reached unknown case";
         }
         // Loop through various field reads
-        for (FwSizeType j = 0; j < 4; j++) {
+        for (FwSizeType j = 0; j < 5; j++) {
             clearEvents();
             this->clearHistory();
             this->m_waits = j;
@@ -529,17 +561,21 @@ void PrmDbTester::runFileWriteError() {
             switch (j) {
                 case 0:
                     ASSERT_EVENTS_PrmFileWriteError_SIZE(1);
-                    ASSERT_EVENTS_PrmFileWriteError(0, PrmWriteError::DELIMITER, 0, this->m_status);
+                    ASSERT_EVENTS_PrmFileWriteError(0, PrmWriteError::CRC_PLACE, 0, this->m_status);
                     break;
                 case 1:
                     ASSERT_EVENTS_PrmFileWriteError_SIZE(1);
-                    ASSERT_EVENTS_PrmFileWriteError(0, PrmWriteError::RECORD_SIZE, 0, this->m_status);
+                    ASSERT_EVENTS_PrmFileWriteError(0, PrmWriteError::DELIMITER, 0, this->m_status);
                     break;
                 case 2:
                     ASSERT_EVENTS_PrmFileWriteError_SIZE(1);
-                    ASSERT_EVENTS_PrmFileWriteError(0, PrmWriteError::PARAMETER_ID, 0, this->m_status);
+                    ASSERT_EVENTS_PrmFileWriteError(0, PrmWriteError::RECORD_SIZE, 0, this->m_status);
                     break;
                 case 3:
+                    ASSERT_EVENTS_PrmFileWriteError_SIZE(1);
+                    ASSERT_EVENTS_PrmFileWriteError(0, PrmWriteError::PARAMETER_ID, 0, this->m_status);
+                    break;
+                case 4:
                     ASSERT_EVENTS_PrmFileWriteError_SIZE(1);
                     ASSERT_EVENTS_PrmFileWriteError(0, PrmWriteError::PARAMETER_VALUE, 0, this->m_status);
                     break;
@@ -1303,7 +1339,9 @@ Os::File::Status PrmDbTester::PrmDbTestFile::read(U8* buffer, FwSizeType& size, 
                 status = s_tester->m_status;
                 break;
             case FILE_SIZE_ERROR:
-                size += 1;
+                if (size != 0) {  
+                    size += 1;
+                }
                 break;
             case FILE_DATA_ERROR:
                 buffer[0] += 1;

--- a/default/config/PrmDbImplCfg.hpp
+++ b/default/config/PrmDbImplCfg.hpp
@@ -13,9 +13,8 @@ namespace {
 
 enum {
     PRMDB_NUM_DB_ENTRIES = 25,     // !< Number of entries in the parameter database
-    PRMDB_ENTRY_DELIMITER = 0xA5,  // !< Byte value that should precede each parameter in file; sanity check against
+    PRMDB_ENTRY_DELIMITER = 0xA5   // !< Byte value that should precede each parameter in file; sanity check against
                                    // file integrity. Should match ground system.
-    PRMDB_CRC_BUFFER_SIZE = 128    // !< Size of buffer
 };
 
 }

--- a/default/config/PrmDbImplCfg.hpp
+++ b/default/config/PrmDbImplCfg.hpp
@@ -12,10 +12,10 @@
 namespace {
 
 enum {
-    PRMDB_NUM_DB_ENTRIES = 25,    // !< Number of entries in the parameter database
+    PRMDB_NUM_DB_ENTRIES = 25,     // !< Number of entries in the parameter database
     PRMDB_ENTRY_DELIMITER = 0xA5,  // !< Byte value that should precede each parameter in file; sanity check against
-                                  // file integrity. Should match ground system.
-    PRMDB_CRC_BUFFER_SIZE = 128   // !< Size of buffer
+                                   // file integrity. Should match ground system.
+    PRMDB_CRC_BUFFER_SIZE = 128    // !< Size of buffer
 };
 
 }

--- a/default/config/PrmDbImplCfg.hpp
+++ b/default/config/PrmDbImplCfg.hpp
@@ -12,9 +12,9 @@
 namespace {
 
 enum {
-    PRMDB_NUM_DB_ENTRIES = 25,     // !< Number of entries in the parameter database
-    PRMDB_ENTRY_DELIMITER = 0xA5   // !< Byte value that should precede each parameter in file; sanity check against
-                                   // file integrity. Should match ground system.
+    PRMDB_NUM_DB_ENTRIES = 25,    // !< Number of entries in the parameter database
+    PRMDB_ENTRY_DELIMITER = 0xA5  // !< Byte value that should precede each parameter in file; sanity check against
+                                  // file integrity. Should match ground system.
 };
 
 }

--- a/default/config/PrmDbImplCfg.hpp
+++ b/default/config/PrmDbImplCfg.hpp
@@ -13,8 +13,9 @@ namespace {
 
 enum {
     PRMDB_NUM_DB_ENTRIES = 25,    // !< Number of entries in the parameter database
-    PRMDB_ENTRY_DELIMITER = 0xA5  // !< Byte value that should precede each parameter in file; sanity check against
+    PRMDB_ENTRY_DELIMITER = 0xA5,  // !< Byte value that should precede each parameter in file; sanity check against
                                   // file integrity. Should match ground system.
+    PRMDB_CRC_BUFFER_SIZE = 128   // !< Size of buffer
 };
 
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

<!-- A description of the changes contained in the PR. -->
Save and read a CRC to validate the contents of the PrmDb file.

## Rationale

<!-- A rationale for this change. e.g. fixes bug, or most projects need XYZ feature. -->
Provides protection against corruption

## Testing/Review Recommendations

<!-- Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality. -->
* made minor updates to TestFile::open, seek, read, and write in order track to the StaticData::data.positionResult, which is used by TestFile::position() to return the current position of the pointer in the paramFile.
* added file CRC to the beginning of the paramFile
* added a few unit test cases to check CRC_SIZE, CRC, and CRC_BUFFER on PrmFileReadError, and CRC_PLACE on PrmWriteError; and PrmFileBadCrc

## Future Work

<!-- Note any additional work that will be done relating to this issue. -->
none

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). -->
