### PR TITLE
Calculate Data Product checksum in the DpWriter component

### DIFF
--- a/Fw/Dp/test/util/DpContainerHeader.hpp
+++ b/Fw/Dp/test/util/DpContainerHeader.hpp
@@ -90,8 +90,6 @@ struct DpContainerHeader {
         checkDeserialAtOffset(deserializer, DpContainer::HEADER_HASH_OFFSET);
         // Check the header hash
         checkHeaderHash(file, line, buffer);
-        // Check the data hash
-        this->checkDataHash(file, line, buffer);
         // Move the deserialization pointer to the data offset
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::DATA_OFFSET);
     }
@@ -105,22 +103,6 @@ struct DpContainerHeader {
         U8* const buffAddr = buffer.getData();
         Utils::Hash::hash(buffAddr, DpContainer::Header::SIZE, computedHashBuffer);
         Utils::HashBuffer storedHashBuffer(&buffAddr[DpContainer::HEADER_HASH_OFFSET], HASH_DIGEST_LENGTH);
-        DP_CONTAINER_HEADER_ASSERT_EQ(computedHashBuffer, storedHashBuffer);
-    }
-
-    //! Check the data hash
-    void checkDataHash(const char* const file,  //!< The call site file name
-                       const U32 line,          //!< The call site line number
-                       Fw::Buffer& buffer       //!< The packet buffer
-    ) {
-        Utils::HashBuffer computedHashBuffer;
-        U8* const buffAddrBase = buffer.getData();
-        U8* const dataAddr = &buffAddrBase[DpContainer::DATA_OFFSET];
-        Utils::Hash::hash(dataAddr, this->m_dataSize, computedHashBuffer);
-        DpContainer container(this->m_id, buffer);
-        container.setDataSize(this->m_dataSize);
-        const FwSizeType dataHashOffset = container.getDataHashOffset();
-        Utils::HashBuffer storedHashBuffer(&buffAddrBase[dataHashOffset], HASH_DIGEST_LENGTH);
         DP_CONTAINER_HEADER_ASSERT_EQ(computedHashBuffer, storedHashBuffer);
     }
 

--- a/Fw/Dp/test/util/DpContainerHeader.hpp
+++ b/Fw/Dp/test/util/DpContainerHeader.hpp
@@ -106,6 +106,22 @@ struct DpContainerHeader {
         DP_CONTAINER_HEADER_ASSERT_EQ(computedHashBuffer, storedHashBuffer);
     }
 
+    //! Check the data hash
+    void checkDataHash(const char* const file,  //!< The call site file name
+                       const U32 line,          //!< The call site line number
+                       Fw::Buffer& buffer       //!< The packet buffer
+    ) {
+        Utils::HashBuffer computedHashBuffer;
+        U8* const buffAddrBase = buffer.getData();
+        U8* const dataAddr = &buffAddrBase[DpContainer::DATA_OFFSET];
+        Utils::Hash::hash(dataAddr, this->m_dataSize, computedHashBuffer);
+        DpContainer container(this->m_id, buffer);
+        container.setDataSize(this->m_dataSize);
+        const FwSizeType dataHashOffset = container.getDataHashOffset();
+        Utils::HashBuffer storedHashBuffer(&buffAddrBase[dataHashOffset], HASH_DIGEST_LENGTH);
+        DP_CONTAINER_HEADER_ASSERT_EQ(computedHashBuffer, storedHashBuffer);
+    }
+
     //! Check a packet header against a buffer
     void check(const char* const file,                         //!< The call site file name
                const U32 line,                                 //!< The call site line number

--- a/Fw/Dp/test/util/DpContainerHeader.hpp
+++ b/Fw/Dp/test/util/DpContainerHeader.hpp
@@ -42,7 +42,7 @@ struct DpContainerHeader {
 
     //! Deserialize a header from a packet buffer
     //! Check that the serialization succeeded at every step
-    //! Check the header hash and the data hash
+    //! Check the header hash
     void deserialize(const char* const file,  //!< The call site file name
                      const U32 line,          //!< The call site line number
                      Fw::Buffer& buffer       //!< The packet buffer

--- a/Svc/DpWriter/DpWriter.cpp
+++ b/Svc/DpWriter/DpWriter.cpp
@@ -88,8 +88,12 @@ void DpWriter::bufferSendIn_handler(const FwIndexType portNum, Fw::Buffer& buffe
         fileName.format(DP_FILENAME_FORMAT, this->m_dpFileNamePrefix.toChar(), containerId, timeTag.getSeconds(),
                         timeTag.getUSeconds());
     }
-    FwSizeType fileSize = 0;
+    // Calculate and populate the file data checksum
+    if (status == Fw::Success::SUCCESS) {
+        container.updateDataHash();
+    }
     // Write the file
+    FwSizeType fileSize = 0;
     if (status == Fw::Success::SUCCESS) {
         status = this->writeFile(container, fileName, fileSize);
     }

--- a/Svc/DpWriter/test/ut/AbstractState.cpp
+++ b/Svc/DpWriter/test/ut/AbstractState.cpp
@@ -65,8 +65,6 @@ Fw::Buffer AbstractState::getDpBuffer() {
     for (FwSizeType i = 0; i <= dataSize; i++) {
         dataPtr[i] = static_cast<U8>(STest::Pick::any());
     }
-    // Update the data hash
-    container.updateDataHash();
     // Return the buffer
     return buffer;
 }

--- a/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
+++ b/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
@@ -69,6 +69,10 @@ void TestState ::action__BufferSendIn__OK() {
     // Check file write
     ASSERT_EQ(buffer.getSize(), fileData.pointer);
     ASSERT_EQ(0, ::memcmp(buffer.getData(), fileData.writeResult, buffer.getSize()));
+    // Check data checksum is valid for the container buffer
+    Utils::HashBuffer storedHash;
+    Utils::HashBuffer computedHash;
+    ASSERT_EQ(Fw::Success::SUCCESS, container.checkDataHash(storedHash, computedHash));
     // Update m_NumBytesWritten
     this->abstractState.m_NumBytesWritten.value += buffer.getSize();
     // Update m_NumSuccessfulWrites

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Flask-Compress==1.15
 Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.3
 fprime-fpl-write-pic==1.0.3
-fprime-fpp==3.1.0
+fprime-fpp==3.1.1a1
 fprime-gds==4.1.0
 fprime-tools==4.1.0
 fprime-visual==1.0.2


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4092  |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| Y |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

Linked with FPP PR https://github.com/nasa/fpp/pull/900

Moves the calculation of the data checksum into DpWriter and after and post processing behaviors occur

## Rationale

Moves expensive CRC calculations out of potentially realtime component contexts and into the non-realtime DpWriter context.

Calculates the CRC after post-processing on the file Buffer object, so the CRC on disk should match the file contents. This was not the case with the previous implementation

## Testing/Review Recommendations

- Updated existing DpWriter unit tests to assume the incoming buffer does not have a checksum
- Added a check that the data product written by DpWriter has a valid data checksum
- Generated a data product with the Ref DpDemo component and validated the checksum

- No testing with processed data products was performed

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
