### PR TITLE
S_ISVTX is part of XSI, which is an optional set of interfaces and ex…

### DIFF
--- a/Os/Posix/File.cpp
+++ b/Os/Posix/File.cpp
@@ -91,7 +91,9 @@ mode_t PosixFile::map_open_create_mode(const U32 create_mode) {
 
     out_mode |= (create_mode & Os::FILE_MODE_ISUID) ? S_ISUID : 0;
     out_mode |= (create_mode & Os::FILE_MODE_ISGID) ? S_ISGID : 0;
+#if defined(S_ISVTX)
     out_mode |= (create_mode & Os::FILE_MODE_ISVTX) ? S_ISVTX : 0;
+#endif
 
     return out_mode;
 }


### PR DESCRIPTION
…tensions on top of the POSIX standard. Some systems do not build with the optional XSI so this file fails to compile in those cases.

| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/4767 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Use a build macro to include the line of code iff the definition exists

## Rationale

Some POSIX build systems don't use the optional XSI interface

## Testing/Review Recommendations

CI

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
