### PR TITLE
FpySequencer use FwTimeBaseStoreType instead of U16

### DIFF
--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -298,7 +298,7 @@ Signal FpySequencer::waitRel_directiveHandler(const FpySequencer_WaitRelDirectiv
 
 //! Internal interface handler for directive_waitAbs
 Signal FpySequencer::waitAbs_directiveHandler(const FpySequencer_WaitAbsDirective& directive, DirectiveError& error) {
-    if (this->m_runtime.stack.size < 10 + sizeof(FwTimeContextStoreType)) {
+    if (this->m_runtime.stack.size < 2 * sizeof(U32) + sizeof(FwTimeContextStoreType) + sizeof(FwTimeBaseStoreType)) {
         error = DirectiveError::STACK_UNDERFLOW;
         return Signal::stmtResponse_failure;
     }
@@ -306,7 +306,7 @@ Signal FpySequencer::waitAbs_directiveHandler(const FpySequencer_WaitAbsDirectiv
     U32 uSeconds = this->m_runtime.stack.pop<U32>();
     U32 seconds = this->m_runtime.stack.pop<U32>();
     FwTimeContextStoreType ctx = this->m_runtime.stack.pop<FwTimeContextStoreType>();
-    U16 base = this->m_runtime.stack.pop<U16>();
+    FwTimeBaseStoreType base = this->m_runtime.stack.pop<FwTimeBaseStoreType>();
 
     this->m_runtime.wakeupTime = Fw::Time(static_cast<TimeBase::T>(base), ctx, seconds, uSeconds);
     return Signal::stmtResponse_beginSleep;

--- a/Svc/FpySequencer/FpySequencerDirectives.fppi
+++ b/Svc/FpySequencer/FpySequencerDirectives.fppi
@@ -6,7 +6,7 @@ struct WaitRelDirective {
 
 @ sleeps until an absolute time
 struct WaitAbsDirective {
-    # pops U32, U32, U8, U16 off stack
+    # pops U32, U32, FwTimeContextStoreType, FwTimeBaseStoreType off stack
     _empty: U8
 }
 

--- a/Svc/FpySequencer/docs/directives.md
+++ b/Svc/FpySequencer/docs/directives.md
@@ -25,7 +25,7 @@ Sleeps until an absolute time.
 | useconds     | U32      | stack  | Microseconds |
 | seconds      | U32      | stack  | Seconds |
 | time_context | FwTimeContextStoreType       | stack  | Time context (user defined value, unused by Fpy) |
-| time_base    | U16      | stack  | Time base |
+| time_base    | FwTimeBaseStoreType      | stack  | Time base |
 
 | Stack Result Type | Description |
 | ------------------|-------------|

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -30,7 +30,7 @@ TEST_F(FpySequencerTester, waitRel) {
 TEST_F(FpySequencerTester, waitAbs) {
     FpySequencer_WaitAbsDirective directive{};
 
-    tester_push<U16>(0);
+    tester_push<FwTimeBaseStoreType>(0);
     tester_push<U8>(0);
     tester_push<U32>(5);
     tester_push<U32>(123);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

* Switch the WAIT_ABS directive to pop FwTimeBaseStoreType off the stack instead of U16, thus respecting the configured store type for TimeBase


## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI was used to write this code