### PR TITLE
Make Fw.LogSeverity a dictionary enum

### DIFF
--- a/Fw/Log/Log.fpp
+++ b/Fw/Log/Log.fpp
@@ -4,7 +4,7 @@ module Fw {
   type TextLogString
 
   @ Enum representing event severity
-  enum LogSeverity : U8 {
+  dictionary enum LogSeverity : U8 {
     FATAL = 1 @< A fatal non-recoverable event
     WARNING_HI = 2 @< A serious but recoverable event
     WARNING_LO = 3 @< A less serious but recoverable event


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4951 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

* Adds the `dictionary` specifier to the `LogSeverity` enum in `Fw/Log.fpp`

## Rationale

That way ground systems can have access to the various log levels in FPrime without having to hard code them.


## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None
