### PR TITLE
Fix incorrect U32 usage in FprimeFrameDetector

### DIFF
--- a/Svc/FrameAccumulator/FrameDetector/FprimeFrameDetector.cpp
+++ b/Svc/FrameAccumulator/FrameDetector/FprimeFrameDetector.cpp
@@ -93,7 +93,7 @@ FrameDetector::Status FprimeFrameDetector::detect(const Types::CircularBuffer& d
     // Compute CRC over the transmitted data (header + body)
     FwSizeType hash_field_size = header.get_lengthField() + FprimeProtocol::FrameHeader::SERIALIZED_SIZE;
     hash.init();
-    for (U32 i = 0; i < hash_field_size; i++) {
+    for (FwSizeType i = 0; i < hash_field_size; i++) {
         U8 byte = 0;
         status = data.peek(byte, i);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Fixes a possible overflow.