### PR TITLE
Clear invalid context in ComAggregator doClear action

### DIFF
--- a/Svc/ComAggregator/ComAggregator.cpp
+++ b/Svc/ComAggregator/ComAggregator.cpp
@@ -68,6 +68,7 @@ void ComAggregator ::Svc_AggregationMachine_action_doClear(SmId smId, Svc_Aggreg
     this->m_allow_timeout = true;  // Allow timeout messages in FILL state
     this->m_frameSerializer.resetSer();
     this->m_frameBuffer.setSize(sizeof(this->m_frameBufferStore));
+    this->m_lastContext = ComCfg::FrameContext();
     if (this->m_held.get_data().isValid()) {
         // Fill the held data
         this->Svc_AggregationMachine_action_doFill(smId, signal, this->m_held);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4301 |
|**_Has Unit Tests (y/n)_**| y (existing tests pass) |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Clear `m_lastContext` in the `doClear` action to prevent stale context from being passed through on subsequent sends.

## Rationale

The FPP action contract states `doClear` should "Clear the buffer fill state, last status" but `m_lastContext` was not being reset. This ensures the context is properly cleared alongside the other state variables.