### PR TITLE
Add FppTestProject Direct Port Call Integration Tests to CI

### DIFF
--- a/.github/workflows/fpp-tests.yml
+++ b/.github/workflows/fpp-tests.yml
@@ -21,7 +21,7 @@ jobs:
     name: Run FppTest
     runs-on: ubuntu-22.04
     steps:
-      - name: "Checkout F´ Repository"
+      - name: "Checkout F´ Repository"
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -50,5 +50,41 @@ jobs:
         if: always()
         with:
           name: FppTest-Logs
+          path: ./FppTestProject/build-fprime-automatic-native-ut/Testing/Temporary/*.log
+          retention-days: 5
+
+  fpptest-direct-port-calls:
+    name: Run FppTest (Direct Port Calls)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Checkout F´ Repository"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: "Install requirements.txt"
+        run: |
+          pip3 install -r ./requirements.txt
+        shell: bash
+      - name: "Generate UT build cache"
+        working-directory: ./FppTestProject
+        run: |
+          fprime-util generate --ut -DFPRIME_ENABLE_DIRECT_PORT_CALLS=ON -DFPRIME_ENABLE_JSON_MODEL_GENERATION=ON
+        shell: bash
+      - name: "Build UTs"
+        working-directory: ./FppTestProject/FppTest
+        run: |
+          fprime-util build --ut
+        shell: bash
+      - name: "Run UTs"
+        working-directory: ./FppTestProject/FppTest
+        run: |
+          fprime-util check --pass-through --output-on-failure
+        shell: bash
+      - name: "Archive Logs"
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: FppTest-DirectPortCalls-Logs
           path: ./FppTestProject/build-fprime-automatic-native-ut/Testing/Temporary/*.log
           retention-days: 5


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Adds a build job with direct port call execution for our FPP integration tests

## Rationale

The standard FppTestProject uses BUILD_UT which disables direct port calls in the standard `FpConfig.h`. This option overrides that default for the topology tests since we don't need indirect port calls for those and allows us to test direct port calls in a unit-testy way.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude did it. I ran it manually as well, seems fine.