### PR TITLE
Remove erroneous include in PassThroughRouterTester

### DIFF
--- a/Svc/PassThroughRouter/test/ut/PassThroughRouterTester.cpp
+++ b/Svc/PassThroughRouter/test/ut/PassThroughRouterTester.cpp
@@ -5,8 +5,6 @@
 // ======================================================================
 
 #include "PassThroughRouterTester.hpp"
-#include "PassThroughRouterGTestBase.hpp"
-#include "Svc/FprimeRouter/FprimeRouterGTestBase.hpp"
 
 namespace Svc {
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

This was causing errors in CI: https://github.com/nasa/fprime/issues/4874#issuecomment-4127694225

Potentially fixes https://github.com/nasa/fprime/issues/4874
