### PR TITLE
Fixed broken CCSDS links

### DIFF
--- a/Svc/Ccsds/ApidManager/docs/sdd.md
+++ b/Svc/Ccsds/ApidManager/docs/sdd.md
@@ -46,4 +46,4 @@ The `ApidManager` is typically used in conjunction with the [`SpacePacketFramer`
 
 - [`Svc::Ccsds::SpacePacketFramer`](../../SpacePacketFramer/docs/sdd.md)
 - [`Svc::Ccsds::SpacePacketDeframer`](../../SpacePacketDeframer/docs/sdd.md)
-- [CCSDS Space Packet Protocol (CCSDS 133.0-B-2)](https://public.ccsds.org/Pubs/133x0b2e1.pdf)
+- [CCSDS Space Packet Protocol (CCSDS 133.0-B-2)](https://ccsds.org/Pubs/133x0b2e2.pdf)

--- a/Svc/Ccsds/SpacePacketFramer/docs/sdd.md
+++ b/Svc/Ccsds/SpacePacketFramer/docs/sdd.md
@@ -1,8 +1,8 @@
 # Svc::Ccsds::SpacePacketFramer
 
-The `Svc::Ccsds::SpacePacketFramer` is an implementation of the [FramerInterface](../../../Interfaces/docs/sdd.md) for the CCSDS [Space Packet Protocol](https://public.ccsds.org/Pubs/133x0b2e1.pdf).
+The `Svc::Ccsds::SpacePacketFramer` is an implementation of the [FramerInterface](../../../Interfaces/docs/sdd.md) for the CCSDS [Space Packet Protocol](https://ccsds.org/Pubs/133x0b2e2.pdf).
 
-It receives user data on its input port and constructs a CCSDS Space Packet. Please refer to the CCSDS [Space Packet Protocol specification (CCSDS 133.0-B-2)](https://public.ccsds.org/Pubs/133x0b2e1.pdf) for details on the packet format.
+It receives user data on its input port and constructs a CCSDS Space Packet. Please refer to the CCSDS [Space Packet Protocol specification (CCSDS 133.0-B-2)](https://ccsds.org/Pubs/133x0b2e2.pdf) for details on the packet format.
 
 The `Svc::Ccsds::SpacePacketFramer` is typically used upstream of a component that adds transfer frame headers, such as the `Svc::Ccsds::TmFramer`. It encapsulates user data into a Space Packet, adding the necessary header fields.
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4742 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Updated broken CCSDS 133.0-B-2 standard reference URLs in SpacePacketFramer and ApidManager documentation.

## Rationale

The original URLs return 404 errors. CCSDS updated their URL structure and released Edition 2 of the 133.0-B-2 standard, making the Edition 1 links obsolete.

## Testing/Review Recommendations

Verify all CCSDS 133.0-B-2 links resolve successfully