### PR TITLE
Add topology ports to subtopologies

### DIFF
--- a/Ref/Top/topology.fpp
+++ b/Ref/Top/topology.fpp
@@ -164,8 +164,8 @@ module Ref {
       ComCcsds.Subtopology.bufferReturnOut[ComCcsds.Ports_ComBufferQueue.FILE] -> FileHandling.Subtopology.fileDownlinkBufferReturn
 
       # Router <-> FileUplink
-      ComCcsds.Subtopology.fileOut                         -> FileHandling.Subtopology.fileUplinkBufferSendIn
-      FileHandling.Subtopology.fileUplinkBufferSendOut     -> ComCcsds.Subtopology.fileBufferReturnIn
+      ComCcsds.Subtopology.fileUplinkOut                    -> FileHandling.Subtopology.fileUplinkBufferSendIn
+      FileHandling.Subtopology.fileUplinkBufferSendOut     -> ComCcsds.Subtopology.fileUplinkReturnIn
     }
 
     connections FileHandling_DataProducts {

--- a/Ref/Top/topology.fpp
+++ b/Ref/Top/topology.fpp
@@ -83,12 +83,12 @@ module Ref {
       rateGroupDriverComp.CycleOut[Ports_RateGroups.rateGroup1] -> rateGroup1Comp.CycleIn
       rateGroup1Comp.RateGroupMemberOut[0] -> SG1.schedIn
       rateGroup1Comp.RateGroupMemberOut[1] -> SG2.schedIn
-      rateGroup1Comp.RateGroupMemberOut[2] -> CdhCore.tlmSend.Run
-      rateGroup1Comp.RateGroupMemberOut[3] -> FileHandling.fileDownlink.Run
+      rateGroup1Comp.RateGroupMemberOut[2] -> CdhCore.tlmSendRun
+      rateGroup1Comp.RateGroupMemberOut[3] -> FileHandling.fileDownlinkRun
       rateGroup1Comp.RateGroupMemberOut[4] -> systemResources.run
-      rateGroup1Comp.RateGroupMemberOut[5] -> ComCcsds.comQueue.run
-      rateGroup1Comp.RateGroupMemberOut[6] -> CdhCore.cmdDisp.run
-      rateGroup1Comp.RateGroupMemberOut[7] -> ComCcsds.aggregator.timeout
+      rateGroup1Comp.RateGroupMemberOut[5] -> ComCcsds.comQueueRun
+      rateGroup1Comp.RateGroupMemberOut[6] -> CdhCore.cmdDispRun
+      rateGroup1Comp.RateGroupMemberOut[7] -> ComCcsds.aggregatorTimeout
 
       # Rate group 2
       rateGroupDriverComp.CycleOut[Ports_RateGroups.rateGroup2] -> rateGroup2Comp.CycleIn
@@ -98,31 +98,31 @@ module Ref {
       rateGroup2Comp.RateGroupMemberOut[3] -> SG4.schedIn
       rateGroup2Comp.RateGroupMemberOut[4] -> dpDemo.run
       #connection to FileManager listing feature command for sequencing
-      rateGroup2Comp.RateGroupMemberOut[5] -> FileHandling.fileManager.schedIn
+      rateGroup2Comp.RateGroupMemberOut[5] -> FileHandling.fileManagerSchedIn
 
       # Rate group 3
       rateGroupDriverComp.CycleOut[Ports_RateGroups.rateGroup3] -> rateGroup3Comp.CycleIn
-      rateGroup3Comp.RateGroupMemberOut[0] -> CdhCore.$health.Run
+      rateGroup3Comp.RateGroupMemberOut[0] -> CdhCore.healthRun
       rateGroup3Comp.RateGroupMemberOut[1] -> SG5.schedIn
       rateGroup3Comp.RateGroupMemberOut[2] -> blockDrv.Sched
-      rateGroup3Comp.RateGroupMemberOut[3] -> ComCcsds.commsBufferManager.schedIn
-      rateGroup3Comp.RateGroupMemberOut[4] -> DataProducts.dpBufferManager.schedIn
-      rateGroup3Comp.RateGroupMemberOut[5] -> DataProducts.dpWriter.schedIn
-      rateGroup3Comp.RateGroupMemberOut[6] -> DataProducts.dpMgr.schedIn
+      rateGroup3Comp.RateGroupMemberOut[3] -> ComCcsds.bufferManagerSchedIn
+      rateGroup3Comp.RateGroupMemberOut[4] -> DataProducts.dpBufferManagerSchedIn
+      rateGroup3Comp.RateGroupMemberOut[5] -> DataProducts.dpWriterSchedIn
+      rateGroup3Comp.RateGroupMemberOut[6] -> DataProducts.dpMgrSchedIn
     }
 
     connections Communications {
       # ComDriver buffer allocations
-      comDriver.allocate      -> ComCcsds.commsBufferManager.bufferGetCallee
-      comDriver.deallocate    -> ComCcsds.commsBufferManager.bufferSendIn
-      
+      comDriver.allocate   -> ComCcsds.commsBufferGetCallee
+      comDriver.deallocate -> ComCcsds.commsBufferSendIn
+
       # ComDriver <-> ComStub (Uplink)
-      comDriver.$recv                     -> ComCcsds.comStub.drvReceiveIn
-      ComCcsds.comStub.drvReceiveReturnOut -> comDriver.recvReturnIn
-      
+      comDriver.$recv              -> ComCcsds.drvReceiveIn
+      ComCcsds.drvReceiveReturnOut -> comDriver.recvReturnIn
+
       # ComStub <-> ComDriver (Downlink)
-      ComCcsds.comStub.drvSendOut      -> comDriver.$send
-      comDriver.ready         -> ComCcsds.comStub.drvConnected
+      ComCcsds.drvSendOut -> comDriver.$send
+      comDriver.ready     -> ComCcsds.drvConnected
     }
 
     connections Ref {
@@ -131,47 +131,46 @@ module Ref {
 
       ### Moved this out of DataProducts Subtopology --> anything specific to deployment should live in Ref connections
       # Synchronous request. Will have both request kinds for demo purposes, not typical
-      SG1.productGetOut -> DataProducts.dpMgr.productGetIn
+      SG1.productGetOut -> DataProducts.productGetIn
       # Asynchronous request
-      SG1.productRequestOut -> DataProducts.dpMgr.productRequestIn
-      DataProducts.dpMgr.productResponseOut -> SG1.productRecvIn
+      SG1.productRequestOut -> DataProducts.productRequestIn
+      DataProducts.productResponseOut -> SG1.productRecvIn
       # Send filled DP
-      SG1.productSendOut -> DataProducts.dpMgr.productSendIn
+      SG1.productSendOut -> DataProducts.productSendIn
       # Synchronous request
-      dpDemo.productGetOut -> DataProducts.dpMgr.productGetIn
+      dpDemo.productGetOut -> DataProducts.productGetIn
       # Send filled DP
-      dpDemo.productSendOut -> DataProducts.dpMgr.productSendIn
+      dpDemo.productSendOut -> DataProducts.productSendIn
       # Asynchronous request
-      dpDemo.productRequestOut -> DataProducts.dpMgr.productRequestIn
-      DataProducts.dpMgr.productResponseOut -> dpDemo.productRecvIn
+      dpDemo.productRequestOut -> DataProducts.productRequestIn
+      DataProducts.productResponseOut -> dpDemo.productRecvIn
     }
 
-    connections ComCcsds_CdhCore{
-      # events and telemetry to comQueue
-      CdhCore.events.PktSend        -> ComCcsds.comQueue.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.EVENTS]
-      CdhCore.tlmSend.PktSend            -> ComCcsds.comQueue.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.TELEMETRY]
+    connections ComCcsds_CdhCore {
+      # Events and telemetry to comQueue
+      CdhCore.eventsPktSend  -> ComCcsds.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.EVENTS]
+      CdhCore.tlmSendPktSend -> ComCcsds.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.TELEMETRY]
 
       # Router <-> CmdDispatcher
-      ComCcsds.fprimeRouter.commandOut  -> CdhCore.cmdDisp.seqCmdBuff
-      CdhCore.cmdDisp.seqCmdStatus     -> ComCcsds.fprimeRouter.cmdResponseIn
-      cmdSeq.comCmdOut -> CdhCore.cmdDisp.seqCmdBuff
-      CdhCore.cmdDisp.seqCmdStatus -> cmdSeq.cmdResponseIn
+      ComCcsds.commandOut    -> CdhCore.seqCmdBuff
+      CdhCore.seqCmdStatus   -> ComCcsds.cmdResponseIn
+      cmdSeq.comCmdOut       -> CdhCore.seqCmdBuff
+      CdhCore.seqCmdStatus   -> cmdSeq.cmdResponseIn
     }
 
     connections ComCcsds_FileHandling {
       # File Downlink <-> ComQueue
-      FileHandling.fileDownlink.bufferSendOut -> ComCcsds.comQueue.bufferQueueIn[ComCcsds.Ports_ComBufferQueue.FILE]
-      ComCcsds.comQueue.bufferReturnOut[ComCcsds.Ports_ComBufferQueue.FILE] -> FileHandling.fileDownlink.bufferReturn
-      
+      FileHandling.fileDownlinkBufferSendOut -> ComCcsds.bufferQueueIn[ComCcsds.Ports_ComBufferQueue.FILE]
+      ComCcsds.bufferReturnOut[ComCcsds.Ports_ComBufferQueue.FILE] -> FileHandling.fileDownlinkBufferReturn
+
       # Router <-> FileUplink
-      ComCcsds.fprimeRouter.fileOut     -> FileHandling.fileUplink.bufferSendIn
-      FileHandling.fileUplink.bufferSendOut -> ComCcsds.fprimeRouter.fileBufferReturnIn
+      ComCcsds.fileOut                     -> FileHandling.fileUplinkBufferSendIn
+      FileHandling.fileUplinkBufferSendOut -> ComCcsds.fileBufferReturnIn
     }
 
-    connections FileHandling_DataProducts{
-      # Data Products
-      DataProducts.dpCat.fileOut             -> FileHandling.fileDownlink.SendFile
-      FileHandling.fileDownlink.FileComplete -> DataProducts.dpCat.fileDone
+    connections FileHandling_DataProducts {
+      DataProducts.dpCatFileOut              -> FileHandling.fileDownlinkSendFile
+      FileHandling.fileDownlinkFileComplete  -> DataProducts.dpCatFileDone
     }
 
   }

--- a/Ref/Top/topology.fpp
+++ b/Ref/Top/topology.fpp
@@ -14,12 +14,12 @@ module Ref {
 
   topology Ref {
     # ----------------------------------------------------------------------
-    # Subtopology imports
+    # Subtopology instances
     # ----------------------------------------------------------------------
-    import CdhCore.Subtopology
-    import ComCcsds.Subtopology
-    import FileHandling.Subtopology
-    import DataProducts.Subtopology
+    instance CdhCore.Subtopology
+    instance ComCcsds.Subtopology
+    instance FileHandling.Subtopology
+    instance DataProducts.Subtopology
 
     # ----------------------------------------------------------------------
     # Instances used in the topology
@@ -83,12 +83,12 @@ module Ref {
       rateGroupDriverComp.CycleOut[Ports_RateGroups.rateGroup1] -> rateGroup1Comp.CycleIn
       rateGroup1Comp.RateGroupMemberOut[0] -> SG1.schedIn
       rateGroup1Comp.RateGroupMemberOut[1] -> SG2.schedIn
-      rateGroup1Comp.RateGroupMemberOut[2] -> CdhCore.tlmSendRun
-      rateGroup1Comp.RateGroupMemberOut[3] -> FileHandling.fileDownlinkRun
+      rateGroup1Comp.RateGroupMemberOut[2] -> CdhCore.Subtopology.tlmSendRun
+      rateGroup1Comp.RateGroupMemberOut[3] -> FileHandling.Subtopology.fileDownlinkRun
       rateGroup1Comp.RateGroupMemberOut[4] -> systemResources.run
-      rateGroup1Comp.RateGroupMemberOut[5] -> ComCcsds.comQueueRun
-      rateGroup1Comp.RateGroupMemberOut[6] -> CdhCore.cmdDispRun
-      rateGroup1Comp.RateGroupMemberOut[7] -> ComCcsds.aggregatorTimeout
+      rateGroup1Comp.RateGroupMemberOut[5] -> ComCcsds.Subtopology.comQueueRun
+      rateGroup1Comp.RateGroupMemberOut[6] -> CdhCore.Subtopology.cmdDispRun
+      rateGroup1Comp.RateGroupMemberOut[7] -> ComCcsds.Subtopology.aggregatorTimeout
 
       # Rate group 2
       rateGroupDriverComp.CycleOut[Ports_RateGroups.rateGroup2] -> rateGroup2Comp.CycleIn
@@ -98,31 +98,31 @@ module Ref {
       rateGroup2Comp.RateGroupMemberOut[3] -> SG4.schedIn
       rateGroup2Comp.RateGroupMemberOut[4] -> dpDemo.run
       #connection to FileManager listing feature command for sequencing
-      rateGroup2Comp.RateGroupMemberOut[5] -> FileHandling.fileManagerSchedIn
+      rateGroup2Comp.RateGroupMemberOut[5] -> FileHandling.Subtopology.fileManagerSchedIn
 
       # Rate group 3
       rateGroupDriverComp.CycleOut[Ports_RateGroups.rateGroup3] -> rateGroup3Comp.CycleIn
-      rateGroup3Comp.RateGroupMemberOut[0] -> CdhCore.healthRun
+      rateGroup3Comp.RateGroupMemberOut[0] -> CdhCore.Subtopology.healthRun
       rateGroup3Comp.RateGroupMemberOut[1] -> SG5.schedIn
       rateGroup3Comp.RateGroupMemberOut[2] -> blockDrv.Sched
-      rateGroup3Comp.RateGroupMemberOut[3] -> ComCcsds.bufferManagerSchedIn
-      rateGroup3Comp.RateGroupMemberOut[4] -> DataProducts.dpBufferManagerSchedIn
-      rateGroup3Comp.RateGroupMemberOut[5] -> DataProducts.dpWriterSchedIn
-      rateGroup3Comp.RateGroupMemberOut[6] -> DataProducts.dpMgrSchedIn
+      rateGroup3Comp.RateGroupMemberOut[3] -> ComCcsds.Subtopology.bufferManagerSchedIn
+      rateGroup3Comp.RateGroupMemberOut[4] -> DataProducts.Subtopology.dpBufferManagerSchedIn
+      rateGroup3Comp.RateGroupMemberOut[5] -> DataProducts.Subtopology.dpWriterSchedIn
+      rateGroup3Comp.RateGroupMemberOut[6] -> DataProducts.Subtopology.dpMgrSchedIn
     }
 
     connections Communications {
       # ComDriver buffer allocations
-      comDriver.allocate   -> ComCcsds.commsBufferGetCallee
-      comDriver.deallocate -> ComCcsds.commsBufferSendIn
+      comDriver.allocate   -> ComCcsds.Subtopology.commsBufferGetCallee
+      comDriver.deallocate -> ComCcsds.Subtopology.commsBufferSendIn
 
       # ComDriver <-> ComStub (Uplink)
-      comDriver.$recv              -> ComCcsds.drvReceiveIn
-      ComCcsds.drvReceiveReturnOut -> comDriver.recvReturnIn
+      comDriver.$recv                          -> ComCcsds.Subtopology.drvReceiveIn
+      ComCcsds.Subtopology.drvReceiveReturnOut -> comDriver.recvReturnIn
 
       # ComStub <-> ComDriver (Downlink)
-      ComCcsds.drvSendOut -> comDriver.$send
-      comDriver.ready     -> ComCcsds.drvConnected
+      ComCcsds.Subtopology.drvSendOut -> comDriver.$send
+      comDriver.ready                 -> ComCcsds.Subtopology.drvConnected
     }
 
     connections Ref {
@@ -131,46 +131,46 @@ module Ref {
 
       ### Moved this out of DataProducts Subtopology --> anything specific to deployment should live in Ref connections
       # Synchronous request. Will have both request kinds for demo purposes, not typical
-      SG1.productGetOut -> DataProducts.productGetIn
+      SG1.productGetOut -> DataProducts.Subtopology.productGetIn
       # Asynchronous request
-      SG1.productRequestOut -> DataProducts.productRequestIn
-      DataProducts.productResponseOut -> SG1.productRecvIn
+      SG1.productRequestOut -> DataProducts.Subtopology.productRequestIn
+      DataProducts.Subtopology.productResponseOut -> SG1.productRecvIn
       # Send filled DP
-      SG1.productSendOut -> DataProducts.productSendIn
+      SG1.productSendOut -> DataProducts.Subtopology.productSendIn
       # Synchronous request
-      dpDemo.productGetOut -> DataProducts.productGetIn
+      dpDemo.productGetOut -> DataProducts.Subtopology.productGetIn
       # Send filled DP
-      dpDemo.productSendOut -> DataProducts.productSendIn
+      dpDemo.productSendOut -> DataProducts.Subtopology.productSendIn
       # Asynchronous request
-      dpDemo.productRequestOut -> DataProducts.productRequestIn
-      DataProducts.productResponseOut -> dpDemo.productRecvIn
+      dpDemo.productRequestOut -> DataProducts.Subtopology.productRequestIn
+      DataProducts.Subtopology.productResponseOut -> dpDemo.productRecvIn
     }
 
     connections ComCcsds_CdhCore {
       # Events and telemetry to comQueue
-      CdhCore.eventsPktSend  -> ComCcsds.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.EVENTS]
-      CdhCore.tlmSendPktSend -> ComCcsds.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.TELEMETRY]
+      CdhCore.Subtopology.eventsPktSend  -> ComCcsds.Subtopology.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.EVENTS]
+      CdhCore.Subtopology.tlmSendPktSend -> ComCcsds.Subtopology.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.TELEMETRY]
 
       # Router <-> CmdDispatcher
-      ComCcsds.commandOut    -> CdhCore.seqCmdBuff
-      CdhCore.seqCmdStatus   -> ComCcsds.cmdResponseIn
-      cmdSeq.comCmdOut       -> CdhCore.seqCmdBuff
-      CdhCore.seqCmdStatus   -> cmdSeq.cmdResponseIn
+      ComCcsds.Subtopology.commandOut        -> CdhCore.Subtopology.seqCmdBuff
+      CdhCore.Subtopology.seqCmdStatus       -> ComCcsds.Subtopology.cmdResponseIn
+      cmdSeq.comCmdOut                       -> CdhCore.Subtopology.seqCmdBuff
+      CdhCore.Subtopology.seqCmdStatus       -> cmdSeq.cmdResponseIn
     }
 
     connections ComCcsds_FileHandling {
       # File Downlink <-> ComQueue
-      FileHandling.fileDownlinkBufferSendOut -> ComCcsds.bufferQueueIn[ComCcsds.Ports_ComBufferQueue.FILE]
-      ComCcsds.bufferReturnOut[ComCcsds.Ports_ComBufferQueue.FILE] -> FileHandling.fileDownlinkBufferReturn
+      FileHandling.Subtopology.fileDownlinkBufferSendOut -> ComCcsds.Subtopology.bufferQueueIn[ComCcsds.Ports_ComBufferQueue.FILE]
+      ComCcsds.Subtopology.bufferReturnOut[ComCcsds.Ports_ComBufferQueue.FILE] -> FileHandling.Subtopology.fileDownlinkBufferReturn
 
       # Router <-> FileUplink
-      ComCcsds.fileOut                     -> FileHandling.fileUplinkBufferSendIn
-      FileHandling.fileUplinkBufferSendOut -> ComCcsds.fileBufferReturnIn
+      ComCcsds.Subtopology.fileOut                         -> FileHandling.Subtopology.fileUplinkBufferSendIn
+      FileHandling.Subtopology.fileUplinkBufferSendOut     -> ComCcsds.Subtopology.fileBufferReturnIn
     }
 
     connections FileHandling_DataProducts {
-      DataProducts.dpCatFileOut              -> FileHandling.fileDownlinkSendFile
-      FileHandling.fileDownlinkFileComplete  -> DataProducts.dpCatFileDone
+      DataProducts.Subtopology.dpCatFileOut              -> FileHandling.Subtopology.fileDownlinkSendFile
+      FileHandling.Subtopology.fileDownlinkFileComplete  -> DataProducts.Subtopology.dpCatFileDone
     }
 
   }

--- a/Svc/Subtopologies/CdhCore/CdhCore.fpp
+++ b/Svc/Subtopologies/CdhCore/CdhCore.fpp
@@ -71,25 +71,25 @@ module CdhCore {
         # Topology ports
         # ----------------------------------------------------------------------
 
-        @ Incoming command buffers from sequencers or other command buffer sources
+        @ Input port for receiving command buffers from sequencers or other command buffer sources
         port seqCmdBuff   = cmdDisp.seqCmdBuff
 
-        @ Outgoing command status responses from the command dispatcher
+        @ Output port returning command execution status to the command source
         port seqCmdStatus = cmdDisp.seqCmdStatus
 
         @ Output port for sending event packets from the EventManager
         port eventsPktSend  = events.PktSend
 
-        @ Output port for packetized telemetry, ordered by Section/Group
+        @ Output port sending packetized telemetry to the comm stack for downlink
         port tlmSendPktSend = tlmSend.PktSend
 
         @ Input port to trigger a telemetry packet send cycle
         port tlmSendRun = tlmSend.Run
 
-        @ Input run port for scheduling the command dispatcher
+        @ Input port for scheduling the command dispatcher
         port cmdDispRun = cmdDisp.run
 
-        @ Input Run port for scheduling the Health component
+        @ Input port for scheduling the Health component
         port healthRun  = $health.Run
 
     } # end topology

--- a/Svc/Subtopologies/CdhCore/CdhCore.fpp
+++ b/Svc/Subtopologies/CdhCore/CdhCore.fpp
@@ -66,6 +66,17 @@ module CdhCore {
         connections FaultProtection {
             events.FatalAnnounce -> fatalHandler.FatalReceive
         }
-        
+
+        # Topology ports
+        port seqCmdBuff   = cmdDisp.seqCmdBuff
+        port seqCmdStatus = cmdDisp.seqCmdStatus
+
+        port eventsPktSend  = events.PktSend
+        port tlmSendPktSend = tlmSend.PktSend
+
+        port tlmSendRun = tlmSend.Run
+        port cmdDispRun = cmdDisp.run
+        port healthRun  = $health.Run
+
     } # end topology
 } # end CdhCore Subtopology

--- a/Svc/Subtopologies/CdhCore/CdhCore.fpp
+++ b/Svc/Subtopologies/CdhCore/CdhCore.fpp
@@ -67,15 +67,29 @@ module CdhCore {
             events.FatalAnnounce -> fatalHandler.FatalReceive
         }
 
+        # ----------------------------------------------------------------------
         # Topology ports
+        # ----------------------------------------------------------------------
+
+        @ Incoming command buffers from sequencers or other command buffer sources
         port seqCmdBuff   = cmdDisp.seqCmdBuff
+
+        @ Outgoing command status responses from the command dispatcher
         port seqCmdStatus = cmdDisp.seqCmdStatus
 
+        @ Output port for sending event packets from the EventManager
         port eventsPktSend  = events.PktSend
+
+        @ Output port for packetized telemetry, ordered by Section/Group
         port tlmSendPktSend = tlmSend.PktSend
 
+        @ Input port to trigger a telemetry packet send cycle
         port tlmSendRun = tlmSend.Run
+
+        @ Input run port for scheduling the command dispatcher
         port cmdDispRun = cmdDisp.run
+
+        @ Input Run port for scheduling the Health component
         port healthRun  = $health.Run
 
     } # end topology

--- a/Svc/Subtopologies/CdhCore/docs/sdd.md
+++ b/Svc/Subtopologies/CdhCore/docs/sdd.md
@@ -80,8 +80,8 @@ Example of integrating `CdhCore` in a deployment topology:
 
 ```fpp
 topology Flight {
-  import CdhCore.Subtopology
-  import ComCcsds.Subtopology  # Used as an example communication subtopology
+  instance CdhCore.Subtopology
+  instance ComCcsds.Subtopology  # Used as an example communication subtopology
 
   # Use CdhCore handler components
   command connections instance CdhCore.cmdDisp
@@ -92,20 +92,20 @@ topology Flight {
 
   connections RateGroups {
     # Connect rate groups to active components inside CdhCore
-    rg.RateGroupMemberOut[0] -> CdhCore.tlmSendRun
-    rg.RateGroupMemberOut[1] -> CdhCore.healthRun
+    rg.RateGroupMemberOut[0] -> CdhCore.Subtopology.tlmSendRun
+    rg.RateGroupMemberOut[1] -> CdhCore.Subtopology.healthRun
   }
 
   connections ComCcsds_CdhCore{
       # events and telemetry to comQueue
-      CdhCore.eventsPktSend  -> ComCcsds.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.EVENTS]
-      CdhCore.tlmSendPktSend -> ComCcsds.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.TELEMETRY]
+      CdhCore.Subtopology.eventsPktSend  -> ComCcsds.Subtopology.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.EVENTS]
+      CdhCore.Subtopology.tlmSendPktSend -> ComCcsds.Subtopology.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.TELEMETRY]
 
       # Router <-> CmdDispatcher
-      ComCcsds.commandOut    -> CdhCore.seqCmdBuff
-      CdhCore.seqCmdStatus   -> ComCcsds.cmdResponseIn
-      cmdSeq.comCmdOut       -> CdhCore.seqCmdBuff
-      CdhCore.seqCmdStatus   -> cmdSeq.cmdResponseIn
+      ComCcsds.Subtopology.commandOut        -> CdhCore.Subtopology.seqCmdBuff
+      CdhCore.Subtopology.seqCmdStatus       -> ComCcsds.Subtopology.cmdResponseIn
+      cmdSeq.comCmdOut                       -> CdhCore.Subtopology.seqCmdBuff
+      CdhCore.Subtopology.seqCmdStatus       -> cmdSeq.cmdResponseIn
   }
 }
 ```

--- a/Svc/Subtopologies/CdhCore/docs/sdd.md
+++ b/Svc/Subtopologies/CdhCore/docs/sdd.md
@@ -92,20 +92,20 @@ topology Flight {
 
   connections RateGroups {
     # Connect rate groups to active components inside CdhCore
-    rg.RateGroupMemberOut[0] -> CdhCore.tlmSend.Run
-    rg.RateGroupMemberOut[1] -> CdhCore.$health.Run
+    rg.RateGroupMemberOut[0] -> CdhCore.tlmSendRun
+    rg.RateGroupMemberOut[1] -> CdhCore.healthRun
   }
 
   connections ComCcsds_CdhCore{
       # events and telemetry to comQueue
-      CdhCore.events.PktSend        -> ComCcsds.comQueue.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.EVENTS]
-      CdhCore.tlmSend.PktSend       -> ComCcsds.comQueue.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.TELEMETRY]
+      CdhCore.eventsPktSend  -> ComCcsds.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.EVENTS]
+      CdhCore.tlmSendPktSend -> ComCcsds.comPacketQueueIn[ComCcsds.Ports_ComPacketQueue.TELEMETRY]
 
       # Router <-> CmdDispatcher
-      ComCcsds.fprimeRouter.commandOut  -> CdhCore.cmdDisp.seqCmdBuff
-      CdhCore.cmdDisp.seqCmdStatus     -> ComCcsds.fprimeRouter.cmdResponseIn
-      cmdSeq.comCmdOut -> CdhCore.cmdDisp.seqCmdBuff
-      CdhCore.cmdDisp.seqCmdStatus -> cmdSeq.cmdResponseIn
+      ComCcsds.commandOut    -> CdhCore.seqCmdBuff
+      CdhCore.seqCmdStatus   -> ComCcsds.cmdResponseIn
+      cmdSeq.comCmdOut       -> CdhCore.seqCmdBuff
+      CdhCore.seqCmdStatus   -> cmdSeq.cmdResponseIn
   }
 }
 ```

--- a/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
+++ b/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
@@ -200,31 +200,61 @@ module ComCcsds {
             ComCcsds.frameAccumulator.dataReturnOut -> comStub.dataReturnIn
         }
 
+        # ----------------------------------------------------------------------
         # Topology ports
+        # ----------------------------------------------------------------------
+        
         # Command routing
+        @ Output port sending routed command packets to the command dispatcher
         port commandOut         = fprimeRouter.commandOut
+
+        @ Input port receiving command response messages back into the router
         port cmdResponseIn      = fprimeRouter.cmdResponseIn
+
+        @ Output port sending file packets
         port fileOut            = fprimeRouter.fileOut
+
+        @ Input port receiving returned file buffers to FprimeRouter (ownership restored)
         port fileBufferReturnIn = fprimeRouter.fileBufferReturnIn
 
         # Telemetry/events/file queuing (array ports - index at connection site)
+        @ Input port array for queueing Fw::ComBuffers
         port comPacketQueueIn = comQueue.comPacketQueueIn
+
+        @ Input port array for queueing Fw::Buffers
         port bufferQueueIn    = comQueue.bufferQueueIn
+
+        @ Output port array returning ownership of Fw::Buffers to their original sender after dequeuing
         port bufferReturnOut  = comQueue.bufferReturnOut
 
         # ComDriver interface (via ComStub)
+        @ Input port receiving data read from the ByteStream driver 
         port drvReceiveIn        = comStub.drvReceiveIn
+
+        @ Output port returning ownership of the buffer that came in on drvReceiveIn back to the driver
         port drvReceiveReturnOut = comStub.drvReceiveReturnOut
+
+        @ Output port sending framed data to the ByteStream driver for transmission
         port drvSendOut          = comStub.drvSendOut
+
+        @ Input port receiving the ready signal when the ByteStream driver has connected
         port drvConnected        = comStub.drvConnected
 
         # Buffer management for ComDriver
+        @ Input port for requesting (allocating) a new Fw::Buffer from the comms buffer pool
         port commsBufferGetCallee = commsBufferManager.bufferGetCallee
+
+        @ Input port for deallocating Fw::Buffers back into the comms buffer pool
         port commsBufferSendIn    = commsBufferManager.bufferSendIn
 
         # Scheduling
+        @ Input port for scheduling ComQueue telemetry output
         port comQueueRun          = comQueue.run
+
+        @ Rate-group driven timeout to flush the ComAggregator buffer
         port aggregatorTimeout    = aggregator.timeout
+
+        @ Input port triggering commsBufferManager telemetry output
         port bufferManagerSchedIn = commsBufferManager.schedIn
 
     } # end Subtopology

--- a/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
+++ b/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
@@ -203,7 +203,7 @@ module ComCcsds {
         # ----------------------------------------------------------------------
         # Topology ports
         # ----------------------------------------------------------------------
-        
+
         # Command routing
         @ Output port sending routed command packets to the command dispatcher
         port commandOut         = fprimeRouter.commandOut
@@ -211,11 +211,11 @@ module ComCcsds {
         @ Input port receiving command response messages back into the router
         port cmdResponseIn      = fprimeRouter.cmdResponseIn
 
-        @ Output port sending file packets
-        port fileOut            = fprimeRouter.fileOut
+        @ Output port sending uplinked file packets to the file handling stack
+        port fileUplinkOut          = fprimeRouter.fileOut
 
-        @ Input port receiving returned file buffers to FprimeRouter (ownership restored)
-        port fileBufferReturnIn = fprimeRouter.fileBufferReturnIn
+        @ Input port receiving back buffer ownership from the file handling stack
+        port fileUplinkReturnIn = fprimeRouter.fileBufferReturnIn
 
         # Telemetry/events/file queuing (array ports - index at connection site)
         @ Input port array for queueing Fw::ComBuffers

--- a/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
+++ b/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
@@ -199,6 +199,34 @@ module ComCcsds {
             comStub.dataOut -> ComCcsds.frameAccumulator.dataIn
             ComCcsds.frameAccumulator.dataReturnOut -> comStub.dataReturnIn
         }
+
+        # Topology ports
+        # Command routing
+        port commandOut         = fprimeRouter.commandOut
+        port cmdResponseIn      = fprimeRouter.cmdResponseIn
+        port fileOut            = fprimeRouter.fileOut
+        port fileBufferReturnIn = fprimeRouter.fileBufferReturnIn
+
+        # Telemetry/events/file queuing (array ports - index at connection site)
+        port comPacketQueueIn = comQueue.comPacketQueueIn
+        port bufferQueueIn    = comQueue.bufferQueueIn
+        port bufferReturnOut  = comQueue.bufferReturnOut
+
+        # ComDriver interface (via ComStub)
+        port drvReceiveIn        = comStub.drvReceiveIn
+        port drvReceiveReturnOut = comStub.drvReceiveReturnOut
+        port drvSendOut          = comStub.drvSendOut
+        port drvConnected        = comStub.drvConnected
+
+        # Buffer management for ComDriver
+        port commsBufferGetCallee = commsBufferManager.bufferGetCallee
+        port commsBufferSendIn    = commsBufferManager.bufferSendIn
+
+        # Scheduling
+        port comQueueRun          = comQueue.run
+        port aggregatorTimeout    = aggregator.timeout
+        port bufferManagerSchedIn = commsBufferManager.schedIn
+
     } # end Subtopology
 
 } # end ComCcsds

--- a/Svc/Subtopologies/ComCcsds/docs/sdd.md
+++ b/Svc/Subtopologies/ComCcsds/docs/sdd.md
@@ -73,21 +73,21 @@ instance comDriver: <ByteStreamDriverInterface>
 
 # (A1) Schedule ComQueue telemetry downlink (optional)
   connections RateGroups {
-    rg.RateGroupMemberOut[0] -> ComCcsds.comQueue.run
+    rg.RateGroupMemberOut[0] -> ComCcsds.comQueueRun
   }
 
   # (A2) Wire ByteStream driver <-> ComStub supplied by the subtopology
   connections Link {
-    comDriver.$recv                        -> ComCcsds.comStub.drvReceiveIn
-    ComCcsds.comStub.drvReceiveReturnOut   -> comDriver.recvReturnIn
-    ComCcsds.comStub.drvSendOut            -> comDriver.$send
-    comDriver.ready                        -> ComCcsds.comStub.drvConnected
+    comDriver.$recv                        -> ComCcsds.drvReceiveIn
+    ComCcsds.drvReceiveReturnOut           -> comDriver.recvReturnIn
+    ComCcsds.drvSendOut                    -> comDriver.$send
+    comDriver.ready                        -> ComCcsds.drvConnected
   }
 }
 ```
 
 > [!TIP]
-> `ComCcsds.commsBufferManager` can be reused if the `ByteStreamDriver` requires buffer management.
+> `ComCcsds.commsBufferGetCallee` and `ComCcsds.commsBufferSendIn` can be used if the `ByteStreamDriver` requires buffer management.
 
 ### 3.2 Variant B — ComCcsds **without** `Svc::ComStub`
 

--- a/Svc/Subtopologies/ComCcsds/docs/sdd.md
+++ b/Svc/Subtopologies/ComCcsds/docs/sdd.md
@@ -67,27 +67,27 @@ Below are **two usage patterns**, one for each variant. Replace identifiers/port
 
 ```fpp
 topology Flight {
-  import ComCcsds.Subtopology
+  instance ComCcsds.Subtopology
 
 instance comDriver: <ByteStreamDriverInterface>
 
 # (A1) Schedule ComQueue telemetry downlink (optional)
   connections RateGroups {
-    rg.RateGroupMemberOut[0] -> ComCcsds.comQueueRun
+    rg.RateGroupMemberOut[0] -> ComCcsds.Subtopology.comQueueRun
   }
 
   # (A2) Wire ByteStream driver <-> ComStub supplied by the subtopology
   connections Link {
-    comDriver.$recv                        -> ComCcsds.drvReceiveIn
-    ComCcsds.drvReceiveReturnOut           -> comDriver.recvReturnIn
-    ComCcsds.drvSendOut                    -> comDriver.$send
-    comDriver.ready                        -> ComCcsds.drvConnected
+    comDriver.$recv                                -> ComCcsds.Subtopology.drvReceiveIn
+    ComCcsds.Subtopology.drvReceiveReturnOut       -> comDriver.recvReturnIn
+    ComCcsds.Subtopology.drvSendOut                -> comDriver.$send
+    comDriver.ready                                -> ComCcsds.Subtopology.drvConnected
   }
 }
 ```
 
 > [!TIP]
-> `ComCcsds.commsBufferGetCallee` and `ComCcsds.commsBufferSendIn` can be used if the `ByteStreamDriver` requires buffer management.
+> `ComCcsds.commsBufferManager` and `ComCcsds.commsBufferSendIn` can be used if the `ByteStreamDriver` requires buffer management.
 
 ### 3.2 Variant B — ComCcsds **without** `Svc::ComStub`
 

--- a/Svc/Subtopologies/ComFprime/ComFprime.fpp
+++ b/Svc/Subtopologies/ComFprime/ComFprime.fpp
@@ -165,29 +165,55 @@ module ComFprime {
             ComFprime.frameAccumulator.dataReturnOut -> comStub.dataReturnIn
         }
 
+        # ----------------------------------------------------------------------
         # Topology ports
+        # ----------------------------------------------------------------------
+        
         # Command routing
+        @ Output port sending routed command packets to the command dispatcher
         port commandOut         = fprimeRouter.commandOut
+
+        @ Input port receiving command response messages back into the router
         port cmdResponseIn      = fprimeRouter.cmdResponseIn
+
+        @ Output port sending file packets
         port fileOut            = fprimeRouter.fileOut
+
+        @ Input port receiving returned file buffers to FprimeRouter (ownership restored)
         port fileBufferReturnIn = fprimeRouter.fileBufferReturnIn
 
         # Telemetry/events/file queuing (array ports - index at connection site)
+        @ Input port array for queueing Fw::ComBuffers
         port comPacketQueueIn = comQueue.comPacketQueueIn
+
+        @ Input port array for queueing Fw::Buffers
         port bufferQueueIn    = comQueue.bufferQueueIn
+
+        @ Output port array returning ownership of Fw::Buffers to their original sender after dequeuing
         port bufferReturnOut  = comQueue.bufferReturnOut
 
         # ComDriver interface (via ComStub)
+        @ Input port receiving data read from the ByteStream driver 
         port drvReceiveIn        = comStub.drvReceiveIn
+
+        @ Output port returning ownership of the buffer that came in on drvReceiveIn back to the driver
         port drvReceiveReturnOut = comStub.drvReceiveReturnOut
+
+        @ Output port sending framed data to the ByteStream driver for transmission
         port drvSendOut          = comStub.drvSendOut
+
+        @ Input port receiving the ready signal when the ByteStream driver has connected
         port drvConnected        = comStub.drvConnected
 
         # Buffer management for ComDriver
+        @ Input port for requesting (allocating) a new Fw::Buffer from the comms buffer pool
         port commsBufferGetCallee = commsBufferManager.bufferGetCallee
+
+        @ Input port for deallocating Fw::Buffers back into the comms buffer pool
         port commsBufferSendIn    = commsBufferManager.bufferSendIn
 
         # Scheduling
+        @ Input port for scheduling ComQueue telemetry output
         port comQueueRun = comQueue.run
 
     } # end Subtopology

--- a/Svc/Subtopologies/ComFprime/ComFprime.fpp
+++ b/Svc/Subtopologies/ComFprime/ComFprime.fpp
@@ -176,11 +176,11 @@ module ComFprime {
         @ Input port receiving command response messages back into the router
         port cmdResponseIn      = fprimeRouter.cmdResponseIn
 
-        @ Output port sending file packets
-        port fileOut            = fprimeRouter.fileOut
+        @ Output port sending uplinked file packets to the file handling stack
+        port fileUplinkOut          = fprimeRouter.fileOut
 
-        @ Input port receiving returned file buffers to FprimeRouter (ownership restored)
-        port fileBufferReturnIn = fprimeRouter.fileBufferReturnIn
+        @ Input port receiving back buffer ownership from the file handling stack
+        port fileUplinkReturnIn = fprimeRouter.fileBufferReturnIn
 
         # Telemetry/events/file queuing (array ports - index at connection site)
         @ Input port array for queueing Fw::ComBuffers

--- a/Svc/Subtopologies/ComFprime/ComFprime.fpp
+++ b/Svc/Subtopologies/ComFprime/ComFprime.fpp
@@ -164,6 +164,32 @@ module ComFprime {
             comStub.dataOut -> ComFprime.frameAccumulator.dataIn
             ComFprime.frameAccumulator.dataReturnOut -> comStub.dataReturnIn
         }
+
+        # Topology ports
+        # Command routing
+        port commandOut         = fprimeRouter.commandOut
+        port cmdResponseIn      = fprimeRouter.cmdResponseIn
+        port fileOut            = fprimeRouter.fileOut
+        port fileBufferReturnIn = fprimeRouter.fileBufferReturnIn
+
+        # Telemetry/events/file queuing (array ports - index at connection site)
+        port comPacketQueueIn = comQueue.comPacketQueueIn
+        port bufferQueueIn    = comQueue.bufferQueueIn
+        port bufferReturnOut  = comQueue.bufferReturnOut
+
+        # ComDriver interface (via ComStub)
+        port drvReceiveIn        = comStub.drvReceiveIn
+        port drvReceiveReturnOut = comStub.drvReceiveReturnOut
+        port drvSendOut          = comStub.drvSendOut
+        port drvConnected        = comStub.drvConnected
+
+        # Buffer management for ComDriver
+        port commsBufferGetCallee = commsBufferManager.bufferGetCallee
+        port commsBufferSendIn    = commsBufferManager.bufferSendIn
+
+        # Scheduling
+        port comQueueRun = comQueue.run
+
     } # end Subtopology
 
 } # end ComFprime

--- a/Svc/Subtopologies/ComFprime/docs/sdd.md
+++ b/Svc/Subtopologies/ComFprime/docs/sdd.md
@@ -63,27 +63,27 @@ Below are **two usage patterns**, one for each variant. Replace identifiers/port
 
 ```fpp
 topology Flight {
-  import ComFprime.Subtopology
+  instance ComFprime.Subtopology
 
   # (A1) Provide a ByteStreamDriver interface (e.g. Drv.TcpClient)
   instance comDriver: ...
 
   # (A2) Schedule ComQueue
   connections RateGroups {
-    rg.RateGroupMemberOut[0] -> ComFprime.comQueueRun
+    rg.RateGroupMemberOut[0] -> ComFprime.Subtopology.comQueueRun
   }
 
   # (A3) Wire ByteStream driver <-> ComStub supplied by the subtopology
-      comDriver.$recv                     -> ComFprime.drvReceiveIn
-      ComFprime.drvReceiveReturnOut       -> comDriver.recvReturnIn
-      ComFprime.drvSendOut              -> comDriver.$send
-      comDriver.ready                     -> ComFprime.drvConnected
+      comDriver.$recv                            -> ComFprime.Subtopology.drvReceiveIn
+      ComFprime.Subtopology.drvReceiveReturnOut  -> comDriver.recvReturnIn
+      ComFprime.Subtopology.drvSendOut           -> comDriver.$send
+      comDriver.ready                            -> ComFprime.Subtopology.drvConnected
   }
 }
 ```
 
 > [!TIP]
-> `ComFprime.commsBufferGetCallee` and `ComFprime.commsBufferSendIn` can be used if the `ByteStreamDriver` requires buffer management.
+> `ComFprime.Subtopology.commsBufferGetCallee` and `ComFprime.Subtopology.commsBufferSendIn` can be used if the `ByteStreamDriver` requires buffer management.
 
 ### 3.2 Variant B — ComFprime **without** `Svc::ComStub`
 

--- a/Svc/Subtopologies/ComFprime/docs/sdd.md
+++ b/Svc/Subtopologies/ComFprime/docs/sdd.md
@@ -70,20 +70,20 @@ topology Flight {
 
   # (A2) Schedule ComQueue
   connections RateGroups {
-    rg.RateGroupMemberOut[0] -> ComFprime.comQueue.run
+    rg.RateGroupMemberOut[0] -> ComFprime.comQueueRun
   }
 
   # (A3) Wire ByteStream driver <-> ComStub supplied by the subtopology
-      comDriver.$recv                     -> ComFprime.comStub.drvReceiveIn
-      ComFprime.comStub.drvReceiveReturnOut -> comDriver.recvReturnIn
-      ComFprime.comStub.drvSendOut      -> comDriver.$send
-      comDriver.ready         -> ComFprime.comStub.drvConnected
+      comDriver.$recv                     -> ComFprime.drvReceiveIn
+      ComFprime.drvReceiveReturnOut       -> comDriver.recvReturnIn
+      ComFprime.drvSendOut              -> comDriver.$send
+      comDriver.ready                     -> ComFprime.drvConnected
   }
 }
 ```
 
 > [!TIP]
-> `ComFprime.commsBufferManager` can be reused if the `ByteStreamDriver` requires buffer management.
+> `ComFprime.commsBufferGetCallee` and `ComFprime.commsBufferSendIn` can be used if the `ByteStreamDriver` requires buffer management.
 
 ### 3.2 Variant B — ComFprime **without** `Svc::ComStub`
 

--- a/Svc/Subtopologies/ComLoggerTee/subtopology-template.fppi
+++ b/Svc/Subtopologies/ComLoggerTee/subtopology-template.fppi
@@ -12,4 +12,8 @@ topology Subtopology{
     connections ComSplitter{
         comSplitter.comOut -> comLog.comIn
     }
+
+    # Topology ports
+    port comIn = comSplitter.comIn
+
 }

--- a/Svc/Subtopologies/DataProducts/DataProducts.fpp
+++ b/Svc/Subtopologies/DataProducts/DataProducts.fpp
@@ -75,17 +75,35 @@ module DataProducts{
             dpWriter.dpWrittenOut -> dpCat.addToCat
         }
 
+        # ----------------------------------------------------------------------
         # Topology ports
+        # ----------------------------------------------------------------------
+
+        @ Input port array for responding to data product get requests from client components
         port productGetIn       = dpMgr.productGetIn
+
+        @ Input port array for receiving data product buffer requests from client components
         port productRequestIn   = dpMgr.productRequestIn
+
+        @ Input port array for receiving filled data product buffers from client components
         port productSendIn      = dpMgr.productSendIn
+
+        @ Output port array for sending requested data product buffers to client components
         port productResponseOut = dpMgr.productResponseOut
 
+        @ Output port for sending file downlink requests to a file downlink component
         port dpCatFileOut  = dpCat.fileOut
+
+        @ Input port for receiving file downlink completion notifications
         port dpCatFileDone = dpCat.fileDone
 
+        @ Input port for scheduling dpBufferManager telemetry output
         port dpBufferManagerSchedIn = dpBufferManager.schedIn
+
+        @ Input port for scheduling dpWriter telemetry output
         port dpWriterSchedIn        = dpWriter.schedIn
+
+        @ Input port for scheduling dpMgr telemetry output
         port dpMgrSchedIn           = dpMgr.schedIn
 
     } # end topology

--- a/Svc/Subtopologies/DataProducts/DataProducts.fpp
+++ b/Svc/Subtopologies/DataProducts/DataProducts.fpp
@@ -74,5 +74,19 @@ module DataProducts{
 
             dpWriter.dpWrittenOut -> dpCat.addToCat
         }
+
+        # Topology ports
+        port productGetIn       = dpMgr.productGetIn
+        port productRequestIn   = dpMgr.productRequestIn
+        port productSendIn      = dpMgr.productSendIn
+        port productResponseOut = dpMgr.productResponseOut
+
+        port dpCatFileOut  = dpCat.fileOut
+        port dpCatFileDone = dpCat.fileDone
+
+        port dpBufferManagerSchedIn = dpBufferManager.schedIn
+        port dpWriterSchedIn        = dpWriter.schedIn
+        port dpMgrSchedIn           = dpMgr.schedIn
+
     } # end topology
 } # end DataProducts Subtopology

--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -47,9 +47,6 @@ module FileHandling {
         instance fileManager
         instance prmDb
 
-        # Pattern graph specifiers
-        param connections instance prmDb
-
         # Topology ports
         port fileDownlinkBufferSendOut = fileDownlink.bufferSendOut
         port fileDownlinkBufferReturn  = fileDownlink.bufferReturn

--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -47,16 +47,32 @@ module FileHandling {
         instance fileManager
         instance prmDb
 
+        # ----------------------------------------------------------------------
         # Topology ports
+        # ----------------------------------------------------------------------
+
+        @ Output port for sending file buffers to a downlink component
         port fileDownlinkBufferSendOut = fileDownlink.bufferSendOut
+
+        @ Input port for returning ownership of buffers sent on fileDownlinkBufferSendOut
         port fileDownlinkBufferReturn  = fileDownlink.bufferReturn
+
+        @ Mutex-locked input port for requesting a file downlink
         port fileDownlinkSendFile      = fileDownlink.SendFile
+
+        @ Output port for notifying that a file downlink has completed
         port fileDownlinkFileComplete  = fileDownlink.FileComplete
+
+        @ Input port for scheduling fileDownlink
         port fileDownlinkRun           = fileDownlink.Run
 
+        @ Input port for receiving uplinked file packets
         port fileUplinkBufferSendIn  = fileUplink.bufferSendIn
+
+        @ Output port for returning ownership of received uplink buffers
         port fileUplinkBufferSendOut = fileUplink.bufferSendOut
 
+        @ Input port for scheduling fileManager operations
         port fileManagerSchedIn = fileManager.schedIn
 
     } # end topology

--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -47,5 +47,20 @@ module FileHandling {
         instance fileManager
         instance prmDb
 
+        # Pattern graph specifiers
+        param connections instance prmDb
+
+        # Topology ports
+        port fileDownlinkBufferSendOut = fileDownlink.bufferSendOut
+        port fileDownlinkBufferReturn  = fileDownlink.bufferReturn
+        port fileDownlinkSendFile      = fileDownlink.SendFile
+        port fileDownlinkFileComplete  = fileDownlink.FileComplete
+        port fileDownlinkRun           = fileDownlink.Run
+
+        port fileUplinkBufferSendIn  = fileUplink.bufferSendIn
+        port fileUplinkBufferSendOut = fileUplink.bufferSendOut
+
+        port fileManagerSchedIn = fileManager.schedIn
+
     } # end topology
 } # end FileHandling Subtopology

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -44,23 +44,22 @@ Focused on **file transfer and on-board file ops** only. It does **not** provide
 
 ```fpp
 topology Flight {
-  import FileHandling.Subtopology
+  instance FileHandling.Subtopology
 
   param connections instance FileHandling.prmDb
 
-  # Schedule the active/queued file components (example)
-  connections RateGroups {
-    rg.RateGroupMemberOut[0] -> FileHandling.fileDownlinkRun
+  # Schedule the active/queued file components (exampctions RateGroups {
+    rg.RateGroupMemberOut[0] -> FileHandling.Subtopology.fileDownlinkRun
   }
 
   connections ComCcsds_FileHandling {
     # File Downlink <-> ComQueue
-    FileHandling.fileDownlinkBufferSendOut -> ComCcsds.bufferQueueIn[ComCcsds.Ports_ComBufferQueue.FILE]
-    ComCcsds.bufferReturnOut[ComCcsds.Ports_ComBufferQueue.FILE] -> FileHandling.fileDownlinkBufferReturn
+    FileHandling.Subtopology.fileDownlinkBufferSendOut -> ComCcsds.Subtopology.bufferQueueIn[ComCcsds.Ports_ComBufferQueue.FILE]
+    ComCcsds.Subtopology.bufferReturnOut[ComCcsds.Ports_ComBufferQueue.FILE] -> FileHandling.Subtopology.fileDownlinkBufferReturn
     
     # Router <-> FileUplink
-    ComCcsds.fileOut                     -> FileHandling.fileUplinkBufferSendIn
-    FileHandling.fileUplinkBufferSendOut -> ComCcsds.fileBufferReturnIn
+    ComCcsds.Subtopology.fileOut                         -> FileHandling.Subtopology.fileUplinkBufferSendIn
+    FileHandling.Subtopology.fileUplinkBufferSendOut     -> ComCcsds.Subtopology.fileBufferReturnIn
   }
 ```
 

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -50,17 +50,17 @@ topology Flight {
 
   # Schedule the active/queued file components (example)
   connections RateGroups {
-    rg.RateGroupMemberOut[0] -> FileHandling.fileDownlink.Run
+    rg.RateGroupMemberOut[0] -> FileHandling.fileDownlinkRun
   }
 
   connections ComCcsds_FileHandling {
     # File Downlink <-> ComQueue
-    FileHandling.fileDownlink.bufferSendOut -> ComCcsds.comQueue.bufferQueueIn[ComCcsds.Ports_ComBufferQueue.FILE]
-    ComCcsds.comQueue.bufferReturnOut[ComCcsds.Ports_ComBufferQueue.FILE] -> FileHandling.fileDownlink.bufferReturn
+    FileHandling.fileDownlinkBufferSendOut -> ComCcsds.bufferQueueIn[ComCcsds.Ports_ComBufferQueue.FILE]
+    ComCcsds.bufferReturnOut[ComCcsds.Ports_ComBufferQueue.FILE] -> FileHandling.fileDownlinkBufferReturn
     
     # Router <-> FileUplink
-    ComCcsds.fprimeRouter.fileOut     -> FileHandling.fileUplink.bufferSendIn
-    FileHandling.fileUplink.bufferSendOut -> ComCcsds.fprimeRouter.fileBufferReturnIn
+    ComCcsds.fileOut                     -> FileHandling.fileUplinkBufferSendIn
+    FileHandling.fileUplinkBufferSendOut -> ComCcsds.fileBufferReturnIn
   }
 ```
 

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -48,7 +48,8 @@ topology Flight {
 
   param connections instance FileHandling.prmDb
 
-  # Schedule the active/queued file components (exampctions RateGroups {
+  # Schedule the active/queued file components (example)
+  connections RateGroups {
     rg.RateGroupMemberOut[0] -> FileHandling.Subtopology.fileDownlinkRun
   }
 

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -59,8 +59,8 @@ topology Flight {
     ComCcsds.Subtopology.bufferReturnOut[ComCcsds.Ports_ComBufferQueue.FILE] -> FileHandling.Subtopology.fileDownlinkBufferReturn
     
     # Router <-> FileUplink
-    ComCcsds.Subtopology.fileOut                         -> FileHandling.Subtopology.fileUplinkBufferSendIn
-    FileHandling.Subtopology.fileUplinkBufferSendOut     -> ComCcsds.Subtopology.fileBufferReturnIn
+    ComCcsds.Subtopology.fileUplinkOut                    -> FileHandling.Subtopology.fileUplinkBufferSendIn
+    FileHandling.Subtopology.fileUplinkBufferSendOut     -> ComCcsds.Subtopology.fileUplinkReturnIn
   }
 ```
 

--- a/docs/how-to/data-products.md
+++ b/docs/how-to/data-products.md
@@ -230,20 +230,20 @@ For example, in the project topology FPP file:
 
 ```fpp
 topology ... {
-    import FileHandling.Subtopology # For file downlink
-    import DataProducts.Subtopology
+    instance FileHandling.Subtopology # For file downlink
+    instance DataProducts.Subtopology
     instance producer
 
     # Connect producers to DpManager
     connections DataProducers {
-        producer.productGetOut  -> DataProducts.productGetIn
-        producer.productSendOut -> DataProducts.productSendIn
+        producer.productGetOut  -> DataProducts.Subtopology.productGetIn
+        producer.productSendOut -> DataProducts.Subtopology.productSendIn
     }
 
     # For connecting the catalog to the file downlink
     connections FileHandling_DataProducts{
-        DataProducts.dpCatFileOut              -> FileHandling.fileDownlinkSendFile
-        FileHandling.fileDownlinkFileComplete  -> DataProducts.dpCatFileDone
+        DataProducts.Subtopology.dpCatFileOut              -> FileHandling.Subtopology.fileDownlinkSendFile
+        FileHandling.Subtopology.fileDownlinkFileComplete  -> DataProducts.Subtopology.dpCatFileDone
     }
 }
 ```

--- a/docs/how-to/data-products.md
+++ b/docs/how-to/data-products.md
@@ -236,14 +236,14 @@ topology ... {
 
     # Connect producers to DpManager
     connections DataProducers {
-        producer.productGetOut  -> DataProducts.dpMgr.productGetIn
-        producer.productSendOut -> DataProducts.dpMgr.productSendIn
+        producer.productGetOut  -> DataProducts.productGetIn
+        producer.productSendOut -> DataProducts.productSendIn
     }
 
     # For connecting the catalog to the file downlink
     connections FileHandling_DataProducts{
-        DataProducts.dpCat.fileOut             -> FileHandling.fileDownlink.SendFile
-        FileHandling.fileDownlink.FileComplete -> DataProducts.dpCat.fileDone
+        DataProducts.dpCatFileOut              -> FileHandling.fileDownlinkSendFile
+        FileHandling.fileDownlinkFileComplete  -> DataProducts.dpCatFileDone
     }
 }
 ```


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4816 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Add topology ports to all core Svc/Subtopologies, and update the relevant usages to use them instead of directly referencing internal component ports.

## Rationale

Adopts the topology ports feature from #4805 in the core subtopologies, enabling them to be used as black boxes.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

GitHub Copilot CLI