### PR TITLE
Optimize `Fw::StringUtils::string_length` with SWAR algorithm

### DIFF
--- a/Fw/Types/Assert.hpp
+++ b/Fw/Types/Assert.hpp
@@ -77,6 +77,20 @@
 #endif
 #endif
 
+// Some trusted functions can be marked as NO_ASAN to avoid false trigger of the Address Sanitizer.
+#ifndef NO_ASAN
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+#if __has_attribute(no_sanitize_address)
+#define NO_ASAN __attribute__((no_sanitize_address))
+#elif __has_attribute(no_sanitize)
+#define NO_ASAN __attribute__((no_sanitize("address")))
+#else
+#define NO_ASAN
+#endif
+#endif
+
 namespace Fw {
 //! Assert with no arguments
 I8 SwAssert(FILE_NAME_ARG file, FwSizeType lineNo) NOINLINE CLANG_ANALYZER_NORETURN;

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -3,6 +3,8 @@
 #include <Fw/Types/ExternalString.hpp>
 #include <cstring>
 #include <limits>
+#include <cstdint>
+#include <algorithm>
 
 char* Fw::StringUtils::string_copy(char* destination, const char* source, FwSizeType num) {
     // Handle self-copy and 0 bytes copy
@@ -21,15 +23,69 @@ char* Fw::StringUtils::string_copy(char* destination, const char* source, FwSize
     return returned;
 }
 
+NO_ASAN
 FwSizeType Fw::StringUtils::string_length(const CHAR* source, FwSizeType buffer_size) {
     FwSizeType length = 0;
     FW_ASSERT(source != nullptr);
-    for (length = 0; length < buffer_size; length++) {
-        if (source[length] == '\0') {
-            break;
+
+    // Fast path for short strings - avoids alignment overhead
+    if (buffer_size <= sizeof(std::size_t))
+    {
+        while (length < buffer_size) {
+            if (source[length] == '\0') {
+                break;
+            }
+            length++;
         }
+        return length;
     }
-    return length;
+    
+    // Get nearest aligned address
+    constexpr std::uintptr_t align_mask = sizeof(std::size_t) - 1;
+    const std::uintptr_t src_addr = reinterpret_cast<std::uintptr_t>(source);
+    const std::size_t align_offset = ((-src_addr) & align_mask);
+    
+    // Prefix to word-aligned data
+    const std::size_t prefix = std::min(align_offset, buffer_size - 1);
+    
+    // Check to word-alignment
+    while (length < prefix) {
+        if (source[length] == '\0') {
+            return length;
+        }
+        length++;
+    }
+    
+    // Word-aligned check
+    constexpr std::size_t low_magic = std::numeric_limits<std::size_t>::max() / 0xFF; // 0x01010101...
+    constexpr std::size_t high_magic = low_magic * 0x80; // 0x80808080...
+    
+    while (length + sizeof(std::size_t) <= buffer_size)
+    {
+        // Check if reading is aligned
+        FW_ASSERT(reinterpret_cast<std::uintptr_t>(source + length) % sizeof(std::size_t) == 0);
+
+        // Safe read
+        std::size_t word;
+        std::memcpy(&word, source + length, sizeof(word));
+        
+        // Check if NUL char
+        std::size_t is_null = (word - low_magic) & ~word & high_magic;
+        if (is_null) break;
+
+        length += sizeof(std::size_t);
+    }
+    
+    // Check tail
+    while (length < buffer_size)
+    {
+        if (source[length] == '\0') {
+            return length;
+        }
+        length++;
+    }
+
+    return buffer_size;
 }
 
 FwSignedSizeType Fw::StringUtils::substring_find(const CHAR* source_string,

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -1724,13 +1724,14 @@ TEST(Nominal, string_len_various_lengths) {
 }
 
 TEST(Nominal, string_len_big_length) {
-    const FwSizeType LEN = 8 * 1024;
+    constexpr FwSizeType LEN = 8 * 1024;
+    constexpr FwSizeType NUL_INDEX = LEN - 1;
+
     char test_buffer[LEN];
-
     (void)::memset(test_buffer, 'a', static_cast<size_t>(LEN));
-    test_buffer[LEN - 1] = '\0';
+    test_buffer[NUL_INDEX] = '\0';
 
-    ASSERT_EQ(Fw::StringUtils::string_length(test_buffer, LEN), LEN - 1);
+    ASSERT_EQ(Fw::StringUtils::string_length(test_buffer, LEN), NUL_INDEX);
 }
 
 TEST(OffNominal, string_len_zero) {
@@ -1739,17 +1740,20 @@ TEST(OffNominal, string_len_zero) {
 }
 
 TEST(OffNominal, string_len_unaligned) {
-    char buffer[64];
-    (void)::memset(buffer, 'a', sizeof(buffer));
-    buffer[60] = '\0';
+    constexpr FwSizeType LEN = 64;
+    constexpr FwSizeType NUL_INDEX = LEN - 1;
+
+    char buffer[LEN];
+    (void)::memset(buffer, 'a', static_cast<size_t>(LEN));
+    buffer[NUL_INDEX] = '\0';
 
     // Check offsets from 0 to 15
     // This is guaranteed to cover all cases
-    for (U32 offset = 0; offset < 16; offset++) {
+    for (FwSizeType offset = 0; offset < 16; offset++) {
         const char* unaligned_ptr = &buffer[offset];
-        FwSizeType expected = static_cast<FwSizeType>(60 - offset);
+        FwSizeType expected = NUL_INDEX - offset;
         
-        ASSERT_EQ(Fw::StringUtils::string_length(unaligned_ptr, static_cast<FwSizeType>(100)), expected)
+        ASSERT_EQ(Fw::StringUtils::string_length(unaligned_ptr, LEN), expected)
             << "Failed at offset: " << offset;
     }
 }

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -1702,9 +1702,56 @@ TEST(Nominal, string_len) {
     ASSERT_EQ(Fw::StringUtils::string_length(test_string, static_cast<FwSizeType>(3)), 3);
 }
 
+TEST(Nominal, string_len_empty) {
+    const char* test_string = "";
+    ASSERT_EQ(Fw::StringUtils::string_length(test_string, static_cast<FwSizeType>(10)), 0);
+}
+
+TEST(Nominal, string_len_various_lengths) {
+    char test_buffer[100];
+    const FwSizeType sizes[] = { 1, 3, 4, 5, 7, 8, 15, 16, 17, 31, 32, 33, 63 };
+
+    for (U32 i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+        FwSizeType len = sizes[i];
+        
+        // Fill buffer with 'a', put NUL at the end
+        (void)::memset(test_buffer, 'a', static_cast<size_t>(len));
+        test_buffer[len] = '\0';
+
+        ASSERT_EQ(Fw::StringUtils::string_length(test_buffer, static_cast<FwSizeType>(100)), len)
+            << "Failed for length: " << len;
+    }
+}
+
+TEST(Nominal, string_len_big_length) {
+    const FwSizeType LEN = 8 * 1024;
+    char test_buffer[LEN];
+
+    (void)::memset(test_buffer, 'a', static_cast<size_t>(LEN));
+    test_buffer[LEN - 1] = '\0';
+
+    ASSERT_EQ(Fw::StringUtils::string_length(test_buffer, LEN), LEN - 1);
+}
+
 TEST(OffNominal, string_len_zero) {
     const char* test_string = "abc123";
     ASSERT_EQ(Fw::StringUtils::string_length(test_string, static_cast<FwSizeType>(0)), 0);
+}
+
+TEST(OffNominal, string_len_unaligned) {
+    char buffer[64];
+    (void)::memset(buffer, 'a', sizeof(buffer));
+    buffer[60] = '\0';
+
+    // Check offsets from 0 to 15
+    // This is guaranteed to cover all cases
+    for (U32 offset = 0; offset < 16; offset++) {
+        const char* unaligned_ptr = &buffer[offset];
+        FwSizeType expected = static_cast<FwSizeType>(60 - offset);
+        
+        ASSERT_EQ(Fw::StringUtils::string_length(unaligned_ptr, static_cast<FwSizeType>(100)), expected)
+            << "Failed at offset: " << offset;
+    }
 }
 
 TEST(OffNominal, sub_string_no_match) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4788 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

This PR implements the performance optimization proposed in #4788. It replaces the naive byte-by-byte string length calculation with a SWAR (SIMD Within A Register) approach using word-sized and bitwise NUL char detection.

### Details:
- Processes the initial unaligned head byte-by-byte to ensure word-alignment before the main loop.
- Uses standard bitwise operations to detect NUL char in parallel within a register.
- For short strings (word-sized or smaller) a simple byte-by-byte loop is used to avoid overhead.
- Added macro NO_ASAN to suppress false positives from AddressSanitizer for trusted functions.
- Added new edge test cases and alignment assert.

## Rationale

SWAR reduces the number of loop iterations and memory load instructions, thus improving performance. This technique is widely used in high-performance standard libraries.

### Benchmarks:
(Tested on Linux x86_64 with GCC 14.2.0)
<details>
<summary><strong> Benchmark Results (aligned) </strong></summary>
<img width="1023" height="700" alt="benchmark32" src="https://github.com/user-attachments/assets/bb5338a4-21cf-4d67-a50d-cd1cec58dd29" />
<img width="1023" height="700" alt="benchmark1024" src="https://github.com/user-attachments/assets/38d0ffcb-3c6a-4312-aba9-91c479ec16ab" />

New version is slightly slower for very short strings, but a lot faster for long ones:
N=2 - 1.28 vs. 2.01 (ns)
N=4 - 1.76 vs. 2.27 (ns)
N=8 - 3.06 vs. 3.01 (ns)
N=16 - 6.05 vs. 3.43 (ns)
N=32 - 19.30 vs. 4.31 (ns)
N=64 - 27.97 vs. 6.37 (ns)
N=128 - 53.45 vs. 10.36 (ns) (x5 faster)
N=256 - 100.27 vs. 22.29 (ns)
N=512 - 191.22 vs. 42.47 (ns)

</details>

<details>
<summary><strong> Benchmark Results (unaligned) </strong></summary>
<img width="1010" height="700" alt="benchmark32_unaligned" src="https://github.com/user-attachments/assets/33f9b682-6f26-4585-bcf3-a9bc5694e0ec" />
<img width="1010" height="700" alt="benchmark1024_unaligned" src="https://github.com/user-attachments/assets/8fd9c777-d849-4bb5-9b35-8d6d64a518cb" />

Unaligned calculations are slower than aligned ones, because of head byte-by-byte cycle, but still faster than old version:
N=2 - 1.33 vs. 1.91 (ns)
N=4 - 2.03 vs. 2.26 (ns)
N=8 - 3.55 vs. 3.02 (ns)
N=16 - 6.65 vs. 5.18 (ns)
N=32 - 17.12 vs. 6.10 (ns)
N=64 - 30.34 vs. 8.44 (ns)
N=128 - 56.18 vs. 12.60 (ns)
N=256 - 103.61 vs. 24.40 (ns)
N=512 - 199.45 vs. 44.11 (ns)

</details>

## Testing/Review Recommendations

<details>
<summary><strong> Benchmark Source </strong></summary>

```cpp

static void BM_string_length(benchmark::State& state)
{
    const size_t LEN = state.range(0);
    std::string src_str = std::string(LEN, 'A');
    const char* src = src_str.c_str();

    for (auto _ : state)
    {
        auto result = Fw::StringUtils::string_length(src, LEN);
        benchmark::DoNotOptimize(result);
    }
}

static void BM_string_lengthV2(benchmark::State& state)
{
    const size_t LEN = state.range(0);
    std::string src_str = std::string(LEN, 'A');
    const char* src = src_str.c_str();

    for (auto _ : state)
    {
        auto result = Fw::StringUtils::string_lengthV2(src, LEN);
        benchmark::DoNotOptimize(result);
    }
}

BENCHMARK(BM_string_length)->RangeMultiplier(2)->Range(0, 1024);
BENCHMARK(BM_string_lengthV2)->RangeMultiplier(2)->Range(0, 1024);

BENCHMARK_MAIN();
```

</details>

## AI Usage

AI was used for research and testing of ideas. All code implementation, algorithm design, benchmarking, and technical decisions were done by me.
