### PR TITLE
CI: stop using runner.debug in reusable project builder

### DIFF
--- a/.github/workflows/reusable-project-builder.yml
+++ b/.github/workflows/reusable-project-builder.yml
@@ -48,7 +48,6 @@ jobs:
     env:
       FPRIME_LOCATION: ${{ inputs.fprime_location }}
       TARGET_PLATFORM: ${{ inputs.target_platform }}
-      VERBOSE_FLAG: ${{ runner.debug == '1' && '--verbose' || '' }}
     steps:
       - name: "Checkout target repository"
         uses: actions/checkout@v4
@@ -68,11 +67,21 @@ jobs:
       - name: "Generate build cache"
         working-directory: ${{ inputs.build_location }}
         run: |
+          if [ "${RUNNER_DEBUG:-0}" = "1" ]; then
+            VERBOSE_FLAG=--verbose
+          else
+            VERBOSE_FLAG=
+          fi
           fprime-util generate ${VERBOSE_FLAG} ${TARGET_PLATFORM}
         shell: bash
       - name: "Build"
         working-directory: ${{ inputs.build_location }}
         run: |
+          if [ "${RUNNER_DEBUG:-0}" = "1" ]; then
+            VERBOSE_FLAG=--verbose
+          else
+            VERBOSE_FLAG=
+          fi
           fprime-util build -j8 ${VERBOSE_FLAG} ${TARGET_PLATFORM}
         shell: bash
 
@@ -83,7 +92,6 @@ jobs:
     env:
       FPRIME_LOCATION: ${{ inputs.fprime_location }}
       TARGET_PLATFORM: ${{ inputs.target_platform }}
-      VERBOSE_FLAG: ${{ runner.debug == '1' && '--verbose' || '' }}
     steps:
       - name: "Checkout target repository"
         uses: actions/checkout@v4
@@ -103,16 +111,31 @@ jobs:
       - name: "Generate UT build cache"
         working-directory: ${{ inputs.build_location }}
         run: |
+          if [ "${RUNNER_DEBUG:-0}" = "1" ]; then
+            VERBOSE_FLAG=--verbose
+          else
+            VERBOSE_FLAG=
+          fi
           fprime-util generate --ut ${VERBOSE_FLAG} ${TARGET_PLATFORM}
         shell: bash
       - name: "Build UTs"
         working-directory: ${{ inputs.build_location }}
         run: |
+          if [ "${RUNNER_DEBUG:-0}" = "1" ]; then
+            VERBOSE_FLAG=--verbose
+          else
+            VERBOSE_FLAG=
+          fi
           fprime-util build --ut -j8 ${VERBOSE_FLAG} ${TARGET_PLATFORM}
         shell: bash
       - name: "Run Unit Tests"
         working-directory: ${{ inputs.build_location }}
         run: |
+          if [ "${RUNNER_DEBUG:-0}" = "1" ]; then
+            VERBOSE_FLAG=--verbose
+          else
+            VERBOSE_FLAG=
+          fi
           fprime-util check -j8 ${VERBOSE_FLAG} ${TARGET_PLATFORM} --pass-through --output-on-failure
         shell: bash
 


### PR DESCRIPTION
this fixes a workflow validation issue in the reusable project builder.

the current workflow sets VERBOSE_FLAG from an expression using runner.debug inside the env block. GitHub is rejecting that in the reusable workflow, which causes the ext-build workflows that call it to fail before they even start the actual build.

the fix here is to stop computing that flag in workflow expressions and instead set it inside each bash step from RUNNER_DEBUG. That keeps the same intent, but avoids the invalid workflow expression.

I checked the updated yaml locally to make sure it still parses cleanly, and this should unblock the external build workflows that were failing at workflow load time.

if there is a better repo-wide pattern for handling optional verbose flags in reusable workflows, I am happy to adjust, but this should be the safest direct fix for the current failure.

Thanks! Dhiego Pagotto...
