### PR TITLE
Fix to `operator=` for `ExternalSerializeBufferWithMemberCopy`

### DIFF
--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -1593,7 +1593,9 @@ class ExternalSerializeBufferWithMemberCopy final : public ExternalSerializeBuff
     ExternalSerializeBufferWithMemberCopy& operator=(const ExternalSerializeBufferWithMemberCopy& src) {
         // Ward against self-assignment
         if (this != &src) {
-            this->setExtBuffer(src.m_buff, src.m_buffSize);
+            this->clear();
+            this->m_buff = src.m_buff;
+            this->m_buffSize = src.m_buffSize;
             this->m_serLoc = src.m_serLoc;
             this->m_deserLoc = src.m_deserLoc;
         }


### PR DESCRIPTION
The `operator=` was calling `setExtBuffer`, which fails an assertion when the buffer is null. It should not do this; it should be possible to copy a default value of this type, which has a null buffer.

Needed to support https://github.com/nasa/fpp/pull/956.