### PR TITLE
Add required fixes for F Prime to have deinit triggered by autocode

### DIFF
--- a/Fpp/ToCpp.fpp
+++ b/Fpp/ToCpp.fpp
@@ -15,6 +15,7 @@ module Fpp {
       stopTasks
       freeThreads
       tearDownComponents
+      deinit
     }
 
   }

--- a/Fw/Comp/QueuedComponentBase.hpp
+++ b/Fw/Comp/QueuedComponentBase.hpp
@@ -26,12 +26,12 @@ class QueuedComponentBase : public PassiveComponentBase {
         MSG_DISPATCH_ERROR,  //!< Errors dispatching messages
         MSG_DISPATCH_EXIT    //!< A message was sent requesting an exit of the loop
     } MsgDispatchStatus;
+    void deinit();                          //!< Allows de-initialization on teardown
 
   protected:
     QueuedComponentBase(const char* name);  //!< Constructor
     virtual ~QueuedComponentBase();         //!< Destructor
     void init(FwEnumStoreType instance);    //!< initialization function
-    void deinit();                          //!< Allows de-initialization on teardown
     Os::Queue m_queue;                      //!< queue object for active component
     Os::Queue::Status createQueue(FwSizeType depth, FwSizeType msgSize);
     virtual MsgDispatchStatus doDispatch() = 0;  //!< method to dispatch a single message in the queue.

--- a/Fw/Comp/QueuedComponentBase.hpp
+++ b/Fw/Comp/QueuedComponentBase.hpp
@@ -26,7 +26,7 @@ class QueuedComponentBase : public PassiveComponentBase {
         MSG_DISPATCH_ERROR,  //!< Errors dispatching messages
         MSG_DISPATCH_EXIT    //!< A message was sent requesting an exit of the loop
     } MsgDispatchStatus;
-    void deinit();                          //!< Allows de-initialization on teardown
+    void deinit();  //!< Allows de-initialization on teardown
 
   protected:
     QueuedComponentBase(const char* name);  //!< Constructor


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

These changes are needed to pair with the `deinit` in the fpp-to-cpp tool