### PR TITLE
FpySequencer send CMD_FAIL directive error code in telemetry when a cmd fails

### DIFF
--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -382,6 +382,8 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
         this->sequencer_sendSignal_stmtResponse_success();
     } else {
         // cmd failed and we want to exit. raise a statement failure
+        this->handleDirectiveErrorCode(static_cast<Fpy::DirectiveId::T>(this->m_runtime.currentStatementOpcode),
+                                       DirectiveError::CMD_FAIL);
         this->log_WARNING_HI_CommandFailed(opCode, this->currentStatementIdx(), this->m_sequenceFilePath, response);
         this->sequencer_sendSignal_stmtResponse_failure();
     }

--- a/Svc/FpySequencer/FpySequencerTypes.fpp
+++ b/Svc/FpySequencer/FpySequencerTypes.fpp
@@ -138,6 +138,7 @@ module Svc {
             ARITHMETIC_UNDERFLOW = 14
             FRAME_START_OUT_OF_BOUNDS = 15
             STACK_UNDERFLOW = 16
+            CMD_FAIL = 17
         }
 
         struct Header {

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -3328,6 +3328,24 @@ TEST_F(FpySequencerTester, flag_EXIT_ON_CMD_FAIL) {
     ASSERT_CMD_RESPONSE(0, 0, get_OPCODE_RUN(), Fw::CmdResponse::OK);
 }
 
+TEST_F(FpySequencerTester, flag_EXIT_ON_CMD_FAIL_setsDirectiveError) {
+    // test that when a cmd fails with EXIT_ON_CMD_FAIL, the directive error fields are updated
+    this->paramSet_FLAG_DEFAULT_EXIT_ON_CMD_FAIL(true, Fw::ParamValid::VALID);
+    this->paramSend_FLAG_DEFAULT_EXIT_ON_CMD_FAIL(0, 0);
+    this->clearHistory();
+    allocMem();
+    add_CONST_CMD(123);
+    writeAndRun();
+    dispatchUntilState(State::RUNNING_AWAITING_STATEMENT_RESPONSE);
+    // send in a failure
+    invoke_to_cmdResponseIn(0, 123, 0x00010001, Fw::CmdResponse::EXECUTION_ERROR);
+    dispatchUntilState(State::IDLE);
+    // verify directive error fields were updated
+    ASSERT_EQ(tester_get_m_tlm_ptr()->lastDirectiveError, DirectiveError::CMD_FAIL);
+    ASSERT_EQ(tester_get_m_tlm_ptr()->directiveErrorIndex, 0);
+    ASSERT_EQ(tester_get_m_tlm_ptr()->directiveErrorId, Fpy::DirectiveId::CONST_CMD);
+}
+
 // ----------------------------------------------------------------------
 // Stack Unit Tests
 // ----------------------------------------------------------------------


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4913  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

* The FpySequencer reports a CMD_FAIL error code in the LastDirectiveError telemetry channel when a command fails now.
 
## Rationale


This guarantees that all cases in which a directive fails and causes the sequence to end early produce an error code. Otherwise, a sequence could end early but say NO_ERROR. This might be confusing.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI wrote the code.
