### PR TITLE
Fix static analysis findings in snprintf_format.cpp

### DIFF
--- a/Fw/Types/snprintf_format.cpp
+++ b/Fw/Types/snprintf_format.cpp
@@ -21,7 +21,7 @@ Fw::FormatStatus Fw::stringFormat(char* destination,
                                   va_list args) {
     Fw::FormatStatus formatStatus = Fw::FormatStatus::SUCCESS;
     // Check destination pointer
-    if (destination == nullptr) {
+    if (destination == nullptr || maximumSize == 0) {
         return Fw::FormatStatus::OTHER_ERROR;
     }
     // Force null termination in error cases

--- a/Fw/Types/snprintf_format.cpp
+++ b/Fw/Types/snprintf_format.cpp
@@ -20,6 +20,10 @@ Fw::FormatStatus Fw::stringFormat(char* destination,
                                   const char* formatString,
                                   va_list args) {
     Fw::FormatStatus formatStatus = Fw::FormatStatus::SUCCESS;
+    // Check destination pointer
+    if (destination == nullptr) {
+        return Fw::FormatStatus::OTHER_ERROR;
+    }
     // Force null termination in error cases
     destination[0] = 0;
     // Check format string
@@ -30,7 +34,8 @@ Fw::FormatStatus Fw::stringFormat(char* destination,
     else if (maximumSize > std::numeric_limits<size_t>::max()) {
         formatStatus = Fw::FormatStatus::SIZE_OVERFLOW;
     } else {
-        int needed_size = vsnprintf(destination, static_cast<size_t>(maximumSize), formatString, args);
+        // Format string is intentionally a runtime parameter; suppressing static analysis warning
+        int needed_size = vsnprintf(destination, static_cast<size_t>(maximumSize), formatString, args);  // NOLINT
         destination[maximumSize - 1] = 0;  // Force null-termination
         if (needed_size < 0) {
             formatStatus = Fw::FormatStatus::OTHER_ERROR;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Fixes #4526 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Address static analysis findings in `Fw/Types/snprintf_format.cpp` reported by SonarQube and CodeSonar:

- **Unchecked Parameter Dereference (CodeSonar, Line 24):** Added a null check for the `destination` pointer before dereferencing it with `destination[0] = 0`. Returns `Fw::FormatStatus::OTHER_ERROR` early if null.
- **S5281: Format string is not a string literal (SonarQube, Line 33):** Added `// NOLINT` suppression with an explanatory comment. This warning is inherent to the function's purpose as a `vsnprintf` passthrough — the format string is intentionally a runtime parameter.

The remaining findings (S923 ellipsis notation, S1905 redundant cast, `<stdio.h>` usage) are either inherent to the function's variadic API design or are defensively correct across platforms, so they are left as-is.

## Rationale

Address static analysis findings to improve code quality and eliminate warnings.

## Testing/Review Recommendations

Static analysis clean build verification.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Generative AI was used to identify and draft fixes for the static analysis findings listed in #4526.