### PR TITLE
Os static analysis findings

### DIFF
--- a/Os/Cpu.hpp
+++ b/Os/Cpu.hpp
@@ -27,7 +27,7 @@ class CpuInterface {
     CpuInterface(const CpuInterface& other) = delete;
 
     //! \brief assignment operator is forbidden
-    virtual CpuInterface& operator=(const CpuInterface& other) = delete; // NOSONAR (cpp:S3657)
+    virtual CpuInterface& operator=(const CpuInterface& other) = delete; // NO_CODESONAR (cpp:S3657)
 
     //! \brief Request the count of the CPUs detected by the system
     //!

--- a/Os/Cpu.hpp
+++ b/Os/Cpu.hpp
@@ -27,7 +27,7 @@ class CpuInterface {
     CpuInterface(const CpuInterface& other) = delete;
 
     //! \brief assignment operator is forbidden
-    virtual CpuInterface& operator=(const CpuInterface& other) = delete; // NO_CODESONAR (cpp:S3657)
+    virtual CpuInterface& operator=(const CpuInterface& other) = delete;  //  NO_CODESONAR (cpp:S3657)
 
     //! \brief Request the count of the CPUs detected by the system
     //!

--- a/Os/Cpu.hpp
+++ b/Os/Cpu.hpp
@@ -27,7 +27,7 @@ class CpuInterface {
     CpuInterface(const CpuInterface& other) = delete;
 
     //! \brief assignment operator is forbidden
-    virtual CpuInterface& operator=(const CpuInterface& other) = delete;
+    virtual CpuInterface& operator=(const CpuInterface& other) = delete; // NOSONAR (cpp:S3657)
 
     //! \brief Request the count of the CPUs detected by the system
     //!

--- a/Os/File.cpp
+++ b/Os/File.cpp
@@ -265,7 +265,7 @@ File::Status File::readline(U8* buffer, FwSizeType& size, File::WaitType wait) {
         size = 0;
         return File::Status::INVALID_MODE;
     }
-    FwSizeType original_location;
+    FwSizeType original_location = 0;
     File::Status status = this->position(original_location);
     if (status != Os::File::Status::OP_OK) {
         size = 0;

--- a/Os/FileSystem.hpp
+++ b/Os/FileSystem.hpp
@@ -57,7 +57,7 @@ class FileSystemInterface {
     FileSystemInterface(const FileSystemInterface& other) = delete;
 
     //! \brief assignment operator is forbidden
-    FileSystemInterface& operator=(const FileSystemInterface& other) = delete; // NO_CODESONAR (cpp:S3657)
+    FileSystemInterface& operator=(const FileSystemInterface& other) = delete;  // NO_CODESONAR (cpp:S3657)
 
     //! \brief return the underlying FileSystem handle (implementation specific)
     //! \return internal FileSystem handle representation

--- a/Os/FileSystem.hpp
+++ b/Os/FileSystem.hpp
@@ -57,7 +57,7 @@ class FileSystemInterface {
     FileSystemInterface(const FileSystemInterface& other) = delete;
 
     //! \brief assignment operator is forbidden
-    FileSystemInterface& operator=(const FileSystemInterface& other) = delete; // NOSONAR (cpp:S3657)
+    FileSystemInterface& operator=(const FileSystemInterface& other) = delete; // NO_CODESONAR (cpp:S3657)
 
     //! \brief return the underlying FileSystem handle (implementation specific)
     //! \return internal FileSystem handle representation

--- a/Os/FileSystem.hpp
+++ b/Os/FileSystem.hpp
@@ -57,7 +57,7 @@ class FileSystemInterface {
     FileSystemInterface(const FileSystemInterface& other) = delete;
 
     //! \brief assignment operator is forbidden
-    FileSystemInterface& operator=(const FileSystemInterface& other) = delete;
+    FileSystemInterface& operator=(const FileSystemInterface& other) = delete; // NOSONAR (cpp:S3657)
 
     //! \brief return the underlying FileSystem handle (implementation specific)
     //! \return internal FileSystem handle representation

--- a/Os/Generic/PriorityQueue.cpp
+++ b/Os/Generic/PriorityQueue.cpp
@@ -64,6 +64,9 @@ QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
     U8* data = nullptr;
     U8* heap_pointer = nullptr;
 
+    // Prevent integer overflow when computing allocation size (depth * sizeof(FwSizeType))
+    FW_ASSERT(depth < std::numeric_limits<FwSizeType>::max() / sizeof(FwSizeType));
+
     // Allocate indices list and construct it when valid
     size = depth * sizeof(FwSizeType);
     allocation = allocator.allocate(identifier, size, alignof(FwSizeType));

--- a/Os/Generic/Types/MaxHeap.cpp
+++ b/Os/Generic/Types/MaxHeap.cpp
@@ -41,7 +41,7 @@ MaxHeap::~MaxHeap() {
 
 void MaxHeap::create(FwSizeType capacity, Fw::ByteArray heap_allocation) {
     FW_ASSERT(this->m_heap == nullptr);
-    FW_ASSERT(heap_allocation.size >= (capacity * sizeof(Node)), static_cast<FwAssertArgType>(capacity),
+    FW_ASSERT((heap_allocation.size / sizeof(Node)) >= capacity, static_cast<FwAssertArgType>(capacity),
               static_cast<FwAssertArgType>(heap_allocation.size));
     FW_ASSERT(heap_allocation.bytes != nullptr);
     // Loop bounds will overflow if capacity set to the max allowable value

--- a/Os/Memory.hpp
+++ b/Os/Memory.hpp
@@ -24,7 +24,7 @@ class MemoryInterface {
     virtual ~MemoryInterface() = default;
 
     //! \brief copy constructor is forbidden
-    MemoryInterface(const MemoryInterface& other) = delete; // NOSONAR (cpp:S3657)
+    MemoryInterface(const MemoryInterface& other) = delete; // NO_CODESONAR (cpp:S3657)
 
     //! \brief assignment operator is forbidden
     virtual MemoryInterface& operator=(const MemoryInterface& other) = delete;

--- a/Os/Memory.hpp
+++ b/Os/Memory.hpp
@@ -24,7 +24,7 @@ class MemoryInterface {
     virtual ~MemoryInterface() = default;
 
     //! \brief copy constructor is forbidden
-    MemoryInterface(const MemoryInterface& other) = delete; // NO_CODESONAR (cpp:S3657)
+    MemoryInterface(const MemoryInterface& other) = delete;  // NO_CODESONAR (cpp:S3657)
 
     //! \brief assignment operator is forbidden
     virtual MemoryInterface& operator=(const MemoryInterface& other) = delete;

--- a/Os/Memory.hpp
+++ b/Os/Memory.hpp
@@ -24,7 +24,7 @@ class MemoryInterface {
     virtual ~MemoryInterface() = default;
 
     //! \brief copy constructor is forbidden
-    MemoryInterface(const MemoryInterface& other) = delete;
+    MemoryInterface(const MemoryInterface& other) = delete; // NOSONAR (cpp:S3657)
 
     //! \brief assignment operator is forbidden
     virtual MemoryInterface& operator=(const MemoryInterface& other) = delete;

--- a/Os/Queue.hpp
+++ b/Os/Queue.hpp
@@ -61,7 +61,7 @@ class QueueInterface {
     QueueInterface(const QueueInterface* other) = delete;
 
     //! \brief assignment operator is forbidden
-    virtual QueueInterface& operator=(const QueueInterface& other) = delete; // NO_CODESONAR (cpp:S3657)
+    virtual QueueInterface& operator=(const QueueInterface& other) = delete;  // NO_CODESONAR (cpp:S3657)
 
     //! \brief create queue storage
     //!

--- a/Os/Queue.hpp
+++ b/Os/Queue.hpp
@@ -61,7 +61,7 @@ class QueueInterface {
     QueueInterface(const QueueInterface* other) = delete;
 
     //! \brief assignment operator is forbidden
-    virtual QueueInterface& operator=(const QueueInterface& other) = delete; // NOSONAR (cpp:S3657)
+    virtual QueueInterface& operator=(const QueueInterface& other) = delete; // NO_CODESONAR (cpp:S3657)
 
     //! \brief create queue storage
     //!

--- a/Os/Queue.hpp
+++ b/Os/Queue.hpp
@@ -61,7 +61,7 @@ class QueueInterface {
     QueueInterface(const QueueInterface* other) = delete;
 
     //! \brief assignment operator is forbidden
-    virtual QueueInterface& operator=(const QueueInterface& other) = delete;
+    virtual QueueInterface& operator=(const QueueInterface& other) = delete; // NOSONAR (cpp:S3657)
 
     //! \brief create queue storage
     //!


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [Os multiple static analysis findings](https://github.com/nasa/fprime/issues/4513) |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

This PR addresses high-severity static analysis findings reported by SonarQube and CodeSonar in the `Os` component:

* **SonarQube rule S3657 (virtual assignment operators):**  The virtual assignment operators are defined as `= delete` and intentionally kept virtual to ensure the same deleted operator applies consistently in derived classes as well. No code change was made. a `// NOSONAR (cpp:S3657)` comment was added solely to suppress this warning.

* **Uninitialized Variable** (`Os/File.cpp:272`): Added explicit initialization to eliminate undefined behavior.

* **Integer / Multiplication Overflow of Allocation Size**: Added explicit overflow checks in  `Os/Generic/PriorityQueue.cpp` and `Os/Generic/Types/MaxHeap.cpp`.

* **Condition Variable Warnings**:
  * `Inappropriate Call Outside Loop` in `PosixConditionVariable::pend`: No functional change. The API is intentionally designed to require the caller to handle spurious wakeups by calling `pend()` inside a loop.
  * `Use of Condition Variable Signal` in `notify()`:  No functional change. The use of `pthread_cond_signal` is correct and intentional.

* **File System Race Condition** (`Os/Posix/Directory.cpp`): there is a time window between the call to `mkdir(path, ...)` and the later call to `opendir(path)`. Since the filesystem is shared state, another process/thread can modify the directory entry at `path` in between these two operations. As a result, `opendir` may end up opening a directory that is not the one this function just created, or it may fail because the directory was removed/changed after creation.
   Is this actually something we need to prevent, or is the current behavior acceptable by design? Would be happy to hear feedback on this.

* **Division By Zero** (`Os/Posix/FileSystem.cpp:86`): Code already contained an explicit guard against `block_size == 0`.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))
ChatGPT was used to help locate and understand the reported static analysis findings.