### PR TITLE
Add regression check for deprecated pkg_resources usage

### DIFF
--- a/cmake/test/src/test_no_deprecated_setuptools_api.py
+++ b/cmake/test/src/test_no_deprecated_setuptools_api.py
@@ -1,0 +1,25 @@
+"""Guard against reintroducing deprecated setuptools resource APIs."""
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_no_deprecated_setuptools_resource_api_usage():
+    """Fail when deprecated setuptools resource APIs appear in tracked Python files."""
+    deprecated_api = "_".join(["pkg", "resources"])
+    result = subprocess.run(
+        ["git", "grep", "-n", deprecated_api, "--", "*.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode in (0, 1), f"git grep failed:\n{result.stderr}"
+    assert result.returncode == 1, (
+        "Found deprecated setuptools resource API usage in Python files:\n"
+        f"{result.stdout}"
+    )


### PR DESCRIPTION
## Summary
- Reference: Fixes #4704
- Ran the requested scans:
  - `grep -r "pkg_resources" . --include="*.py" -n`
  - `grep -r "from pkg_resources" . --include="*.py" -n`
  - `grep -r "import pkg_resources" . --include="*.py" -n`
- Result: no current `pkg_resources` usages were found in Python files, so there were no direct call sites to replace with `importlib.metadata` / `importlib.resources`.
- Added a regression test so CI fails if deprecated setuptools resource API usage is reintroduced.

## Files changed
- `cmake/test/src/test_no_deprecated_setuptools_api.py`
  - Added a test that uses `git grep` over tracked `*.py` files and fails if deprecated setuptools resource API usage appears.

## Python version confirmation
- Confirmed minimum supported Python is 3.9+ from:
  - `docs/getting-started/installing-fprime.md` (states Python 3.9+)
  - `.github/workflows/pip-check.yml` (matrix includes Python 3.9 through 3.14)
- This satisfies compatibility for stdlib `importlib.metadata` and `importlib.resources.files` in this repository context.

## Validation
- `pytest cmake/test/src/test_no_deprecated_setuptools_api.py -q` (passes)
- `pytest cmake/test/src -q` (fails in this environment due existing CMake generation/setup issues unrelated to this change)
- Re-ran the three required `grep` scans above; all return no matches.
