### PR TITLE
TlmPacketizer: Remove Double-Buffering

### DIFF
--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -47,7 +47,6 @@ TlmPacketizer ::TlmPacketizer(const char* const compName)
     // clear packet buffers
     for (FwChanIdType buffer = 0; buffer < MAX_PACKETIZER_PACKETS; buffer++) {
         this->m_fillBuffers[buffer].updated = false;
-        this->m_sendBuffers[buffer].updated = false;
     }
 
     // enable sections
@@ -358,27 +357,23 @@ Fw::TlmValid TlmPacketizer ::TlmGet_handler(FwIndexType portNum,  //!< The port 
 void TlmPacketizer ::Run_handler(const FwIndexType portNum, U32 context) {
     FW_ASSERT(this->m_configured);
 
-    // lock mutex long enough to copy fill buffers to send buffers
-    // so the data can be read without worrying about updates
-    this->m_lock.lock();
-    // copy buffers from fill side to send side
+    // For each packet, send if update, enable, and rate conditions are met
     for (FwChanIdType pkt = 0; pkt < this->m_numPackets; pkt++) {
-        if (this->m_fillBuffers[pkt].updated == true) {
-            (void)(this->m_sendBuffers[pkt] = this->m_fillBuffers[pkt]);
-        }
-        this->m_fillBuffers[pkt].updated = false;
-    }
-    this->m_lock.unLock();
+        this->m_lock.lock();
 
-    // push all updated packet buffers
-    for (FwChanIdType pkt = 0; pkt < this->m_numPackets; pkt++) {
-        FwChanIdType entryGroup = this->m_sendBuffers[pkt].level;
+        // Copy packet data to avoid concurrent updates
+        FwChanIdType entryGroup = this->m_fillBuffers[pkt].level;
+        Fw::ComBuffer sendBuffer = this->m_fillBuffers[pkt].buffer;
+        Fw::Time time = this->m_fillBuffers[pkt].latestTime;
+        bool updated = this->m_fillBuffers[pkt].updated;
+        this->m_fillBuffers[pkt].updated = false;
+
+        this->m_lock.unLock();
 
         // Iterate through output sections
         for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
             // Packet is updated and not REQUESTED (Keep REQUESTED marking to bypass disable checks)
-            if (this->m_sendBuffers[pkt].updated and
-                this->m_packetFlags[section][pkt].updateFlag != UpdateFlag::REQUESTED) {
+            if (updated and this->m_packetFlags[section][pkt].updateFlag != UpdateFlag::REQUESTED) {
                 this->m_packetFlags[section][pkt].updateFlag = UpdateFlag::NEW;
             }
 
@@ -450,17 +445,16 @@ void TlmPacketizer ::Run_handler(const FwIndexType portNum, U32 context) {
             if (sendOutFlag) {
                 // serialize time into time offset in packet
                 Fw::ExternalSerializeBuffer buff(
-                    &this->m_sendBuffers[pkt]
-                         .buffer.getBuffAddr()[sizeof(FwPacketDescriptorType) + sizeof(FwTlmPacketizeIdType)],
+                    &sendBuffer.getBuffAddr()[sizeof(FwPacketDescriptorType) + sizeof(FwTlmPacketizeIdType)],
                     Fw::Time::SERIALIZED_SIZE);
-                Fw::SerializeStatus stat = buff.serializeFrom(this->m_sendBuffers[pkt].latestTime);
+                Fw::SerializeStatus stat = buff.serializeFrom(time);
                 FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, stat);
-                this->PktSend_out(outIndex, this->m_sendBuffers[pkt].buffer, pktEntryFlags.prevSentCounter);
+                this->PktSend_out(outIndex, sendBuffer, pktEntryFlags.prevSentCounter);
+
                 pktEntryFlags.prevSentCounter = 0;
                 pktEntryFlags.updateFlag = UpdateFlag::PAST;
             }
         }
-        this->m_sendBuffers[pkt].updated = false;
     }
 }
 

--- a/Svc/TlmPacketizer/TlmPacketizer.hpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.hpp
@@ -161,8 +161,6 @@ class TlmPacketizer final : public TlmPacketizerComponentBase {
 
     // buffers for filling with telemetry
     BufferEntry m_fillBuffers[MAX_PACKETIZER_PACKETS];
-    // buffers for sending - will be copied from fill buffers
-    BufferEntry m_sendBuffers[MAX_PACKETIZER_PACKETS];
 
     struct TlmEntry {
         FwChanIdType id;  //!< telemetry id stored in slot


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4758 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Replace the double-buffering in TlmPacketizer::Run_handler with a per-packet stack snapshot. Instead of copying the entire fill buffer table into a separate send buffer table, each packet is snapshotted individually (buffer, time, level, updated flag) under a short lock before iterating over sections.

## Rationale

The previous double-buffer approach stored a full mirror of all packet buffers, doubling memory usage. It also locked over a full table copy which is more CPU intensive than needed. The new approach snapshots one packet at a time on the stack, keeping the lock duration minimal and eliminating the extra buffer table entirely.