### PR TITLE
Use FPP constant for FileDownlink filename length

### DIFF
--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -13,6 +13,7 @@
 #define Svc_FileDownlink_HPP
 
 #include <Fw/FilePacket/FilePacket.hpp>
+#include <Fw/Types/FileNameString.hpp>
 #include <Os/File.hpp>
 #include <Os/Mutex.hpp>
 #include <Os/Queue.hpp>
@@ -193,12 +194,10 @@ class FileDownlink final : public FileDownlinkComponentBase {
     //! Sources of send file requests
     enum CallerSource { COMMAND, PORT };
 
-#define FILE_ENTRY_FILENAME_LEN 101
-
     //! Used to track a single file downlink request
     struct FileEntry {
-        char srcFilename[FILE_ENTRY_FILENAME_LEN];   // Name of requested file
-        char destFilename[FILE_ENTRY_FILENAME_LEN];  // Name of requested file
+        char srcFilename[Fw::FileNameString::STRING_SIZE];   // Name of requested file
+        char destFilename[Fw::FileNameString::STRING_SIZE];  // Name of requested file
         U32 offset;
         U32 length;
         CallerSource source;  // Source of the downlink request


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4587 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Replace hardcoded `FILE_ENTRY_FILENAME_LEN` (101) with `Fw::FileNameString::STRING_SIZE` (200) in FileDownlink.hpp.

## Rationale

The filename length should be consistent with the FPP constant used throughout F´ rather than having a separate hardcoded value.

## Testing/Review Recommendations

Verify that FileDownlink compiles and existing unit tests pass. The change increases buffer size from 101 to 200 characters, aligning with the standard filename string size.