### PR TITLE
Remove flag system from FpySequencer

### DIFF
--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -216,31 +216,6 @@ void FpySequencer::STEP_cmdHandler(FwOpcodeType opCode,  //!< The opcode
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }
 
-//! Handler for command SET_FLAG
-//!
-//! Sets the value of a flag. See Fpy.FlagId docstrings for info on each flag.
-//! This command is only valid in the RUNNING state.
-void FpySequencer::SET_FLAG_cmdHandler(FwOpcodeType opCode,  //!< The opcode
-                                       U32 cmdSeq,           //!< The command sequence number
-                                       Svc::Fpy::FlagId flag,
-                                       bool value) {
-    if (!this->isRunningState(this->sequencer_getState())) {
-        // can only set flag while running
-        this->log_WARNING_HI_InvalidCommand(static_cast<I32>(sequencer_getState()));
-        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
-        return;
-    }
-
-    // this is a sanity check, we shouldn't even get here if this isn't true
-    // because the enum should check for validity and raise a format err if not valid.
-    // actually what this really catches is an incorrect FLAG_COUNT value
-    FW_ASSERT(static_cast<I32>(flag.e) < Fpy::FLAG_COUNT, static_cast<FwAssertArgType>(flag.e));
-
-    this->m_runtime.flags[flag.e] = value;
-
-    this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
-}
-
 //! Handler for command DUMP_STACK_TO_FILE
 //!
 //! Writes the contents of the stack to a file. This command is only valid in the RUNNING.PAUSED state.
@@ -374,17 +349,9 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
     // 3) the response is from the correct opcode
     // 4) the response is from the correct instance of that opcode in the sequence
 
-    // if we aren't supposed to exit on fail, succeed unconditionally
-    if (!this->m_runtime.flags[Fpy::FlagId::EXIT_ON_CMD_FAIL]) {
-        this->sequencer_sendSignal_stmtResponse_success();
-    } else if (response == Fw::CmdResponse::OK) {
-        // if we didn't fail, succeed!
-        this->sequencer_sendSignal_stmtResponse_success();
-    } else {
-        // cmd failed and we want to exit. raise a statement failure
-        this->log_WARNING_HI_CommandFailed(opCode, this->currentStatementIdx(), this->m_sequenceFilePath, response);
-        this->sequencer_sendSignal_stmtResponse_failure();
-    }
+    // always succeed; the cmd response value is pushed to the stack so the sequence
+    // can branch on it if desired
+    this->sequencer_sendSignal_stmtResponse_success();
 
     // push the cmd response to the stack so we can branch off of it
     this->m_runtime.stack.push(static_cast<I32>(response.e));
@@ -489,7 +456,6 @@ void FpySequencer::updateDebugTelemetryStruct() {
 
 void FpySequencer::parametersLoaded() {
     parameterUpdated(PARAMID_STATEMENT_TIMEOUT_SECS);
-    parameterUpdated(PARAMID_FLAG_DEFAULT_EXIT_ON_CMD_FAIL);
 }
 
 void FpySequencer::parameterUpdated(FwPrmIdType id) {
@@ -497,10 +463,6 @@ void FpySequencer::parameterUpdated(FwPrmIdType id) {
     switch (id) {
         case PARAMID_STATEMENT_TIMEOUT_SECS: {
             this->tlmWrite_PRM_STATEMENT_TIMEOUT_SECS(this->paramGet_STATEMENT_TIMEOUT_SECS(valid));
-            break;
-        }
-        case PARAMID_FLAG_DEFAULT_EXIT_ON_CMD_FAIL: {
-            this->tlmWrite_PRM_FLAG_DEFAULT_EXIT_ON_CMD_FAIL(this->paramGet_FLAG_DEFAULT_EXIT_ON_CMD_FAIL(valid));
             break;
         }
         default: {

--- a/Svc/FpySequencer/FpySequencer.hpp
+++ b/Svc/FpySequencer/FpySequencer.hpp
@@ -13,7 +13,6 @@
 #include "Fw/Types/WaitEnumAc.hpp"
 #include "Os/File.hpp"
 #include "Svc/FpySequencer/DirectiveIdEnumAc.hpp"
-#include "Svc/FpySequencer/FlagIdEnumAc.hpp"
 #include "Svc/FpySequencer/FooterSerializableAc.hpp"
 #include "Svc/FpySequencer/FppConstantsAc.hpp"
 #include "Svc/FpySequencer/FpySequencerComponentAc.hpp"
@@ -33,7 +32,6 @@ static_assert(Svc::Fpy::MAX_STACK_SIZE >= static_cast<FwSizeType>(FW_TLM_BUFFER_
               "Max stack size must be greater than max tlm buffer size");
 static_assert(Svc::Fpy::MAX_STACK_SIZE >= static_cast<FwSizeType>(FW_PARAM_BUFFER_MAX_SIZE),
               "Max stack size must be greater than max prm buffer size");
-static_assert(Svc::Fpy::FLAG_COUNT < std::numeric_limits<U8>::max(), "Flag count must be less than U8 max");
 
 namespace Svc {
 
@@ -65,8 +63,6 @@ class FpySequencer : public FpySequencerComponentBase {
         FpySequencer_MemCmpDirective memCmp;
         FpySequencer_StackCmdDirective stackCmd;
         FpySequencer_PushTimeDirective pushTime;
-        FpySequencer_SetFlagDirective setFlag;
-        FpySequencer_GetFlagDirective getFlag;
         FpySequencer_GetFieldDirective getField;
         FpySequencer_PeekDirective peek;
         FpySequencer_StoreRelDirective storeRel;
@@ -218,14 +214,6 @@ class FpySequencer : public FpySequencerComponentBase {
                          U32 cmdSeq            //!< The command sequence number
                          ) override;
 
-    //! Handler for command SET_FLAG
-    //!
-    //! Sets the value of a flag. See Fpy.FlagId docstrings for info on each flag.
-    //! This command is only valid in the RUNNING state.
-    void SET_FLAG_cmdHandler(FwOpcodeType opCode,  //!< The opcode
-                             U32 cmdSeq,           //!< The command sequence number
-                             Svc::Fpy::FlagId flag,
-                             bool value) override;
     //! Handler for command DUMP_STACK_TO_FILE
     //!
     //! Writes the contents of the stack to a file. This command is only valid in the RUNNING.PAUSED state.
@@ -552,12 +540,6 @@ class FpySequencer : public FpySequencerComponentBase {
     //! Internal interface handler for directive_pushTime
     void directive_pushTime_internalInterfaceHandler(const Svc::FpySequencer_PushTimeDirective& directive) override;
 
-    //! Internal interface handler for directive_setFlag
-    void directive_setFlag_internalInterfaceHandler(const Svc::FpySequencer_SetFlagDirective& directive) override;
-
-    //! Internal interface handler for directive_getFlag
-    void directive_getFlag_internalInterfaceHandler(const Svc::FpySequencer_GetFlagDirective& directive) override;
-
     //! Internal interface handler for directive_getField
     void directive_getField_internalInterfaceHandler(const Svc::FpySequencer_GetFieldDirective& directive) override;
 
@@ -646,11 +628,6 @@ class FpySequencer : public FpySequencerComponentBase {
         Fw::Time wakeupTime = Fw::Time();
 
         Stack stack = Stack();
-
-        // the sequencer runtime flags. these are modifiable by the sequence and control
-        // various aspects of the sequencer.
-        // these get set to a default value from FpySequencerCfg
-        bool flags[Fpy::FLAG_COUNT] = {0};
     } m_runtime;
 
     // the state of the debugger. debugger is separate from runtime
@@ -857,8 +834,6 @@ class FpySequencer : public FpySequencerComponentBase {
     Signal memCmp_directiveHandler(const FpySequencer_MemCmpDirective& directive, DirectiveError& error);
     Signal stackCmd_directiveHandler(const FpySequencer_StackCmdDirective& directive, DirectiveError& error);
     Signal pushTime_directiveHandler(const FpySequencer_PushTimeDirective& directive, DirectiveError& error);
-    Signal setFlag_directiveHandler(const FpySequencer_SetFlagDirective& directive, DirectiveError& error);
-    Signal getFlag_directiveHandler(const FpySequencer_GetFlagDirective& directive, DirectiveError& error);
     Signal getField_directiveHandler(const FpySequencer_GetFieldDirective& directive, DirectiveError& error);
     Signal peek_directiveHandler(const FpySequencer_PeekDirective& directive, DirectiveError& error);
     Signal storeRel_directiveHandler(const FpySequencer_StoreRelDirective& directive, DirectiveError& error);

--- a/Svc/FpySequencer/FpySequencerCommands.fppi
+++ b/Svc/FpySequencer/FpySequencerCommands.fppi
@@ -57,15 +57,8 @@ async command CLEAR_BREAKPOINT() \
 async command STEP() \
     opcode 8 priority 7 assert
 
-@ Sets the value of a flag. See Fpy.FlagId docstrings for info on each flag. 
-@ This command is only valid in the RUNNING state.
-async command SET_FLAG(
-    flag: Fpy.FlagId, value: bool
-) \
-    opcode 9 priority 7 assert
-
 @ Writes the contents of the stack to a file. This command is only valid in the RUNNING.PAUSED state.
 async command DUMP_STACK_TO_FILE(
     fileName: string size FileNameStringSize @< The name of the output file
 ) \
-    opcode 10 priority 7 assert
+    opcode 9 priority 7 assert

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -208,20 +208,6 @@ void FpySequencer::directive_pushTime_internalInterfaceHandler(const Svc::FpySeq
     handleDirectiveErrorCode(Fpy::DirectiveId::PUSH_TIME, error);
 }
 
-//! Internal interface handler for directive_setFlag
-void FpySequencer::directive_setFlag_internalInterfaceHandler(const Svc::FpySequencer_SetFlagDirective& directive) {
-    DirectiveError error = DirectiveError::NO_ERROR;
-    this->sendSignal(this->setFlag_directiveHandler(directive, error));
-    handleDirectiveErrorCode(Fpy::DirectiveId::SET_FLAG, error);
-}
-
-//! Internal interface handler for directive_getFlag
-void FpySequencer::directive_getFlag_internalInterfaceHandler(const Svc::FpySequencer_GetFlagDirective& directive) {
-    DirectiveError error = DirectiveError::NO_ERROR;
-    this->sendSignal(this->getFlag_directiveHandler(directive, error));
-    handleDirectiveErrorCode(Fpy::DirectiveId::GET_FLAG, error);
-}
-
 //! Internal interface handler for directive_getField
 void FpySequencer::directive_getField_internalInterfaceHandler(const Svc::FpySequencer_GetFieldDirective& directive) {
     DirectiveError error = DirectiveError::NO_ERROR;
@@ -1293,39 +1279,6 @@ Signal FpySequencer::pushTime_directiveHandler(const FpySequencer_PushTimeDirect
 
     // push time to end of stack
     this->m_runtime.stack.push(timeEsb.getBuffAddr(), static_cast<Fpy::StackSizeType>(timeEsb.getSize()));
-    return Signal::stmtResponse_success;
-}
-
-Signal FpySequencer::setFlag_directiveHandler(const FpySequencer_SetFlagDirective& directive, DirectiveError& error) {
-    if (this->m_runtime.stack.size < 1) {
-        error = DirectiveError::STACK_UNDERFLOW;
-        return Signal::stmtResponse_failure;
-    }
-    if (directive.get_flagIdx() >= Fpy::FLAG_COUNT) {
-        error = DirectiveError::FLAG_IDX_OUT_OF_BOUNDS;
-        return Signal::stmtResponse_failure;
-    }
-
-    // 1 if the stack bool is nonzero, 0 otherwise
-    U8 flagVal = this->m_runtime.stack.pop<U8>() != 0;
-
-    this->m_runtime.flags[directive.get_flagIdx()] = flagVal == 1;
-    return Signal::stmtResponse_success;
-}
-
-Signal FpySequencer::getFlag_directiveHandler(const FpySequencer_GetFlagDirective& directive, DirectiveError& error) {
-    if (Fpy::MAX_STACK_SIZE - this->m_runtime.stack.size < 1) {
-        error = DirectiveError::STACK_OVERFLOW;
-        return Signal::stmtResponse_failure;
-    }
-    if (directive.get_flagIdx() >= Fpy::FLAG_COUNT) {
-        error = DirectiveError::FLAG_IDX_OUT_OF_BOUNDS;
-        return Signal::stmtResponse_failure;
-    }
-
-    bool flagVal = this->m_runtime.flags[directive.get_flagIdx()];
-    this->m_runtime.stack.push<U8>(flagVal ? static_cast<U8>(FW_SERIALIZE_TRUE_VALUE)
-                                           : static_cast<U8>(FW_SERIALIZE_FALSE_VALUE));
     return Signal::stmtResponse_success;
 }
 

--- a/Svc/FpySequencer/FpySequencerDirectives.fppi
+++ b/Svc/FpySequencer/FpySequencerDirectives.fppi
@@ -122,16 +122,6 @@ struct PushTimeDirective {
     _empty: U8
 }
 
-@ pops a bool off the stack, sets a flag with a specific index to that bool
-struct SetFlagDirective {
-    flagIdx: U8
-}
-
-@ gets a flag and pushes its value as a U8 to the stack
-struct GetFlagDirective {
-    flagIdx: U8
-}
-
 @ grabs a specified region from a struct, pushes it to the stack, removing
 @ the rest of the struct
 struct GetFieldDirective {
@@ -226,10 +216,6 @@ internal port directive_memCmp(directive: MemCmpDirective) priority 6 assert
 internal port directive_stackCmd(directive: StackCmdDirective) priority 6 assert
 
 internal port directive_pushTime(directive: PushTimeDirective) priority 6 assert
-
-internal port directive_setFlag(directive: SetFlagDirective) priority 6 assert
-
-internal port directive_getFlag(directive: GetFlagDirective) priority 6 assert
 
 internal port directive_getField(directive: GetFieldDirective) priority 6 assert
 

--- a/Svc/FpySequencer/FpySequencerParams.fppi
+++ b/Svc/FpySequencer/FpySequencerParams.fppi
@@ -3,6 +3,3 @@
 @ accuracy of this timeout is determined by the rate group driving this
 @ component. it will be rounded up
 param STATEMENT_TIMEOUT_SECS: F32 default 0
-
-@ the default value of the EXIT_ON_CMD_FAIL sequence flag
-param FLAG_DEFAULT_EXIT_ON_CMD_FAIL: bool default false

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -358,26 +358,6 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
             }
             break;
         }
-        case Fpy::DirectiveId::SET_FLAG: {
-            new (&deserializedDirective.setFlag) FpySequencer_SetFlagDirective();
-            status = argBuf.deserializeTo(deserializedDirective.setFlag);
-            if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getDeserializeSizeLeft() != 0) {
-                this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
-                                                               argBuf.getDeserializeSizeLeft(), argBuf.getSize());
-                return Fw::Success::FAILURE;
-            }
-            break;
-        }
-        case Fpy::DirectiveId::GET_FLAG: {
-            new (&deserializedDirective.getFlag) FpySequencer_GetFlagDirective();
-            status = argBuf.deserializeTo(deserializedDirective.getFlag);
-            if (status != Fw::SerializeStatus::FW_SERIALIZE_OK || argBuf.getDeserializeSizeLeft() != 0) {
-                this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
-                                                               argBuf.getDeserializeSizeLeft(), argBuf.getSize());
-                return Fw::Success::FAILURE;
-            }
-            break;
-        }
         case Fpy::DirectiveId::GET_FIELD: {
             new (&deserializedDirective.getField) FpySequencer_GetFieldDirective();
             status = argBuf.deserializeTo(deserializedDirective.getField);
@@ -598,14 +578,6 @@ void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy:
         }
         case Fpy::DirectiveId::PUSH_TIME: {
             this->directive_pushTime_internalInterfaceInvoke(directive.pushTime);
-            return;
-        }
-        case Fpy::DirectiveId::SET_FLAG: {
-            this->directive_setFlag_internalInterfaceInvoke(directive.setFlag);
-            return;
-        }
-        case Fpy::DirectiveId::GET_FLAG: {
-            this->directive_getFlag_internalInterfaceInvoke(directive.getFlag);
             return;
         }
         case Fpy::DirectiveId::GET_FIELD: {

--- a/Svc/FpySequencer/FpySequencerStateMachine.cpp
+++ b/Svc/FpySequencer/FpySequencerStateMachine.cpp
@@ -172,8 +172,6 @@ void FpySequencer::Svc_FpySequencer_SequencerStateMachine_action_resetRuntime(
     // explicitly call dtor
     this->m_runtime.~Runtime();
     new (&this->m_runtime) Runtime();
-    Fw::ParamValid valid;
-    this->m_runtime.flags[Fpy::FlagId::EXIT_ON_CMD_FAIL] = this->paramGet_FLAG_DEFAULT_EXIT_ON_CMD_FAIL(valid);
 }
 
 //! Implementation for action validate of state machine

--- a/Svc/FpySequencer/FpySequencerTelemetry.fppi
+++ b/Svc/FpySequencer/FpySequencerTelemetry.fppi
@@ -60,6 +60,3 @@ telemetry BreakBeforeNextLine: bool update on change
 
 @ value of prm STATEMENT_TIMEOUT_SECS
 telemetry PRM_STATEMENT_TIMEOUT_SECS: F32 update on change
-
-@ value of prm FLAG_DEFAULT_EXIT_ON_CMD_FAIL
-telemetry PRM_FLAG_DEFAULT_EXIT_ON_CMD_FAIL: bool update on change

--- a/Svc/FpySequencer/FpySequencerTypes.fpp
+++ b/Svc/FpySequencer/FpySequencerTypes.fpp
@@ -1,17 +1,7 @@
 module Svc {
     module Fpy {
         @ the current schema version (must be representable in U8)
-        constant SCHEMA_VERSION = 4;
-
-        @ the number of runtime configurable flags. flags modify the sequencer behavior and can be set by the sequence
-        # should be equal to (last flag id) + 1
-        constant FLAG_COUNT = 1
-
-        dictionary enum FlagId : U8 {
-            # must start at 0 and increment by 1 each time
-            @ if true, the sequence will exit with an error if a command fails
-            EXIT_ON_CMD_FAIL = 0
-        }
+        constant SCHEMA_VERSION = 5;
 
         @ the type which everything referencing a size or offset on the stack is represented in
         # we use a U32 because U16 is too small (would only allow up to 65 kB max stack size)
@@ -108,16 +98,14 @@ module Svc {
             STACK_CMD = 64
             PUSH_TLM_VAL_AND_TIME = 65
             PUSH_TIME = 66
-            SET_FLAG = 67
-            GET_FLAG = 68
-            GET_FIELD = 69
-            PEEK = 70
-            STORE_REL = 71
-            CALL = 72
-            RETURN = 73
-            LOAD_ABS = 74
-            STORE_ABS = 75
-            STORE_ABS_CONST_OFFSET = 76
+            GET_FIELD = 67
+            PEEK = 68
+            STORE_REL = 69
+            CALL = 70
+            RETURN = 71
+            LOAD_ABS = 72
+            STORE_ABS = 73
+            STORE_ABS_CONST_OFFSET = 74
         }
 
         enum DirectiveErrorCode : U8 {
@@ -132,12 +120,12 @@ module Svc {
             STACK_ACCESS_OUT_OF_BOUNDS = 8
             STACK_OVERFLOW = 9
             DOMAIN_ERROR = 10
-            FLAG_IDX_OUT_OF_BOUNDS = 11
-            ARRAY_OUT_OF_BOUNDS = 12
-            ARITHMETIC_OVERFLOW = 13
-            ARITHMETIC_UNDERFLOW = 14
-            FRAME_START_OUT_OF_BOUNDS = 15
-            STACK_UNDERFLOW = 16
+            ARRAY_OUT_OF_BOUNDS = 11
+            ARITHMETIC_OVERFLOW = 12
+            ARITHMETIC_UNDERFLOW = 13
+            FRAME_START_OUT_OF_BOUNDS = 14
+            STACK_UNDERFLOW = 15
+            CMD_FAIL = 16
         }
 
         struct Header {

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -1365,71 +1365,6 @@ TEST_F(FpySequencerTester, memCmp) {
     ASSERT_EQ(err, DirectiveError::STACK_UNDERFLOW);
 }
 
-TEST_F(FpySequencerTester, setFlag) {
-    FpySequencer_SetFlagDirective directive(0);
-    tester_push<U8>(1);
-    DirectiveError err = DirectiveError::NO_ERROR;
-    Signal result = tester_setFlag_directiveHandler(directive, err);
-    ASSERT_EQ(result, Signal::stmtResponse_success);
-    ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_TRUE(tester_get_m_runtime_ptr()->flags[static_cast<Fpy::FlagId::T>(0)]);
-
-    // Test setting flag to false
-    tester_push<U8>(0);
-    result = tester_setFlag_directiveHandler(directive, err);
-    ASSERT_EQ(result, Signal::stmtResponse_success);
-    ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_FALSE(tester_get_m_runtime_ptr()->flags[static_cast<Fpy::FlagId::T>(0)]);
-
-    // Test invalid flag index
-    directive.set_flagIdx(Fpy::FLAG_COUNT);
-    tester_push<U8>(1);
-    result = tester_setFlag_directiveHandler(directive, err);
-    ASSERT_EQ(result, Signal::stmtResponse_failure);
-    ASSERT_EQ(err, DirectiveError::FLAG_IDX_OUT_OF_BOUNDS);
-    tester_get_m_runtime_ptr()->stack.size = 0;
-
-    // Test stack underflow
-    directive.set_flagIdx(0);
-    result = tester_setFlag_directiveHandler(directive, err);
-    ASSERT_EQ(result, Signal::stmtResponse_failure);
-    ASSERT_EQ(err, DirectiveError::STACK_UNDERFLOW);
-}
-
-TEST_F(FpySequencerTester, getFlag) {
-    tester_get_m_runtime_ptr()->flags[0] = true;
-    FpySequencer_GetFlagDirective directive(0);
-    DirectiveError err = DirectiveError::NO_ERROR;
-    Signal result = tester_getFlag_directiveHandler(directive, err);
-    ASSERT_EQ(result, Signal::stmtResponse_success);
-    ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 1);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_TRUE_VALUE);
-
-    // reset stack
-    tester_get_m_runtime_ptr()->stack.size = 0;
-    // test getting false flag
-    tester_get_m_runtime_ptr()->flags[0] = false;
-    result = tester_getFlag_directiveHandler(directive, err);
-    ASSERT_EQ(result, Signal::stmtResponse_success);
-    ASSERT_EQ(err, DirectiveError::NO_ERROR);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.size, 1);
-    ASSERT_EQ(tester_get_m_runtime_ptr()->stack.bytes[0], FW_SERIALIZE_FALSE_VALUE);
-
-    // Test invalid flag index
-    directive.set_flagIdx(Fpy::FLAG_COUNT);
-    result = tester_getFlag_directiveHandler(directive, err);
-    ASSERT_EQ(result, Signal::stmtResponse_failure);
-    ASSERT_EQ(err, DirectiveError::FLAG_IDX_OUT_OF_BOUNDS);
-
-    // Test stack overflow
-    tester_get_m_runtime_ptr()->stack.size = Fpy::MAX_STACK_SIZE;
-    directive.set_flagIdx(0);
-    result = tester_getFlag_directiveHandler(directive, err);
-    ASSERT_EQ(result, Signal::stmtResponse_failure);
-    ASSERT_EQ(err, DirectiveError::STACK_OVERFLOW);
-}
-
 TEST_F(FpySequencerTester, pushTime) {
     FpySequencer_PushTimeDirective directive;
     DirectiveError err = DirectiveError::NO_ERROR;
@@ -2354,28 +2289,6 @@ TEST_F(FpySequencerTester, cmd_CONTINUE) {
     ASSERT_EQ(this->tester_getState(), State::RUNNING_DISPATCH_STATEMENT);
 }
 
-TEST_F(FpySequencerTester, cmd_SET_FLAG) {
-    this->tester_setState(State::IDLE);
-    sendCmd_SET_FLAG(0, 0, Svc::Fpy::FlagId::EXIT_ON_CMD_FAIL, false);
-    this->tester_doDispatch();
-    ASSERT_CMD_RESPONSE_SIZE(1);
-    // should fail in IDLE
-    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_SET_FLAG(), 0, Fw::CmdResponse::EXECUTION_ERROR);
-    this->clearHistory();
-
-    tester_get_m_runtime_ptr()->flags[Fpy::FlagId::EXIT_ON_CMD_FAIL] = false;
-
-    // okay try setting in await stmt response
-    this->tester_setState(State::RUNNING_AWAITING_STATEMENT_RESPONSE);
-    sendCmd_SET_FLAG(0, 0, Fpy::FlagId::EXIT_ON_CMD_FAIL, true);
-    // dispatch cmd handler
-    this->tester_doDispatch();
-    ASSERT_CMD_RESPONSE_SIZE(1);
-    // should work in await stmt response
-    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_SET_FLAG(), 0, Fw::CmdResponse::OK);
-    ASSERT_TRUE(tester_get_m_runtime_ptr()->flags[Fpy::FlagId::EXIT_ON_CMD_FAIL]);
-}
-
 TEST_F(FpySequencerTester, cmd_STEP) {
     // Test STEP command in IDLE state (should fail)
     this->tester_setState(State::IDLE);
@@ -3020,46 +2933,6 @@ TEST_F(FpySequencerTester, deserialize_memCmp) {
     ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
 }
 
-TEST_F(FpySequencerTester, deserialize_setFlag) {
-    FpySequencer::DirectiveUnion actual;
-    FpySequencer_SetFlagDirective dir(123);
-    add_SET_FLAG(dir);
-    Fw::Success result = tester_deserializeDirective(seq.get_statements()[0], actual);
-    ASSERT_EQ(result, Fw::Success::SUCCESS);
-    ASSERT_EQ(actual.setFlag, dir);
-    // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serializeFrom(123);
-    result = tester_deserializeDirective(seq.get_statements()[0], actual);
-    ASSERT_EQ(result, Fw::Success::FAILURE);
-    ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
-    this->clearHistory();
-    // clear args, make sure it fails
-    seq.get_statements()[0].get_argBuf().resetSer();
-    result = tester_deserializeDirective(seq.get_statements()[0], actual);
-    ASSERT_EQ(result, Fw::Success::FAILURE);
-    ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
-}
-
-TEST_F(FpySequencerTester, deserialize_getFlag) {
-    FpySequencer::DirectiveUnion actual;
-    FpySequencer_GetFlagDirective dir(123);
-    add_GET_FLAG(dir);
-    Fw::Success result = tester_deserializeDirective(seq.get_statements()[0], actual);
-    ASSERT_EQ(result, Fw::Success::SUCCESS);
-    ASSERT_EQ(actual.getFlag, dir);
-    // write some junk after buf, make sure it fails
-    seq.get_statements()[0].get_argBuf().serializeFrom(123);
-    result = tester_deserializeDirective(seq.get_statements()[0], actual);
-    ASSERT_EQ(result, Fw::Success::FAILURE);
-    ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
-    this->clearHistory();
-    // clear args, make sure it fails
-    seq.get_statements()[0].get_argBuf().resetSer();
-    result = tester_deserializeDirective(seq.get_statements()[0], actual);
-    ASSERT_EQ(result, Fw::Success::FAILURE);
-    ASSERT_EVENTS_DirectiveDeserializeError_SIZE(1);
-}
-
 TEST_F(FpySequencerTester, deserialize_getField) {
     FpySequencer::DirectiveUnion actual;
     FpySequencer_GetFieldDirective dir(123, 123);
@@ -3297,35 +3170,6 @@ TEST_F(FpySequencerTester, seqRunIn) {
     this->tester_doDispatch();
     ASSERT_EVENTS_InvalidSeqRunCall_SIZE(1);
     removeFile("test.bin");
-}
-
-TEST_F(FpySequencerTester, flag_EXIT_ON_CMD_FAIL) {
-    // test a simple seq that fails because a cmd fails
-    this->paramSet_FLAG_DEFAULT_EXIT_ON_CMD_FAIL(true, Fw::ParamValid::VALID);
-    this->paramSend_FLAG_DEFAULT_EXIT_ON_CMD_FAIL(0, 0);
-    this->clearHistory();
-    allocMem();
-    add_CONST_CMD(123);
-    writeAndRun();
-    dispatchUntilState(State::RUNNING_AWAITING_STATEMENT_RESPONSE);
-    // okay now send in a failure
-    invoke_to_cmdResponseIn(0, 123, 0x00010001, Fw::CmdResponse::EXECUTION_ERROR);
-    dispatchUntilState(State::IDLE);
-    ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, 0, get_OPCODE_RUN(), Fw::CmdResponse::EXECUTION_ERROR);
-
-    // now test that it doesn't fail if we set flag to false
-    this->paramSet_FLAG_DEFAULT_EXIT_ON_CMD_FAIL(false, Fw::ParamValid::VALID);
-    this->paramSend_FLAG_DEFAULT_EXIT_ON_CMD_FAIL(0, 0);
-    this->clearHistory();
-    // cmd is already in seq, can just rerun
-    writeAndRun();
-    dispatchUntilState(State::RUNNING_AWAITING_STATEMENT_RESPONSE);
-    // okay now send in a failure
-    invoke_to_cmdResponseIn(0, 123, 0x00020002, Fw::CmdResponse::EXECUTION_ERROR);
-    dispatchUntilState(State::IDLE);
-    ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, 0, get_OPCODE_RUN(), Fw::CmdResponse::OK);
 }
 
 // ----------------------------------------------------------------------
@@ -4105,19 +3949,6 @@ TEST_F(FpySequencerTester, IntegrationMemCmp) {
     add_PUSH_VAL<U8>(0x42);
     add_PUSH_VAL<U8>(0x42);
     add_MEMCMP(1);
-    add_DISCARD(1);
-    writeAndRun();
-    dispatchUntilState(State::IDLE);
-    ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, get_OPCODE_RUN(), 0, Fw::CmdResponse::OK);
-}
-
-TEST_F(FpySequencerTester, IntegrationSetGetFlag) {
-    allocMem();
-    // Sequence: PUSH_VAL<U8>(1), SET_FLAG(0), GET_FLAG(0), DISCARD(1)
-    add_PUSH_VAL<U8>(1);
-    add_SET_FLAG(0);
-    add_GET_FLAG(0);
     add_DISCARD(1);
     writeAndRun();
     dispatchUntilState(State::IDLE);

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.cpp
@@ -278,22 +278,6 @@ void FpySequencerTester::add_MEMCMP(FpySequencer_MemCmpDirective dir) {
     FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
     addDirective(Fpy::DirectiveId::MEMCMP, buf);
 }
-void FpySequencerTester::add_SET_FLAG(U8 flagIdx) {
-    add_SET_FLAG(FpySequencer_SetFlagDirective(flagIdx));
-}
-void FpySequencerTester::add_SET_FLAG(FpySequencer_SetFlagDirective dir) {
-    Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
-    addDirective(Fpy::DirectiveId::SET_FLAG, buf);
-}
-void FpySequencerTester::add_GET_FLAG(U8 flagIdx) {
-    add_GET_FLAG(FpySequencer_GetFlagDirective(flagIdx));
-}
-void FpySequencerTester::add_GET_FLAG(FpySequencer_GetFlagDirective dir) {
-    Fw::StatementArgBuffer buf;
-    FW_ASSERT(buf.serializeFrom(dir) == Fw::SerializeStatus::FW_SERIALIZE_OK);
-    addDirective(Fpy::DirectiveId::GET_FLAG, buf);
-}
 void FpySequencerTester::add_PUSH_TIME() {
     Fw::StatementArgBuffer buf;
     addDirective(Fpy::DirectiveId::PUSH_TIME, buf);
@@ -499,16 +483,6 @@ Signal FpySequencerTester::tester_stackCmd_directiveHandler(const FpySequencer_S
 Signal FpySequencerTester::tester_memCmp_directiveHandler(const FpySequencer_MemCmpDirective& directive,
                                                           DirectiveError& err) {
     return this->cmp.memCmp_directiveHandler(directive, err);
-}
-
-Signal FpySequencerTester::tester_setFlag_directiveHandler(const FpySequencer_SetFlagDirective& directive,
-                                                           DirectiveError& err) {
-    return this->cmp.setFlag_directiveHandler(directive, err);
-}
-
-Signal FpySequencerTester::tester_getFlag_directiveHandler(const FpySequencer_GetFlagDirective& directive,
-                                                           DirectiveError& err) {
-    return this->cmp.getFlag_directiveHandler(directive, err);
 }
 
 Signal FpySequencerTester::tester_getField_directiveHandler(const FpySequencer_GetFieldDirective& directive,

--- a/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTester.hpp
@@ -111,10 +111,6 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     void add_STACK_CMD(FpySequencer_StackCmdDirective dir);
     void add_MEMCMP(Fpy::StackSizeType size);
     void add_MEMCMP(FpySequencer_MemCmpDirective dir);
-    void add_SET_FLAG(U8 flagIdx);
-    void add_SET_FLAG(FpySequencer_SetFlagDirective dir);
-    void add_GET_FLAG(U8 flagIdx);
-    void add_GET_FLAG(FpySequencer_GetFlagDirective dir);
     void add_PUSH_TIME();
     void add_GET_FIELD(Fpy::StackSizeType parentSize, Fpy::StackSizeType memberSize);
     void add_GET_FIELD(FpySequencer_GetFieldDirective dir);
@@ -174,8 +170,6 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
     Signal tester_discard_directiveHandler(const FpySequencer_DiscardDirective& directive, DirectiveError& err);
     Signal tester_stackCmd_directiveHandler(const FpySequencer_StackCmdDirective& directive, DirectiveError& err);
     Signal tester_memCmp_directiveHandler(const FpySequencer_MemCmpDirective& directive, DirectiveError& err);
-    Signal tester_setFlag_directiveHandler(const FpySequencer_SetFlagDirective& directive, DirectiveError& err);
-    Signal tester_getFlag_directiveHandler(const FpySequencer_GetFlagDirective& directive, DirectiveError& err);
     Signal tester_getField_directiveHandler(const FpySequencer_GetFieldDirective& directive, DirectiveError& err);
     Signal tester_peek_directiveHandler(const FpySequencer_PeekDirective& directive, DirectiveError& err);
     Signal tester_storeRel_directiveHandler(const FpySequencer_StoreRelDirective& directive, DirectiveError& err);
@@ -298,9 +292,6 @@ class FpySequencerTester : public FpySequencerGTestBase, public ::testing::Test 
 
     //! Get the OPCODE_BREAK value
     static FwOpcodeType get_OPCODE_BREAK() { return FpySequencerComponentBase::OPCODE_BREAK; }
-
-    //! Get the OPCODE_SET_FLAG value
-    static FwOpcodeType get_OPCODE_SET_FLAG() { return FpySequencerComponentBase::OPCODE_SET_FLAG; }
 
     //! Get the OPCODE_CONTINUE value
     static FwOpcodeType get_OPCODE_CONTINUE() { return FpySequencerComponentBase::OPCODE_CONTINUE; }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4946  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

* Remove the flag struct, flag directives, flag commands, flag tests, flag parameters, and flag telemetry
* No matter the value of a command response, the sequencer always sends `stmtResponse_success`. It is up to the sequence to handle failed cmd responses.
* Add a CMD_FAIL DirectiveErrorCode enum constant, that the sequence can reference when it is failing due to a command response.
## Rationale

* This is the simplest and most general way to handle command responses and flags

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI wrote all the code.