### PR TITLE
Adding sscanf replacement implementation, and tests

### DIFF
--- a/Fw/Types/CMakeLists.txt
+++ b/Fw/Types/CMakeLists.txt
@@ -20,6 +20,7 @@ register_fprime_module(
     __fprime_config # Only module that should ever list __fprime_config in DEPENDS. Use Fw_Types instead.
   REQUIRES_IMPLEMENTATIONS
     Fw_StringFormat
+    Fw_StringScan
 )
 
 register_fprime_implementation(
@@ -31,6 +32,17 @@ register_fprime_implementation(
   SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/snprintf_format.cpp"
 )
+
+register_fprime_implementation(
+    Fw_StringFormat_sscanf
+  IMPLEMENTS
+    Fw_StringScan
+  DEPENDS
+    Fw_Types
+  SOURCES
+    "${CMAKE_CURRENT_LIST_DIR}/sscanf_scan.cpp"
+)
+
 
 ### UTs ###
 register_fprime_ut(
@@ -55,6 +67,16 @@ register_fprime_ut(
     Fw_Types
   CHOOSES_IMPLEMENTATIONS
     Fw_StringFormat_snprintf
+)
+
+register_fprime_ut(
+    Fw_StringScan_sscanf_ut_exe
+  SOURCES
+    "${CMAKE_CURRENT_LIST_DIR}/test/ut/ScanfScanTest.cpp"
+  DEPENDS
+    Fw_Types
+  CHOOSES_IMPLEMENTATIONS
+    Fw_StringFormat_sscanf
 )
 
 

--- a/Fw/Types/CMakeLists.txt
+++ b/Fw/Types/CMakeLists.txt
@@ -34,7 +34,7 @@ register_fprime_implementation(
 )
 
 register_fprime_implementation(
-    Fw_StringFormat_sscanf
+    Fw_StringScan_sscanf
   IMPLEMENTS
     Fw_StringScan
   DEPENDS
@@ -76,7 +76,7 @@ register_fprime_ut(
   DEPENDS
     Fw_Types
   CHOOSES_IMPLEMENTATIONS
-    Fw_StringFormat_sscanf
+    Fw_StringScan_sscanf
 )
 
 

--- a/Fw/Types/format.hpp
+++ b/Fw/Types/format.hpp
@@ -52,7 +52,7 @@ FormatStatus stringFormat(char* destination, const FwSizeType maximumSize, const
 //!   OTHER_ERROR: another error occurred in an underlying function call
 //! Otherwise SUCCESS is returned.  destination may be modified even in the case of an error.
 //!
-//! This version take a variable argument list
+//! This version takes a variable argument list
 //!
 //! \param destination: destination to fill with the formatted string
 //! \param maximumSize: size of the buffer represented by destination

--- a/Fw/Types/scan.hpp
+++ b/Fw/Types/scan.hpp
@@ -1,0 +1,66 @@
+// ======================================================================
+// \title  scan.hpp
+// \author mstarch
+// \brief  hpp file for c-string scan function (sscanf equivalent)
+//
+// \copyright
+// Copyright (C) 2026 California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+// ======================================================================
+#ifndef FW_TYPES_SCAN_HPP_
+#define FW_TYPES_SCAN_HPP_
+#include <Fw/FPrimeBasicTypes.hpp>
+#include <cstdarg>
+namespace Fw {
+
+//! \brief status of string scan calls
+enum class ScanStatus {
+    SUCCESS,                //!< Scan worked
+    INVALID_FORMAT_STRING,  //!< Format provided invalid format string
+    SIZE_OVERFLOW,          //!< FwSizeType overflowed the range of size_t
+    UNTERMINATED_SOURCE_STRING, //!< The source string was not null-terminated within the maximum size
+    OTHER_ERROR             //!< An error was returned from an underlying call
+};
+
+//! \brief scan a c-string
+//!
+//! Scan a string using sscanf family formatting semantics. Source will be read according to the format string. The
+//! number of filled fields will be returned in count. Read characters will not exceed maximumSize.
+//!
+//! This function can return several error codes:
+//!   INVALID_FORMAT_STRING: the format string was null
+//!   SIZE_OVERFLOW: FwSizeType overflowed the range of size_t
+//!   OTHER_ERROR: another error occurred in an underlying function call
+//! Otherwise SUCCESS is returned.
+//!
+//! \param count: [output] number of filled fields
+//! \param source: source string to scan
+//! \param maximumSize: size of the buffer represented by source
+//! \param formatString: format string to fill
+//! \param ...: variable arguments inputs
+//! \return: SUCCESS on successful formatting, SIZE_OVERFLOW on overflow, and something else on any error
+ScanStatus stringScan(FwSizeType& count, char* source, const FwSizeType maximumSize, const char* formatString, ...);
+
+//! \brief scan a c-string using a variable argument list
+//!
+//! Scan a string using sscanf family formatting semantics. Source will be read according to the format string. The
+//! number of filled fields will be returned in count. Read characters will not exceed maximumSize.
+//!
+//! This function can return several error codes:
+//!   INVALID_FORMAT_STRING: the format string was null
+//!   SIZE_OVERFLOW: FwSizeType overflowed the range of size_t
+//!   OTHER_ERROR: another error occurred in an underlying function call
+//! Otherwise SUCCESS is returned.
+//!
+//! This version takes a variable argument list
+//!
+//! \param count: [output] number of filled fields
+//! \param source: source string to scan
+//! \param maximumSize: size of the buffer represented by source
+//! \param formatString: format string to fill
+//! \param args: variable arguments list
+//! \return: SUCCESS on successful formatting, SIZE_OVERFLOW on overflow, and something else on any error
+ScanStatus stringScan(FwSizeType& count, char* source, const FwSizeType maximumSize, const char* formatString, va_list args);
+}  // namespace Fw
+#endif  // FW_TYPES_SCAN_HPP_

--- a/Fw/Types/scan.hpp
+++ b/Fw/Types/scan.hpp
@@ -16,11 +16,11 @@ namespace Fw {
 
 //! \brief status of string scan calls
 enum class ScanStatus {
-    SUCCESS,                //!< Scan worked
-    INVALID_FORMAT_STRING,  //!< Format provided invalid format string
-    SIZE_OVERFLOW,          //!< FwSizeType overflowed the range of size_t
-    UNTERMINATED_SOURCE_STRING, //!< The source string was not null-terminated within the maximum size
-    OTHER_ERROR             //!< An error was returned from an underlying call
+    SUCCESS,                     //!< Scan worked
+    INVALID_FORMAT_STRING,       //!< Format provided invalid format string
+    SIZE_OVERFLOW,               //!< FwSizeType overflowed the range of size_t
+    UNTERMINATED_SOURCE_STRING,  //!< The source string was not null-terminated within the maximum size
+    OTHER_ERROR                  //!< An error was returned from an underlying call
 };
 
 //! \brief scan a c-string
@@ -61,6 +61,10 @@ ScanStatus stringScan(FwSizeType& count, char* source, const FwSizeType maximumS
 //! \param formatString: format string to fill
 //! \param args: variable arguments list
 //! \return: SUCCESS on successful formatting, SIZE_OVERFLOW on overflow, and something else on any error
-ScanStatus stringScan(FwSizeType& count, char* source, const FwSizeType maximumSize, const char* formatString, va_list args);
+ScanStatus stringScan(FwSizeType& count,
+                      char* source,
+                      const FwSizeType maximumSize,
+                      const char* formatString,
+                      va_list args);
 }  // namespace Fw
 #endif  // FW_TYPES_SCAN_HPP_

--- a/Fw/Types/scan.hpp
+++ b/Fw/Types/scan.hpp
@@ -40,7 +40,7 @@ enum class ScanStatus {
 //! \param formatString: format string to fill
 //! \param ...: variable arguments inputs
 //! \return: SUCCESS on successful formatting, SIZE_OVERFLOW on overflow, and something else on any error
-ScanStatus stringScan(FwSizeType& count, char* source, const FwSizeType maximumSize, const char* formatString, ...);
+ScanStatus stringScan(FwSizeType& count, const char* source, FwSizeType maximumSize, const char* formatString, ...);
 
 //! \brief scan a c-string using a variable argument list
 //!
@@ -62,8 +62,8 @@ ScanStatus stringScan(FwSizeType& count, char* source, const FwSizeType maximumS
 //! \param args: variable arguments list
 //! \return: SUCCESS on successful formatting, SIZE_OVERFLOW on overflow, and something else on any error
 ScanStatus stringScan(FwSizeType& count,
-                      char* source,
-                      const FwSizeType maximumSize,
+                      const char* source,
+                      FwSizeType maximumSize,
                       const char* formatString,
                       va_list args);
 }  // namespace Fw

--- a/Fw/Types/sscanf_scan.cpp
+++ b/Fw/Types/sscanf_scan.cpp
@@ -1,0 +1,44 @@
+// ======================================================================
+// \title  format.cpp
+// \author mstarch
+// \brief  cpp file for c-string format function as a implementation using snprintf
+// ======================================================================
+#include <Fw/Types/scan.hpp>
+#include <Fw/Types/StringUtils.hpp>
+#include <cstdio>
+#include <limits>
+
+Fw::ScanStatus Fw::stringScan(FwSizeType& count, char* source, const FwSizeType maximumSize, const char* formatString, ...) {
+    va_list args;
+    va_start(args, formatString);
+    Fw::ScanStatus status = Fw::stringScan(count, source, maximumSize, formatString, args);
+    va_end(args);
+    return status;
+}
+
+Fw::ScanStatus Fw::stringScan(FwSizeType& count, char* source, const FwSizeType maximumSize, const char* formatString, va_list args) {
+    Fw::ScanStatus scanStatus = Fw::ScanStatus::SUCCESS;
+    count = 0;
+    // Check format string
+    if (formatString == nullptr) {
+        scanStatus = Fw::ScanStatus::INVALID_FORMAT_STRING;
+    }
+    // Must allow the compiler to choose the correct type for comparison
+    else if (maximumSize > std::numeric_limits<size_t>::max()) {
+        scanStatus = Fw::ScanStatus::SIZE_OVERFLOW;
+    }
+    // Check for null-termination of the source string bounded by maximumSize
+    else if (StringUtils::string_length(source, maximumSize) >= maximumSize) { 
+        scanStatus = Fw::ScanStatus::UNTERMINATED_SOURCE_STRING;
+    }
+    else {
+        const int scannedFields = vsscanf(source, formatString, args);
+        if (scannedFields < 0) {
+            scanStatus = Fw::ScanStatus::OTHER_ERROR;
+        }
+        else {
+            count = static_cast<FwSizeType>(scannedFields);
+        }
+    }
+    return scanStatus;
+}

--- a/Fw/Types/sscanf_scan.cpp
+++ b/Fw/Types/sscanf_scan.cpp
@@ -9,8 +9,8 @@
 #include <limits>
 
 Fw::ScanStatus Fw::stringScan(FwSizeType& count,
-                              char* source,
-                              const FwSizeType maximumSize,
+                              const char* source,
+                              FwSizeType maximumSize,
                               const char* formatString,
                               ...) {
     va_list args;
@@ -21,8 +21,8 @@ Fw::ScanStatus Fw::stringScan(FwSizeType& count,
 }
 
 Fw::ScanStatus Fw::stringScan(FwSizeType& count,
-                              char* source,
-                              const FwSizeType maximumSize,
+                              const char* source,
+                              FwSizeType maximumSize,
                               const char* formatString,
                               va_list args) {
     Fw::ScanStatus scanStatus = Fw::ScanStatus::SUCCESS;

--- a/Fw/Types/sscanf_scan.cpp
+++ b/Fw/Types/sscanf_scan.cpp
@@ -3,12 +3,16 @@
 // \author mstarch
 // \brief  cpp file for c-string format function as a implementation using snprintf
 // ======================================================================
-#include <Fw/Types/scan.hpp>
 #include <Fw/Types/StringUtils.hpp>
+#include <Fw/Types/scan.hpp>
 #include <cstdio>
 #include <limits>
 
-Fw::ScanStatus Fw::stringScan(FwSizeType& count, char* source, const FwSizeType maximumSize, const char* formatString, ...) {
+Fw::ScanStatus Fw::stringScan(FwSizeType& count,
+                              char* source,
+                              const FwSizeType maximumSize,
+                              const char* formatString,
+                              ...) {
     va_list args;
     va_start(args, formatString);
     Fw::ScanStatus status = Fw::stringScan(count, source, maximumSize, formatString, args);
@@ -16,7 +20,11 @@ Fw::ScanStatus Fw::stringScan(FwSizeType& count, char* source, const FwSizeType 
     return status;
 }
 
-Fw::ScanStatus Fw::stringScan(FwSizeType& count, char* source, const FwSizeType maximumSize, const char* formatString, va_list args) {
+Fw::ScanStatus Fw::stringScan(FwSizeType& count,
+                              char* source,
+                              const FwSizeType maximumSize,
+                              const char* formatString,
+                              va_list args) {
     Fw::ScanStatus scanStatus = Fw::ScanStatus::SUCCESS;
     count = 0;
     // Check format string
@@ -28,15 +36,13 @@ Fw::ScanStatus Fw::stringScan(FwSizeType& count, char* source, const FwSizeType 
         scanStatus = Fw::ScanStatus::SIZE_OVERFLOW;
     }
     // Check for null-termination of the source string bounded by maximumSize
-    else if (StringUtils::string_length(source, maximumSize) >= maximumSize) { 
+    else if (StringUtils::string_length(source, maximumSize) >= maximumSize) {
         scanStatus = Fw::ScanStatus::UNTERMINATED_SOURCE_STRING;
-    }
-    else {
+    } else {
         const int scannedFields = vsscanf(source, formatString, args);
         if (scannedFields < 0) {
             scanStatus = Fw::ScanStatus::OTHER_ERROR;
-        }
-        else {
+        } else {
             count = static_cast<FwSizeType>(scannedFields);
         }
     }

--- a/Fw/Types/test/ut/ScanfScanTest.cpp
+++ b/Fw/Types/test/ut/ScanfScanTest.cpp
@@ -1,0 +1,114 @@
+#include <gtest/gtest.h>
+
+#include "Fw/Types/scan.hpp"
+
+#include <cstdarg>
+#include <limits>
+
+namespace {
+
+Fw::ScanStatus stringScanWithVaList( FwSizeType& count,char* source,
+                                    const FwSizeType maximumSize,
+                                    const char* formatString,
+                                   
+                                    ...) {
+    va_list args;
+    va_start(args, formatString);
+    Fw::ScanStatus status = Fw::stringScan(count, source, maximumSize, formatString, args);
+    va_end(args);
+    return status;
+}
+
+TEST(Nominal, scanIntegerWithVariadicOverload) {
+    char source[] = "123";
+    int parsed = 0;
+    FwSizeType count = 0;
+
+    const Fw::ScanStatus status = Fw::stringScan(count, source, sizeof(source), "%d", &parsed);
+
+    EXPECT_EQ(status, Fw::ScanStatus::SUCCESS);
+    EXPECT_EQ(count, 1);
+    EXPECT_EQ(parsed, 123);
+}
+
+TEST(Nominal, scanIntegerAndWordWithVaListOverload) {
+    char source[] = "42 abc";
+    int parsedNumber = 0;
+    char parsedWord[4] = {};
+    FwSizeType count = 0;
+
+    const Fw::ScanStatus status = stringScanWithVaList(count, source, sizeof(source), "%d %3s", &parsedNumber, parsedWord);
+
+    EXPECT_EQ(status, Fw::ScanStatus::SUCCESS);
+    EXPECT_EQ(count, 2);
+    EXPECT_EQ(parsedNumber, 42);
+    EXPECT_STREQ(parsedWord, "abc");
+}
+
+TEST(Errors, nullFormatStringReturnsInvalidFormatString) {
+    char source[] = "123";
+    int parsed = 0;
+    FwSizeType count = 0;
+
+    const Fw::ScanStatus status = Fw::stringScan(count, source, sizeof(source), nullptr, &parsed);
+
+    EXPECT_EQ(status, Fw::ScanStatus::INVALID_FORMAT_STRING);
+    EXPECT_EQ(count, 0);
+}
+
+TEST(Errors, unterminatedSourceReturnsError) {
+    char source[4] = {'1', '2', '3', '4'};
+    int parsed = 0;
+    FwSizeType count = 0;
+
+    const Fw::ScanStatus status = Fw::stringScan(count, source, sizeof(source), "%d", &parsed);
+
+    EXPECT_EQ(status, Fw::ScanStatus::UNTERMINATED_SOURCE_STRING);
+    EXPECT_EQ(count, 0);
+}
+
+TEST(Nominal, zeroConversionsReturnsSuccessAndCountZero) {
+    char source[] = "abc";
+    int parsed = 77;
+    FwSizeType count = 99;
+
+    const Fw::ScanStatus status = Fw::stringScan(count, source, sizeof(source), "%d", &parsed);
+
+    EXPECT_EQ(status, Fw::ScanStatus::SUCCESS);
+    EXPECT_EQ(count, 0);
+    EXPECT_EQ(parsed, 77);
+}
+
+TEST(Nominal, noCaptureFormatReturnsSuccessAndCountZero) {
+    char source[] = "literal";
+    FwSizeType count = 99;
+
+    const Fw::ScanStatus status = Fw::stringScan(count, source, sizeof(source), "literal");
+
+    EXPECT_EQ(status, Fw::ScanStatus::SUCCESS);
+    EXPECT_EQ(count, 0);
+}
+
+TEST(Errors, overflowMaximumSizeReturnsSizeOverflow) {
+    if (std::numeric_limits<FwSizeType>::max() <= std::numeric_limits<size_t>::max()) {
+        GTEST_SKIP() << "Cannot create maximumSize > size_t::max() when FwSizeType and size_t have equal max.";
+    }
+
+    char source[] = "123";
+    int parsed = 0;
+    FwSizeType count = 0;
+    const FwSizeType overflowMaximumSize = static_cast<FwSizeType>(std::numeric_limits<size_t>::max()) +
+                                           static_cast<FwSizeType>(1);
+
+    const Fw::ScanStatus status = Fw::stringScan(count, source, overflowMaximumSize, "%d", &parsed);
+
+    EXPECT_EQ(status, Fw::ScanStatus::SIZE_OVERFLOW);
+    EXPECT_EQ(count, 0);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/Fw/Types/test/ut/ScanfScanTest.cpp
+++ b/Fw/Types/test/ut/ScanfScanTest.cpp
@@ -7,10 +7,11 @@
 
 namespace {
 
-Fw::ScanStatus stringScanWithVaList( FwSizeType& count,char* source,
+Fw::ScanStatus stringScanWithVaList(FwSizeType& count,
+                                    char* source,
                                     const FwSizeType maximumSize,
                                     const char* formatString,
-                                   
+
                                     ...) {
     va_list args;
     va_start(args, formatString);
@@ -37,7 +38,8 @@ TEST(Nominal, scanIntegerAndWordWithVaListOverload) {
     char parsedWord[4] = {};
     FwSizeType count = 0;
 
-    const Fw::ScanStatus status = stringScanWithVaList(count, source, sizeof(source), "%d %3s", &parsedNumber, parsedWord);
+    const Fw::ScanStatus status =
+        stringScanWithVaList(count, source, sizeof(source), "%d %3s", &parsedNumber, parsedWord);
 
     EXPECT_EQ(status, Fw::ScanStatus::SUCCESS);
     EXPECT_EQ(count, 2);
@@ -97,8 +99,8 @@ TEST(Errors, overflowMaximumSizeReturnsSizeOverflow) {
     char source[] = "123";
     int parsed = 0;
     FwSizeType count = 0;
-    const FwSizeType overflowMaximumSize = static_cast<FwSizeType>(std::numeric_limits<size_t>::max()) +
-                                           static_cast<FwSizeType>(1);
+    const FwSizeType overflowMaximumSize =
+        static_cast<FwSizeType>(std::numeric_limits<size_t>::max()) + static_cast<FwSizeType>(1);
 
     const Fw::ScanStatus status = Fw::stringScan(count, source, overflowMaximumSize, "%d", &parsed);
 

--- a/cmake/platform/unix/Platform/CMakeLists.txt
+++ b/cmake/platform/unix/Platform/CMakeLists.txt
@@ -17,7 +17,7 @@ register_fprime_config(
         Os_Generic_PriorityQueue
         Os_RawTime_Posix
         Fw_StringFormat_snprintf
-        Fw_StringFormat_sscanf
+        Fw_StringScan_sscanf
         # No posix API
         Os_Cpu_Stub
         Os_Memory_Stub

--- a/cmake/platform/unix/Platform/CMakeLists.txt
+++ b/cmake/platform/unix/Platform/CMakeLists.txt
@@ -17,6 +17,7 @@ register_fprime_config(
         Os_Generic_PriorityQueue
         Os_RawTime_Posix
         Fw_StringFormat_snprintf
+        Fw_StringFormat_sscanf
         # No posix API
         Os_Cpu_Stub
         Os_Memory_Stub

--- a/cmake/test/data/cmake/target/test_recursion.cmake
+++ b/cmake/test/data/cmake/target/test_recursion.cmake
@@ -19,7 +19,7 @@ set(EXPECTED_FULL_DEPENDENCIES
     Fw_Port
     Fw_Prm
     Fw_StringFormat_snprintf
-    Fw_StringFormat_sscanf
+    Fw_StringScan_sscanf
     Fw_Time
     Fw_Tlm
     Fw_Types

--- a/cmake/test/data/cmake/target/test_recursion.cmake
+++ b/cmake/test/data/cmake/target/test_recursion.cmake
@@ -19,6 +19,7 @@ set(EXPECTED_FULL_DEPENDENCIES
     Fw_Port
     Fw_Prm
     Fw_StringFormat_snprintf
+    Fw_StringFormat_sscanf
     Fw_Time
     Fw_Tlm
     Fw_Types


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4040  |
|**_Has Unit Tests (y/n)_**| y  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Adds sscanf implementation.

## Rationale

Allow projects to replace it if necessary.


## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Autocomplete and UT generation.