### PR TITLE
PR-5034 - Fix ground file upload processing of different file size fo…

### DIFF
--- a/Svc/FileUplink/File.cpp
+++ b/Svc/FileUplink/File.cpp
@@ -27,8 +27,7 @@ Os::File::Status FileUplink::File::open(const Fw::FilePacket::StartPacket& start
     this->size = startPacket.getFileSize();
     CFDP::Checksum checksum;
     this->m_checksum = checksum;
-    return this->osFile.open(path, Os::File::OPEN_CREATE,
-                                   Os::File::OverwriteType::OVERWRITE);
+    return this->osFile.open(path, Os::File::OPEN_CREATE, Os::File::OverwriteType::OVERWRITE);
 }
 
 Os::File::Status FileUplink::File::write(const U8* const data, const U32 byteOffset, const U32 length) {

--- a/Svc/FileUplink/File.cpp
+++ b/Svc/FileUplink/File.cpp
@@ -27,7 +27,8 @@ Os::File::Status FileUplink::File::open(const Fw::FilePacket::StartPacket& start
     this->size = startPacket.getFileSize();
     CFDP::Checksum checksum;
     this->m_checksum = checksum;
-    return this->osFile.open(path, Os::File::OPEN_WRITE);
+    return this->osFile.open(path, Os::File::OPEN_CREATE,
+                                   Os::File::OverwriteType::OVERWRITE);
 }
 
 Os::File::Status FileUplink::File::write(const U8* const data, const U32 byteOffset, const U32 length) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_5034_**|  |
|**_Has Unit Tests (N)_**|  |
|**_Documentation Included (N)_**|  |
|**_Generative AI was used in this contribution (N)_**|  |

---
## Change Description

Added explicit OVERWRITE to trigger the logic in Os/Posix/File.cpp to overwrite the file when opening the file the ground is uploading:

WAS:  return this->osFile.open(path, Os::File::OPEN_WRITE);
   I S:   return this->osFile.open(path, Os::File::OPEN_CREATE,
                                                                  Os::File::OverwriteType::OVERWRITE);

## Rationale

The overwrite ensures any older stale data in the older version of the file will be erased. 

## Testing/Review Recommendations

Re-run unit tests; Upload larger and then smaller versions of the same file.

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
