### PR TITLE
docs: fix typos and duplicated words in port patterns guide

### DIFF
--- a/.nav.yml
+++ b/.nav.yml
@@ -25,7 +25,7 @@ nav:
       - Framework: docs/user-manual/framework/
       - FPP: 'https://nasa.github.io/fpp/fpp-users-guide.html'
       - GDS: docs/user-manual/gds
-      - Design Pattens: docs/user-manual/design-patterns/
+      - Design Patterns: docs/user-manual/design-patterns/
       - Build System: docs/user-manual/build-system/
       - Security: docs/user-manual/security/
     - How To: docs/how-to

--- a/docs/user-manual/design-patterns/common-port-patterns.md
+++ b/docs/user-manual/design-patterns/common-port-patterns.md
@@ -89,7 +89,7 @@ Callback ports can be of any instance kind (`sync`, `guarded`, `async`) but are 
 
 ### Implementation
 
-The requestor side of the callback port patten instantiates an `output` request port instance of any port type, and an `input` receive port instance of any type.  In the example below, `Fw.Signal` is used as the request type, and response port types, however; any port type may be used.
+The requestor side of the callback port pattern instantiates an `output` request port instance of any port type, and an `input` receive port instance of any type.  In the example below, `Fw.Signal` is used as the request type, and response port types, however; any port type may be used.
 
 ```fpp
 component MyRequestor {
@@ -124,7 +124,7 @@ connections CallbackPattern {
 
 ### Conclusion
 
-The callback port patten is used to separate a request from the response allowing the requestor to return to other work while the request is completed.
+The callback port pattern is used to separate a request from the response allowing the requestor to return to other work while the request is completed.
 
 ## Parallel Ports
 
@@ -182,7 +182,7 @@ connections ParallelPorts {
 }
 ```
 
-Notice how `comp0` in this snippet is is wired to `myComponent`'s ports always using the 0th index. The same is true for `comp1` on the 1st index. This allows the component to correlate the remote component via index.
+Notice how `comp0` in this snippet is wired to `myComponent`'s ports always using the 0th index. The same is true for `comp1` on the 1st index. This allows the component to correlate the remote component via index.
 
 In the C++ implementation this would look like:
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| None (small fix) |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

- Corrected multiple instances of "patten" to "pattern" in the Callback Ports section.
- Removed a duplicated "is" in the Parallel Ports implementation section.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None.
