### PR TITLE
Replace cmd dispatch table with map

### DIFF
--- a/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
@@ -20,31 +20,23 @@ static_assert(CMD_DISPATCHER_SEQUENCER_TABLE_SIZE <= std::numeric_limits<U32>::m
 namespace Svc {
 CommandDispatcherImpl::CommandDispatcherImpl(const char* name)
     : CommandDispatcherComponentBase(name), m_seq(0), m_numCmdsDispatched(0), m_numCmdErrors(0), m_numCmdsDropped(0) {
-    memset(this->m_entryTable, 0, sizeof(this->m_entryTable));
     memset(this->m_sequenceTracker, 0, sizeof(this->m_sequenceTracker));
 }
 
 CommandDispatcherImpl::~CommandDispatcherImpl() {}
 
 void CommandDispatcherImpl::compCmdReg_handler(FwIndexType portNum, FwOpcodeType opCode) {
-    // search for an empty slot
-    bool slotFound = false;
-    for (FwOpcodeType slot = 0; slot < FW_NUM_ARRAY_ELEMENTS(this->m_entryTable); slot++) {
-        if ((not this->m_entryTable[slot].used) and (not slotFound)) {
-            this->m_entryTable[slot].opcode = opCode;
-            this->m_entryTable[slot].port = portNum;
-            this->m_entryTable[slot].used = true;
-            this->log_DIAGNOSTIC_OpCodeRegistered(opCode, portNum, static_cast<I32>(slot));
-            slotFound = true;
-        } else if ((this->m_entryTable[slot].used) && (this->m_entryTable[slot].opcode == opCode) &&
-                   (this->m_entryTable[slot].port == portNum) && (not slotFound)) {
-            slotFound = true;
-            this->log_DIAGNOSTIC_OpCodeReregistered(opCode, portNum);
-        } else if (this->m_entryTable[slot].used) {  // make sure no duplicates
-            FW_ASSERT(this->m_entryTable[slot].opcode != opCode, static_cast<FwAssertArgType>(opCode));
-        }
+    FwIndexType existingPort;
+    if (this->m_entryTable.find(opCode, existingPort) == Fw::Success::SUCCESS) {
+        // Opcode already present — must be the same port (re-registration)
+        FW_ASSERT(existingPort == portNum, static_cast<FwAssertArgType>(opCode));
+        this->log_DIAGNOSTIC_OpCodeReregistered(opCode, portNum);
+    } else {
+        const I32 slot = static_cast<I32>(this->m_entryTable.getSize());
+        const Fw::Success status = this->m_entryTable.insert(opCode, portNum);
+        FW_ASSERT(status == Fw::Success::SUCCESS, static_cast<FwAssertArgType>(opCode));
+        this->log_DIAGNOSTIC_OpCodeRegistered(opCode, portNum, slot);
     }
-    FW_ASSERT(slotFound, static_cast<FwAssertArgType>(opCode));
 }
 
 void CommandDispatcherImpl::compCmdStat_handler(FwIndexType portNum,
@@ -97,17 +89,10 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
         return;
     }
 
-    // search for opcode in dispatch table
-    FwOpcodeType entry;
-    bool entryFound = false;
-
-    for (entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_entryTable); entry++) {
-        if ((this->m_entryTable[entry].used) and (cmdPkt.getOpCode() == this->m_entryTable[entry].opcode)) {
-            entryFound = true;
-            break;
-        }
-    }
-    if (entryFound and this->isConnected_compCmdSend_OutputPort(this->m_entryTable[entry].port)) {
+    // look up opcode in dispatch map
+    FwIndexType entryPort;
+    Fw::Success findStatus = this->m_entryTable.find(cmdPkt.getOpCode(), entryPort);
+    if (findStatus == Fw::Success::SUCCESS and this->isConnected_compCmdSend_OutputPort(entryPort)) {
         // register command in command tracker only if response port is connect
         if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
             bool pendingFound = false;
@@ -134,9 +119,9 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
             }
         }  // end if status port connected
         // pass arguments to argument buffer
-        this->compCmdSend_out(this->m_entryTable[entry].port, cmdPkt.getOpCode(), this->m_seq, cmdPkt.getArgBuffer());
+        this->compCmdSend_out(entryPort, cmdPkt.getOpCode(), this->m_seq, cmdPkt.getArgBuffer());
         // log dispatched command
-        this->log_COMMAND_OpCodeDispatched(cmdPkt.getOpCode(), this->m_entryTable[entry].port);
+        this->log_COMMAND_OpCodeDispatched(cmdPkt.getOpCode(), entryPort);
 
         // increment command count
         this->m_numCmdsDispatched++;

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
@@ -13,6 +13,7 @@
 #ifndef COMMANDDISPATCHERIMPL_HPP_
 #define COMMANDDISPATCHERIMPL_HPP_
 
+#include <Fw/DataStructures/RedBlackTreeMap.hpp>
 #include <Os/Mutex.hpp>
 #include <Svc/CmdDispatcher/CommandDispatcherComponentAc.hpp>
 #include <config/CommandDispatcherImplCfg.hpp>
@@ -142,22 +143,12 @@ class CommandDispatcherImpl final : public CommandDispatcherComponentBase {
     //!  \param context call value defined by user
     void seqCmdBuff_overflowHook(FwIndexType portNum, Fw::ComBuffer& data, U32 context) override;
 
-    //! \struct DispatchEntry
-    //! \brief table used to store opcode to port mappings
+    //! \brief map from opcode to output port index
     //!
-    //! The DispatchEntry table is used to map incoming opcodes to the port
-    //! connected to the component that implements the opcode.
-    //! As each command opcode is registered, a new entry is found
-    //! in the table by checking for the "used" flag. The opcode
-    //! member is set to the opcode, and the port member set to the
-    //! port to dispatch to. When a new opcode is received for
-    //! execution, the table is traversed until the opcode is located.
-
-    struct DispatchEntry {
-        bool used;                                       //!< if entry has been used yet
-        FwOpcodeType opcode;                             //!< opcode of entry
-        FwIndexType port;                                //!< which port the entry invokes
-    } m_entryTable[CMD_DISPATCHER_DISPATCH_TABLE_SIZE];  //!< table of dispatch entries
+    //! Maps each registered command opcode to the output port index of the
+    //! component that implements it. Replaces the former linear DispatchEntry
+    //! array with an O(log n) red-black tree lookup.
+    Fw::RedBlackTreeMap<FwOpcodeType, FwIndexType, CMD_DISPATCHER_DISPATCH_TABLE_SIZE> m_entryTable;
 
     //! \struct SequenceTracker
     //! \brief table used to store opcode that are being executed

--- a/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.cpp
+++ b/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.cpp
@@ -46,46 +46,48 @@ void CommandDispatcherTester::from_seqCmdStatus_handler(FwIndexType portNum,
     this->m_seqStatusCmdResponse = response;
 }
 
-void CommandDispatcherTester::runNominalDispatch() {
+void CommandDispatcherTester::registerBuiltinCommands() {
     // verify dispatch table is empty
-    for (FwOpcodeType entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_entryTable); entry++) {
-        ASSERT_TRUE(this->m_impl.m_entryTable[entry].used == false);
-    }
-
-    // verify sequence tracker table is empty
-
-    for (U32 entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_sequenceTracker); entry++) {
-        ASSERT_TRUE(this->m_impl.m_sequenceTracker[entry].used == false);
-    }
-    // clear reg events
+    ASSERT_EQ(this->m_impl.m_entryTable.getSize(), 0);
     this->clearEvents();
     // register built-in commands
     this->m_impl.regCommands();
-    // verify registrations
-    ASSERT_TRUE(this->m_impl.m_entryTable[0].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].port, 1);
 
-    ASSERT_TRUE(this->m_impl.m_entryTable[1].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].port, 1);
+    ASSERT_EQ(this->m_impl.m_entryTable.getSize(), 4);
 
-    ASSERT_TRUE(this->m_impl.m_entryTable[2].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].opcode, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].port, 1);
+    FwIndexType port;
+    Fw::Success exists = Fw::Success::FAILURE;
+    exists = this->m_impl.m_entryTable.find(CommandDispatcherImpl::OPCODE_CMD_NO_OP, port);
+    ASSERT_EQ(exists, Fw::Success::SUCCESS);
+    ASSERT_EQ(port, 1);
 
-    ASSERT_TRUE(this->m_impl.m_entryTable[3].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].opcode, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].port, 1);
+    exists = this->m_impl.m_entryTable.find(CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING, port);
+    ASSERT_EQ(exists, Fw::Success::SUCCESS);
+    ASSERT_EQ(port, 1);
+
+    exists = this->m_impl.m_entryTable.find(CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1, port);
+    ASSERT_EQ(exists, Fw::Success::SUCCESS);
+    ASSERT_EQ(port, 1);
+
+    exists = this->m_impl.m_entryTable.find(CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING, port);
+    ASSERT_EQ(exists, Fw::Success::SUCCESS);
+    ASSERT_EQ(port, 1);
 
     // verify event
-    printTextLogHistory(stdout);
     ASSERT_EVENTS_SIZE(4);
     ASSERT_EVENTS_OpCodeRegistered_SIZE(4);
     ASSERT_EVENTS_OpCodeRegistered(0, CommandDispatcherImpl::OPCODE_CMD_NO_OP, 1, 0);
     ASSERT_EVENTS_OpCodeRegistered(1, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING, 1, 1);
     ASSERT_EVENTS_OpCodeRegistered(2, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1, 1, 2);
     ASSERT_EVENTS_OpCodeRegistered(3, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING, 1, 3);
+}
+
+void CommandDispatcherTester::runNominalDispatch() {
+    // verify sequence tracker table is empty
+    for (U32 entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_sequenceTracker); entry++) {
+        ASSERT_TRUE(this->m_impl.m_sequenceTracker[entry].used == false);
+    }
+    this->registerBuiltinCommands();
 
     REQUIREMENT("CD-003");
     // register our own command
@@ -93,9 +95,10 @@ void CommandDispatcherTester::runNominalDispatch() {
 
     this->clearEvents();
     this->invoke_to_compCmdReg(0, 0x50);
-    ASSERT_TRUE(this->m_impl.m_entryTable[4].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].opcode, testOpCode);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].port, 0);
+    ASSERT_EQ(this->m_impl.m_entryTable.getSize(), 5);
+    FwIndexType port;
+    ASSERT_EQ(Fw::Success::SUCCESS, this->m_impl.m_entryTable.find(testOpCode, port));
+    ASSERT_EQ(port, 0);
 
     // verify registration event
     ASSERT_EVENTS_SIZE(1);
@@ -166,46 +169,12 @@ void CommandDispatcherTester::runNominalDispatch() {
 }
 
 void CommandDispatcherTester::runNopCommands() {
-    // verify dispatch table is empty
-    for (FwOpcodeType entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_entryTable); entry++) {
-        ASSERT_TRUE(this->m_impl.m_entryTable[entry].used == false);
-    }
-
     // verify sequence tracker table is empty
 
     for (U32 entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_sequenceTracker); entry++) {
         ASSERT_TRUE(this->m_impl.m_sequenceTracker[entry].used == false);
     }
-
-    // clear reg events
-    this->clearEvents();
-    // register built-in commands
-    this->m_impl.regCommands();
-    // verify registrations
-    ASSERT_TRUE(this->m_impl.m_entryTable[0].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[1].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[2].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].opcode, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[3].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].opcode, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].port, 1);
-
-    // verify event
-
-    ASSERT_EVENTS_SIZE(4);
-    ASSERT_EVENTS_OpCodeRegistered_SIZE(4);
-    ASSERT_EVENTS_OpCodeRegistered(0, CommandDispatcherImpl::OPCODE_CMD_NO_OP, 1, 0);
-    ASSERT_EVENTS_OpCodeRegistered(1, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING, 1, 1);
-    ASSERT_EVENTS_OpCodeRegistered(2, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1, 1, 2);
-    ASSERT_EVENTS_OpCodeRegistered(3, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING, 1, 3);
+    this->registerBuiltinCommands();
 
     // send NO_OP command
     this->m_seqStatusRcvd = false;
@@ -298,17 +267,17 @@ void CommandDispatcherTester::runNopCommands() {
 }
 
 void CommandDispatcherTester::runCommandReregister() {
-    // register built-in commands
-    this->m_impl.regCommands();
+    this->registerBuiltinCommands();
     // clear reg events
     this->clearEvents();
 
     // register our own command
     FwOpcodeType testOpCode = 0x50;
     this->invoke_to_compCmdReg(0, 0x50);
-    ASSERT_TRUE(this->m_impl.m_entryTable[4].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].opcode, testOpCode);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].port, 0);
+    ASSERT_EQ(this->m_impl.m_entryTable.getSize(), 5);
+    FwIndexType port;
+    ASSERT_EQ(Fw::Success::SUCCESS, this->m_impl.m_entryTable.find(testOpCode, port));
+    ASSERT_EQ(port, 0);
 
     // verify registration event
     ASSERT_EVENTS_SIZE(1);
@@ -320,9 +289,9 @@ void CommandDispatcherTester::runCommandReregister() {
 
     // verify we can call cmdReg port again with the same opcode
     this->invoke_to_compCmdReg(0, 0x50);
-    ASSERT_TRUE(this->m_impl.m_entryTable[4].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].opcode, testOpCode);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].port, 0);
+    ASSERT_EQ(this->m_impl.m_entryTable.getSize(), 5);
+    ASSERT_EQ(Fw::Success::SUCCESS, this->m_impl.m_entryTable.find(testOpCode, port));
+    ASSERT_EQ(port, 0);
 
     // verify re-registration event
     ASSERT_EVENTS_SIZE(1);
@@ -331,53 +300,22 @@ void CommandDispatcherTester::runCommandReregister() {
 }
 
 void CommandDispatcherTester::runInvalidOpcodeDispatch() {
-    // verify dispatch table is empty
-    for (FwOpcodeType entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_entryTable); entry++) {
-        ASSERT_TRUE(this->m_impl.m_entryTable[entry].used == false);
-    }
-
     // verify sequence tracker table is empty
 
     for (U32 entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_sequenceTracker); entry++) {
         ASSERT_TRUE(this->m_impl.m_sequenceTracker[entry].used == false);
     }
-    // clear reg events
-    this->clearEvents();
-    // register built-in commands
-    this->m_impl.regCommands();
-    // verify registrations
-    ASSERT_TRUE(this->m_impl.m_entryTable[0].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[1].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[2].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].opcode, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[3].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].opcode, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].port, 1);
-
-    // verify event
-    ASSERT_EVENTS_SIZE(4);
-    ASSERT_EVENTS_OpCodeRegistered_SIZE(4);
-    ASSERT_EVENTS_OpCodeRegistered(0, CommandDispatcherImpl::OPCODE_CMD_NO_OP, 1, 0);
-    ASSERT_EVENTS_OpCodeRegistered(1, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING, 1, 1);
-    ASSERT_EVENTS_OpCodeRegistered(2, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1, 1, 2);
-    ASSERT_EVENTS_OpCodeRegistered(3, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING, 1, 3);
+    this->registerBuiltinCommands();
 
     // register our own command
     FwOpcodeType testOpCode = 0x50;
 
     this->clearEvents();
     this->invoke_to_compCmdReg(0, 0x50);
-    ASSERT_TRUE(this->m_impl.m_entryTable[4].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].opcode, testOpCode);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].port, 0);
+    ASSERT_EQ(this->m_impl.m_entryTable.getSize(), 5);
+    FwIndexType port;
+    ASSERT_EQ(Fw::Success::SUCCESS, this->m_impl.m_entryTable.find(testOpCode, port));
+    ASSERT_EQ(port, 0);
 
     // verify registration event
     ASSERT_EVENTS_SIZE(1);
@@ -412,52 +350,21 @@ void CommandDispatcherTester::runInvalidOpcodeDispatch() {
 }
 
 void CommandDispatcherTester::runFailedCommand() {
-    // verify dispatch table is empty
-    for (FwOpcodeType entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_entryTable); entry++) {
-        ASSERT_TRUE(this->m_impl.m_entryTable[entry].used == false);
-    }
-
     // verify sequence tracker table is empty
-
     for (U32 entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_sequenceTracker); entry++) {
         ASSERT_TRUE(this->m_impl.m_sequenceTracker[entry].used == false);
     }
-    // clear reg events
-    this->clearEvents();
-    // register built-in commands
-    this->m_impl.regCommands();
-    // verify registrations
-    ASSERT_TRUE(this->m_impl.m_entryTable[0].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].port, 1);
 
-    ASSERT_TRUE(this->m_impl.m_entryTable[1].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[2].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].opcode, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[3].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].opcode, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].port, 1);
-
-    // verify event
-    ASSERT_EVENTS_SIZE(4);
-    ASSERT_EVENTS_OpCodeRegistered_SIZE(4);
-    ASSERT_EVENTS_OpCodeRegistered(0, CommandDispatcherImpl::OPCODE_CMD_NO_OP, 1, 0);
-    ASSERT_EVENTS_OpCodeRegistered(1, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING, 1, 1);
-    ASSERT_EVENTS_OpCodeRegistered(2, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1, 1, 2);
-    ASSERT_EVENTS_OpCodeRegistered(3, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING, 1, 3);
+    this->registerBuiltinCommands();
     // register our own command
     FwOpcodeType testOpCode = 0x50;
 
     this->clearEvents();
     this->invoke_to_compCmdReg(0, 0x50);
-    ASSERT_TRUE(this->m_impl.m_entryTable[4].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].opcode, testOpCode);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].port, 0);
+    ASSERT_EQ(this->m_impl.m_entryTable.getSize(), 5);
+    FwIndexType port;
+    ASSERT_EQ(Fw::Success::SUCCESS, this->m_impl.m_entryTable.find(testOpCode, port));
+    ASSERT_EQ(port, 0);
 
     // verify registration event
     ASSERT_EVENTS_SIZE(1);
@@ -631,13 +538,7 @@ void CommandDispatcherTester::runFailedCommand() {
 }
 
 void CommandDispatcherTester::runInvalidCommand() {
-    // verify dispatch table is empty
-    for (FwOpcodeType entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_entryTable); entry++) {
-        ASSERT_TRUE(this->m_impl.m_entryTable[entry].used == false);
-    }
-
     // verify sequence tracker table is empty
-
     for (U32 entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_sequenceTracker); entry++) {
         ASSERT_TRUE(this->m_impl.m_sequenceTracker[entry].used == false);
     }
@@ -666,35 +567,11 @@ void CommandDispatcherTester::runInvalidCommand() {
 }
 
 void CommandDispatcherTester::runOverflowCommands() {
-    // verify dispatch table is empty
-    for (FwOpcodeType entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_entryTable); entry++) {
-        ASSERT_TRUE(this->m_impl.m_entryTable[entry].used == false);
-    }
-
     // verify sequence tracker table is empty
     for (U32 entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_sequenceTracker); entry++) {
         ASSERT_TRUE(this->m_impl.m_sequenceTracker[entry].used == false);
     }
-    // clear reg events
-    this->clearEvents();
-    // register built-in commands
-    this->m_impl.regCommands();
-    // verify registrations
-    ASSERT_TRUE(this->m_impl.m_entryTable[0].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[1].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[2].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].opcode, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[3].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].opcode, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].port, 1);
+    this->registerBuiltinCommands();
 
     // verify event
     ASSERT_EVENTS_SIZE(4);
@@ -709,9 +586,10 @@ void CommandDispatcherTester::runOverflowCommands() {
 
     this->clearEvents();
     this->invoke_to_compCmdReg(0, 0x50);
-    ASSERT_TRUE(this->m_impl.m_entryTable[4].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].opcode, testOpCode);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].port, 0);
+    ASSERT_EQ(this->m_impl.m_entryTable.getSize(), 5);
+    FwIndexType port;
+    ASSERT_EQ(Fw::Success::SUCCESS, this->m_impl.m_entryTable.find(testOpCode, port));
+    ASSERT_EQ(port, 0);
 
     // verify registration event
     ASSERT_EVENTS_SIZE(1);
@@ -762,43 +640,11 @@ void CommandDispatcherTester::runOverflowCommands() {
 }
 
 void CommandDispatcherTester::runClearCommandTracking() {
-    // verify dispatch table is empty
-    for (FwOpcodeType entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_entryTable); entry++) {
-        ASSERT_TRUE(this->m_impl.m_entryTable[entry].used == false);
-    }
-
     // verify sequence tracker table is empty
     for (U32 entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_sequenceTracker); entry++) {
         ASSERT_TRUE(this->m_impl.m_sequenceTracker[entry].used == false);
     }
-    // clear reg events
-    this->clearEvents();
-    // register built-in commands
-    this->m_impl.regCommands();
-    // verify registrations
-    ASSERT_TRUE(this->m_impl.m_entryTable[0].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[1].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[2].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].opcode, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[3].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].opcode, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].port, 1);
-
-    // verify event
-    ASSERT_EVENTS_SIZE(4);
-    ASSERT_EVENTS_OpCodeRegistered_SIZE(4);
-    ASSERT_EVENTS_OpCodeRegistered(0, CommandDispatcherImpl::OPCODE_CMD_NO_OP, 1, 0);
-    ASSERT_EVENTS_OpCodeRegistered(1, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING, 1, 1);
-    ASSERT_EVENTS_OpCodeRegistered(2, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1, 1, 2);
-    ASSERT_EVENTS_OpCodeRegistered(3, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING, 1, 3);
+    this->registerBuiltinCommands();
 
     // register our own command
     FwOpcodeType testOpCode = 0x50;
@@ -806,9 +652,10 @@ void CommandDispatcherTester::runClearCommandTracking() {
 
     this->clearEvents();
     this->invoke_to_compCmdReg(0, testOpCode);
-    ASSERT_TRUE(this->m_impl.m_entryTable[4].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].opcode, testOpCode);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].port, 0);
+    ASSERT_EQ(this->m_impl.m_entryTable.getSize(), 5);
+    FwIndexType port;
+    ASSERT_EQ(Fw::Success::SUCCESS, this->m_impl.m_entryTable.find(testOpCode, port));
+    ASSERT_EQ(port, 0);
 
     // verify registration event
     ASSERT_EVENTS_SIZE(1);
@@ -883,54 +730,21 @@ void CommandDispatcherTester::runClearCommandTracking() {
 void CommandDispatcherTester::runCommandQueueOverflow() {
     U8 testNumCmdsToSend = 19;
 
-    // verify dispatch table is empty
-    for (FwOpcodeType entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_entryTable); entry++) {
-        ASSERT_TRUE(this->m_impl.m_entryTable[entry].used == false);
-    }
-
     // verify sequence tracker table is empty
-
     for (U32 entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_impl.m_sequenceTracker); entry++) {
         ASSERT_TRUE(this->m_impl.m_sequenceTracker[entry].used == false);
     }
-    // clear reg events
-    this->clearEvents();
-    // register built-in commands
-    this->m_impl.regCommands();
-    // verify registrations
-    ASSERT_TRUE(this->m_impl.m_entryTable[0].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP);
-    ASSERT_EQ(this->m_impl.m_entryTable[0].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[1].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].opcode, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING);
-    ASSERT_EQ(this->m_impl.m_entryTable[1].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[2].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].opcode, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1);
-    ASSERT_EQ(this->m_impl.m_entryTable[2].port, 1);
-
-    ASSERT_TRUE(this->m_impl.m_entryTable[3].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].opcode, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING);
-    ASSERT_EQ(this->m_impl.m_entryTable[3].port, 1);
-
-    // verify event
-    printTextLogHistory(stdout);
-    ASSERT_EVENTS_SIZE(4);
-    ASSERT_EVENTS_OpCodeRegistered_SIZE(4);
-    ASSERT_EVENTS_OpCodeRegistered(0, CommandDispatcherImpl::OPCODE_CMD_NO_OP, 1, 0);
-    ASSERT_EVENTS_OpCodeRegistered(1, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING, 1, 1);
-    ASSERT_EVENTS_OpCodeRegistered(2, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1, 1, 2);
-    ASSERT_EVENTS_OpCodeRegistered(3, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING, 1, 3);
+    this->registerBuiltinCommands();
 
     // register our own command
     FwOpcodeType testOpCode = 0x50;
 
     this->clearEvents();
     this->invoke_to_compCmdReg(0, 0x50);
-    ASSERT_TRUE(this->m_impl.m_entryTable[4].used);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].opcode, testOpCode);
-    ASSERT_EQ(this->m_impl.m_entryTable[4].port, 0);
+    ASSERT_EQ(this->m_impl.m_entryTable.getSize(), 5);
+    FwIndexType port;
+    ASSERT_EQ(Fw::Success::SUCCESS, this->m_impl.m_entryTable.find(testOpCode, port));
+    ASSERT_EQ(port, 0);
 
     // verify registration event
     ASSERT_EVENTS_SIZE(1);

--- a/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.hpp
+++ b/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.hpp
@@ -28,6 +28,8 @@ class CommandDispatcherTester : public CommandDispatcherGTestBase {
     void runClearCommandTracking();
     void runCommandQueueOverflow();
 
+    void registerBuiltinCommands();
+
   private:
     Svc::CommandDispatcherImpl& m_impl;
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Replaces the command dispatch table with a r/b map!

## Rationale

Faster, less code.

## Testing/Review Recommendations


## Future Work

Replace the sequence table for outstanding commands.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Co-Pilot + Man for UTs.