### PR TITLE
Add dict specifier to FpySequencer consts

### DIFF
--- a/default/config/FpySequencerCfg.fpp
+++ b/default/config/FpySequencerCfg.fpp
@@ -1,12 +1,12 @@
 module Svc {
     module Fpy {
         @ The maximum number of arguments a sequence can have
-        constant MAX_SEQUENCE_ARG_COUNT = 16
+        dictionary constant MAX_SEQUENCE_ARG_COUNT = 16
         @ The maximum number of statements a sequence can have
-        constant MAX_SEQUENCE_STATEMENT_COUNT = 1024
+        dictionary constant MAX_SEQUENCE_STATEMENT_COUNT = 2048
         @ the maximum number of bytes in a stack
-        constant MAX_STACK_SIZE = 65535
+        dictionary constant MAX_STACK_SIZE = 65535
         @ the maximum number of bytes in a directive
-        constant MAX_DIRECTIVE_SIZE = 2048
+        dictionary constant MAX_DIRECTIVE_SIZE = 2048
     }
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#4637 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

* Add dict specifier to all FpySequencer config consts

## Rationale

Allows fpyc to read these in without having to pass in via cmd line
