### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/nasa/fprime)
+
 <h2 align="center">A Flight-Proven, Multi-Platform, Open-Source Flight Software Framework</h2>
 <p align="center"><br/>
 <img width="200em" src="docs/img/fprime-logo.svg"><br/>


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/nasa/fprime) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.