### PR TITLE
Improve data copying efficiency in TlmPacketizer

### DIFF
--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -363,7 +363,7 @@ Fw::TlmValid TlmPacketizer ::TlmGet_handler(FwIndexType portNum,  //!< The port 
     return Fw::TlmValid::INVALID;
 }
 
-void TlmPacketizer::Run_handler(const FwIndexType portNum, U32 context) {
+void TlmPacketizer ::Run_handler(const FwIndexType portNum, U32 context) {
     FW_ASSERT(this->m_configured);
 
     for (FwChanIdType pkt = 0; pkt < this->m_numPackets; pkt++) {

--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -363,35 +363,30 @@ Fw::TlmValid TlmPacketizer ::TlmGet_handler(FwIndexType portNum,  //!< The port 
     return Fw::TlmValid::INVALID;
 }
 
-void TlmPacketizer ::Run_handler(const FwIndexType portNum, U32 context) {
+void TlmPacketizer::Run_handler(const FwIndexType portNum, U32 context) {
     FW_ASSERT(this->m_configured);
 
-    // For each packet, send if update, enable, and rate conditions are met
     for (FwChanIdType pkt = 0; pkt < this->m_numPackets; pkt++) {
+        // Local flags to track which sections require a packet dispatch
+        bool sectionNeedsSend[TelemetrySection::NUM_SECTIONS] = {false};
+        bool anySectionNeedsSend = false;
+        
+        // Lock only to capture the update status and reset the fill buffer flag.
         this->m_lock.lock();
-
-        // Copy packet data to avoid concurrent updates
+        bool isNewData = this->m_fillBuffers[pkt].updated;
         FwChanIdType entryGroup = this->m_fillBuffers[pkt].level;
-        Fw::ComBuffer sendBuffer = this->m_fillBuffers[pkt].buffer;
-        Fw::Time time = this->m_fillBuffers[pkt].latestTime;
-        bool updated = this->m_fillBuffers[pkt].updated;
         this->m_fillBuffers[pkt].updated = false;
-
         this->m_lock.unLock();
 
-        // Iterate through output sections
         for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
-            // Packet is updated and not REQUESTED (Keep REQUESTED marking to bypass disable checks)
-            if (updated and this->m_packetFlags[section][pkt].updateFlag != UpdateFlag::REQUESTED) {
-                this->m_packetFlags[section][pkt].updateFlag = UpdateFlag::NEW;
-            }
-
-            bool sendOutFlag = false;
-            const FwIndexType outIndex = this->sectionGroupToPort(section, entryGroup);
-
             PktSendCounters& pktEntryFlags = this->m_packetFlags[static_cast<FwSizeType>(section)][pkt];
-            TlmPacketizer_GroupConfig& entryGroupConfig =
+            TlmPacketizer_GroupConfig& entryGroupConfig = 
                 this->m_groupConfigs[static_cast<FwSizeType>(section)][entryGroup];
+
+            // Packet is updated and not REQUESTED (Keep REQUESTED marking to bypass disable checks)
+            if (isNewData && pktEntryFlags.updateFlag != UpdateFlag::REQUESTED) {
+                pktEntryFlags.updateFlag = UpdateFlag::NEW;
+            }
 
             /* Base conditions for sending
             1. Output port is connected
@@ -402,11 +397,12 @@ void TlmPacketizer ::Run_handler(const FwIndexType portNum, U32 context) {
             4. The rate logic is not SILENCED.
             5. The packet has data (marked updated in the past or new)
             */
-            if (not this->isConnected_PktSend_OutputPort(outIndex)) {
+            if (!this->isConnected_PktSend_OutputPort(this->sectionGroupToPort(section, entryGroup))){
                 continue;
             }
+
             if (pktEntryFlags.updateFlag == UpdateFlag::REQUESTED) {
-                sendOutFlag = true;
+                sectionNeedsSend[section] = true;
             } else {
                 if (not((entryGroupConfig.get_enabled() and
                          this->m_sectionEnabled[static_cast<FwSizeType>(section)] == Fw::Enabled::ENABLED) or
@@ -434,7 +430,7 @@ void TlmPacketizer ::Run_handler(const FwIndexType portNum, U32 context) {
             if (pktEntryFlags.updateFlag == UpdateFlag::NEW and
                 entryGroupConfig.get_rateLogic() != Svc::RateLogic::EVERY_MAX and
                 pktEntryFlags.prevSentCounter >= entryGroupConfig.get_min()) {
-                sendOutFlag = true;
+                sectionNeedsSend[section] = true;
             }
 
             /*
@@ -443,25 +439,36 @@ void TlmPacketizer ::Run_handler(const FwIndexType portNum, U32 context) {
             */
             if (entryGroupConfig.get_rateLogic() != Svc::RateLogic::ON_CHANGE_MIN and
                 pktEntryFlags.prevSentCounter >= entryGroupConfig.get_max()) {
-                sendOutFlag = true;
+                sectionNeedsSend[section] = true;
             }
 
-            // Send under the following conditions:
-            // 1. Packet received updates and it has been past delta min counts since last packet (min enabled)
-            // 2. Packet has passed delta max counts since last packet (max enabled)
-            // With the above, the group must be either enabled or force enabled.
-            // 3. If the packet was requested.
-            if (sendOutFlag) {
-                // serialize time into time offset in packet
-                Fw::ExternalSerializeBuffer buff(
-                    &sendBuffer.getBuffAddr()[sizeof(FwPacketDescriptorType) + sizeof(FwTlmPacketizeIdType)],
-                    Fw::Time::SERIALIZED_SIZE);
-                Fw::SerializeStatus stat = buff.serializeFrom(time);
-                FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, stat);
-                this->PktSend_out(outIndex, sendBuffer, pktEntryFlags.prevSentCounter);
+            if (sectionNeedsSend[section]){
+                anySectionNeedsSend = true;
+            }
+        }
 
-                pktEntryFlags.prevSentCounter = 0;
-                pktEntryFlags.updateFlag = UpdateFlag::PAST;
+        // Only perform the buffer copy if at least one section needs to send.
+        if (anySectionNeedsSend) {
+            this->m_lock.lock();
+            BufferEntry sendBuffer = this->m_fillBuffers[pkt]; 
+            this->m_lock.unLock();
+
+            // serialize time into time offset in packet
+            Fw::ExternalSerializeBuffer buff(
+                &sendBuffer.buffer.getBuffAddr()[sizeof(FwPacketDescriptorType) + sizeof(FwTlmPacketizeIdType)],
+                Fw::Time::SERIALIZED_SIZE);
+            (void)buff.serializeFrom(sendBuffer.latestTime);
+
+            for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
+                if (sectionNeedsSend[section]) {
+                    PktSendCounters& pktEntryFlags = this->m_packetFlags[section][pkt];
+                    FwIndexType outIndex = this->sectionGroupToPort(section, entryGroup);
+
+                    this->PktSend_out(outIndex, sendBuffer.buffer, pktEntryFlags.prevSentCounter);
+
+                    pktEntryFlags.prevSentCounter = 0;
+                    pktEntryFlags.updateFlag = UpdateFlag::PAST;
+                }
             }
         }
     }

--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -370,7 +370,7 @@ void TlmPacketizer::Run_handler(const FwIndexType portNum, U32 context) {
         // Local flags to track which sections require a packet dispatch
         bool sectionNeedsSend[TelemetrySection::NUM_SECTIONS] = {false};
         bool anySectionNeedsSend = false;
-        
+
         // Lock only to capture the update status and reset the fill buffer flag.
         this->m_lock.lock();
         bool isNewData = this->m_fillBuffers[pkt].updated;
@@ -380,7 +380,7 @@ void TlmPacketizer::Run_handler(const FwIndexType portNum, U32 context) {
 
         for (FwIndexType section = 0; section < TelemetrySection::NUM_SECTIONS; section++) {
             PktSendCounters& pktEntryFlags = this->m_packetFlags[static_cast<FwSizeType>(section)][pkt];
-            TlmPacketizer_GroupConfig& entryGroupConfig = 
+            TlmPacketizer_GroupConfig& entryGroupConfig =
                 this->m_groupConfigs[static_cast<FwSizeType>(section)][entryGroup];
 
             // Packet is updated and not REQUESTED (Keep REQUESTED marking to bypass disable checks)
@@ -397,7 +397,7 @@ void TlmPacketizer::Run_handler(const FwIndexType portNum, U32 context) {
             4. The rate logic is not SILENCED.
             5. The packet has data (marked updated in the past or new)
             */
-            if (!this->isConnected_PktSend_OutputPort(this->sectionGroupToPort(section, entryGroup))){
+            if (!this->isConnected_PktSend_OutputPort(this->sectionGroupToPort(section, entryGroup))) {
                 continue;
             }
 
@@ -442,7 +442,7 @@ void TlmPacketizer::Run_handler(const FwIndexType portNum, U32 context) {
                 sectionNeedsSend[section] = true;
             }
 
-            if (sectionNeedsSend[section]){
+            if (sectionNeedsSend[section]) {
                 anySectionNeedsSend = true;
             }
         }
@@ -450,7 +450,7 @@ void TlmPacketizer::Run_handler(const FwIndexType portNum, U32 context) {
         // Only perform the buffer copy if at least one section needs to send.
         if (anySectionNeedsSend) {
             this->m_lock.lock();
-            BufferEntry sendBuffer = this->m_fillBuffers[pkt]; 
+            BufferEntry sendBuffer = this->m_fillBuffers[pkt];
             this->m_lock.unLock();
 
             // serialize time into time offset in packet

--- a/Svc/TlmPacketizer/docs/sdd.md
+++ b/Svc/TlmPacketizer/docs/sdd.md
@@ -64,7 +64,7 @@ The `Svc::TlmPacketizer` component has an input port `TlmRecv` that receives cha
 
 The implementation uses a hashing function to find the location of telemetry channels that is tuned in the configuration file `TlmPacketizerImplCfg.hpp`. See section 3.5 for description.
 
-When a call to the `Run()` interface is called, the packet writes are locked and all the packets are copied to a second set of packets. Once the copy is complete, the packets writes are unlocked. The destination packet set gets updated with the current time tag and are sent out the `pktSend` port.
+When a call to the `Run()` interface is called, each packet's update status and group level are read under a lock. The send conditions for each section are then evaluated, and the sections that need to send are recorded. If any section requires sending, the packet buffer is copied under a second lock, updated with the current time tag, and sent out the `pktSend` port for all recorded sections.
 
 Each telemetry group, depending on section and group configurations, are sent out on the `pktSend` port array. Since each group is evaluated for each section, a packet with group 1 (and a configuration of 3 sections), will be sent up to 3 times based on the section/group configuration. Each of these sends (section/group) will run through a configurable map to determine which output port to use. Should the output port index be repeated for different section/group pairs, the packet will be sent to that port multiple times.
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4758  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Follow-up on #4822.
Refactors the send logic into two loops per packet: first determine which sections require sending, then perform a single buffer copy and iterate over those sections to send it. This avoids unnecessary buffer copies when some sections do not require sending.

## Rationale

Reduces CPU and memory usage by skipping buffer copies for packets not needed by any section.