### PR TITLE
Correct TmFramer size assertion math

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,21 @@
 repos:
-    -   repo: https://github.com/psf/black
-        rev: 19.3b0
-        hooks:
-        -   id: black
-            name: Format Python Code (black) in Fw/Python/
-            files: '^Fw/Python/'
-        -   id: black
-            name: Format Python Code (black) in Gds/
-            files: '^Gds/'
-            exclude: '^Gds/src/fprime_gds/wxgui/'
+  - repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+      - id: black
+        name: Format Python Code (black) in Fw/Python/
+        files: '^Fw/Python/'
+      - id: black
+        name: Format Python Code (black) in Gds/
+        files: '^Gds/'
+        exclude: '^Gds/src/fprime_gds/wxgui/'
+
+  - repo: local
+    hooks:
+      - id: fprime-util-format
+        name: Format Changed C++ Code (clang-format)
+        entry: fprime-util
+        language: system
+        files: \.(c|h|cpp|hpp)$
+        pass_filenames: true
+        args: ["format", "-f"]

--- a/Svc/Ccsds/TmFramer/TmFramer.hpp
+++ b/Svc/Ccsds/TmFramer/TmFramer.hpp
@@ -23,18 +23,18 @@ class TmFramer final : public TmFramerComponentBase {
     static_assert(ComCfg::TmFrameFixedSize > TMHeader::SERIALIZED_SIZE + TMTrailer::SERIALIZED_SIZE,
                   "TM Frame Fixed Size must be at least large enough to hold header, trailer and data");
 
-    static constexpr FwSizeType TmPayloadCapacity = ComCfg::TmFrameFixedSize - (TMHeader::SERIALIZED_SIZE + TMTrailer::SERIALIZED_SIZE);
+    static constexpr FwSizeType TmPayloadCapacity =
+        ComCfg::TmFrameFixedSize - (TMHeader::SERIALIZED_SIZE + TMTrailer::SERIALIZED_SIZE);
     static constexpr FwSizeType SppOverhead = (2 * SpacePacketHeader::SERIALIZED_SIZE) + 1;
-
 
     // These are to ensure the frame can hold the packet buffer, its SP header and an idle packet of 1 byte
     // This is because TM specifies a frame to be padded with an idle packet of at least 1 byte of idle data
-    static_assert(
-        TmPayloadCapacity >= FW_COM_BUFFER_MAX_SIZE + SppOverhead,
-        "TM Frame Fixed Size must be at least large enough to hold Tm Header + Footer, a full com buffer, 2 SP headers, and 1 idle byte");
-    static_assert(
-        TmPayloadCapacity >= FW_FILE_BUFFER_MAX_SIZE + SppOverhead,
-        "TM Frame Fixed Size must be at least large enough to hold Tm Header + Footer, a full file buffer, 2 SP headers, and 1 idle byte");
+    static_assert(TmPayloadCapacity >= FW_COM_BUFFER_MAX_SIZE + SppOverhead,
+                  "TM Frame Fixed Size must be at least large enough to hold Tm Header + Footer, a full com buffer, 2 "
+                  "SP headers, and 1 idle byte");
+    static_assert(TmPayloadCapacity >= FW_FILE_BUFFER_MAX_SIZE + SppOverhead,
+                  "TM Frame Fixed Size must be at least large enough to hold Tm Header + Footer, a full file buffer, 2 "
+                  "SP headers, and 1 idle byte");
 
     static constexpr U8 IDLE_DATA_PATTERN = 0x44;
 

--- a/Svc/Ccsds/TmFramer/TmFramer.hpp
+++ b/Svc/Ccsds/TmFramer/TmFramer.hpp
@@ -22,14 +22,19 @@ class TmFramer final : public TmFramerComponentBase {
 
     static_assert(ComCfg::TmFrameFixedSize > TMHeader::SERIALIZED_SIZE + TMTrailer::SERIALIZED_SIZE,
                   "TM Frame Fixed Size must be at least large enough to hold header, trailer and data");
+
+    static constexpr FwSizeType TmPayloadCapacity = ComCfg::TmFrameFixedSize - (TMHeader::SERIALIZED_SIZE + TMTrailer::SERIALIZED_SIZE);
+    static constexpr FwSizeType SppOverhead = (2 * SpacePacketHeader::SERIALIZED_SIZE) + 1;
+
+
     // These are to ensure the frame can hold the packet buffer, its SP header and an idle packet of 1 byte
     // This is because TM specifies a frame to be padded with an idle packet of at least 1 byte of idle data
     static_assert(
-        ComCfg::TmFrameFixedSize >= FW_COM_BUFFER_MAX_SIZE + (2 * SpacePacketHeader::SERIALIZED_SIZE) + 1,
-        "TM Frame Fixed Size must be at least large enough to hold a full com buffer, 2 SP headers and 1 byte");
+        TmPayloadCapacity >= FW_COM_BUFFER_MAX_SIZE + SppOverhead,
+        "TM Frame Fixed Size must be at least large enough to hold Tm Header + Footer, a full com buffer, 2 SP headers, and 1 idle byte");
     static_assert(
-        ComCfg::TmFrameFixedSize >= FW_FILE_BUFFER_MAX_SIZE + (2 * SpacePacketHeader::SERIALIZED_SIZE) + 1,
-        "TM Frame Fixed Size must be at least large enough to hold a full com buffer, 2 SP headers and 1 byte");
+        TmPayloadCapacity >= FW_FILE_BUFFER_MAX_SIZE + SppOverhead,
+        "TM Frame Fixed Size must be at least large enough to hold Tm Header + Footer, a full file buffer, 2 SP headers, and 1 idle byte");
 
     static constexpr U8 IDLE_DATA_PATTERN = 0x44;
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| N  |
|**_Documentation Included (y/n)_**|  N |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

The math in TmFramer's assertions was corrected to prevent runtime assertions

## Rationale

The math on the TmFramer's size assertions allowed for runtime assertions during file downlink.

```bash
Assert: "Svc/Ccsds/TmFramer/TmFramer.cpp:116" 2
FATAL 5761 handled.
Exiting with abort signal and core dump file.
```

## Testing/Review Recommendations

Make sure you believe File Downlink works right at the limit of the new assertion

## Future Work

I am working on an AOS framer that can do many PDU per one Frame and many Frames per one PDU. The changes could either be ported to TM or we could move the fprime ccsds stackup over to AOS at the point that is done.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Nope