### PR TITLE
Add methods to convert from Fw::Time* to Fw::Time*Value

### DIFF
--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -77,6 +77,10 @@ bool Time::operator<=(const Time& other) const {
     return ((TimeComparison::LT == c) or (TimeComparison::EQ == c));
 }
 
+TimeValue Time::asTimeValue() const {
+    return this->m_val;
+}
+
 SerializeStatus Time::serializeTo(SerialBufferBase& buffer, Fw::Endianness mode) const {
     return this->m_val.serializeTo(buffer, mode);
 }

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -49,6 +49,10 @@ class Time : public Serializable {
     bool operator<=(const Time& other) const;
     Time& operator=(const Time& other);
 
+    //! \brief get the underlying TimeValue
+    //! \return the TimeValue representation of this Time as a copy
+    TimeValue asTimeValue() const;
+
     // Static methods:
     //! The type of a comparison result
 

--- a/Fw/Time/TimeInterval.cpp
+++ b/Fw/Time/TimeInterval.cpp
@@ -53,6 +53,10 @@ bool TimeInterval::operator<=(const TimeInterval& other) const {
     return ((LT == c) or (EQ == c));
 }
 
+TimeIntervalValue TimeInterval::asTimeIntervalValue() const {
+    return this->m_val;
+}
+
 SerializeStatus TimeInterval::serializeTo(SerialBufferBase& buffer, Fw::Endianness mode) const {
     // Use TimeIntervalValue's built-in serialization
     return this->m_val.serializeTo(buffer, mode);

--- a/Fw/Time/TimeInterval.hpp
+++ b/Fw/Time/TimeInterval.hpp
@@ -43,6 +43,10 @@ class TimeInterval : public Serializable {
     bool operator<=(const TimeInterval& other) const;
     TimeInterval& operator=(const TimeInterval& other);
 
+    //! \brief get the underlying TimeIntervalValue
+    //! \return the TimeIntervalValue representation of this TimeInterval as a copy
+    TimeIntervalValue asTimeIntervalValue() const;
+
     //! The type of a comparison result
     typedef enum { LT = -1, EQ = 0, GT = 1, INCOMPARABLE = 2 } Comparison;
 

--- a/Fw/Time/test/ut/TimeIntervalTester.cpp
+++ b/Fw/Time/test/ut/TimeIntervalTester.cpp
@@ -129,4 +129,18 @@ void TimeIntervalTester::test_TimeIntervalSubtractionTest() {
     ASSERT_EQ(result4.getUSeconds(), 0);
 }
 
+void TimeIntervalTester::test_TimeIntervalToTimeIntervalValue() {
+    U32 seconds = 5;
+    U32 useconds = 500000;
+    Fw::TimeInterval time_interval(seconds, useconds);
+
+    Fw::TimeIntervalValue time_interval_value = time_interval.asTimeIntervalValue();
+
+    // Alter the original
+    time_interval.set(0, 0);
+
+    ASSERT_EQ(time_interval_value.get_seconds(), seconds);
+    ASSERT_EQ(time_interval_value.get_useconds(), useconds);
+}
+
 }  // namespace Fw

--- a/Fw/Time/test/ut/TimeIntervalTester.hpp
+++ b/Fw/Time/test/ut/TimeIntervalTester.hpp
@@ -21,6 +21,7 @@ class TimeIntervalTester {
     void test_TimeIntervalCompareStaticTest();
     void test_TimeIntervalAdditionTest();
     void test_TimeIntervalSubtractionTest();
+    void test_TimeIntervalToTimeIntervalValue();
 };
 }  // namespace Fw
 

--- a/Fw/Time/test/ut/TimeTestMain.cpp
+++ b/Fw/Time/test/ut/TimeTestMain.cpp
@@ -29,6 +29,11 @@ TEST(TimeTestNominal, ZeroTimeEquality) {
     tester.test_ZeroTimeEquality();
 }
 
+TEST(TimeTestNominal, TimeToTimeValue) {
+    Fw::TimeTester tester;
+    tester.test_TimeToTimeValue();
+}
+
 // TimeInterval tests
 TEST(TimeIntervalTestNominal, test_TimeIntervalInstantiateTest) {
     Fw::TimeIntervalTester tester;
@@ -53,6 +58,11 @@ TEST(TimeIntervalTestNominal, test_TimeIntervalAdditionTest) {
 TEST(TimeIntervalTestNominal, test_TimeIntervalSubtractionTest) {
     Fw::TimeIntervalTester tester;
     tester.test_TimeIntervalSubtractionTest();
+}
+
+TEST(TimeIntervalTestNominal, test_TimeIntervalToTimeIntervalValue) {
+    Fw::TimeIntervalTester tester;
+    tester.test_TimeIntervalToTimeIntervalValue();
 }
 
 int main(int argc, char* argv[]) {

--- a/Fw/Time/test/ut/TimeTester.cpp
+++ b/Fw/Time/test/ut/TimeTester.cpp
@@ -149,4 +149,23 @@ void TimeTester::test_ZeroTimeEquality() {
     ASSERT_EQ(time2, Fw::ZERO_TIME);
 }
 
+void TimeTester::test_TimeToTimeValue() {
+    U32 seconds = 5;
+    U32 useconds = 500000;
+    TimeBase timeBase = TimeBase::TB_WORKSTATION_TIME;
+    FwTimeContextStoreType context = 3;
+
+    Fw::Time time(timeBase, context, seconds, useconds);
+
+    Fw::TimeValue time_value = time.asTimeValue();
+
+    // Alter the original
+    time.set(TimeBase::TB_NONE, 0, 0, 0);
+
+    ASSERT_EQ(time_value.get_timeBase(), timeBase);
+    ASSERT_EQ(time_value.get_timeContext(), context);
+    ASSERT_EQ(time_value.get_seconds(), seconds);
+    ASSERT_EQ(time_value.get_useconds(), useconds);
+}
+
 }  // namespace Fw

--- a/Fw/Time/test/ut/TimeTester.hpp
+++ b/Fw/Time/test/ut/TimeTester.hpp
@@ -20,6 +20,7 @@ class TimeTester {
     void test_MathTest();
     void test_CopyTest();
     void test_ZeroTimeEquality();
+    void test_TimeToTimeValue();
 };
 }  // namespace Fw
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Because it is **really** annoying