### PR TITLE
Modify circular buffer overflow test to handle zero-length random input

### DIFF
--- a/Utils/Types/test/ut/CircularBuffer/CircularRules.cpp
+++ b/Utils/Types/test/ut/CircularBuffer/CircularRules.cpp
@@ -42,12 +42,13 @@ void SerializeOkRule::action(MockTypes::CircularState& state) {
 SerializeOverflowRule::SerializeOverflowRule(const char* const name) : STest::Rule<MockTypes::CircularState>(name) {}
 
 bool SerializeOverflowRule::precondition(const MockTypes::CircularState& state) {
-    return state.getRemainingSize() < state.getRandomSize();
+    return state.getRemainingSize() <= state.getRandomSize();
 }
 
 void SerializeOverflowRule::action(MockTypes::CircularState& state) {
     Fw::SerializeStatus status = state.getTestBuffer().serialize(state.getBuffer(), state.getRandomSize());
-    ASSERT_EQ(status, Fw::FW_SERIALIZE_NO_ROOM_LEFT);
+    Fw::SerializeStatus expected_status = (state.getRandomSize() == 0) ? (Fw::FW_SERIALIZE_OK) : (Fw::FW_SERIALIZE_NO_ROOM_LEFT);
+    ASSERT_EQ(status, expected_status);
 }
 
 PeekOkRule::PeekOkRule(const char* const name) : STest::Rule<MockTypes::CircularState>(name) {}

--- a/Utils/Types/test/ut/CircularBuffer/CircularRules.cpp
+++ b/Utils/Types/test/ut/CircularBuffer/CircularRules.cpp
@@ -14,14 +14,17 @@
 
 namespace Types {
 
-RandomizeRule::RandomizeRule(const char* const name) : STest::Rule<MockTypes::CircularState>(name) {}
+RandomizeRule::RandomizeRule(const char* const name, U32 min_buffer_size, U32 max_buffer_size)
+    : STest::Rule<MockTypes::CircularState>(name),
+      m_min_buffer_size(min_buffer_size),
+      m_max_buffer_size(max_buffer_size) {}
 
 bool RandomizeRule::precondition(const MockTypes::CircularState& state) {
     return true;
 }
 
 void RandomizeRule::action(MockTypes::CircularState& truth) {
-    (void)truth.generateRandomBuffer();
+    (void)truth.generateRandomBuffer(m_min_buffer_size, m_max_buffer_size);
 }
 
 SerializeOkRule::SerializeOkRule(const char* const name) : STest::Rule<MockTypes::CircularState>(name) {}
@@ -42,13 +45,12 @@ void SerializeOkRule::action(MockTypes::CircularState& state) {
 SerializeOverflowRule::SerializeOverflowRule(const char* const name) : STest::Rule<MockTypes::CircularState>(name) {}
 
 bool SerializeOverflowRule::precondition(const MockTypes::CircularState& state) {
-    return state.getRemainingSize() <= state.getRandomSize();
+    return (state.getRemainingSize() < state.getRandomSize()) && (state.getRandomSize() != 0);
 }
 
 void SerializeOverflowRule::action(MockTypes::CircularState& state) {
     Fw::SerializeStatus status = state.getTestBuffer().serialize(state.getBuffer(), state.getRandomSize());
-    Fw::SerializeStatus expected_status = (state.getRandomSize() == 0) ? (Fw::FW_SERIALIZE_OK) : (Fw::FW_SERIALIZE_NO_ROOM_LEFT);
-    ASSERT_EQ(status, expected_status);
+    ASSERT_EQ(status, Fw::FW_SERIALIZE_NO_ROOM_LEFT);
 }
 
 PeekOkRule::PeekOkRule(const char* const name) : STest::Rule<MockTypes::CircularState>(name) {}

--- a/Utils/Types/test/ut/CircularBuffer/CircularRules.hpp
+++ b/Utils/Types/test/ut/CircularBuffer/CircularRules.hpp
@@ -34,13 +34,17 @@ namespace Types {
  */
 struct RandomizeRule : public STest::Rule<MockTypes::CircularState> {
     // Constructor
-    RandomizeRule(const char* const name);
+    RandomizeRule(const char* const name, U32 min_buffer_size = 0, U32 max_buffer_size = MAX_BUFFER_SIZE);
 
     // Always valid
     bool precondition(const MockTypes::CircularState& state);
 
     // Will randomize the test state
     void action(MockTypes::CircularState& truth);
+
+  private:
+    U32 m_min_buffer_size;
+    U32 m_max_buffer_size;
 };
 
 /**

--- a/Utils/Types/test/ut/CircularBuffer/CircularState.cpp
+++ b/Utils/Types/test/ut/CircularBuffer/CircularState.cpp
@@ -36,10 +36,10 @@ CircularState::~CircularState() {
 }
 
 // Generates a random buffer
-FwSizeType CircularState::generateRandomBuffer() {
+FwSizeType CircularState::generateRandomBuffer(U32 min_size, U32 max_size) {
     m_peek_offset = static_cast<FwSizeType>(STest::Pick::lowerUpper(0, sizeof(m_buffer)));
     m_peek_type = static_cast<FwSizeType>(STest::Pick::lowerUpper(0, 4));
-    FwSizeType random_size = static_cast<FwSizeType>(STest::Pick::lowerUpper(0, sizeof(m_buffer)));
+    FwSizeType random_size = static_cast<FwSizeType>(STest::Pick::lowerUpper(min_size, max_size));
     for (U32 i = 0; i < random_size; i++) {
         m_buffer[i] = static_cast<U8>(STest::Pick::lowerUpper(0, 256));
     }

--- a/Utils/Types/test/ut/CircularBuffer/CircularState.hpp
+++ b/Utils/Types/test/ut/CircularBuffer/CircularState.hpp
@@ -25,9 +25,10 @@ class CircularState {
     ~CircularState();
     /**
      * Generates a random buffer for input to various calls to the CircularBuffer.
+     * The size of the random buffer will be within min_size and max_size inclusive.
      * @return size of this buffer
      */
-    FwSizeType generateRandomBuffer();
+    FwSizeType generateRandomBuffer(U32 min_size = 0, U32 max_size = sizeof(m_buffer));
     /**
      * Sets the random settings
      * @param random: random size

--- a/Utils/Types/test/ut/CircularBuffer/Main.cpp
+++ b/Utils/Types/test/ut/CircularBuffer/Main.cpp
@@ -79,7 +79,7 @@ TEST(CircularBufferTests, BasicOverflowTest) {
     state.setRemainingSize(0);
 
     // Create rules, and assign them into the array
-    Types::RandomizeRule randomGo("randomGo");
+    Types::RandomizeRule randomGo("randomGo", 1);
     Types::SerializeOverflowRule serializeOverflow("serializeOverflow");
 
     randomGo.apply(state);


### PR DESCRIPTION


| | |
|:---|:---|
|**_Related Issue(s)_**| #4737  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Modify basic overflow test to handle zero-length random input - if input has zero length then we don't expect a call to `Types::CircularBuffer::serialize` to return an error code, even if the circular buffer is full.

An alternative approach might be to modify `MockTypes::CircularState::generateRandomBuffer()` so that it doesn't generate zero-size random buffers, or to parameterise the function so that an allowable range of `random_size` can be passed in by the caller / per test case.

## Rationale

Fix failing test case.