### PR TITLE
PR 5036 - Event vs. ASSERT if DP file is corrupted

### DIFF
--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -204,18 +204,16 @@ Fw::CmdResponse DpCatalog::loadStateFile() {
         // the source buffer was specifically sized to hold the data
 
         // Deserialize the file directory index. If an error occurs processing the file,
-        // generate event and return EXECUTION_ERROR. 
+        // generate event and return EXECUTION_ERROR.
         Fw::SerializeStatus status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.dir);
         if (status != Fw::FW_SERIALIZE_OK) {
-            this->log_WARNING_HI_FileCorruptedDataError
-                (this->m_stateFile, static_cast<I32>(status));
+            this->log_WARNING_HI_FileCorruptedDataError(this->m_stateFile, static_cast<I32>(status));
             stateFile.close();
             return Fw::CmdResponse::EXECUTION_ERROR;
         }
         status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.record);
         if (status != Fw::FW_SERIALIZE_OK) {
-            this->log_WARNING_HI_FileCorruptedDataError
-                (this->m_stateFile, static_cast<I32>(status));
+            this->log_WARNING_HI_FileCorruptedDataError(this->m_stateFile, static_cast<I32>(status));
             stateFile.close();
             return Fw::CmdResponse::EXECUTION_ERROR;
         }

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -203,11 +203,22 @@ Fw::CmdResponse DpCatalog::loadStateFile() {
         // deserialization after this point should always work, since
         // the source buffer was specifically sized to hold the data
 
-        // Deserialize the file directory index
+        // Deserialize the file directory index. If an error occurs processing the file,
+        // generate event and return EXECUTION_ERROR. 
         Fw::SerializeStatus status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.dir);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status, status);
+        if (status != Fw::FW_SERIALIZE_OK) {
+            this->log_WARNING_HI_FileCorruptedDataError
+                (this->m_stateFile, static_cast<I32>(status));
+            stateFile.close();
+            return Fw::CmdResponse::EXECUTION_ERROR;
+        }
         status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.record);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status, status);
+        if (status != Fw::FW_SERIALIZE_OK) {
+            this->log_WARNING_HI_FileCorruptedDataError
+                (this->m_stateFile, static_cast<I32>(status));
+            stateFile.close();
+            return Fw::CmdResponse::EXECUTION_ERROR;
+        }
         this->m_stateFileData[entry].used = true;
         this->m_stateFileData[entry].visited = false;
 

--- a/Svc/DpCatalog/DpCatalog.fpp
+++ b/Svc/DpCatalog/DpCatalog.fpp
@@ -402,6 +402,15 @@ module Svc {
       id 46 \
       format "Cannot Transmit a Catalog before Building"
 
+    @ The file contained malformed or invalid data during deserialization
+    event FileCorruptedDataError(
+                             file: string size FileNameStringSize @< The file
+                             stat: I32
+      ) \
+      severity warning high \
+      id 47 \
+      format "DP file {} contains malformed data (status {})"     
+
     # ----------------------------------------------------------------------
     # Telemetry
     # ----------------------------------------------------------------------

--- a/Svc/DpCatalog/test/ut/DpCatalogTestMain.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTestMain.cpp
@@ -304,6 +304,11 @@ TEST(OffNominal, ProcessFileInvalidDir) {
     tester.test_ProcessFileInvalidDir();
 }
 
+TEST(OffNominal, MalformedFile) {
+    Svc::DpCatalogTester tester;
+    tester.test_MalformedFile();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
@@ -756,4 +756,47 @@ void DpCatalogTester::test_ProcessFileInvalidDir() {
     this->component.shutdown();
 }
 
+void DpCatalogTester::test_MalformedFile() {
+
+    // 1. Setup paths and corrupted data
+    Fw::FileNameString stateFile("DpState.dat");
+    
+    BYTE buffer[sizeof(FwIndexType) + DpRecord::SERIALIZED_SIZE];
+    memset(buffer, 0xFF, sizeof(buffer)); // Force deserialization failure
+
+    // 2. Write the malformed data to disk
+    Os::File f;
+    ASSERT_EQ(Os::File::OP_OK, f.open(stateFile.toChar(), Os::File::OPEN_CREATE, Os::FileInterface::OVERWRITE));
+    
+    FwSizeType writeSize = sizeof(buffer);
+    ASSERT_EQ(Os::File::OP_OK, f.write(buffer, writeSize));
+    f.close();
+
+    // 3. Configure the Component
+    Fw::MallocAllocator mockAllocator;
+    Fw::FileNameString dirs[DP_MAX_DIRECTORIES];
+    this->component.configure(dirs, 0, stateFile, 0, mockAllocator);
+
+    // 4. Dispatch the BUILD_CATALOG command
+    this->sendCmd_BUILD_CATALOG(0, 0);
+    this->component.doDispatch();
+
+    // 5. Command should generate event instead of ASSERT
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    //ASSERT_CMD_RESPONSE(0, DpCatalogComponentBase::OPCODE_BUILD_CATALOG, 0, Fw::CmdResponse::EXECUTION_ERROR);
+
+    // High-priority warning event should be caught by this test
+    ASSERT_EVENTS_SIZE(2);
+    ASSERT_EVENTS_FileCorruptedDataError_SIZE(1);
+    ASSERT_EVENTS_FileCorruptedDataError(
+        0, 
+        stateFile.toChar(), 
+        static_cast<I32>(Fw::FW_DESERIALIZE_FORMAT_ERROR)
+    );
+
+    // 6. Cleanup
+    Os::FileSystem::removeFile(stateFile.toChar());
+    this->component.shutdown();
+}
+
 }  // namespace Svc

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
@@ -757,17 +757,16 @@ void DpCatalogTester::test_ProcessFileInvalidDir() {
 }
 
 void DpCatalogTester::test_MalformedFile() {
-
     // 1. Setup paths and corrupted data
     Fw::FileNameString stateFile("DpState.dat");
-    
+
     BYTE buffer[sizeof(FwIndexType) + DpRecord::SERIALIZED_SIZE];
-    memset(buffer, 0xFF, sizeof(buffer)); // Force deserialization failure
+    memset(buffer, 0xFF, sizeof(buffer));  // Force deserialization failure
 
     // 2. Write the malformed data to disk
     Os::File f;
     ASSERT_EQ(Os::File::OP_OK, f.open(stateFile.toChar(), Os::File::OPEN_CREATE, Os::FileInterface::OVERWRITE));
-    
+
     FwSizeType writeSize = sizeof(buffer);
     ASSERT_EQ(Os::File::OP_OK, f.write(buffer, writeSize));
     f.close();
@@ -783,16 +782,12 @@ void DpCatalogTester::test_MalformedFile() {
 
     // 5. Command should generate event instead of ASSERT
     ASSERT_CMD_RESPONSE_SIZE(1);
-    //ASSERT_CMD_RESPONSE(0, DpCatalogComponentBase::OPCODE_BUILD_CATALOG, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    // ASSERT_CMD_RESPONSE(0, DpCatalogComponentBase::OPCODE_BUILD_CATALOG, 0, Fw::CmdResponse::EXECUTION_ERROR);
 
     // High-priority warning event should be caught by this test
     ASSERT_EVENTS_SIZE(2);
     ASSERT_EVENTS_FileCorruptedDataError_SIZE(1);
-    ASSERT_EVENTS_FileCorruptedDataError(
-        0, 
-        stateFile.toChar(), 
-        static_cast<I32>(Fw::FW_DESERIALIZE_FORMAT_ERROR)
-    );
+    ASSERT_EVENTS_FileCorruptedDataError(0, stateFile.toChar(), static_cast<I32>(Fw::FW_DESERIALIZE_FORMAT_ERROR));
 
     // 6. Cleanup
     Os::FileSystem::removeFile(stateFile.toChar());

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.hpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.hpp
@@ -149,6 +149,7 @@ class DpCatalogTester : public DpCatalogGTestBase {
     void test_PingIn();
     void test_BadFileDone();
     void test_ProcessFileInvalidDir();
+    void test_MalformedFile();
 };
 
 }  // namespace Svc


### PR DESCRIPTION
| | |
|:---|:---|
|**_5036_**|  |
|**_Has Unit Tests (Y)_**|  |
|**_Documentation Included (N)_**|  |
|**_Generative AI was used in this contribution (Y)_**|  |

---
## Change Description

If DP file is corrupted, a new event named FileCorruptedDataError is generated vs. ASSERT

## Rationale

Add robust FSW response to off-nominal condition rather than crashing.

## Testing/Review Recommendations

A new unit test called test_MalformedFile was added.  All other baseline unit test pass without modification. 

To test this implementation, I also created a DpState.dat file that contained all 0xFF:
00000000: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000010: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000020: ffff ffff ffff ffff                      ........

When DataProducts.dpCat.BUILD_CATALOG was called, the new FileCorruptedDataError event was generated and the FSW continued to operate nominally. 

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI was used to generate Unit Test for new functionality.
