### PR TITLE
Expose default file create permissions through a new OsCfg.fpp config file

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -39,6 +39,7 @@ bibtex
 Bies
 binaryfile
 BINDIR
+bitfield
 bitmaps
 bitshifts
 bitwidth

--- a/Os/Posix/File.hpp
+++ b/Os/Posix/File.hpp
@@ -6,6 +6,8 @@
 #ifndef OS_POSIX_FILE_HPP
 #define OS_POSIX_FILE_HPP
 
+#include <sys/stat.h>
+
 namespace Os {
 namespace Posix {
 namespace File {
@@ -169,6 +171,16 @@ class PosixFile : public FileInterface {
     //! \return raw file handle
     //!
     FileHandle* getHandle() override;
+
+  private:
+    //! \brief Maps FILE_MODE_ constants in config/OsCfg.fpp to mode_t type for open
+    //!
+    //! \param create_mode: Bitmask of file permissions derived from the FILE_MODE_
+    //!                     constants in OsCfg.fpp
+    //!
+    //! \return mode_t value that corresponds to the provided create_mode bitmask
+    //!
+    static mode_t map_open_create_mode(const U32 create_mode);
 
   private:
     //! File handle for PosixFile

--- a/default/config/CMakeLists.txt
+++ b/default/config/CMakeLists.txt
@@ -15,6 +15,7 @@ register_fprime_config(
         "${CMAKE_CURRENT_LIST_DIR}/GenericHubCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/MemoryAllocation.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/MemoryAllocation.hpp"
+        "${CMAKE_CURRENT_LIST_DIR}/OsCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/PlatformCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/PolyDbCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/VersionCfg.fpp"

--- a/default/config/OsCfg.fpp
+++ b/default/config/OsCfg.fpp
@@ -25,5 +25,10 @@ module Os {
     constant FILE_MODE_ISGID = 0x400
     constant FILE_MODE_ISVTX = 0x200
 
+    @ File creation mode used when calling Os::File "open" with
+    @ the OPEN_CREATE mode flag.
+    @ The FILE_DEFAULT_CREATE_MODE constant @ is a bitfield of the
+    @ above FILE_MODE_* bits that should be present in the created file
+    @ The default value corresponds to a mode of 600, or user R/W bits set
     constant FILE_DEFAULT_CREATE_MODE = FILE_MODE_IRUSR + FILE_MODE_IWUSR
 }

--- a/default/config/OsCfg.fpp
+++ b/default/config/OsCfg.fpp
@@ -1,0 +1,29 @@
+
+
+module Os {
+
+    @ File open mode permission bits
+    @ Constant values are derived from standard
+    @ Unix values, but should not be assumed
+    @ to match
+    constant FILE_MODE_IRUSR = 0x040
+    constant FILE_MODE_IWUSR = 0x080
+    constant FILE_MODE_IXUSR = 0x100
+    constant FILE_MODE_IRWXU = 0x1C0
+
+    constant FILE_MODE_IRGRP = 0x008
+    constant FILE_MODE_IWGRP = 0x010
+    constant FILE_MODE_IXGRP = 0x020
+    constant FILE_MODE_IRWXG = 0x038
+
+    constant FILE_MODE_IROTH = 0x001
+    constant FILE_MODE_IWOTH = 0x002
+    constant FILE_MODE_IXOTH = 0x004
+    constant FILE_MODE_IRWXO = 0x007
+
+    constant FILE_MODE_ISUID = 0x800
+    constant FILE_MODE_ISGID = 0x400
+    constant FILE_MODE_ISVTX = 0x200
+
+    constant FILE_DEFAULT_CREATE_MODE = FILE_MODE_IRUSR + FILE_MODE_IWUSR
+}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4604 |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**| Y |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

Creates an OsCfg.fpp configuration file with a default file creation mode constant. Os/Posix/File is updated to use this constant when creating new files. This allows the F Prime developer to control permissions on files created with Os::File, at least globally for the deployment

## Rationale

This is a fix that would have been useful for a previous F Prime project, where the default 600 permissions caused operational headaches when the files were created by root, but access by a normal user

## Testing/Review Recommendations

A small bit of test code was added to the reference topology to create files with this interface. All defined FILE_MODE_ bits were tested in one form or another on a Debian 13 system. The code was also compiled under Darwin and files were created with the expected permissions.

```
diff --git a/Ref/Top/RefTopology.cpp b/Ref/Top/RefTopology.cpp
index 6d18f751d..389f120f3 100644
--- a/Ref/Top/RefTopology.cpp
+++ b/Ref/Top/RefTopology.cpp
@@ -53,6 +53,10 @@ void configureTopology() {
 
     // Command sequencer needs to allocate memory to hold contents of command sequences
     cmdSeq.allocateBuffer(0, mallocator, 5 * 1024);
+
+    Os::File test_file;
+    test_file.open("test_file.txt", Os::FileInterface::OPEN_CREATE);
+    test_file.close();
 }
```

No testing was done on other operating systems. In particular, I am not sure how the VxWorks, FreeRTOS or Zephr OS layers will behave if they use the Os/Posix abstraction for File.

## Future Work

I would also like to change the default creation mode from 600 to 666. That is the default used by multiple unix tools (touch, vim). End users can drop permissions by changing the config constant or by using umask with their application.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

No AI assistance used.
