### PR TITLE
Initialize variables to fix static analysis warnings

### DIFF
--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -82,7 +82,7 @@ void AssertHook::reportAssert(FILE_NAME_ARG file,
                               FwAssertArgType arg4,
                               FwAssertArgType arg5,
                               FwAssertArgType arg6) {
-    CHAR destBuffer[FW_ASSERT_TEXT_SIZE];
+    CHAR destBuffer[FW_ASSERT_TEXT_SIZE] = {0};
     defaultReportAssert(file, lineNo, numArgs, arg1, arg2, arg3, arg4, arg5, arg6, destBuffer,
                         static_cast<FwSizeType>(sizeof(destBuffer)));
     // print message

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -352,7 +352,7 @@ SerializeStatus LinearBufferBase::deserializeTo(U16& val, Endianness mode) {
 }
 
 SerializeStatus LinearBufferBase::deserializeTo(I16& val, Endianness mode) {
-    U16 unsignVal;
+    U16 unsignVal = 0;
     SerializeStatus res = deserializeTo(unsignVal, mode);
     if (res == SerializeStatus::FW_SERIALIZE_OK) {
         val = static_cast<I16>(unsignVal);
@@ -394,7 +394,7 @@ SerializeStatus LinearBufferBase::deserializeTo(U32& val, Endianness mode) {
 }
 
 SerializeStatus LinearBufferBase::deserializeTo(I32& val, Endianness mode) {
-    U32 unsignVal;
+    U32 unsignVal = 0;
     SerializeStatus res = deserializeTo(unsignVal, mode);
     if (res == SerializeStatus::FW_SERIALIZE_OK) {
         val = static_cast<I32>(unsignVal);
@@ -501,7 +501,7 @@ SerializeStatus LinearBufferBase::deserializeTo(void*& val, Endianness mode) {
 
 SerializeStatus LinearBufferBase::deserializeTo(F32& val, Endianness mode) {
     // deserialize as 64-bit int to handle endianness
-    U32 tempVal;
+    U32 tempVal = 0;
     SerializeStatus stat = this->deserializeTo(tempVal, mode);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
@@ -525,7 +525,7 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
     FW_ASSERT(this->getBuffAddr());
 
     if (lengthMode == Serialization::INCLUDE_LENGTH) {
-        FwSizeStoreType storedLength;
+        FwSizeStoreType storedLength = 0;
 
         SerializeStatus stat = this->deserializeTo(storedLength, endianMode);
 
@@ -563,7 +563,7 @@ SerializeStatus LinearBufferBase::deserializeTo(LinearBufferBase& val, Endiannes
     FW_ASSERT(val.getBuffAddr());
     SerializeStatus stat = FW_SERIALIZE_OK;
 
-    FwSizeStoreType storedLength;
+    FwSizeStoreType storedLength = 0;
 
     stat = this->deserializeTo(storedLength, mode);
 

--- a/Os/File.cpp
+++ b/Os/File.cpp
@@ -265,7 +265,7 @@ File::Status File::readline(U8* buffer, FwSizeType& size, File::WaitType wait) {
         size = 0;
         return File::Status::INVALID_MODE;
     }
-    FwSizeType original_location;
+    FwSizeType original_location = 0;
     File::Status status = this->position(original_location);
     if (status != Os::File::Status::OP_OK) {
         size = 0;

--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -277,7 +277,7 @@ void ComQueue::sendComBuffer(Fw::ComBuffer& comBuffer, FwIndexType queueIndex) {
 
     // Context value is used to determine what to do when the buffer returns on the dataReturnIn port
     ComCfg::FrameContext context;
-    FwPacketDescriptorType descriptor;
+    FwPacketDescriptorType descriptor = 0;
     Fw::SerializeStatus status = comBuffer.deserializeTo(descriptor);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     context.set_apid(static_cast<ComCfg::Apid::T>(descriptor));

--- a/Svc/FileUplink/FileUplink.cpp
+++ b/Svc/FileUplink/FileUplink.cpp
@@ -45,7 +45,7 @@ void FileUplink::bufferSendIn_handler(const FwIndexType portNum, Fw::Buffer& buf
     }
 
     // Read the packet type from the packet buffer
-    FwPacketDescriptorType packetType;
+    FwPacketDescriptorType packetType = 0;
     Fw::SerializeStatus status = buffer.getDeserializer().deserializeTo(packetType);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 

--- a/Svc/FprimeDeframer/FprimeDeframer.cpp
+++ b/Svc/FprimeDeframer/FprimeDeframer.cpp
@@ -66,7 +66,7 @@ void FprimeDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, cons
     } else {
         // If PacketDescriptor translates to an invalid APID, let it default to FW_PACKET_UNKNOWN
         // and let downstream components (e.g. custom router) handle it
-        FwPacketDescriptorType packetDescriptor;
+        FwPacketDescriptorType packetDescriptor = 0;
         status = deserializer.deserializeTo(packetDescriptor);
         FW_ASSERT(status == Fw::SerializeStatus::FW_SERIALIZE_OK, status);
         // If a valid descriptor is deserialized, set it in the context

--- a/Utils/Hash/libcrc/CRC32.cpp
+++ b/Utils/Hash/libcrc/CRC32.cpp
@@ -44,7 +44,7 @@ void Hash ::init() {
 
 void Hash ::update(const void* const data, FwSizeType len) {
     FW_ASSERT(data);
-    char c;
+    char c = 0;
     for (FwSizeType index = 0; index < len; index++) {
         c = static_cast<const char*>(data)[index];
         this->hash_handle = static_cast<HASH_HANDLE_TYPE>(update_crc_32(this->hash_handle, c));


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4296  |
|**_Has Unit Tests (y/n)_**|n  |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Initialize variables at declaration to fix static analysis warnings for uninitialized variables at 11 locations in 7 source files.

## Rationale

Variables flagged by static analysis could potentially be read before being assigned, which is undefined behavior in C++.

## Testing/Review Recommendations

- Build passes locally
- Changes are minimal (only adding `= 0` or `= {0}` initialization)


Fixes #4501 