### PR TITLE
Add checks to TC deframing stack to prevent underflows

### DIFF
--- a/Svc/Ccsds/TcDeframer/TcDeframer.cpp
+++ b/Svc/Ccsds/TcDeframer/TcDeframer.cpp
@@ -68,7 +68,10 @@ void TcDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const Co
         this->dataReturnOut_out(0, data, context);  // drop the frame
         return;
     }
-    if (data.getSize() < static_cast<Fw::Buffer::SizeType>(total_frame_length)) {
+    // check that deserialized frame_length is at least large enough to hold header and trailer, and
+    // that it is not larger than the actual data available in the buffer
+    if ((data.getSize() < static_cast<Fw::Buffer::SizeType>(total_frame_length)) or
+        (total_frame_length < TCHeader::SERIALIZED_SIZE + TCTrailer::SERIALIZED_SIZE)) {
         FwSizeType maxDataAvailable = static_cast<FwSizeType>(data.getSize());
         this->log_WARNING_HI_InvalidFrameLength(total_frame_length, maxDataAvailable);
         this->errorNotifyHelper(Ccsds::FrameError::TC_INVALID_LENGTH);

--- a/Svc/FrameAccumulator/FrameDetector/CcsdsTcFrameDetector.cpp
+++ b/Svc/FrameAccumulator/FrameDetector/CcsdsTcFrameDetector.cpp
@@ -46,9 +46,14 @@ FrameDetector::Status CcsdsTcFrameDetector::detect(const Types::CircularBuffer& 
         static_cast<FwSizeType>((header.get_vcIdAndLength() & Ccsds::TCSubfields::FrameLengthMask) + 1);
     const U16 data_to_crc_length = static_cast<U16>(expected_frame_length - Ccsds::TCTrailer::SERIALIZED_SIZE);
 
+    // If the full frame is not yet available, report that more data is needed
     if (data.get_allocated_size() < expected_frame_length) {
         size_out = expected_frame_length;
         return Status::MORE_DATA_NEEDED;
+    }
+    // If the deserialized length is too small to even hold the header and trailer, we don't have a valid frame
+    if (expected_frame_length < Ccsds::TCHeader::SERIALIZED_SIZE + Ccsds::TCTrailer::SERIALIZED_SIZE) {
+        return Status::NO_FRAME_DETECTED;
     }
 
     // ---------------- Frame Trailer ----------------


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Fix potential underflow issues in the TC deframing stack, where receiving an ill-crafted length token could result in an assertion.
