### PR TITLE
Skip Zephyr integration tests in CI (temporarily)

### DIFF
--- a/.github/workflows/ext-fprime-zephyr-reference-pico2.yml
+++ b/.github/workflows/ext-fprime-zephyr-reference-pico2.yml
@@ -32,5 +32,5 @@ jobs:
         target_repository: fprime-community/fprime-zephyr-reference
         target_ref: ${{ needs.get-branch.outputs.target-branch }}
         ci_config_file: ./lib/fprime-zephyr/ci/sample-configs/pico2.yml
-        run_unit_tests: false # FIXME: temporary disable until we work around hardware issues
+        run_int: false # FIXME: temporary disable until we work around hardware issues
 

--- a/.github/workflows/ext-fprime-zephyr-reference-pico2.yml
+++ b/.github/workflows/ext-fprime-zephyr-reference-pico2.yml
@@ -32,5 +32,5 @@ jobs:
         target_repository: fprime-community/fprime-zephyr-reference
         target_ref: ${{ needs.get-branch.outputs.target-branch }}
         ci_config_file: ./lib/fprime-zephyr/ci/sample-configs/pico2.yml
+        run_unit_tests: false # FIXME: temporary disable until we work around hardware issues
 
-      

--- a/.github/workflows/ext-fprime-zephyr-reference-teensy41.yml
+++ b/.github/workflows/ext-fprime-zephyr-reference-teensy41.yml
@@ -32,5 +32,5 @@ jobs:
         target_repository: fprime-community/fprime-zephyr-reference
         target_ref: ${{ needs.get-branch.outputs.target-branch }}
         ci_config_file: ./lib/fprime-zephyr/ci/sample-configs/teensy41.yml
+        run_unit_tests: false # FIXME: temporary disable until we work around hardware issues
 
-      

--- a/.github/workflows/ext-fprime-zephyr-reference-teensy41.yml
+++ b/.github/workflows/ext-fprime-zephyr-reference-teensy41.yml
@@ -32,5 +32,5 @@ jobs:
         target_repository: fprime-community/fprime-zephyr-reference
         target_ref: ${{ needs.get-branch.outputs.target-branch }}
         ci_config_file: ./lib/fprime-zephyr/ci/sample-configs/teensy41.yml
-        run_unit_tests: false # FIXME: temporary disable until we work around hardware issues
+        run_int: false # FIXME: temporary disable until we work around hardware issues
 

--- a/.github/workflows/reusable-project-ci.yml
+++ b/.github/workflows/reusable-project-ci.yml
@@ -22,8 +22,8 @@ on:
       ci_config_file:
         required: true
         type: string
-      run_unit_tests:
-        description: "Run an additional job in parallel to run unit tests."
+      run_int:
+        description: "Run an additional job in parallel to run integration tests."
         required: false
         type: boolean
         default: true
@@ -65,6 +65,7 @@ jobs:
           name: archive.tar.gz
           path: ./archive.tar.gz
   integration-tests:
+    if: ${{ inputs.run_int }}
     needs: build
     name: "Integration Tests"
     runs-on: ${{ inputs.runs_on_int }}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Temporarily disable integration tests in CI for Zephyr, as we are having hardware issues.

## Future Work

- [x] #4690
