### PR TITLE
Update dictionary spec to require FW_FIXED_LENGTH_STRING_SIZE

### DIFF
--- a/docs/reference/fpp-json-dict.md
+++ b/docs/reference/fpp-json-dict.md
@@ -1394,4 +1394,4 @@ The following framework definitions are required by the dictionary and will alwa
 | `Fw.DpState` | [Enum type definition](#enumeration-type-definition)| `typeDefinitions` | The data product state | |
 | `Fw.DpCfg.ProcType` | [Enum type definition](#enumeration-type-definition)| `typeDefinitions` | A bit mask for selecting the type of processing to perform on a container before writing it to disk. |
 | `Fw.DpCfg.CONTAINER_USER_DATA_SIZE` | [Constant Definition](#constants)| `constants` | The size in bytes of the user-configurable data in the container packet header |
-
+| `FW_FIXED_LENGTH_STRING_SIZE` | [Constant Definition](#constants)| `constants` | Configuration for Fw::String |

--- a/docs/reference/fpp-json-dict.md
+++ b/docs/reference/fpp-json-dict.md
@@ -1395,3 +1395,4 @@ The following framework definitions are required by the dictionary and will alwa
 | `Fw.DpCfg.ProcType` | [Enum type definition](#enumeration-type-definition)| `typeDefinitions` | A bit mask for selecting the type of processing to perform on a container before writing it to disk. |
 | `Fw.DpCfg.CONTAINER_USER_DATA_SIZE` | [Constant Definition](#constants)| `constants` | The size in bytes of the user-configurable data in the container packet header |
 | `FW_FIXED_LENGTH_STRING_SIZE` | [Constant Definition](#constants)| `constants` | Configuration for Fw::String |
+


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  https://github.com/nasa/fpp/issues/903 |
|**_Has Unit Tests (y/n)_**|  n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Updated JSON dictionary spec to require FW_FIXED_LENGTH_STRING_SIZE

## Rationale

The dictionary now requires that this constant be defined per https://github.com/nasa/fpp/issues/903.
