### PR TITLE
Telemeter params on startup for FpySeq

### DIFF
--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -482,14 +482,8 @@ void FpySequencer::updateDebugTelemetryStruct() {
 }
 
 void FpySequencer::parametersLoaded() {
-    Fw::ParamValid valid;
-    // check for coding errors--all prms should have a default
-    this->paramGet_STATEMENT_TIMEOUT_SECS(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
-    this->paramGet_FLAG_DEFAULT_EXIT_ON_CMD_FAIL(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    parameterUpdated(PARAMID_STATEMENT_TIMEOUT_SECS);
+    parameterUpdated(PARAMID_FLAG_DEFAULT_EXIT_ON_CMD_FAIL);
 }
 
 void FpySequencer::parameterUpdated(FwPrmIdType id) {
@@ -507,6 +501,9 @@ void FpySequencer::parameterUpdated(FwPrmIdType id) {
             FW_ASSERT(0, static_cast<FwAssertArgType>(id));  // coding error, forgot to include in switch statement
         }
     }
+
+    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
+              static_cast<FwAssertArgType>(valid.e));
 }
 
 bool FpySequencer::isRunningState(State state) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Ensure the FpySequencer telemeters params on startup

## Rationale

Make it easy for users to know the parameters a sequencer is using.

## Testing/Review Recommendations

* Ensure the changes are needed for default values to be telemetered.

* It would be nice if this logic was baked into the framework

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
