### PR TITLE
Updated default file creation mode to a+rw equivalent

### DIFF
--- a/default/config/OsCfg.fpp
+++ b/default/config/OsCfg.fpp
@@ -29,7 +29,7 @@ module Os {
     @ the OPEN_CREATE mode flag.
     @ The FILE_DEFAULT_CREATE_MODE constant @ is a bitfield of the
     @ above FILE_MODE_* bits that should be present in the created file
-    @ The default value corresponds to a mode of 600, or user R/W bits set
+    @ The default value corresponds to a mode of 666 (a+rw) on Linux
     constant FILE_DEFAULT_CREATE_MODE = FILE_MODE_IRUSR + FILE_MODE_IWUSR + \
                                         FILE_MODE_IRGRP + FILE_MODE_IWGRP + \
                                         FILE_MODE_IROTH + FILE_MODE_IWOTH

--- a/default/config/OsCfg.fpp
+++ b/default/config/OsCfg.fpp
@@ -30,5 +30,7 @@ module Os {
     @ The FILE_DEFAULT_CREATE_MODE constant @ is a bitfield of the
     @ above FILE_MODE_* bits that should be present in the created file
     @ The default value corresponds to a mode of 600, or user R/W bits set
-    constant FILE_DEFAULT_CREATE_MODE = FILE_MODE_IRUSR + FILE_MODE_IWUSR
+    constant FILE_DEFAULT_CREATE_MODE = FILE_MODE_IRUSR + FILE_MODE_IWUSR + \
+                                        FILE_MODE_IRGRP + FILE_MODE_IWGRP + \
+                                        FILE_MODE_IROTH + FILE_MODE_IWOTH
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4604  |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**| N |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

Updated default file creation mode to a+rw, from u+rw. This will by default give user, group and other R/W permissions on files created by F Prime. This matches the permissions given by other standard unix tools, such as `touch`, `vim`.

This changes the default permission provided in the default config file to match Linux expectations and projects are able to modify it as they see fit.

## Rationale

More permissive file creation modes make these files easier to work with AND give more tools to system administrators to configure file permissions. It is easier to take away permissions at execution, through umask, than to add permissions, which must be done through a separate chmod command. This is also the standard permissions set used by many Linux tools, so it is what I expected when developing a recent system.

This rationale is Linux specific. I am not sure that these are necessarily the best defaults for non-Linux/MacOS systems, but projects are free to change them. 

## Testing/Review Recommendations

I modified the Ref deployment to create `test_file.txt` on startup and checked the file permissions
```
diff --git a/Ref/Top/RefTopology.cpp b/Ref/Top/RefTopology.cpp
index 6d18f751d..389f120f3 100644
--- a/Ref/Top/RefTopology.cpp
+++ b/Ref/Top/RefTopology.cpp
@@ -53,6 +53,10 @@ void configureTopology() {
 
     // Command sequencer needs to allocate memory to hold contents of command sequences
     cmdSeq.allocateBuffer(0, mallocator, 5 * 1024);
+
+    Os::File test_file;
+    test_file.open("test_file.txt", Os::FileInterface::OPEN_CREATE);
+    test_file.close();
 }
```

```
-rw-rw-rw- 1 kubiak kubiak     0 Feb  2 11:20 test_file.txt
```

Resulting permissions were as expected

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None
