### PR TITLE
Remove bufferAllocate and bufferDeallocate ports

### DIFF
--- a/Svc/FprimeRouter/FprimeRouter.cpp
+++ b/Svc/FprimeRouter/FprimeRouter.cpp
@@ -48,21 +48,13 @@ void FprimeRouter ::dataIn_handler(FwIndexType portNum, Fw::Buffer& packetBuffer
         case Fw::ComPacketType::FW_PACKET_FILE: {
             // If the file uplink output port is connected, send the file packet. Otherwise take no action.
             if (this->isConnected_fileOut_OutputPort(0)) {
-                // Copy buffer into a new allocated buffer. This lets us return the original buffer with dataReturnOut,
-                // and FprimeRouter can handle the deallocation of the file buffer when it returns on fileBufferReturnIn
-                Fw::Buffer packetBufferCopy = this->bufferAllocate_out(0, packetBuffer.getSize());
-                // Confirm we got a valid buffer before using it
-                if (packetBufferCopy.isValid()) {
-                    auto copySerializer = packetBufferCopy.getSerializer();
-                    status = copySerializer.serializeFrom(packetBuffer.getData(), packetBuffer.getSize(),
-                                                          Fw::Serialization::OMIT_LENGTH);
-                    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-                    // Send the copied buffer out. It will come back on fileBufferReturnIn once the receiver is done
-                    // with it
-                    this->fileOut_out(0, packetBufferCopy);
-                } else {
-                    this->log_WARNING_HI_AllocationError(FprimeRouter_AllocationReason::FILE_UPLINK);
-                }
+                auto copySerializer = packetBufferCopy.getSerializer();
+                status = copySerializer.serializeFrom(packetBuffer.getData(), packetBuffer.getSize(),
+                                                      Fw::Serialization::OMIT_LENGTH);
+                FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+                // Send the copied buffer out. It will come back on fileBufferReturnIn once the receiver is done
+                // with it
+                this->fileOut_out(0, packetBufferCopy);
             }
             break;
         }
@@ -70,28 +62,17 @@ void FprimeRouter ::dataIn_handler(FwIndexType portNum, Fw::Buffer& packetBuffer
             // Packet type is not known to the F Prime protocol. If the unknownDataOut port is
             // connected, forward packet and context for further processing
             if (this->isConnected_unknownDataOut_OutputPort(0)) {
-                // Copy buffer into a new allocated buffer. This lets us return the original buffer with dataReturnOut,
-                // and FprimeRouter can handle the deallocation of the unknown buffer when it returns on bufferReturnIn
-                Fw::Buffer packetBufferCopy = this->bufferAllocate_out(0, packetBuffer.getSize());
-                // Confirm we got a valid buffer before using it
-                if (packetBufferCopy.isValid()) {
-                    auto copySerializer = packetBufferCopy.getSerializer();
-                    status = copySerializer.serializeFrom(packetBuffer.getData(), packetBuffer.getSize(),
-                                                          Fw::Serialization::OMIT_LENGTH);
-                    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-                    // Send the copied buffer out. It will come back on fileBufferReturnIn once the receiver is done
-                    // with it
-                    this->unknownDataOut_out(0, packetBufferCopy, context);
-                } else {
-                    this->log_WARNING_HI_AllocationError(FprimeRouter_AllocationReason::USER_BUFFER);
-                }
+                auto copySerializer = packetBufferCopy.getSerializer();
+                status = copySerializer.serializeFrom(packetBuffer.getData(), packetBuffer.getSize(),
+                                                      Fw::Serialization::OMIT_LENGTH);
+                FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+                // Send the copied buffer out. It will come back on fileBufferReturnIn once the receiver is done
+                // with it
+                this->unknownDataOut_out(0, packetBufferCopy, context);
             }
             break;
         }
     }
-
-    // Return ownership of the incoming packetBuffer
-    this->dataReturnOut_out(0, packetBuffer, context);
 }
 
 void FprimeRouter ::cmdResponseIn_handler(FwIndexType portNum,
@@ -102,7 +83,8 @@ void FprimeRouter ::cmdResponseIn_handler(FwIndexType portNum,
 }
 
 void FprimeRouter ::fileBufferReturnIn_handler(FwIndexType portNum, Fw::Buffer& fwBuffer) {
-    this->bufferDeallocate_out(0, fwBuffer);
+    const ComCfg::FrameContext context;
+    this->dataReturnOut_out(0, fwBuffer, context);
 }
 
 }  // namespace Svc

--- a/Svc/FprimeRouter/FprimeRouter.fpp
+++ b/Svc/FprimeRouter/FprimeRouter.fpp
@@ -17,12 +17,6 @@ module Svc {
         @ components should either process data synchronously, or copy the data if needed
         output port unknownDataOut: Svc.ComDataWithContext
 
-        @ Port for allocating buffers
-        output port bufferAllocate: Fw.BufferGet
-
-        @ Port for deallocating buffers
-        output port bufferDeallocate: Fw.BufferSend
-
         @ An error occurred while serializing a com buffer
         event SerializationError(
                 status: U32 @< The status of the operation

--- a/Svc/FprimeRouter/FprimeRouter.fpp
+++ b/Svc/FprimeRouter/FprimeRouter.fpp
@@ -30,11 +30,6 @@ module Svc {
             ) \
             severity warning high \
             format "Deserializing packet type failed with status {}"
-        
-        @ An allocation error occurred
-        event AllocationError(reason: AllocationReason) severity warning high \
-            format "Buffer allocation for {} failed"
-
 
         ###############################################################################
         # Standard AC Ports for Events 


### PR DESCRIPTION
Removed buffer allocation and deallocation ports from FprimeRouter.

| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

No allocation.