### PR TITLE
Fixed corner case in shadow write when writing 0 bytes in append mode

### DIFF
--- a/Os/test/ut/file/FileRules.cpp
+++ b/Os/test/ut/file/FileRules.cpp
@@ -53,6 +53,12 @@ void Os::Test::FileTest::Tester::shadow_write(const std::vector<U8>& write_data)
     if (write_data.data() != nullptr) {
         status = m_shadow.write(write_data.data(), size, Os::File::WaitType::WAIT);
     }
+    // If in APPEND mode, need to set position to the end
+    if (this->m_mode == Os::File::Mode::OPEN_APPEND) {
+        FwSizeType shadow_size = 0;
+        ASSERT_EQ(this->m_shadow.size(shadow_size), Os::File::Status::OP_OK);
+        this->shadow_seek(shadow_size, Os::File::SeekType::ABSOLUTE);
+    }
     ASSERT_EQ(status, Os::File::Status::OP_OK);
     ASSERT_EQ(size, original_size);
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/fprime-community/fprime-baremetal/issues/18 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**|  n|
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Update shadow-write function to update current position when in APPEND mode

## Rationale

A test that opens a file in APPEND mode and tries to write 0 bytes to a file would result in the file position changing to the end of file. The shadow class is missing this feature, which resulted in some random-based unit tests failing.

## Testing/Review Recommendations

Run CI

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
