### PR TITLE
Fix memory leak in priority queue (#4898)

### DIFF
--- a/Os/Generic/PriorityQueue.cpp
+++ b/Os/Generic/PriorityQueue.cpp
@@ -39,7 +39,9 @@ void PriorityQueueHandle ::load_data(FwSizeType index, U8* destination, FwSizeTy
     (void)::memcpy(destination, this->m_data + offset, static_cast<size_t>(size));
 }
 
-PriorityQueue::~PriorityQueue() {}
+PriorityQueue::~PriorityQueue() {
+    this->teardownInternal();
+}
 
 QueueInterface::Status PriorityQueue::create(FwEnumStoreType id,
                                              const Fw::ConstStringBase& name,


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

teardownInternal() into PriorityQueue::~PriorityQueue() in Os/Generic/PriorityQueue.cpp. The destructor was previously empty despite teardownInternal() already existing with complete and correct deallocation logic.

## Rationale

teardownInternal() correctly deallocates all 4 of these allocations and already null-guards against double-free. However, it was never called from the destructor, meaning any active or queued component that goes out of scope leaks all 4 allocations. This is detectable by LeakSanitizer in unit tests as a consistent 5640 byte leak in 4 allocations originating from QueuedComponentBase::createQueue().

## Testing/Review Recommendations

Run fprime-util check on any active or queued component unit test with AddressSanitizer enabled (default in F Prime UT builds).

## Future Work

None. The fix is self-contained. teardownInternal() was already written correctly — this change only wires it to the destructor.

