### PR TITLE
PR 5038 - Force Framers to setSize on Fw::Buffer before outputting it

### DIFF
--- a/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
@@ -71,6 +71,8 @@ void SpacePacketFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, c
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = frameSerializer.serializeFrom(data.getData(), data.getSize(), Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    // Trim to actual frame size in case allocator returned a larger buffer
+    frameBuffer.setSize(static_cast<Fw::Buffer::SizeType>(frameSize));
 
     this->dataOut_out(0, frameBuffer, context);
     this->dataReturnOut_out(0, data, context);  // return ownership of the original data buffer

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTestMain.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTestMain.cpp
@@ -21,6 +21,11 @@ TEST(SpacePacketFramer, testNominalFraming) {
     tester.testNominalFraming();
 }
 
+TEST(SpacePacketFramer, OversizedAllocatorBufferIsTrimmed) {
+    Svc::Ccsds::SpacePacketFramerTester tester;
+    tester.testOversizedAllocatorBufferIsTrimmed();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
@@ -81,6 +81,34 @@ void SpacePacketFramerTester::testNominalFraming() {
     ASSERT_EQ(this->fromPortHistory_dataReturnOut->at(0).data.getSize(), sizeof(payload));
 }
 
+void SpacePacketFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
+   U8 payload[16];
+    for (U32 i = 0; i < sizeof(payload); ++i) {
+        payload[i] = static_cast<U8>(STest::Random::lowerUpper(0, 0xFF));
+    }
+    Fw::Buffer data(payload, sizeof(payload));
+    ComCfg::FrameContext context;
+    context.set_apid(static_cast<ComCfg::Apid::T>(0x01));
+    this->m_nextSeqCount = 0;
+ 
+    // Signal the allocator handler to return a larger-than-needed buffer,
+    // simulating a BufferManager bin that is bigger than the exact packet size.
+    this->m_useOversizedAlloc = true;
+    this->invoke_to_dataIn(0, data, context);
+    this->m_useOversizedAlloc = false;
+ 
+    ASSERT_from_dataOut_SIZE(1);
+    ASSERT_from_dataReturnOut_SIZE(1);
+ 
+    const FwSizeType expectedFrameSize = sizeof(payload) + SpacePacketHeader::SERIALIZED_SIZE;
+ 
+    Fw::Buffer outBuffer = this->fromPortHistory_dataOut->at(0).data;
+    // If setSize() is missing from SpacePacketFramer, getSize() returns the
+    // oversized allocation (2 * expectedFrameSize) and this assertion fails.
+    ASSERT_EQ(outBuffer.getSize(), expectedFrameSize);
+}
+
+
 // ----------------------------------------------------------------------
 // Output port handler overrides
 // ----------------------------------------------------------------------

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
@@ -82,7 +82,7 @@ void SpacePacketFramerTester::testNominalFraming() {
 }
 
 void SpacePacketFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
-   U8 payload[16];
+    U8 payload[16];
     for (U32 i = 0; i < sizeof(payload); ++i) {
         payload[i] = static_cast<U8>(STest::Random::lowerUpper(0, 0xFF));
     }
@@ -90,24 +90,23 @@ void SpacePacketFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
     ComCfg::FrameContext context;
     context.set_apid(static_cast<ComCfg::Apid::T>(0x01));
     this->m_nextSeqCount = 0;
- 
+
     // Signal the allocator handler to return a larger-than-needed buffer,
     // simulating a BufferManager bin that is bigger than the exact packet size.
     this->m_useOversizedAlloc = true;
     this->invoke_to_dataIn(0, data, context);
     this->m_useOversizedAlloc = false;
- 
+
     ASSERT_from_dataOut_SIZE(1);
     ASSERT_from_dataReturnOut_SIZE(1);
- 
+
     const FwSizeType expectedFrameSize = sizeof(payload) + SpacePacketHeader::SERIALIZED_SIZE;
- 
+
     Fw::Buffer outBuffer = this->fromPortHistory_dataOut->at(0).data;
     // If setSize() is missing from SpacePacketFramer, getSize() returns the
     // oversized allocation (2 * expectedFrameSize) and this assertion fails.
     ASSERT_EQ(outBuffer.getSize(), expectedFrameSize);
 }
-
 
 // ----------------------------------------------------------------------
 // Output port handler overrides

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
@@ -46,6 +46,7 @@ class SpacePacketFramerTester final : public SpacePacketFramerGTestBase {
     void testComStatusPassthrough();
     void testDataReturnPassthrough();
     void testNominalFraming();
+    void testOversizedAllocatorBufferIsTrimmed();
 
   private:
     // ----------------------------------------------------------------------
@@ -80,6 +81,12 @@ class SpacePacketFramerTester final : public SpacePacketFramerGTestBase {
     U8 m_internalDataBuffer[SpacePacketHeader::SERIALIZED_SIZE + MAX_TEST_PACKET_DATA_SIZE];
 
     U16 m_nextSeqCount;  // Sequence count to be returned by getApidSeqCount output port
+
+    // Backing store for the oversized allocation path
+    U8 m_oversizedDataBuffer[512];
+
+    // Flag read by from_bufferAllocate_handler to choose which path to take
+    bool m_useOversizedAlloc = false;
 };
 
 }  // namespace Ccsds

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -204,18 +204,16 @@ Fw::CmdResponse DpCatalog::loadStateFile() {
         // the source buffer was specifically sized to hold the data
 
         // Deserialize the file directory index. If an error occurs processing the file,
-        // generate event and return EXECUTION_ERROR. 
+        // generate event and return EXECUTION_ERROR.
         Fw::SerializeStatus status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.dir);
         if (status != Fw::FW_SERIALIZE_OK) {
-            this->log_WARNING_HI_FileCorruptedDataError
-                (this->m_stateFile, static_cast<I32>(status));
+            this->log_WARNING_HI_FileCorruptedDataError(this->m_stateFile, static_cast<I32>(status));
             stateFile.close();
             return Fw::CmdResponse::EXECUTION_ERROR;
         }
         status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.record);
         if (status != Fw::FW_SERIALIZE_OK) {
-            this->log_WARNING_HI_FileCorruptedDataError
-                (this->m_stateFile, static_cast<I32>(status));
+            this->log_WARNING_HI_FileCorruptedDataError(this->m_stateFile, static_cast<I32>(status));
             stateFile.close();
             return Fw::CmdResponse::EXECUTION_ERROR;
         }

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -203,11 +203,22 @@ Fw::CmdResponse DpCatalog::loadStateFile() {
         // deserialization after this point should always work, since
         // the source buffer was specifically sized to hold the data
 
-        // Deserialize the file directory index
+        // Deserialize the file directory index. If an error occurs processing the file,
+        // generate event and return EXECUTION_ERROR. 
         Fw::SerializeStatus status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.dir);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status, status);
+        if (status != Fw::FW_SERIALIZE_OK) {
+            this->log_WARNING_HI_FileCorruptedDataError
+                (this->m_stateFile, static_cast<I32>(status));
+            stateFile.close();
+            return Fw::CmdResponse::EXECUTION_ERROR;
+        }
         status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.record);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status, status);
+        if (status != Fw::FW_SERIALIZE_OK) {
+            this->log_WARNING_HI_FileCorruptedDataError
+                (this->m_stateFile, static_cast<I32>(status));
+            stateFile.close();
+            return Fw::CmdResponse::EXECUTION_ERROR;
+        }
         this->m_stateFileData[entry].used = true;
         this->m_stateFileData[entry].visited = false;
 

--- a/Svc/DpCatalog/DpCatalog.fpp
+++ b/Svc/DpCatalog/DpCatalog.fpp
@@ -402,6 +402,15 @@ module Svc {
       id 46 \
       format "Cannot Transmit a Catalog before Building"
 
+    @ The file contained malformed or invalid data during deserialization
+    event FileCorruptedDataError(
+                             file: string size FileNameStringSize @< The file
+                             stat: I32
+      ) \
+      severity warning high \
+      id 47 \
+      format "DP file {} contains malformed data (status {})"     
+
     # ----------------------------------------------------------------------
     # Telemetry
     # ----------------------------------------------------------------------

--- a/Svc/DpCatalog/test/ut/DpCatalogTestMain.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTestMain.cpp
@@ -304,6 +304,11 @@ TEST(OffNominal, ProcessFileInvalidDir) {
     tester.test_ProcessFileInvalidDir();
 }
 
+TEST(OffNominal, MalformedFile) {
+    Svc::DpCatalogTester tester;
+    tester.test_MalformedFile();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
@@ -756,4 +756,47 @@ void DpCatalogTester::test_ProcessFileInvalidDir() {
     this->component.shutdown();
 }
 
+void DpCatalogTester::test_MalformedFile() {
+
+    // 1. Setup paths and corrupted data
+    Fw::FileNameString stateFile("DpState.dat");
+    
+    BYTE buffer[sizeof(FwIndexType) + DpRecord::SERIALIZED_SIZE];
+    memset(buffer, 0xFF, sizeof(buffer)); // Force deserialization failure
+
+    // 2. Write the malformed data to disk
+    Os::File f;
+    ASSERT_EQ(Os::File::OP_OK, f.open(stateFile.toChar(), Os::File::OPEN_CREATE, Os::FileInterface::OVERWRITE));
+    
+    FwSizeType writeSize = sizeof(buffer);
+    ASSERT_EQ(Os::File::OP_OK, f.write(buffer, writeSize));
+    f.close();
+
+    // 3. Configure the Component
+    Fw::MallocAllocator mockAllocator;
+    Fw::FileNameString dirs[DP_MAX_DIRECTORIES];
+    this->component.configure(dirs, 0, stateFile, 0, mockAllocator);
+
+    // 4. Dispatch the BUILD_CATALOG command
+    this->sendCmd_BUILD_CATALOG(0, 0);
+    this->component.doDispatch();
+
+    // 5. Command should generate event instead of ASSERT
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    //ASSERT_CMD_RESPONSE(0, DpCatalogComponentBase::OPCODE_BUILD_CATALOG, 0, Fw::CmdResponse::EXECUTION_ERROR);
+
+    // High-priority warning event should be caught by this test
+    ASSERT_EVENTS_SIZE(2);
+    ASSERT_EVENTS_FileCorruptedDataError_SIZE(1);
+    ASSERT_EVENTS_FileCorruptedDataError(
+        0, 
+        stateFile.toChar(), 
+        static_cast<I32>(Fw::FW_DESERIALIZE_FORMAT_ERROR)
+    );
+
+    // 6. Cleanup
+    Os::FileSystem::removeFile(stateFile.toChar());
+    this->component.shutdown();
+}
+
 }  // namespace Svc

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
@@ -757,17 +757,16 @@ void DpCatalogTester::test_ProcessFileInvalidDir() {
 }
 
 void DpCatalogTester::test_MalformedFile() {
-
     // 1. Setup paths and corrupted data
     Fw::FileNameString stateFile("DpState.dat");
-    
+
     BYTE buffer[sizeof(FwIndexType) + DpRecord::SERIALIZED_SIZE];
-    memset(buffer, 0xFF, sizeof(buffer)); // Force deserialization failure
+    memset(buffer, 0xFF, sizeof(buffer));  // Force deserialization failure
 
     // 2. Write the malformed data to disk
     Os::File f;
     ASSERT_EQ(Os::File::OP_OK, f.open(stateFile.toChar(), Os::File::OPEN_CREATE, Os::FileInterface::OVERWRITE));
-    
+
     FwSizeType writeSize = sizeof(buffer);
     ASSERT_EQ(Os::File::OP_OK, f.write(buffer, writeSize));
     f.close();
@@ -783,16 +782,12 @@ void DpCatalogTester::test_MalformedFile() {
 
     // 5. Command should generate event instead of ASSERT
     ASSERT_CMD_RESPONSE_SIZE(1);
-    //ASSERT_CMD_RESPONSE(0, DpCatalogComponentBase::OPCODE_BUILD_CATALOG, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    // ASSERT_CMD_RESPONSE(0, DpCatalogComponentBase::OPCODE_BUILD_CATALOG, 0, Fw::CmdResponse::EXECUTION_ERROR);
 
     // High-priority warning event should be caught by this test
     ASSERT_EVENTS_SIZE(2);
     ASSERT_EVENTS_FileCorruptedDataError_SIZE(1);
-    ASSERT_EVENTS_FileCorruptedDataError(
-        0, 
-        stateFile.toChar(), 
-        static_cast<I32>(Fw::FW_DESERIALIZE_FORMAT_ERROR)
-    );
+    ASSERT_EVENTS_FileCorruptedDataError(0, stateFile.toChar(), static_cast<I32>(Fw::FW_DESERIALIZE_FORMAT_ERROR));
 
     // 6. Cleanup
     Os::FileSystem::removeFile(stateFile.toChar());

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.hpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.hpp
@@ -149,6 +149,7 @@ class DpCatalogTester : public DpCatalogGTestBase {
     void test_PingIn();
     void test_BadFileDone();
     void test_ProcessFileInvalidDir();
+    void test_MalformedFile();
 };
 
 }  // namespace Svc

--- a/Svc/FprimeFramer/FprimeFramer.cpp
+++ b/Svc/FprimeFramer/FprimeFramer.cpp
@@ -55,6 +55,8 @@ void FprimeFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const 
     trailer.set_crcField(hashBuffer.asBigEndianU32());
     status = frameSerializer.serializeFrom(trailer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    // Trim to actual frame size in case allocator returned a larger buffer
+    frameBuffer.setSize(static_cast<Fw::Buffer::SizeType>(frameSize));
 
     // Send the full frame out - this port shall always be connected
     this->dataOut_out(0, frameBuffer, context);

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTestMain.cpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTestMain.cpp
@@ -21,6 +21,11 @@ TEST(Nominal, testNominalFraming) {
     tester.testNominalFraming();
 }
 
+TEST(OffNominal, OversizedAllocatorBufferIsTrimmed) {
+    Svc::FprimeFramerTester tester;
+    tester.testOversizedAllocatorBufferIsTrimmed();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
@@ -79,28 +79,26 @@ void FprimeFramerTester ::testNominalFraming() {
 }
 
 void FprimeFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
-
     U8 bufferData[100];
     Fw::Buffer buffer(bufferData, sizeof(bufferData));
     ComCfg::FrameContext context;
- 
+
     for (U32 i = 0; i < sizeof(bufferData); ++i) {
         bufferData[i] = static_cast<U8>(i);
     }
- 
+
     // Signal the allocator handler to return a larger-than-needed buffer,
     // simulating a BufferManager bin that is bigger than the exact frame size.
     this->m_useOversizedAlloc = true;
     this->invoke_to_dataIn(0, buffer, context);
     this->m_useOversizedAlloc = false;
- 
+
     ASSERT_from_dataOut_SIZE(1);
     ASSERT_from_dataReturnOut_SIZE(1);
- 
-    const FwSizeType expectedFrameSize = sizeof(bufferData) +
-                                         FprimeProtocol::FrameHeader::SERIALIZED_SIZE +
+
+    const FwSizeType expectedFrameSize = sizeof(bufferData) + FprimeProtocol::FrameHeader::SERIALIZED_SIZE +
                                          FprimeProtocol::FrameTrailer::SERIALIZED_SIZE;
- 
+
     Fw::Buffer outputBuffer = this->fromPortHistory_dataOut->at(0).data;
     // If setSize() is missing from FprimeFramer, getSize() returns the
     // oversized allocation (2 * expectedFrameSize) and this assertion fails.

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
@@ -78,6 +78,35 @@ void FprimeFramerTester ::testNominalFraming() {
     }
 }
 
+void FprimeFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
+
+    U8 bufferData[100];
+    Fw::Buffer buffer(bufferData, sizeof(bufferData));
+    ComCfg::FrameContext context;
+ 
+    for (U32 i = 0; i < sizeof(bufferData); ++i) {
+        bufferData[i] = static_cast<U8>(i);
+    }
+ 
+    // Signal the allocator handler to return a larger-than-needed buffer,
+    // simulating a BufferManager bin that is bigger than the exact frame size.
+    this->m_useOversizedAlloc = true;
+    this->invoke_to_dataIn(0, buffer, context);
+    this->m_useOversizedAlloc = false;
+ 
+    ASSERT_from_dataOut_SIZE(1);
+    ASSERT_from_dataReturnOut_SIZE(1);
+ 
+    const FwSizeType expectedFrameSize = sizeof(bufferData) +
+                                         FprimeProtocol::FrameHeader::SERIALIZED_SIZE +
+                                         FprimeProtocol::FrameTrailer::SERIALIZED_SIZE;
+ 
+    Fw::Buffer outputBuffer = this->fromPortHistory_dataOut->at(0).data;
+    // If setSize() is missing from FprimeFramer, getSize() returns the
+    // oversized allocation (2 * expectedFrameSize) and this assertion fails.
+    ASSERT_EQ(outputBuffer.getSize(), expectedFrameSize);
+}
+
 // ----------------------------------------------------------------------
 // Test Harness: Handler implementations for output ports
 // ----------------------------------------------------------------------

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTester.hpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTester.hpp
@@ -49,6 +49,9 @@ class FprimeFramerTester final : public FprimeFramerGTestBase {
     //! Test framing of data
     void testNominalFraming();
 
+    //! Test oversized buffer allocation (trimming) of data
+    void testOversizedAllocatorBufferIsTrimmed();
+
   private:
     // ----------------------------------------------------------------------
     // Helper functions
@@ -76,6 +79,9 @@ class FprimeFramerTester final : public FprimeFramerGTestBase {
 
     U8 m_buffer_slot[2048];
     Fw::Buffer m_buffer;  // buffer to be returned by mocked allocate call
+
+    // Flag read by from_bufferAllocate_handler to choose which path to take
+    bool m_useOversizedAlloc = false;
 };
 
 }  // namespace Svc


### PR DESCRIPTION
| | |
|:---|:---|
|**_5038_**|  |
|**_Has Unit Tests (Y)_**|  |
|**_Documentation Included (N)_**|  |
|**_Generative AI was used in this contribution (Y)_**|  |

---
## Change Description

Added a single `setSize()` call in each framer immediately before `dataOut_out`, trimming the buffer to the exact computed frame size. `frameSize` is already in scope in both handlers at that point and requires no additional computation.

**`Svc/FprimeFramer/FprimeFramer.cpp`**
```cpp
// Trim to actual frame size in case allocator returned a larger buffer
frameBuffer.setSize(static_cast<Fw::Buffer::SizeType>(frameSize));
```

**`Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp`**
```cpp
// Trim to actual frame size in case allocator returned a larger buffer
frameBuffer.setSize(static_cast<Fw::Buffer::SizeType>(frameSize));
```

## Rationale

Trim any extra data.

## Testing/Review Recommendations

Created a test case `testOversizedAllocatorBufferIsTrimmed` to both `FprimeFramerTester` and `SpacePacketFramerTester`. Each test case overrides `from_bufferAllocate_handler` to return a buffer twice the requested size (simulating a `BufferManager` bin fallback), then asserts that the buffer received by `dataOut` reports `getSize()` equal to the exact expected frame size. Extra capacity is filled with sentinel byte `0xAB` so any stale-tail leak produces obviously wrong bytes rather than silent zeroes.

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI was used to write the unit test `testOversizedAllocatorBufferIsTrimmed for FprimeFramerTester and SpacePacketFramerTester.
