### PR TITLE
Allow bypassing ignore list

### DIFF
--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -35,7 +35,7 @@ TlmPacketizer ::TlmPacketizer(const char* const compName)
         this->m_tlmEntries.buckets[entry].bucketNo = entry;
         this->m_tlmEntries.buckets[entry].next = nullptr;
         this->m_tlmEntries.buckets[entry].id = 0;
-        this->m_tlmEntries.buckets[entry].ignored = true; // Default to ignoring channels until configured otherwise
+        this->m_tlmEntries.buckets[entry].ignored = true;  // Default to ignoring channels until configured otherwise
     }
     // clear free index
     this->m_tlmEntries.free = 0;
@@ -70,7 +70,7 @@ void TlmPacketizer::setPacketList(const TlmPacketizerPacketList& packetList,
     // Ignore list may be nullptr as long as numEntries is 0. Providing an ignore list with numEntries 0 disables
     // functionality for two reasons:
     //     1. There are no ignored channels as configured by FPP.
-    //     2. Ignore functionality is intentionally diabled by project where nullptr was intentionally supplied.
+    //     2. Ignore functionality is intentionally disabled by project where nullptr was intentionally supplied.
     FW_ASSERT(ignoreList.list || ignoreList.numEntries == 0);
     FW_ASSERT(packetList.numEntries <= MAX_PACKETIZER_PACKETS, static_cast<FwAssertArgType>(packetList.numEntries));
     // validate packet sizes against maximum com buffer size and populate hash

--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -35,6 +35,7 @@ TlmPacketizer ::TlmPacketizer(const char* const compName)
         this->m_tlmEntries.buckets[entry].bucketNo = entry;
         this->m_tlmEntries.buckets[entry].next = nullptr;
         this->m_tlmEntries.buckets[entry].id = 0;
+        this->m_tlmEntries.buckets[entry].ignored = true; // Default to ignoring channels until configured otherwise
     }
     // clear free index
     this->m_tlmEntries.free = 0;
@@ -66,7 +67,11 @@ void TlmPacketizer::setPacketList(const TlmPacketizerPacketList& packetList,
                                   const FwChanIdType startLevel,
                                   const TlmPacketizer_GroupConfig& defaultGroupConfig) {
     FW_ASSERT(packetList.list);
-    FW_ASSERT(ignoreList.list);
+    // Ignore list may be nullptr as long as numEntries is 0. Providing an ignore list with numEntries 0 disables
+    // functionality for two reasons:
+    //     1. There are no ignored channels as configured by FPP.
+    //     2. Ignore functionality is intentionally diabled by project where nullptr was intentionally supplied.
+    FW_ASSERT(ignoreList.list || ignoreList.numEntries == 0);
     FW_ASSERT(packetList.numEntries <= MAX_PACKETIZER_PACKETS, static_cast<FwAssertArgType>(packetList.numEntries));
     // validate packet sizes against maximum com buffer size and populate hash
     // table
@@ -132,7 +137,11 @@ void TlmPacketizer::setPacketList(const TlmPacketizerPacketList& packetList,
         }
     }
 
-    // populate hash table with ignore list
+    // This section sets up buckets in the hashmap for channels that are intended to be ignored. When the user supplies
+    // a list with no length, this loop is skipped. To turn-off ignoring of channels, the user can provided a null
+    // list with 0 length.
+    //
+    // This removes the need for hash buckets for "ignored" telemetry.
     for (FwChanIdType channelEntry = 0; channelEntry < ignoreList.numEntries; channelEntry++) {
         // get hash value for id
         FwChanIdType id = ignoreList.list[channelEntry].id;

--- a/Svc/TlmPacketizer/TlmPacketizer.hpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.hpp
@@ -20,6 +20,9 @@
 
 namespace Svc {
 
+//! Constant allowing users to ignore the omit list allowing a reduction in required buckets and thus storage
+constexpr Svc::TlmPacketizerPacket IGNORE_OMIT_LIST = {nullptr, 0, 0, 0};
+
 class TlmPacketizer final : public TlmPacketizerComponentBase {
     friend class TlmPacketizerTester;
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

This fixes #4760 allowing bypass of the omit channels list.   This allows users to configure away omitted channels.