### PR TITLE
Refactor EventManager to use `Fw::ArraySet`

### DIFF
--- a/Svc/EventManager/EventManager.cpp
+++ b/Svc/EventManager/EventManager.cpp
@@ -5,12 +5,9 @@
  *      Author: tcanham
  */
 
-#include <cstdio>
-
 #include <Fw/Types/Assert.hpp>
 #include <Os/File.hpp>
 #include <Svc/EventManager/EventManager.hpp>
-#include <cstring>
 
 namespace Svc {
 static_assert(std::numeric_limits<FwSizeType>::max() >= TELEM_ID_FILTER_SIZE,

--- a/Svc/EventManager/EventManager.cpp
+++ b/Svc/EventManager/EventManager.cpp
@@ -32,8 +32,6 @@ EventManager::EventManager(const char* name) : EventManagerComponentBase(name) {
         FILTER_ACTIVITY_LO_DEFAULT ? Enabled::ENABLED : Enabled::DISABLED;
     this->m_filterState[FilterSeverity::DIAGNOSTIC].enabled =
         FILTER_DIAGNOSTIC_DEFAULT ? Enabled::ENABLED : Enabled::DISABLED;
-
-    memset(m_filteredIDs, 0, sizeof(m_filteredIDs));
 }
 
 EventManager::~EventManager() {}
@@ -43,9 +41,6 @@ void EventManager::LogRecv_handler(FwIndexType portNum,
                                    Fw::Time& timeTag,
                                    const Fw::LogSeverity& severity,
                                    Fw::LogBuffer& args) {
-    // make sure ID is not zero. Zero is reserved for ID filter.
-    FW_ASSERT(id != 0);
-
     switch (severity.e) {
         case Fw::LogSeverity::FATAL:  // always pass FATAL
             break;
@@ -85,10 +80,9 @@ void EventManager::LogRecv_handler(FwIndexType portNum,
     }
 
     // check ID filters
-    for (FwSizeType entry = 0; entry < TELEM_ID_FILTER_SIZE; entry++) {
-        if ((m_filteredIDs[entry] == id) && (severity != Fw::LogSeverity::FATAL)) {
-            return;
-        }
+    Fw::Success findStatus = m_filteredIDs.find(id);
+    if ((findStatus == Fw::Success::SUCCESS) && (severity != Fw::LogSeverity::FATAL)) {
+        return;
     }
 
     // send event to the logger thread
@@ -133,39 +127,23 @@ void EventManager::SET_ID_FILTER_cmdHandler(FwOpcodeType opCode,  //!< The opcod
                                             Enabled idEnabled  //!< ID filter state
 ) {
     if (Enabled::ENABLED == idEnabled.e) {  // add ID
-        // search list for existing entry
-        for (FwSizeType entry = 0; entry < TELEM_ID_FILTER_SIZE; entry++) {
-            if (this->m_filteredIDs[entry] == ID) {
-                this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
-                this->log_ACTIVITY_HI_ID_FILTER_ENABLED(ID);
-                return;
-            }
+        if (m_filteredIDs.insert(ID) == Fw::Success::SUCCESS) {
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
+            this->log_ACTIVITY_HI_ID_FILTER_ENABLED(ID);
+        } else {
+            // if an empty slot was not found, send an error event
+            this->log_WARNING_LO_ID_FILTER_LIST_FULL(ID);
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
         }
-        // if not already a match, search for an open slot
-        for (FwSizeType entry = 0; entry < TELEM_ID_FILTER_SIZE; entry++) {
-            if (this->m_filteredIDs[entry] == 0) {
-                this->m_filteredIDs[entry] = ID;
-                this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
-                this->log_ACTIVITY_HI_ID_FILTER_ENABLED(ID);
-                return;
-            }
-        }
-        // if an empty slot was not found, send an error event
-        this->log_WARNING_LO_ID_FILTER_LIST_FULL(ID);
-        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
     } else {  // remove ID
-        // search list for existing entry
-        for (FwSizeType entry = 0; entry < TELEM_ID_FILTER_SIZE; entry++) {
-            if (this->m_filteredIDs[entry] == ID) {
-                this->m_filteredIDs[entry] = 0;  // zero entry
-                this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
-                this->log_ACTIVITY_HI_ID_FILTER_REMOVED(ID);
-                return;
-            }
+        if (m_filteredIDs.remove(ID) == Fw::Success::SUCCESS) {
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
+            this->log_ACTIVITY_HI_ID_FILTER_REMOVED(ID);
+        } else {
+            // Entry wasn't found
+            this->log_WARNING_LO_ID_FILTER_NOT_FOUND(ID);
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
         }
-        // if it gets here, wasn't found
-        this->log_WARNING_LO_ID_FILTER_NOT_FOUND(ID);
-        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
     }
 }
 
@@ -180,10 +158,8 @@ void EventManager::DUMP_FILTER_STATE_cmdHandler(FwOpcodeType opCode,  //!< The o
     }
 
     // iterate through ID filter
-    for (FwSizeType entry = 0; entry < TELEM_ID_FILTER_SIZE; entry++) {
-        if (this->m_filteredIDs[entry] != 0) {
-            this->log_ACTIVITY_HI_ID_FILTER_ENABLED(this->m_filteredIDs[entry]);
-        }
+    for (FwEventIdType ID : m_filteredIDs) {
+        this->log_ACTIVITY_HI_ID_FILTER_ENABLED(ID);
     }
 
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);

--- a/Svc/EventManager/EventManager.hpp
+++ b/Svc/EventManager/EventManager.hpp
@@ -9,6 +9,7 @@
 #define Svc_EventManager_HPP_
 
 #include <Fw/Log/LogPacket.hpp>
+#include <Fw/DataStructures/ArraySet.hpp>
 #include <Svc/EventManager/EventManagerComponentAc.hpp>
 #include <config/EventManagerCfg.hpp>
 
@@ -61,9 +62,8 @@ class EventManager final : public EventManagerComponentBase {
     Fw::LogPacket m_logPacket;  //!< packet buffer for assembling log packets
     Fw::ComBuffer m_comBuffer;  //!< com buffer for sending event buffers
 
-    // array of filtered event IDs.
-    // value of 0 means no entry
-    FwEventIdType m_filteredIDs[TELEM_ID_FILTER_SIZE];
+    // Set of filtered event IDs.
+    Fw::ArraySet<FwEventIdType, TELEM_ID_FILTER_SIZE> m_filteredIDs;
 };
 
 }  // namespace Svc

--- a/Svc/EventManager/EventManager.hpp
+++ b/Svc/EventManager/EventManager.hpp
@@ -8,8 +8,8 @@
 #ifndef Svc_EventManager_HPP_
 #define Svc_EventManager_HPP_
 
-#include <Fw/Log/LogPacket.hpp>
 #include <Fw/DataStructures/ArraySet.hpp>
+#include <Fw/Log/LogPacket.hpp>
 #include <Svc/EventManager/EventManagerComponentAc.hpp>
 #include <config/EventManagerCfg.hpp>
 

--- a/Svc/EventManager/docs/sdd.md
+++ b/Svc/EventManager/docs/sdd.md
@@ -45,8 +45,6 @@ developers to specify a set of events in the component FPP.
 autocoder will add an `Fw::Log` output port to send events in serialized form. The EventManager receives these port
 calls and provides commands to filter these events. The filtered events are sent to other components such as the ground
 interface. 
- 
-**Note:** the Event ID value 0 is reserved for the logger.
 
 Should a FATAL severity event arrive, it is announced using a FATAL out port allow the system to respond when a FATAL
 event is seen.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Use `Fw::ArraySet` instead of custom tracking algo.

## Rationale

Best practice, simple code.

