### PR TITLE
Fix #5007 by dropping frame when full

### DIFF
--- a/Svc/FrameAccumulator/FrameAccumulator.cpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.cpp
@@ -151,8 +151,20 @@ void FrameAccumulator ::processRing() {
                 ComCfg::FrameContext context;
                 this->dataOut_out(0, buffer, context);
             } else {
-                // No buffer is available, we need to exit and try again later
+                // No buffer is available
                 this->log_WARNING_HI_NoBufferAvailable();
+                // In the case where no buffer is available and the circular buffer is full, we have to drop the buffer
+                // as there is no other way to retry. Without dropping it, the back pressure would assert the
+                // processing call, which is built on the assumption that at least one byte would process
+                if (this->m_inRing.get_free_size() == 0) {
+                    // Discard the whole frame as a last attempt to keep the system afloat
+                    Fw::SerializeStatus serialize_status = this->m_inRing.rotate(size_out);
+                    FW_ASSERT(serialize_status == Fw::SerializeStatus::FW_SERIALIZE_OK);
+                    FW_ASSERT(m_inRing.get_allocated_size() == remaining - size_out,
+                            static_cast<FwAssertArgType>(m_inRing.get_allocated_size()),
+                            static_cast<FwAssertArgType>(remaining), static_cast<FwAssertArgType>(size_out));
+                    this->log_WARNING_HI_FrameDetectionValidFrameDropped();
+                }
                 break;
             }
         }

--- a/Svc/FrameAccumulator/FrameAccumulator.cpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.cpp
@@ -161,8 +161,8 @@ void FrameAccumulator ::processRing() {
                     Fw::SerializeStatus serialize_status = this->m_inRing.rotate(size_out);
                     FW_ASSERT(serialize_status == Fw::SerializeStatus::FW_SERIALIZE_OK);
                     FW_ASSERT(m_inRing.get_allocated_size() == remaining - size_out,
-                            static_cast<FwAssertArgType>(m_inRing.get_allocated_size()),
-                            static_cast<FwAssertArgType>(remaining), static_cast<FwAssertArgType>(size_out));
+                              static_cast<FwAssertArgType>(m_inRing.get_allocated_size()),
+                              static_cast<FwAssertArgType>(remaining), static_cast<FwAssertArgType>(size_out));
                     this->log_WARNING_HI_FrameDetectionValidFrameDropped();
                 }
                 break;

--- a/Svc/FrameAccumulator/FrameAccumulator.fpp
+++ b/Svc/FrameAccumulator/FrameAccumulator.fpp
@@ -24,6 +24,11 @@ module Svc {
             severity warning high \
             format "Reported size_out={} exceeds accumulation buffer capacity"
 
+        @ A frame was detected but dropped because there was no buffer to hold it
+        event FrameDetectionValidFrameDropped \
+            severity warning high \
+            format "A valid frame was detected but dropped"
+
         ###############################################################################
         # Standard AC Ports for Events 
         ###############################################################################

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTestMain.cpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTestMain.cpp
@@ -47,6 +47,11 @@ TEST(FrameAccumulator, testBufferReturnDeallocation) {
     tester.testBufferReturnDeallocation();
 }
 
+TEST(FrameAccumulator, testDropValidFrameWhenAllocationFailsAndRingIsFull) {
+    Svc::FrameAccumulatorTester tester;
+    tester.testDropValidFrameWhenAllocationFailsAndRingIsFull();
+}
+
 TEST(FrameAccumulator, testDetectionErrorHandling) {
     Svc::FrameAccumulatorTester tester;
     tester.testDetectionErrorHandling();

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
@@ -16,7 +16,8 @@ namespace Svc {
 
 FrameAccumulatorTester ::FrameAccumulatorTester()
     : FrameAccumulatorGTestBase("FrameAccumulatorTester", FrameAccumulatorTester::MAX_HISTORY_SIZE),
-      component("FrameAccumulator") {
+            component("FrameAccumulator"),
+            m_failBufferAllocate(false) {
     component.configure(this->mockDetector, 1, this->mallocator, 2048);
     this->initComponents();
     this->connectPorts();
@@ -160,6 +161,28 @@ void FrameAccumulatorTester ::testBufferReturnDeallocation() {
     ASSERT_EQ(this->fromPortHistory_bufferDeallocate->at(0).fwBuffer.getSize(), sizeof(data));
 }
 
+void FrameAccumulatorTester ::testDropValidFrameWhenAllocationFailsAndRingIsFull() {
+    U8 data[2048] = {};
+    Fw::Buffer buffer(data, sizeof(data));
+    ComCfg::FrameContext context;
+    const FwSizeType ringCapacity = this->component.m_inRing.get_capacity();
+
+    ASSERT_EQ(ringCapacity, sizeof(data));
+    ASSERT_EQ(this->component.m_inRing.get_free_size(), ringCapacity);
+
+    this->m_failBufferAllocate = true;
+    this->mockDetector.set_next_result(FrameDetector::Status::FRAME_DETECTED, buffer.getSize());
+    this->invoke_to_dataIn(0, buffer, context);
+
+    ASSERT_from_dataReturnOut_SIZE(1);  // input buffer ownership was returned
+    ASSERT_from_dataOut_SIZE(0);        // no frame was sent because allocation failed
+    ASSERT_EQ(this->component.m_inRing.get_allocated_size(), 0);
+    ASSERT_EQ(this->component.m_inRing.get_free_size(), ringCapacity);
+    ASSERT_EVENTS_SIZE(2);
+    ASSERT_EVENTS_NoBufferAvailable_SIZE(1);
+    ASSERT_EVENTS_FrameDetectionValidFrameDropped_SIZE(1);
+}
+
 void FrameAccumulatorTester ::testDetectionErrorHandling() {
     FwSizeType too_large_size = this->component.m_inRing.get_capacity() + 1;
     // Using buffer_size=1 to simplify test since otherwise Accumulator will loop `buffer_size` times
@@ -247,6 +270,10 @@ void FrameAccumulatorTester ::mockAccumulateFullFrame(U32& frame_size, U32& buff
 // ----------------------------------------------------------------------
 Fw::Buffer FrameAccumulatorTester ::from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) {
     this->pushFromPortEntry_bufferAllocate(size);
+    if (this->m_failBufferAllocate) {
+        this->m_failBufferAllocate = false;
+        return Fw::Buffer();
+    }
     this->m_buffer.setData(this->m_buffer_slot);
     this->m_buffer.setSize(size);
     ::memset(this->m_buffer.getData(), 0, size);

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.cpp
@@ -16,8 +16,8 @@ namespace Svc {
 
 FrameAccumulatorTester ::FrameAccumulatorTester()
     : FrameAccumulatorGTestBase("FrameAccumulatorTester", FrameAccumulatorTester::MAX_HISTORY_SIZE),
-            component("FrameAccumulator"),
-            m_failBufferAllocate(false) {
+      component("FrameAccumulator"),
+      m_failBufferAllocate(false) {
     component.configure(this->mockDetector, 1, this->mallocator, 2048);
     this->initComponents();
     this->connectPorts();

--- a/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.hpp
+++ b/Svc/FrameAccumulator/test/ut/FrameAccumulatorTester.hpp
@@ -66,6 +66,9 @@ class FrameAccumulatorTester : public FrameAccumulatorGTestBase {
     //! Test returning ownership of a buffer
     void testBufferReturnDeallocation();
 
+    //! Test dropping a detected frame when allocation fails and the ring is full
+    void testDropValidFrameWhenAllocationFailsAndRingIsFull();
+
     //! Test handling of errors from the FrameDetector (too large size_out)
     void testDetectionErrorHandling();
 
@@ -122,6 +125,7 @@ class FrameAccumulatorTester : public FrameAccumulatorGTestBase {
     //! The component under test (should be listed after mallocator for safe destruction)
     Svc::FrameAccumulator component;
 
+    bool m_failBufferAllocate;
     Fw::Buffer m_buffer;  // buffer to be returned by mocked bufferAllocate call
     U8 m_buffer_slot[2048];
 };


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5007 |
|**_Has Unit Tests (y/n)_**|  y |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Fixes the issue where a full circular buffer won't drain when allocation fails thus causing an uplink failure.

## Rationale

This can deadlock uplink.

## Testing/Review Recommendations

## Future Work

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

For the UT
