### PR TITLE
Remove legacy Cheetah3 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ click==8.1.7
 cmake==3.26.0
 colorlog==6.8.2
 cookiecutter==2.6.0
-CT3==3.4.0.post5
 et-xmlfile==1.1.0
 Flask==3.1.3
 Flask-Compress==1.15


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Remove legacy dependency. Used to be for XML autocoders. Nothing should depend on it anymore.
