### PR TITLE
refactor: replace FW_MIN/FW_MAX macros with std::min/std::max

### DIFF
--- a/Fw/DataStructures/test/ut/ExternalArrayTest.cpp
+++ b/Fw/DataStructures/test/ut/ExternalArrayTest.cpp
@@ -4,8 +4,8 @@
 // \brief  cpp file for ExternalArray tests
 // ======================================================================
 
-#include <algorithm>
 #include <gtest/gtest.h>
+#include <algorithm>
 
 #include "Fw/Buffer/Buffer.hpp"
 #include "Fw/DataStructures/ExternalArray.hpp"

--- a/Fw/DataStructures/test/ut/ExternalArrayTest.cpp
+++ b/Fw/DataStructures/test/ut/ExternalArrayTest.cpp
@@ -4,6 +4,7 @@
 // \brief  cpp file for ExternalArray tests
 // ======================================================================
 
+#include <algorithm>
 #include <gtest/gtest.h>
 
 #include "Fw/Buffer/Buffer.hpp"
@@ -71,7 +72,7 @@ void testCopyDataFrom(ExternalArray<U32> a1, ExternalArray<U32> a2) {
         a2[i] = 0;
     }
     a2.copyDataFrom(a1);
-    const FwSizeType size = FW_MIN(size1, size2);
+    const FwSizeType size = std::min(size1, size2);
     for (FwSizeType i = 0; i < size; i++) {
         ASSERT_EQ(a2[i], a1[i]);
     }

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -88,8 +88,10 @@ typedef double F64;   //!< 64-bit floating point (double). Required for compiler
 /* Useful macro definitions                                                   */
 /*----------------------------------------------------------------------------*/
 #define FW_NUM_ARRAY_ELEMENTS(a) (sizeof(a) / sizeof((a)[0]))  //!< number of elements in an array
-#define FW_MAX(a, b) (((a) > (b)) ? (a) : (b))                 //!< MAX macro
-#define FW_MIN(a, b) (((a) < (b)) ? (a) : (b))                 //!< MIN macro
+// Deprecated: prefer std::max/std::min from <algorithm> in C++ code.
+// Kept for C compatibility only.
+#define FW_MAX(a, b) (((a) > (b)) ? (a) : (b))                 //!< MAX macro (deprecated in C++, use std::max)
+#define FW_MIN(a, b) (((a) < (b)) ? (a) : (b))                 //!< MIN macro (deprecated in C++, use std::min)
 
 #define FW_NO_ASSERT (1)  //!< Asserts turned off
 #define FW_FILEID_ASSERT \

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -90,8 +90,8 @@ typedef double F64;   //!< 64-bit floating point (double). Required for compiler
 #define FW_NUM_ARRAY_ELEMENTS(a) (sizeof(a) / sizeof((a)[0]))  //!< number of elements in an array
 // Deprecated: prefer std::max/std::min from <algorithm> in C++ code.
 // Kept for C compatibility only.
-#define FW_MAX(a, b) (((a) > (b)) ? (a) : (b))                 //!< MAX macro (deprecated in C++, use std::max)
-#define FW_MIN(a, b) (((a) < (b)) ? (a) : (b))                 //!< MIN macro (deprecated in C++, use std::min)
+#define FW_MAX(a, b) (((a) > (b)) ? (a) : (b))  //!< MAX macro (deprecated in C++, use std::max)
+#define FW_MIN(a, b) (((a) < (b)) ? (a) : (b))  //!< MIN macro (deprecated in C++, use std::min)
 
 #define FW_NO_ASSERT (1)  //!< Asserts turned off
 #define FW_FILEID_ASSERT \

--- a/Fw/Types/ConstStringBase.cpp
+++ b/Fw/Types/ConstStringBase.cpp
@@ -12,6 +12,7 @@
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/StringType.hpp>
 #include <Fw/Types/StringUtils.hpp>
+#include <algorithm>
 #include <cstdarg>
 #include <cstring>
 
@@ -41,7 +42,7 @@ ConstStringBase::SizeType ConstStringBase::serializedSize() const {
 }
 
 ConstStringBase::SizeType ConstStringBase::serializedTruncatedSize(FwSizeType maxLength) const {
-    return static_cast<SizeType>(sizeof(FwSizeStoreType)) + static_cast<SizeType>(FW_MIN(this->length(), maxLength));
+    return static_cast<SizeType>(sizeof(FwSizeStoreType)) + static_cast<SizeType>(std::min(this->length(), maxLength));
 }
 
 bool ConstStringBase::operator==(const ConstStringBase& other) const {
@@ -77,7 +78,7 @@ SerializeStatus ConstStringBase::serializeTo(SerialBufferBase& buffer, Fw::Endia
 }
 
 SerializeStatus ConstStringBase::serializeTo(SerialBufferBase& buffer, SizeType maxLength, Fw::Endianness mode) const {
-    const FwSizeType len = FW_MIN(maxLength, this->length());
+    const FwSizeType len = std::min(maxLength, this->length());
     // Serialize length and then bytes
     return buffer.serializeFrom(reinterpret_cast<const U8*>(this->toChar()), len, Serialization::INCLUDE_LENGTH);
 }

--- a/Os/File.cpp
+++ b/Os/File.cpp
@@ -4,6 +4,7 @@
 // ======================================================================
 #include <Fw/Types/Assert.hpp>
 #include <Os/File.hpp>
+#include <algorithm>
 
 extern "C" {
 #include <Utils/Hash/libcrc/lib_crc.h>  // borrow CRC
@@ -275,7 +276,8 @@ File::Status File::readline(U8* buffer, FwSizeType& size, File::WaitType wait) {
     FwSizeType read = 0;
     // Loop reading chunk by chunk
     for (FwSizeType i = 0; i < size; i += read) {
-        FwSizeType current_chunk_size = FW_MIN(size - i, static_cast<FwSizeType>(FW_FILE_CHUNK_SIZE));
+        // read in chunks to avoid large buffer allocations
+        FwSizeType current_chunk_size = std::min(size - i, static_cast<FwSizeType>(FW_FILE_CHUNK_SIZE));
         read = current_chunk_size;
         status = this->read(buffer + i, read, wait);
         if (status != File::Status::OP_OK) {

--- a/Os/FileSystem.cpp
+++ b/Os/FileSystem.cpp
@@ -298,6 +298,7 @@ FileSystem::Status FileSystem::copyFileData(File& source, File& destination, FwS
     for (copiedSize = 0; (copiedSize < size) && (i < maximum); copiedSize += chunkSize, i++) {
         // chunkSize is FILE_SYSTEM_FILE_CHUNK_SIZE unless size-copiedSize is less than that
         // in which case chunkSize is size-copiedSize, ensuring the last chunk reads the remaining data
+        // static_cast needed to avoid ODR linker issue with static constexpr passed by reference to std::min
         chunkSize = std::min(static_cast<FwSizeType>(FILE_SYSTEM_FILE_CHUNK_SIZE), size - copiedSize);
         file_status = source.read(fileBuffer, chunkSize, Os::File::WaitType::WAIT);
         if (file_status != File::OP_OK) {

--- a/Os/FileSystem.cpp
+++ b/Os/FileSystem.cpp
@@ -298,7 +298,7 @@ FileSystem::Status FileSystem::copyFileData(File& source, File& destination, FwS
     for (copiedSize = 0; (copiedSize < size) && (i < maximum); copiedSize += chunkSize, i++) {
         // chunkSize is FILE_SYSTEM_FILE_CHUNK_SIZE unless size-copiedSize is less than that
         // in which case chunkSize is size-copiedSize, ensuring the last chunk reads the remaining data
-        chunkSize = std::min(FILE_SYSTEM_FILE_CHUNK_SIZE, size - copiedSize);
+        chunkSize = std::min(static_cast<FwSizeType>(FILE_SYSTEM_FILE_CHUNK_SIZE), size - copiedSize);
         file_status = source.read(fileBuffer, chunkSize, Os::File::WaitType::WAIT);
         if (file_status != File::OP_OK) {
             return FileSystem::handleFileError(file_status);

--- a/Os/FileSystem.cpp
+++ b/Os/FileSystem.cpp
@@ -4,6 +4,7 @@
 // ======================================================================
 #include <Fw/Types/Assert.hpp>
 #include <Os/FileSystem.hpp>
+#include <algorithm>
 
 namespace Os {
 
@@ -297,7 +298,7 @@ FileSystem::Status FileSystem::copyFileData(File& source, File& destination, FwS
     for (copiedSize = 0; (copiedSize < size) && (i < maximum); copiedSize += chunkSize, i++) {
         // chunkSize is FILE_SYSTEM_FILE_CHUNK_SIZE unless size-copiedSize is less than that
         // in which case chunkSize is size-copiedSize, ensuring the last chunk reads the remaining data
-        chunkSize = FW_MIN(FILE_SYSTEM_FILE_CHUNK_SIZE, size - copiedSize);
+        chunkSize = std::min(FILE_SYSTEM_FILE_CHUNK_SIZE, size - copiedSize);
         file_status = source.read(fileBuffer, chunkSize, Os::File::WaitType::WAIT);
         if (file_status != File::OP_OK) {
             return FileSystem::handleFileError(file_status);

--- a/Os/Generic/PriorityQueue.cpp
+++ b/Os/Generic/PriorityQueue.cpp
@@ -3,6 +3,7 @@
 // \brief priority queue implementation for Os::Queue
 // ======================================================================
 #include "Os/Generic/PriorityQueue.hpp"
+#include <algorithm>
 #include <cstring>
 #include "Fw/LanguageHelpers.hpp"
 #include "Fw/Types/Assert.hpp"
@@ -199,7 +200,8 @@ QueueInterface::Status PriorityQueue::send(const U8* buffer,
         FW_ASSERT(this->m_handle.m_heap.push(priority, index));
         this->m_handle.store_data(index, buffer, size);
         this->m_handle.m_sizes[index] = size;
-        this->m_handle.m_highMark = FW_MAX(this->m_handle.m_highMark, this->getMessagesAvailable());
+        // track high water mark for queue depth monitoring
+        this->m_handle.m_highMark = std::max(this->m_handle.m_highMark, this->getMessagesAvailable());
     }
     this->m_handle.m_empty.notify();
     return QueueInterface::Status::OP_OK;

--- a/Os/Generic/PriorityQueue.cpp
+++ b/Os/Generic/PriorityQueue.cpp
@@ -200,7 +200,6 @@ QueueInterface::Status PriorityQueue::send(const U8* buffer,
         FW_ASSERT(this->m_handle.m_heap.push(priority, index));
         this->m_handle.store_data(index, buffer, size);
         this->m_handle.m_sizes[index] = size;
-        // track high water mark for queue depth monitoring
         this->m_handle.m_highMark = std::max(this->m_handle.m_highMark, this->getMessagesAvailable());
     }
     this->m_handle.m_empty.notify();

--- a/Os/Stub/test/File.cpp
+++ b/Os/Stub/test/File.cpp
@@ -1,4 +1,5 @@
 #include "Os/Stub/test/File.hpp"
+#include <algorithm>
 #include <new>
 #include "Os/File.hpp"
 namespace Os {
@@ -108,7 +109,7 @@ FileInterface::Status TestFile::read(U8* buffer, FwSizeType& size, WaitType wait
     StaticData::data.lastCalled = StaticData::READ_FN;
     // Copy read data if set
     if (nullptr != StaticData::data.readResult) {
-        size = FW_MIN(size, StaticData::data.readResultSize - StaticData::data.pointer);
+        size = std::min(size, StaticData::data.readResultSize - StaticData::data.pointer);
         (void)::memcpy(buffer, StaticData::data.readResult + StaticData::data.pointer, static_cast<size_t>(size));
         StaticData::data.pointer += size;
         StaticData::data.positionResult = StaticData::data.pointer;
@@ -125,7 +126,7 @@ FileInterface::Status TestFile::write(const U8* buffer, FwSizeType& size, WaitTy
     StaticData::data.lastCalled = StaticData::WRITE_FN;
     // Copy read data if set
     if (nullptr != StaticData::data.writeResult) {
-        size = FW_MIN(size, StaticData::data.writeResultSize - StaticData::data.pointer);
+        size = std::min(size, StaticData::data.writeResultSize - StaticData::data.pointer);
         (void)::memcpy(StaticData::data.writeResult + StaticData::data.pointer, buffer, static_cast<size_t>(size));
         StaticData::data.pointer += size;
         StaticData::data.positionResult = StaticData::data.pointer;

--- a/Os/Stub/test/Queue.cpp
+++ b/Os/Stub/test/Queue.cpp
@@ -2,6 +2,7 @@
 // Created by Michael Starch on 8/27/24.
 //
 #include "Queue.hpp"
+#include <algorithm>
 #include <cstring>
 #include "Fw/Types/Assert.hpp"
 
@@ -73,7 +74,7 @@ QueueInterface::Status InjectableStlQueue::send(const U8* buffer,
     message.size = size;
     message.order = InjectableStlQueueHandle::Message::order_counter++;
     this->m_handle.m_storage.push(message);
-    this->m_handle.m_high_water = FW_MAX(this->m_handle.m_high_water, this->m_handle.m_storage.size());
+    this->m_handle.m_high_water = std::max(this->m_handle.m_high_water, this->m_handle.m_storage.size());
     return QueueInterface::Status::OP_OK;
 }
 

--- a/Os/Stub/test/Queue.cpp
+++ b/Os/Stub/test/Queue.cpp
@@ -74,7 +74,8 @@ QueueInterface::Status InjectableStlQueue::send(const U8* buffer,
     message.size = size;
     message.order = InjectableStlQueueHandle::Message::order_counter++;
     this->m_handle.m_storage.push(message);
-    this->m_handle.m_high_water = std::max(this->m_handle.m_high_water, static_cast<FwSizeType>(this->m_handle.m_storage.size()));
+    this->m_handle.m_high_water =
+        std::max(this->m_handle.m_high_water, static_cast<FwSizeType>(this->m_handle.m_storage.size()));
     return QueueInterface::Status::OP_OK;
 }
 

--- a/Os/Stub/test/Queue.cpp
+++ b/Os/Stub/test/Queue.cpp
@@ -74,7 +74,7 @@ QueueInterface::Status InjectableStlQueue::send(const U8* buffer,
     message.size = size;
     message.order = InjectableStlQueueHandle::Message::order_counter++;
     this->m_handle.m_storage.push(message);
-    this->m_handle.m_high_water = std::max(this->m_handle.m_high_water, this->m_handle.m_storage.size());
+    this->m_handle.m_high_water = std::max(this->m_handle.m_high_water, static_cast<FwSizeType>(this->m_handle.m_storage.size()));
     return QueueInterface::Status::OP_OK;
 }
 

--- a/Os/Stub/test/ut/StubQueueTests.cpp
+++ b/Os/Stub/test/ut/StubQueueTests.cpp
@@ -38,10 +38,10 @@ TEST(Interface, Create) {
     Fw::String name = "My queue";
     const FwSizeType depth =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     const FwSizeType messageSize =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     Os::Stub::Queue::Test::StaticData::data.createStatus = Os::QueueInterface::Status::INVALID_PRIORITY;
     Os::QueueInterface::Status status = queue.create(0, name, depth, messageSize);
     ASSERT_EQ(Os::Stub::Queue::Test::StaticData::data.lastCalled, Os::Stub::Queue::Test::StaticData::CREATE_FN);
@@ -58,10 +58,10 @@ TEST(Interface, SendPointer) {
     Fw::String name = "My queue";
     const FwSizeType depth =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     const FwSizeType messageSize = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     const FwQueuePriorityType priority = STest::Random::lowerUpper(
-        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
+        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
     U8 buffer[messageSize];
     ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     ASSERT_STREQ(name.toChar(), queue.getName().toChar());
@@ -85,10 +85,10 @@ TEST(Interface, SendBuffer) {
     Fw::String name = "My queue";
     const FwSizeType depth =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     const FwSizeType messageSize = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     const FwQueuePriorityType priority = STest::Random::lowerUpper(
-        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
+        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
     U8 storage[messageSize];
     Fw::ExternalSerializeBuffer buffer(storage, sizeof storage);
     Fw::String message = "hello";
@@ -115,10 +115,10 @@ TEST(Interface, ReceivePointer) {
     Fw::String name = "My queue";
     const FwSizeType depth =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     const FwSizeType sizeOut = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     const FwQueuePriorityType priorityOut = STest::Random::lowerUpper(
-        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
+        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
 
     FwSizeType size = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     FwQueuePriorityType priority;
@@ -150,10 +150,10 @@ TEST(Interface, ReceiveBuffer) {
     Fw::String name = "My queue";
     const FwSizeType depth =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     const FwSizeType sizeOut = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     const FwQueuePriorityType priorityOut = STest::Random::lowerUpper(
-        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
+        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
 
     FwSizeType size = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     FwQueuePriorityType priority;
@@ -186,7 +186,7 @@ TEST(Interface, MessageCount) {
     const FwSizeType messageSize = 1;
     const FwSizeType messages =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     Os::Stub::Queue::Test::StaticData::data.messages = messages;
     ASSERT_EQ(queue.getMessagesAvailable(), messages);
@@ -201,7 +201,7 @@ TEST(Interface, MessageHighWaterMarkCount) {
     const FwSizeType messageSize = 200;
     const FwSizeType highWater =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     Os::Stub::Queue::Test::StaticData::data.highWaterMark = highWater;
     ASSERT_EQ(queue.getMessageHighWaterMark(), highWater);

--- a/Os/Stub/test/ut/StubQueueTests.cpp
+++ b/Os/Stub/test/ut/StubQueueTests.cpp
@@ -2,8 +2,8 @@
 // \title Os/Stub/test/ut/StubFileTests.cpp
 // \brief tests using stub implementation for Os::File interface testing
 // ======================================================================
-#include <algorithm>
 #include <gtest/gtest.h>
+#include <algorithm>
 #include "Fw/Types/String.hpp"
 #include "Os/Os.hpp"
 #include "Os/Queue.hpp"
@@ -36,12 +36,12 @@ TEST(Interface, Destruction) {
 TEST(Interface, Create) {
     Os::Queue queue;
     Fw::String name = "My queue";
-    const FwSizeType depth =
-        STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
-    const FwSizeType messageSize =
-        STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
+    const FwSizeType depth = STest::Random::lowerUpper(
+        std::numeric_limits<FwSizeType>::min(),
+        std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
+    const FwSizeType messageSize = STest::Random::lowerUpper(
+        std::numeric_limits<FwSizeType>::min(),
+        std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     Os::Stub::Queue::Test::StaticData::data.createStatus = Os::QueueInterface::Status::INVALID_PRIORITY;
     Os::QueueInterface::Status status = queue.create(0, name, depth, messageSize);
     ASSERT_EQ(Os::Stub::Queue::Test::StaticData::data.lastCalled, Os::Stub::Queue::Test::StaticData::CREATE_FN);
@@ -56,12 +56,13 @@ TEST(Interface, Create) {
 TEST(Interface, SendPointer) {
     Os::Queue queue;
     Fw::String name = "My queue";
-    const FwSizeType depth =
-        STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
+    const FwSizeType depth = STest::Random::lowerUpper(
+        std::numeric_limits<FwSizeType>::min(),
+        std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     const FwSizeType messageSize = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
-    const FwQueuePriorityType priority = STest::Random::lowerUpper(
-        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
+    const FwQueuePriorityType priority =
+        STest::Random::lowerUpper(0, std::min(std::numeric_limits<FwQueuePriorityType>::max(),
+                                              static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
     U8 buffer[messageSize];
     ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     ASSERT_STREQ(name.toChar(), queue.getName().toChar());
@@ -83,12 +84,13 @@ TEST(Interface, SendPointer) {
 TEST(Interface, SendBuffer) {
     Os::Queue queue;
     Fw::String name = "My queue";
-    const FwSizeType depth =
-        STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
+    const FwSizeType depth = STest::Random::lowerUpper(
+        std::numeric_limits<FwSizeType>::min(),
+        std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     const FwSizeType messageSize = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
-    const FwQueuePriorityType priority = STest::Random::lowerUpper(
-        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
+    const FwQueuePriorityType priority =
+        STest::Random::lowerUpper(0, std::min(std::numeric_limits<FwQueuePriorityType>::max(),
+                                              static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
     U8 storage[messageSize];
     Fw::ExternalSerializeBuffer buffer(storage, sizeof storage);
     Fw::String message = "hello";
@@ -113,12 +115,13 @@ TEST(Interface, SendBuffer) {
 TEST(Interface, ReceivePointer) {
     Os::Queue queue;
     Fw::String name = "My queue";
-    const FwSizeType depth =
-        STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
+    const FwSizeType depth = STest::Random::lowerUpper(
+        std::numeric_limits<FwSizeType>::min(),
+        std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     const FwSizeType sizeOut = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
-    const FwQueuePriorityType priorityOut = STest::Random::lowerUpper(
-        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
+    const FwQueuePriorityType priorityOut =
+        STest::Random::lowerUpper(0, std::min(std::numeric_limits<FwQueuePriorityType>::max(),
+                                              static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
 
     FwSizeType size = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     FwQueuePriorityType priority;
@@ -148,12 +151,13 @@ TEST(Interface, ReceivePointer) {
 TEST(Interface, ReceiveBuffer) {
     Os::Queue queue;
     Fw::String name = "My queue";
-    const FwSizeType depth =
-        STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
+    const FwSizeType depth = STest::Random::lowerUpper(
+        std::numeric_limits<FwSizeType>::min(),
+        std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     const FwSizeType sizeOut = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
-    const FwQueuePriorityType priorityOut = STest::Random::lowerUpper(
-        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
+    const FwQueuePriorityType priorityOut =
+        STest::Random::lowerUpper(0, std::min(std::numeric_limits<FwQueuePriorityType>::max(),
+                                              static_cast<FwQueuePriorityType>(std::numeric_limits<U32>::max())));
 
     FwSizeType size = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     FwQueuePriorityType priority;
@@ -184,9 +188,9 @@ TEST(Interface, MessageCount) {
     Fw::String name = "My queue";
     const FwSizeType depth = 1;
     const FwSizeType messageSize = 1;
-    const FwSizeType messages =
-        STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
+    const FwSizeType messages = STest::Random::lowerUpper(
+        std::numeric_limits<FwSizeType>::min(),
+        std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     Os::Stub::Queue::Test::StaticData::data.messages = messages;
     ASSERT_EQ(queue.getMessagesAvailable(), messages);
@@ -199,9 +203,9 @@ TEST(Interface, MessageHighWaterMarkCount) {
     Fw::String name = "My queue";
     const FwSizeType depth = 100;
     const FwSizeType messageSize = 200;
-    const FwSizeType highWater =
-        STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
+    const FwSizeType highWater = STest::Random::lowerUpper(
+        std::numeric_limits<FwSizeType>::min(),
+        std::min(std::numeric_limits<FwSizeType>::max(), static_cast<FwSizeType>(std::numeric_limits<U32>::max())));
     ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     Os::Stub::Queue::Test::StaticData::data.highWaterMark = highWater;
     ASSERT_EQ(queue.getMessageHighWaterMark(), highWater);

--- a/Os/Stub/test/ut/StubQueueTests.cpp
+++ b/Os/Stub/test/ut/StubQueueTests.cpp
@@ -2,6 +2,7 @@
 // \title Os/Stub/test/ut/StubFileTests.cpp
 // \brief tests using stub implementation for Os::File interface testing
 // ======================================================================
+#include <algorithm>
 #include <gtest/gtest.h>
 #include "Fw/Types/String.hpp"
 #include "Os/Os.hpp"
@@ -37,10 +38,10 @@ TEST(Interface, Create) {
     Fw::String name = "My queue";
     const FwSizeType depth =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  FW_MIN(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
     const FwSizeType messageSize =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  FW_MIN(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
     Os::Stub::Queue::Test::StaticData::data.createStatus = Os::QueueInterface::Status::INVALID_PRIORITY;
     Os::QueueInterface::Status status = queue.create(0, name, depth, messageSize);
     ASSERT_EQ(Os::Stub::Queue::Test::StaticData::data.lastCalled, Os::Stub::Queue::Test::StaticData::CREATE_FN);
@@ -57,10 +58,10 @@ TEST(Interface, SendPointer) {
     Fw::String name = "My queue";
     const FwSizeType depth =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  FW_MIN(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
     const FwSizeType messageSize = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     const FwQueuePriorityType priority = STest::Random::lowerUpper(
-        0, FW_MIN(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
+        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
     U8 buffer[messageSize];
     ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     ASSERT_STREQ(name.toChar(), queue.getName().toChar());
@@ -84,10 +85,10 @@ TEST(Interface, SendBuffer) {
     Fw::String name = "My queue";
     const FwSizeType depth =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  FW_MIN(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
     const FwSizeType messageSize = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     const FwQueuePriorityType priority = STest::Random::lowerUpper(
-        0, FW_MIN(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
+        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
     U8 storage[messageSize];
     Fw::ExternalSerializeBuffer buffer(storage, sizeof storage);
     Fw::String message = "hello";
@@ -114,10 +115,10 @@ TEST(Interface, ReceivePointer) {
     Fw::String name = "My queue";
     const FwSizeType depth =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  FW_MIN(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
     const FwSizeType sizeOut = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     const FwQueuePriorityType priorityOut = STest::Random::lowerUpper(
-        0, FW_MIN(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
+        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
 
     FwSizeType size = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     FwQueuePriorityType priority;
@@ -149,10 +150,10 @@ TEST(Interface, ReceiveBuffer) {
     Fw::String name = "My queue";
     const FwSizeType depth =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  FW_MIN(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
     const FwSizeType sizeOut = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     const FwQueuePriorityType priorityOut = STest::Random::lowerUpper(
-        0, FW_MIN(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
+        0, std::min(std::numeric_limits<FwQueuePriorityType>::max(), std::numeric_limits<U32>::max()));
 
     FwSizeType size = sizeof Os::Stub::Queue::Test::InjectableStlQueueHandle::Message::data;
     FwQueuePriorityType priority;
@@ -185,7 +186,7 @@ TEST(Interface, MessageCount) {
     const FwSizeType messageSize = 1;
     const FwSizeType messages =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  FW_MIN(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
     ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     Os::Stub::Queue::Test::StaticData::data.messages = messages;
     ASSERT_EQ(queue.getMessagesAvailable(), messages);
@@ -200,7 +201,7 @@ TEST(Interface, MessageHighWaterMarkCount) {
     const FwSizeType messageSize = 200;
     const FwSizeType highWater =
         STest::Random::lowerUpper(std::numeric_limits<FwSizeType>::min(),
-                                  FW_MIN(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
+                                  std::min(std::numeric_limits<FwSizeType>::max(), std::numeric_limits<U32>::max()));
     ASSERT_EQ(Os::QueueInterface::Status::OP_OK, queue.create(0, name, depth, messageSize));
     Os::Stub::Queue::Test::StaticData::data.highWaterMark = highWater;
     ASSERT_EQ(queue.getMessageHighWaterMark(), highWater);

--- a/Os/test/ut/directory/DirectoryRules.cpp
+++ b/Os/test/ut/directory/DirectoryRules.cpp
@@ -186,7 +186,7 @@ bool Os::Test::Directory::Tester::ReadAllFiles::precondition(const Os::Test::Dir
 void Os::Test::Directory::Tester::ReadAllFiles::action(Os::Test::Directory::Tester& state) {
     ASSERT_TRUE(state.m_directory.isOpen());
     // size can be 0 during testing so ensure at least 1
-    const FwSizeType arraySize = std::max(state.m_filenames.size(), static_cast<size_t>(1));
+    const FwSizeType arraySize = std::max<FwSizeType>(state.m_filenames.size(), 1);
     Fw::String outArray[arraySize];
     FwSizeType outFileCount = 0;
     Os::Directory::Status status = state.m_directory.readDirectory(outArray, arraySize, outFileCount);

--- a/Os/test/ut/directory/DirectoryRules.cpp
+++ b/Os/test/ut/directory/DirectoryRules.cpp
@@ -4,6 +4,7 @@
 // ======================================================================
 
 #include "DirectoryRules.hpp"
+#include <algorithm>
 #include <string>
 #include "RulesHeaders.hpp"
 #include "STest/Pick/Pick.hpp"
@@ -184,8 +185,8 @@ bool Os::Test::Directory::Tester::ReadAllFiles::precondition(const Os::Test::Dir
 
 void Os::Test::Directory::Tester::ReadAllFiles::action(Os::Test::Directory::Tester& state) {
     ASSERT_TRUE(state.m_directory.isOpen());
-    const FwSizeType arraySize =
-        FW_MAX(state.m_filenames.size(), 1);  // .size() can be 0 during testing so ensure at least 1
+    // size can be 0 during testing so ensure at least 1
+    const FwSizeType arraySize = std::max(state.m_filenames.size(), static_cast<size_t>(1));
     Fw::String outArray[arraySize];
     FwSizeType outFileCount = 0;
     Os::Directory::Status status = state.m_directory.readDirectory(outArray, arraySize, outFileCount);

--- a/Os/test/ut/file/FileRules.cpp
+++ b/Os/test/ut/file/FileRules.cpp
@@ -97,7 +97,7 @@ void Os::Test::FileTest::Tester::shadow_partial_crc(FwSizeType& size) {
     SyntheticFileData data = *reinterpret_cast<SyntheticFileData*>(this->m_shadow.getHandle());
 
     // Calculate CRC on full file starting at m_pointer
-    const FwSizeType bound = std::min(static_cast<FwSizeType>(data.m_pointer) + size, data.m_data.size());
+    const FwSizeType bound = std::min(static_cast<FwSizeType>(data.m_pointer) + size, static_cast<FwSizeType>(data.m_data.size()));
     size = (data.m_pointer >= bound) ? 0 : static_cast<FwSizeType>(bound - data.m_pointer);
     for (FwSizeType i = data.m_pointer; i < bound; i++) {
         this->m_independent_crc = update_crc_32(this->m_independent_crc, static_cast<char>(data.m_data.at(i)));

--- a/Os/test/ut/file/FileRules.cpp
+++ b/Os/test/ut/file/FileRules.cpp
@@ -97,7 +97,8 @@ void Os::Test::FileTest::Tester::shadow_partial_crc(FwSizeType& size) {
     SyntheticFileData data = *reinterpret_cast<SyntheticFileData*>(this->m_shadow.getHandle());
 
     // Calculate CRC on full file starting at m_pointer
-    const FwSizeType bound = std::min(static_cast<FwSizeType>(data.m_pointer) + size, static_cast<FwSizeType>(data.m_data.size()));
+    const FwSizeType bound =
+        std::min(static_cast<FwSizeType>(data.m_pointer) + size, static_cast<FwSizeType>(data.m_data.size()));
     size = (data.m_pointer >= bound) ? 0 : static_cast<FwSizeType>(bound - data.m_pointer);
     for (FwSizeType i = data.m_pointer; i < bound; i++) {
         this->m_independent_crc = update_crc_32(this->m_independent_crc, static_cast<char>(data.m_data.at(i)));

--- a/Os/test/ut/file/FileRules.cpp
+++ b/Os/test/ut/file/FileRules.cpp
@@ -2,6 +2,7 @@
 // \title Os/test/ut/file/MyRules.cpp
 // \brief rule implementations for common testing
 // ======================================================================
+#include <algorithm>
 #include <cstdio>
 #include "RulesHeaders.hpp"
 #include "STest/Pick/Pick.hpp"
@@ -96,7 +97,7 @@ void Os::Test::FileTest::Tester::shadow_partial_crc(FwSizeType& size) {
     SyntheticFileData data = *reinterpret_cast<SyntheticFileData*>(this->m_shadow.getHandle());
 
     // Calculate CRC on full file starting at m_pointer
-    const FwSizeType bound = FW_MIN(static_cast<FwSizeType>(data.m_pointer) + size, data.m_data.size());
+    const FwSizeType bound = std::min(static_cast<FwSizeType>(data.m_pointer) + size, data.m_data.size());
     size = (data.m_pointer >= bound) ? 0 : static_cast<FwSizeType>(bound - data.m_pointer);
     for (FwSizeType i = data.m_pointer; i < bound; i++) {
         this->m_independent_crc = update_crc_32(this->m_independent_crc, static_cast<char>(data.m_data.at(i)));
@@ -534,7 +535,7 @@ void Os::Test::FileTest::Tester::Preallocate::action(Os::Test::FileTest::Tester&
     ASSERT_EQ(Os::File::Status::OP_OK, status);
     state.shadow_preallocate(offset, length);
     FileState final_file_state = state.current_file_state();
-    ASSERT_EQ(final_file_state.size, FW_MAX(original_file_state.size, offset + length));
+    ASSERT_EQ(final_file_state.size, std::max(original_file_state.size, offset + length));
     ASSERT_EQ(final_file_state.position, original_file_state.position);
     state.assert_file_consistent();
 }

--- a/Os/test/ut/file/SyntheticFileSystem.cpp
+++ b/Os/test/ut/file/SyntheticFileSystem.cpp
@@ -3,6 +3,7 @@
 // \brief standard template library driven synthetic file system implementation
 // ======================================================================
 #include "Os/test/ut/file/SyntheticFileSystem.hpp"
+#include <algorithm>
 #include "Fw/Types/Assert.hpp"
 
 namespace Os {
@@ -131,8 +132,8 @@ Os::File::Status SyntheticFile::read(U8* buffer, FwSizeType& size, WaitType wait
     // Checks on the shadow data to ensure consistency
     FW_ASSERT(this->m_data->m_data.size() == static_cast<size_t>(original_size));
     FW_ASSERT(this->m_data->m_pointer ==
-              ((original_pointer > original_size) ? original_pointer : FW_MIN(original_pointer + size, original_size)));
-    FW_ASSERT(size == ((original_pointer > original_size) ? 0 : FW_MIN(size, original_size - original_pointer)));
+              ((original_pointer > original_size) ? original_pointer : std::min(original_pointer + size, original_size)));
+    FW_ASSERT(size == ((original_pointer > original_size) ? 0 : std::min(size, original_size - original_pointer)));
     return Os::File::Status::OP_OK;
 }
 
@@ -169,7 +170,7 @@ Os::File::Status SyntheticFile::write(const U8* buffer, FwSizeType& size, WaitTy
     FW_ASSERT(static_cast<size_t>(this->m_data->m_pointer) <= this->m_data->m_data.size());
     FW_ASSERT(this->m_data->m_data.size() == static_cast<size_t>((Os::File::Mode::OPEN_APPEND == this->m_data->m_mode)
                                                                      ? original_size
-                                                                     : FW_MAX(original_position, original_size)));
+                                                                     : std::max(original_position, original_size)));
 
     FwSizeType pre_write_position = this->m_data->m_pointer;
     FwSizeType pre_write_size = static_cast<FwSizeType>(this->m_data->m_data.size());
@@ -188,7 +189,7 @@ Os::File::Status SyntheticFile::write(const U8* buffer, FwSizeType& size, WaitTy
     }
     size = i;
     // Checks on the shadow data to ensure consistency
-    FW_ASSERT(this->m_data->m_data.size() == static_cast<size_t>(FW_MAX(pre_write_position + size, pre_write_size)));
+    FW_ASSERT(this->m_data->m_data.size() == static_cast<size_t>(std::max(pre_write_position + size, pre_write_size)));
     FW_ASSERT(this->m_data->m_pointer ==
               ((Os::File::Mode::OPEN_APPEND == this->m_data->m_mode) ? pre_write_size : pre_write_position) + size);
     return Os::File::Status::OP_OK;
@@ -242,7 +243,7 @@ Os::File::Status SyntheticFile::preallocate(const FwSizeType offset, const FwSiz
         for (FwSizeType i = static_cast<FwSizeType>(this->m_data->m_data.size()); i < new_length; i++) {
             this->m_data->m_data.push_back(0);
         }
-        FW_ASSERT(this->m_data->m_data.size() == static_cast<size_t>(FW_MAX(offset + length, original_size)));
+        FW_ASSERT(this->m_data->m_data.size() == static_cast<size_t>(std::max(offset + length, original_size)));
     }
     return status;
 }

--- a/Os/test/ut/file/SyntheticFileSystem.cpp
+++ b/Os/test/ut/file/SyntheticFileSystem.cpp
@@ -131,8 +131,9 @@ Os::File::Status SyntheticFile::read(U8* buffer, FwSizeType& size, WaitType wait
     size = i;
     // Checks on the shadow data to ensure consistency
     FW_ASSERT(this->m_data->m_data.size() == static_cast<size_t>(original_size));
-    FW_ASSERT(this->m_data->m_pointer ==
-              ((original_pointer > original_size) ? original_pointer : std::min(original_pointer + size, original_size)));
+    FW_ASSERT(
+        this->m_data->m_pointer ==
+        ((original_pointer > original_size) ? original_pointer : std::min(original_pointer + size, original_size)));
     FW_ASSERT(size == ((original_pointer > original_size) ? 0 : std::min(size, original_size - original_pointer)));
     return Os::File::Status::OP_OK;
 }

--- a/Os/test/ut/queue/CommonTests.cpp
+++ b/Os/test/ut/queue/CommonTests.cpp
@@ -61,7 +61,7 @@ Os::QueueInterface::Status Tester::shadow_send(const U8* buffer,
         return QueueInterface::Status::FULL;
     } else {
         this->shadow.queue.push(qm);
-        this->shadow.highMark = std::max(this->shadow.highMark, this->shadow.queue.size());
+        this->shadow.highMark = std::max(this->shadow.highMark, static_cast<FwSizeType>(this->shadow.queue.size()));
         return QueueInterface::Status::OP_OK;
     }
     return QueueInterface::Status::OP_OK;
@@ -70,7 +70,7 @@ Os::QueueInterface::Status Tester::shadow_send(const U8* buffer,
 void Tester::shadow_send_unblock() {
     // send the shadow send buffered message
     this->shadow.queue.push(this->shadow.send_block);
-    this->shadow.highMark = std::max(this->shadow.highMark, this->shadow.queue.size());
+    this->shadow.highMark = std::max(this->shadow.highMark, static_cast<FwSizeType>(this->shadow.queue.size()));
 }
 
 Os::QueueInterface::Status Tester::shadow_receive(U8* destination,

--- a/Os/test/ut/queue/CommonTests.cpp
+++ b/Os/test/ut/queue/CommonTests.cpp
@@ -3,6 +3,7 @@
 // \brief common test implementations
 // ======================================================================
 #include "Os/test/ut/queue/CommonTests.hpp"
+#include <algorithm>
 #include <gtest/gtest.h>
 #include "Fw/Types/String.hpp"
 #include "Os/Queue.hpp"
@@ -60,16 +61,16 @@ Os::QueueInterface::Status Tester::shadow_send(const U8* buffer,
         return QueueInterface::Status::FULL;
     } else {
         this->shadow.queue.push(qm);
-        this->shadow.highMark = FW_MAX(this->shadow.highMark, this->shadow.queue.size());
+        this->shadow.highMark = std::max(this->shadow.highMark, this->shadow.queue.size());
         return QueueInterface::Status::OP_OK;
     }
     return QueueInterface::Status::OP_OK;
 }
 
 void Tester::shadow_send_unblock() {
-    // Send the shadow send buffered message
+    // send the shadow send buffered message
     this->shadow.queue.push(this->shadow.send_block);
-    this->shadow.highMark = FW_MAX(this->shadow.highMark, this->shadow.queue.size());
+    this->shadow.highMark = std::max(this->shadow.highMark, this->shadow.queue.size());
 }
 
 Os::QueueInterface::Status Tester::shadow_receive(U8* destination,

--- a/Os/test/ut/queue/CommonTests.cpp
+++ b/Os/test/ut/queue/CommonTests.cpp
@@ -3,8 +3,8 @@
 // \brief common test implementations
 // ======================================================================
 #include "Os/test/ut/queue/CommonTests.hpp"
-#include <algorithm>
 #include <gtest/gtest.h>
+#include <algorithm>
 #include "Fw/Types/String.hpp"
 #include "Os/Queue.hpp"
 #include "Os/test/ConcurrentRule.hpp"

--- a/Svc/AssertFatalAdapter/test/ut/AssertFatalAdapterTester.cpp
+++ b/Svc/AssertFatalAdapter/test/ut/AssertFatalAdapterTester.cpp
@@ -41,9 +41,9 @@ void AssertFatalAdapterTester::testAsserts() {
     U32 lineNo;
 
     // apply all truncations to file buffer size
-    const FwSizeType fileMaxSize = std::min({static_cast<FwSizeType>(AssertFatalAdapterEventFileSize),
-                                             static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
-                                             static_cast<FwSizeType>(FW_ASSERT_TEXT_SIZE)});
+    const FwSizeType fileMaxSize =
+        std::min({static_cast<FwSizeType>(AssertFatalAdapterEventFileSize),
+                  static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_ASSERT_TEXT_SIZE)});
 
     char file[Fw::StringBase::BUFFER_SIZE(fileMaxSize)];
     Fw::String fileString;

--- a/Svc/AssertFatalAdapter/test/ut/AssertFatalAdapterTester.cpp
+++ b/Svc/AssertFatalAdapter/test/ut/AssertFatalAdapterTester.cpp
@@ -11,6 +11,7 @@
 // ======================================================================
 
 #include "AssertFatalAdapterTester.hpp"
+#include <algorithm>
 #include "Fw/Types/String.hpp"
 #include "Fw/Types/StringUtils.hpp"
 #include "config/FppConstantsAc.hpp"
@@ -39,10 +40,10 @@ AssertFatalAdapterTester::~AssertFatalAdapterTester() {}
 void AssertFatalAdapterTester::testAsserts() {
     U32 lineNo;
 
-    // Apply all truncations to file buffer size
-    const FwSizeType fileMaxSize = FW_MIN(FW_MIN(static_cast<FwSizeType>(AssertFatalAdapterEventFileSize),
-                                                 static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE)),
-                                          static_cast<FwSizeType>(FW_ASSERT_TEXT_SIZE));
+    // apply all truncations to file buffer size
+    const FwSizeType fileMaxSize = std::min({static_cast<FwSizeType>(AssertFatalAdapterEventFileSize),
+                                             static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
+                                             static_cast<FwSizeType>(FW_ASSERT_TEXT_SIZE)});
 
     char file[Fw::StringBase::BUFFER_SIZE(fileMaxSize)];
     Fw::String fileString;

--- a/Svc/BufferRepeater/test/ut/BufferRepeaterTester.cpp
+++ b/Svc/BufferRepeater/test/ut/BufferRepeaterTester.cpp
@@ -5,6 +5,7 @@
 // ======================================================================
 
 #include "BufferRepeaterTester.hpp"
+#include <algorithm>
 
 #define INSTANCE 0
 #define MAX_HISTORY_SIZE 10
@@ -49,7 +50,7 @@ void BufferRepeaterTester ::testRepeater() {
         ASSERT_EQ(i, port_index);
         Fw::Buffer buffer_under_test = this->fromPortHistory_portOut->at(i).fwBuffer;
         ASSERT_EQ(buffer_under_test.getSize(), m_initial_buffer.getSize());
-        for (U32 j = 0; j < FW_MIN(buffer_under_test.getSize(), m_initial_buffer.getSize()); j++) {
+        for (U32 j = 0; j < std::min(buffer_under_test.getSize(), m_initial_buffer.getSize()); j++) {
             ASSERT_EQ(buffer_under_test.getData()[j], m_initial_buffer.getData()[j])
                 << "Data not copied correctly at offset: " << j;
         }

--- a/Svc/CmdSplitter/test/ut/CmdSplitterTester.cpp
+++ b/Svc/CmdSplitter/test/ut/CmdSplitterTester.cpp
@@ -5,10 +5,10 @@
 // ======================================================================
 
 #include "CmdSplitterTester.hpp"
-#include <algorithm>
 #include <Fw/Cmd/CmdPacket.hpp>
 #include <Fw/Test/UnitTest.hpp>
 #include <STest/Pick/Pick.hpp>
+#include <algorithm>
 #include "config/FppConstantsAc.hpp"
 
 namespace Svc {

--- a/Svc/CmdSplitter/test/ut/CmdSplitterTester.cpp
+++ b/Svc/CmdSplitter/test/ut/CmdSplitterTester.cpp
@@ -5,6 +5,7 @@
 // ======================================================================
 
 #include "CmdSplitterTester.hpp"
+#include <algorithm>
 #include <Fw/Cmd/CmdPacket.hpp>
 #include <Fw/Test/UnitTest.hpp>
 #include <STest/Pick/Pick.hpp>
@@ -51,7 +52,7 @@ FwOpcodeType CmdSplitterTester ::setup_and_pick_valid_opcode(bool for_local) {
         FwOpcodeType base = static_cast<FwOpcodeType>(STest::Pick::lowerUpper(1, MAX_OPCODE));
         component.configure(base);
         EXPECT_GT(base, 0);  // Must leave some room for local commands
-        return static_cast<FwOpcodeType>(STest::Pick::lowerUpper(0, FW_MIN(static_cast<U32>(base) - 1, MAX_OPCODE)));
+        return static_cast<FwOpcodeType>(STest::Pick::lowerUpper(0, std::min(static_cast<U32>(base) - 1, MAX_OPCODE)));
     }
     FwOpcodeType base = static_cast<FwOpcodeType>(STest::Pick::lowerUpper(0, MAX_OPCODE));
     component.configure(base);

--- a/Utils/TokenBucket.cpp
+++ b/Utils/TokenBucket.cpp
@@ -12,6 +12,7 @@
 // ======================================================================
 
 #include <Utils/TokenBucket.hpp>
+#include <algorithm>
 
 namespace Utils {
 
@@ -72,7 +73,8 @@ bool TokenBucket ::trigger(const Fw::Time time) {
         Fw::Time nextTime = Fw::Time::add(this->m_time, replenishInterval);
         while (this->m_tokens < this->m_maxTokens && nextTime <= time) {
             // replenish by replenish rate, or up to maxTokens
-            this->m_tokens += FW_MIN(this->m_replenishRate, this->m_maxTokens - this->m_tokens);
+            // replenish tokens up to max capacity
+            this->m_tokens += std::min(this->m_replenishRate, this->m_maxTokens - this->m_tokens);
             this->m_time = nextTime;
             nextTime = Fw::Time::add(this->m_time, replenishInterval);
         }

--- a/Utils/TokenBucket.cpp
+++ b/Utils/TokenBucket.cpp
@@ -73,7 +73,6 @@ bool TokenBucket ::trigger(const Fw::Time time) {
         Fw::Time nextTime = Fw::Time::add(this->m_time, replenishInterval);
         while (this->m_tokens < this->m_maxTokens && nextTime <= time) {
             // replenish by replenish rate, or up to maxTokens
-            // replenish tokens up to max capacity
             this->m_tokens += std::min(this->m_replenishRate, this->m_maxTokens - this->m_tokens);
             this->m_time = nextTime;
             nextTime = Fw::Time::add(this->m_time, replenishInterval);


### PR DESCRIPTION
Hey, this PR replaces the FW_MIN and FW_MAX macros with std::min and std::max from the standard library in all cpp files.

As discussed in #4826, the macros expand to ternary operators wich isnt type safe. Using std::min/std::max is the more common c++ practice and provides better type checking at compile time.

Changes:
  - added #include <algorithm> where needed
  - replaced FW_MIN with std::min
  - replaced FW_MAX with std::max
  - used std::min with initializer list for nested min calls (cleaner imo)

The macros in BasicTypes.h are kept for backwards compatability with any C code that might include the headers.

Only touched .cpp files to be safe, as LeStarch mentioned in the issue that .h files might be used in C context.

Let me know if theres anything that needs adjusting.

Closes #4826