### PR TITLE
Serial port topology testing

### DIFF
--- a/FppTestProject/FppTest/interfaces/typed_ports.fpp
+++ b/FppTestProject/FppTest/interfaces/typed_ports.fpp
@@ -4,37 +4,37 @@ module FppTest {
         # Typed input ports with no return type
         # ----------------------------------------------------------------------
 
-        sync input port noArgsSync: [2] NoArgs
+        sync input port noArgsSync: [3] NoArgs
 
-        sync input port primitiveArgsSync: [2] PrimitiveArgs
+        sync input port primitiveArgsSync: [3] PrimitiveArgs
 
-        sync input port stringArgsSync: [2] StringArgs
+        sync input port stringArgsSync: [3] StringArgs
 
-        sync input port enumArgsSync: [2] EnumArgs
+        sync input port enumArgsSync: [3] EnumArgs
 
-        sync input port arrayArgsSync: [2] ArrayArgs
+        sync input port arrayArgsSync: [3] ArrayArgs
 
-        sync input port structArgsSync: [2] StructArgs
+        sync input port structArgsSync: [3] StructArgs
 
         # ----------------------------------------------------------------------
         # Typed input ports with return type
         # ----------------------------------------------------------------------
 
-        sync input port noArgsReturnSync: [2] NoArgsReturn
+        sync input port noArgsReturnSync: [3] NoArgsReturn
 
-        sync input port primitiveReturnSync: [2] PrimitiveReturn
+        sync input port primitiveReturnSync: [3] PrimitiveReturn
 
-        sync input port stringReturnSync: [2] StringReturn
+        sync input port stringReturnSync: [3] StringReturn
 
-        sync input port stringAliasReturnSync: [2] StringAliasReturn
+        sync input port stringAliasReturnSync: [3] StringAliasReturn
 
-        sync input port enumReturnSync: [2] EnumReturn
+        sync input port enumReturnSync: [3] EnumReturn
 
-        sync input port arrayReturnSync: [2] ArrayReturn
+        sync input port arrayReturnSync: [3] ArrayReturn
 
-        sync input port arrayStringAliasReturnSync: [2] ArrayStringAliasReturn
+        sync input port arrayStringAliasReturnSync: [3] ArrayStringAliasReturn
 
-        sync input port structReturnSync: [2] StructReturn
+        sync input port structReturnSync: [3] StructReturn
 
     }
 
@@ -44,37 +44,37 @@ module FppTest {
         # Typed input ports with no return type
         # ----------------------------------------------------------------------
 
-        guarded input port noArgsGuarded: [2] NoArgs
+        guarded input port noArgsGuarded: [3] NoArgs
 
-        guarded input port primitiveArgsGuarded: [2] PrimitiveArgs
+        guarded input port primitiveArgsGuarded: [3] PrimitiveArgs
 
-        guarded input port stringArgsGuarded: [2] StringArgs
+        guarded input port stringArgsGuarded: [3] StringArgs
 
-        guarded input port enumArgsGuarded: [2] EnumArgs
+        guarded input port enumArgsGuarded: [3] EnumArgs
 
-        guarded input port arrayArgsGuarded: [2] ArrayArgs
+        guarded input port arrayArgsGuarded: [3] ArrayArgs
 
-        guarded input port structArgsGuarded: [2] StructArgs
+        guarded input port structArgsGuarded: [3] StructArgs
 
         # ----------------------------------------------------------------------
         # Typed input ports with return type
         # ----------------------------------------------------------------------
 
-        guarded input port noArgsReturnGuarded: [2] NoArgsReturn
+        guarded input port noArgsReturnGuarded: [3] NoArgsReturn
 
-        guarded input port primitiveReturnGuarded: [2] PrimitiveReturn
+        guarded input port primitiveReturnGuarded: [3] PrimitiveReturn
 
-        guarded input port stringReturnGuarded: [2] StringReturn
+        guarded input port stringReturnGuarded: [3] StringReturn
 
-        guarded input port stringAliasReturnGuarded: [2] StringAliasReturn
+        guarded input port stringAliasReturnGuarded: [3] StringAliasReturn
 
-        guarded input port enumReturnGuarded: [2] EnumReturn
+        guarded input port enumReturnGuarded: [3] EnumReturn
 
-        guarded input port arrayReturnGuarded: [2] ArrayReturn
+        guarded input port arrayReturnGuarded: [3] ArrayReturn
 
-        guarded input port arrayStringAliasReturnGuarded: [2] ArrayStringAliasReturn
+        guarded input port arrayStringAliasReturnGuarded: [3] ArrayStringAliasReturn
 
-        guarded input port structReturnGuarded: [2] StructReturn
+        guarded input port structReturnGuarded: [3] StructReturn
 
     }
 
@@ -83,37 +83,37 @@ module FppTest {
         # Typed output ports with no return type
         # ----------------------------------------------------------------------
 
-        output port noArgsOut: [2] NoArgs
+        output port noArgsOut: [3] NoArgs
 
-        output port primitiveArgsOut: [2] PrimitiveArgs
+        output port primitiveArgsOut: [3] PrimitiveArgs
 
-        output port stringArgsOut: [2] StringArgs
+        output port stringArgsOut: [3] StringArgs
 
-        output port enumArgsOut: [2] EnumArgs
+        output port enumArgsOut: [3] EnumArgs
 
-        output port arrayArgsOut: [2] ArrayArgs
+        output port arrayArgsOut: [3] ArrayArgs
 
-        output port structArgsOut: [2] StructArgs
+        output port structArgsOut: [3] StructArgs
 
         # ----------------------------------------------------------------------
         # Typed output ports with return type
         # ----------------------------------------------------------------------
 
-        output port noArgsReturnOut: [2] NoArgsReturn
+        output port noArgsReturnOut: [3] NoArgsReturn
 
-        output port primitiveReturnOut: [2] PrimitiveReturn
+        output port primitiveReturnOut: [3] PrimitiveReturn
 
-        output port stringReturnOut: [2] StringReturn
+        output port stringReturnOut: [3] StringReturn
 
-        output port stringAliasReturnOut: [2] StringAliasReturn
+        output port stringAliasReturnOut: [3] StringAliasReturn
 
-        output port enumReturnOut: [2] EnumReturn
+        output port enumReturnOut: [3] EnumReturn
 
-        output port arrayReturnOut: [2] ArrayReturn
+        output port arrayReturnOut: [3] ArrayReturn
 
-        output port arrayStringAliasReturnOut: [2] ArrayStringAliasReturn
+        output port arrayStringAliasReturnOut: [3] ArrayStringAliasReturn
 
-        output port structReturnOut: [2] StructReturn
+        output port structReturnOut: [3] StructReturn
 
     }
 

--- a/FppTestProject/FppTest/interfaces/typed_ports_async.fpp
+++ b/FppTestProject/FppTest/interfaces/typed_ports_async.fpp
@@ -1,18 +1,18 @@
 module FppTest {
     interface TypedPortsAsync {
-        async input port noArgsAsync: [2] NoArgs
+        async input port noArgsAsync: [3] NoArgs
 
-        async input port primitiveArgsAsync: [2] PrimitiveArgs
+        async input port primitiveArgsAsync: [3] PrimitiveArgs
 
-        async input port stringArgsAsync: [2] StringArgs
+        async input port stringArgsAsync: [3] StringArgs
 
-        async input port enumArgsAsync: [2] EnumArgs assert
+        async input port enumArgsAsync: [3] EnumArgs assert
 
-        async input port arrayArgsAsync: [2] ArrayArgs priority 10 block
+        async input port arrayArgsAsync: [3] ArrayArgs priority 10 block
 
-        async input port structArgsAsync: [2] StructArgs priority 5 drop
+        async input port structArgsAsync: [3] StructArgs priority 5 drop
 
-        async input port enumArgsHook: [2] EnumArgs hook
+        async input port enumArgsHook: [3] EnumArgs hook
 
     }
 }

--- a/FppTestProject/FppTest/topology/async/async.fpp
+++ b/FppTestProject/FppTest/topology/async/async.fpp
@@ -10,8 +10,8 @@ module FppTest {
             receiver1.replyOut[SenderId.ASYNC] -> sender1Async.replyIn
             receiver2.replyOut[SenderId.ASYNC] -> sender2Async.replyIn
 
-            receiver1.replyOut[SenderId.SERIAL_ASYNC] -> sender1Async.serialReplyIn
-            receiver2.replyOut[SenderId.SERIAL_ASYNC] -> sender2Async.serialReplyIn
+            receiver1.serialReplyOut[SenderId.ASYNC] -> sender1Async.serialReplyIn
+            receiver2.serialReplyOut[SenderId.ASYNC] -> sender2Async.serialReplyIn
         }
 
         connections AsyncInstance1 {
@@ -55,12 +55,12 @@ module FppTest {
         }
 
         connections AsyncSerialInstance1 {
-            sender1Async.serialOut[TestDeploymentPort.NO_ARGS_ASYNC] -> receiver1.noArgsAsync[SenderId.ASYNC]
-            sender1Async.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_ASYNC] -> receiver1.primitiveArgsAsync[SenderId.ASYNC]
-            sender1Async.serialOut[TestDeploymentPort.STRING_ARGS_ASYNC] -> receiver1.stringArgsAsync[SenderId.ASYNC]
-            sender1Async.serialOut[TestDeploymentPort.ENUM_ARGS_ASYNC] -> receiver1.enumArgsAsync[SenderId.ASYNC]
-            sender1Async.serialOut[TestDeploymentPort.ARRAY_ARGS_ASYNC] -> receiver1.arrayArgsAsync[SenderId.ASYNC]
-            sender1Async.serialOut[TestDeploymentPort.STRUCT_ARGS_ASYNC] -> receiver1.structArgsAsync[SenderId.ASYNC]
+            sender1Async.serialOut[TestDeploymentPort.NO_ARGS_ASYNC] -> receiver1.noArgsAsync[2]
+            sender1Async.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_ASYNC] -> receiver1.primitiveArgsAsync[2]
+            sender1Async.serialOut[TestDeploymentPort.STRING_ARGS_ASYNC] -> receiver1.stringArgsAsync[2]
+            sender1Async.serialOut[TestDeploymentPort.ENUM_ARGS_ASYNC] -> receiver1.enumArgsAsync[2]
+            sender1Async.serialOut[TestDeploymentPort.ARRAY_ARGS_ASYNC] -> receiver1.arrayArgsAsync[2]
+            sender1Async.serialOut[TestDeploymentPort.STRUCT_ARGS_ASYNC] -> receiver1.structArgsAsync[2]
 
             sender1Async.noArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.NO_ARGS_ASYNC]
             sender1Async.primitiveArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_ASYNC]
@@ -71,12 +71,12 @@ module FppTest {
         }
 
         connections AsyncSerialInstance2 {
-            sender2Async.serialOut[TestDeploymentPort.NO_ARGS_ASYNC] -> receiver2.noArgsAsync[SenderId.ASYNC]
-            sender2Async.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_ASYNC] -> receiver2.primitiveArgsAsync[SenderId.ASYNC]
-            sender2Async.serialOut[TestDeploymentPort.STRING_ARGS_ASYNC] -> receiver2.stringArgsAsync[SenderId.ASYNC]
-            sender2Async.serialOut[TestDeploymentPort.ENUM_ARGS_ASYNC] -> receiver2.enumArgsAsync[SenderId.ASYNC]
-            sender2Async.serialOut[TestDeploymentPort.ARRAY_ARGS_ASYNC] -> receiver2.arrayArgsAsync[SenderId.ASYNC]
-            sender2Async.serialOut[TestDeploymentPort.STRUCT_ARGS_ASYNC] -> receiver2.structArgsAsync[SenderId.ASYNC]
+            sender2Async.serialOut[TestDeploymentPort.NO_ARGS_ASYNC] -> receiver2.noArgsAsync[2]
+            sender2Async.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_ASYNC] -> receiver2.primitiveArgsAsync[2]
+            sender2Async.serialOut[TestDeploymentPort.STRING_ARGS_ASYNC] -> receiver2.stringArgsAsync[2]
+            sender2Async.serialOut[TestDeploymentPort.ENUM_ARGS_ASYNC] -> receiver2.enumArgsAsync[2]
+            sender2Async.serialOut[TestDeploymentPort.ARRAY_ARGS_ASYNC] -> receiver2.arrayArgsAsync[2]
+            sender2Async.serialOut[TestDeploymentPort.STRUCT_ARGS_ASYNC] -> receiver2.structArgsAsync[2]
 
             sender2Async.noArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.NO_ARGS_ASYNC]
             sender2Async.primitiveArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_ASYNC]

--- a/FppTestProject/FppTest/topology/async/async.fpp
+++ b/FppTestProject/FppTest/topology/async/async.fpp
@@ -9,6 +9,9 @@ module FppTest {
         connections AsyncReply {
             receiver1.replyOut[SenderId.ASYNC] -> sender1Async.replyIn
             receiver2.replyOut[SenderId.ASYNC] -> sender2Async.replyIn
+
+            receiver1.replyOut[SenderId.SERIAL_ASYNC] -> sender1Async.serialReplyIn
+            receiver2.replyOut[SenderId.SERIAL_ASYNC] -> sender2Async.serialReplyIn
         }
 
         connections AsyncInstance1 {
@@ -49,6 +52,38 @@ module FppTest {
 
             sender2Async.structArgsOut[0] -> receiver2.structArgsAsync[0]
             sender2Async.structArgsOut[1] -> receiver2.structArgsAsync[1]
+        }
+
+        connections AsyncSerialInstance1 {
+            sender1Async.serialOut[TestDeploymentPort.NO_ARGS_ASYNC] -> receiver1.noArgsAsync[SenderId.ASYNC]
+            sender1Async.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_ASYNC] -> receiver1.primitiveArgsAsync[SenderId.ASYNC]
+            sender1Async.serialOut[TestDeploymentPort.STRING_ARGS_ASYNC] -> receiver1.stringArgsAsync[SenderId.ASYNC]
+            sender1Async.serialOut[TestDeploymentPort.ENUM_ARGS_ASYNC] -> receiver1.enumArgsAsync[SenderId.ASYNC]
+            sender1Async.serialOut[TestDeploymentPort.ARRAY_ARGS_ASYNC] -> receiver1.arrayArgsAsync[SenderId.ASYNC]
+            sender1Async.serialOut[TestDeploymentPort.STRUCT_ARGS_ASYNC] -> receiver1.structArgsAsync[SenderId.ASYNC]
+
+            sender1Async.noArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.NO_ARGS_ASYNC]
+            sender1Async.primitiveArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_ASYNC]
+            sender1Async.stringArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.STRING_ARGS_ASYNC]
+            sender1Async.enumArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.ENUM_ARGS_ASYNC]
+            sender1Async.arrayArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.ARRAY_ARGS_ASYNC]
+            sender1Async.structArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.STRUCT_ARGS_ASYNC]
+        }
+
+        connections AsyncSerialInstance2 {
+            sender2Async.serialOut[TestDeploymentPort.NO_ARGS_ASYNC] -> receiver2.noArgsAsync[SenderId.ASYNC]
+            sender2Async.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_ASYNC] -> receiver2.primitiveArgsAsync[SenderId.ASYNC]
+            sender2Async.serialOut[TestDeploymentPort.STRING_ARGS_ASYNC] -> receiver2.stringArgsAsync[SenderId.ASYNC]
+            sender2Async.serialOut[TestDeploymentPort.ENUM_ARGS_ASYNC] -> receiver2.enumArgsAsync[SenderId.ASYNC]
+            sender2Async.serialOut[TestDeploymentPort.ARRAY_ARGS_ASYNC] -> receiver2.arrayArgsAsync[SenderId.ASYNC]
+            sender2Async.serialOut[TestDeploymentPort.STRUCT_ARGS_ASYNC] -> receiver2.structArgsAsync[SenderId.ASYNC]
+
+            sender2Async.noArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.NO_ARGS_ASYNC]
+            sender2Async.primitiveArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_ASYNC]
+            sender2Async.stringArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.STRING_ARGS_ASYNC]
+            sender2Async.enumArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.ENUM_ARGS_ASYNC]
+            sender2Async.arrayArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.ARRAY_ARGS_ASYNC]
+            sender2Async.structArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.STRUCT_ARGS_ASYNC]
         }
     }
 

--- a/FppTestProject/FppTest/topology/components/Receiver/Receiver.cpp
+++ b/FppTestProject/FppTest/topology/components/Receiver/Receiver.cpp
@@ -449,11 +449,11 @@ FormalParamStruct Receiver ::structReturnSync_handler(FwIndexType portNum,
 }
 
 void Receiver ::serialIn_handler(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Determine the appropriate SERIAL_* SenderId from TestDeploymentPort
+    // The port number will map to the typed port ID this serial data represents
     SenderId::T senderId;
     const auto portId = static_cast<TestDeploymentPort::T>(portNum);
 
-    // Map TestDeploymentPort to SERIAL_* SenderId based on the port type suffix
+    // Determine which instance to reply to based on the port they send to
     switch (portId) {
         case TestDeploymentPort::ARRAY_ARGS_ASYNC:
         case TestDeploymentPort::ENUM_ARGS_ASYNC:
@@ -484,6 +484,7 @@ void Receiver ::serialIn_handler(FwIndexType portNum, Fw::LinearBufferBase& buff
             return;
     }
 
+    // Copy the data into out receiver buffer
     m_recv.resetSer();
     if (buffer.getDeserializeSizeLeft() > 0) {
         buffer.copyRaw(m_recv, buffer.getDeserializeSizeLeft());
@@ -492,7 +493,8 @@ void Receiver ::serialIn_handler(FwIndexType portNum, Fw::LinearBufferBase& buff
     Fw::Buffer data(m_data, m_recv.getSize());
 
     // Reply over the serial reply
-    // This will trigger the serialReplyIn on the sender which send a signal out on the serial output to typedPort[2]
+    // This will trigger the serialReplyIn on the sender which send a
+    // signal out on the serial output to typedPort[2]
     serialReplyOut_out(senderId, 2, portId, data);
 }
 

--- a/FppTestProject/FppTest/topology/components/Receiver/Receiver.cpp
+++ b/FppTestProject/FppTest/topology/components/Receiver/Receiver.cpp
@@ -451,7 +451,7 @@ FormalParamStruct Receiver ::structReturnSync_handler(FwIndexType portNum,
 void Receiver ::serialIn_handler(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
     // Determine the appropriate SERIAL_* SenderId from TestDeploymentPort
     SenderId::T senderId;
-    TestDeploymentPort::T portId = static_cast<TestDeploymentPort::T>(portNum);
+    const auto portId = static_cast<TestDeploymentPort::T>(portNum);
 
     // Map TestDeploymentPort to SERIAL_* SenderId based on the port type suffix
     switch (portId) {
@@ -461,7 +461,7 @@ void Receiver ::serialIn_handler(FwIndexType portNum, Fw::LinearBufferBase& buff
         case TestDeploymentPort::PRIMITIVE_ARGS_ASYNC:
         case TestDeploymentPort::STRING_ARGS_ASYNC:
         case TestDeploymentPort::STRUCT_ARGS_ASYNC:
-            senderId = SenderId::SERIAL_ASYNC;
+            senderId = SenderId::ASYNC;
             break;
         case TestDeploymentPort::ARRAY_ARGS_GUARDED:
         case TestDeploymentPort::ENUM_ARGS_GUARDED:
@@ -469,7 +469,7 @@ void Receiver ::serialIn_handler(FwIndexType portNum, Fw::LinearBufferBase& buff
         case TestDeploymentPort::PRIMITIVE_ARGS_GUARDED:
         case TestDeploymentPort::STRING_ARGS_GUARDED:
         case TestDeploymentPort::STRUCT_ARGS_GUARDED:
-            senderId = SenderId::SERIAL_GUARDED;
+            senderId = SenderId::GUARDED;
             break;
         case TestDeploymentPort::ARRAY_ARGS_SYNC:
         case TestDeploymentPort::ENUM_ARGS_SYNC:
@@ -477,18 +477,23 @@ void Receiver ::serialIn_handler(FwIndexType portNum, Fw::LinearBufferBase& buff
         case TestDeploymentPort::PRIMITIVE_ARGS_SYNC:
         case TestDeploymentPort::STRING_ARGS_SYNC:
         case TestDeploymentPort::STRUCT_ARGS_SYNC:
-            senderId = SenderId::SERIAL_SYNC;
+            senderId = SenderId::SYNC;
             break;
         default:
             FW_ASSERT(0, portId);
             return;
     }
 
-    // Create Fw::Buffer from the serialized data
-    Fw::Buffer data(buffer.getBuffAddr(), buffer.getSize());
+    m_recv.resetSer();
+    if (buffer.getDeserializeSizeLeft() > 0) {
+        buffer.copyRaw(m_recv, buffer.getDeserializeSizeLeft());
+    }
 
-    // Reply with the serialized data using the appropriate SERIAL_* SenderId and handlerPortNum=3
-    replyOut_out(senderId, 3, portId, data);
+    Fw::Buffer data(m_data, m_recv.getSize());
+
+    // Reply over the serial reply
+    // This will trigger the serialReplyIn on the sender which send a signal out on the serial output to typedPort[2]
+    serialReplyOut_out(senderId, 2, portId, data);
 }
 
 // ----------------------------------------------------------------------

--- a/FppTestProject/FppTest/topology/components/Receiver/Receiver.cpp
+++ b/FppTestProject/FppTest/topology/components/Receiver/Receiver.cpp
@@ -448,6 +448,49 @@ FormalParamStruct Receiver ::structReturnSync_handler(FwIndexType portNum,
     return s;
 }
 
+void Receiver ::serialIn_handler(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Determine the appropriate SERIAL_* SenderId from TestDeploymentPort
+    SenderId::T senderId;
+    TestDeploymentPort::T portId = static_cast<TestDeploymentPort::T>(portNum);
+
+    // Map TestDeploymentPort to SERIAL_* SenderId based on the port type suffix
+    switch (portId) {
+        case TestDeploymentPort::ARRAY_ARGS_ASYNC:
+        case TestDeploymentPort::ENUM_ARGS_ASYNC:
+        case TestDeploymentPort::NO_ARGS_ASYNC:
+        case TestDeploymentPort::PRIMITIVE_ARGS_ASYNC:
+        case TestDeploymentPort::STRING_ARGS_ASYNC:
+        case TestDeploymentPort::STRUCT_ARGS_ASYNC:
+            senderId = SenderId::SERIAL_ASYNC;
+            break;
+        case TestDeploymentPort::ARRAY_ARGS_GUARDED:
+        case TestDeploymentPort::ENUM_ARGS_GUARDED:
+        case TestDeploymentPort::NO_ARGS_GUARDED:
+        case TestDeploymentPort::PRIMITIVE_ARGS_GUARDED:
+        case TestDeploymentPort::STRING_ARGS_GUARDED:
+        case TestDeploymentPort::STRUCT_ARGS_GUARDED:
+            senderId = SenderId::SERIAL_GUARDED;
+            break;
+        case TestDeploymentPort::ARRAY_ARGS_SYNC:
+        case TestDeploymentPort::ENUM_ARGS_SYNC:
+        case TestDeploymentPort::NO_ARGS_SYNC:
+        case TestDeploymentPort::PRIMITIVE_ARGS_SYNC:
+        case TestDeploymentPort::STRING_ARGS_SYNC:
+        case TestDeploymentPort::STRUCT_ARGS_SYNC:
+            senderId = SenderId::SERIAL_SYNC;
+            break;
+        default:
+            FW_ASSERT(0, portId);
+            return;
+    }
+
+    // Create Fw::Buffer from the serialized data
+    Fw::Buffer data(buffer.getBuffAddr(), buffer.getSize());
+
+    // Reply with the serialized data using the appropriate SERIAL_* SenderId and handlerPortNum=3
+    replyOut_out(senderId, 3, portId, data);
+}
+
 // ----------------------------------------------------------------------
 // Overflow hook implementations for typed input ports
 // ----------------------------------------------------------------------

--- a/FppTestProject/FppTest/topology/components/Receiver/Receiver.fpp
+++ b/FppTestProject/FppTest/topology/components/Receiver/Receiver.fpp
@@ -8,7 +8,8 @@ module FppTest {
 
     output port replyOut: [SenderId.N] Reply
 
-    async input port serialIn : [TestDeploymentPort.N] serial
+    sync input port serialIn : [TestDeploymentPort.N] serial
+    output port serialReplyOut: [SenderId.N] Reply
 
   }
 

--- a/FppTestProject/FppTest/topology/components/Receiver/Receiver.fpp
+++ b/FppTestProject/FppTest/topology/components/Receiver/Receiver.fpp
@@ -8,6 +8,8 @@ module FppTest {
 
     output port replyOut: [SenderId.N] Reply
 
+    async input port serialIn : [TestDeploymentPort.N] serial
+
   }
 
 }

--- a/FppTestProject/FppTest/topology/components/Receiver/Receiver.hpp
+++ b/FppTestProject/FppTest/topology/components/Receiver/Receiver.hpp
@@ -273,6 +273,15 @@ class Receiver final : public ReceiverComponentBase {
                                                FormalParamStruct& sRef      //!< A struct ref
                                                ) override;
 
+    // ----------------------------------------------------------------------
+    // Handlers to implement for serial input ports
+    // ----------------------------------------------------------------------
+
+    //! Handler for input port serialIn
+    void serialIn_handler(FwIndexType portNum,          //!< The port number
+                          Fw::LinearBufferBase& buffer  //!< The serialization buffer
+                          ) override;
+
   private:
     // ----------------------------------------------------------------------
     // Overflow hook implementations for typed input ports

--- a/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
+++ b/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
@@ -251,9 +251,7 @@ void Sender::replyIn_handler(FwIndexType portNum,
 
 void Sender::testSerialToSerial(const TestDeploymentPort& portId) {
     auto args = initTestCase<Types::PrimitiveTypes>(
-        /* We expect this message will eventually reach index 2 Ï(serial) handler */ 2,
-        portId
-    );
+        /* We expect this message will eventually reach index 2 Ï(serial) handler */ 2, portId);
 
     // Send serial data directly through serialOut at SERIAL index
     Fw::ExternalSerializeBuffer buffer(m_expectedData, sizeof(m_expectedData));

--- a/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
+++ b/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
@@ -47,6 +47,8 @@ void Sender::testNoArgs(const TestDeploymentPort& portId) {
         if (i == 2) {
             EXPECT_TRUE(m_serialReplyReceived);
             EXPECT_EQ(m_serialReplyPortId, portId);
+        } else {
+            EXPECT_FALSE(m_serialReplyReceived);
         }
     }
 
@@ -62,6 +64,8 @@ void Sender::testPrimitiveArgs(const TestDeploymentPort& portId) {
         if (i == 2) {
             EXPECT_TRUE(m_serialReplyReceived);
             EXPECT_EQ(m_serialReplyPortId, portId);
+        } else {
+            EXPECT_FALSE(m_serialReplyReceived);
         }
     }
 
@@ -77,6 +81,8 @@ void Sender::testStringArgs(const TestDeploymentPort& portId) {
         if (i == 2) {
             EXPECT_TRUE(m_serialReplyReceived);
             EXPECT_EQ(m_serialReplyPortId, portId);
+        } else {
+            EXPECT_FALSE(m_serialReplyReceived);
         }
     }
 
@@ -92,6 +98,8 @@ void Sender::testEnumArgs(const TestDeploymentPort& portId) {
         if (i == 2) {
             EXPECT_TRUE(m_serialReplyReceived);
             EXPECT_EQ(m_serialReplyPortId, portId);
+        } else {
+            EXPECT_FALSE(m_serialReplyReceived);
         }
     }
 
@@ -107,6 +115,8 @@ void Sender::testArrayArgs(const TestDeploymentPort& portId) {
         if (i == 2) {
             EXPECT_TRUE(m_serialReplyReceived);
             EXPECT_EQ(m_serialReplyPortId, portId);
+        } else {
+            EXPECT_FALSE(m_serialReplyReceived);
         }
     }
 
@@ -122,6 +132,8 @@ void Sender::testStructArgs(const TestDeploymentPort& portId) {
         if (i == 2) {
             EXPECT_TRUE(m_serialReplyReceived);
             EXPECT_EQ(m_serialReplyPortId, portId);
+        } else {
+            EXPECT_FALSE(m_serialReplyReceived);
         }
     }
 

--- a/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
+++ b/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
@@ -237,6 +237,27 @@ void Sender::replyIn_handler(FwIndexType portNum,
     done_internalInterfaceInvoke();
 }
 
+void Sender::testSerialToSerial(const TestDeploymentPort& portId) {
+    auto args = initTestCase<Types::PrimitiveTypes>(
+        /* We expect this message will eventually reach index 2 Ï(serial) handler */ 2,
+        portId
+    );
+
+    // Send serial data directly through serialOut at SERIAL index
+    Fw::ExternalSerializeBuffer buffer(m_expectedData, sizeof(m_expectedData));
+    buffer.moveSerToOffset(m_expected.getSize());
+    auto status = serialOut_out(TestDeploymentPort::SERIAL, buffer);
+    EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
+
+    wait();
+
+    // Verify serial reply was received
+    EXPECT_TRUE(m_serialReplyReceived);
+    EXPECT_EQ(m_serialReplyPortId, portId);
+
+    m_expectedPortNum = -1;
+}
+
 void Sender::serialReplyIn_handler(FwIndexType portNum,
                                    FwIndexType handlerPortNum,
                                    const TestDeploymentPort& portId,

--- a/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
+++ b/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
@@ -241,13 +241,17 @@ void Sender::serialReplyIn_handler(FwIndexType portNum,
                                    FwIndexType handlerPortNum,
                                    const TestDeploymentPort& portId,
                                    const Fw::Buffer& inputData) {
+    FW_ASSERT(inputData.getData() != nullptr);
+
     // Mark that we received a serial reply
     m_serialReplyReceived = true;
     m_serialReplyPortId = portId;
 
     // Relay the serialized data through serialOut at the corresponding TestDeploymentPort index
     Fw::ExternalSerializeBuffer buffer(inputData.getData(), inputData.getSize());
-    serialOut_out(portId, buffer);
+    buffer.moveSerToOffset(inputData.getSize());
+    auto status = serialOut_out(portId, buffer);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 }
 
 void Sender::done_internalInterfaceHandler() {

--- a/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
+++ b/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
@@ -19,7 +19,9 @@ Sender ::Sender(const char* const compName)
       m_expected(m_expectedData, sizeof(m_expectedData)),
       m_expectedData{},
       m_expectedPortNum{-1},
-      m_expectedPortId(TestDeploymentPort::INVALID) {}
+      m_expectedPortId(TestDeploymentPort::INVALID),
+      m_serialReplyReceived(false),
+      m_serialReplyPortId(TestDeploymentPort::INVALID) {}
 
 Sender ::~Sender() = default;
 
@@ -28,66 +30,99 @@ ArgTy Sender::initTestCase(FwIndexType portNum, const TestDeploymentPort& portId
     auto args = ArgTy();
     m_expectedPortNum = portNum;
     m_expectedPortId = portId;
+    m_serialReplyReceived = false;
+    m_serialReplyPortId = TestDeploymentPort::INVALID;
     m_expected.resetSer();
     args.serializeTo(m_expected, Fw::Endianness::BIG);
     return args;
 }
 
 void Sender::testNoArgs(const TestDeploymentPort& portId) {
-    for (FwIndexType i = 0; i < 2; i++) {
+    for (FwIndexType i = 0; i < 3; i++) {
         auto args = initTestCase<Types::Empty>(i, portId);
         noArgsOut_out(m_expectedPortNum);
         wait();
+
+        // Verify serial reply was received for i=2
+        if (i == 2) {
+            EXPECT_TRUE(m_serialReplyReceived);
+            EXPECT_EQ(m_serialReplyPortId, portId);
+        }
     }
 
     m_expectedPortNum = -1;
 }
 
 void Sender::testPrimitiveArgs(const TestDeploymentPort& portId) {
-    for (FwIndexType i = 0; i < 2; i++) {
+    for (FwIndexType i = 0; i < 3; i++) {
         auto args = initTestCase<Types::PrimitiveTypes>(i, portId);
         primitiveArgsOut_out(m_expectedPortNum, args.val1, args.val2, args.val3, args.val4, args.val5, args.val6);
         wait();
+
+        if (i == 2) {
+            EXPECT_TRUE(m_serialReplyReceived);
+            EXPECT_EQ(m_serialReplyPortId, portId);
+        }
     }
 
     m_expectedPortNum = -1;
 }
 
 void Sender::testStringArgs(const TestDeploymentPort& portId) {
-    for (FwIndexType i = 0; i < 2; i++) {
+    for (FwIndexType i = 0; i < 3; i++) {
         auto args = initTestCase<Types::PortStringTypes>(i, portId);
         stringArgsOut_out(m_expectedPortNum, args.val1, args.val2, args.val3, args.val4);
         wait();
+
+        if (i == 2) {
+            EXPECT_TRUE(m_serialReplyReceived);
+            EXPECT_EQ(m_serialReplyPortId, portId);
+        }
     }
 
     m_expectedPortNum = -1;
 }
 
 void Sender::testEnumArgs(const TestDeploymentPort& portId) {
-    for (FwIndexType i = 0; i < 2; i++) {
+    for (FwIndexType i = 0; i < 3; i++) {
         auto args = initTestCase<Types::EnumTypes>(i, portId);
         enumArgsOut_out(m_expectedPortNum, args.val1, args.val2, args.val3, args.val4);
         wait();
+
+        if (i == 2) {
+            EXPECT_TRUE(m_serialReplyReceived);
+            EXPECT_EQ(m_serialReplyPortId, portId);
+        }
     }
 
     m_expectedPortNum = -1;
 }
 
 void Sender::testArrayArgs(const TestDeploymentPort& portId) {
-    for (FwIndexType i = 0; i < 2; i++) {
+    for (FwIndexType i = 0; i < 3; i++) {
         auto args = initTestCase<Types::ArrayTypes>(i, portId);
         arrayArgsOut_out(m_expectedPortNum, args.val1, args.val2, args.val3, args.val4, args.val5, args.val6);
         wait();
+
+        if (i == 2) {
+            EXPECT_TRUE(m_serialReplyReceived);
+            EXPECT_EQ(m_serialReplyPortId, portId);
+        }
     }
 
     m_expectedPortNum = -1;
 }
 
 void Sender::testStructArgs(const TestDeploymentPort& portId) {
-    for (FwIndexType i = 0; i < 2; i++) {
+    for (FwIndexType i = 0; i < 3; i++) {
         auto args = initTestCase<Types::StructTypes>(i, portId);
         structArgsOut_out(m_expectedPortNum, args.val1, args.val2);
         wait();
+
+        if (i == 2) {
+            EXPECT_TRUE(m_serialReplyReceived);
+            EXPECT_EQ(m_serialReplyPortId, portId);
+        }
     }
 
     m_expectedPortNum = -1;
@@ -201,6 +236,20 @@ void Sender::replyIn_handler(FwIndexType portNum,
     replyIn_handlerImpl(portNum, handlerPortNum, portId, inputData);
     done_internalInterfaceInvoke();
 }
+
+void Sender::serialReplyIn_handler(FwIndexType portNum,
+                                   FwIndexType handlerPortNum,
+                                   const TestDeploymentPort& portId,
+                                   const Fw::Buffer& inputData) {
+    // Mark that we received a serial reply
+    m_serialReplyReceived = true;
+    m_serialReplyPortId = portId;
+
+    // Relay the serialized data through serialOut at the corresponding TestDeploymentPort index
+    Fw::ExternalSerializeBuffer buffer(inputData.getData(), inputData.getSize());
+    serialOut_out(portId, buffer);
+}
+
 void Sender::done_internalInterfaceHandler() {
     // This message is just sent to unblock to internal queue to signal the test
     // to continue. This handler should never be called via `doDispatch`

--- a/FppTestProject/FppTest/topology/components/Sender/Sender.fpp
+++ b/FppTestProject/FppTest/topology/components/Sender/Sender.fpp
@@ -6,6 +6,9 @@ module FppTest {
 
     internal port done
     sync input port replyIn: Reply
+    sync input port serialReplyIn: Reply
+
+    output port serialOut : [TestDeploymentPort.N] serial
 
   }
 

--- a/FppTestProject/FppTest/topology/components/Sender/Sender.hpp
+++ b/FppTestProject/FppTest/topology/components/Sender/Sender.hpp
@@ -43,6 +43,7 @@ class Sender final : public SenderComponentBase {
     void testArrayReturn(const TestDeploymentPort& portId);
     void testArrayStringAliasReturn(const TestDeploymentPort& portId);
     void testStructReturn(const TestDeploymentPort& portId);
+    void testSerialToSerial(const TestDeploymentPort& portId);
 
   private:
     void replyIn_handlerImpl(FwIndexType portNum,

--- a/FppTestProject/FppTest/topology/components/Sender/Sender.hpp
+++ b/FppTestProject/FppTest/topology/components/Sender/Sender.hpp
@@ -53,6 +53,10 @@ class Sender final : public SenderComponentBase {
                          FwIndexType handlerPortNum,
                          const FppTest::TestDeploymentPort& portId,
                          const Fw::Buffer& inputData) override;
+    void serialReplyIn_handler(FwIndexType portNum,
+                               FwIndexType handlerPortNum,
+                               const FppTest::TestDeploymentPort& portId,
+                               const Fw::Buffer& inputData) override;
 
     void done_internalInterfaceHandler() override;
     void wait();
@@ -65,6 +69,9 @@ class Sender final : public SenderComponentBase {
 
     FwIndexType m_expectedPortNum;
     TestDeploymentPort m_expectedPortId;
+
+    bool m_serialReplyReceived;
+    TestDeploymentPort m_serialReplyPortId;
 };
 
 }  // namespace FppTest

--- a/FppTestProject/FppTest/topology/guarded/guarded.fpp
+++ b/FppTestProject/FppTest/topology/guarded/guarded.fpp
@@ -10,8 +10,8 @@ module FppTest {
             receiver1.replyOut[SenderId.GUARDED] -> sender1Guarded.replyIn
             receiver2.replyOut[SenderId.GUARDED] -> sender2Guarded.replyIn
 
-            receiver1.replyOut[SenderId.SERIAL_GUARDED] -> sender1Guarded.serialReplyIn
-            receiver2.replyOut[SenderId.SERIAL_GUARDED] -> sender2Guarded.serialReplyIn
+            receiver1.serialReplyOut[SenderId.GUARDED] -> sender1Guarded.serialReplyIn
+            receiver2.serialReplyOut[SenderId.GUARDED] -> sender2Guarded.serialReplyIn
         }
 
         connections GuardedInstance1 {
@@ -103,12 +103,12 @@ module FppTest {
         }
 
         connections GuardedSerialInstance1 {
-            sender1Guarded.serialOut[TestDeploymentPort.NO_ARGS_GUARDED] -> receiver1.noArgsGuarded[SenderId.GUARDED]
-            sender1Guarded.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_GUARDED] -> receiver1.primitiveArgsGuarded[SenderId.GUARDED]
-            sender1Guarded.serialOut[TestDeploymentPort.STRING_ARGS_GUARDED] -> receiver1.stringArgsGuarded[SenderId.GUARDED]
-            sender1Guarded.serialOut[TestDeploymentPort.ENUM_ARGS_GUARDED] -> receiver1.enumArgsGuarded[SenderId.GUARDED]
-            sender1Guarded.serialOut[TestDeploymentPort.ARRAY_ARGS_GUARDED] -> receiver1.arrayArgsGuarded[SenderId.GUARDED]
-            sender1Guarded.serialOut[TestDeploymentPort.STRUCT_ARGS_GUARDED] -> receiver1.structArgsGuarded[SenderId.GUARDED]
+            sender1Guarded.serialOut[TestDeploymentPort.NO_ARGS_GUARDED] -> receiver1.noArgsGuarded[2]
+            sender1Guarded.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_GUARDED] -> receiver1.primitiveArgsGuarded[2]
+            sender1Guarded.serialOut[TestDeploymentPort.STRING_ARGS_GUARDED] -> receiver1.stringArgsGuarded[2]
+            sender1Guarded.serialOut[TestDeploymentPort.ENUM_ARGS_GUARDED] -> receiver1.enumArgsGuarded[2]
+            sender1Guarded.serialOut[TestDeploymentPort.ARRAY_ARGS_GUARDED] -> receiver1.arrayArgsGuarded[2]
+            sender1Guarded.serialOut[TestDeploymentPort.STRUCT_ARGS_GUARDED] -> receiver1.structArgsGuarded[2]
 
             sender1Guarded.noArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.NO_ARGS_GUARDED]
             sender1Guarded.primitiveArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_GUARDED]
@@ -119,12 +119,12 @@ module FppTest {
         }
 
         connections GuardedSerialInstance2 {
-            sender2Guarded.serialOut[TestDeploymentPort.NO_ARGS_GUARDED] -> receiver2.noArgsGuarded[SenderId.GUARDED]
-            sender2Guarded.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_GUARDED] -> receiver2.primitiveArgsGuarded[SenderId.GUARDED]
-            sender2Guarded.serialOut[TestDeploymentPort.STRING_ARGS_GUARDED] -> receiver2.stringArgsGuarded[SenderId.GUARDED]
-            sender2Guarded.serialOut[TestDeploymentPort.ENUM_ARGS_GUARDED] -> receiver2.enumArgsGuarded[SenderId.GUARDED]
-            sender2Guarded.serialOut[TestDeploymentPort.ARRAY_ARGS_GUARDED] -> receiver2.arrayArgsGuarded[SenderId.GUARDED]
-            sender2Guarded.serialOut[TestDeploymentPort.STRUCT_ARGS_GUARDED] -> receiver2.structArgsGuarded[SenderId.GUARDED]
+            sender2Guarded.serialOut[TestDeploymentPort.NO_ARGS_GUARDED] -> receiver2.noArgsGuarded[2]
+            sender2Guarded.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_GUARDED] -> receiver2.primitiveArgsGuarded[2]
+            sender2Guarded.serialOut[TestDeploymentPort.STRING_ARGS_GUARDED] -> receiver2.stringArgsGuarded[2]
+            sender2Guarded.serialOut[TestDeploymentPort.ENUM_ARGS_GUARDED] -> receiver2.enumArgsGuarded[2]
+            sender2Guarded.serialOut[TestDeploymentPort.ARRAY_ARGS_GUARDED] -> receiver2.arrayArgsGuarded[2]
+            sender2Guarded.serialOut[TestDeploymentPort.STRUCT_ARGS_GUARDED] -> receiver2.structArgsGuarded[2]
 
             sender2Guarded.noArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.NO_ARGS_GUARDED]
             sender2Guarded.primitiveArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_GUARDED]

--- a/FppTestProject/FppTest/topology/guarded/guarded.fpp
+++ b/FppTestProject/FppTest/topology/guarded/guarded.fpp
@@ -9,6 +9,9 @@ module FppTest {
         connections GuardedReply {
             receiver1.replyOut[SenderId.GUARDED] -> sender1Guarded.replyIn
             receiver2.replyOut[SenderId.GUARDED] -> sender2Guarded.replyIn
+
+            receiver1.replyOut[SenderId.SERIAL_GUARDED] -> sender1Guarded.serialReplyIn
+            receiver2.replyOut[SenderId.SERIAL_GUARDED] -> sender2Guarded.serialReplyIn
         }
 
         connections GuardedInstance1 {
@@ -97,6 +100,38 @@ module FppTest {
 
             sender2Guarded.structReturnOut[0] -> receiver2.structReturnGuarded[0]
             sender2Guarded.structReturnOut[1] -> receiver2.structReturnGuarded[1]
+        }
+
+        connections GuardedSerialInstance1 {
+            sender1Guarded.serialOut[TestDeploymentPort.NO_ARGS_GUARDED] -> receiver1.noArgsGuarded[SenderId.GUARDED]
+            sender1Guarded.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_GUARDED] -> receiver1.primitiveArgsGuarded[SenderId.GUARDED]
+            sender1Guarded.serialOut[TestDeploymentPort.STRING_ARGS_GUARDED] -> receiver1.stringArgsGuarded[SenderId.GUARDED]
+            sender1Guarded.serialOut[TestDeploymentPort.ENUM_ARGS_GUARDED] -> receiver1.enumArgsGuarded[SenderId.GUARDED]
+            sender1Guarded.serialOut[TestDeploymentPort.ARRAY_ARGS_GUARDED] -> receiver1.arrayArgsGuarded[SenderId.GUARDED]
+            sender1Guarded.serialOut[TestDeploymentPort.STRUCT_ARGS_GUARDED] -> receiver1.structArgsGuarded[SenderId.GUARDED]
+
+            sender1Guarded.noArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.NO_ARGS_GUARDED]
+            sender1Guarded.primitiveArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_GUARDED]
+            sender1Guarded.stringArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.STRING_ARGS_GUARDED]
+            sender1Guarded.enumArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.ENUM_ARGS_GUARDED]
+            sender1Guarded.arrayArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.ARRAY_ARGS_GUARDED]
+            sender1Guarded.structArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.STRUCT_ARGS_GUARDED]
+        }
+
+        connections GuardedSerialInstance2 {
+            sender2Guarded.serialOut[TestDeploymentPort.NO_ARGS_GUARDED] -> receiver2.noArgsGuarded[SenderId.GUARDED]
+            sender2Guarded.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_GUARDED] -> receiver2.primitiveArgsGuarded[SenderId.GUARDED]
+            sender2Guarded.serialOut[TestDeploymentPort.STRING_ARGS_GUARDED] -> receiver2.stringArgsGuarded[SenderId.GUARDED]
+            sender2Guarded.serialOut[TestDeploymentPort.ENUM_ARGS_GUARDED] -> receiver2.enumArgsGuarded[SenderId.GUARDED]
+            sender2Guarded.serialOut[TestDeploymentPort.ARRAY_ARGS_GUARDED] -> receiver2.arrayArgsGuarded[SenderId.GUARDED]
+            sender2Guarded.serialOut[TestDeploymentPort.STRUCT_ARGS_GUARDED] -> receiver2.structArgsGuarded[SenderId.GUARDED]
+
+            sender2Guarded.noArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.NO_ARGS_GUARDED]
+            sender2Guarded.primitiveArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_GUARDED]
+            sender2Guarded.stringArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.STRING_ARGS_GUARDED]
+            sender2Guarded.enumArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.ENUM_ARGS_GUARDED]
+            sender2Guarded.arrayArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.ARRAY_ARGS_GUARDED]
+            sender2Guarded.structArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.STRUCT_ARGS_GUARDED]
         }
     }
 

--- a/FppTestProject/FppTest/topology/main/README.md
+++ b/FppTestProject/FppTest/topology/main/README.md
@@ -15,7 +15,7 @@ while the third is meant for [serial port tests](#serial-port-tests).
 Typed port tests represent the connections between
 typed-port -> typed-port. There are two for each typed port.
 The receiver will implement a handler to serialize the values
-coming in on the port and send out a replyOut back to the sender
+coming in on the port and send out a `replyOut` back to the sender
 which will verify that what the receiver got was the same as
 what the sender sent.
 

--- a/FppTestProject/FppTest/topology/main/README.md
+++ b/FppTestProject/FppTest/topology/main/README.md
@@ -1,0 +1,44 @@
+# FppTest Topology
+
+This test is an integration/system test meant to test fpp
+code-generation for topologies. The basic principle is to use
+two components, Sender and Receiver and to ping-pong messages
+between them and validate.
+
+Both sender and receiver include a set of typed ports with
+most permutations of arguments. All port instance specifiers
+have 3 items. The first two are meant for [typed port tests](#typed-port-tests)
+while the third is meant for [serial port tests](#serial-port-tests).
+
+## Typed Port Tests
+
+Typed port tests represent the connections between
+typed-port -> typed-port. There are two for each typed port.
+The receiver will implement a handler to serialize the values
+coming in on the port and send out a replyOut back to the sender
+which will verify that what the receiver got was the same as
+what the sender sent.
+
+## Serial Port Tests
+
+Because testing serial ports requires testing two permutations of
+all types of serial connections (i.e. serial -> typed and typed -> serial (serial -> serial not handled here)),
+we utilize the existing [typed port tests](#typed-port-tests) to
+implement these tests. Instead of connecting `sender.typedPort[2]` to
+`receiver.typedPort[2]` we instead go through two sets of serial ports:
+
+```fpp
+sender.typedPort[2] -> receiver.serialIn[TYPED_PORT_ID]
+receiver.serialReplyOut -> sender.serialReplyIn
+
+sender.serialOut[TYPED_PORT_ID] -> receiver.typedPort[2]
+receiver.replyOut -> sender.replyIn
+```
+
+The above connections are listed in the order in which the message is passed
+between the components. We end up testing both typed to serial (first connection)
+and serial to typed (third connection).
+
+### Serial to Serial
+
+Serial to serial is a simple special case of serial port tests which is manually implemented.

--- a/FppTestProject/FppTest/topology/main/main.cpp
+++ b/FppTestProject/FppTest/topology/main/main.cpp
@@ -10,55 +10,14 @@
 #include "FppTest/topology/main/FppTestTopologyAc.hpp"
 #include "FppTest/topology/ports/SenderIdEnumAc.hpp"
 #include "FppTestTopologyDefs.hpp"
-#include "Fw/Types/Assert.hpp"
 #include "Os/Os.hpp"
-
-// For stack trace printing
-#if defined(__linux__) || defined(__APPLE__)
-#include <cxxabi.h>
-#include <dlfcn.h>
-#include <execinfo.h>
-#include <unistd.h>
-#include <cstdio>
-#include <cstdlib>
-#endif
 
 namespace FppTest {
 static TopologyState state;
 
-// Custom assertion hook that prints stack trace
-class StackTraceAssertHook : public Fw::AssertHook {
-  public:
-    void reportAssert(FILE_NAME_ARG file,
-                      FwSizeType lineNo,
-                      FwSizeType numArgs,
-                      FwAssertArgType arg1,
-                      FwAssertArgType arg2,
-                      FwAssertArgType arg3,
-                      FwAssertArgType arg4,
-                      FwAssertArgType arg5,
-                      FwAssertArgType arg6) override {
-        // Call base class to print the assertion message
-        Fw::AssertHook::reportAssert(file, lineNo, numArgs, arg1, arg2, arg3, arg4, arg5, arg6);
-
-        // Print stack trace
-        void* callstack[128];
-        int frames = backtrace(callstack, 128);
-        char** strs = backtrace_symbols(callstack, frames);
-        fprintf(stderr, "\nStack trace:\n");
-        for (int i = 0; i < frames; i++) {
-            fprintf(stderr, "  [%d] %s\n", i, strs[i]);
-        }
-        free(strs);
-    }
-};
-
-static StackTraceAssertHook assertHook;
-
 class SenderTester : public testing::Test {
   public:
     static void SetUpTestSuite() {
-        assertHook.registerHook();
         Os::init();
         setup(state);
     }

--- a/FppTestProject/FppTest/topology/main/main.cpp
+++ b/FppTestProject/FppTest/topology/main/main.cpp
@@ -228,6 +228,11 @@ TEST_F(SenderTester, SenderTop) {
     sender2Top.testPrimitiveArgs(TestDeploymentPort::PRIMITIVE_ARGS_SYNC);
 }
 
+TEST_F(SenderTester, SerialToSerial) {
+    sender1Top.testSerialToSerial(TestDeploymentPort::PRIMITIVE_ARGS_SYNC);
+    sender2Top.testSerialToSerial(TestDeploymentPort::PRIMITIVE_ARGS_SYNC);
+}
+
 TEST_F(SenderTester, IsReceiverConnected) {
     ReceiverTester::testIsConnected();
 }

--- a/FppTestProject/FppTest/topology/main/main.cpp
+++ b/FppTestProject/FppTest/topology/main/main.cpp
@@ -10,14 +10,97 @@
 #include "FppTest/topology/main/FppTestTopologyAc.hpp"
 #include "FppTest/topology/ports/SenderIdEnumAc.hpp"
 #include "FppTestTopologyDefs.hpp"
+#include "Fw/Types/Assert.hpp"
 #include "Os/Os.hpp"
+
+// For stack trace printing
+#if defined(__linux__) || defined(__APPLE__)
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#endif
 
 namespace FppTest {
 static TopologyState state;
 
+// Custom assertion hook that prints stack trace
+class StackTraceAssertHook : public Fw::AssertHook {
+  public:
+    void reportAssert(FILE_NAME_ARG file,
+                      FwSizeType lineNo,
+                      FwSizeType numArgs,
+                      FwAssertArgType arg1,
+                      FwAssertArgType arg2,
+                      FwAssertArgType arg3,
+                      FwAssertArgType arg4,
+                      FwAssertArgType arg5,
+                      FwAssertArgType arg6) override {
+        // Call base class to print the assertion message
+        Fw::AssertHook::reportAssert(file, lineNo, numArgs, arg1, arg2, arg3, arg4, arg5, arg6);
+
+        // Print stack trace
+#if defined(__linux__) || defined(__APPLE__)
+        void* callstack[128];
+        int frames = backtrace(callstack, 128);
+        fprintf(stderr, "\nStack trace:\n");
+
+        for (int i = 0; i < frames; i++) {
+            Dl_info info;
+            if (dladdr(callstack[i], &info)) {
+                // Demangle C++ symbol name
+                char* demangled = nullptr;
+                int status = -1;
+                if (info.dli_sname) {
+                    demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
+                }
+
+                // Calculate offset from symbol
+                ptrdiff_t offset = reinterpret_cast<char*>(callstack[i]) - reinterpret_cast<char*>(info.dli_saddr);
+
+                fprintf(stderr, "  [%d] %p %s + %td", i, callstack[i],
+                        (status == 0 && demangled) ? demangled : (info.dli_sname ? info.dli_sname : "???"), offset);
+
+#ifdef __APPLE__
+                // On macOS, use atos to get file:line information
+                char cmd[1024];
+                snprintf(cmd, sizeof(cmd), "atos -o %s -l %p %p 2>/dev/null", info.dli_fname, info.dli_fbase,
+                         callstack[i]);
+                FILE* pipe = popen(cmd, "r");
+                if (pipe) {
+                    char atos_output[512];
+                    if (fgets(atos_output, sizeof(atos_output), pipe)) {
+                        // Remove trailing newline
+                        size_t len = strlen(atos_output);
+                        if (len > 0 && atos_output[len - 1] == '\n') {
+                            atos_output[len - 1] = '\0';
+                        }
+                        fprintf(stderr, " (%s)", atos_output);
+                    }
+                    pclose(pipe);
+                }
+#endif
+                fprintf(stderr, "\n");
+
+                if (demangled) {
+                    free(demangled);
+                }
+            } else {
+                fprintf(stderr, "  [%d] %p ???\n", i, callstack[i]);
+            }
+        }
+#endif
+    }
+};
+
+static StackTraceAssertHook assertHook;
+
 class SenderTester : public testing::Test {
   public:
     static void SetUpTestSuite() {
+        assertHook.registerHook();
         Os::init();
         setup(state);
     }

--- a/FppTestProject/FppTest/topology/main/main.cpp
+++ b/FppTestProject/FppTest/topology/main/main.cpp
@@ -42,56 +42,14 @@ class StackTraceAssertHook : public Fw::AssertHook {
         Fw::AssertHook::reportAssert(file, lineNo, numArgs, arg1, arg2, arg3, arg4, arg5, arg6);
 
         // Print stack trace
-#if defined(__linux__) || defined(__APPLE__)
         void* callstack[128];
         int frames = backtrace(callstack, 128);
+        char** strs = backtrace_symbols(callstack, frames);
         fprintf(stderr, "\nStack trace:\n");
-
         for (int i = 0; i < frames; i++) {
-            Dl_info info;
-            if (dladdr(callstack[i], &info)) {
-                // Demangle C++ symbol name
-                char* demangled = nullptr;
-                int status = -1;
-                if (info.dli_sname) {
-                    demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
-                }
-
-                // Calculate offset from symbol
-                ptrdiff_t offset = reinterpret_cast<char*>(callstack[i]) - reinterpret_cast<char*>(info.dli_saddr);
-
-                fprintf(stderr, "  [%d] %p %s + %td", i, callstack[i],
-                        (status == 0 && demangled) ? demangled : (info.dli_sname ? info.dli_sname : "???"), offset);
-
-#ifdef __APPLE__
-                // On macOS, use atos to get file:line information
-                char cmd[1024];
-                snprintf(cmd, sizeof(cmd), "atos -o %s -l %p %p 2>/dev/null", info.dli_fname, info.dli_fbase,
-                         callstack[i]);
-                FILE* pipe = popen(cmd, "r");
-                if (pipe) {
-                    char atos_output[512];
-                    if (fgets(atos_output, sizeof(atos_output), pipe)) {
-                        // Remove trailing newline
-                        size_t len = strlen(atos_output);
-                        if (len > 0 && atos_output[len - 1] == '\n') {
-                            atos_output[len - 1] = '\0';
-                        }
-                        fprintf(stderr, " (%s)", atos_output);
-                    }
-                    pclose(pipe);
-                }
-#endif
-                fprintf(stderr, "\n");
-
-                if (demangled) {
-                    free(demangled);
-                }
-            } else {
-                fprintf(stderr, "  [%d] %p ???\n", i, callstack[i]);
-            }
+            fprintf(stderr, "  [%d] %s\n", i, strs[i]);
         }
-#endif
+        free(strs);
     }
 };
 

--- a/FppTestProject/FppTest/topology/ports/Ports.fpp
+++ b/FppTestProject/FppTest/topology/ports/Ports.fpp
@@ -6,6 +6,9 @@ module FppTest {
     SYNC,
     GUARDED,
     ASYNC,
+    SERIAL_SYNC,
+    SERIAL_GUARDED,
+    SERIAL_ASYNC,
     N
   }
 
@@ -58,6 +61,8 @@ module FppTest {
     STRUCT_ARGS_SYNC,
     STRUCT_RETURN_GUARDED,
     STRUCT_RETURN_SYNC,
+    SERIAL,
+    N
   }
 
 }

--- a/FppTestProject/FppTest/topology/ports/Ports.fpp
+++ b/FppTestProject/FppTest/topology/ports/Ports.fpp
@@ -6,9 +6,6 @@ module FppTest {
     SYNC,
     GUARDED,
     ASYNC,
-    SERIAL_SYNC,
-    SERIAL_GUARDED,
-    SERIAL_ASYNC,
     N
   }
 

--- a/FppTestProject/FppTest/topology/sync/sync.fpp
+++ b/FppTestProject/FppTest/topology/sync/sync.fpp
@@ -9,6 +9,9 @@ module FppTest {
         connections SyncReply {
             receiver1.replyOut[SenderId.SYNC] -> sender1Sync.replyIn
             receiver2.replyOut[SenderId.SYNC] -> sender2Sync.replyIn
+
+            receiver1.replyOut[SenderId.SERIAL_SYNC] -> sender1Sync.serialReplyIn
+            receiver2.replyOut[SenderId.SERIAL_SYNC] -> sender2Sync.serialReplyIn
         }
 
         connections SyncInstance1 {
@@ -97,6 +100,38 @@ module FppTest {
 
             sender2Sync.structReturnOut[0] -> receiver2.structReturnSync[0]
             sender2Sync.structReturnOut[1] -> receiver2.structReturnSync[1]
+        }
+
+        connections SyncSerialInstance1 {
+            sender1Sync.serialOut[TestDeploymentPort.NO_ARGS_SYNC] -> receiver1.noArgsSync[SenderId.SYNC]
+            sender1Sync.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_SYNC] -> receiver1.primitiveArgsSync[SenderId.SYNC]
+            sender1Sync.serialOut[TestDeploymentPort.STRING_ARGS_SYNC] -> receiver1.stringArgsSync[SenderId.SYNC]
+            sender1Sync.serialOut[TestDeploymentPort.ENUM_ARGS_SYNC] -> receiver1.enumArgsSync[SenderId.SYNC]
+            sender1Sync.serialOut[TestDeploymentPort.ARRAY_ARGS_SYNC] -> receiver1.arrayArgsSync[SenderId.SYNC]
+            sender1Sync.serialOut[TestDeploymentPort.STRUCT_ARGS_SYNC] -> receiver1.structArgsSync[SenderId.SYNC]
+
+            sender1Sync.noArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.NO_ARGS_SYNC]
+            sender1Sync.primitiveArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_SYNC]
+            sender1Sync.stringArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.STRING_ARGS_SYNC]
+            sender1Sync.enumArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.ENUM_ARGS_SYNC]
+            sender1Sync.arrayArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.ARRAY_ARGS_SYNC]
+            sender1Sync.structArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.STRUCT_ARGS_SYNC]
+        }
+
+        connections SyncSerialInstance2 {
+            sender2Sync.serialOut[TestDeploymentPort.NO_ARGS_SYNC] -> receiver2.noArgsSync[SenderId.SYNC]
+            sender2Sync.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_SYNC] -> receiver2.primitiveArgsSync[SenderId.SYNC]
+            sender2Sync.serialOut[TestDeploymentPort.STRING_ARGS_SYNC] -> receiver2.stringArgsSync[SenderId.SYNC]
+            sender2Sync.serialOut[TestDeploymentPort.ENUM_ARGS_SYNC] -> receiver2.enumArgsSync[SenderId.SYNC]
+            sender2Sync.serialOut[TestDeploymentPort.ARRAY_ARGS_SYNC] -> receiver2.arrayArgsSync[SenderId.SYNC]
+            sender2Sync.serialOut[TestDeploymentPort.STRUCT_ARGS_SYNC] -> receiver2.structArgsSync[SenderId.SYNC]
+
+            sender2Sync.noArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.NO_ARGS_SYNC]
+            sender2Sync.primitiveArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_SYNC]
+            sender2Sync.stringArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.STRING_ARGS_SYNC]
+            sender2Sync.enumArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.ENUM_ARGS_SYNC]
+            sender2Sync.arrayArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.ARRAY_ARGS_SYNC]
+            sender2Sync.structArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.STRUCT_ARGS_SYNC]
         }
     }
 

--- a/FppTestProject/FppTest/topology/sync/sync.fpp
+++ b/FppTestProject/FppTest/topology/sync/sync.fpp
@@ -10,8 +10,8 @@ module FppTest {
             receiver1.replyOut[SenderId.SYNC] -> sender1Sync.replyIn
             receiver2.replyOut[SenderId.SYNC] -> sender2Sync.replyIn
 
-            receiver1.replyOut[SenderId.SERIAL_SYNC] -> sender1Sync.serialReplyIn
-            receiver2.replyOut[SenderId.SERIAL_SYNC] -> sender2Sync.serialReplyIn
+            receiver1.serialReplyOut[SenderId.SYNC] -> sender1Sync.serialReplyIn
+            receiver2.serialReplyOut[SenderId.SYNC] -> sender2Sync.serialReplyIn
         }
 
         connections SyncInstance1 {
@@ -103,12 +103,12 @@ module FppTest {
         }
 
         connections SyncSerialInstance1 {
-            sender1Sync.serialOut[TestDeploymentPort.NO_ARGS_SYNC] -> receiver1.noArgsSync[SenderId.SYNC]
-            sender1Sync.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_SYNC] -> receiver1.primitiveArgsSync[SenderId.SYNC]
-            sender1Sync.serialOut[TestDeploymentPort.STRING_ARGS_SYNC] -> receiver1.stringArgsSync[SenderId.SYNC]
-            sender1Sync.serialOut[TestDeploymentPort.ENUM_ARGS_SYNC] -> receiver1.enumArgsSync[SenderId.SYNC]
-            sender1Sync.serialOut[TestDeploymentPort.ARRAY_ARGS_SYNC] -> receiver1.arrayArgsSync[SenderId.SYNC]
-            sender1Sync.serialOut[TestDeploymentPort.STRUCT_ARGS_SYNC] -> receiver1.structArgsSync[SenderId.SYNC]
+            sender1Sync.serialOut[TestDeploymentPort.NO_ARGS_SYNC] -> receiver1.noArgsSync[2]
+            sender1Sync.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_SYNC] -> receiver1.primitiveArgsSync[2]
+            sender1Sync.serialOut[TestDeploymentPort.STRING_ARGS_SYNC] -> receiver1.stringArgsSync[2]
+            sender1Sync.serialOut[TestDeploymentPort.ENUM_ARGS_SYNC] -> receiver1.enumArgsSync[2]
+            sender1Sync.serialOut[TestDeploymentPort.ARRAY_ARGS_SYNC] -> receiver1.arrayArgsSync[2]
+            sender1Sync.serialOut[TestDeploymentPort.STRUCT_ARGS_SYNC] -> receiver1.structArgsSync[2]
 
             sender1Sync.noArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.NO_ARGS_SYNC]
             sender1Sync.primitiveArgsOut[2] -> receiver1.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_SYNC]
@@ -119,12 +119,12 @@ module FppTest {
         }
 
         connections SyncSerialInstance2 {
-            sender2Sync.serialOut[TestDeploymentPort.NO_ARGS_SYNC] -> receiver2.noArgsSync[SenderId.SYNC]
-            sender2Sync.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_SYNC] -> receiver2.primitiveArgsSync[SenderId.SYNC]
-            sender2Sync.serialOut[TestDeploymentPort.STRING_ARGS_SYNC] -> receiver2.stringArgsSync[SenderId.SYNC]
-            sender2Sync.serialOut[TestDeploymentPort.ENUM_ARGS_SYNC] -> receiver2.enumArgsSync[SenderId.SYNC]
-            sender2Sync.serialOut[TestDeploymentPort.ARRAY_ARGS_SYNC] -> receiver2.arrayArgsSync[SenderId.SYNC]
-            sender2Sync.serialOut[TestDeploymentPort.STRUCT_ARGS_SYNC] -> receiver2.structArgsSync[SenderId.SYNC]
+            sender2Sync.serialOut[TestDeploymentPort.NO_ARGS_SYNC] -> receiver2.noArgsSync[2]
+            sender2Sync.serialOut[TestDeploymentPort.PRIMITIVE_ARGS_SYNC] -> receiver2.primitiveArgsSync[2]
+            sender2Sync.serialOut[TestDeploymentPort.STRING_ARGS_SYNC] -> receiver2.stringArgsSync[2]
+            sender2Sync.serialOut[TestDeploymentPort.ENUM_ARGS_SYNC] -> receiver2.enumArgsSync[2]
+            sender2Sync.serialOut[TestDeploymentPort.ARRAY_ARGS_SYNC] -> receiver2.arrayArgsSync[2]
+            sender2Sync.serialOut[TestDeploymentPort.STRUCT_ARGS_SYNC] -> receiver2.structArgsSync[2]
 
             sender2Sync.noArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.NO_ARGS_SYNC]
             sender2Sync.primitiveArgsOut[2] -> receiver2.serialIn[TestDeploymentPort.PRIMITIVE_ARGS_SYNC]

--- a/FppTestProject/FppTest/topology/top_ports/Topology.fpp
+++ b/FppTestProject/FppTest/topology/top_ports/Topology.fpp
@@ -72,6 +72,11 @@ module FppTest {
         SenderTop.serialOut1[TestDeploymentPort.PRIMITIVE_ARGS_SYNC] -> ReceiverTop.primitiveArgsSync1[2]
         SenderTop.serialOut2[TestDeploymentPort.PRIMITIVE_ARGS_SYNC] -> ReceiverTop.primitiveArgsSync2[2]
     }
+
+    connections SerialToSerialTest {
+      SenderTop.serialOut1[TestDeploymentPort.SERIAL] -> ReceiverTop.serialIn1[TestDeploymentPort.PRIMITIVE_ARGS_SYNC]
+      SenderTop.serialOut2[TestDeploymentPort.SERIAL] -> ReceiverTop.serialIn2[TestDeploymentPort.PRIMITIVE_ARGS_SYNC]
+    }
   }
 
 }

--- a/FppTestProject/FppTest/topology/top_ports/Topology.fpp
+++ b/FppTestProject/FppTest/topology/top_ports/Topology.fpp
@@ -22,6 +22,15 @@ module FppTest {
 
     port replyIn1 = sender1Top.replyIn
     port replyIn2 = sender2Top.replyIn
+
+    port serialReplyIn1 = sender1Top.serialReplyIn
+    port serialReplyIn2 = sender2Top.serialReplyIn
+
+    port serialReplyOut1 = sender1Top.serialReplyIn
+    port serialReplyOut2 = sender2Top.serialReplyIn
+
+    port serialOut1 = sender1Top.serialOut
+    port serialOut2 = sender2Top.serialOut
   }
 
   topology ReceiverTop {
@@ -33,6 +42,12 @@ module FppTest {
 
     port replyOut1 = receiver1Top.replyOut
     port replyOut2 = receiver2Top.replyOut
+
+    port serialIn1 = receiver1Top.serialIn
+    port serialIn2 = receiver2Top.serialIn
+
+    port serialReplyOut1 = receiver1Top.serialReplyOut
+    port serialReplyOut2 = receiver2Top.serialReplyOut
   }
 
   topology TopPorts {
@@ -42,12 +57,20 @@ module FppTest {
     connections Top2Top {
         SenderTop.primitiveArgsOut1[0] -> ReceiverTop.primitiveArgsSync1[0]
         SenderTop.primitiveArgsOut1[1] -> ReceiverTop.primitiveArgsSync1[1]
+        SenderTop.primitiveArgsOut1[2] -> ReceiverTop.serialIn1[TestDeploymentPort.PRIMITIVE_ARGS_SYNC]
 
         SenderTop.primitiveArgsOut2[0] -> ReceiverTop.primitiveArgsSync2[0]
         SenderTop.primitiveArgsOut2[1] -> ReceiverTop.primitiveArgsSync2[1]
+        SenderTop.primitiveArgsOut2[2] -> ReceiverTop.serialIn2[TestDeploymentPort.PRIMITIVE_ARGS_SYNC]
 
         ReceiverTop.replyOut1[SenderId.SYNC] -> SenderTop.replyIn1
         ReceiverTop.replyOut2[SenderId.SYNC] -> SenderTop.replyIn2
+
+        ReceiverTop.serialReplyOut1[SenderId.SYNC] -> SenderTop.serialReplyIn1
+        ReceiverTop.serialReplyOut2[SenderId.SYNC] -> SenderTop.serialReplyIn2
+
+        SenderTop.serialOut1[TestDeploymentPort.PRIMITIVE_ARGS_SYNC] -> ReceiverTop.primitiveArgsSync1[2]
+        SenderTop.serialOut2[TestDeploymentPort.PRIMITIVE_ARGS_SYNC] -> ReceiverTop.primitiveArgsSync2[2]
     }
   }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fpp/pull/981 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

This PR implements three types of topology connection tests:

1. Typed to serial (for all our typed ports that don't have a return value)
2. Serial to typed (for all our typed ports that don't have a return value)
3. Serial to serial (for a single type of port data)

You can read more about how the tests work in the [README](https://github.com/Kronos3/fprime/blob/6cfa049f71b1439bf09bfe139103f8ad4c4faab2/FppTestProject/FppTest/topology/main/README.md) since it's a bit hard to follow the connection trail

## Rationale

We need comprehensive topology-level testing to validate no-regressions when we bring in direct port calling

## Future Work

No

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

I manually wrote ASYNC tests and had Claude write GUARDED and SYNC based on that