### PR TITLE
Implement Os::Queue::setRegistry

### DIFF
--- a/Os/Queue.cpp
+++ b/Os/Queue.cpp
@@ -146,4 +146,11 @@ Os::Mutex& Queue::getStaticMutex() {
     return s_mutex;
 }
 
+#if FW_QUEUE_REGISTRATION
+void Queue::setRegistry(QueueRegistry* registry) {
+    ScopeLock lock(Queue::getStaticMutex());
+    Queue::s_queueRegistry = registry;
+}
+#endif
+
 }  // namespace Os

--- a/Os/test/ut/queue/CommonTests.cpp
+++ b/Os/test/ut/queue/CommonTests.cpp
@@ -19,6 +19,10 @@ U64 Tester::QueueMessage::order_counter = 0;
 
 PriorityCompare const Tester::QueueMessageComparer::HELPER = PriorityCompare();
 
+Tester::Tester() {
+    Os::Queue::setRegistry(this);
+}
+
 Os::QueueInterface::Status Tester::shadow_create(FwSizeType depth, FwSizeType messageSize) {
     Os::QueueInterface::Status status = Os::QueueInterface::ALREADY_CREATED;
     if (not this->shadow.created) {
@@ -108,6 +112,10 @@ void Tester::shadow_receive_unblock() {
     this->shadow.receive_block.destination = nullptr;
     this->shadow.receive_block.size = nullptr;
     this->shadow.receive_block.priority = nullptr;
+}
+
+void Tester::registerQueue(Os::Queue* q) {
+    this->m_all_queues.push_back(q);
 }
 
 }  // namespace Queue
@@ -229,6 +237,7 @@ TEST(BasicRules, Create) {
     create_rule.action(tester);
     // Repetitive create
     create_rule.action(tester);
+    EXPECT_GT(tester.m_all_queues.size(), 0) << "No queues were registered.";
 }
 
 TEST(BasicRules, Send) {

--- a/Os/test/ut/queue/CommonTests.cpp
+++ b/Os/test/ut/queue/CommonTests.cpp
@@ -20,7 +20,9 @@ U64 Tester::QueueMessage::order_counter = 0;
 PriorityCompare const Tester::QueueMessageComparer::HELPER = PriorityCompare();
 
 Tester::Tester() {
+#if FW_QUEUE_REGISTRATION
     Os::Queue::setRegistry(this);
+#endif
 }
 
 Os::QueueInterface::Status Tester::shadow_create(FwSizeType depth, FwSizeType messageSize) {
@@ -237,7 +239,9 @@ TEST(BasicRules, Create) {
     create_rule.action(tester);
     // Repetitive create
     create_rule.action(tester);
-    EXPECT_GT(tester.m_all_queues.size(), 0) << "No queues were registered.";
+#if FW_QUEUE_REGISTRATION
+ EXPECT_GT(tester.m_all_queues.size(), 0) << "No queues were registered.";
+#endif
 }
 
 TEST(BasicRules, Send) {

--- a/Os/test/ut/queue/CommonTests.cpp
+++ b/Os/test/ut/queue/CommonTests.cpp
@@ -240,7 +240,7 @@ TEST(BasicRules, Create) {
     // Repetitive create
     create_rule.action(tester);
 #if FW_QUEUE_REGISTRATION
- EXPECT_GT(tester.m_all_queues.size(), 0) << "No queues were registered.";
+    EXPECT_GT(tester.m_all_queues.size(), 0) << "No queues were registered.";
 #endif
 }
 

--- a/Os/test/ut/queue/RulesHeaders.hpp
+++ b/Os/test/ut/queue/RulesHeaders.hpp
@@ -120,7 +120,6 @@ struct Tester : public Os::QueueRegistry {
     //! Complete a previous blocking queue receive
     void shadow_receive_unblock();
 
-
     //! Register a queue with the registry
     void registerQueue(Os::Queue* q) override;
 

--- a/Os/test/ut/queue/RulesHeaders.hpp
+++ b/Os/test/ut/queue/RulesHeaders.hpp
@@ -23,10 +23,10 @@ namespace Queue {
 
 constexpr FwSizeType DEPTH_BOUND = 100000;
 
-struct Tester {
+struct Tester : public Os::QueueRegistry {
   public:
     //! Constructor
-    Tester() = default;
+    Tester();
     virtual ~Tester() { queue.teardown(); };
 
     struct QueueMessage {
@@ -72,6 +72,7 @@ struct Tester {
     };
     QueueState shadow;
     Os::Queue queue;
+    std::vector<Os::Queue*> m_all_queues;
 
     //! Shadow is created
     bool is_shadow_created() const {
@@ -118,6 +119,10 @@ struct Tester {
                                               FwQueuePriorityType& priority);
     //! Complete a previous blocking queue receive
     void shadow_receive_unblock();
+
+
+    //! Register a queue with the registry
+    void registerQueue(Os::Queue* q) override;
 
   public:
 #include "QueueRules.hpp"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/4646 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Adds an implementation for `Os::Queue::setRegistry` and tests this using the Queue Tester.

## Rationale

This method was previously unimplemented, leading to linker errors if used.

## Testing/Review Recommendations

1. Add basic QueueRegistry implementation
2. Attempt to register it without the fix and note the linker error
3. Attempt to register it after the fix and note the absence of the linker error

## Future Work

N/A, this should cover it.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

No AI was used in the discovery, fix, or testing of this bug.
