### PR TITLE
Add DpCfg PROC_TYPE_NONE

### DIFF
--- a/default/config/DpCfg.fpp
+++ b/default/config/DpCfg.fpp
@@ -13,6 +13,8 @@ module Fw {
     @ A bit mask for selecting the type of processing to perform on
     @ a container before writing it to disk.
     enum ProcType: U8 {
+      @ No processing type selected
+      PROC_TYPE_NONE = 0x00
       @ Processing type 0
       PROC_TYPE_ZERO = 0x01
       @ Processing type 1


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Fix #4650 

Adds a zero value to ProcType enum so that uninitialized values are not unrecognized by ground tools.
