### PR TITLE
Fix String type in FileDownlink

### DIFF
--- a/Svc/FileDownlink/File.cpp
+++ b/Svc/FileDownlink/File.cpp
@@ -17,9 +17,8 @@
 
 namespace Svc {
 
-Os::File::Status FileDownlink::File ::open(
-    const Fw::FileNameString& sourceFileName, 
-    const Fw::FileNameString& destFileName) {
+Os::File::Status FileDownlink::File ::open(const Fw::FileNameString& sourceFileName,
+                                           const Fw::FileNameString& destFileName) {
     // Set source name
     Fw::LogStringArg sourceLogStringArg(sourceFileName);
     this->m_sourceName = sourceLogStringArg;

--- a/Svc/FileDownlink/File.cpp
+++ b/Svc/FileDownlink/File.cpp
@@ -17,7 +17,9 @@
 
 namespace Svc {
 
-Os::File::Status FileDownlink::File ::open(const char* const sourceFileName, const char* const destFileName) {
+Os::File::Status FileDownlink::File ::open(
+    const Fw::FileNameString& sourceFileName, 
+    const Fw::FileNameString& destFileName) {
     // Set source name
     Fw::LogStringArg sourceLogStringArg(sourceFileName);
     this->m_sourceName = sourceLogStringArg;
@@ -28,7 +30,7 @@ Os::File::Status FileDownlink::File ::open(const char* const sourceFileName, con
 
     // Set size
     FwSizeType file_size;
-    const Os::FileSystem::Status status = Os::FileSystem::getFileSize(sourceFileName, file_size);
+    const Os::FileSystem::Status status = Os::FileSystem::getFileSize(sourceFileName.toChar(), file_size);
     if (status != Os::FileSystem::OP_OK) {
         return Os::File::BAD_SIZE;
     }
@@ -43,7 +45,7 @@ Os::File::Status FileDownlink::File ::open(const char* const sourceFileName, con
     this->m_checksum = checksum;
 
     // Open osFile for reading
-    return this->m_osFile.open(sourceFileName, Os::File::OPEN_READ);
+    return this->m_osFile.open(sourceFileName.toChar(), Os::File::OPEN_READ);
 }
 
 Os::File::Status FileDownlink::File ::read(U8* const data, const U32 byteOffset, const U32 size) {

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -107,8 +107,6 @@ Svc::SendFileResponse FileDownlink ::SendFile_handler(
     U32 offset,
     U32 length) {
     struct FileEntry entry;
-    entry.srcFilename[0] = 0;
-    entry.destFilename[0] = 0;
     entry.offset = offset;
     entry.length = length;
     entry.source = FileDownlink::PORT;
@@ -116,12 +114,10 @@ Svc::SendFileResponse FileDownlink ::SendFile_handler(
     entry.cmdSeq = 0;
     entry.context = m_cntxId++;
 
-    FW_ASSERT(sourceFilename.length() < sizeof(entry.srcFilename));
-    FW_ASSERT(destFilename.length() < sizeof(entry.destFilename));
-    (void)Fw::StringUtils::string_copy(entry.srcFilename, sourceFilename.toChar(),
-                                       static_cast<FwSizeType>(sizeof(entry.srcFilename)));
-    (void)Fw::StringUtils::string_copy(entry.destFilename, destFilename.toChar(),
-                                       static_cast<FwSizeType>(sizeof(entry.destFilename)));
+    FW_ASSERT(sourceFilename.length() < entry.srcFilename.getCapacity());
+    FW_ASSERT(destFilename.length() < entry.destFilename.getCapacity());
+    entry.srcFilename = sourceFilename;
+    entry.destFilename = destFilename;
 
     Os::Queue::Status status = m_fileQueue.send(reinterpret_cast<U8*>(&entry), static_cast<FwSizeType>(sizeof(entry)),
                                                 0, Os::Queue::BlockingType::NONBLOCKING);
@@ -167,8 +163,6 @@ void FileDownlink ::SendFile_cmdHandler(const FwOpcodeType opCode,
                                         const Fw::CmdStringArg& sourceFilename,
                                         const Fw::CmdStringArg& destFilename) {
     struct FileEntry entry;
-    entry.srcFilename[0] = 0;
-    entry.destFilename[0] = 0;
     entry.offset = 0;
     entry.length = 0;
     entry.source = FileDownlink::COMMAND;
@@ -176,12 +170,10 @@ void FileDownlink ::SendFile_cmdHandler(const FwOpcodeType opCode,
     entry.cmdSeq = cmdSeq;
     entry.context = std::numeric_limits<U32>::max();
 
-    FW_ASSERT(sourceFilename.length() < sizeof(entry.srcFilename));
-    FW_ASSERT(destFilename.length() < sizeof(entry.destFilename));
-    (void)Fw::StringUtils::string_copy(entry.srcFilename, sourceFilename.toChar(),
-                                       static_cast<FwSizeType>(sizeof(entry.srcFilename)));
-    (void)Fw::StringUtils::string_copy(entry.destFilename, destFilename.toChar(),
-                                       static_cast<FwSizeType>(sizeof(entry.destFilename)));
+    FW_ASSERT(sourceFilename.length() < entry.srcFilename.getCapacity());
+    FW_ASSERT(destFilename.length() < entry.destFilename.getCapacity());
+    entry.srcFilename = sourceFilename;
+    entry.destFilename = destFilename;
 
     Os::Queue::Status status = m_fileQueue.send(reinterpret_cast<U8*>(&entry), static_cast<FwSizeType>(sizeof(entry)),
                                                 0, Os::Queue::BlockingType::NONBLOCKING);
@@ -198,8 +190,6 @@ void FileDownlink ::SendPartial_cmdHandler(FwOpcodeType opCode,
                                            U32 startOffset,
                                            U32 length) {
     struct FileEntry entry;
-    entry.srcFilename[0] = 0;
-    entry.destFilename[0] = 0;
     entry.offset = startOffset;
     entry.length = length;
     entry.source = FileDownlink::COMMAND;
@@ -207,12 +197,10 @@ void FileDownlink ::SendPartial_cmdHandler(FwOpcodeType opCode,
     entry.cmdSeq = cmdSeq;
     entry.context = std::numeric_limits<U32>::max();
 
-    FW_ASSERT(sourceFilename.length() < sizeof(entry.srcFilename));
-    FW_ASSERT(destFilename.length() < sizeof(entry.destFilename));
-    (void)Fw::StringUtils::string_copy(entry.srcFilename, sourceFilename.toChar(),
-                                       static_cast<FwSizeType>(sizeof(entry.srcFilename)));
-    (void)Fw::StringUtils::string_copy(entry.destFilename, destFilename.toChar(),
-                                       static_cast<FwSizeType>(sizeof(entry.destFilename)));
+    FW_ASSERT(sourceFilename.length() < entry.srcFilename.getCapacity());
+    FW_ASSERT(destFilename.length() < entry.destFilename.getCapacity());
+    entry.srcFilename = sourceFilename;
+    entry.destFilename = destFilename;
 
     Os::Queue::Status status = m_fileQueue.send(reinterpret_cast<U8*>(&entry), static_cast<FwSizeType>(sizeof(entry)),
                                                 0, Os::Queue::BlockingType::NONBLOCKING);
@@ -265,7 +253,11 @@ void FileDownlink ::sendResponse(SendFileStatus resp) {
     }
 }
 
-void FileDownlink ::sendFile(const char* sourceFilename, const char* destFilename, U32 startOffset, U32 length) {
+void FileDownlink ::sendFile(
+    const Fw::FileNameString& sourceFilename, 
+    const Fw::FileNameString& destFilename, 
+    U32 startOffset,
+    U32 length) {
     // Open file for downlink
     Os::File::Status status = this->m_file.open(sourceFilename, destFilename);
 

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -253,11 +253,10 @@ void FileDownlink ::sendResponse(SendFileStatus resp) {
     }
 }
 
-void FileDownlink ::sendFile(
-    const Fw::FileNameString& sourceFilename, 
-    const Fw::FileNameString& destFilename, 
-    U32 startOffset,
-    U32 length) {
+void FileDownlink ::sendFile(const Fw::FileNameString& sourceFilename,
+                             const Fw::FileNameString& destFilename,
+                             U32 startOffset,
+                             U32 length) {
     // Open file for downlink
     Os::File::Status status = this->m_file.open(sourceFilename, destFilename);
 

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -312,7 +312,7 @@ class FileDownlink final : public FileDownlinkComponentBase {
     void sendFile(
         const Fw::FileNameString& sourceFilename,  //!< The name of the on-board file to send
         const Fw::FileNameString& destFilename,    //!< The name of the destination file on the ground
-        U32 startOffset,             //!< Starting offset of the source file
+        U32 startOffset,                           //!< Starting offset of the source file
         U32 length  //!< Number of bytes to send from starting offset. Length of 0 implies until the end of the file
     );
 

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -92,8 +92,8 @@ class FileDownlink final : public FileDownlinkComponentBase {
 
       public:
         //! Open the OS file for reading and initialize the checksum
-        Os::File::Status open(const char* const sourceFileName,  //!< The source file name
-                              const char* const destFileName     //!< The destination file name
+        Os::File::Status open(const Fw::FileNameString& sourceFileName,  //!< The source file name
+                              const Fw::FileNameString& destFileName     //!< The destination file name
         );
 
         //! Read bytes from the OS file and update the checksum
@@ -199,8 +199,8 @@ class FileDownlink final : public FileDownlinkComponentBase {
 
     //! Used to track a single file downlink request
     struct FileEntry {
-        char srcFilename[Fw::FileNameString::STRING_SIZE];   // Name of requested file
-        char destFilename[Fw::FileNameString::STRING_SIZE];  // Name of requested file
+        Fw::FileNameString srcFilename;   // Name of requested file
+        Fw::FileNameString destFilename;  // Name of requested file
         U32 offset;
         U32 length;
         CallerSource source;  // Source of the downlink request
@@ -310,8 +310,8 @@ class FileDownlink final : public FileDownlinkComponentBase {
     // ----------------------------------------------------------------------
 
     void sendFile(
-        const char* sourceFilename,  //!< The name of the on-board file to send
-        const char* destFilename,    //!< The name of the destination file on the ground
+        const Fw::FileNameString& sourceFilename,  //!< The name of the on-board file to send
+        const Fw::FileNameString& destFilename,    //!< The name of the destination file on the ground
         U32 startOffset,             //!< Starting offset of the source file
         U32 length  //!< Number of bytes to send from starting offset. Length of 0 implies until the end of the file
     );


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4624 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Change String type in FileDownlink from `const char*` to `Fw::FileNameString`