### PR TITLE
FpySequencer push FW_SERIALIZE_TRUE/FALSE for boolean ops

### DIFF
--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -426,6 +426,7 @@ void FpySequencer::tlmWrite_handler(FwIndexType portNum,  //!< The port number
     this->tlmWrite_Debug_NextCmdOpcode(this->m_debug.nextCmdOpcode);
     this->tlmWrite_Debug_NextStatementOpcode(this->m_debug.nextStatementOpcode);
     this->tlmWrite_Debug_NextStatementReadSuccess(this->m_debug.nextStatementReadSuccess);
+    this->tlmWrite_Debug_NextStatementIndex(this->m_debug.nextStatementIndex);
     this->tlmWrite_Debug_ReachedEndOfFile(this->m_debug.reachedEndOfFile);
     this->tlmWrite_Debug_StackSize(this->m_debug.stackSize);
 }
@@ -439,6 +440,7 @@ void FpySequencer::updateDebugTelemetryStruct() {
             this->m_debug.nextStatementReadSuccess = false;
             this->m_debug.nextStatementOpcode = 0;
             this->m_debug.nextCmdOpcode = 0;
+            this->m_debug.nextStatementIndex = this->m_runtime.nextStatementIndex;
             this->m_debug.stackSize = this->m_runtime.stack.size;
             return;
         }
@@ -452,6 +454,7 @@ void FpySequencer::updateDebugTelemetryStruct() {
             this->m_debug.nextStatementReadSuccess = false;
             this->m_debug.nextStatementOpcode = nextStmt.get_opCode();
             this->m_debug.nextCmdOpcode = 0;
+            this->m_debug.nextStatementIndex = this->m_runtime.nextStatementIndex;
             this->m_debug.stackSize = this->m_runtime.stack.size;
             return;
         }
@@ -462,6 +465,7 @@ void FpySequencer::updateDebugTelemetryStruct() {
             this->m_debug.nextStatementReadSuccess = true;
             this->m_debug.nextStatementOpcode = nextStmt.get_opCode();
             this->m_debug.nextCmdOpcode = directiveUnion.constCmd.get_opCode();
+            this->m_debug.nextStatementIndex = this->m_runtime.nextStatementIndex;
             this->m_debug.stackSize = this->m_runtime.stack.size;
             return;
         }
@@ -470,6 +474,7 @@ void FpySequencer::updateDebugTelemetryStruct() {
         this->m_debug.nextStatementReadSuccess = true;
         this->m_debug.nextStatementOpcode = nextStmt.get_opCode();
         this->m_debug.nextCmdOpcode = 0;
+        this->m_debug.nextStatementIndex = this->m_runtime.nextStatementIndex;
         this->m_debug.stackSize = this->m_runtime.stack.size;
         return;
     }
@@ -478,6 +483,7 @@ void FpySequencer::updateDebugTelemetryStruct() {
     this->m_debug.nextStatementReadSuccess = false;
     this->m_debug.nextStatementOpcode = 0;
     this->m_debug.nextCmdOpcode = 0;
+    this->m_debug.nextStatementIndex = 0;
     this->m_debug.stackSize = 0;
 }
 

--- a/Svc/FpySequencer/FpySequencer.hpp
+++ b/Svc/FpySequencer/FpySequencer.hpp
@@ -679,6 +679,8 @@ class FpySequencer : public FpySequencerComponentBase {
         U8 nextStatementOpcode = 0;
         // if the next statement is a cmd directive, the opcode of that cmd
         FwOpcodeType nextCmdOpcode = 0;
+        // the index of the next statement we're going to execute
+        U32 nextStatementIndex = 0;
         // the size of the stack. store this separately from the real stack size
         // so we can avoid changing this during runtime, only modify it during
         // debug

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -463,14 +463,18 @@ DirectiveError FpySequencer::op_ieq() {
     if (this->m_runtime.stack.size < sizeof(I64) * 2) {
         return DirectiveError::STACK_UNDERFLOW;
     }
-    this->m_runtime.stack.push(static_cast<U8>((this->m_runtime.stack.pop<I64>() == this->m_runtime.stack.pop<I64>()) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((this->m_runtime.stack.pop<I64>() == this->m_runtime.stack.pop<I64>())
+                                                   ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                   : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_ine() {
     if (this->m_runtime.stack.size < sizeof(I64) * 2) {
         return DirectiveError::STACK_UNDERFLOW;
     }
-    this->m_runtime.stack.push(static_cast<U8>((this->m_runtime.stack.pop<I64>() != this->m_runtime.stack.pop<I64>()) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((this->m_runtime.stack.pop<I64>() != this->m_runtime.stack.pop<I64>())
+                                                   ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                   : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_ult() {
@@ -479,7 +483,8 @@ DirectiveError FpySequencer::op_ult() {
     }
     U64 rhs = this->m_runtime.stack.pop<U64>();
     U64 lhs = this->m_runtime.stack.pop<U64>();
-    this->m_runtime.stack.push(static_cast<U8>((lhs < rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((lhs < rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                           : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_ule() {
@@ -488,7 +493,8 @@ DirectiveError FpySequencer::op_ule() {
     }
     U64 rhs = this->m_runtime.stack.pop<U64>();
     U64 lhs = this->m_runtime.stack.pop<U64>();
-    this->m_runtime.stack.push(static_cast<U8>((lhs <= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((lhs <= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                            : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_ugt() {
@@ -497,7 +503,8 @@ DirectiveError FpySequencer::op_ugt() {
     }
     U64 rhs = this->m_runtime.stack.pop<U64>();
     U64 lhs = this->m_runtime.stack.pop<U64>();
-    this->m_runtime.stack.push(static_cast<U8>((lhs > rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((lhs > rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                           : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_uge() {
@@ -506,7 +513,8 @@ DirectiveError FpySequencer::op_uge() {
     }
     U64 rhs = this->m_runtime.stack.pop<U64>();
     U64 lhs = this->m_runtime.stack.pop<U64>();
-    this->m_runtime.stack.push(static_cast<U8>((lhs >= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((lhs >= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                            : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_slt() {
@@ -515,7 +523,8 @@ DirectiveError FpySequencer::op_slt() {
     }
     I64 rhs = this->m_runtime.stack.pop<I64>();
     I64 lhs = this->m_runtime.stack.pop<I64>();
-    this->m_runtime.stack.push(static_cast<U8>((lhs < rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((lhs < rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                           : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_sle() {
@@ -524,7 +533,8 @@ DirectiveError FpySequencer::op_sle() {
     }
     I64 rhs = this->m_runtime.stack.pop<I64>();
     I64 lhs = this->m_runtime.stack.pop<I64>();
-    this->m_runtime.stack.push(static_cast<U8>((lhs <= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((lhs <= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                            : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_sgt() {
@@ -533,7 +543,8 @@ DirectiveError FpySequencer::op_sgt() {
     }
     I64 rhs = this->m_runtime.stack.pop<I64>();
     I64 lhs = this->m_runtime.stack.pop<I64>();
-    this->m_runtime.stack.push(static_cast<U8>((lhs > rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((lhs > rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                           : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_sge() {
@@ -542,7 +553,8 @@ DirectiveError FpySequencer::op_sge() {
     }
     I64 rhs = this->m_runtime.stack.pop<I64>();
     I64 lhs = this->m_runtime.stack.pop<I64>();
-    this->m_runtime.stack.push(static_cast<U8>((lhs >= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((lhs >= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                            : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_feq() {
@@ -552,7 +564,8 @@ DirectiveError FpySequencer::op_feq() {
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
     // eq is true if they are equal and neither is nan
-    this->m_runtime.stack.push(static_cast<U8>((lhs == rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((lhs == rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                            : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_fne() {
@@ -562,7 +575,8 @@ DirectiveError FpySequencer::op_fne() {
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
     // ne is true if they are not equal or either is nan
-    this->m_runtime.stack.push(static_cast<U8>((lhs != rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((lhs != rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                            : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_flt() {
@@ -571,7 +585,8 @@ DirectiveError FpySequencer::op_flt() {
     }
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
-    this->m_runtime.stack.push(static_cast<U8>(std::isless(lhs, rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>(std::isless(lhs, rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                                     : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_fle() {
@@ -580,7 +595,8 @@ DirectiveError FpySequencer::op_fle() {
     }
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
-    this->m_runtime.stack.push(static_cast<U8>(std::islessequal(lhs, rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>(std::islessequal(lhs, rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                                          : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_fgt() {
@@ -589,7 +605,8 @@ DirectiveError FpySequencer::op_fgt() {
     }
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
-    this->m_runtime.stack.push(static_cast<U8>(std::isgreater(lhs, rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>(std::isgreater(lhs, rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                                        : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_fge() {
@@ -598,14 +615,18 @@ DirectiveError FpySequencer::op_fge() {
     }
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
-    this->m_runtime.stack.push(static_cast<U8>(std::isgreaterequal(lhs, rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>(std::isgreaterequal(lhs, rhs)
+                                                   ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                   : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_not() {
     if (this->m_runtime.stack.size < sizeof(U8)) {
         return DirectiveError::STACK_UNDERFLOW;
     }
-    this->m_runtime.stack.push(static_cast<U8>((this->m_runtime.stack.pop<U8>() == 0) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
+    this->m_runtime.stack.push(static_cast<U8>((this->m_runtime.stack.pop<U8>() == 0)
+                                                   ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                                   : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_fpext() {
@@ -1303,7 +1324,8 @@ Signal FpySequencer::getFlag_directiveHandler(const FpySequencer_GetFlagDirectiv
     }
 
     bool flagVal = this->m_runtime.flags[directive.get_flagIdx()];
-    this->m_runtime.stack.push<U8>(flagVal ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE));
+    this->m_runtime.stack.push<U8>(flagVal ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
+                                           : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE));
     return Signal::stmtResponse_success;
 }
 

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -463,14 +463,14 @@ DirectiveError FpySequencer::op_ieq() {
     if (this->m_runtime.stack.size < sizeof(I64) * 2) {
         return DirectiveError::STACK_UNDERFLOW;
     }
-    this->m_runtime.stack.push(static_cast<U8>(this->m_runtime.stack.pop<I64>() == this->m_runtime.stack.pop<I64>()));
+    this->m_runtime.stack.push(static_cast<U8>((this->m_runtime.stack.pop<I64>() == this->m_runtime.stack.pop<I64>()) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_ine() {
     if (this->m_runtime.stack.size < sizeof(I64) * 2) {
         return DirectiveError::STACK_UNDERFLOW;
     }
-    this->m_runtime.stack.push(static_cast<U8>(this->m_runtime.stack.pop<I64>() != this->m_runtime.stack.pop<I64>()));
+    this->m_runtime.stack.push(static_cast<U8>((this->m_runtime.stack.pop<I64>() != this->m_runtime.stack.pop<I64>()) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_ult() {
@@ -479,7 +479,7 @@ DirectiveError FpySequencer::op_ult() {
     }
     U64 rhs = this->m_runtime.stack.pop<U64>();
     U64 lhs = this->m_runtime.stack.pop<U64>();
-    this->m_runtime.stack.push(static_cast<U8>(lhs < rhs));
+    this->m_runtime.stack.push(static_cast<U8>((lhs < rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_ule() {
@@ -488,7 +488,7 @@ DirectiveError FpySequencer::op_ule() {
     }
     U64 rhs = this->m_runtime.stack.pop<U64>();
     U64 lhs = this->m_runtime.stack.pop<U64>();
-    this->m_runtime.stack.push(static_cast<U8>(lhs <= rhs));
+    this->m_runtime.stack.push(static_cast<U8>((lhs <= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_ugt() {
@@ -497,7 +497,7 @@ DirectiveError FpySequencer::op_ugt() {
     }
     U64 rhs = this->m_runtime.stack.pop<U64>();
     U64 lhs = this->m_runtime.stack.pop<U64>();
-    this->m_runtime.stack.push(static_cast<U8>(lhs > rhs));
+    this->m_runtime.stack.push(static_cast<U8>((lhs > rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_uge() {
@@ -506,7 +506,7 @@ DirectiveError FpySequencer::op_uge() {
     }
     U64 rhs = this->m_runtime.stack.pop<U64>();
     U64 lhs = this->m_runtime.stack.pop<U64>();
-    this->m_runtime.stack.push(static_cast<U8>(lhs >= rhs));
+    this->m_runtime.stack.push(static_cast<U8>((lhs >= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_slt() {
@@ -515,7 +515,7 @@ DirectiveError FpySequencer::op_slt() {
     }
     I64 rhs = this->m_runtime.stack.pop<I64>();
     I64 lhs = this->m_runtime.stack.pop<I64>();
-    this->m_runtime.stack.push(static_cast<U8>(lhs < rhs));
+    this->m_runtime.stack.push(static_cast<U8>((lhs < rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_sle() {
@@ -524,7 +524,7 @@ DirectiveError FpySequencer::op_sle() {
     }
     I64 rhs = this->m_runtime.stack.pop<I64>();
     I64 lhs = this->m_runtime.stack.pop<I64>();
-    this->m_runtime.stack.push(static_cast<U8>(lhs <= rhs));
+    this->m_runtime.stack.push(static_cast<U8>((lhs <= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_sgt() {
@@ -533,7 +533,7 @@ DirectiveError FpySequencer::op_sgt() {
     }
     I64 rhs = this->m_runtime.stack.pop<I64>();
     I64 lhs = this->m_runtime.stack.pop<I64>();
-    this->m_runtime.stack.push(static_cast<U8>(lhs > rhs));
+    this->m_runtime.stack.push(static_cast<U8>((lhs > rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_sge() {
@@ -542,7 +542,7 @@ DirectiveError FpySequencer::op_sge() {
     }
     I64 rhs = this->m_runtime.stack.pop<I64>();
     I64 lhs = this->m_runtime.stack.pop<I64>();
-    this->m_runtime.stack.push(static_cast<U8>(lhs >= rhs));
+    this->m_runtime.stack.push(static_cast<U8>((lhs >= rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_feq() {
@@ -552,7 +552,7 @@ DirectiveError FpySequencer::op_feq() {
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
     // eq is true if they are equal and neither is nan
-    this->m_runtime.stack.push(static_cast<U8>((lhs == rhs) ? 1 : 0));
+    this->m_runtime.stack.push(static_cast<U8>((lhs == rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_fne() {
@@ -562,7 +562,7 @@ DirectiveError FpySequencer::op_fne() {
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
     // ne is true if they are not equal or either is nan
-    this->m_runtime.stack.push(static_cast<U8>((lhs != rhs) ? 1 : 0));
+    this->m_runtime.stack.push(static_cast<U8>((lhs != rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_flt() {
@@ -571,7 +571,7 @@ DirectiveError FpySequencer::op_flt() {
     }
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
-    this->m_runtime.stack.push(static_cast<U8>(std::isless(lhs, rhs)));
+    this->m_runtime.stack.push(static_cast<U8>(std::isless(lhs, rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_fle() {
@@ -580,7 +580,7 @@ DirectiveError FpySequencer::op_fle() {
     }
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
-    this->m_runtime.stack.push(static_cast<U8>(std::islessequal(lhs, rhs)));
+    this->m_runtime.stack.push(static_cast<U8>(std::islessequal(lhs, rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_fgt() {
@@ -589,7 +589,7 @@ DirectiveError FpySequencer::op_fgt() {
     }
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
-    this->m_runtime.stack.push(static_cast<U8>(std::isgreater(lhs, rhs)));
+    this->m_runtime.stack.push(static_cast<U8>(std::isgreater(lhs, rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_fge() {
@@ -598,14 +598,14 @@ DirectiveError FpySequencer::op_fge() {
     }
     F64 rhs = this->m_runtime.stack.pop<F64>();
     F64 lhs = this->m_runtime.stack.pop<F64>();
-    this->m_runtime.stack.push(static_cast<U8>(std::isgreaterequal(lhs, rhs)));
+    this->m_runtime.stack.push(static_cast<U8>(std::isgreaterequal(lhs, rhs) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_not() {
     if (this->m_runtime.stack.size < sizeof(U8)) {
         return DirectiveError::STACK_UNDERFLOW;
     }
-    this->m_runtime.stack.push(static_cast<U8>(this->m_runtime.stack.pop<U8>() == 0));
+    this->m_runtime.stack.push(static_cast<U8>((this->m_runtime.stack.pop<U8>() == 0) ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE)));
     return DirectiveError::NO_ERROR;
 }
 DirectiveError FpySequencer::op_fpext() {
@@ -1212,12 +1212,12 @@ Signal FpySequencer::memCmp_directiveHandler(const FpySequencer_MemCmpDirective&
     // after the byte arrays
     this->m_runtime.stack.size -= directive.get_size() * 2;
 
-    // memcmp the two byte arrays, push 1 if they were equal, 0 otherwise
+    // memcmp the two byte arrays, push FW_SERIALIZE_TRUE_VALUE if they were equal, FW_SERIALIZE_FALSE_VALUE otherwise
     if (memcmp(this->m_runtime.stack.bytes + lhsOffset, this->m_runtime.stack.bytes + rhsOffset,
                directive.get_size()) == 0) {
-        this->m_runtime.stack.push<U8>(1);
+        this->m_runtime.stack.push<U8>(static_cast<U8>(FW_SERIALIZE_TRUE_VALUE));
     } else {
-        this->m_runtime.stack.push<U8>(0);
+        this->m_runtime.stack.push<U8>(static_cast<U8>(FW_SERIALIZE_FALSE_VALUE));
     }
     return Signal::stmtResponse_success;
 }
@@ -1303,7 +1303,7 @@ Signal FpySequencer::getFlag_directiveHandler(const FpySequencer_GetFlagDirectiv
     }
 
     bool flagVal = this->m_runtime.flags[directive.get_flagIdx()];
-    this->m_runtime.stack.push<U8>(flagVal);
+    this->m_runtime.stack.push<U8>(flagVal ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE) : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE));
     return Signal::stmtResponse_success;
 }
 

--- a/Svc/FpySequencer/FpySequencerTelemetry.fppi
+++ b/Svc/FpySequencer/FpySequencerTelemetry.fppi
@@ -38,6 +38,8 @@ telemetry Debug_ReachedEndOfFile: bool update on change
 telemetry Debug_NextStatementReadSuccess: bool update on change
 @ the opcode of the next statement to dispatch.
 telemetry Debug_NextStatementOpcode: U8 update on change
+@ the index of the next statement to be executed
+telemetry Debug_NextStatementIndex: U32 update on change
 @ if the next statement is a cmd directive, the opcode of that cmd
 telemetry Debug_NextCmdOpcode: FwOpcodeType update on change
 @ the size of the stack in bytes

--- a/Svc/FpySequencer/docs/directives.md
+++ b/Svc/FpySequencer/docs/directives.md
@@ -3,6 +3,7 @@
 * Format is DIRECTIVE_NAME (opcode).
 * Arguments can either be "hardcoded", meaning they are present in the sequence binary after the opcode, or "stack", meaning they are popped off the stack at runtime.
 * Directives can have a "stack result type", which is the type that they push to the stack after execution.
+* The `bool` type is encoded as a single byte: `FW_SERIALIZE_TRUE_VALUE` (`0xFF`) for true and `FW_SERIALIZE_FALSE_VALUE` (`0x00`) for false.
 
 ## WAIT_REL (1)
 Sleeps for a relative duration from the current time.
@@ -136,7 +137,7 @@ Performs an `and` between two booleans, pushes result to stack.
 **Requirement:**  FPY-SEQ-002
 
 ## IEQ (11)
-Compares two integers for equality, pushes result to stack. Doesn't differentiate between signed and unsigned.
+Compares two integers for equality. If equal, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`. Doesn't differentiate between signed and unsigned.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | U64      | stack  | Right operand |
@@ -149,7 +150,7 @@ Compares two integers for equality, pushes result to stack. Doesn't differentiat
 **Requirement:**  FPY-SEQ-002
 
 ## INE (12)
-Compares two integers for inequality, pushes result to stack. Doesn't differentiate between signed and unsigned.
+Compares two integers for inequality. If not equal, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`. Doesn't differentiate between signed and unsigned.
 
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
@@ -163,7 +164,7 @@ Compares two integers for inequality, pushes result to stack. Doesn't differenti
 **Requirement:**  FPY-SEQ-002
 
 ## ULT (13)
-Performs an unsigned less than comparison on two unsigned integers, pushes result to stack
+Performs an unsigned less than comparison on two unsigned integers. If the second < first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | U64      | stack  | Right operand |
@@ -176,7 +177,7 @@ Performs an unsigned less than comparison on two unsigned integers, pushes resul
 **Requirement:**  FPY-SEQ-002
 
 ## ULE (14)
-Performs an unsigned less than or equal to comparison on two unsigned integers, pushes result to stack.
+Performs an unsigned less than or equal to comparison on two unsigned integers. If the second <= first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | U64      | stack  | Right operand |
@@ -189,7 +190,7 @@ Performs an unsigned less than or equal to comparison on two unsigned integers, 
 **Requirement:**  FPY-SEQ-002
 
 ## UGT (15)
-Performs an unsigned greater than comparison on two unsigned integers, pushes result to stack.
+Performs an unsigned greater than comparison on two unsigned integers. If the second > first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | U64      | stack  | Right operand |
@@ -202,7 +203,7 @@ Performs an unsigned greater than comparison on two unsigned integers, pushes re
 **Requirement:**  FPY-SEQ-002
 
 ## UGE (16)
-Performs an unsigned greater than or equal to comparison on two unsigned integers, pushes result to stack.
+Performs an unsigned greater than or equal to comparison on two unsigned integers. If the second >= first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | U64      | stack  | Right operand |
@@ -215,7 +216,7 @@ Performs an unsigned greater than or equal to comparison on two unsigned integer
 **Requirement:**  FPY-SEQ-002
 
 ## SLT (17)
-Performs a signed less than comparison on two signed integers, pushes result to stack.
+Performs a signed less than comparison on two signed integers. If the second < first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | I64      | stack  | Right operand |
@@ -228,7 +229,7 @@ Performs a signed less than comparison on two signed integers, pushes result to 
 **Requirement:**  FPY-SEQ-002
 
 ## SLE (18)
-Performs a signed less than or equal to comparison on two signed integers, pushes result to stack.
+Performs a signed less than or equal to comparison on two signed integers. If the second <= first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | I64      | stack  | Right operand |
@@ -241,7 +242,7 @@ Performs a signed less than or equal to comparison on two signed integers, pushe
 **Requirement:**  FPY-SEQ-002
 
 ## SGT (19)
-Performs a signed greater than comparison on two signed integers, pushes result to stack.
+Performs a signed greater than comparison on two signed integers. If the second > first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | I64      | stack  | Right operand |
@@ -254,7 +255,7 @@ Performs a signed greater than comparison on two signed integers, pushes result 
 **Requirement:**  FPY-SEQ-002
 
 ## SGE (20)
-Performs a signed greater than or equal to comparison on two signed integers, pushes result to stack.
+Performs a signed greater than or equal to comparison on two signed integers. If the second >= first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | I64      | stack  | Right operand |
@@ -267,7 +268,7 @@ Performs a signed greater than or equal to comparison on two signed integers, pu
 **Requirement:**  FPY-SEQ-002
 
 ## FEQ (21)
-Compares two floats for equality, pushes result to stack. If neither is NaN and they are otherwise equal, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
+Compares two floats for equality, pushes result to stack. If neither is NaN and they are otherwise equal, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | F64      | stack  | Right operand |
@@ -280,7 +281,7 @@ Compares two floats for equality, pushes result to stack. If neither is NaN and 
 **Requirement:**  FPY-SEQ-002
 
 ## FNE (22)
-Compares two floats for inequality, pushes result to stack. If either is NaN or they are not equal, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
+Compares two floats for inequality, pushes result to stack. If either is NaN or they are not equal, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | F64      | stack  | Right operand |
@@ -293,7 +294,7 @@ Compares two floats for inequality, pushes result to stack. If either is NaN or 
 **Requirement:**  FPY-SEQ-002
 
 ## FLT (23)
-Performs a less than comparison on two floats, pushes result to stack. If neither is NaN and the second < first, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
+Performs a less than comparison on two floats, pushes result to stack. If neither is NaN and the second < first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | F64      | stack  | Right operand |
@@ -306,7 +307,7 @@ Performs a less than comparison on two floats, pushes result to stack. If neithe
 **Requirement:**  FPY-SEQ-002
 
 ## FLE (24)
-Performs a less than or equal to comparison on two floats, pushes result to stack. If neither is NaN and the second <= first, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
+Performs a less than or equal to comparison on two floats, pushes result to stack. If neither is NaN and the second <= first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | F64      | stack  | Right operand |
@@ -319,7 +320,7 @@ Performs a less than or equal to comparison on two floats, pushes result to stac
 **Requirement:**  FPY-SEQ-002
 
 ## FGT (25)
-Performs a greater than comparison on two floats, pushes result to stack. If neither is NaN and the second > first, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
+Performs a greater than comparison on two floats, pushes result to stack. If neither is NaN and the second > first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | F64      | stack  | Right operand |
@@ -332,7 +333,7 @@ Performs a greater than comparison on two floats, pushes result to stack. If nei
 **Requirement:**  FPY-SEQ-002
 
 ## FGE (26)
-Performs a greater than or equal to comparison on two floats, pushes result to stack. If neither is NaN and the second >= first, pushes 1 to stack, otherwise 0. Infinity is handled consistent with C++.
+Performs a greater than or equal to comparison on two floats, pushes result to stack. If neither is NaN and the second >= first, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`. Infinity is handled consistent with C++.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | rhs      | F64      | stack  | Right operand |
@@ -345,7 +346,7 @@ Performs a greater than or equal to comparison on two floats, pushes result to s
 **Requirement:**  FPY-SEQ-002
 
 ## NOT (27)
-Performs a boolean not operation on a boolean, pushes result to stack.
+Performs a boolean not operation on a boolean. If the operand is `FW_SERIALIZE_FALSE_VALUE`, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | value    | bool     | stack  | Value to negate |
@@ -820,7 +821,7 @@ Discards bytes from the top of the stack.
 
 ## MEMCMP (63)
 
-Pops 2x `size` bytes off the stack.  Compares the first `size` bytes to the second `size` bytes with a byte-for-byte comparison pushing a boolean true when equal and false when unequal.
+Pops 2x `size` bytes off the stack.  Compares the first `size` bytes to the second `size` bytes with a byte-for-byte comparison. If equal, pushes `FW_SERIALIZE_TRUE_VALUE` to stack, otherwise `FW_SERIALIZE_FALSE_VALUE`.
 
 | Arg Name | Arg Type | Source     | Description |
 |----------|----------|------------|-------------|
@@ -880,7 +881,7 @@ Pops a bool off the stack, and sets a command sequencer flag from the value.
 **Requirement:**  FPY-SEQ-020
 
 ## GET_FLAG (68)
-Gets a command sequencer flag and pushes its value as a U8 to the stack.
+Gets a command sequencer flag and pushes its value to the stack as `FW_SERIALIZE_TRUE_VALUE` or `FW_SERIALIZE_FALSE_VALUE`.
 | Arg Name | Arg Type | Source | Description |
 |----------|----------|--------|-------------|
 | flag_idx | U8 | hardcoded | Index of the flag to get |

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -280,7 +280,7 @@ TEST_F(FpySequencerTester, stackOp) {
     Signal result = tester_stackOp_directiveHandler(directiveEQ, err);
     ASSERT_EQ(result, Signal::stmtResponse_success);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 1);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
@@ -291,7 +291,7 @@ TEST_F(FpySequencerTester, stackOp) {
     result = tester_stackOp_directiveHandler(directiveNE, err);
     ASSERT_EQ(result, Signal::stmtResponse_success);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 1);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
@@ -324,7 +324,7 @@ TEST_F(FpySequencerTester, stackOp) {
     result = tester_stackOp_directiveHandler(directiveSLT, err);
     ASSERT_EQ(result, Signal::stmtResponse_success);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 1);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
@@ -335,7 +335,7 @@ TEST_F(FpySequencerTester, stackOp) {
     result = tester_stackOp_directiveHandler(directiveULT, err);
     ASSERT_EQ(result, Signal::stmtResponse_success);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 1);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
@@ -346,7 +346,7 @@ TEST_F(FpySequencerTester, stackOp) {
     result = tester_stackOp_directiveHandler(directiveUGT, err);
     ASSERT_EQ(result, Signal::stmtResponse_success);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 1);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
@@ -357,7 +357,7 @@ TEST_F(FpySequencerTester, stackOp) {
     result = tester_stackOp_directiveHandler(directiveFLT, err);
     ASSERT_EQ(result, Signal::stmtResponse_success);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 1);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
@@ -368,7 +368,7 @@ TEST_F(FpySequencerTester, stackOp) {
     result = tester_stackOp_directiveHandler(directiveFGE, err);
     ASSERT_EQ(result, Signal::stmtResponse_success);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 1);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
@@ -387,378 +387,378 @@ TEST_F(FpySequencerTester, ieq) {
     tester_push<I64>(-1);
     tester_push<I64>(-1);
     ASSERT_EQ(tester_op_ieq(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
     tester_push<I64>(-1);
     tester_push<I64>(1);
     ASSERT_EQ(tester_op_ieq(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 }
 
 TEST_F(FpySequencerTester, ine) {
     tester_push<I64>(-1);
     tester_push<I64>(-1);
     ASSERT_EQ(tester_op_ine(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
     tester_push<I64>(-1);
     tester_push<I64>(1);
     ASSERT_EQ(tester_op_ine(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
 }
 
 TEST_F(FpySequencerTester, or) {
-    tester_push<U8>(true);
-    tester_push<U8>(true);
+    tester_push<U8>(FW_SERIALIZE_TRUE_VALUE);
+    tester_push<U8>(FW_SERIALIZE_TRUE_VALUE);
     ASSERT_EQ(tester_op_or(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
-    tester_push<U8>(true);
-    tester_push<U8>(false);
+    tester_push<U8>(FW_SERIALIZE_TRUE_VALUE);
+    tester_push<U8>(FW_SERIALIZE_FALSE_VALUE);
     ASSERT_EQ(tester_op_or(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
-    tester_push<U8>(false);
-    tester_push<U8>(false);
+    tester_push<U8>(FW_SERIALIZE_FALSE_VALUE);
+    tester_push<U8>(FW_SERIALIZE_FALSE_VALUE);
     ASSERT_EQ(tester_op_or(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 }
 
 TEST_F(FpySequencerTester, and) {
-    tester_push<U8>(false);
-    tester_push<U8>(false);
+    tester_push<U8>(FW_SERIALIZE_FALSE_VALUE);
+    tester_push<U8>(FW_SERIALIZE_FALSE_VALUE);
     ASSERT_EQ(tester_op_and(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
-    tester_push<U8>(true);
-    tester_push<U8>(false);
+    tester_push<U8>(FW_SERIALIZE_TRUE_VALUE);
+    tester_push<U8>(FW_SERIALIZE_FALSE_VALUE);
     ASSERT_EQ(tester_op_and(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
-    tester_push<U8>(true);
-    tester_push<U8>(true);
+    tester_push<U8>(FW_SERIALIZE_TRUE_VALUE);
+    tester_push<U8>(FW_SERIALIZE_TRUE_VALUE);
     ASSERT_EQ(tester_op_and(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
 }
 
 TEST_F(FpySequencerTester, ult) {
     tester_push<U64>(0);
     tester_push<U64>(std::numeric_limits<U64>::max());
     ASSERT_EQ(tester_op_ult(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<U64>(0);
     tester_push<U64>(0);
     ASSERT_EQ(tester_op_ult(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<U64>(0);
     tester_push<U64>(1);
     ASSERT_EQ(tester_op_ult(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
 }
 
 TEST_F(FpySequencerTester, ule) {
     tester_push<U64>(0);
     tester_push<U64>(std::numeric_limits<U64>::max());
     ASSERT_EQ(tester_op_ule(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<U64>(0);
     tester_push<U64>(0);
     ASSERT_EQ(tester_op_ule(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<U64>(0);
     tester_push<U64>(1);
     ASSERT_EQ(tester_op_ule(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<U64>(2);
     tester_push<U64>(1);
     ASSERT_EQ(tester_op_ule(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 }
 
 TEST_F(FpySequencerTester, ugt) {
     tester_push<U64>(std::numeric_limits<U64>::max());
     tester_push<U64>(0);
     ASSERT_EQ(tester_op_ugt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<U64>(0);
     tester_push<U64>(0);
     ASSERT_EQ(tester_op_ugt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<U64>(1);
     tester_push<U64>(0);
     ASSERT_EQ(tester_op_ugt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
 }
 
 TEST_F(FpySequencerTester, uge) {
     tester_push<U64>(std::numeric_limits<U64>::max());
     tester_push<U64>(0);
     ASSERT_EQ(tester_op_uge(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<U64>(0);
     tester_push<U64>(0);
     ASSERT_EQ(tester_op_uge(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<U64>(1);
     tester_push<U64>(0);
     ASSERT_EQ(tester_op_uge(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<U64>(1);
     tester_push<U64>(2);
     ASSERT_EQ(tester_op_uge(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 }
 
 TEST_F(FpySequencerTester, slt) {
     tester_push<I64>(0);
     tester_push<I64>(std::numeric_limits<I64>::max());
     ASSERT_EQ(tester_op_slt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<I64>(0);
     tester_push<I64>(0);
     ASSERT_EQ(tester_op_slt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<I64>(0);
     tester_push<I64>(1);
     ASSERT_EQ(tester_op_slt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
 }
 
 TEST_F(FpySequencerTester, sle) {
     tester_push<I64>(0);
     tester_push<I64>(std::numeric_limits<I64>::max());
     ASSERT_EQ(tester_op_sle(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<I64>(0);
     tester_push<I64>(0);
     ASSERT_EQ(tester_op_sle(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<I64>(0);
     tester_push<I64>(-1);
     ASSERT_EQ(tester_op_sle(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 }
 
 TEST_F(FpySequencerTester, sgt) {
     tester_push<I64>(0);
     tester_push<I64>(std::numeric_limits<I64>::max());
     ASSERT_EQ(tester_op_sgt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<I64>(0);
     tester_push<I64>(0);
     ASSERT_EQ(tester_op_sgt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<I64>(0);
     tester_push<I64>(-1);
     ASSERT_EQ(tester_op_sgt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
 }
 
 TEST_F(FpySequencerTester, sge) {
     tester_push<I64>(0);
     tester_push<I64>(std::numeric_limits<I64>::max());
     ASSERT_EQ(tester_op_sge(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<I64>(0);
     tester_push<I64>(0);
     ASSERT_EQ(tester_op_sge(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<I64>(0);
     tester_push<I64>(-1);
     ASSERT_EQ(tester_op_sge(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
 }
 
 TEST_F(FpySequencerTester, flt) {
     tester_push<F64>(0.0);
     tester_push<F64>(std::numeric_limits<F64>::max());
     ASSERT_EQ(tester_op_flt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(0.0);
     ASSERT_EQ(tester_op_flt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(-1.0);
     ASSERT_EQ(tester_op_flt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(std::numeric_limits<F64>::quiet_NaN());
     ASSERT_EQ(tester_op_flt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 }
 
 TEST_F(FpySequencerTester, fle) {
     tester_push<F64>(0.0);
     tester_push<F64>(std::numeric_limits<F64>::max());
     ASSERT_EQ(tester_op_fle(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(0.0);
     ASSERT_EQ(tester_op_fle(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(-1.0);
     ASSERT_EQ(tester_op_fle(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(std::numeric_limits<F64>::quiet_NaN());
     tester_push<F64>(std::numeric_limits<F64>::quiet_NaN());
     ASSERT_EQ(tester_op_fle(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 }
 
 TEST_F(FpySequencerTester, fgt) {
     tester_push<F64>(0.0);
     tester_push<F64>(std::numeric_limits<F64>::max());
     ASSERT_EQ(tester_op_fgt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(0.0);
     ASSERT_EQ(tester_op_fgt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(-1.0);
     ASSERT_EQ(tester_op_fgt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(std::numeric_limits<F64>::quiet_NaN());
     ASSERT_EQ(tester_op_fgt(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 }
 
 TEST_F(FpySequencerTester, fge) {
     tester_push<F64>(0.0);
     tester_push<F64>(std::numeric_limits<F64>::max());
     ASSERT_EQ(tester_op_fge(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(0.0);
     ASSERT_EQ(tester_op_fge(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(-1.0);
     ASSERT_EQ(tester_op_fge(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(std::numeric_limits<F64>::quiet_NaN());
     tester_push<F64>(std::numeric_limits<F64>::quiet_NaN());
     ASSERT_EQ(tester_op_fge(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 }
 
 TEST_F(FpySequencerTester, feq) {
     tester_push<F64>(0.0);
     tester_push<F64>(std::numeric_limits<F64>::max());
     ASSERT_EQ(tester_op_feq(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(0.0);
     ASSERT_EQ(tester_op_feq(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(-1.0);
     ASSERT_EQ(tester_op_feq(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(std::numeric_limits<F64>::quiet_NaN());
     tester_push<F64>(std::numeric_limits<F64>::quiet_NaN());
     ASSERT_EQ(tester_op_feq(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 }
 
 TEST_F(FpySequencerTester, fne) {
     tester_push<F64>(0.0);
     tester_push<F64>(std::numeric_limits<F64>::max());
     ASSERT_EQ(tester_op_fne(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(0.0);
     ASSERT_EQ(tester_op_fne(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(0.0);
     tester_push<F64>(-1.0);
     ASSERT_EQ(tester_op_fne(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
     tester_get_m_runtime_ptr()->stack.size = 0;
 
     tester_push<F64>(std::numeric_limits<F64>::quiet_NaN());
     tester_push<F64>(std::numeric_limits<F64>::quiet_NaN());
     ASSERT_EQ(tester_op_fne(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
 }
 
 TEST_F(FpySequencerTester, not) {
-    tester_push<U8>(true);
+    tester_push<U8>(FW_SERIALIZE_TRUE_VALUE);
     ASSERT_EQ(tester_op_not(), DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 }
 
 TEST_F(FpySequencerTester, fptrunc) {
@@ -986,7 +986,7 @@ TEST_F(FpySequencerTester, memCmp) {
     Signal result = tester_memCmp_directiveHandler(directive, err);
     ASSERT_EQ(result, Signal::stmtResponse_success);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_pop<U8>(), 1);  // Should be true
+    ASSERT_EQ(tester_pop<U8>(), FW_SERIALIZE_TRUE_VALUE);  // Should be true
 
     // Test unequal memory blocks
     tester_push<U32>(0x12345678);
@@ -994,7 +994,7 @@ TEST_F(FpySequencerTester, memCmp) {
     result = tester_memCmp_directiveHandler(directive, err);
     ASSERT_EQ(result, Signal::stmtResponse_success);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_pop<U8>(), 0);  // Should be false
+    ASSERT_EQ(tester_pop<U8>(), FW_SERIALIZE_FALSE_VALUE);  // Should be false
 
     // test not enough bytes on stack
     tester_push<U32>(0x12345678);
@@ -1053,7 +1053,7 @@ TEST_F(FpySequencerTester, getFlag) {
     ASSERT_EQ(result, Signal::stmtResponse_success);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
     ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 1);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 1);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
 
     // reset stack
     tester_get_m_runtime_ptr()->stack.size = 0;
@@ -1063,7 +1063,7 @@ TEST_F(FpySequencerTester, getFlag) {
     ASSERT_EQ(result, Signal::stmtResponse_success);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
     ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 1);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], 0);
+    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
 
     // Test invalid flag index
     directive.set_flagIdx(Fpy::FLAG_COUNT);
@@ -2918,7 +2918,7 @@ TEST_F(FpySequencerTester, tlmWrite) {
     invoke_to_tlmWrite(0, 0);
     this->tester_doDispatch();
     // make sure that all tlm is written every call
-    ASSERT_TLM_SIZE(19);
+    ASSERT_TLM_SIZE(20);
 }
 
 TEST_F(FpySequencerTester, seqRunIn) {


### PR DESCRIPTION
…dx tlm to debug

| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#4050 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

* Instead of pushing 1 or 0 to the stack, operators that push a boolean value to the stack now push the `FW_SERIALIZE_TRUE_VALUE` or `FW_SERIALIZE_FALSE_VALUE`
* Add a Debug_NextStatementIndex telemetry point so that you can always see what statement is next without looking at events while debugging a sequence

## Rationale

This change fixes a bug where `(1 == 1) == True` evaluates to False, because the lhs pushes 1, and the rhs pushes `FW_SERIALIZE_TRUE_VALUE`. They would be compared with MEMCMP, which sees two diff binary values.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI wrote all the code and tests.
