### PR TITLE
Fix PolyType Static Analysis Issues

### DIFF
--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -340,7 +340,7 @@ PolyType::PolyType(const PolyType& original) : Fw::Serializable() {
     this->m_val = original.m_val;
 }
 
-PolyType::~PolyType() {}
+PolyType::~PolyType() = default
 
 PolyType& PolyType::operator=(const PolyType& src) {
     this->m_dataType = src.m_dataType;

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -336,10 +336,7 @@ PolyType& PolyType::operator=(void* other) {
 }
 
 PolyType::PolyType(const PolyType& original)
-    : Fw::Serializable(),
-      m_dataType(original.m_dataType),
-      m_val(original.m_val)
-{}
+    : Fw::Serializable(), m_dataType(original.m_dataType), m_val(original.m_val) {}
 
 PolyType::~PolyType() = default;
 

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -21,7 +21,6 @@ PolyType::operator U8() const {
 }
 
 void PolyType::get(U8& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_U8 == this->m_dataType);
     val = this->m_val.u8Val;
 }
@@ -49,7 +48,6 @@ PolyType::operator I8() const {
 }
 
 void PolyType::get(I8& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_I8 == this->m_dataType);
     val = this->m_val.i8Val;
 }
@@ -79,7 +77,6 @@ PolyType::operator U16() const {
 }
 
 void PolyType::get(U16& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_U16 == this->m_dataType);
     val = this->m_val.u16Val;
 }
@@ -107,7 +104,6 @@ PolyType::operator I16() const {
 }
 
 void PolyType::get(I16& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_I16 == this->m_dataType);
     val = this->m_val.i16Val;
 }
@@ -139,7 +135,6 @@ PolyType::operator U32() const {
 }
 
 void PolyType::get(U32& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_U32 == this->m_dataType);
     val = this->m_val.u32Val;
 }
@@ -167,7 +162,6 @@ PolyType::operator I32() const {
 }
 
 void PolyType::get(I32& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_I32 == this->m_dataType);
     val = this->m_val.i32Val;
 }
@@ -198,7 +192,6 @@ PolyType::operator U64() const {
 }
 
 void PolyType::get(U64& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_U64 == this->m_dataType);
     val = this->m_val.u64Val;
 }
@@ -226,7 +219,6 @@ PolyType::operator I64() const {
 }
 
 void PolyType::get(I64& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_I64 == this->m_dataType);
     val = this->m_val.i64Val;
 }
@@ -254,7 +246,6 @@ PolyType::operator F64() const {
 }
 
 void PolyType::get(F64& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_F64 == this->m_dataType);
     val = this->m_val.f64Val;
 }
@@ -280,7 +271,6 @@ PolyType::operator F32() const {
 }
 
 void PolyType::get(F32& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_F32 == this->m_dataType);
     val = this->m_val.f32Val;
 }
@@ -306,7 +296,6 @@ PolyType::operator bool() const {
 }
 
 void PolyType::get(bool& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_BOOL == this->m_dataType);
     val = this->m_val.boolVal;
 }
@@ -332,7 +321,6 @@ PolyType::operator void*() const {
 }
 
 void PolyType::get(void*& val) const {
-    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_PTR == this->m_dataType);
     val = this->m_val.ptrVal;
 }
@@ -602,7 +590,6 @@ SerializeStatus PolyType::deserializeFrom(SerialBufferBase& buffer, Fw::Endianne
 #if FW_SERIALIZABLE_TO_STRING || BUILD_UT
 
 void PolyType::toString(StringBase& dest) const {
-    FW_ASSERT(this != nullptr);
     this->toString(dest, false);
 }
 

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -21,6 +21,7 @@ PolyType::operator U8() const {
 }
 
 void PolyType::get(U8& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_U8 == this->m_dataType);
     val = this->m_val.u8Val;
 }
@@ -48,6 +49,7 @@ PolyType::operator I8() const {
 }
 
 void PolyType::get(I8& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_I8 == this->m_dataType);
     val = this->m_val.i8Val;
 }
@@ -77,6 +79,7 @@ PolyType::operator U16() const {
 }
 
 void PolyType::get(U16& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_U16 == this->m_dataType);
     val = this->m_val.u16Val;
 }
@@ -104,6 +107,7 @@ PolyType::operator I16() const {
 }
 
 void PolyType::get(I16& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_I16 == this->m_dataType);
     val = this->m_val.i16Val;
 }
@@ -135,6 +139,7 @@ PolyType::operator U32() const {
 }
 
 void PolyType::get(U32& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_U32 == this->m_dataType);
     val = this->m_val.u32Val;
 }
@@ -162,6 +167,7 @@ PolyType::operator I32() const {
 }
 
 void PolyType::get(I32& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_I32 == this->m_dataType);
     val = this->m_val.i32Val;
 }
@@ -192,6 +198,7 @@ PolyType::operator U64() const {
 }
 
 void PolyType::get(U64& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_U64 == this->m_dataType);
     val = this->m_val.u64Val;
 }
@@ -219,6 +226,7 @@ PolyType::operator I64() const {
 }
 
 void PolyType::get(I64& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_I64 == this->m_dataType);
     val = this->m_val.i64Val;
 }
@@ -246,6 +254,7 @@ PolyType::operator F64() const {
 }
 
 void PolyType::get(F64& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_F64 == this->m_dataType);
     val = this->m_val.f64Val;
 }
@@ -271,6 +280,7 @@ PolyType::operator F32() const {
 }
 
 void PolyType::get(F32& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_F32 == this->m_dataType);
     val = this->m_val.f32Val;
 }
@@ -296,6 +306,7 @@ PolyType::operator bool() const {
 }
 
 void PolyType::get(bool& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_BOOL == this->m_dataType);
     val = this->m_val.boolVal;
 }
@@ -321,6 +332,7 @@ PolyType::operator void*() const {
 }
 
 void PolyType::get(void*& val) const {
+    FW_ASSERT(this != nullptr);
     FW_ASSERT(TYPE_PTR == this->m_dataType);
     val = this->m_val.ptrVal;
 }
@@ -590,6 +602,7 @@ SerializeStatus PolyType::deserializeFrom(SerialBufferBase& buffer, Fw::Endianne
 #if FW_SERIALIZABLE_TO_STRING || BUILD_UT
 
 void PolyType::toString(StringBase& dest) const {
+    FW_ASSERT(this != nullptr);
     this->toString(dest, false);
 }
 

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -144,7 +144,7 @@ void PolyType::get(U32& val) const {
     val = this->m_val.u32Val;
 }
 
-bool PolyType::isU32() {
+bool PolyType::isU32() const {
     return (TYPE_U32 == this->m_dataType);
 }
 
@@ -353,7 +353,7 @@ PolyType::PolyType(const PolyType& original)
       m_val(original.m_val)
 {}
 
-PolyType::~PolyType() = default
+PolyType::~PolyType() = default;
 
 PolyType& PolyType::operator=(const PolyType& src) {
     this->m_dataType = src.m_dataType;

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -15,17 +15,17 @@ PolyType::PolyType(U8 val) {
     this->m_val.u8Val = val;
 }
 
-PolyType::operator U8() {
+PolyType::operator U8() const {
     FW_ASSERT(TYPE_U8 == this->m_dataType);
     return this->m_val.u8Val;
 }
 
-void PolyType::get(U8& val) {
+void PolyType::get(U8& val) const {
     FW_ASSERT(TYPE_U8 == this->m_dataType);
     val = this->m_val.u8Val;
 }
 
-bool PolyType::isU8() {
+bool PolyType::isU8() const {
     return (TYPE_U8 == this->m_dataType);
 }
 
@@ -42,17 +42,17 @@ PolyType::PolyType(I8 val) {
     this->m_val.i8Val = val;
 }
 
-PolyType::operator I8() {
+PolyType::operator I8() const {
     FW_ASSERT(TYPE_I8 == this->m_dataType);
     return this->m_val.i8Val;
 }
 
-void PolyType::get(I8& val) {
+void PolyType::get(I8& val) const {
     FW_ASSERT(TYPE_I8 == this->m_dataType);
     val = this->m_val.i8Val;
 }
 
-bool PolyType::isI8() {
+bool PolyType::isI8() const {
     return (TYPE_I8 == this->m_dataType);
 }
 
@@ -71,17 +71,17 @@ PolyType::PolyType(U16 val) {
     this->m_val.u16Val = val;
 }
 
-PolyType::operator U16() {
+PolyType::operator U16() const {
     FW_ASSERT(TYPE_U16 == this->m_dataType);
     return this->m_val.u16Val;
 }
 
-void PolyType::get(U16& val) {
+void PolyType::get(U16& val) const {
     FW_ASSERT(TYPE_U16 == this->m_dataType);
     val = this->m_val.u16Val;
 }
 
-bool PolyType::isU16() {
+bool PolyType::isU16() const {
     return (TYPE_U16 == this->m_dataType);
 }
 
@@ -98,17 +98,17 @@ PolyType::PolyType(I16 val) {
     this->m_val.i16Val = val;
 }
 
-PolyType::operator I16() {
+PolyType::operator I16() const {
     FW_ASSERT(TYPE_I16 == this->m_dataType);
     return this->m_val.i16Val;
 }
 
-void PolyType::get(I16& val) {
+void PolyType::get(I16& val) const {
     FW_ASSERT(TYPE_I16 == this->m_dataType);
     val = this->m_val.i16Val;
 }
 
-bool PolyType::isI16() {
+bool PolyType::isI16() const {
     return (TYPE_I16 == this->m_dataType);
 }
 
@@ -129,12 +129,12 @@ PolyType::PolyType(U32 val) {
     this->m_val.u32Val = val;
 }
 
-PolyType::operator U32() {
+PolyType::operator U32() const {
     FW_ASSERT(TYPE_U32 == this->m_dataType);
     return this->m_val.u32Val;
 }
 
-void PolyType::get(U32& val) {
+void PolyType::get(U32& val) const {
     FW_ASSERT(TYPE_U32 == this->m_dataType);
     val = this->m_val.u32Val;
 }
@@ -156,17 +156,17 @@ PolyType::PolyType(I32 val) {
     this->m_val.i32Val = val;
 }
 
-PolyType::operator I32() {
+PolyType::operator I32() const {
     FW_ASSERT(TYPE_I32 == this->m_dataType);
     return this->m_val.i32Val;
 }
 
-void PolyType::get(I32& val) {
+void PolyType::get(I32& val) const {
     FW_ASSERT(TYPE_I32 == this->m_dataType);
     val = this->m_val.i32Val;
 }
 
-bool PolyType::isI32() {
+bool PolyType::isI32() const {
     return (TYPE_I32 == this->m_dataType);
 }
 
@@ -186,17 +186,17 @@ PolyType::PolyType(U64 val) {
     this->m_val.u64Val = val;
 }
 
-PolyType::operator U64() {
+PolyType::operator U64() const {
     FW_ASSERT(TYPE_U64 == this->m_dataType);
     return this->m_val.u64Val;
 }
 
-void PolyType::get(U64& val) {
+void PolyType::get(U64& val) const {
     FW_ASSERT(TYPE_U64 == this->m_dataType);
     val = this->m_val.u64Val;
 }
 
-bool PolyType::isU64() {
+bool PolyType::isU64() const {
     return (TYPE_U64 == this->m_dataType);
 }
 
@@ -213,17 +213,17 @@ PolyType::PolyType(I64 val) {
     this->m_val.i64Val = val;
 }
 
-PolyType::operator I64() {
+PolyType::operator I64() const {
     FW_ASSERT(TYPE_I64 == this->m_dataType);
     return this->m_val.i64Val;
 }
 
-void PolyType::get(I64& val) {
+void PolyType::get(I64& val) const {
     FW_ASSERT(TYPE_I64 == this->m_dataType);
     val = this->m_val.i64Val;
 }
 
-bool PolyType::isI64() {
+bool PolyType::isI64() const {
     return (TYPE_I64 == this->m_dataType);
 }
 
@@ -240,17 +240,17 @@ PolyType::PolyType(F64 val) {
     this->m_val.f64Val = val;
 }
 
-PolyType::operator F64() {
+PolyType::operator F64() const {
     FW_ASSERT(TYPE_F64 == this->m_dataType);
     return this->m_val.f64Val;
 }
 
-void PolyType::get(F64& val) {
+void PolyType::get(F64& val) const {
     FW_ASSERT(TYPE_F64 == this->m_dataType);
     val = this->m_val.f64Val;
 }
 
-bool PolyType::isF64() {
+bool PolyType::isF64() const {
     return (TYPE_F64 == this->m_dataType);
 }
 
@@ -265,17 +265,17 @@ PolyType::PolyType(F32 val) {
     this->m_val.f32Val = val;
 }
 
-PolyType::operator F32() {
+PolyType::operator F32() const {
     FW_ASSERT(TYPE_F32 == this->m_dataType);
     return this->m_val.f32Val;
 }
 
-void PolyType::get(F32& val) {
+void PolyType::get(F32& val) const {
     FW_ASSERT(TYPE_F32 == this->m_dataType);
     val = this->m_val.f32Val;
 }
 
-bool PolyType::isF32() {
+bool PolyType::isF32() const {
     return (TYPE_F32 == this->m_dataType);
 }
 
@@ -290,17 +290,17 @@ PolyType::PolyType(bool val) {
     this->m_val.boolVal = val;
 }
 
-PolyType::operator bool() {
+PolyType::operator bool() const {
     FW_ASSERT(TYPE_BOOL == this->m_dataType);
     return this->m_val.boolVal;
 }
 
-void PolyType::get(bool& val) {
+void PolyType::get(bool& val) const {
     FW_ASSERT(TYPE_BOOL == this->m_dataType);
     val = this->m_val.boolVal;
 }
 
-bool PolyType::isBool() {
+bool PolyType::isBool() const {
     return (TYPE_BOOL == this->m_dataType);
 }
 
@@ -315,17 +315,17 @@ PolyType::PolyType(void* val) {
     this->m_val.ptrVal = val;
 }
 
-PolyType::operator void*() {
+PolyType::operator void*() const {
     FW_ASSERT(TYPE_PTR == this->m_dataType);
     return this->m_val.ptrVal;
 }
 
-void PolyType::get(void*& val) {
+void PolyType::get(void*& val) const {
     FW_ASSERT(TYPE_PTR == this->m_dataType);
     val = this->m_val.ptrVal;
 }
 
-bool PolyType::isPtr() {
+bool PolyType::isPtr() const {
     return (TYPE_PTR == this->m_dataType);
 }
 

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -646,7 +646,7 @@ void PolyType::toString(StringBase& dest, bool append) const {
     if (append) {
         dest += external;
     } else {
-        dest = external;
+        dest = static_cast<const StringBase&>(external);
     }
 }
 

--- a/Fw/Types/PolyType.cpp
+++ b/Fw/Types/PolyType.cpp
@@ -335,10 +335,11 @@ PolyType& PolyType::operator=(void* other) {
     return *this;
 }
 
-PolyType::PolyType(const PolyType& original) : Fw::Serializable() {
-    this->m_dataType = original.m_dataType;
-    this->m_val = original.m_val;
-}
+PolyType::PolyType(const PolyType& original)
+    : Fw::Serializable(),
+      m_dataType(original.m_dataType),
+      m_val(original.m_val)
+{}
 
 PolyType::~PolyType() = default
 

--- a/Fw/Types/PolyType.hpp
+++ b/Fw/Types/PolyType.hpp
@@ -11,79 +11,79 @@ namespace Fw {
 class PolyType : public Serializable {
   public:
     PolyType(U8 val);             //!< U8 constructor
-    operator U8();                //!< U8 cast operator
-    void get(U8& val);            //!< U8 accessor
-    bool isU8();                  //!< U8 checker
+    operator U8() const;                //!< U8 cast operator
+    void get(U8& val) const;            //!< U8 accessor
+    bool isU8() const;                  //!< U8 checker
     PolyType& operator=(U8 val);  //!< U8 operator=
 
     PolyType(I8 val);             //!< I8 constructor
-    operator I8();                //!< I8 cast operator
-    void get(I8& val);            //!< I8 accessor
-    bool isI8();                  //!< I8 checker
+    operator I8() const;                //!< I8 cast operator
+    void get(I8& val) const;            //!< I8 accessor
+    bool isI8() const;                  //!< I8 checker
     PolyType& operator=(I8 val);  //!< I8 operator=
 
 #if FW_HAS_16_BIT
     PolyType(U16 val);             //!< U16 constructor
-    operator U16();                //!< U16 cast operator
-    void get(U16& val);            //!< U16 accessor
-    bool isU16();                  //!< U16 checker
+    operator U16() const;                //!< U16 cast operator
+    void get(U16& val) const;            //!< U16 accessor
+    bool isU16() const;                  //!< U16 checker
     PolyType& operator=(U16 val);  //!< I8 operator=
 
     PolyType(I16 val);             //!< I16 constructor
-    operator I16();                //!< I16 cast operator
-    void get(I16& val);            //!< I16 accessor
-    bool isI16();                  //!< I16 checker
+    operator I16() const;                //!< I16 cast operator
+    void get(I16& val) const;            //!< I16 accessor
+    bool isI16() const;                  //!< I16 checker
     PolyType& operator=(I16 val);  //!< I16 operator=
 #endif
 #if FW_HAS_32_BIT
     PolyType(U32 val);             //!< U32 constructor
-    operator U32();                //!< U32 cast operator
-    void get(U32& val);            //!< U32 accessor
-    bool isU32();                  //!< U32 checker
+    operator U32() const;                //!< U32 cast operator
+    void get(U32& val) const;            //!< U32 accessor
+    bool isU32() const;                  //!< U32 checker
     PolyType& operator=(U32 val);  //!< U32 operator=
 
     PolyType(I32 val);             //!< I32 constructor
-    operator I32();                //!< I32 cast operator
-    void get(I32& val);            //!< I32 accessor
-    bool isI32();                  //!< I32 checker
+    operator I32() const;                //!< I32 cast operator
+    void get(I32& val) const;            //!< I32 accessor
+    bool isI32() const;                  //!< I32 checker
     PolyType& operator=(I32 val);  //!< I32 operator=
 #endif
 #if FW_HAS_64_BIT
     PolyType(U64 val);             //!< U64 constructor
-    operator U64();                //!< U64 cast operator
-    void get(U64& val);            //!< U64 accessor
-    bool isU64();                  //!< U64 checker
+    operator U64() const;                //!< U64 cast operator
+    void get(U64& val) const;            //!< U64 accessor
+    bool isU64() const;                  //!< U64 checker
     PolyType& operator=(U64 val);  //!< U64 operator=
 
     PolyType(I64 val);             //!< I64 constructor
-    operator I64();                //!< I64 cast operator
-    void get(I64& val);            //!< I64 accessor
-    bool isI64();                  //!< I64 checker
+    operator I64() const;                //!< I64 cast operator
+    void get(I64& val) const;            //!< I64 accessor
+    bool isI64() const;                  //!< I64 checker
     PolyType& operator=(I64 val);  //!< I64 operator=
 #endif
 
     PolyType(F64 val);             //!< F64 constructor
-    operator F64();                //!< F64 cast operator
-    void get(F64& val);            //!< F64 accessor
-    bool isF64();                  //!< F64 checker
+    operator F64() const;                //!< F64 cast operator
+    void get(F64& val) const;            //!< F64 accessor
+    bool isF64() const;                  //!< F64 checker
     PolyType& operator=(F64 val);  //!< F64 operator=
 
     PolyType(F32 val);             //!< F32 constructor
-    operator F32();                //!< F32 cast operator
-    void get(F32& val);            //!< F32 accessor
-    bool isF32();                  //!< F32 checker
+    operator F32() const;                //!< F32 cast operator
+    void get(F32& val) const;            //!< F32 accessor
+    bool isF32() const;                  //!< F32 checker
     PolyType& operator=(F32 val);  //!< F32 operator=
 
     PolyType(bool val);             //!< bool constructor
-    operator bool();                //!< bool cast operator
-    void get(bool& val);            //!< bool accessor
-    bool isBool();                  //!< bool checker
+    operator bool() const;                //!< bool cast operator
+    void get(bool& val) const;            //!< bool accessor
+    bool isBool() const;                  //!< bool checker
     PolyType& operator=(bool val);  //!< bool operator=
 
     PolyType(void* val);             //!< void* constructor.
-    operator void*();                //!< void* cast operator
-    void get(void*& val);            //!< void* accessor
-    bool isPtr();                    //!< void* checker
+    operator void*() const;                //!< void* cast operator
+    void get(void*& val) const;            //!< void* accessor
+    bool isPtr() const;                    //!< void* checker
     PolyType& operator=(void* val);  //!< void* operator=
 
     PolyType();                          //!< default constructor

--- a/Fw/Types/PolyType.hpp
+++ b/Fw/Types/PolyType.hpp
@@ -11,79 +11,79 @@ namespace Fw {
 class PolyType : public Serializable {
   public:
     PolyType(U8 val);             //!< U8 constructor
-    operator U8() const;                //!< U8 cast operator
-    void get(U8& val) const;            //!< U8 accessor
-    bool isU8() const;                  //!< U8 checker
+    operator U8() const;          //!< U8 cast operator
+    void get(U8& val) const;      //!< U8 accessor
+    bool isU8() const;            //!< U8 checker
     PolyType& operator=(U8 val);  //!< U8 operator=
 
     PolyType(I8 val);             //!< I8 constructor
-    operator I8() const;                //!< I8 cast operator
-    void get(I8& val) const;            //!< I8 accessor
-    bool isI8() const;                  //!< I8 checker
+    operator I8() const;          //!< I8 cast operator
+    void get(I8& val) const;      //!< I8 accessor
+    bool isI8() const;            //!< I8 checker
     PolyType& operator=(I8 val);  //!< I8 operator=
 
 #if FW_HAS_16_BIT
     PolyType(U16 val);             //!< U16 constructor
-    operator U16() const;                //!< U16 cast operator
-    void get(U16& val) const;            //!< U16 accessor
-    bool isU16() const;                  //!< U16 checker
+    operator U16() const;          //!< U16 cast operator
+    void get(U16& val) const;      //!< U16 accessor
+    bool isU16() const;            //!< U16 checker
     PolyType& operator=(U16 val);  //!< I8 operator=
 
     PolyType(I16 val);             //!< I16 constructor
-    operator I16() const;                //!< I16 cast operator
-    void get(I16& val) const;            //!< I16 accessor
-    bool isI16() const;                  //!< I16 checker
+    operator I16() const;          //!< I16 cast operator
+    void get(I16& val) const;      //!< I16 accessor
+    bool isI16() const;            //!< I16 checker
     PolyType& operator=(I16 val);  //!< I16 operator=
 #endif
 #if FW_HAS_32_BIT
     PolyType(U32 val);             //!< U32 constructor
-    operator U32() const;                //!< U32 cast operator
-    void get(U32& val) const;            //!< U32 accessor
-    bool isU32() const;                  //!< U32 checker
+    operator U32() const;          //!< U32 cast operator
+    void get(U32& val) const;      //!< U32 accessor
+    bool isU32() const;            //!< U32 checker
     PolyType& operator=(U32 val);  //!< U32 operator=
 
     PolyType(I32 val);             //!< I32 constructor
-    operator I32() const;                //!< I32 cast operator
-    void get(I32& val) const;            //!< I32 accessor
-    bool isI32() const;                  //!< I32 checker
+    operator I32() const;          //!< I32 cast operator
+    void get(I32& val) const;      //!< I32 accessor
+    bool isI32() const;            //!< I32 checker
     PolyType& operator=(I32 val);  //!< I32 operator=
 #endif
 #if FW_HAS_64_BIT
     PolyType(U64 val);             //!< U64 constructor
-    operator U64() const;                //!< U64 cast operator
-    void get(U64& val) const;            //!< U64 accessor
-    bool isU64() const;                  //!< U64 checker
+    operator U64() const;          //!< U64 cast operator
+    void get(U64& val) const;      //!< U64 accessor
+    bool isU64() const;            //!< U64 checker
     PolyType& operator=(U64 val);  //!< U64 operator=
 
     PolyType(I64 val);             //!< I64 constructor
-    operator I64() const;                //!< I64 cast operator
-    void get(I64& val) const;            //!< I64 accessor
-    bool isI64() const;                  //!< I64 checker
+    operator I64() const;          //!< I64 cast operator
+    void get(I64& val) const;      //!< I64 accessor
+    bool isI64() const;            //!< I64 checker
     PolyType& operator=(I64 val);  //!< I64 operator=
 #endif
 
     PolyType(F64 val);             //!< F64 constructor
-    operator F64() const;                //!< F64 cast operator
-    void get(F64& val) const;            //!< F64 accessor
-    bool isF64() const;                  //!< F64 checker
+    operator F64() const;          //!< F64 cast operator
+    void get(F64& val) const;      //!< F64 accessor
+    bool isF64() const;            //!< F64 checker
     PolyType& operator=(F64 val);  //!< F64 operator=
 
     PolyType(F32 val);             //!< F32 constructor
-    operator F32() const;                //!< F32 cast operator
-    void get(F32& val) const;            //!< F32 accessor
-    bool isF32() const;                  //!< F32 checker
+    operator F32() const;          //!< F32 cast operator
+    void get(F32& val) const;      //!< F32 accessor
+    bool isF32() const;            //!< F32 checker
     PolyType& operator=(F32 val);  //!< F32 operator=
 
     PolyType(bool val);             //!< bool constructor
-    operator bool() const;                //!< bool cast operator
-    void get(bool& val) const;            //!< bool accessor
-    bool isBool() const;                  //!< bool checker
+    operator bool() const;          //!< bool cast operator
+    void get(bool& val) const;      //!< bool accessor
+    bool isBool() const;            //!< bool checker
     PolyType& operator=(bool val);  //!< bool operator=
 
     PolyType(void* val);             //!< void* constructor.
-    operator void*() const;                //!< void* cast operator
-    void get(void*& val) const;            //!< void* accessor
-    bool isPtr() const;                    //!< void* checker
+    operator void*() const;          //!< void* cast operator
+    void get(void*& val) const;      //!< void* accessor
+    bool isPtr() const;              //!< void* checker
     PolyType& operator=(void* val);  //!< void* operator=
 
     PolyType();                          //!< default constructor


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
PolyType.cpp multiple static analysis findings #4523
|**_Has Unit Tests (y/n)_**|  |
n
|**_Documentation Included (y/n)_**|  |
n
|**_Generative AI was used in this contribution (y/n)_**|  |
n

---
## Change Description

Made various changes to address static analysis issues found in PolyType.cpp. Changes include
* Cast an ExternalString to StringBase& when assigning to a StringBase variable
* Added const modifiers to const-qualified member functions
* Changed destructor to use =default instead of {}
* Added FW_ASSERT statements to ensure the 'this' pointer is not null
* Moved data member assignments to an initializer list

Note:
Did not address the `Replace this use of "void *" with a more meaningful type.` or `Use "std::string" instead of a C-style char array.`  flags.

## Rationale

Most changes were directly suggested in the SonarQube or CodeSonar flags. Casting ExternalString to StringBase in assignment removes the object slicing blocker without affecting functionality.  The FW_ASSERT statements are to address the `Unchecked Parameter Dereference` flags and assume that those functions should never be called on a nullptr object.

The flags I did not address either did not make sense to change in the context of the code or would require large refactoring that seemed out of scope for this issue.

## Future Work

Could perhaps address the remaining flags in the future

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI was used for code understanding and debugging help.
