### PR TITLE
Fix CmdArgBuffer SERIALIZED_SIZE computation

### DIFF
--- a/Drv/Ports/DataTypes/DataBuffer.hpp
+++ b/Drv/Ports/DataTypes/DataBuffer.hpp
@@ -11,7 +11,7 @@ class DataBuffer : public Fw::SerializeBufferBase {
     enum {
         DATA_BUFFER_SIZE = 256,
         SERIALIZED_TYPE_ID = 1010,
-        SERIALIZED_SIZE = DATA_BUFFER_SIZE + sizeof(FwBuffSizeType)
+        SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(DATA_BUFFER_SIZE)
     };
 
     DataBuffer(const U8* args, FwSizeType size);

--- a/Fw/Cmd/CmdArgBuffer.hpp
+++ b/Fw/Cmd/CmdArgBuffer.hpp
@@ -22,7 +22,7 @@ class CmdArgBuffer final : public SerializeBufferBase {
   public:
     enum {
         SERIALIZED_TYPE_ID = FW_TYPEID_CMD_BUFF,                    //!< type id for CmdArgBuffer
-        SERIALIZED_SIZE = FW_CMD_ARG_BUFFER_MAX_SIZE + sizeof(I32)  //!< size when serialized. Buffer + size of buffer
+        SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(FW_CMD_ARG_BUFFER_MAX_SIZE)  //!< size when serialized. Buffer + size of buffer
     };
 
     CmdArgBuffer(const U8* args, FwSizeType size);       //!< buffer source constructor

--- a/Fw/Cmd/CmdArgBuffer.hpp
+++ b/Fw/Cmd/CmdArgBuffer.hpp
@@ -21,8 +21,9 @@ namespace Fw {
 class CmdArgBuffer final : public SerializeBufferBase {
   public:
     enum {
-        SERIALIZED_TYPE_ID = FW_TYPEID_CMD_BUFF,                    //!< type id for CmdArgBuffer
-        SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(FW_CMD_ARG_BUFFER_MAX_SIZE)  //!< size when serialized. Buffer + size of buffer
+        SERIALIZED_TYPE_ID = FW_TYPEID_CMD_BUFF,  //!< type id for CmdArgBuffer
+        SERIALIZED_SIZE =
+            STATIC_SERIALIZED_SIZE(FW_CMD_ARG_BUFFER_MAX_SIZE)  //!< size when serialized. Buffer + size of buffer
     };
 
     CmdArgBuffer(const U8* args, FwSizeType size);       //!< buffer source constructor

--- a/Fw/Com/ComBuffer.hpp
+++ b/Fw/Com/ComBuffer.hpp
@@ -21,7 +21,7 @@ class ComBuffer final : public SerializeBufferBase {
   public:
     enum {
         SERIALIZED_TYPE_ID = 1010,
-        SERIALIZED_SIZE = FW_COM_BUFFER_MAX_SIZE + sizeof(FwBuffSizeType)  // size of buffer + storage of size word
+        SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(FW_COM_BUFFER_MAX_SIZE)  // size of buffer + storage of size word
     };
 
     ComBuffer(const U8* args, FwSizeType size);

--- a/Fw/Fpy/StatementArgBuffer.hpp
+++ b/Fw/Fpy/StatementArgBuffer.hpp
@@ -11,7 +11,7 @@ class StatementArgBuffer : public SerializeBufferBase {
   public:
     enum {
         SERIALIZED_TYPE_ID = FW_TYPEID_TLM_BUFF,
-        SERIALIZED_SIZE = FW_STATEMENT_ARG_BUFFER_MAX_SIZE + sizeof(FwBuffSizeType)
+        SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(FW_STATEMENT_ARG_BUFFER_MAX_SIZE)
     };
 
     StatementArgBuffer(const U8* args, FwSizeType size);

--- a/Fw/Log/LogBuffer.hpp
+++ b/Fw/Log/LogBuffer.hpp
@@ -20,7 +20,7 @@ namespace Fw {
 
 class LogBuffer final : public SerializeBufferBase {
   public:
-    enum { SERIALIZED_TYPE_ID = FW_TYPEID_LOG_BUFF, SERIALIZED_SIZE = FW_LOG_BUFFER_MAX_SIZE + sizeof(FwBuffSizeType) };
+    enum { SERIALIZED_TYPE_ID = FW_TYPEID_LOG_BUFF, SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(FW_LOG_BUFFER_MAX_SIZE) };
 
     LogBuffer(const U8* args, FwSizeType size);
     LogBuffer();

--- a/Fw/Prm/PrmBuffer.hpp
+++ b/Fw/Prm/PrmBuffer.hpp
@@ -27,7 +27,7 @@ class ParamBuffer final : public SerializeBufferBase {
   public:
     enum {
         SERIALIZED_TYPE_ID = FW_TYPEID_PRM_BUFF,
-        SERIALIZED_SIZE = FW_PARAM_BUFFER_MAX_SIZE + sizeof(FwBuffSizeType)
+        SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(FW_PARAM_BUFFER_MAX_SIZE)
     };
 
     ParamBuffer(const U8* args, FwSizeType size);

--- a/Fw/Sm/SmSignalBuffer.hpp
+++ b/Fw/Sm/SmSignalBuffer.hpp
@@ -19,7 +19,7 @@ class SmSignalBuffer final : public SerializeBufferBase {
   public:
     enum {
         SERIALIZED_TYPE_ID = 1010,
-        SERIALIZED_SIZE = FW_COM_BUFFER_MAX_SIZE + sizeof(FwSizeStoreType)  // size of buffer + storage of size word
+        SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(FW_COM_BUFFER_MAX_SIZE)  // size of buffer + storage of size word
     };
 
     SmSignalBuffer(const U8* args, Serializable::SizeType size);

--- a/Fw/Tlm/TlmBuffer.hpp
+++ b/Fw/Tlm/TlmBuffer.hpp
@@ -19,7 +19,7 @@ namespace Fw {
 
 class TlmBuffer final : public SerializeBufferBase {
   public:
-    enum { SERIALIZED_TYPE_ID = FW_TYPEID_TLM_BUFF, SERIALIZED_SIZE = FW_TLM_BUFFER_MAX_SIZE + sizeof(FwBuffSizeType) };
+    enum { SERIALIZED_TYPE_ID = FW_TYPEID_TLM_BUFF, SERIALIZED_SIZE = STATIC_SERIALIZED_SIZE(FW_TLM_BUFFER_MAX_SIZE) };
 
     TlmBuffer(const U8* args, FwSizeType size);
     TlmBuffer();

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -682,6 +682,14 @@ class LinearBufferBase : public SerialBufferBase {
     LinearBufferBase& operator=(const LinearBufferBase& src);
 
   public:
+    //! \brief Get the static serialized size of a buffer
+    //! This is the max size of the buffer data plus the size of the stored size
+    static constexpr Serializable::SizeType STATIC_SERIALIZED_SIZE(
+        Serializable::SizeType maxSize  //!< The maximum buffer data size
+    ) {
+        return static_cast<Serializable::SizeType>(sizeof(FwSizeStoreType)) + maxSize;
+    }
+
     //! \brief Destructor
     //!
     //! Destroys a LinearBufferBase instance. This is a virtual destructor


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4896 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Fix `CmdArgBuffer::SERIALIZED_SIZE`, which incorrectly used sizeof(I32) instead of sizeof(FwSizeStoreType).
To prevent this kind of mistake, this PR adds a STATIC_SERIALIZED_SIZE constexpr helper to LinearBufferBase and updates all buffer-derived classes to use it.

## Rationale

If FwSizeStoreType is configured larger than I32 (e.g. U64), `CmdArgBuffer::SERIALIZED_SIZE` would be too small, potentially causing serialization issues.

## Testing/Review Recommendations

N/A

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

GitHub Copilot CLI (Claude)