### PR TITLE
Refactor PrmDb to use Fw::ArrayMap

### DIFF
--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -41,8 +41,8 @@ class WorkingBuffer : public Fw::SerializeBufferBase {
 //! Construction, initialization, and destruction
 //! ----------------------------------------------------------------------
 PrmDbImpl::PrmDbImpl(const char* name) : PrmDbComponentBase(name), m_state(PrmDbFileLoadState::IDLE) {
-    this->m_activeDb = this->m_dbStore1;
-    this->m_stagingDb = this->m_dbStore2;
+    this->m_activeDb = &this->m_dbStore1;
+    this->m_stagingDb = &this->m_dbStore2;
 
     this->clearDb(PrmDbType::DB_ACTIVE);
     this->clearDb(PrmDbType::DB_STAGING);
@@ -77,24 +77,18 @@ void PrmDbImpl::readParamFile() {
 
 Fw::ParamValid PrmDbImpl::getPrm_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
     // search for entry
-    Fw::ParamValid stat = Fw::ParamValid::INVALID;
+    auto success = this->m_activeDb->find(id, val);
 
-    for (FwSizeType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
-        if (this->m_activeDb[entry].used) {
-            if (this->m_activeDb[entry].id == id) {
-                val = this->m_activeDb[entry].val;
-                stat = Fw::ParamValid::VALID;
-                break;
-            }
-        }
+    switch (success.e) {
+        case Fw::Success::FAILURE:
+            // if unable to find parameter, send error message
+            this->log_WARNING_LO_PrmIdNotFound(id);
+            return Fw::ParamValid::INVALID;
+        case Fw::Success::SUCCESS:
+            return Fw::ParamValid::VALID;
+        default:
+            FW_ASSERT(0, success.e);
     }
-
-    // if unable to find parameter, send error message
-    if (Fw::ParamValid::INVALID == stat.e) {
-        this->log_WARNING_LO_PrmIdNotFound(id);
-    }
-
-    return stat;
 }
 
 void PrmDbImpl::setPrm_handler(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) {
@@ -176,119 +170,116 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     }
 
     this->lock();
-    t_dbStruct* db = getDbPtr(PrmDbType::DB_ACTIVE);
+    auto db = getDbPtr(PrmDbType::DB_ACTIVE);
     FW_ASSERT(db != nullptr);
 
     // Traverse the parameter list, saving each entry
 
     U32 numRecords = 0;
 
-    for (FwSizeType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
-        if (db[entry].used) {
-            // write delimiter
-            static const U8 delim = PRMDB_ENTRY_DELIMITER;
-            writeSize = static_cast<FwSizeType>(sizeof(delim));
-            stat = paramFile.write(&delim, writeSize, Os::File::WaitType::WAIT);
-            if (stat != Os::File::OP_OK) {
-                this->unLock();
-                this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::DELIMITER, static_cast<I32>(numRecords), stat);
-                this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
-                return;
-            }
-            if (writeSize != sizeof(delim)) {
-                this->unLock();
-                this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::DELIMITER_SIZE, static_cast<I32>(numRecords),
-                                                       static_cast<I32>(writeSize));
-                this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
-                return;
-            }
+    for (const auto& entry : *db) {
+        // write delimiter
+        static const U8 delim = PRMDB_ENTRY_DELIMITER;
+        writeSize = static_cast<FwSizeType>(sizeof(delim));
+        stat = paramFile.write(&delim, writeSize, Os::File::WaitType::WAIT);
+        if (stat != Os::File::OP_OK) {
+            this->unLock();
+            this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::DELIMITER, static_cast<I32>(numRecords), stat);
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
+        if (writeSize != sizeof(delim)) {
+            this->unLock();
+            this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::DELIMITER_SIZE, static_cast<I32>(numRecords),
+                                                   static_cast<I32>(writeSize));
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
 
-            // add delimiter to CRC
-            crc = this->computeCrc(crc, &delim, sizeof(delim));
+        // add delimiter to CRC
+        crc = this->computeCrc(crc, &delim, sizeof(delim));
 
-            // serialize record size = id field + data
-            U32 recordSize = static_cast<U32>(sizeof(FwPrmIdType) + db[entry].val.getSize());
+        // serialize record size = id field + data
+        U32 recordSize = static_cast<U32>(sizeof(FwPrmIdType) + entry.getValue().getSize());
 
-            // reset buffer
-            buff.resetSer();
-            Fw::SerializeStatus serStat = buff.serializeFrom(recordSize);
-            // should always work
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
+        // reset buffer
+        buff.resetSer();
+        Fw::SerializeStatus serStat = buff.serializeFrom(recordSize);
+        // should always work
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
 
-            // write record size
-            writeSize = static_cast<FwSizeType>(buff.getSize());
-            stat = paramFile.write(buff.getBuffAddr(), writeSize, Os::File::WaitType::WAIT);
-            if (stat != Os::File::OP_OK) {
-                this->unLock();
-                this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::RECORD_SIZE, static_cast<I32>(numRecords), stat);
-                this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
-                return;
-            }
-            if (writeSize != sizeof(recordSize)) {
-                this->unLock();
-                this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::RECORD_SIZE_SIZE, static_cast<I32>(numRecords),
-                                                       static_cast<I32>(writeSize));
-                this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
-                return;
-            }
+        // write record size
+        writeSize = static_cast<FwSizeType>(buff.getSize());
+        stat = paramFile.write(buff.getBuffAddr(), writeSize, Os::File::WaitType::WAIT);
+        if (stat != Os::File::OP_OK) {
+            this->unLock();
+            this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::RECORD_SIZE, static_cast<I32>(numRecords), stat);
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
+        if (writeSize != sizeof(recordSize)) {
+            this->unLock();
+            this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::RECORD_SIZE_SIZE, static_cast<I32>(numRecords),
+                                                   static_cast<I32>(writeSize));
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
 
-            // add recordSize to CRC
-            crc = this->computeCrc(crc, buff.getBuffAddr(), writeSize);
+        // add recordSize to CRC
+        crc = this->computeCrc(crc, buff.getBuffAddr(), writeSize);
 
-            // reset buffer
-            buff.resetSer();
+        // reset buffer
+        buff.resetSer();
 
-            // serialize parameter id
+        // serialize parameter id
 
-            serStat = buff.serializeFrom(db[entry].id);
-            // should always work
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
+        serStat = buff.serializeFrom(entry.getKey());
+        // should always work
+        FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
 
-            // write parameter ID
-            writeSize = static_cast<FwSizeType>(buff.getSize());
-            stat = paramFile.write(buff.getBuffAddr(), writeSize, Os::File::WaitType::WAIT);
-            if (stat != Os::File::OP_OK) {
-                this->unLock();
-                this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::PARAMETER_ID, static_cast<I32>(numRecords), stat);
-                this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
-                return;
-            }
-            if (writeSize != static_cast<FwSizeType>(buff.getSize())) {
-                this->unLock();
-                this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::PARAMETER_ID_SIZE, static_cast<I32>(numRecords),
-                                                       static_cast<I32>(writeSize));
-                this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
-                return;
-            }
+        // write parameter ID
+        writeSize = static_cast<FwSizeType>(buff.getSize());
+        stat = paramFile.write(buff.getBuffAddr(), writeSize, Os::File::WaitType::WAIT);
+        if (stat != Os::File::OP_OK) {
+            this->unLock();
+            this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::PARAMETER_ID, static_cast<I32>(numRecords), stat);
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
+        if (writeSize != static_cast<FwSizeType>(buff.getSize())) {
+            this->unLock();
+            this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::PARAMETER_ID_SIZE, static_cast<I32>(numRecords),
+                                                   static_cast<I32>(writeSize));
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
 
-            // add parameter ID to CRC
-            crc = this->computeCrc(crc, buff.getBuffAddr(), writeSize);
+        // add parameter ID to CRC
+        crc = this->computeCrc(crc, buff.getBuffAddr(), writeSize);
 
-            // write serialized parameter value
+        // write serialized parameter value
 
-            writeSize = static_cast<FwSizeType>(db[entry].val.getSize());
-            stat = paramFile.write(db[entry].val.getBuffAddr(), writeSize, Os::File::WaitType::WAIT);
-            if (stat != Os::File::OP_OK) {
-                this->unLock();
-                this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::PARAMETER_VALUE, static_cast<I32>(numRecords),
-                                                       stat);
-                this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
-                return;
-            }
-            if (writeSize != static_cast<FwSizeType>(db[entry].val.getSize())) {
-                this->unLock();
-                this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::PARAMETER_VALUE_SIZE,
-                                                       static_cast<I32>(numRecords), static_cast<I32>(writeSize));
-                this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
-                return;
-            }
+        writeSize = static_cast<FwSizeType>(entry.getValue().getSize());
+        stat = paramFile.write(entry.getValue().getBuffAddr(), writeSize, Os::File::WaitType::WAIT);
+        if (stat != Os::File::OP_OK) {
+            this->unLock();
+            this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::PARAMETER_VALUE, static_cast<I32>(numRecords), stat);
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
+        if (writeSize != static_cast<FwSizeType>(entry.getValue().getSize())) {
+            this->unLock();
+            this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::PARAMETER_VALUE_SIZE, static_cast<I32>(numRecords),
+                                                   static_cast<I32>(writeSize));
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
 
-            // add serialized parameter value to crc
-            crc = this->computeCrc(crc, db[entry].val.getBuffAddr(), writeSize);
+        // add serialized parameter value to crc
+        crc = this->computeCrc(crc, entry.getValue().getBuffAddr(), writeSize);
 
-            numRecords++;
-        }  // end if record in use
-    }  // end for each record
+        numRecords++;
+    }
 
     this->unLock();
 
@@ -379,7 +370,7 @@ void PrmDbImpl::PRM_COMMIT_STAGED_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
 
     // Swap active and staging databases, safely w.r.t. prmGet
     this->lock();
-    t_dbStruct* temp = this->m_activeDb;
+    PrmDbStore* temp = this->m_activeDb;
     this->m_activeDb = this->m_stagingDb;
     this->unLock();
     this->m_stagingDb = temp;
@@ -580,34 +571,28 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
 }
 
 PrmDbImpl::PrmUpdateType PrmDbImpl::updateAddPrmImpl(FwPrmIdType id, Fw::ParamBuffer& val, PrmDbType prmDbType) {
-    t_dbStruct* db = getDbPtr(prmDbType);
+    auto* db = getDbPtr(prmDbType);
 
     PrmUpdateType updateStatus = NO_SLOTS;
 
     this->lock();
-    // search for existing entry
-    bool existingEntry = false;
 
-    for (FwSizeType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
-        if ((db[entry].used) && (id == db[entry].id)) {
-            db[entry].val = val;
-            existingEntry = true;
-            updateStatus = PARAM_UPDATED;
+    auto prevSize = db->getSize();
+    switch (db->insert(id, val)) {
+        case Fw::Success::FAILURE:
+            updateStatus = NO_SLOTS;
             break;
-        }
-    }
-
-    // if there is no existing entry, add one
-    if (!existingEntry) {
-        for (FwSizeType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
-            if (!(db[entry].used)) {
-                db[entry].val = val;
-                db[entry].id = id;
-                db[entry].used = true;
+        case Fw::Success::SUCCESS:
+            if (prevSize < db->getSize()) {
                 updateStatus = PARAM_ADDED;
-                break;
+            } else {
+                FW_ASSERT(prevSize == db->getSize(), static_cast<FwAssertArgType>(prevSize),
+                          static_cast<FwAssertArgType>(db->getSize()));
+                updateStatus = PARAM_UPDATED;
             }
-        }
+            break;
+        default:
+            FW_ASSERT(false);
     }
 
     this->unLock();
@@ -619,40 +604,15 @@ PrmDbImpl::PrmUpdateType PrmDbImpl::updateAddPrmImpl(FwPrmIdType id, Fw::ParamBu
 //! ----------------------------------------------------------------------
 
 void PrmDbImpl::clearDb(PrmDbType prmDbType) {
-    t_dbStruct* db = getDbPtr(prmDbType);
-    for (FwSizeType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
-        db[entry].used = false;
-        db[entry].id = 0;
-    }
-}
-
-bool PrmDbImpl::dbEqual() {
-    for (FwSizeType i = 0; i < PRMDB_NUM_DB_ENTRIES; i++) {
-        if (!(this->m_dbStore1[i] == this->m_dbStore2[i])) {
-            return false;
-        }
-    }
-    return true;
+    getDbPtr(prmDbType)->clear();
 }
 
 void PrmDbImpl::dbCopy(PrmDbType dest, PrmDbType src) {
-    for (FwSizeType i = 0; i < PRMDB_NUM_DB_ENTRIES; i++) {
-        dbCopySingle(dest, src, i);
-    }
+    *getDbPtr(dest) = *getDbPtr(src);
     this->log_ACTIVITY_HI_PrmDbCopyAllComplete(getDbString(src), getDbString(dest));
 }
 
-void PrmDbImpl::dbCopySingle(PrmDbType dest, PrmDbType src, FwSizeType index) {
-    t_dbStruct* srcPtr = getDbPtr(src);
-    t_dbStruct* destPtr = getDbPtr(dest);
-
-    FW_ASSERT(index < PRMDB_NUM_DB_ENTRIES);
-    destPtr[index].used = srcPtr[index].used;
-    destPtr[index].id = srcPtr[index].id;
-    destPtr[index].val = srcPtr[index].val;
-}
-
-PrmDbImpl::t_dbStruct* PrmDbImpl::getDbPtr(PrmDbType dbType) {
+PrmDbImpl::PrmDbStore* PrmDbImpl::getDbPtr(PrmDbType dbType) {
     FW_ASSERT(dbType == PrmDbType::DB_ACTIVE or dbType == PrmDbType::DB_STAGING);
     if (dbType == PrmDbType::DB_ACTIVE) {
         return m_activeDb;

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -88,6 +88,7 @@ Fw::ParamValid PrmDbImpl::getPrm_handler(FwIndexType portNum, FwPrmIdType id, Fw
             return Fw::ParamValid::VALID;
         default:
             FW_ASSERT(0, success.e);
+            return Fw::ParamValid::INVALID;
     }
 }
 

--- a/Svc/PrmDb/PrmDbImpl.hpp
+++ b/Svc/PrmDb/PrmDbImpl.hpp
@@ -13,6 +13,7 @@
 #ifndef PRMDBIMPL_HPP_
 #define PRMDBIMPL_HPP_
 
+#include <Fw/DataStructures/ArrayMap.hpp>
 #include <Fw/Types/String.hpp>
 #include <Os/Mutex.hpp>
 #include <Svc/PrmDb/PrmDbComponentAc.hpp>
@@ -37,6 +38,8 @@ typedef PrmDb_PrmDbFileLoadState PrmDbFileLoadState;
 
 class PrmDbImpl final : public PrmDbComponentBase {
     friend class PrmDbTester;
+
+    using PrmDbStore = Fw::ArrayMap<FwPrmIdType, Fw::ParamBuffer, PRMDB_NUM_DB_ENTRIES>;
 
   public:
     //!  \brief PrmDb constructor
@@ -85,25 +88,6 @@ class PrmDbImpl final : public PrmDbComponentBase {
 
     PrmDbFileLoadState m_state;  // Current file load state of the parameter database
 
-    // Structure for a single parameter entry
-    struct t_dbStruct {
-        bool used;            //!< whether slot is being used
-        FwPrmIdType id;       //!< the id being stored in the slot
-        Fw::ParamBuffer val;  //!< the serialized value of the parameter
-
-        bool operator==(const t_dbStruct& other) const {
-            if (used != other.used)
-                return false;
-            if (id != other.id)
-                return false;
-            // Compare lengths first
-            if (val.getSize() != other.val.getSize())
-                return false;
-            // Compare buffer contents
-            return std::memcmp(val.getBuffAddr(), other.val.getBuffAddr(), val.getSize()) == 0;
-        }
-    };
-
     // helper to compute CRC over a buffer
     U32 computeCrc(U32 crc, const BYTE* buff, FwSizeType size);
 
@@ -114,12 +98,12 @@ class PrmDbImpl final : public PrmDbComponentBase {
     // when commanded. Upon reading the file, the parameters are "staged"
     // into the staging database, and then committed to the active database
     // when a commit command is received.
-    t_dbStruct* m_activeDb;   //!< Pointer to the active database
-    t_dbStruct* m_stagingDb;  //!< Pointer to the staging database
+    PrmDbStore* m_activeDb;   //!< Pointer to the active database
+    PrmDbStore* m_stagingDb;  //!< Pointer to the staging database
 
     // Actual storage for the active and staging databases
-    t_dbStruct m_dbStore1[PRMDB_NUM_DB_ENTRIES];
-    t_dbStruct m_dbStore2[PRMDB_NUM_DB_ENTRIES];
+    PrmDbStore m_dbStore1;
+    PrmDbStore m_dbStore2;
 
     //! ----------------------------------------------------------------------
     //! Port & Command Handlers
@@ -226,7 +210,7 @@ class PrmDbImpl final : public PrmDbComponentBase {
     //!  This function returns a pointer to the requested database
     //!  \param dbType The type of database requested (active or staging)
     //!  \return Pointer to the database array to be set
-    t_dbStruct* getDbPtr(PrmDbType dbType);
+    PrmDbStore* getDbPtr(PrmDbType dbType);
 
     //!  \brief PrmDb get db string function
     //!  This function returns a string for the requested database
@@ -234,26 +218,12 @@ class PrmDbImpl final : public PrmDbComponentBase {
     //!  \return string representing the database
     static Fw::String getDbString(PrmDbType dbType);
 
-    //! \brief Check param db equality
-    //!
-    //!  This helper method verifies the active and staging parameter dbs are equal
-    bool dbEqual();
-
     //! \brief Deep copy for db
     //!
     //!  Copies one db to another
     //! \param dest The destination db to copy to  (active or staging)
     //! \param src The source db to copy from  (active or staging)
     void dbCopy(PrmDbType dest, PrmDbType src);
-
-    //! \brief Deep copy for single db entry
-    //!
-    //!  Copies one db entry to another at specified index
-    //!
-    //! \param dest The destination db to copy to  (active or staging)
-    //! \param src The source db to copy from  (active or staging)
-    //! \param index The index of the entry to copy
-    void dbCopySingle(PrmDbType dest, PrmDbType src, FwSizeType index);
 };
 }  // namespace Svc
 

--- a/Svc/PrmDb/test/ut/PrmDbTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.cpp
@@ -586,13 +586,38 @@ void PrmDbTester::runFileWriteError() {
     }
 }
 
+bool PrmDbTester::dbEqual() {
+    if (this->m_impl.m_activeDb->getSize() != this->m_impl.m_stagingDb->getSize()) {
+        return false;
+    }
+
+    Fw::ParamBuffer b;
+
+    for (const auto& entry : *this->m_impl.m_activeDb) {
+        auto found = this->m_impl.m_stagingDb->find(entry.getKey(), b);
+        if (found != Fw::Success::SUCCESS) {
+            return false;
+        }
+
+        if (b.getSize() != entry.getValue().getSize()) {
+            return false;
+        }
+
+        if (std::memcmp(b.getBuffAddr(), entry.getValue().getBuffAddr(), b.getSize()) != 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void PrmDbTester::runDbEqualTest() {
     Fw::SerializeStatus serStat;
 
     // 1. Test with empty databases - should be equal
     this->m_impl.clearDb(PrmDb_PrmDbType::DB_ACTIVE);
     this->m_impl.clearDb(PrmDb_PrmDbType::DB_STAGING);
-    EXPECT_TRUE(this->m_impl.dbEqual());
+    EXPECT_TRUE(this->dbEqual());
 
     // 2. Add an entry to active DB only - should not be equal
     U32 val1 = 0x42;
@@ -603,7 +628,7 @@ void PrmDbTester::runDbEqualTest() {
     EXPECT_EQ(Fw::FW_SERIALIZE_OK, serStat);
 
     this->m_impl.updateAddPrmImpl(id1, pBuff, PrmDb_PrmDbType::DB_ACTIVE);
-    EXPECT_FALSE(this->m_impl.dbEqual());
+    EXPECT_FALSE(this->dbEqual());
 
     // 3. Add same entry to staging DB - should be equal again
     pBuff.resetSer();
@@ -611,7 +636,7 @@ void PrmDbTester::runDbEqualTest() {
     EXPECT_EQ(Fw::FW_SERIALIZE_OK, serStat);
 
     this->m_impl.updateAddPrmImpl(id1, pBuff, PrmDb_PrmDbType::DB_STAGING);
-    EXPECT_TRUE(this->m_impl.dbEqual());
+    EXPECT_TRUE(this->dbEqual());
 
     // 4. Update entry in active DB only - should not be equal
     U32 val2 = 0x43;
@@ -620,7 +645,7 @@ void PrmDbTester::runDbEqualTest() {
     EXPECT_EQ(Fw::FW_SERIALIZE_OK, serStat);
 
     this->m_impl.updateAddPrmImpl(id1, pBuff, PrmDb_PrmDbType::DB_STAGING);
-    EXPECT_FALSE(this->m_impl.dbEqual());
+    EXPECT_FALSE(this->dbEqual());
 
     // 5. Update staging DB to match - should be equal again
     pBuff.resetSer();
@@ -628,7 +653,7 @@ void PrmDbTester::runDbEqualTest() {
     EXPECT_EQ(Fw::FW_SERIALIZE_OK, serStat);
 
     this->m_impl.updateAddPrmImpl(id1, pBuff, PrmDb_PrmDbType::DB_ACTIVE);
-    EXPECT_TRUE(this->m_impl.dbEqual());
+    EXPECT_TRUE(this->dbEqual());
 
     // 6. Add different entry to staging DB - should not be equal
     U32 val3 = 0x44;
@@ -638,7 +663,7 @@ void PrmDbTester::runDbEqualTest() {
     EXPECT_EQ(Fw::FW_SERIALIZE_OK, serStat);
 
     this->m_impl.updateAddPrmImpl(id2, pBuff, PrmDb_PrmDbType::DB_STAGING);
-    EXPECT_FALSE(this->m_impl.dbEqual());
+    EXPECT_FALSE(this->dbEqual());
 }
 
 void PrmDbTester::runDbCopyTest() {
@@ -668,28 +693,21 @@ void PrmDbTester::runDbCopyTest() {
     this->m_impl.updateAddPrmImpl(id2, pBuff, PrmDb_PrmDbType::DB_ACTIVE);
 
     // Verify databases are not equal
-    EXPECT_FALSE(this->m_impl.dbEqual());
+    EXPECT_FALSE(this->dbEqual());
 
     // Copy active DB to staging DB
     this->m_impl.dbCopy(PrmDb_PrmDbType::DB_STAGING, PrmDb_PrmDbType::DB_ACTIVE);
 
     // Verify databases are now equal
-    EXPECT_TRUE(this->m_impl.dbEqual());
+    EXPECT_TRUE(this->dbEqual());
 
     // Verify values in the staging DB
     pBuff.resetSer();
     U32 testVal1;
-    FwSizeType idx = 0;
-    // Find the parameter and get its index
-    for (FwSizeType i = 0; i < PRMDB_NUM_DB_ENTRIES; i++) {
-        if (this->m_impl.m_activeDb[i].used && this->m_impl.m_stagingDb[i].id == id1) {
-            idx = i;
-            break;
-        }
-    }
-    EXPECT_TRUE(this->m_impl.m_activeDb[idx].used);
-    EXPECT_EQ(id1, this->m_impl.m_stagingDb[idx].id);
-    pBuff = this->m_impl.m_stagingDb[idx].val;
+
+    // Find the parameter
+    auto findStatus = this->m_impl.m_activeDb->find(id1, pBuff);
+    EXPECT_EQ(findStatus, Fw::Success::SUCCESS);
     serStat = pBuff.deserializeTo(testVal1);
     EXPECT_EQ(Fw::FW_SERIALIZE_OK, serStat);
     EXPECT_EQ(val1, testVal1);
@@ -721,42 +739,38 @@ void PrmDbTester::runDbCopyTest() {
     this->m_impl.updateAddPrmImpl(id3, pBuff, PrmDb_PrmDbType::DB_STAGING);
 
     // Verify databases are not equal
-    EXPECT_FALSE(this->m_impl.dbEqual());
+    EXPECT_FALSE(this->dbEqual());
 
     // Copy only the second entry from active to staging at the same index
-    FwSizeType activeIdx2 = 1;  // Index of second entry in active DB
-    this->m_impl.dbCopySingle(PrmDb_PrmDbType::DB_STAGING, PrmDb_PrmDbType::DB_ACTIVE, activeIdx2);
+    pBuff.resetSer();
+    auto findSuccess = this->m_impl.m_activeDb->find(id2, pBuff);
+    EXPECT_EQ(findSuccess, Fw::Success::SUCCESS);
 
-    // Verify the specific entry was copied correctly
-    EXPECT_TRUE(this->m_impl.m_stagingDb[activeIdx2].used);
-    EXPECT_EQ(id2, this->m_impl.m_stagingDb[activeIdx2].id);
+    auto insertSuccess = this->m_impl.m_stagingDb->insert(id2, pBuff);
+    EXPECT_EQ(insertSuccess, Fw::Success::SUCCESS);
 
     // Verify value matches
-    pBuff = this->m_impl.m_stagingDb[activeIdx2].val;
+    pBuff.resetSer();
+
+    findSuccess = this->m_impl.m_stagingDb->find(id2, pBuff);
+    EXPECT_EQ(findSuccess, Fw::Success::SUCCESS);
+
     F32 testVal2;
     serStat = pBuff.deserializeTo(testVal2);
     EXPECT_EQ(Fw::FW_SERIALIZE_OK, serStat);
     EXPECT_EQ(val2, testVal2);
 
     // Verify the original entry in staging DB is still there
-    bool foundOriginal = false;
-    for (FwSizeType i = 0; i < PRMDB_NUM_DB_ENTRIES; i++) {
-        if (this->m_impl.m_stagingDb[i].used && this->m_impl.m_stagingDb[i].id == id3) {
-            foundOriginal = true;
+    auto foundOriginal = this->m_impl.m_stagingDb->find(id3, pBuff);
+    EXPECT_EQ(foundOriginal, Fw::Success::SUCCESS);
 
-            // Verify value is still correct
-            pBuff = this->m_impl.m_stagingDb[i].val;
-            U16 testVal3;
-            serStat = pBuff.deserializeTo(testVal3);
-            EXPECT_EQ(Fw::FW_SERIALIZE_OK, serStat);
-            EXPECT_EQ(val3, testVal3);
-            break;
-        }
-    }
-    EXPECT_TRUE(foundOriginal);
+    U16 testVal3;
+    serStat = pBuff.deserializeTo(testVal3);
+    EXPECT_EQ(Fw::FW_SERIALIZE_OK, serStat);
+    EXPECT_EQ(val3, testVal3);
 
     // Databases should still not be equal since we only copied one entry
-    EXPECT_FALSE(this->m_impl.dbEqual());
+    EXPECT_FALSE(this->dbEqual());
 }
 
 void PrmDbTester::runDbCommitTest() {
@@ -794,8 +808,8 @@ void PrmDbTester::runDbCommitTest() {
     this->m_impl.updateAddPrmImpl(stagingId2, pBuff, PrmDbType::DB_STAGING);
 
     // Store pointers to databases before swap for verification
-    PrmDbImpl::t_dbStruct* preSwapActiveDb = this->m_impl.m_activeDb;
-    PrmDbImpl::t_dbStruct* preSwapStagingDb = this->m_impl.m_stagingDb;
+    auto* preSwapActiveDb = this->m_impl.m_activeDb;
+    auto* preSwapStagingDb = this->m_impl.m_stagingDb;
 
     // Clear events and command history
     this->clearEvents();
@@ -824,14 +838,7 @@ void PrmDbTester::runDbCommitTest() {
     EXPECT_EQ(this->m_impl.m_stagingDb, preSwapActiveDb);
 
     // Verify that the new staging database is empty
-    bool allEntriesCleared = true;
-    for (FwSizeType i = 0; i < PRMDB_NUM_DB_ENTRIES; i++) {
-        if (this->m_impl.m_stagingDb[i].used) {
-            allEntriesCleared = false;
-            break;
-        }
-    }
-    EXPECT_TRUE(allEntriesCleared);
+    EXPECT_EQ(this->m_impl.m_stagingDb->getSize(), 0);
 
     // Verify that parameters can be accessed from the newly active database
     // (which was formerly the staging database)
@@ -868,8 +875,8 @@ void PrmDbTester::runPrmFileLoadNominal() {
     Fw::QueuedComponentBase::MsgDispatchStatus dispatchStatus;
 
     // Store pointers to databases before swap for verification
-    PrmDbImpl::t_dbStruct* preSwapActiveDb = this->m_impl.m_activeDb;
-    PrmDbImpl::t_dbStruct* preSwapStagingDb = this->m_impl.m_stagingDb;
+    auto* preSwapActiveDb = this->m_impl.m_activeDb;
+    auto* preSwapStagingDb = this->m_impl.m_stagingDb;
 
     // Ensure we're in IDLE state
     EXPECT_EQ(this->m_impl.m_state, PrmDbFileLoadState::IDLE);
@@ -954,23 +961,26 @@ void PrmDbTester::runPrmFileLoadNominal() {
     ASSERT_CMD_RESPONSE(0, PrmDbImpl::OPCODE_PRM_LOAD_FILE, 10, Fw::CmdResponse::OK);
 
     // Verify that parameters in staging database have expected values
-    for (FwSizeType i = 0; i < PRMDB_NUM_DB_ENTRIES; i++) {
-        // Check for the parameter that we added after the save file (since we are merging)
-        if (this->m_impl.m_stagingDb[i].used && this->m_impl.m_stagingDb[i].id == activeId1) {
-            pBuff = this->m_impl.m_stagingDb[i].val;
-            U32 checkVal;
-            stat = pBuff.deserializeTo(checkVal);
-            EXPECT_EQ(Fw::FW_SERIALIZE_OK, stat);
-            EXPECT_EQ(checkVal, activeVal1);
-        }
-        // Check for the parameter that we updated after the save file (since we are merging)
-        if (this->m_impl.m_stagingDb[i].used && this->m_impl.m_stagingDb[i].id == activeId2) {
-            pBuff = this->m_impl.m_stagingDb[i].val;
-            U32 checkVal;
-            stat = pBuff.deserializeTo(checkVal);
-            EXPECT_EQ(Fw::FW_SERIALIZE_OK, stat);
-            EXPECT_EQ(checkVal, activeVal2Original);  // Value should match what was in the file, not what we set
-        }
+    {
+        auto found = this->m_impl.m_stagingDb->find(activeId1, pBuff);
+        EXPECT_EQ(found, Fw::Success::SUCCESS);
+
+        U32 checkVal;
+        stat = pBuff.deserializeTo(checkVal);
+        EXPECT_EQ(Fw::FW_SERIALIZE_OK, stat);
+        EXPECT_EQ(checkVal, activeVal1);
+    }
+
+    {
+        auto found = this->m_impl.m_stagingDb->find(activeId2, pBuff);
+        EXPECT_EQ(found, Fw::Success::SUCCESS);
+
+        U32 checkVal;
+        stat = pBuff.deserializeTo(checkVal);
+        EXPECT_EQ(Fw::FW_SERIALIZE_OK, stat);
+
+        // Value should match what was in the file, not what we set
+        EXPECT_EQ(checkVal, activeVal2Original);
     }
 
     // Send PRM_COMMIT_STAGED command
@@ -992,14 +1002,7 @@ void PrmDbTester::runPrmFileLoadNominal() {
     EXPECT_EQ(this->m_impl.m_stagingDb, preSwapActiveDb);
 
     // Verify the new staging database (former active) is empty
-    bool allEntriesCleared = true;
-    for (FwSizeType i = 0; i < PRMDB_NUM_DB_ENTRIES; i++) {
-        if (this->m_impl.m_stagingDb[i].used) {
-            allEntriesCleared = false;
-            break;
-        }
-    }
-    EXPECT_TRUE(allEntriesCleared);
+    EXPECT_EQ(this->m_impl.m_stagingDb->getSize(), 0);
 
     // Verify we can now perform operations only allowed in IDLE state
     // Try setting a parameter - should work in IDLE state
@@ -1033,8 +1036,8 @@ void PrmDbTester::runPrmFileLoadWithErrors() {
     Fw::QueuedComponentBase::MsgDispatchStatus dispatchStatus;
 
     // Store pointers to databases before swap for verification
-    PrmDbImpl::t_dbStruct* preSwapActiveDb = this->m_impl.m_activeDb;
-    PrmDbImpl::t_dbStruct* preSwapStagingDb = this->m_impl.m_stagingDb;
+    auto* preSwapActiveDb = this->m_impl.m_activeDb;
+    auto* preSwapStagingDb = this->m_impl.m_stagingDb;
 
     // Ensure we're in IDLE state
     EXPECT_EQ(this->m_impl.m_state, PrmDbFileLoadState::IDLE);
@@ -1123,14 +1126,7 @@ void PrmDbTester::runPrmFileLoadWithErrors() {
     EXPECT_EQ(this->m_impl.m_stagingDb, preSwapStagingDb);
 
     // Verify the staging database is empty
-    bool allEntriesCleared = true;
-    for (FwSizeType i = 0; i < PRMDB_NUM_DB_ENTRIES; i++) {
-        if (this->m_impl.m_stagingDb[i].used) {
-            allEntriesCleared = false;
-            break;
-        }
-    }
-    EXPECT_TRUE(allEntriesCleared);
+    EXPECT_EQ(this->m_impl.m_stagingDb->getSize(), 0);
 }
 
 void PrmDbTester::runPrmFileLoadIllegal() {
@@ -1386,20 +1382,17 @@ void PrmDbTester ::from_pingOut_handler(const FwIndexType portNum, U32 key) {
 }
 
 void PrmDbTester::printDb(PrmDb_PrmDbType dbType) {
-    PrmDbImpl::t_dbStruct* db = this->m_impl.getDbPtr(dbType);
+    auto* db = this->m_impl.getDbPtr(dbType);
     printf("%s Parameter DB @ %p \n", PrmDbImpl::getDbString(dbType).toChar(), static_cast<void*>(db));
-    for (FwSizeType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
-        U8* data = db[entry].val.getBuffAddr();
-        FwSizeType len = db[entry].val.getSize();
-        if (db[entry].used) {
-            std::cout << "  " << std::setw(2) << entry << " :";
-            printf(" ID = %08X", db[entry].id);
-            printf(" Value = ");
-            for (FwSizeType i = 0; i < len; ++i) {
-                printf("%02X ", data[i]);
-            }
-            printf("\n");
+    for (const auto& entry : *db) {
+        printf(" ID = %08X", entry.getKey());
+        printf(" Value = ");
+        const U8* data = entry.getValue().getBuffAddr();
+        FwSizeType len = entry.getValue().getSize();
+        for (FwSizeType i = 0; i < len; ++i) {
+            printf("%02X ", data[i]);
         }
+        printf("\n");
     }
 }
 

--- a/Svc/PrmDb/test/ut/PrmDbTester.hpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.hpp
@@ -36,6 +36,8 @@ class PrmDbTester : public PrmDbGTestBase {
     void runRefPrmFile();
 
   private:
+    bool dbEqual();
+
     //! Handler for from_pingOut
     //!
     void from_pingOut_handler(const FwIndexType portNum, /*!< The port number*/


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| N |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

I refactored the inline array-map in PrmDb to use `Fw::ArrayMap`

## Rationale

Cleaner implementation.

## Testing/Review Recommendations

UTs have been updated to use the ArrayMap api instead of inline array searching code.
