### PR TITLE
Fix static analysis warning in Posix ConditionVariable.cpp

### DIFF
--- a/Os/Posix/ConditionVariable.cpp
+++ b/Os/Posix/ConditionVariable.cpp
@@ -21,6 +21,7 @@ PosixConditionVariable::~PosixConditionVariable() {
 
 PosixConditionVariable::Status PosixConditionVariable::pend(Os::Mutex& mutex) {
     PosixMutexHandle* mutex_handle = reinterpret_cast<PosixMutexHandle*>(mutex.getHandle());
+    FW_ASSERT(mutex_handle != nullptr);
     int status = pthread_cond_wait(&this->m_handle.m_condition, &mutex_handle->m_mutex_descriptor);
     return posix_status_to_conditional_status(status);
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Fix #4502 

De-reference the pointer in the line below; Posix Mutex should never return a nullptr, so assert it.