### PR TITLE
Fix off-by-one in Stack::push() and Stack::pushZeroes() boundary checks

### DIFF
--- a/Svc/FpySequencer/FpySequencerStack.cpp
+++ b/Svc/FpySequencer/FpySequencerStack.cpp
@@ -57,7 +57,7 @@ F64 FpySequencer::Stack::pop<F64>() {
 template <typename T>
 void FpySequencer::Stack::push(T val) {
     static_assert(sizeof(T) == 8 || sizeof(T) == 4 || sizeof(T) == 2 || sizeof(T) == 1, "size must be 1, 2, 4, 8");
-    FW_ASSERT(this->size + sizeof(val) < Fpy::MAX_STACK_SIZE, static_cast<FwAssertArgType>(this->size),
+    FW_ASSERT(this->size + sizeof(val) <= Fpy::MAX_STACK_SIZE, static_cast<FwAssertArgType>(this->size),
               static_cast<FwAssertArgType>(sizeof(T)));
     // first make a byte array which can definitely store our val
     U8 valBytes[8] = {0};
@@ -131,7 +131,7 @@ void FpySequencer::Stack::push(U8* src, Fpy::StackSizeType srcSize) {
 
 // pushes zero bytes to the stack
 void FpySequencer::Stack::pushZeroes(Fpy::StackSizeType byteCount) {
-    FW_ASSERT(this->size + byteCount < Fpy::MAX_STACK_SIZE, static_cast<FwAssertArgType>(this->size),
+    FW_ASSERT(this->size + byteCount <= Fpy::MAX_STACK_SIZE, static_cast<FwAssertArgType>(this->size),
               static_cast<FwAssertArgType>(byteCount));
     memset(this->top(), 0, byteCount);
     this->size += byteCount;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| y  |

---
## Change Description

Change strict less-than (<) to less-than-or-equal (<=) in the FW_ASSERT guards of Stack::push<T>() and Stack::pushZeroes(), matching the existing Stack::push(U8*, StackSizeType) overload.

The old strict check rejected exact-fit growth (size + growth == MAX_STACK_SIZE) with a hard assertion, even though the directive handlers (ALLOCATE, CALL, etc.) correctly allow it. This mismatch let validated sequences abort the process at runtime instead of returning a handled STACK_OVERFLOW error.

## Rationale

Fixes nasa/fprime#5008

## Testing/Review Recommendations

## Future Work

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Devin