### PR TITLE
Change configure method parameters to const

### DIFF
--- a/Svc/ActiveRateGroup/ActiveRateGroup.cpp
+++ b/Svc/ActiveRateGroup/ActiveRateGroup.cpp
@@ -29,7 +29,7 @@ ActiveRateGroup::ActiveRateGroup(const char* compName)
       m_overrunThrottle(0),
       m_cycleSlips(0) {}
 
-void ActiveRateGroup::configure(U32 contexts[], FwIndexType numContexts) {
+void ActiveRateGroup::configure(const U32 contexts[], const FwIndexType numContexts) {
     FW_ASSERT(contexts);
     FW_ASSERT(numContexts == this->getNum_RateGroupMemberOut_OutputPorts(), static_cast<FwAssertArgType>(numContexts),
               static_cast<FwAssertArgType>(this->getNum_RateGroupMemberOut_OutputPorts()));

--- a/Svc/ActiveRateGroup/ActiveRateGroup.hpp
+++ b/Svc/ActiveRateGroup/ActiveRateGroup.hpp
@@ -52,7 +52,7 @@ class ActiveRateGroup final : public ActiveRateGroupComponentBase {
     //!         output port number.
     //!  \param numContexts The number of elements in the context array.
 
-    void configure(U32 contexts[], FwIndexType numContexts);
+    void configure(const U32 contexts[], const FwIndexType numContexts);
 
     //!  \brief ActiveRateGroup destructor
     //!

--- a/Svc/PassiveRateGroup/PassiveRateGroup.cpp
+++ b/Svc/PassiveRateGroup/PassiveRateGroup.cpp
@@ -22,7 +22,7 @@ PassiveRateGroup::PassiveRateGroup(const char* compName)
 
 PassiveRateGroup::~PassiveRateGroup() {}
 
-void PassiveRateGroup::configure(U32 contexts[], FwIndexType numContexts) {
+void PassiveRateGroup::configure(const U32 contexts[], const FwIndexType numContexts) {
     FW_ASSERT(contexts);
     FW_ASSERT(numContexts == this->getNum_RateGroupMemberOut_OutputPorts(), static_cast<FwAssertArgType>(numContexts),
               static_cast<FwAssertArgType>(this->getNum_RateGroupMemberOut_OutputPorts()));

--- a/Svc/PassiveRateGroup/PassiveRateGroup.hpp
+++ b/Svc/PassiveRateGroup/PassiveRateGroup.hpp
@@ -46,7 +46,7 @@ class PassiveRateGroup final : public PassiveRateGroupComponentBase {
     //!         to each member component. The index of the array corresponds to the
     //!         output port number.
     //!  \param numContexts The number of elements in the context array.
-    void configure(U32 contexts[], FwIndexType numContexts);
+    void configure(const U32 contexts[], const FwIndexType numContexts);
 
     //!  \brief PassiveRateGroupImpl destructor
     //!

--- a/Svc/RateGroupDriver/RateGroupDriver.hpp
+++ b/Svc/RateGroupDriver/RateGroupDriver.hpp
@@ -40,9 +40,9 @@ class RateGroupDriver final : public RateGroupDriverComponentBase {
     //! \brief Struct describing a divider
     struct Divider {
         //! Initializes divisor and offset to 0 (unused)
-        Divider() : divisor(0), offset(0) {}
+        constexpr Divider() : divisor(0), offset(0) {}
         //! Initializes divisor and offset to passed-in pair
-        Divider(FwSizeType divisorIn, FwSizeType offsetIn) : divisor(divisorIn), offset(offsetIn) {}
+        constexpr Divider(FwSizeType divisorIn, FwSizeType offsetIn) : divisor(divisorIn), offset(offsetIn) {}
         //! Divisor
         FwSizeType divisor;
         //! Offset


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Because `const`