### PR TITLE
Remove priority from ActiveTextLogger

### DIFF
--- a/Svc/ActiveTextLogger/ActiveTextLogger.fpp
+++ b/Svc/ActiveTextLogger/ActiveTextLogger.fpp
@@ -10,7 +10,6 @@ module Svc {
     internal port TextQueue(
                              $text: string size 256 @< The text string
                            ) \
-      priority 1 \
       drop
 
   }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/4797 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Remove priority from ActiveTextLogger.

## Rationale

Allows it to be used with non-priority queues

## Testing/Review Recommendations

Unit tests were re-run and passed.

## Future Work

Nono

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI not used; minor change
