### PR TITLE
Configurable Default for TlmPacketizer MIN/MAX Tables

### DIFF
--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -628,15 +628,15 @@ FwIndexType TlmPacketizer::sectionGroupToPort(const FwIndexType section, const F
 }
 
 void TlmPacketizer::parametersLoaded() {
-    parameterUpdated(PARAMID_DEFAULTMINDELTA);
-    parameterUpdated(PARAMID_DEFAULTMAXDELTA);
+    parameterUpdated(PARAMID_DEFAULT_MIN_DELTA);
+    parameterUpdated(PARAMID_DEFAULT_MAX_DELTA);
 }
 
 void TlmPacketizer::parameterUpdated(FwPrmIdType id) {
     Fw::ParamValid valid;
     switch (id) {
-        case PARAMID_DEFAULTMINDELTA: {
-            U32 minDelta = this->paramGet_DefaultMinDelta(valid);
+        case PARAMID_DEFAULT_MIN_DELTA: {
+            U32 minDelta = this->paramGet_DEFAULT_MIN_DELTA(valid);
             FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
                       static_cast<FwAssertArgType>(valid.e));
             for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
@@ -645,11 +645,11 @@ void TlmPacketizer::parameterUpdated(FwPrmIdType id) {
                 }
             }
             this->tlmWrite_GroupConfigs(this->m_groupConfigs);
-            this->tlmWrite_DefaultMinDelta(minDelta);
+            this->tlmWrite_DEFAULT_MIN_DELTA(minDelta);
             break;
         }
-        case PARAMID_DEFAULTMAXDELTA: {
-            U32 maxDelta = this->paramGet_DefaultMaxDelta(valid);
+        case PARAMID_DEFAULT_MAX_DELTA: {
+            U32 maxDelta = this->paramGet_DEFAULT_MAX_DELTA(valid);
             FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
                       static_cast<FwAssertArgType>(valid.e));
             for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
@@ -658,7 +658,7 @@ void TlmPacketizer::parameterUpdated(FwPrmIdType id) {
                 }
             }
             this->tlmWrite_GroupConfigs(this->m_groupConfigs);
-            this->tlmWrite_DefaultMaxDelta(maxDelta);
+            this->tlmWrite_DEFAULT_MAX_DELTA(maxDelta);
             break;
         }
         default:

--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -627,6 +627,46 @@ FwIndexType TlmPacketizer::sectionGroupToPort(const FwIndexType section, const F
     return outIndex;
 }
 
+void TlmPacketizer::parametersLoaded() {
+    parameterUpdated(PARAMID_DEFAULTMINDELTA);
+    parameterUpdated(PARAMID_DEFAULTMAXDELTA);
+}
+
+void TlmPacketizer::parameterUpdated(FwPrmIdType id) {
+    Fw::ParamValid valid;
+    switch (id) {
+        case PARAMID_DEFAULTMINDELTA: {
+            U32 minDelta = this->paramGet_DefaultMinDelta(valid);
+            FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
+                      static_cast<FwAssertArgType>(valid.e));
+            for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
+                for (FwChanIdType group = 0; group < NUM_CONFIGURABLE_TLMPACKETIZER_GROUPS; group++) {
+                    this->m_groupConfigs[static_cast<FwSizeType>(section)][group].set_min(minDelta);
+                }
+            }
+            this->tlmWrite_GroupConfigs(this->m_groupConfigs);
+            this->tlmWrite_DefaultMinDelta(minDelta);
+            break;
+        }
+        case PARAMID_DEFAULTMAXDELTA: {
+            U32 maxDelta = this->paramGet_DefaultMaxDelta(valid);
+            FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
+                      static_cast<FwAssertArgType>(valid.e));
+            for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
+                for (FwChanIdType group = 0; group < NUM_CONFIGURABLE_TLMPACKETIZER_GROUPS; group++) {
+                    this->m_groupConfigs[static_cast<FwSizeType>(section)][group].set_max(maxDelta);
+                }
+            }
+            this->tlmWrite_GroupConfigs(this->m_groupConfigs);
+            this->tlmWrite_DefaultMaxDelta(maxDelta);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+            break;
+    }
+}
+
 FwChanIdType TlmPacketizer::doHash(FwChanIdType id) {
     return (id % TLMPACKETIZER_HASH_MOD_VALUE) % TLMPACKETIZER_NUM_TLM_HASH_SLOTS;
 }

--- a/Svc/TlmPacketizer/TlmPacketizer.fpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.fpp
@@ -87,13 +87,13 @@ module Svc {
     # ----------------------------------------------------------------------
 
     @ Default minimum sched ticks when using ON_CHANGE_MIN rate logic.
-    param DefaultMinDelta: U32 default 0 \
+    param DEFAULT_MIN_DELTA: U32 default 0 \
       id 0 \
       set opcode 0x10 \
       save opcode 0x11
 
     @ Default maximum sched ticks when using EVERY_MAX rate logic.
-    param DefaultMaxDelta: U32 default 0 \
+    param DEFAULT_MAX_DELTA: U32 default 0 \
       id 1 \
       set opcode 0x12 \
       save opcode 0x13
@@ -211,11 +211,11 @@ module Svc {
     telemetry GroupConfigs: SectionConfigs id 0
     telemetry SectionEnabled: SectionEnabled id 1
 
-    @ Readback of DefaultMinDelta parameter
-    telemetry DefaultMinDelta: U32 id 2 update on change
+    @ Readback of DEFAULT_MIN_DELTA parameter
+    telemetry DEFAULT_MIN_DELTA: U32 id 2 update on change
 
-    @ Readback of DefaultMaxDelta parameter
-    telemetry DefaultMaxDelta: U32 id 3 update on change
+    @ Readback of DEFAULT_MAX_DELTA parameter
+    telemetry DEFAULT_MAX_DELTA: U32 id 3 update on change
 
     array TelemetrySendSection = [NUM_CONFIGURABLE_TLMPACKETIZER_GROUPS] FwIndexType
     array TelemetrySendPortMap = [TelemetrySection.NUM_SECTIONS] TelemetrySendSection default TELEMETRY_SEND_PORT_MAPPING

--- a/Svc/TlmPacketizer/TlmPacketizer.fpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.fpp
@@ -76,6 +76,28 @@ module Svc {
     @ Time get
     time get port timeGetOut
 
+    @ Port to return the value of a parameter
+    param get port prmGetOut
+
+    @Port to set the value of a parameter
+    param set port prmSetOut
+
+    # ----------------------------------------------------------------------
+    # Parameters
+    # ----------------------------------------------------------------------
+
+    @ Default minimum sched ticks when using ON_CHANGE_MIN rate logic.
+    param DefaultMinDelta: U32 default 0 \
+      id 0 \
+      set opcode 0x10 \
+      save opcode 0x11
+
+    @ Default maximum sched ticks when using EVERY_MAX rate logic.
+    param DefaultMaxDelta: U32 default 0 \
+      id 1 \
+      set opcode 0x12 \
+      save opcode 0x13
+
     # ----------------------------------------------------------------------
     # Commands
     # ----------------------------------------------------------------------
@@ -180,7 +202,7 @@ module Svc {
       severity warning low \
       id 5 \
       format "Section {} is unconfigurable and cannot be set to {}"
-    
+
     # ----------------------------------------------------------------------
     # Telemetry
     # ----------------------------------------------------------------------
@@ -188,6 +210,12 @@ module Svc {
     @ Telemetry send level
     telemetry GroupConfigs: SectionConfigs id 0
     telemetry SectionEnabled: SectionEnabled id 1
+
+    @ Readback of DefaultMinDelta parameter
+    telemetry DefaultMinDelta: U32 id 2 update on change
+
+    @ Readback of DefaultMaxDelta parameter
+    telemetry DefaultMaxDelta: U32 id 3 update on change
 
     array TelemetrySendSection = [NUM_CONFIGURABLE_TLMPACKETIZER_GROUPS] FwIndexType
     array TelemetrySendPortMap = [TelemetrySection.NUM_SECTIONS] TelemetrySendSection default TELEMETRY_SEND_PORT_MAPPING

--- a/Svc/TlmPacketizer/TlmPacketizer.hpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.hpp
@@ -218,6 +218,10 @@ class TlmPacketizer final : public TlmPacketizerComponentBase {
     //! Mapping of section/group to the output port used to send telemetry
     static const TlmPacketizer_TelemetrySendPortMap TELEMETRY_SEND_PORT_MAP;
 
+    void parametersLoaded() override;
+
+    void parameterUpdated(FwPrmIdType id) override;
+
   private:
     //! Handler implementation for configureSectionGroupRate
     //!

--- a/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
+++ b/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
@@ -1627,6 +1627,83 @@ void TlmPacketizerTester ::advancedControlGroupTests() {
     this->clearHistory();
 }
 
+void TlmPacketizerTester ::parameterLoadDefaultMinMaxTest() {
+    // Configure the component with packets
+    this->component.setPacketList(packetList, ignore, 2);
+
+    // Load parameters without setting any value first (will get FPP defaults: 0, 0)
+    this->component.loadParameters();
+
+    // parametersLoaded reads both params and applies them
+    ASSERT_TLM_DefaultMinDelta_SIZE(1);
+    ASSERT_TLM_DefaultMinDelta(0, 0);
+    ASSERT_TLM_DefaultMaxDelta_SIZE(1);
+    ASSERT_TLM_DefaultMaxDelta(0, 0);
+}
+
+void TlmPacketizerTester ::parameterLoadStoredMinMaxTest() {
+    // Configure the component with packets
+    this->component.setPacketList(packetList, ignore, 2);
+
+    // Set stored parameter values (simulates non-volatile storage)
+    this->paramSet_DefaultMinDelta(5, Fw::ParamValid::VALID);
+    this->paramSet_DefaultMaxDelta(10, Fw::ParamValid::VALID);
+
+    // Load parameters - should pick up the stored values
+    this->component.loadParameters();
+
+    ASSERT_TLM_DefaultMinDelta_SIZE(1);
+    ASSERT_TLM_DefaultMinDelta(0, 5);
+    ASSERT_TLM_DefaultMaxDelta_SIZE(1);
+    ASSERT_TLM_DefaultMaxDelta(0, 10);
+
+    // Verify all groups got the new min/max values
+    for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
+        for (FwChanIdType group = 0; group < NUM_CONFIGURABLE_TLMPACKETIZER_GROUPS; group++) {
+            ASSERT_EQ(this->component.m_groupConfigs[static_cast<FwSizeType>(section)][group].get_min(), 5U);
+            ASSERT_EQ(this->component.m_groupConfigs[static_cast<FwSizeType>(section)][group].get_max(), 10U);
+        }
+    }
+}
+
+void TlmPacketizerTester ::parameterUpdateMinMaxTest() {
+    this->component.setPacketList(packetList, ignore, 0);
+
+    this->paramSet_DefaultMinDelta(3, Fw::ParamValid::VALID);
+    this->paramSend_DefaultMinDelta(0, 0);
+
+    // Only min telemetry should be emitted
+    ASSERT_TLM_DefaultMinDelta_SIZE(1);
+    ASSERT_TLM_DefaultMinDelta(0, 3);
+    ASSERT_TLM_DefaultMaxDelta_SIZE(0);
+
+    // Only min values should be updated; max stays at default (0)
+    for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
+        for (FwChanIdType group = 0; group < NUM_CONFIGURABLE_TLMPACKETIZER_GROUPS; group++) {
+            ASSERT_EQ(this->component.m_groupConfigs[static_cast<FwSizeType>(section)][group].get_min(), 3U);
+            ASSERT_EQ(this->component.m_groupConfigs[static_cast<FwSizeType>(section)][group].get_max(), 0U);
+        }
+    }
+
+    this->clearTlm();
+
+    this->paramSet_DefaultMaxDelta(7, Fw::ParamValid::VALID);
+    this->paramSend_DefaultMaxDelta(0, 0);
+
+    // Only max telemetry should be emitted
+    ASSERT_TLM_DefaultMinDelta_SIZE(0);
+    ASSERT_TLM_DefaultMaxDelta_SIZE(1);
+    ASSERT_TLM_DefaultMaxDelta(0, 7);
+
+    // Min stays at 3, max now 7
+    for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
+        for (FwChanIdType group = 0; group < NUM_CONFIGURABLE_TLMPACKETIZER_GROUPS; group++) {
+            ASSERT_EQ(this->component.m_groupConfigs[static_cast<FwSizeType>(section)][group].get_min(), 3U);
+            ASSERT_EQ(this->component.m_groupConfigs[static_cast<FwSizeType>(section)][group].get_max(), 7U);
+        }
+    }
+}
+
 // ----------------------------------------------------------------------
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
@@ -1693,6 +1770,12 @@ void TlmPacketizerTester ::connectPorts() {
     this->connect_to_controlIn(0, this->component.get_controlIn_InputPort(0));
 
     this->connect_to_configureSectionGroupRate(0, this->component.get_configureSectionGroupRate_InputPort(0));
+
+    // prmGetOut
+    this->component.set_prmGetOut_OutputPort(0, this->get_from_prmGetOut(0));
+
+    // prmSetOut
+    this->component.set_prmSetOut_OutputPort(0, this->get_from_prmSetOut(0));
 }
 
 void TlmPacketizerTester::textLogIn(const FwEventIdType id,          //!< The event ID

--- a/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
+++ b/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
@@ -1635,10 +1635,10 @@ void TlmPacketizerTester ::parameterLoadDefaultMinMaxTest() {
     this->component.loadParameters();
 
     // parametersLoaded reads both params and applies them
-    ASSERT_TLM_DefaultMinDelta_SIZE(1);
-    ASSERT_TLM_DefaultMinDelta(0, 0);
-    ASSERT_TLM_DefaultMaxDelta_SIZE(1);
-    ASSERT_TLM_DefaultMaxDelta(0, 0);
+    ASSERT_TLM_DEFAULT_MIN_DELTA_SIZE(1);
+    ASSERT_TLM_DEFAULT_MIN_DELTA(0, 0);
+    ASSERT_TLM_DEFAULT_MAX_DELTA_SIZE(1);
+    ASSERT_TLM_DEFAULT_MAX_DELTA(0, 0);
 }
 
 void TlmPacketizerTester ::parameterLoadStoredMinMaxTest() {
@@ -1646,16 +1646,16 @@ void TlmPacketizerTester ::parameterLoadStoredMinMaxTest() {
     this->component.setPacketList(packetList, ignore, 2);
 
     // Set stored parameter values (simulates non-volatile storage)
-    this->paramSet_DefaultMinDelta(5, Fw::ParamValid::VALID);
-    this->paramSet_DefaultMaxDelta(10, Fw::ParamValid::VALID);
+    this->paramSet_DEFAULT_MIN_DELTA(5, Fw::ParamValid::VALID);
+    this->paramSet_DEFAULT_MAX_DELTA(10, Fw::ParamValid::VALID);
 
     // Load parameters - should pick up the stored values
     this->component.loadParameters();
 
-    ASSERT_TLM_DefaultMinDelta_SIZE(1);
-    ASSERT_TLM_DefaultMinDelta(0, 5);
-    ASSERT_TLM_DefaultMaxDelta_SIZE(1);
-    ASSERT_TLM_DefaultMaxDelta(0, 10);
+    ASSERT_TLM_DEFAULT_MIN_DELTA_SIZE(1);
+    ASSERT_TLM_DEFAULT_MIN_DELTA(0, 5);
+    ASSERT_TLM_DEFAULT_MAX_DELTA_SIZE(1);
+    ASSERT_TLM_DEFAULT_MAX_DELTA(0, 10);
 
     // Verify all groups got the new min/max values
     for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
@@ -1669,13 +1669,13 @@ void TlmPacketizerTester ::parameterLoadStoredMinMaxTest() {
 void TlmPacketizerTester ::parameterUpdateMinMaxTest() {
     this->component.setPacketList(packetList, ignore, 0);
 
-    this->paramSet_DefaultMinDelta(3, Fw::ParamValid::VALID);
-    this->paramSend_DefaultMinDelta(0, 0);
+    this->paramSet_DEFAULT_MIN_DELTA(3, Fw::ParamValid::VALID);
+    this->paramSend_DEFAULT_MIN_DELTA(0, 0);
 
     // Only min telemetry should be emitted
-    ASSERT_TLM_DefaultMinDelta_SIZE(1);
-    ASSERT_TLM_DefaultMinDelta(0, 3);
-    ASSERT_TLM_DefaultMaxDelta_SIZE(0);
+    ASSERT_TLM_DEFAULT_MIN_DELTA_SIZE(1);
+    ASSERT_TLM_DEFAULT_MIN_DELTA(0, 3);
+    ASSERT_TLM_DEFAULT_MAX_DELTA_SIZE(0);
 
     // Only min values should be updated; max stays at default (0)
     for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
@@ -1687,13 +1687,13 @@ void TlmPacketizerTester ::parameterUpdateMinMaxTest() {
 
     this->clearTlm();
 
-    this->paramSet_DefaultMaxDelta(7, Fw::ParamValid::VALID);
-    this->paramSend_DefaultMaxDelta(0, 0);
+    this->paramSet_DEFAULT_MAX_DELTA(7, Fw::ParamValid::VALID);
+    this->paramSend_DEFAULT_MAX_DELTA(0, 0);
 
     // Only max telemetry should be emitted
-    ASSERT_TLM_DefaultMinDelta_SIZE(0);
-    ASSERT_TLM_DefaultMaxDelta_SIZE(1);
-    ASSERT_TLM_DefaultMaxDelta(0, 7);
+    ASSERT_TLM_DEFAULT_MIN_DELTA_SIZE(0);
+    ASSERT_TLM_DEFAULT_MAX_DELTA_SIZE(1);
+    ASSERT_TLM_DEFAULT_MAX_DELTA(0, 7);
 
     // Min stays at 3, max now 7
     for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {

--- a/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.hpp
+++ b/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.hpp
@@ -87,6 +87,18 @@ class TlmPacketizerTester : public TlmPacketizerGTestBase {
     //!
     void advancedControlGroupTests(void);
 
+    //! parameter load with default min/max test
+    //!
+    void parameterLoadDefaultMinMaxTest(void);
+
+    //! parameter load with stored min/max values test
+    //!
+    void parameterLoadStoredMinMaxTest(void);
+
+    //! parameter update min/max test
+    //!
+    void parameterUpdateMinMaxTest(void);
+
   private:
     // ----------------------------------------------------------------------
     // Handlers for typed from ports

--- a/Svc/TlmPacketizer/test/ut/main.cpp
+++ b/Svc/TlmPacketizer/test/ut/main.cpp
@@ -85,6 +85,24 @@ TEST(TestNominal, advancedControlGroupTests) {
     tester.advancedControlGroupTests();
 }
 
+TEST(TestNominal, ParameterLoadDefaultMinMaxTest) {
+    TEST_CASE(100.1.9, "Parameter load with default min/max");
+    Svc::TlmPacketizerTester tester;
+    tester.parameterLoadDefaultMinMaxTest();
+}
+
+TEST(TestNominal, ParameterLoadStoredMinMaxTest) {
+    TEST_CASE(100.1.11, "Parameter load with stored min/max values");
+    Svc::TlmPacketizerTester tester;
+    tester.parameterLoadStoredMinMaxTest();
+}
+
+TEST(TestNominal, ParameterUpdateMinMaxTest) {
+    TEST_CASE(100.1.12, "Parameter update min/max via SET command");
+    Svc::TlmPacketizerTester tester;
+    tester.parameterUpdateMinMaxTest();
+}
+
 int main(int argc, char* argv[]) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4757 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Parameterizes the MIN/MAX group config tables in `TlmPacketizer` with two new parameters: `DefaultMinDelta` and `DefaultMaxDelta`. Values are loaded from non-volatile storage on startup and can be updated at runtime via SET commands. Telemetry readback channels are included for both.

## Rationale

MIN/MAX tables need to be set on startup from non-volatile storage, with a static default as fallback.

## Testing/Review Recommendations

Three unit tests added: default load, stored value load, and runtime SET update. All tests pass.