### PR TITLE
fix: bounds check logic error in ENABLE_GROUP_cmdHandler and missing check in SEND_PKT_cmdHandler

### DIFF
--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -417,6 +417,10 @@ void TlmPacketizer ::SEND_PKT_cmdHandler(const FwOpcodeType opCode,
                                          const U32 id,
                                          const Svc::TelemetrySection section) {
     FW_ASSERT(section.isValid());
+    if (section < 0 or section >= TelemetrySection::NUM_SECTIONS) {
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     FwChanIdType pkt = 0;
     for (pkt = 0; pkt < this->m_numPackets; pkt++) {
         if (this->m_fillBuffers[pkt].id == id) {
@@ -464,8 +468,7 @@ void TlmPacketizer ::ENABLE_GROUP_cmdHandler(FwOpcodeType opCode,
                                              Fw::Enabled enable) {
     FW_ASSERT(section.isValid());
     FW_ASSERT(enable.isValid());
-    if ((0 <= section and section >= TelemetrySection::NUM_SECTIONS) or
-        tlmGroup > MAX_CONFIGURABLE_TLMPACKETIZER_GROUP) {
+    if (section < 0 or section >= TelemetrySection::NUM_SECTIONS or tlmGroup > MAX_CONFIGURABLE_TLMPACKETIZER_GROUP) {
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
         return;
     }


### PR DESCRIPTION
hey,

found a bug in the bounds cheking logic for the section param in TlmPacketizer.

in ENABLE_GROUP_cmdHandler the condition was:
if ((0 <= section and section >= TelemetrySection::NUM_SECTIONS) or ...)

this doesnt actualy catch negative section values. when section is like -1, the first part (0 <= section) evals to false, wich makes the whole AND expression false and skips the validation entierly. then it goes straight into m_groupConfigs[section][tlmGroup] with an out of bounds index.

the sister functions FORCE_GROUP_cmdHandler and CONFIGURE_GROUP_RATES_cmdHandler already use the corect pattern:
if (section < 0 or section >= TelemetrySection::NUM_SECTIONS or ...)

so i just made ENABLE_GROUP consistnet with them.

also noticed that SEND_PKT_cmdHandler was mising the section bounds check altogether before indexing into m_packetFlags[section][pkt], so i added the same validaiton there too.

summary of changes:
- fixed the broken logic in ENABLE_GROUP_cmdHandler
- added mising bounds check in SEND_PKT_cmdHandler
- both now return VALIDATION_ERROR for out of range section values, same as the othr handlers

thanks
Dhiego Pagotto