### PR TITLE
Fix static analysis issues in Serializable.cpp

### DIFF
--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -287,7 +287,7 @@ SerializeStatus LinearBufferBase::serializeFrom(const LinearBufferBase& val, End
 
 SerializeStatus LinearBufferBase::serializeSize(const FwSizeType size, Endianness mode) {
     SerializeStatus status = FW_SERIALIZE_OK;
-    if (size > std::numeric_limits<FwSizeStoreType>::max()) {
+    if ((size < std::numeric_limits<FwSizeStoreType>::min()) || (size > std::numeric_limits<FwSizeStoreType>::max())) {
         status = FW_SERIALIZE_FORMAT_ERROR;
     }
     if (status == FW_SERIALIZE_OK) {

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -247,6 +247,10 @@ SerializeStatus LinearBufferBase::serializeFrom(const U8* buff,
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
 
+    if (length > 0) {
+        FW_ASSERT(buff);
+    }
+    FW_ASSERT(this->getBuffAddr());
     // copy buffer to our buffer
     (void)memcpy(&this->getBuffAddr()[this->m_serLoc], buff, static_cast<size_t>(length));
     this->m_serLoc += static_cast<Serializable::SizeType>(length);
@@ -537,7 +541,10 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
         if ((storedLength > this->getDeserializeSizeLeft()) or (storedLength > length)) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
-
+        
+        if (storedLength > 0) {
+            FW_ASSERT(buff);
+        }
         (void)memcpy(buff, &this->getBuffAddr()[this->m_deserLoc], static_cast<size_t>(storedLength));
 
         length = static_cast<FwSizeType>(storedLength);
@@ -548,6 +555,9 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
 
+        if (length > 0) {
+            FW_ASSERT(buff);
+        }
         (void)memcpy(buff, &this->getBuffAddr()[this->m_deserLoc], static_cast<size_t>(length));
     }
 
@@ -725,11 +735,13 @@ SerializeStatus LinearBufferBase::copyRawOffset(SerialBufferBase& dest, Serializ
 // return address of buffer not yet deserialized. This is used
 // to copy the remainder of a buffer.
 const U8* LinearBufferBase::getBuffAddrLeft() const {
+    FW_ASSERT(this->getBuffAddr());
     return &this->getBuffAddr()[this->m_deserLoc];
 }
 
 //!< gets address of end of serialization. Used to manually place data at the end
 U8* LinearBufferBase::getBuffAddrSer() {
+    FW_ASSERT(this->getBuffAddr());
     return &this->getBuffAddr()[this->m_serLoc];
 }
 

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -541,7 +541,7 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
         if ((storedLength > this->getDeserializeSizeLeft()) or (storedLength > length)) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
-        
+
         if (storedLength > 0) {
             FW_ASSERT(buff);
         }

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -283,7 +283,7 @@ SerializeStatus LinearBufferBase::serializeFrom(const LinearBufferBase& val, End
 
 SerializeStatus LinearBufferBase::serializeSize(const FwSizeType size, Endianness mode) {
     SerializeStatus status = FW_SERIALIZE_OK;
-    if ((size < std::numeric_limits<FwSizeStoreType>::min()) || (size > std::numeric_limits<FwSizeStoreType>::max())) {
+    if (size > std::numeric_limits<FwSizeStoreType>::max()) {
         status = FW_SERIALIZE_FORMAT_ERROR;
     }
     if (status == FW_SERIALIZE_OK) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [Serializable.cpp multiple static analysis findings](https://github.com/nasa/fprime/issues/4527) |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

- Fixed SonarQube finding: `<High> Line 281: cpp:S1768 result of comparison of unsigned expression < 0 is always false`
  - Removed `(size < std::numeric_limits<FwSizeStoreType>::min())` from the range check, keeping the upper-bound validation.
- Addressed several `Unchecked Parameter Dereference` findings by adding explicit assertions before dereferencing pointers, e.g.:
    - `if (length > 0) { FW_ASSERT(buff); }`
    - `FW_ASSERT(this->getBuffAddr());`
   
 The remaining High-severity findings were reviewed but did not appear to represent actual issues.

## Rationale

 - Both types are unsigned, so `min()` is 0 and `size < min()` is always false. The redundant check was removed, the upper-bound check remains.
- Assertions were added to prevent writing to a NULL buffer and to ensure the source buffer is non-null when writing more than zero bytes.

## Future Work

Review and address remaining Medium and Low severity findings.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

ChatGPT was used to help identify the source of the static analysis findings.
