### PR TITLE
Fix defaults to work around nasa/fpp#984

### DIFF
--- a/Svc/TlmPacketizer/TlmPacketizer.fpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.fpp
@@ -14,7 +14,7 @@ module Svc {
     }
 
     array GroupConfigs = [NUM_CONFIGURABLE_TLMPACKETIZER_GROUPS] GroupConfig
-    array SectionConfigs = [TelemetrySection.NUM_SECTIONS] GroupConfigs
+    array SectionConfigs = [TelemetrySection.NUM_SECTIONS] GroupConfigs default TELEMETRY_SECTION_DEFAULTS
     array SectionEnabled = [TelemetrySection.NUM_SECTIONS] Fw.Enabled default TELEMETRY_SECTION_ENABLED_DEFAULTS
 
     # ----------------------------------------------------------------------


### PR DESCRIPTION
Works around the fact that `external parameters` don't respect default values.

| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fpp#984 |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

The default configuration was not respected because the default parameter values are ignored.

## Rationale

By adding the default to the type, the `{}` construction will fix this.

## Testing/Review Recommendations


## Future Work

Add TlmPacketizer to proper CI.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))
none.