### PR TITLE
Fix: Clean up generated files in ComLoggerTester

### DIFF
--- a/Svc/ComLogger/test/ut/ComLoggerTester.hpp
+++ b/Svc/ComLogger/test/ut/ComLoggerTester.hpp
@@ -36,6 +36,7 @@ class ComLoggerTester : public ComLoggerGTestBase {
     void noInitError();
 
   private:
+    void cleanupFiles();
     void connectPorts();
     void initComponents();
     void dispatchOne();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4733 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Automatically clean up ComLogger unit test log files by adding a cleanupFiles() helper and calling it from ComLoggerTester’s destructor, so binary test artifacts no longer accumulate under Svc/ComLogger/.

## Rationale

Unit tests in ComLogger generate binary log files that were accumulating in the directory. This change automatically cleans up those files.

