### PR TITLE
Add Fw.DataProduct FPP interface

### DIFF
--- a/Fw/Interfaces/CMakeLists.txt
+++ b/Fw/Interfaces/CMakeLists.txt
@@ -10,6 +10,7 @@ register_fprime_module(
   AUTOCODER_INPUTS
     "${CMAKE_CURRENT_LIST_DIR}/Channel.fpp"
     "${CMAKE_CURRENT_LIST_DIR}/Command.fpp"
+    "${CMAKE_CURRENT_LIST_DIR}/DataProduct.fpp"
     "${CMAKE_CURRENT_LIST_DIR}/Event.fpp"
   INTERFACE
 )

--- a/Fw/Interfaces/CMakeLists.txt
+++ b/Fw/Interfaces/CMakeLists.txt
@@ -10,7 +10,7 @@ register_fprime_module(
   AUTOCODER_INPUTS
     "${CMAKE_CURRENT_LIST_DIR}/Channel.fpp"
     "${CMAKE_CURRENT_LIST_DIR}/Command.fpp"
-    "${CMAKE_CURRENT_LIST_DIR}/DataProduct.fpp"
+    "${CMAKE_CURRENT_LIST_DIR}/DataProductSync.fpp"
     "${CMAKE_CURRENT_LIST_DIR}/Event.fpp"
   INTERFACE
 )

--- a/Fw/Interfaces/DataProduct.fpp
+++ b/Fw/Interfaces/DataProduct.fpp
@@ -1,0 +1,11 @@
+module Fw {
+    interface DataProduct {
+
+        @ Data product get port: allocates a data product container
+        product get port productGetOut
+
+        @ Data product send port: sends the filled data product container
+        product send port productSendOut
+
+    }
+}

--- a/Fw/Interfaces/DataProductSync.fpp
+++ b/Fw/Interfaces/DataProductSync.fpp
@@ -1,5 +1,6 @@
 module Fw {
-    interface DataProduct {
+    @ Defines ports for synchronous data product operations (get/send)
+    interface DataProductSync {
 
         @ Data product get port: allocates a data product container
         product get port productGetOut


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Following the other Fw.Event, Fw.Channel etc. interfaces
Allows to have 

```python
active component MyComponent {
    import Fw.Event
    import Fw.Command
    import Fw.Channel
    import Fw.DataProduct
}
```

... and off to the races!
