### PR TITLE
Add deinit function for passive components

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -162,6 +162,7 @@ deframe
 deframed
 deframer
 deframing
+Deinitialization
 deployables
 DEPRECATEDLIST
 deser

--- a/Fpp/ToCpp.fpp
+++ b/Fpp/ToCpp.fpp
@@ -15,7 +15,7 @@ module Fpp {
       stopTasks
       freeThreads
       tearDownComponents
-      deinit
+      deinitComponents
     }
 
   }

--- a/Fw/Comp/PassiveComponentBase.cpp
+++ b/Fw/Comp/PassiveComponentBase.cpp
@@ -32,6 +32,8 @@ void PassiveComponentBase::toString(char* buffer, FwSizeType size) {
 
 PassiveComponentBase::~PassiveComponentBase() {}
 
+void deinit() {}
+
 void PassiveComponentBase::init(FwEnumStoreType instance) {
     ObjBase::init();
     this->m_instance = instance;

--- a/Fw/Comp/PassiveComponentBase.cpp
+++ b/Fw/Comp/PassiveComponentBase.cpp
@@ -32,7 +32,7 @@ void PassiveComponentBase::toString(char* buffer, FwSizeType size) {
 
 PassiveComponentBase::~PassiveComponentBase() {}
 
-void deinit() {}
+void PassiveComponentBase::deinit() {}
 
 void PassiveComponentBase::init(FwEnumStoreType instance) {
     ObjBase::init();

--- a/Fw/Comp/PassiveComponentBase.hpp
+++ b/Fw/Comp/PassiveComponentBase.hpp
@@ -16,6 +16,8 @@ class PassiveComponentBase : public Fw::ObjBase {
     //! \return The ID base
     FwIdType getIdBase() const;
 
+    void deinit();  //!< Deinitialization function
+
   protected:
     PassiveComponentBase(const char* name);  //!< Named constructor
     virtual ~PassiveComponentBase();         //!< Destructor

--- a/Fw/Comp/PassiveComponentBase.hpp
+++ b/Fw/Comp/PassiveComponentBase.hpp
@@ -16,7 +16,7 @@ class PassiveComponentBase : public Fw::ObjBase {
     //! \return The ID base
     FwIdType getIdBase() const;
 
-    void deinit();  //!< Deinitialization function
+    virtual void deinit();  //!< Deinitialization function
 
   protected:
     PassiveComponentBase(const char* name);  //!< Named constructor

--- a/Fw/Comp/QueuedComponentBase.hpp
+++ b/Fw/Comp/QueuedComponentBase.hpp
@@ -26,7 +26,7 @@ class QueuedComponentBase : public PassiveComponentBase {
         MSG_DISPATCH_ERROR,  //!< Errors dispatching messages
         MSG_DISPATCH_EXIT    //!< A message was sent requesting an exit of the loop
     } MsgDispatchStatus;
-    void deinit();  //!< Allows de-initialization on teardown
+    void deinit() override;  //!< Allows de-initialization on teardown
 
   protected:
     QueuedComponentBase(const char* name);  //!< Constructor
@@ -36,7 +36,7 @@ class QueuedComponentBase : public PassiveComponentBase {
     Os::Queue::Status createQueue(FwSizeType depth, FwSizeType msgSize);
     virtual MsgDispatchStatus doDispatch() = 0;  //!< method to dispatch a single message in the queue.
 #if FW_OBJECT_TO_STRING == 1
-    virtual const char* getToStringFormatString();  //!< Format string for toString function
+    const char* getToStringFormatString() override;  //!< Format string for toString function
 #endif
     FwSizeType getNumMsgsDropped();  //!< return number of messages dropped
     void incNumMsgDropped();         //!< increment the number of messages dropped


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Add `deinit` to passive components

## Rationale

Passives have `init` and thus should have `deinit`.

## Testing/Review Recommendations

None.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Autocomplete.