### PR TITLE
Ref: call deinitComponents during topology teardown

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,5 +1,6 @@
 AUTOGEN
 atype
+deinit
 github
 https
 ssh

--- a/Ref/Top/RefTopology.cpp
+++ b/Ref/Top/RefTopology.cpp
@@ -108,5 +108,6 @@ void teardownTopology(const TopologyState& state) {
     // Resource deallocation
     cmdSeq.deallocateBuffer(mallocator);
     tearDownComponents(state);
+    deinitComponents(state);
 }
 }  // namespace Ref

--- a/Ref/Top/RefTopology.hpp
+++ b/Ref/Top/RefTopology.hpp
@@ -54,6 +54,8 @@ void setupTopology(const TopologyState& state);
  *   3. Stop the tasks not owned by active components
  *   4. Join to the tasks not owned by active components
  *   5. Deallocate other resources
+ *   6. Call the autocoded `tearDownComponents()` function to tear down component-owned resources
+ *   7. Call the autocoded `deinitComponents()` function to finish component shutdown
  *
  * Step 1, 2, 3, and 4 must occur in-order as the tasks must be stopped before being joined. These tasks must be stopped
  * and joined before any active resources may be deallocated.


### PR DESCRIPTION
this fixes a small gap in the Ref teardown flow.

today teardown calls tearDownComponents(state), but it does not call deinitComponents(state). That leaves the shutdown path incomplete, since component owned teardown runs but final deinit never happens.

the fix is to call deinitComponents(state) right after tearDownComponents(state), and update the header comment so the documented lifecylce matches the actual one.

I validated this locally with generate, build, and execution on WSL, and I did not hit any regresison on that path.

if there is any reason this deinit step was intentionally skipped before, I would aprecaite a second look, but from what I can see this was just a missnig step in teardown.

Thanks! Dhiego Pagotto...
