### PR TITLE
Suppress duplicate library warning on macos

### DIFF
--- a/cmake/platform/Darwin.cmake
+++ b/cmake/platform/Darwin.cmake
@@ -24,3 +24,4 @@ register_fprime_config(
    BASE_CONFIG
 )
 target_compile_definitions(PlatformDarwin INTERFACE -DTGT_OS_TYPE_DARWIN)
+target_link_options(PlatformDarwin INTERFACE -Wl,-no_warn_duplicate_libraries)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Added `-no_warn_duplicate_libraries` to Darwin link options to suppress linker spam about duplicate libraries.

## Rationale

After a macOS update in the past couple of months, I've started getting linker spam about duplicate libraries when compiling the upstream fprime repo:
```
ld: warning: ignoring duplicate libraries: 'lib/Darwin/libFw_Cmd.a', 'lib/Darwin/libFw_Com.a', 'lib/Darwin/libFw_CompQueued.a', 'lib/Darwin/libFw_Fpy.a', 'lib/Darwin/libFw_Log.a', 'lib/Darwin/libFw_Prm.a', 'lib/Darwin/libFw_Tlm.a', 'lib/Darwin/libOs.a', 'lib/Darwin/libSvc_FpySequencer.a', 'lib/Darwin/libSvc_Ping.a', 'lib/Darwin/libSvc_Sched.a', 'lib/Darwin/libSvc_Seq.a', 'lib/Darwin/libdefault_config.a'
```

## Testing/Review Recommendations

Ensure compilation still works on your macOS setups

## Future Work

Potentially there is value in reducing the actual duplicate linked libraries; however,  from what I can tell, the linux standard is to ignore passing the same lib twice so not a huge deal.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

OpenAI Codex runing gpt-5.2-codex was used to diagnose and apply the linker option change to cmake