### PR TITLE
Clean up DpCatalog test artifacts in destructor

### DIFF
--- a/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
@@ -32,6 +32,7 @@ DpCatalogTester ::DpCatalogTester()
 
 DpCatalogTester ::~DpCatalogTester() {
     this->component.deinit();
+    std::system("rm -rf ./DpTest*");
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4360 |
|**_Has Unit Tests (y/n)_**| Y (existing tests pass) |
|**_Documentation Included (y/n)_**| N |
|**_Generative AI was used in this contribution (y/n)_**| Y |

---
## Change Description

Adds `std::system("rm -rf ./DpTest*")` to the `DpCatalogTester` destructor, mirroring the identical cleanup already present in the constructor.

## Rationale

When a test assertion fails, the cleanup at the end of `readDps()` never runs, leaving residual `DpTest*` directories on disk. The constructor cleans up before the next run, but only if you run the tests again. Adding cleanup to the destructor ensures artifacts are removed on every exit since C++ guarantees destructor execution during stack unwinding.

## Testing/Review Recommendations

All 19 existing DpCatalog unit tests pass. Verified no `DpTest*` artifacts remain on disk after the test run completes.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude Code was used for codebase exploration, identifying the root cause, and drafting the one-line fix. The change was reviewed and tested manually.