### PR TITLE
Refactor FileManager for no shell command

### DIFF
--- a/Svc/FileManager/Commands.fppi
+++ b/Svc/FileManager/Commands.fppi
@@ -24,13 +24,6 @@ async command RemoveFile(
                         ) \
   opcode 0x03
 
-@ Perform a Linux shell command and write the output to a log file.
-async command ShellCommand(
-                            $command: string size 256 @< The shell command string
-                            logFileName: string size FileNameStringSize @< The name of the log file
-                          ) \
-  opcode 0x04
-
 @ Append 1 file's contents to the end of another.
 async command AppendFile(
                           source: string size FileNameStringSize @< The name of the file to take content from

--- a/Svc/FileManager/Events.fppi
+++ b/Svc/FileManager/Events.fppi
@@ -35,15 +35,6 @@ event FileRemoveError(
   id 0x03 \
   format "Could not remove file {}, returned status {}"
 
-@ The File System component executed a shell command that returned status non-zero
-event ShellCommandFailed(
-                          $command: string size 256 @< The command string
-                          status: U32 @< The status code
-                        ) \
-  severity warning high \
-  id 0x04 \
-  format "Shell command {} failed with status {}"
-
 @ The File System component returned status non-zero when trying to append 2 files together
 event AppendFileFailed(
                         source: string size FileNameStringSize @< The name of the file being read from
@@ -62,14 +53,6 @@ event AppendFileSucceeded(
   severity activity high \
   id 0x06 \
   format "Appended {} to the end of {}"
-
-@ The File System component executed a shell command that returned status zero
-event ShellCommandSucceeded(
-                             $command: string size FileNameStringSize @< The command string
-                           ) \
-  severity activity high \
-  id 0x07 \
-  format "Shell command {} succeeded"
 
 @ The File System component created a new directory without error
 event CreateDirectorySucceeded(
@@ -112,14 +95,6 @@ event AppendFileStarted(
   severity activity high \
   id 0x0C \
   format "Appending file {} to the end of {}..."
-
-@ The File System component began executing a shell command
-event ShellCommandStarted(
-                           $command: string size 256 @< The command string
-                         ) \
-  severity activity high \
-  id 0x0D \
-  format "Running shell command {}..."
 
 @ The File System component began creating a new directory
 event CreateDirectoryStarted(

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -113,22 +113,6 @@ void FileManager ::RemoveDirectory_cmdHandler(const FwOpcodeType opCode,
     this->sendCommandResponse(opCode, cmdSeq, status);
 }
 
-void FileManager ::ShellCommand_cmdHandler(const FwOpcodeType opCode,
-                                           const U32 cmdSeq,
-                                           const Fw::CmdStringArg& command,
-                                           const Fw::CmdStringArg& logFileName) {
-    Fw::LogStringArg logStringCommand(command.toChar());
-    this->log_ACTIVITY_HI_ShellCommandStarted(logStringCommand);
-    int status = this->systemCall(command, logFileName);
-    if (status == 0) {
-        this->log_ACTIVITY_HI_ShellCommandSucceeded(logStringCommand);
-    } else {
-        this->log_WARNING_HI_ShellCommandFailed(logStringCommand, static_cast<U32>(status));
-    }
-    this->emitTelemetry(status == 0 ? Os::FileSystem::OP_OK : Os::FileSystem::OTHER_ERROR);
-    this->sendCommandResponse(opCode, cmdSeq, status == 0 ? Os::FileSystem::OP_OK : Os::FileSystem::OTHER_ERROR);
-}
-
 void FileManager ::AppendFile_cmdHandler(const FwOpcodeType opCode,
                                          const U32 cmdSeq,
                                          const Fw::CmdStringArg& source,
@@ -297,24 +281,6 @@ void FileManager ::run_internalInterfaceHandler() {
 // ----------------------------------------------------------------------
 // Helper methods
 // ----------------------------------------------------------------------
-
-int FileManager ::systemCall(const Fw::CmdStringArg& command, const Fw::CmdStringArg& logFileName) const {
-    // Create a buffer of at least enough size for storing the eval string less the 2 %s tokens, two command strings,
-    // and a null terminator at the end
-    const char evalStr[] = "eval '%s' 1>>%s 2>&1\n";
-    constexpr U32 bufferSize = (sizeof(evalStr) - 4) + (2 * FW_CMD_STRING_MAX_SIZE) + 1;
-    char buffer[bufferSize];
-
-    // Wrap that buffer in an external string for formatting purposes
-    Fw::ExternalString stringBuffer(buffer, bufferSize);
-    Fw::FormatStatus formatStatus = stringBuffer.format(evalStr, command.toChar(), logFileName.toChar());
-    // Since the buffer is exactly sized, the only error can occur is a software error not caused by ground
-    FW_ASSERT(formatStatus == Fw::FormatStatus::SUCCESS);
-
-    // Call the system
-    const int status = system(stringBuffer.toChar());
-    return status;
-}
 
 void FileManager ::emitTelemetry(const Os::FileSystem::Status status) {
     if (status == Os::FileSystem::OP_OK) {

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -71,14 +71,6 @@ class FileManager final : public FileManagerComponentBase {
                                     const Fw::CmdStringArg& dirName  //!< The directory to remove
                                     ) override;
 
-    //! Implementation for ShellCommand command handler
-    //!
-    void ShellCommand_cmdHandler(const FwOpcodeType opCode,           //!< The opcode
-                                 const U32 cmdSeq,                    //!< The command sequence number
-                                 const Fw::CmdStringArg& command,     //!< The shell command string
-                                 const Fw::CmdStringArg& logFileName  //!< The name of the log file
-                                 ) override;
-
     //! Implementation for ConcatFiles command handler
     //! Append 1 file's contents to the end of another.
     void AppendFile_cmdHandler(const FwOpcodeType opCode,       //!< The opcode
@@ -128,12 +120,6 @@ class FileManager final : public FileManagerComponentBase {
     // ----------------------------------------------------------------------
     // Helper methods
     // ----------------------------------------------------------------------
-
-    //! A system command with no arguments
-    //!
-    int systemCall(const Fw::CmdStringArg& command,     //!< The command
-                   const Fw::CmdStringArg& logFileName  //!< The log file name
-    ) const;
 
     //! Emit telemetry based on status
     //!

--- a/Svc/FileManager/docs/sdd.md
+++ b/Svc/FileManager/docs/sdd.md
@@ -1,34 +1,26 @@
 # Svc::FileManager Component
 
-## 1. Introduction
+## Overview
 
-The `Svc::FileManager` is a component that performs various file operations.
+`Svc::FileManager` provides a set of ground commands for common file and filesystem operations.
+It is a wrapper around the OSAL file, filesystem and directory APIs. The component accepts
+commands, calls the corresponding OSAL operation, and reports the result through events,
+telemetry, and command responses.
 
-## 2. Requirements
+## Functionality
 
-TBD
+`Svc::FileManager` supports common filesystem operations. They are currently:
 
-## 3. Design
+- CreateDirectory
+- RemoveDirectory
+- ListDirectory
+- MoveFile
+- RemoveFile
+- AppendFile
+- FileSize
+- CalculateCrc
 
-### 3.1 Context
-
-#### 3.1.1 Component Diagram
-
-TBD
-
-## 4. Dictionaries
-
-TBD
-
-## 5. Module Checklists
-
-## 6. Unit Testing
-
-## 7. Change Log
-
-Date | Description
----- | -----------
-4/20/2017 | Initial Version
-
+For each command, the component returns success or failure and emits status
+information for operators.
 
 

--- a/Svc/FileManager/test/int/test_cmd_fileManager.py
+++ b/Svc/FileManager/test/int/test_cmd_fileManager.py
@@ -2,7 +2,6 @@
 
 Test the command FileManager with basic integration tests.
     fileManager.CreateDirectory
-    fileManager.ShellCommand  # Don't use ShellCommand
     fileManager.FileSize
     fileManager.MoveFile
     fileManager.AppendFile

--- a/Svc/FileManager/test/ut/FileManagerMain.cpp
+++ b/Svc/FileManager/test/ut/FileManagerMain.cpp
@@ -44,16 +44,6 @@ TEST(Test, removeFileFail) {
     tester.removeFileFail();
 }
 
-TEST(Test, shellCommandSucceed) {
-    Svc::FileManagerTester tester;
-    tester.shellCommandSucceed();
-}
-
-TEST(Test, shellCommandFail) {
-    Svc::FileManagerTester tester;
-    tester.shellCommandFail();
-}
-
 TEST(Test, appendFileSucceedNewFile) {
     Svc::FileManagerTester tester;
     tester.appendFileSucceed_newFile();

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -213,54 +213,6 @@ void FileManagerTester ::removeFileFail() {
     ASSERT_EVENTS_FileRemoveError(0, "test_file", Os::FileSystem::DOESNT_EXIST);
 }
 
-void FileManagerTester ::shellCommandSucceed() {
-#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
-    // Remove test_file, if it exists
-    this->system("rm -rf test_file");
-
-    // Create test_file
-    this->shellCommand("touch test_file", LOG_FILE);
-#else
-    FAIL();  // Commands not implemented for this OS
-#endif
-
-    // Assert success
-    this->assertSuccess(FileManager::OPCODE_SHELLCOMMAND);
-    ASSERT_EVENTS_ShellCommandSucceeded_SIZE(1);
-    ASSERT_EVENTS_ShellCommandSucceeded(0, "touch test_file");
-
-#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
-    // Check that test_file is there
-    this->system("test -f test_file");
-
-    // Clean up
-    this->system("rm test_file");
-#else
-    FAIL();  // Commands not implemented for this OS
-#endif
-}
-
-void FileManagerTester ::shellCommandFail() {
-#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
-    // Remove test_file, if it exists
-    this->system("rm -rf test_file");
-
-    // Attempt to remove test_file (should fail)
-    this->shellCommand("rm test_file", LOG_FILE);
-#else
-    FAIL();  // Commands not implemented for this OS
-#endif
-    {
-        // Assert failure
-        this->assertFailure(FileManager::OPCODE_SHELLCOMMAND);
-        ASSERT_EVENTS_ShellCommandFailed_SIZE(1);
-        const EventEntry_ShellCommandFailed& e = this->eventHistory_ShellCommandFailed->at(0);
-        const U32 status = e.status;
-        ASSERT_NE(static_cast<U32>(0), status);
-        ASSERT_EVENTS_ShellCommandFailed(0, "rm test_file", status);
-    }
-}
-
 void FileManagerTester ::appendFileSucceed_newFile() {
 #if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
     // Remove testing files, if they exist
@@ -546,13 +498,6 @@ void FileManagerTester ::removeDirectory(const char* const dirName) {
 void FileManagerTester ::removeFile(const char* const fileName, bool ignoreErrors) {
     Fw::CmdStringArg cmdStringFile(fileName);
     this->sendCmd_RemoveFile(INSTANCE, CMD_SEQ, cmdStringFile, ignoreErrors);
-    this->component.doDispatch();
-}
-
-void FileManagerTester ::shellCommand(const char* const command, const char* const logFileName) {
-    Fw::CmdStringArg cmdStringCommand(command);
-    Fw::CmdStringArg cmdStringLogFile(logFileName);
-    this->sendCmd_ShellCommand(INSTANCE, CMD_SEQ, cmdStringCommand, cmdStringLogFile);
     this->component.doDispatch();
 }
 

--- a/Svc/FileManager/test/ut/FileManagerTester.hpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.hpp
@@ -74,14 +74,6 @@ class FileManagerTester : public FileManagerGTestBase {
     //!
     void removeFileFail();
 
-    //! Shell command (succeed)
-    //!
-    void shellCommandSucceed();
-
-    //! Shell command (fail)
-    //!
-    void shellCommandFail();
-
     //! Append file (succeed, append to new file)
     //!
     void appendFileSucceed_newFile();
@@ -146,9 +138,6 @@ class FileManagerTester : public FileManagerGTestBase {
 
     //! Remove a file
     void removeFile(const char* const fileName, bool ignoreErrors);
-
-    //! Perform a shell command
-    void shellCommand(const char* const command, const char* const logFileName);
 
     //! Append 2 files together
     void appendFile(const char* const source, const char* const target);

--- a/Svc/FileManager/test/ut/log.txt
+++ b/Svc/FileManager/test/ut/log.txt
@@ -1,1 +1,0 @@
-rm: test_file: No such file or directory


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

- Take the shell functionality out of the FileManager. It does not belong here.
- Add some content in the SDD

## Future Work

Pull the Shell functionality in an `fprime-community` component if desired.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Took the functionality out manually, then asked AI if I missed anything.
