### PR TITLE
Make `Os::QueueInterface::teardown()` pure virtual

### DIFF
--- a/Os/Queue.hpp
+++ b/Os/Queue.hpp
@@ -83,8 +83,6 @@ class QueueInterface {
     //!
     //! Allow for queues to deallocate resources as part of system shutdown. This delegates to the underlying queue
     //! implementation.
-    //!
-    //! Note: the default implementation does nothing.
     virtual void teardown() = 0;
 
     //! \brief send a message into the queue

--- a/Os/Queue.hpp
+++ b/Os/Queue.hpp
@@ -85,7 +85,7 @@ class QueueInterface {
     //! implementation.
     //!
     //! Note: the default implementation does nothing.
-    virtual void teardown() {}
+    virtual void teardown() = 0;
 
     //! \brief send a message into the queue
     //!

--- a/Os/Stub/Queue.cpp
+++ b/Os/Stub/Queue.cpp
@@ -15,9 +15,7 @@ QueueInterface::Status StubQueue::create(FwEnumStoreType id,
     return QueueInterface::Status::UNKNOWN_ERROR;
 }
 
-void StubQueue::teardown() {
-
-}
+void StubQueue::teardown() {}
 
 QueueInterface::Status StubQueue::send(const U8* buffer,
                                        FwSizeType size,

--- a/Os/Stub/Queue.cpp
+++ b/Os/Stub/Queue.cpp
@@ -15,6 +15,10 @@ QueueInterface::Status StubQueue::create(FwEnumStoreType id,
     return QueueInterface::Status::UNKNOWN_ERROR;
 }
 
+void StubQueue::teardown() {
+
+}
+
 QueueInterface::Status StubQueue::send(const U8* buffer,
                                        FwSizeType size,
                                        FwQueuePriorityType priority,

--- a/Os/Stub/Queue.hpp
+++ b/Os/Stub/Queue.hpp
@@ -42,6 +42,11 @@ class StubQueue : public QueueInterface {
                   const Fw::ConstStringBase& name,
                   FwSizeType depth,
                   FwSizeType messageSize) override;
+    
+    //! \brief teardown the queue
+    //!
+    //! Allow for queues to deallocate resources as part of system shutdown. 
+    void teardown() override;
 
     //! \brief send a message into the queue
     //!

--- a/Os/Stub/Queue.hpp
+++ b/Os/Stub/Queue.hpp
@@ -42,10 +42,10 @@ class StubQueue : public QueueInterface {
                   const Fw::ConstStringBase& name,
                   FwSizeType depth,
                   FwSizeType messageSize) override;
-    
+
     //! \brief teardown the queue
     //!
-    //! Allow for queues to deallocate resources as part of system shutdown. 
+    //! Allow for queues to deallocate resources as part of system shutdown.
     void teardown() override;
 
     //! \brief send a message into the queue

--- a/Os/Stub/test/Queue.cpp
+++ b/Os/Stub/test/Queue.cpp
@@ -48,6 +48,8 @@ QueueInterface::Status InjectableStlQueue::create(FwEnumStoreType id,
     return StaticData::data.createStatus;
 }
 
+void InjectableStlQueue::teardown() {}
+
 QueueInterface::Status InjectableStlQueue::send(const U8* buffer,
                                                 FwSizeType size,
                                                 FwQueuePriorityType priority,

--- a/Os/Stub/test/Queue.hpp
+++ b/Os/Stub/test/Queue.hpp
@@ -119,7 +119,7 @@ class InjectableStlQueue : public QueueInterface {
 
     //! \brief teardown the queue
     //!
-    //! Allow for queues to deallocate resources as part of system shutdown. 
+    //! Allow for queues to deallocate resources as part of system shutdown.
     void teardown() override;
 
     //! \brief send a message into the queue

--- a/Os/Stub/test/Queue.hpp
+++ b/Os/Stub/test/Queue.hpp
@@ -117,6 +117,11 @@ class InjectableStlQueue : public QueueInterface {
                   FwSizeType depth,
                   FwSizeType messageSize) override;
 
+    //! \brief teardown the queue
+    //!
+    //! Allow for queues to deallocate resources as part of system shutdown. 
+    void teardown() override;
+
     //! \brief send a message into the queue
     //!
     //! Send a message into the queue, providing the message data, size, priority, and blocking type. When


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4494 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Make `Os::QueueInterface::teardown()` pure virtual and implement it in derived classes.
