### PR TITLE
Refactor Ccsds.ApidManager to use `Fw::ArrayMap`

### DIFF
--- a/Svc/Ccsds/ApidManager/ApidManager.cpp
+++ b/Svc/Ccsds/ApidManager/ApidManager.cpp
@@ -41,38 +41,25 @@ U16 ApidManager ::getApidSeqCountIn_handler(FwIndexType portNum, const ComCfg::A
 // ----------------------------------------------------------------------
 
 U16 ApidManager ::getAndIncrementSeqCount(ComCfg::Apid::T apid) {
-    U16 seqCount = SEQUENCE_COUNT_ERROR;  // Default to error value
-    // Search the APID in the sequence table
-    for (U16 i = 0; i < MAX_TRACKED_APIDS; i++) {
-        if (this->m_apidSequences[i].apid == apid) {
-            seqCount = this->m_apidSequences[i].sequenceCount;
-            // Increment entry for next call
-            this->m_apidSequences[i].sequenceCount =
-                static_cast<U16>((seqCount + 1) % (1 << SpacePacketSubfields::SeqCountWidth));
-            return seqCount;  // Return the current sequence count
-        }
+    U16 seqCount = 0;
+    // Find sequence count if exists, otherwise use 0
+    (void)m_apidSequences.find(apid, seqCount);
+    // Increment sequence count for next call
+    U16 updatedSeqCount = static_cast<U16>((seqCount + 1) % (1 << SpacePacketSubfields::SeqCountWidth));
+    
+    Fw::Success insert_status = m_apidSequences.insert(apid, updatedSeqCount);
+    if (insert_status == Fw::Success::SUCCESS) {
+        return seqCount;  // Return the current sequence count
     }
-    // If not found, search for an uninitialized entry to track this APID
-    for (U16 i = 0; i < MAX_TRACKED_APIDS; i++) {
-        if (this->m_apidSequences[i].apid == ComCfg::Apid::INVALID_UNINITIALIZED) {
-            this->m_apidSequences[i].apid = apid;               // Initialize this entry with the new APID
-            seqCount = this->m_apidSequences[i].sequenceCount;  // Entries default to 0 unless otherwise specified
-            // Increment entry for next call
-            this->m_apidSequences[i].sequenceCount =
-                static_cast<U16>((seqCount + 1) % (1 << SpacePacketSubfields::SeqCountWidth));
-            return seqCount;  // Return the initialized sequence count
-        }
-    }
+    
     this->log_WARNING_HI_ApidTableFull(apid);
     return SEQUENCE_COUNT_ERROR;
 }
 
 void ApidManager::setNextSeqCount(ComCfg::Apid::T apid, U16 seqCount) {
-    for (U16 i = 0; i < MAX_TRACKED_APIDS; i++) {
-        if (this->m_apidSequences[i].apid == apid) {
-            this->m_apidSequences[i].sequenceCount = seqCount;
-            return;
-        }
+    Fw::Success insert_status = m_apidSequences.insert(apid, seqCount);
+    if (insert_status == Fw::Success::SUCCESS) {
+        return;
     }
     // This code should not be reachable with the if statement in validateApidSeqCountIn_handler
     FW_ASSERT(false, static_cast<FwAssertArgType>(apid));

--- a/Svc/Ccsds/ApidManager/ApidManager.cpp
+++ b/Svc/Ccsds/ApidManager/ApidManager.cpp
@@ -27,7 +27,7 @@ U16 ApidManager ::validateApidSeqCountIn_handler(FwIndexType portNum, const ComC
         // Likely a packet was dropped or out of order
         this->log_WARNING_LO_UnexpectedSequenceCount(receivedSeqCount, expectedSequenceCount);
         // Synchronize onboard count with received number so that count can keep going
-        this->setNextSeqCount(apid, static_cast<U16>(receivedSeqCount + 1));
+        this->setNextSeqCount(apid, this->calculateNextSeqCount(receivedSeqCount));
     }
     return receivedSeqCount;
 }
@@ -45,24 +45,24 @@ U16 ApidManager ::getAndIncrementSeqCount(ComCfg::Apid::T apid) {
     // Find sequence count if exists, otherwise use 0
     (void)m_apidSequences.find(apid, seqCount);
     // Increment sequence count for next call
-    U16 updatedSeqCount = static_cast<U16>((seqCount + 1) % (1 << SpacePacketSubfields::SeqCountWidth));
-    
+    U16 updatedSeqCount = this->calculateNextSeqCount(seqCount);
+
     Fw::Success insert_status = m_apidSequences.insert(apid, updatedSeqCount);
     if (insert_status == Fw::Success::SUCCESS) {
         return seqCount;  // Return the current sequence count
     }
-    
+
     this->log_WARNING_HI_ApidTableFull(apid);
     return SEQUENCE_COUNT_ERROR;
 }
 
 void ApidManager::setNextSeqCount(ComCfg::Apid::T apid, U16 seqCount) {
     Fw::Success insert_status = m_apidSequences.insert(apid, seqCount);
-    if (insert_status == Fw::Success::SUCCESS) {
-        return;
-    }
-    // This code should not be reachable with the if statement in validateApidSeqCountIn_handler
-    FW_ASSERT(false, static_cast<FwAssertArgType>(apid));
+    FW_ASSERT(insert_status == Fw::Success::SUCCESS, static_cast<FwAssertArgType>(apid));
+}
+
+U16 ApidManager::calculateNextSeqCount(const U16 seqCount) const {
+    return static_cast<U16>((seqCount + 1) % (1 << SpacePacketSubfields::SeqCountWidth));
 }
 
 }  // namespace Ccsds

--- a/Svc/Ccsds/ApidManager/ApidManager.cpp
+++ b/Svc/Ccsds/ApidManager/ApidManager.cpp
@@ -47,8 +47,8 @@ U16 ApidManager ::getAndIncrementSeqCount(ComCfg::Apid::T apid) {
     // Increment sequence count for next call
     U16 updatedSeqCount = this->calculateNextSeqCount(seqCount);
 
-    Fw::Success insert_status = m_apidSequences.insert(apid, updatedSeqCount);
-    if (insert_status == Fw::Success::SUCCESS) {
+    Fw::Success insertStatus = m_apidSequences.insert(apid, updatedSeqCount);
+    if (insertStatus == Fw::Success::SUCCESS) {
         return seqCount;  // Return the current sequence count
     }
 
@@ -57,8 +57,8 @@ U16 ApidManager ::getAndIncrementSeqCount(ComCfg::Apid::T apid) {
 }
 
 void ApidManager::setNextSeqCount(ComCfg::Apid::T apid, U16 seqCount) {
-    Fw::Success insert_status = m_apidSequences.insert(apid, seqCount);
-    FW_ASSERT(insert_status == Fw::Success::SUCCESS, static_cast<FwAssertArgType>(apid));
+    Fw::Success insertStatus = m_apidSequences.insert(apid, seqCount);
+    FW_ASSERT(insertStatus == Fw::Success::SUCCESS, static_cast<FwAssertArgType>(apid));
 }
 
 U16 ApidManager::calculateNextSeqCount(const U16 seqCount) const {

--- a/Svc/Ccsds/ApidManager/ApidManager.hpp
+++ b/Svc/Ccsds/ApidManager/ApidManager.hpp
@@ -8,8 +8,8 @@
 #define Svc_Ccsds_ApidManager_HPP
 
 #include "Fw/Com/ComPacket.hpp"
-#include "Svc/Ccsds/ApidManager/ApidManagerComponentAc.hpp"
 #include "Fw/DataStructures/ArrayMap.hpp"
+#include "Svc/Ccsds/ApidManager/ApidManagerComponentAc.hpp"
 
 namespace Svc {
 
@@ -75,9 +75,12 @@ class ApidManager final : public ApidManagerComponentBase {
     //! Set the next expected sequence count for a given APID
     void setNextSeqCount(ComCfg::Apid::T apid, U16 seqCount);
 
+    //! Helper function for wrapping around at 14 bits when calculating the next sequence count
+    U16 calculateNextSeqCount(const U16 seqCount) const;
+
     //! ArrayMap with internal storage
-    //! Key: APID 
-    //! Value: sequence count 
+    //! Key: APID
+    //! Value: sequence count
     //! Capacity: MAX_TRACKED_APIDS
     using MapType = Fw::ArrayMap<ComCfg::Apid::T, U16, MAX_TRACKED_APIDS>;
 

--- a/Svc/Ccsds/ApidManager/ApidManager.hpp
+++ b/Svc/Ccsds/ApidManager/ApidManager.hpp
@@ -9,6 +9,7 @@
 
 #include "Fw/Com/ComPacket.hpp"
 #include "Svc/Ccsds/ApidManager/ApidManagerComponentAc.hpp"
+#include "Fw/DataStructures/ArrayMap.hpp"
 
 namespace Svc {
 
@@ -74,18 +75,17 @@ class ApidManager final : public ApidManagerComponentBase {
     //! Set the next expected sequence count for a given APID
     void setNextSeqCount(ComCfg::Apid::T apid, U16 seqCount);
 
-    //! This struct helps track sequence counts per APID
-    //! Future work: update to using a map from Fw/DataStructures when available
-    struct ApidSequenceEntry {
-        ComCfg::Apid::T apid = ComCfg::Apid::INVALID_UNINITIALIZED;
-        U16 sequenceCount = 0;
-    };
+    //! ArrayMap with internal storage
+    //! Key: APID 
+    //! Value: sequence count 
+    //! Capacity: MAX_TRACKED_APIDS
+    using MapType = Fw::ArrayMap<ComCfg::Apid::T, U16, MAX_TRACKED_APIDS>;
 
   private:
     // ----------------------------------------------------------------------
     // Member variables
     // ----------------------------------------------------------------------
-    ApidSequenceEntry m_apidSequences[MAX_TRACKED_APIDS];
+    MapType m_apidSequences;
 };
 
 }  // namespace Ccsds

--- a/Svc/Ccsds/ApidManager/docs/sdd.md
+++ b/Svc/Ccsds/ApidManager/docs/sdd.md
@@ -6,10 +6,10 @@ The `ApidManager` is typically used in conjunction with the [`SpacePacketFramer`
 
 ## Functionality
 
-- Maintains a table of APIDs and their associated 14-bit sequence counts.
+- Maintains a `Fw::ArrayMap` of APIDs and their associated 14-bit sequence counts.
 - Handles a fixed maximum number of tracked APIDs (as configured in the project).
 - Provides a way to retrieve the current sequence count for a given APID through a port call.
-- Provides a way to validate a received sequence counts for a given APID through a port call.
+- Provides a way to validate a received sequence count for a given APID through a port call.
 
 ## Port Descriptions
 

--- a/Svc/Ccsds/ApidManager/test/ut/ApidManagerTestMain.cpp
+++ b/Svc/Ccsds/ApidManager/test/ut/ApidManagerTestMain.cpp
@@ -43,7 +43,7 @@ TEST(ApidManager, RandomizedTesting) {
     STest::RandomScenario<Svc::Ccsds::ApidManagerTester> random("Random Rules", rules, FW_NUM_ARRAY_ELEMENTS(rules));
 
     // Create a bounded scenario wrapping the random scenario
-    STest::BoundedScenario<Svc::Ccsds::ApidManagerTester> bounded("Bounded Random Rules Scenario", random, 1000);
+    STest::BoundedScenario<Svc::Ccsds::ApidManagerTester> bounded("Bounded Random Rules Scenario", random, 10000);
     // Run!
     const U32 numSteps = bounded.run(tester);
     printf("Ran %u steps.\n", numSteps);

--- a/Svc/Ccsds/ApidManager/test/ut/ApidManagerTester.cpp
+++ b/Svc/Ccsds/ApidManager/test/ut/ApidManagerTester.cpp
@@ -26,7 +26,7 @@ ApidManagerTester ::ApidManagerTester()
     this->connectPorts();
     // Initialize existing sequence counts for common APIDs
     for (FwIndexType i = 0; i < static_cast<FwIndexType>(FW_NUM_ARRAY_ELEMENTS(TEST_REGISTERED_APIDS)); i++) {
-        this->component.m_apidSequences[i].apid = TEST_REGISTERED_APIDS[i];
+        this->component.m_apidSequences.insert(TEST_REGISTERED_APIDS[i], static_cast<U16>(0));
         this->shadow_seqCounts[TEST_REGISTERED_APIDS[i]] = 0;  // Initialize shadow sequence counts to 0
     }
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4338 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Use `Fw::ArrayMap` instead of a custom dictionary in `Ccsds::ApidManager` class.

## Rationale

Best practice, simple code.