### PR TITLE
Add floating point operations for `Fw::Time`

### DIFF
--- a/Fw/Time/Time.cpp
+++ b/Fw/Time/Time.cpp
@@ -44,10 +44,30 @@ void Time::set(TimeBase timeBase, FwTimeContextStoreType context, U32 seconds, U
     this->m_val.set(timeBase, context, seconds, useconds);
 }
 
+Fw::Time::Time(F64 seconds) {
+    this->set(seconds);
+}
+
+void Fw::Time::set(F64 seconds) {
+    U32 parsedSeconds = this->parseSeconds(seconds);
+    U32 parsedUseconds = this->parseUSeconds(seconds);
+    this->set(parsedSeconds, parsedUseconds);
+}
+
 Time& Time::operator=(const Time& other) {
     if (this != &other) {
         this->m_val = other.m_val;
     }
+    return *this;
+}
+
+Time& Fw::Time::operator=(F64 seconds) {
+    this->set(seconds);
+    return *this;
+}
+
+Time& Fw::Time::operator+=(F64 seconds) {
+    this->add(seconds);
     return *this;
 }
 
@@ -75,6 +95,12 @@ bool Time::operator>=(const Time& other) const {
 bool Time::operator<=(const Time& other) const {
     TimeComparison c = Time::compare(*this, other);
     return ((TimeComparison::LT == c) or (TimeComparison::EQ == c));
+}
+
+Fw::Time::operator F64() const {
+    const U32 seconds = this->m_val.get_seconds();
+    const U32 useconds = this->m_val.get_useconds();
+    return static_cast<F64>(seconds) + (static_cast<F64>(useconds) / 1000000.0);
 }
 
 TimeValue Time::asTimeValue() const {
@@ -185,6 +211,22 @@ Time Time ::sub(const Time& minuend,    //!< Time minuend
     return Time(minuend.getTimeBase(), context, seconds, static_cast<U32>(uSeconds));
 }
 
+U32 Fw::Time::parseSeconds(F64 seconds) {
+    // Assert negative value
+    FW_ASSERT(seconds >= static_cast<F64>(0.0));
+    return static_cast<U32>(seconds);
+}
+
+U32 Fw::Time::parseUSeconds(F64 seconds) {
+    // Assert negative value
+    FW_ASSERT(seconds >= static_cast<F64>(0.0));
+    U32 parsedSeconds = static_cast<U32>(seconds);
+    const F64 fractionalPart = seconds - static_cast<F64>(parsedSeconds);
+    // Add 0.5 to round to nearest microsecond (e.g, 999999.9999 = 1000000)
+    U32 parsedUSeconds = static_cast<U32>(fractionalPart * static_cast<F64>(1000000.0) + static_cast<F64>(0.5));
+    return parsedUSeconds;
+}
+
 void Time::add(U32 seconds, U32 useconds) {
     U32 newSeconds = this->m_val.get_seconds() + seconds;
     U32 newUSeconds = this->m_val.get_useconds() + useconds;
@@ -194,6 +236,13 @@ void Time::add(U32 seconds, U32 useconds) {
         newUSeconds -= 1000000;
     }
     this->set(newSeconds, newUSeconds);
+}
+
+void Time::add(F64 seconds) {
+    U32 parsedSeconds = this->parseSeconds(seconds);
+    U32 parsedUseconds = this->parseUSeconds(seconds);
+    // Add parsed seconds and useconds
+    this->add(parsedSeconds, parsedUseconds);
 }
 
 void Time::setTimeBase(TimeBase timeBase) {

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -20,9 +20,14 @@ class Time : public Serializable {
     Time(U32 seconds, U32 useconds);                     // !< Constructor with member values as arguments
     Time(TimeBase timeBase, U32 seconds, U32 useconds);  // !< Constructor with member values as arguments
     Time(TimeBase timeBase,
-         FwTimeContextStoreType context,
-         U32 seconds,
-         U32 useconds);                                      // !< Constructor with member values as arguments
+      FwTimeContextStoreType context,
+      U32 seconds,
+      U32 useconds);                                     // !< Constructor with member values as arguments
+    
+    //! \brief Constructor with floating-point (F64) seconds
+    //! \warning Negative value (seconds < 0) results in undefined behavior (assert fail in Debug)
+    explicit Time(F64 seconds);
+
     virtual ~Time();                                         // !< Destructor
     void set(U32 seconds, U32 useconds);                     // !< Sets value of time stored
     void set(TimeBase timeBase, U32 seconds, U32 useconds);  // !< Sets value of time stored
@@ -30,6 +35,11 @@ class Time : public Serializable {
              FwTimeContextStoreType context,
              U32 seconds,
              U32 useconds);  // !< Sets value of time stored
+
+    //! \brief Sets value of time stored
+    //! \warning Negative value (seconds < 0) results in undefined behavior (assert fail in Debug)
+    void set(F64 seconds);
+    
     void setTimeBase(TimeBase timeBase);
     void setTimeContext(FwTimeContextStoreType context);
     U32 getSeconds() const;   // !< Gets seconds part of time
@@ -48,6 +58,18 @@ class Time : public Serializable {
     bool operator>=(const Time& other) const;
     bool operator<=(const Time& other) const;
     Time& operator=(const Time& other);
+    
+    //! \brief Assign this Time from floating-point (F64) seconds
+    //! \warning Negative value (seconds < 0) results in undefined behavior (assert fail in Debug mode)
+    Time& operator=(F64 seconds);
+    
+    //! \brief Add floating-point (F64) value to this Time
+    //! \warning Negative value (seconds < 0) results in undefined behavior (assert fail in Debug mode)
+    Time& operator+=(F64 seconds);
+    
+    //! \brief Convert object to floating point (F64) representation
+    //! \return The floating point (F64) representation of this Time
+    operator F64() const;
 
     //! \brief get the underlying TimeValue
     //! \return the TimeValue representation of this Time as a copy
@@ -77,8 +99,22 @@ class Time : public Serializable {
                     const Time& subtrahend  //!< Value being subtracted
     );
 
+    //! \brief Extract seconds from a floating-point (F64)
+    //! \warning Negative value (seconds < 0) results in undefined behavior (assert fail in Debug mode)
+    //! \return Seconds count as U32
+    static U32 parseSeconds(F64 seconds);
+
+    //! \brief Extract microseconds from a floating-point (F64)
+    //! \warning Negative value (seconds < 0) results in undefined behavior (assert fail in Debug)
+    //! \return Microseconds count as U32
+    static U32 parseUSeconds(F64 seconds);
+
     // add seconds and microseconds to existing time
     void add(U32 seconds, U32 mseconds);
+
+    //! \brief Add floating-point (F64) seconds to existing time
+    //! \warning Negative value (seconds < 0) results in undefined behavior (assert fail in Debug)
+    void add(F64 seconds);
 
 #ifdef BUILD_UT  // Stream operators to support Googletest
     friend std::ostream& operator<<(std::ostream& os, const Time& val);

--- a/Fw/Time/Time.hpp
+++ b/Fw/Time/Time.hpp
@@ -20,10 +20,10 @@ class Time : public Serializable {
     Time(U32 seconds, U32 useconds);                     // !< Constructor with member values as arguments
     Time(TimeBase timeBase, U32 seconds, U32 useconds);  // !< Constructor with member values as arguments
     Time(TimeBase timeBase,
-      FwTimeContextStoreType context,
-      U32 seconds,
-      U32 useconds);                                     // !< Constructor with member values as arguments
-    
+         FwTimeContextStoreType context,
+         U32 seconds,
+         U32 useconds);  // !< Constructor with member values as arguments
+
     //! \brief Constructor with floating-point (F64) seconds
     //! \warning Negative value (seconds < 0) results in undefined behavior (assert fail in Debug)
     explicit Time(F64 seconds);
@@ -39,7 +39,7 @@ class Time : public Serializable {
     //! \brief Sets value of time stored
     //! \warning Negative value (seconds < 0) results in undefined behavior (assert fail in Debug)
     void set(F64 seconds);
-    
+
     void setTimeBase(TimeBase timeBase);
     void setTimeContext(FwTimeContextStoreType context);
     U32 getSeconds() const;   // !< Gets seconds part of time
@@ -58,15 +58,15 @@ class Time : public Serializable {
     bool operator>=(const Time& other) const;
     bool operator<=(const Time& other) const;
     Time& operator=(const Time& other);
-    
+
     //! \brief Assign this Time from floating-point (F64) seconds
     //! \warning Negative value (seconds < 0) results in undefined behavior (assert fail in Debug mode)
     Time& operator=(F64 seconds);
-    
+
     //! \brief Add floating-point (F64) value to this Time
     //! \warning Negative value (seconds < 0) results in undefined behavior (assert fail in Debug mode)
     Time& operator+=(F64 seconds);
-    
+
     //! \brief Convert object to floating point (F64) representation
     //! \return The floating point (F64) representation of this Time
     operator F64() const;

--- a/Fw/Time/test/ut/TimeTestMain.cpp
+++ b/Fw/Time/test/ut/TimeTestMain.cpp
@@ -12,11 +12,22 @@
 // Time tests
 TEST(TimeTestNominal, InstantiateTest) {
     Fw::TimeTester tester;
+    tester.test_InstantiateTest();
+}
+
+TEST(TimeTestNominal, InstantiateFromFloatTest) {
+    Fw::TimeTester tester;
+    tester.test_InstantiateFromFloatTest();
 }
 
 TEST(TimeTestNominal, MathTest) {
     Fw::TimeTester tester;
     tester.test_MathTest();
+}
+
+TEST(TimeTestNominal, FloatOperationsTest) {
+    Fw::TimeTester tester;
+    tester.test_FloatOperations();
 }
 
 TEST(TimeTestNominal, CopyTest) {

--- a/Fw/Time/test/ut/TimeTester.cpp
+++ b/Fw/Time/test/ut/TimeTester.cpp
@@ -133,7 +133,7 @@ void Fw::TimeTester::test_FloatOperations() {
     // Rounding check
     EXPECT_EQ(1000000, Fw::Time::parseUSeconds(0.99999999999999));
     EXPECT_EQ(0, Fw::Time::parseUSeconds(0.00000011111111));
-    
+
     // Add float value
     time.add(2000.004000);
     EXPECT_EQ(time.getSeconds(), 3000);
@@ -154,7 +154,7 @@ void Fw::TimeTester::test_FloatOperations() {
     time = 1234.567890;
     EXPECT_EQ(time.getSeconds(), 1234);
     EXPECT_EQ(time.getUSeconds(), 567890);
-    
+
     // Convert to F64
     EXPECT_EQ(static_cast<F64>(time), 1234.567890);
 

--- a/Fw/Time/test/ut/TimeTester.cpp
+++ b/Fw/Time/test/ut/TimeTester.cpp
@@ -24,6 +24,15 @@ void TimeTester::test_InstantiateTest() {
     std::cout << time << std::endl;
 }
 
+void Fw::TimeTester::test_InstantiateFromFloatTest() {
+    Fw::Time time(static_cast<F64>(1.000002));
+    ASSERT_EQ(time.getTimeBase(), TimeBase::TB_NONE);
+    ASSERT_EQ(time.getContext(), 0);
+    ASSERT_EQ(time.getSeconds(), 1);
+    ASSERT_EQ(time.getUSeconds(), 2);
+    std::cout << time << std::endl;
+}
+
 void TimeTester::test_MathTest() {
     Fw::Time time1;
     Fw::Time time2;
@@ -108,6 +117,53 @@ void TimeTester::test_MathTest() {
     time_sum = Fw::Time::sub(time1, time2);
     EXPECT_EQ(time_sum.getContext(), 0);
     EXPECT_EQ(time_sum.getSeconds(), 1500);
+}
+
+void Fw::TimeTester::test_FloatOperations() {
+    Fw::Time time;
+
+    // Set float
+    time.set(1000.002000);
+    EXPECT_EQ(1000, time.getSeconds());
+    EXPECT_EQ(2000, time.getUSeconds());
+
+    // Parse seconds and microseconds
+    EXPECT_EQ(1234, Fw::Time::parseSeconds(1234.567890));
+    EXPECT_EQ(567890, Fw::Time::parseUSeconds(1234.567890));
+    // Rounding check
+    EXPECT_EQ(1000000, Fw::Time::parseUSeconds(0.99999999999999));
+    EXPECT_EQ(0, Fw::Time::parseUSeconds(0.00000011111111));
+    
+    // Add float value
+    time.add(2000.004000);
+    EXPECT_EQ(time.getSeconds(), 3000);
+    EXPECT_EQ(time.getUSeconds(), 6000);
+    time.add(0.99999999999999);
+    EXPECT_EQ(time.getSeconds(), 3001);
+    EXPECT_EQ(time.getUSeconds(), 6000);
+    time.add(0.00000011111111);
+    EXPECT_EQ(time.getSeconds(), 3001);
+    EXPECT_EQ(time.getUSeconds(), 6000);
+
+    // Add assign float value
+    time += 1000.005000;
+    EXPECT_EQ(time.getSeconds(), 4001);
+    EXPECT_EQ(time.getUSeconds(), 11000);
+
+    // Assign float value
+    time = 1234.567890;
+    EXPECT_EQ(time.getSeconds(), 1234);
+    EXPECT_EQ(time.getUSeconds(), 567890);
+    
+    // Convert to F64
+    EXPECT_EQ(static_cast<F64>(time), 1234.567890);
+
+    // Assert negative value
+    ASSERT_DEATH_IF_SUPPORTED(Fw::Time::parseSeconds(-1.0), "Assert:.*Time\\.cpp");
+    ASSERT_DEATH_IF_SUPPORTED(Fw::Time::parseUSeconds(-1.0), "Assert:.*Time\\.cpp");
+    ASSERT_DEATH_IF_SUPPORTED(time.add(-1.0), "Assert:.*Time\\.cpp");
+    ASSERT_DEATH_IF_SUPPORTED(time.operator=(-1.0), "Assert:.*Time\\.cpp");
+    ASSERT_DEATH_IF_SUPPORTED(time.operator+=(-1.0), "Assert:.*Time\\.cpp");
 }
 
 void TimeTester::test_CopyTest() {

--- a/Fw/Time/test/ut/TimeTester.hpp
+++ b/Fw/Time/test/ut/TimeTester.hpp
@@ -17,7 +17,9 @@ class TimeTester {
     // Tests
     // ----------------------------------------------------------------------
     void test_InstantiateTest();
+    void test_InstantiateFromFloatTest();
     void test_MathTest();
+    void test_FloatOperations();
     void test_CopyTest();
     void test_ZeroTimeEquality();
     void test_TimeToTimeValue();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #1088  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Added new `Fw::Time` methods to work with F64 values - assignment, addition and conversion. Current implementation rounds microseconds to nearest value (0.99 to 1, but 1.49 remains 1). Negative values are forbidden.

## Rationale

Often time values handled with floating-point types, compatibility might be useful.