### PR TITLE
docs: fix double word and formatting in introduction

### DIFF
--- a/docs/user-manual/overview/01-full-intro.md
+++ b/docs/user-manual/overview/01-full-intro.md
@@ -57,8 +57,7 @@ taken by the system, and channels representing the current state of the system b
 contain a portion of the state. e.g. an **Event** might be "Established Communications" and a **Channel** might be
 "Current Temperature: 3C".
 
-All projects using F´ are composed of **Components**, **Ports**, and **Topologies**. Although F´ does not require the
-the user to control the system using **Commands**, **Events**, and **Channels**, these constructs represent the typical
+All projects using F´ are composed of **Components**, **Ports**, and **Topologies**. Although F´ does not require the user to control the system using **Commands**, **Events**, and **Channels**, these constructs represent the typical
 use case for F´projects and such constructs are built-in. Thus helpful to understand both **Components**, **Ports**, and
 **Topologies**, as well as **Command**, **Events**, and **Channels** in order to fully understand the power of the F´
 framework.
@@ -82,12 +81,12 @@ communication such that the system can function.
 ## Threads, Multi-Core Architectures and F´
 
 F´ was built for use on platforms running an Operating System (OS) and executing on a single core. Notably, these systems
-come with a thread scheduler. That being said it is entirely possible to use F´ on a baremetal system , or a multi-core
+come with a thread scheduler. That being said it is entirely possible to use F´ on a baremetal system, or a multi-core
 system, however; some care should be taken when designing for such systems an understanding of execution context is
 required.  See: [F´ on Multi-Core Systems](../framework/run-multi-core.md) and [F´ on Baremetal](../framework/run-baremetal.md)
 
 ## Conclusion
 
 The F′ software framework is released as open source and has been ported to Linux, macOS, Windows (WSL), VxWorks, ARINC
- 653, Baremetal(No OS), PPC, Leon3, x86, ARM (A15/A7), and MSP430. Mature sets of CD&H components are available
+ 653, Baremetal (No OS), PPC, Leon3, x86, ARM (A15/A7), and MSP430. Mature sets of CD&H components are available
 following flight process, such as code inspections, static analysis, and full-coverage unit testing.

--- a/docs/user-manual/overview/01-full-intro.md
+++ b/docs/user-manual/overview/01-full-intro.md
@@ -58,7 +58,7 @@ contain a portion of the state. e.g. an **Event** might be "Established Communic
 "Current Temperature: 3C".
 
 All projects using F´ are composed of **Components**, **Ports**, and **Topologies**. Although F´ does not require the user to control the system using **Commands**, **Events**, and **Channels**, these constructs represent the typical
-use case for F´projects and such constructs are built-in. Thus helpful to understand both **Components**, **Ports**, and
+use case for F´ projects and such constructs are built-in. Thus helpful to understand both **Components**, **Ports**, and
 **Topologies**, as well as **Command**, **Events**, and **Channels** in order to fully understand the power of the F´
 framework.
 


### PR DESCRIPTION
While reviewing the F´ introduction documentation, I identified a few minor typographical and formatting inconsistencies in docs/user-manual/overview/01-full-intro.md that could affect the professional quality of the manual.

Proposed Changes:

Fixed a double word typo: Removed an extra "the" in the sentence: "...does not require the the user to control..."

Corrected spacing before punctuation: Removed a leading space before a comma in the phrase: "...on a baremetal system , or a multi-core system..."

Improved formatting consistency: Added a missing space in "Baremetal(No OS)" to match the project's overall documentation style.

| | |
|:---|:---|
|**_Related Issue(s)_**| Fixes #4923 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

This PR fixes minor typographical and formatting issues in the `docs/user-manual/overview/01-full-intro.md` file to improve documentation quality.

## Rationale

These changes improve readability and consistency in the F´ framework’s introduction manual.

## Testing/Review Recommendations

Since this is a documentation-only change, a simple visual inspection of the `01-full-intro.md` file is sufficient to verify the fixes.

## Future Work

None at this time.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Generative AI was used to help draft and format the Pull Request description according to the project's contribution guidelines.