### PR TITLE
Fix hard-asserts in GenericHub deserialization

### DIFF
--- a/Svc/GenericHub/GenericHub.cpp
+++ b/Svc/GenericHub/GenericHub.cpp
@@ -116,7 +116,7 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
         status = Fw::FW_DESERIALIZE_INVALID_DATA;
     }
     // If the deserialization was good and the type was valid, set the type and move onto port deserialization
-     else if (status == Fw::FW_SERIALIZE_OK) {
+    else if (status == Fw::FW_SERIALIZE_OK) {
         type = static_cast<HubType>(type_in);
         status = incoming.deserializeTo(port);
     }
@@ -125,7 +125,8 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
         status = incoming.deserializeTo(size);
     }
     // All deserialization looks good, check that the size matches the buffer size before calling the appropriate ports
-    if (status == Fw::FW_SERIALIZE_OK && (size == (fwBuffer.getSize() - sizeof(U32) - sizeof(U32) - sizeof(FwBuffSizeType)))) {
+    if (status == Fw::FW_SERIALIZE_OK &&
+        (size == (fwBuffer.getSize() - sizeof(U32) - sizeof(U32) - sizeof(FwBuffSizeType)))) {
         // invokeSerial deserializes arguments before calling a normal invoke, this will return ownership immediately
         U8* rawData = fwBuffer.getData() + sizeof(U32) + sizeof(U32) + sizeof(FwBuffSizeType);
         FwSizeType rawSize = fwBuffer.getSize() - sizeof(U32) - sizeof(U32) - sizeof(FwBuffSizeType);
@@ -135,7 +136,8 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
             status = wrapper.setBuffLen(rawSize);
             FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             // Confirm that the port is valid and connected before calling out
-            if (port < this->getNum_serialOut_OutputPorts() && this->isConnected_serialOut_OutputPort(static_cast<FwIndexType>(port))) {
+            if (port < this->getNum_serialOut_OutputPorts() &&
+                this->isConnected_serialOut_OutputPort(static_cast<FwIndexType>(port))) {
                 serialOut_out(static_cast<FwIndexType>(port), wrapper);
             }
             // Deallocate the existing buffer
@@ -144,7 +146,8 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
             // Fw::Buffers can reuse the existing data buffer as the storage type!  No deallocation done.
             fwBuffer.set(rawData, rawSize, fwBuffer.getContext());
             // Confirm that the port is valid and connected before calling out
-            if (port < this->getNum_bufferOut_OutputPorts() && this->isConnected_bufferOut_OutputPort(static_cast<FwIndexType>(port))) {
+            if (port < this->getNum_bufferOut_OutputPorts() &&
+                this->isConnected_bufferOut_OutputPort(static_cast<FwIndexType>(port))) {
                 bufferOut_out(static_cast<FwIndexType>(port), fwBuffer);
             }
         } else if (type == HUB_TYPE_EVENT) {
@@ -166,7 +169,8 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
             }
 
             // Send it!
-            if (status == Fw::FW_SERIALIZE_OK && this->isConnected_eventOut_OutputPort(static_cast<FwIndexType>(port))) {
+            if (status == Fw::FW_SERIALIZE_OK &&
+                this->isConnected_eventOut_OutputPort(static_cast<FwIndexType>(port))) {
                 this->eventOut_out(static_cast<FwIndexType>(port), id, timeTag, severity, args);
             }
             // Deallocate the existing buffer
@@ -193,10 +197,10 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
             fromBufferDriverReturn_out(0, fwBuffer);
         } else if (type == HUB_TYPE_CMD_DISP) {
             U32 context;
-            // Check that the size is sufficient for the contecxt
+            // Check that the size is sufficient for the context
             if (rawSize < sizeof(U32)) {
                 status = Fw::FW_DESERIALIZE_SIZE_MISMATCH;
-            } 
+            }
             // Shift the command buffer out and deserialize the context
             if (status == Fw::FW_SERIALIZE_OK) {
                 Fw::ComBuffer wrapper(rawData, (rawSize - sizeof(U32)));
@@ -205,7 +209,8 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
                 incoming.deserializeSkip(rawSize - sizeof(U32));
                 status = incoming.deserializeTo(context);
                 // Send it!
-                if (status == Fw::FW_SERIALIZE_OK && this->isConnected_cmdDispOut_OutputPort(static_cast<FwIndexType>(port))) {
+                if (status == Fw::FW_SERIALIZE_OK &&
+                    this->isConnected_cmdDispOut_OutputPort(static_cast<FwIndexType>(port))) {
                     this->cmdDispOut_out(static_cast<FwIndexType>(port), wrapper, context);
                 }
             }
@@ -225,7 +230,8 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
                 status = incoming.deserializeTo(response);
             }
             // Send it!
-            if (status == Fw::FW_SERIALIZE_OK && this->isConnected_cmdRespOut_OutputPort(static_cast<FwIndexType>(port))) {
+            if (status == Fw::FW_SERIALIZE_OK &&
+                this->isConnected_cmdRespOut_OutputPort(static_cast<FwIndexType>(port))) {
                 this->cmdRespOut_out(static_cast<FwIndexType>(port), opCode, cmdSeq, response);
             }
             // Return the received buffer

--- a/Svc/GenericHub/GenericHub.cpp
+++ b/Svc/GenericHub/GenericHub.cpp
@@ -124,12 +124,8 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
     if (status == Fw::FW_SERIALIZE_OK) {
         status = incoming.deserializeTo(size);
     }
-    // Check that the declared size matches the size of the data available
-    if ((status == Fw::FW_SERIALIZE_OK) && (size != (fwBuffer.getSize() - sizeof(U32) - sizeof(U32) - sizeof(FwBuffSizeType)))) {
-        status = Fw::FW_DESERIALIZE_INVALID_DATA;
-    }
-    // All deserialization looks good
-    else if (status == Fw::FW_SERIALIZE_OK) {
+    // All deserialization looks good, check that the size matches the buffer size before calling the appropriate ports
+    if (status == Fw::FW_SERIALIZE_OK && (size == (fwBuffer.getSize() - sizeof(U32) - sizeof(U32) - sizeof(FwBuffSizeType)))) {
         // invokeSerial deserializes arguments before calling a normal invoke, this will return ownership immediately
         U8* rawData = fwBuffer.getData() + sizeof(U32) + sizeof(U32) + sizeof(FwBuffSizeType);
         FwSizeType rawSize = fwBuffer.getSize() - sizeof(U32) - sizeof(U32) - sizeof(FwBuffSizeType);

--- a/Svc/GenericHub/GenericHub.cpp
+++ b/Svc/GenericHub/GenericHub.cpp
@@ -39,9 +39,9 @@ void GenericHub::send_data(const HubType type, const FwIndexType port, const U8*
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = serialize.serializeFrom(static_cast<U32>(port));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = serialize.serializeFrom(data, size);
+    status = serialize.serializeFrom(data, static_cast<FwBuffSizeType>(size));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    outgoing.setSize(static_cast<U32>(serialize.getSize()));
+    outgoing.setSize(serialize.getSize());
     toBufferDriver_out(0, outgoing);
 }
 
@@ -105,103 +105,138 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
 
     // Representation of incoming data prepped for serialization
     auto incoming = fwBuffer.getDeserializer();
-    status = incoming.deserializeTo(type_in);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    type = static_cast<HubType>(type_in);
-    FW_ASSERT(type < HUB_TYPE_MAX, type);
-    status = incoming.deserializeTo(port);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = incoming.deserializeTo(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    // Check the size of the data first
+    if (fwBuffer.getSize() < (sizeof(U32) + sizeof(U32) + sizeof(FwBuffSizeType))) {
+        status = Fw::FW_DESERIALIZE_SIZE_MISMATCH;
+    } else {
+        status = incoming.deserializeTo(type_in);
+    }
+    // If the deserialization was good, but the type is invalid, set invalid data
+    if ((status == Fw::FW_SERIALIZE_OK) && (type_in >= HUB_TYPE_MAX)) {
+        status = Fw::FW_DESERIALIZE_INVALID_DATA;
+    }
+    // If the deserialization was good and the type was valid, set the type and move onto port deserialization
+     else if (status == Fw::FW_SERIALIZE_OK) {
+        type = static_cast<HubType>(type_in);
+        status = incoming.deserializeTo(port);
+    }
+    // If the deserialization was good and the port was valid, move onto size deserialization
+    if (status == Fw::FW_SERIALIZE_OK) {
+        status = incoming.deserializeTo(size);
+    }
+    // Check that the declared size matches the size of the data available
+    if ((status == Fw::FW_SERIALIZE_OK) && (size != (fwBuffer.getSize() - sizeof(U32) - sizeof(U32) - sizeof(FwBuffSizeType)))) {
+        status = Fw::FW_DESERIALIZE_INVALID_DATA;
+    }
+    // All deserialization looks good
+    else if (status == Fw::FW_SERIALIZE_OK) {
+        // invokeSerial deserializes arguments before calling a normal invoke, this will return ownership immediately
+        U8* rawData = fwBuffer.getData() + sizeof(U32) + sizeof(U32) + sizeof(FwBuffSizeType);
+        FwSizeType rawSize = fwBuffer.getSize() - sizeof(U32) - sizeof(U32) - sizeof(FwBuffSizeType);
+        if (type == HUB_TYPE_PORT) {
+            // Com buffer representations should be copied before the call returns, so we need not "allocate" new data
+            Fw::ExternalSerializeBuffer wrapper(rawData, rawSize);
+            status = wrapper.setBuffLen(rawSize);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Confirm that the port is valid and connected before calling out
+            if (port < this->getNum_serialOut_OutputPorts() && this->isConnected_serialOut_OutputPort(static_cast<FwIndexType>(port))) {
+                serialOut_out(static_cast<FwIndexType>(port), wrapper);
+            }
+            // Deallocate the existing buffer
+            fromBufferDriverReturn_out(0, fwBuffer);
+        } else if (type == HUB_TYPE_BUFFER) {
+            // Fw::Buffers can reuse the existing data buffer as the storage type!  No deallocation done.
+            fwBuffer.set(rawData, rawSize, fwBuffer.getContext());
+            // Confirm that the port is valid and connected before calling out
+            if (port < this->getNum_bufferOut_OutputPorts() && this->isConnected_bufferOut_OutputPort(static_cast<FwIndexType>(port))) {
+                bufferOut_out(static_cast<FwIndexType>(port), fwBuffer);
+            }
+        } else if (type == HUB_TYPE_EVENT) {
+            FwEventIdType id;
+            Fw::Time timeTag;
+            Fw::LogSeverity severity;
+            Fw::LogBuffer args;
 
-    // invokeSerial deserializes arguments before calling a normal invoke, this will return ownership immediately
-    U8* rawData = fwBuffer.getData() + sizeof(U32) + sizeof(U32) + sizeof(FwBuffSizeType);
-    U32 rawSize = static_cast<U32>(fwBuffer.getSize() - sizeof(U32) - sizeof(U32) - sizeof(FwBuffSizeType));
-    FW_ASSERT(rawSize == static_cast<U32>(size));
-    if (type == HUB_TYPE_PORT) {
-        // Com buffer representations should be copied before the call returns, so we need not "allocate" new data
-        Fw::ExternalSerializeBuffer wrapper(rawData, rawSize);
-        status = wrapper.setBuffLen(rawSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        serialOut_out(static_cast<FwIndexType>(port), wrapper);
-        // Deallocate the existing buffer
-        fromBufferDriverReturn_out(0, fwBuffer);
-    } else if (type == HUB_TYPE_BUFFER) {
-        // Fw::Buffers can reuse the existing data buffer as the storage type!  No deallocation done.
-        fwBuffer.set(rawData, rawSize, fwBuffer.getContext());
-        bufferOut_out(static_cast<FwIndexType>(port), fwBuffer);
-    } else if (type == HUB_TYPE_EVENT) {
-        FwEventIdType id;
-        Fw::Time timeTag;
-        Fw::LogSeverity severity;
-        Fw::LogBuffer args;
+            // Deserialize tokens for events
+            status = incoming.deserializeTo(id);
+            if (status == Fw::FW_SERIALIZE_OK) {
+                status = incoming.deserializeTo(timeTag);
+            }
+            if (status == Fw::FW_SERIALIZE_OK) {
+                status = incoming.deserializeTo(severity);
+            }
+            if (status == Fw::FW_SERIALIZE_OK) {
+                status = incoming.deserializeTo(args);
+            }
 
-        // Deserialize tokens for events
-        status = incoming.deserializeTo(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = incoming.deserializeTo(timeTag);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = incoming.deserializeTo(severity);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = incoming.deserializeTo(args);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Send it!
+            if (status == Fw::FW_SERIALIZE_OK && this->isConnected_eventOut_OutputPort(static_cast<FwIndexType>(port))) {
+                this->eventOut_out(static_cast<FwIndexType>(port), id, timeTag, severity, args);
+            }
+            // Deallocate the existing buffer
+            fromBufferDriverReturn_out(0, fwBuffer);
+        } else if (type == HUB_TYPE_CHANNEL) {
+            FwChanIdType id;
+            Fw::Time timeTag;
+            Fw::TlmBuffer val;
 
-        // Send it!
-        this->eventOut_out(static_cast<FwIndexType>(port), id, timeTag, severity, args);
+            // Deserialize tokens for channels
+            status = incoming.deserializeTo(id);
+            if (status == Fw::FW_SERIALIZE_OK) {
+                status = incoming.deserializeTo(timeTag);
+            }
+            if (status == Fw::FW_SERIALIZE_OK) {
+                status = incoming.deserializeTo(val);
+            }
+            if (status == Fw::FW_SERIALIZE_OK && this->isConnected_tlmOut_OutputPort(static_cast<FwIndexType>(port))) {
+                // Send it!
+                this->tlmOut_out(static_cast<FwIndexType>(port), id, timeTag, val);
+            }
 
-        // Deallocate the existing buffer
-        fromBufferDriverReturn_out(0, fwBuffer);
-    } else if (type == HUB_TYPE_CHANNEL) {
-        FwChanIdType id;
-        Fw::Time timeTag;
-        Fw::TlmBuffer val;
+            // Return the received buffer
+            fromBufferDriverReturn_out(0, fwBuffer);
+        } else if (type == HUB_TYPE_CMD_DISP) {
+            U32 context;
+            // Check that the size is sufficient for the contecxt
+            if (rawSize < sizeof(U32)) {
+                status = Fw::FW_DESERIALIZE_SIZE_MISMATCH;
+            } 
+            // Shift the command buffer out and deserialize the context
+            if (status == Fw::FW_SERIALIZE_OK) {
+                Fw::ComBuffer wrapper(rawData, (rawSize - sizeof(U32)));
+                status = wrapper.setBuffLen(rawSize - sizeof(U32));
+                FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+                incoming.deserializeSkip(rawSize - sizeof(U32));
+                status = incoming.deserializeTo(context);
+                // Send it!
+                if (status == Fw::FW_SERIALIZE_OK && this->isConnected_cmdDispOut_OutputPort(static_cast<FwIndexType>(port))) {
+                    this->cmdDispOut_out(static_cast<FwIndexType>(port), wrapper, context);
+                }
+            }
+            // Deallocate the existing buffer
+            fromBufferDriverReturn_out(0, fwBuffer);
+        } else if (type == HUB_TYPE_CMD_RESP) {
+            FwOpcodeType opCode;
+            U32 cmdSeq;
+            Fw::CmdResponse response;
 
-        // Deserialize tokens for channels
-        status = incoming.deserializeTo(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = incoming.deserializeTo(timeTag);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = incoming.deserializeTo(val);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-
-        // Send it!
-        this->tlmOut_out(static_cast<FwIndexType>(port), id, timeTag, val);
-
-        // Return the received buffer
-        fromBufferDriverReturn_out(0, fwBuffer);
-    } else if (type == HUB_TYPE_CMD_DISP) {
-        U32 context;
-
-        // Com buffer representations should be copied before the call returns, so we need not "allocate" new data
-        Fw::ComBuffer wrapper(rawData, (rawSize - sizeof(U32)));
-        status = wrapper.setBuffLen(rawSize - sizeof(U32));
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-
-        incoming.deserializeSkip(rawSize - sizeof(U32));
-        status = incoming.deserializeTo(context);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-
-        this->cmdDispOut_out(static_cast<FwIndexType>(port), wrapper, context);
-
-        // Deallocate the existing buffer
-        fromBufferDriverReturn_out(0, fwBuffer);
-    } else if (type == HUB_TYPE_CMD_RESP) {
-        FwOpcodeType opCode;
-        U32 cmdSeq;
-        Fw::CmdResponse response;
-
-        // Deserialize tokens for channels
-        status = incoming.deserializeTo(opCode);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = incoming.deserializeTo(cmdSeq);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = incoming.deserializeTo(response);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-
-        // Send it!
-        this->cmdRespOut_out(static_cast<FwIndexType>(port), opCode, cmdSeq, response);
-
-        // Return the received buffer
+            // Deserialize tokens for channels
+            status = incoming.deserializeTo(opCode);
+            if (status == Fw::FW_SERIALIZE_OK) {
+                status = incoming.deserializeTo(cmdSeq);
+            }
+            if (status == Fw::FW_SERIALIZE_OK) {
+                status = incoming.deserializeTo(response);
+            }
+            // Send it!
+            if (status == Fw::FW_SERIALIZE_OK && this->isConnected_cmdRespOut_OutputPort(static_cast<FwIndexType>(port))) {
+                this->cmdRespOut_out(static_cast<FwIndexType>(port), opCode, cmdSeq, response);
+            }
+            // Return the received buffer
+            fromBufferDriverReturn_out(0, fwBuffer);
+        }
+    } else {
+        // On deserialization failure, return the buffer to avoid leaks
         fromBufferDriverReturn_out(0, fwBuffer);
     }
 }

--- a/Svc/GenericHub/GenericHub.cpp
+++ b/Svc/GenericHub/GenericHub.cpp
@@ -120,7 +120,7 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
         type = static_cast<HubType>(type_in);
         status = incoming.deserializeTo(port);
     }
-    // If the deserialization was good and the port was valid, move onto size deserialization
+    // If the deserialization was good, move onto size deserialization
     if (status == Fw::FW_SERIALIZE_OK) {
         status = incoming.deserializeTo(size);
     }
@@ -149,6 +149,9 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
             if (port < this->getNum_bufferOut_OutputPorts() &&
                 this->isConnected_bufferOut_OutputPort(static_cast<FwIndexType>(port))) {
                 bufferOut_out(static_cast<FwIndexType>(port), fwBuffer);
+            } else {
+                // Return the buffer if the port is invalid or not connected to avoid leaks
+                fromBufferDriverReturn_out(0, fwBuffer);
             }
         } else if (type == HUB_TYPE_EVENT) {
             FwEventIdType id;
@@ -169,7 +172,7 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
             }
 
             // Send it!
-            if (status == Fw::FW_SERIALIZE_OK &&
+            if ((status == Fw::FW_SERIALIZE_OK) && (port < this->getNum_eventOut_OutputPorts()) &&
                 this->isConnected_eventOut_OutputPort(static_cast<FwIndexType>(port))) {
                 this->eventOut_out(static_cast<FwIndexType>(port), id, timeTag, severity, args);
             }
@@ -188,7 +191,8 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
             if (status == Fw::FW_SERIALIZE_OK) {
                 status = incoming.deserializeTo(val);
             }
-            if (status == Fw::FW_SERIALIZE_OK && this->isConnected_tlmOut_OutputPort(static_cast<FwIndexType>(port))) {
+            if ((status == Fw::FW_SERIALIZE_OK) && (port < this->getNum_tlmOut_OutputPorts()) &&
+                this->isConnected_tlmOut_OutputPort(static_cast<FwIndexType>(port))) {
                 // Send it!
                 this->tlmOut_out(static_cast<FwIndexType>(port), id, timeTag, val);
             }
@@ -198,7 +202,7 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
         } else if (type == HUB_TYPE_CMD_DISP) {
             U32 context;
             // Check that the size is sufficient for the context
-            if (rawSize < sizeof(U32)) {
+            if (rawSize < sizeof(U32) || (rawSize - sizeof(U32)) > Fw::ComBuffer::SERIALIZED_SIZE) {
                 status = Fw::FW_DESERIALIZE_SIZE_MISMATCH;
             }
             // Shift the command buffer out and deserialize the context
@@ -206,10 +210,12 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
                 Fw::ComBuffer wrapper(rawData, (rawSize - sizeof(U32)));
                 status = wrapper.setBuffLen(rawSize - sizeof(U32));
                 FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-                incoming.deserializeSkip(rawSize - sizeof(U32));
+                // Skip the command buffer that has already been wrapped
+                status = incoming.deserializeSkip(rawSize - sizeof(U32));
+                FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
                 status = incoming.deserializeTo(context);
                 // Send it!
-                if (status == Fw::FW_SERIALIZE_OK &&
+                if ((status == Fw::FW_SERIALIZE_OK) && (port < this->getNum_cmdDispOut_OutputPorts()) &&
                     this->isConnected_cmdDispOut_OutputPort(static_cast<FwIndexType>(port))) {
                     this->cmdDispOut_out(static_cast<FwIndexType>(port), wrapper, context);
                 }
@@ -230,7 +236,7 @@ void GenericHub::fromBufferDriver_handler(const FwIndexType portNum, Fw::Buffer&
                 status = incoming.deserializeTo(response);
             }
             // Send it!
-            if (status == Fw::FW_SERIALIZE_OK &&
+            if ((status == Fw::FW_SERIALIZE_OK) && (port < this->getNum_cmdRespOut_OutputPorts()) &&
                 this->isConnected_cmdRespOut_OutputPort(static_cast<FwIndexType>(port))) {
                 this->cmdRespOut_out(static_cast<FwIndexType>(port), opCode, cmdSeq, response);
             }

--- a/Svc/GenericHub/test/ut/GenericHubTestMain.cpp
+++ b/Svc/GenericHub/test/ut/GenericHubTestMain.cpp
@@ -34,6 +34,11 @@ TEST(Nominal, TestCommands) {
     tester.test_commands();
 }
 
+TEST(Invalid, TestDeserializationGuards) {
+    Svc::GenericHubTester tester;
+    tester.test_invalid_deserialization_paths();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/GenericHub/test/ut/GenericHubTester.cpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.cpp
@@ -180,6 +180,129 @@ void GenericHubTester ::test_commands() {
     this->test_command_response();
 }
 
+void GenericHubTester ::send_from_driver_packet(U32 type,
+                                                U32 port,
+                                                FwBuffSizeType declaredSize,
+                                                const U8* payload,
+                                                FwBuffSizeType payloadSize) {
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    Fw::ExternalSerializeBuffer serializer(m_data_for_allocation, sizeof(m_data_for_allocation));
+    serializer.resetSer();
+
+    status = serializer.serializeFrom(type);
+    ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
+    status = serializer.serializeFrom(port);
+    ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
+    status = serializer.serializeFrom(declaredSize);
+    ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
+
+    if (payloadSize > 0) {
+        ASSERT_NE(payload, nullptr);
+        status = serializer.serializeFrom(payload, payloadSize, Fw::Serialization::OMIT_LENGTH);
+        ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);
+    }
+
+    Fw::Buffer buffer(m_data_for_allocation, serializer.getSize());
+    this->invoke_to_fromBufferDriver(0, buffer);
+}
+
+void GenericHubTester ::test_invalid_deserialization_paths() {
+
+    // Header too short to deserialize
+    clearFromPortHistory();
+    Fw::Buffer shortBuffer(m_data_for_allocation, sizeof(U32) + sizeof(U32) + sizeof(FwBuffSizeType) - 1);
+    this->invoke_to_fromBufferDriver(0, shortBuffer);
+    ASSERT_from_fromBufferDriverReturn_SIZE(1);
+    ASSERT_EQ(m_comm_out, 0U);
+    ASSERT_from_bufferOut_SIZE(0);
+    ASSERT_from_eventOut_SIZE(0);
+    ASSERT_from_tlmOut_SIZE(0);
+    ASSERT_from_cmdDispOut_SIZE(0);
+    ASSERT_from_cmdRespOut_SIZE(0);
+
+
+    // Invalid type should be dropped
+    clearFromPortHistory();
+    this->send_from_driver_packet(static_cast<U32>(GenericHub::HUB_TYPE_MAX), 0, 0, nullptr, 0);
+    ASSERT_from_fromBufferDriverReturn_SIZE(1);
+    ASSERT_EQ(m_comm_out, 0U);
+    ASSERT_from_bufferOut_SIZE(0);
+    ASSERT_from_eventOut_SIZE(0);
+    ASSERT_from_tlmOut_SIZE(0);
+    ASSERT_from_cmdDispOut_SIZE(0);
+    ASSERT_from_cmdRespOut_SIZE(0);
+
+    // Declared payload size mismatch should be dropped
+    clearFromPortHistory();
+    this->send_from_driver_packet(static_cast<U32>(GenericHub::HUB_TYPE_PORT), 0, 1, nullptr, 0);
+    ASSERT_from_fromBufferDriverReturn_SIZE(1);
+    ASSERT_EQ(m_comm_out, 0U);
+    ASSERT_from_bufferOut_SIZE(0);
+    ASSERT_from_eventOut_SIZE(0);
+    ASSERT_from_tlmOut_SIZE(0);
+    ASSERT_from_cmdDispOut_SIZE(0);
+    ASSERT_from_cmdRespOut_SIZE(0);
+
+    // Invalid serialOut destination port should not invoke output
+    clearFromPortHistory();
+    this->send_from_driver_packet(static_cast<U32>(GenericHub::HUB_TYPE_PORT),
+                                  this->componentOut.getNum_serialOut_OutputPorts(),
+                                  0,
+                                  nullptr,
+                                  0);
+    ASSERT_from_fromBufferDriverReturn_SIZE(1);
+    ASSERT_EQ(m_comm_out, 0U);
+    ASSERT_from_bufferOut_SIZE(0);
+    ASSERT_from_eventOut_SIZE(0);
+    ASSERT_from_tlmOut_SIZE(0);
+    ASSERT_from_cmdDispOut_SIZE(0);
+    ASSERT_from_cmdRespOut_SIZE(0);
+
+    // Invalid bufferOut destination port should return the buffer
+    clearFromPortHistory();
+    this->send_from_driver_packet(static_cast<U32>(GenericHub::HUB_TYPE_BUFFER),
+                                  this->componentOut.getNum_bufferOut_OutputPorts(),
+                                  0,
+                                  nullptr,
+                                  0);
+    ASSERT_from_fromBufferDriverReturn_SIZE(1);
+    ASSERT_EQ(m_comm_out, 0U);
+    ASSERT_from_bufferOut_SIZE(0);
+    ASSERT_from_eventOut_SIZE(0);
+    ASSERT_from_tlmOut_SIZE(0);
+    ASSERT_from_cmdDispOut_SIZE(0);
+    ASSERT_from_cmdRespOut_SIZE(0);
+
+    // Command dispatch path: raw payload too small to include context
+    clearFromPortHistory();
+    this->send_from_driver_packet(static_cast<U32>(GenericHub::HUB_TYPE_CMD_DISP), 0, 0, nullptr, 0);
+    ASSERT_from_fromBufferDriverReturn_SIZE(1);
+    ASSERT_EQ(m_comm_out, 0U);
+    ASSERT_from_bufferOut_SIZE(0);
+    ASSERT_from_eventOut_SIZE(0);
+    ASSERT_from_tlmOut_SIZE(0);
+    ASSERT_from_cmdDispOut_SIZE(0);
+    ASSERT_from_cmdRespOut_SIZE(0);
+
+    // Command dispatch path: raw payload larger than ComBuffer supports
+    clearFromPortHistory();
+    const FwBuffSizeType tooLargeCmdSize = static_cast<FwBuffSizeType>(Fw::ComBuffer::SERIALIZED_SIZE + sizeof(U32) + 1);
+    this->send_from_driver_packet(static_cast<U32>(GenericHub::HUB_TYPE_CMD_DISP),
+                                  0,
+                                  tooLargeCmdSize,
+                                  m_data_store,
+                                  tooLargeCmdSize);
+    ASSERT_from_fromBufferDriverReturn_SIZE(1);
+    ASSERT_EQ(m_comm_out, 0U);
+    ASSERT_from_bufferOut_SIZE(0);
+    ASSERT_from_eventOut_SIZE(0);
+    ASSERT_from_tlmOut_SIZE(0);
+    ASSERT_from_cmdDispOut_SIZE(0);
+    ASSERT_from_cmdRespOut_SIZE(0);
+
+    clearFromPortHistory();
+}
+
 // ----------------------------------------------------------------------
 // Handlers for typed from ports
 // ----------------------------------------------------------------------

--- a/Svc/GenericHub/test/ut/GenericHubTester.cpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.cpp
@@ -207,7 +207,6 @@ void GenericHubTester ::send_from_driver_packet(U32 type,
 }
 
 void GenericHubTester ::test_invalid_deserialization_paths() {
-
     // Header too short to deserialize
     clearFromPortHistory();
     Fw::Buffer shortBuffer(m_data_for_allocation, sizeof(U32) + sizeof(U32) + sizeof(FwBuffSizeType) - 1);
@@ -219,7 +218,6 @@ void GenericHubTester ::test_invalid_deserialization_paths() {
     ASSERT_from_tlmOut_SIZE(0);
     ASSERT_from_cmdDispOut_SIZE(0);
     ASSERT_from_cmdRespOut_SIZE(0);
-
 
     // Invalid type should be dropped
     clearFromPortHistory();
@@ -246,10 +244,7 @@ void GenericHubTester ::test_invalid_deserialization_paths() {
     // Invalid serialOut destination port should not invoke output
     clearFromPortHistory();
     this->send_from_driver_packet(static_cast<U32>(GenericHub::HUB_TYPE_PORT),
-                                  this->componentOut.getNum_serialOut_OutputPorts(),
-                                  0,
-                                  nullptr,
-                                  0);
+                                  this->componentOut.getNum_serialOut_OutputPorts(), 0, nullptr, 0);
     ASSERT_from_fromBufferDriverReturn_SIZE(1);
     ASSERT_EQ(m_comm_out, 0U);
     ASSERT_from_bufferOut_SIZE(0);
@@ -261,10 +256,7 @@ void GenericHubTester ::test_invalid_deserialization_paths() {
     // Invalid bufferOut destination port should return the buffer
     clearFromPortHistory();
     this->send_from_driver_packet(static_cast<U32>(GenericHub::HUB_TYPE_BUFFER),
-                                  this->componentOut.getNum_bufferOut_OutputPorts(),
-                                  0,
-                                  nullptr,
-                                  0);
+                                  this->componentOut.getNum_bufferOut_OutputPorts(), 0, nullptr, 0);
     ASSERT_from_fromBufferDriverReturn_SIZE(1);
     ASSERT_EQ(m_comm_out, 0U);
     ASSERT_from_bufferOut_SIZE(0);
@@ -286,11 +278,9 @@ void GenericHubTester ::test_invalid_deserialization_paths() {
 
     // Command dispatch path: raw payload larger than ComBuffer supports
     clearFromPortHistory();
-    const FwBuffSizeType tooLargeCmdSize = static_cast<FwBuffSizeType>(Fw::ComBuffer::SERIALIZED_SIZE + sizeof(U32) + 1);
-    this->send_from_driver_packet(static_cast<U32>(GenericHub::HUB_TYPE_CMD_DISP),
-                                  0,
-                                  tooLargeCmdSize,
-                                  m_data_store,
+    const FwBuffSizeType tooLargeCmdSize =
+        static_cast<FwBuffSizeType>(Fw::ComBuffer::SERIALIZED_SIZE + sizeof(U32) + 1);
+    this->send_from_driver_packet(static_cast<U32>(GenericHub::HUB_TYPE_CMD_DISP), 0, tooLargeCmdSize, m_data_store,
                                   tooLargeCmdSize);
     ASSERT_from_fromBufferDriverReturn_SIZE(1);
     ASSERT_EQ(m_comm_out, 0U);

--- a/Svc/GenericHub/test/ut/GenericHubTester.hpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.hpp
@@ -64,6 +64,10 @@ class GenericHubTester : public GenericHubGTestBase {
     //!
     void test_commands();
 
+    //! Test invalid input/deserialization guard paths
+    //!
+    void test_invalid_deserialization_paths();
+
   private:
     // ----------------------------------------------------------------------
     // Handlers for typed from ports
@@ -132,6 +136,12 @@ class GenericHubTester : public GenericHubGTestBase {
     void test_command_dispatch();
 
     void test_command_response();
+
+    void send_from_driver_packet(U32 type,
+                   U32 port,
+                   FwBuffSizeType declaredSize,
+                   const U8* payload,
+                   FwBuffSizeType payloadSize);
 
     // ----------------------------------------------------------------------
     // Helper methods

--- a/Svc/GenericHub/test/ut/GenericHubTester.hpp
+++ b/Svc/GenericHub/test/ut/GenericHubTester.hpp
@@ -138,10 +138,10 @@ class GenericHubTester : public GenericHubGTestBase {
     void test_command_response();
 
     void send_from_driver_packet(U32 type,
-                   U32 port,
-                   FwBuffSizeType declaredSize,
-                   const U8* payload,
-                   FwBuffSizeType payloadSize);
+                                 U32 port,
+                                 FwBuffSizeType declaredSize,
+                                 const U8* payload,
+                                 FwBuffSizeType payloadSize);
 
     // ----------------------------------------------------------------------
     // Helper methods


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

GenericHub's deserialization routines used hard asserts. These might cause a crash on garbage data.  Now they are just dropped.


## Rationale

No crash.

## Testing/Review Recommendations

Reviewer: please make sure the buffer is deallocated in each branch.

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Autocomplete.