### PR TITLE
Issue 4931 prm db crc endian fix

### DIFF
--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -307,11 +307,8 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     buff.resetSer();
     serStat = buff.serializeFrom(crc);
 
-    FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));  
+    FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
     writeSize = static_cast<FwSizeType>(buff.getSize());
-
-    printf("DEBUG: file: %s, line: %d CINDY PRM_SAVE_FILE_cmdHandler: crc=0x%08x, writeSize=%llu\n ", 
-                __FILE__, __LINE__,  crc, static_cast<unsigned long long>(writeSize));
 
     stat = paramFile.write(buff.getBuffAddr(), writeSize, Os::File::WaitType::WAIT);
     if (stat != Os::File::OP_OK) {
@@ -433,15 +430,11 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
         return PrmLoadStatus::ERROR;
     }
 
-    // Deserialize the CRC in a portable way  
+    // Deserialize the CRC in a portable way
     buff.setBuffLen(readSize);
-    buff.resetDeser();  
-    Fw::SerializeStatus serStat = buff.deserializeTo(fileCrc);  
+    buff.resetDeser();
+    Fw::SerializeStatus serStat = buff.deserializeTo(fileCrc);
     FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
-
-     printf("DEBUG: file: %s, line: %d readParamFileImpl: fileCrc=0x%08x, readSize=%llu\n ", 
-                __FILE__, __LINE__,  fileCrc, static_cast<unsigned long long>(readSize));
-
 
     U32 crc = 0xFFFFFFFF;
     // read into CRC buffer for checking

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -431,9 +431,10 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
     }
 
     // Deserialize the CRC in a portable way
-    buff.setBuffLen(readSize);
+    Fw::SerializeStatus serStat = buff.setBuffLen(readSize);
+    FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
     buff.resetDeser();
-    Fw::SerializeStatus serStat = buff.deserializeTo(fileCrc);
+    serStat = buff.deserializeTo(fileCrc);
     FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
 
     U32 crc = 0xFFFFFFFF;

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -34,6 +34,7 @@ class WorkingBuffer : public Fw::SerializeBufferBase {
   private:
     // Set to max of parameter buffer + id
     U8 m_buff[FW_PARAM_BUFFER_MAX_SIZE + sizeof(FwPrmIdType)];
+    static_assert(sizeof(m_buff) >= sizeof(U32), "Size of parameter buffer storage must be >= sizeof(U32)");
 };
 }  // namespace
 

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -161,8 +161,11 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
 
     // write placeholder for the CRC
     U32 crc = 0xFFFFFFFF;
-    FwSizeType writeSize = static_cast<FwSizeType>(sizeof(crc));
-    stat = paramFile.write(reinterpret_cast<const U8*>(&crc), writeSize, Os::File::WaitType::WAIT);
+    buff.resetSer();
+    Fw::SerializeStatus serStat = buff.serializeFrom(crc);
+    FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
+    FwSizeType writeSize = static_cast<FwSizeType>(buff.getSize());
+    stat = paramFile.write(buff.getBuffAddr(), writeSize, Os::File::WaitType::WAIT);
 
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::CRC_PLACE, 0, stat);
@@ -205,7 +208,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
 
         // reset buffer
         buff.resetSer();
-        Fw::SerializeStatus serStat = buff.serializeFrom(recordSize);
+        serStat = buff.serializeFrom(recordSize);
         // should always work
         FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
 
@@ -301,8 +304,16 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
         return;
     }
-    writeSize = static_cast<FwSizeType>(sizeof(crc));
-    stat = paramFile.write(reinterpret_cast<const U8*>(&crc), writeSize, Os::File::WaitType::WAIT);
+    buff.resetSer();
+    serStat = buff.serializeFrom(crc);
+
+    FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));  
+    writeSize = static_cast<FwSizeType>(buff.getSize());
+
+    printf("DEBUG: file: %s, line: %d CINDY PRM_SAVE_FILE_cmdHandler: crc=0x%08x, writeSize=%llu\n ", 
+                __FILE__, __LINE__,  crc, static_cast<unsigned long long>(writeSize));
+
+    stat = paramFile.write(buff.getBuffAddr(), writeSize, Os::File::WaitType::WAIT);
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::CRC_REAL, 0, stat);
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
@@ -406,10 +417,12 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
     }
     //===========================================================================
     // read CRC from beginning of file
+    WorkingBuffer buff;
     U32 fileCrc;
     FwSizeType readSize = static_cast<FwSizeType>(sizeof(fileCrc));
 
-    stat = paramFile.read(reinterpret_cast<U8*>(&fileCrc), readSize);
+    // Read raw CRC bytes from file
+    stat = paramFile.read(buff.getBuffAddr(), readSize);
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC, static_cast<I32>(0), stat);
         return PrmLoadStatus::ERROR;
@@ -419,6 +432,16 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
         this->log_WARNING_HI_PrmFileReadError(PrmReadError::CRC_SIZE, static_cast<I32>(0), static_cast<I32>(readSize));
         return PrmLoadStatus::ERROR;
     }
+
+    // Deserialize the CRC in a portable way  
+    buff.setBuffLen(readSize);
+    buff.resetDeser();  
+    Fw::SerializeStatus serStat = buff.deserializeTo(fileCrc);  
+    FW_ASSERT(Fw::FW_SERIALIZE_OK == serStat, static_cast<FwAssertArgType>(serStat));
+
+     printf("DEBUG: file: %s, line: %d readParamFileImpl: fileCrc=0x%08x, readSize=%llu\n ", 
+                __FILE__, __LINE__,  fileCrc, static_cast<unsigned long long>(readSize));
+
 
     U32 crc = 0xFFFFFFFF;
     // read into CRC buffer for checking
@@ -441,8 +464,6 @@ PrmDbImpl::PrmLoadStatus PrmDbImpl::readParamFileImpl(const Fw::StringBase& file
         return PrmLoadStatus::ERROR;
     }
     //===========================================================================
-
-    WorkingBuffer buff;
 
     U32 recordNumTotal = 0;
     U32 recordNumAdded = 0;

--- a/Svc/PrmDb/test/ut/PrmDbTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.cpp
@@ -445,7 +445,6 @@ void PrmDbTester::runFileReadError() {
         this->m_waits = i + xa;
         this->m_impl.readParamFile();
         ASSERT_EVENTS_SIZE(1);
-        printf("DEBUG: PrmFileBadCrc case %d: m_waits=%d\n", static_cast<I32>(i), static_cast<I32>(i + xa));
 
         switch (i) {
             case 0:

--- a/Svc/PrmDb/test/ut/PrmDbTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.cpp
@@ -356,7 +356,6 @@ void PrmDbTester::runFileReadError() {
     for (FwSizeType i = 0; i < 5; i++) {
         clearEvents();
         this->m_waits = i + za;
-        printf("DEBUG: FILE_SIZE_ERROR case %d: m_waits=%d\n", static_cast<I32>(i), static_cast<I32>(i + za));
         this->m_impl.readParamFile();
         ASSERT_EVENTS_SIZE(1);
         switch (i) {
@@ -446,11 +445,13 @@ void PrmDbTester::runFileReadError() {
         this->m_waits = i + xa;
         this->m_impl.readParamFile();
         ASSERT_EVENTS_SIZE(1);
+        printf("DEBUG: PrmFileBadCrc case %d: m_waits=%d\n", static_cast<I32>(i), static_cast<I32>(i + xa));
+
         switch (i) {
             case 0:
                 ASSERT_EVENTS_PrmFileBadCrc_SIZE(1);
                 // Parameter read error caused by adding one to the expected read
-                ASSERT_EVENTS_PrmFileBadCrc(0, 0x33d79cd4, 0xc180712b);
+                ASSERT_EVENTS_PrmFileBadCrc(0, 0x34D79CD3, 0xc180712b);
                 xa++;
                 break;
             case 1:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  https://github.com/nasa/fprime/issues/4931|
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**|  y|
|**_Generative AI was used in this contribution (y/n)_**|  y |

---
## Change Description

<!-- A description of the changes contained in the PR. -->
Fix the PrmDb CRC to use a serial buffer in F Prime to serialize the CRC for writing/reading to/from the param file.

## Rationale

<!-- A rationale for this change. e.g. fixes bug, or most projects need XYZ feature. -->
Without this serialization,  the stored CRC value is determined by the endian-ness of the processor, not a generic.

## Testing/Review Recommendations

<!-- Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality. -->
I just fixed and re-ran the existing unit test.

## Future Work

<!-- Note any additional work that will be done relating to this issue. -->

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). -->
I used AI to confirm my approach.  I also made changes to it to better fit my programming style and fixed an error in it since it was trying to use a non-existent (or perhaps old) method name.
