### PR TITLE
Add new constructor and setter for Fw::String

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -25,6 +25,7 @@ ARGN
 ARINC
 arpa
 ASize
+ASTRI
 ATL
 AUTOBRIEF
 autocode

--- a/Fw/Types/String.hpp
+++ b/Fw/Types/String.hpp
@@ -8,6 +8,8 @@
 #define FW_STRING_HPP
 
 #include <Fw/FPrimeBasicTypes.hpp>
+#include <Fw/Types/Assert.hpp>
+#include <Fw/Types/StringUtils.hpp>
 
 #include "Fw/Types/SerIds.hpp"
 #include "Fw/Types/StringBase.hpp"
@@ -30,6 +32,10 @@ class String final : public StringBase {
 
     String(const char* src) : StringBase() { *this = src; }
 
+    String(const char* src, FwSizeType length) : StringBase() {
+        setString(src, length);
+    }
+
     ~String() {}
 
     String& operator=(const String& src) {
@@ -50,6 +56,12 @@ class String final : public StringBase {
     const char* toChar() const { return this->m_buf; }
 
     StringBase::SizeType getCapacity() const { return sizeof this->m_buf; }
+
+    void setString(const char* src, FwSizeType length) {
+        // "length" non-null bytes should be followed by a null byte
+        FW_ASSERT(length < this->getCapacity());
+        (void)Fw::StringUtils::string_copy(const_cast<char*>(this->toChar()), src, length + 1);
+    }
 
   private:
     char m_buf[BUFFER_SIZE(STRING_SIZE)];

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -1401,6 +1401,10 @@ TEST(TypesTest, StringTest) {
     ASSERT_EQ(copyStr2, "ASTRING");
     Fw::String copyStr3(copyStr2);
     ASSERT_EQ(copyStr3, "ASTRING");
+    Fw::String copyStr4("ASTRING", 10);
+    ASSERT_EQ(copyStr4, "ASTRING");
+    Fw::String copyStr5("ASTRING", 5);
+    ASSERT_EQ(copyStr5, "ASTRI");
 
     Fw::InternalInterfaceString ifstr("IfString");
     Fw::String if2(ifstr);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4572 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Add a new Fw::String constructor and setter to copy the first n bytes of a string into Fw::String.

## Rationale

This could come in handy when writing to a field/buffer whose length is known beforehand.

## Testing/Review Recommendations

Two test cases have been added to `Fw/Types/test/ut/TypesTest.cpp:StringTest`.

## Future Work

NA

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))
NA
