### PR TITLE
Move Includes for ComCcsds into SubTopology

### DIFF
--- a/Ref/Top/RefTopologyDefs.hpp
+++ b/Ref/Top/RefTopologyDefs.hpp
@@ -26,10 +26,6 @@
 #include "Svc/Subtopologies/DataProducts/SubtopologyTopologyDefs.hpp"
 #include "Svc/Subtopologies/FileHandling/SubtopologyTopologyDefs.hpp"
 
-// ComCcsds Enum Includes
-#include "Svc/Subtopologies/ComCcsds/Ports_ComBufferQueueEnumAc.hpp"
-#include "Svc/Subtopologies/ComCcsds/Ports_ComPacketQueueEnumAc.hpp"
-
 /**
  * \brief required ping constants
  *

--- a/Svc/Subtopologies/ComCcsds/SubtopologyTopologyDefs.hpp
+++ b/Svc/Subtopologies/ComCcsds/SubtopologyTopologyDefs.hpp
@@ -6,6 +6,8 @@
 #include <Svc/FrameAccumulator/FrameDetector/CcsdsTcFrameDetector.hpp>
 #include "ComCcsdsConfig/ComCcsdsSubtopologyConfig.hpp"
 #include "Svc/Subtopologies/ComCcsds/ComCcsdsConfig/FppConstantsAc.hpp"
+#include "Svc/Subtopologies/ComCcsds/Ports_ComBufferQueueEnumAc.hpp"
+#include "Svc/Subtopologies/ComCcsds/Ports_ComPacketQueueEnumAc.hpp"
 
 namespace ComCcsds {
 struct SubtopologyState {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

The ComCcsds subtopology relies on includes that were not part of the subtopology definition.