### PR TITLE
Correct isConnected check in FpySequencer for seqStartOut

### DIFF
--- a/Svc/FpySequencer/FpySequencerStateMachine.cpp
+++ b/Svc/FpySequencer/FpySequencerStateMachine.cpp
@@ -344,7 +344,7 @@ void FpySequencer::Svc_FpySequencer_SequencerStateMachine_action_report_seqStart
     SmId smId,                                             //!< The state machine id
     Svc_FpySequencer_SequencerStateMachine::Signal signal  //!< The signal
 ) {
-    if (this->isConnected_seqDoneOut_OutputPort(0)) {
+    if (this->isConnected_seqStartOut_OutputPort(0)) {
         // report that the sequence started to internal callers
         this->seqStartOut_out(0, this->m_sequenceFilePath);
     }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Correct a isConnected check to ensure it matches the port call we are guarding

## Rationale

FSW will assert if port is unconnected otherwise

## Testing/Review Recommendations

Check if anything else in FpySequencer has a mismatch

## Future Work

Can we get a func that checks then invokes if the port is connected?

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A