### PR TITLE
Add README explaining tutorial directory structure

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,13 @@
+# Tutorials
+
+The files in this directory are used as part of the generated F´ documentation and are not intended to be browsed directly from the GitHub repository.
+
+The F´ tutorials are maintained in separate repositories under the `fprime-community` organization:
+
+https://github.com/fprime-community/#tutorials
+
+For the official tutorial documentation, please visit the F´ documentation site:
+
+https://fprime.jpl.nasa.gov/latest/docs/tutorials/
+
+Each tutorial repository contains the source code and documentation for that tutorial.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4808 |
|**_Has Unit Tests (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| Y |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

Added `docs/tutorials/README.md` to explain that the tutorial markdown files in the repository are placeholders used for generating documentation and are not intended for direct browsing. The README points users to the `fprime-community` repositories and the official F´ documentation site for the canonical tutorial content.

## Rationale

Clarifies the purpose and location of tutorials, addressing confusion caused by dead links in `docs/tutorials/index.md`. Provides clear guidance on where to find the actual tutorial content, aligning with the recommendation from the maintainers.

## Testing/Review Recommendations

Verify that `docs/tutorials/README.md` renders correctly on GitHub and clearly communicates where tutorial content is hosted. Confirm that links to the `fprime-community` repositories and the official documentation site are correct.

## Future Work

No immediate follow-up, future updates may include maintaining the README if tutorial locations or documentation URLs change.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
