### PR TITLE
DpCatalog - validate fdp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ Packet-Views
 docs/reference/api/cpp
 docs/reference/api/cmake
 temp_dir/
+
+.codex
+dest.bin
+GEMINI.md

--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,3 @@ Packet-Views
 docs/reference/api/cpp
 docs/reference/api/cmake
 temp_dir/
-
-.codex
-dest.bin
-GEMINI.md

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -13,6 +13,7 @@
 #include "Fw/Types/StringUtils.hpp"
 #include "Os/File.hpp"
 #include "Os/FileSystem.hpp"
+#include "Utils/Hash/Hash.hpp"
 
 namespace Svc {
 static_assert(DP_MAX_DIRECTORIES > 0, "Configuration DP_MAX_DIRECTORIES must be positive");
@@ -408,11 +409,14 @@ Fw::CmdResponse DpCatalog::fillBinaryTree() {
         for (FwSizeType file = 0; file < filesRead; file++) {
             // only consider files with the DP extension
 
-            FwSignedSizeType loc =
-                Fw::StringUtils::substring_find(this->m_fileList[file].toChar(), this->m_fileList[file].length(),
-                                                DP_EXT, Fw::StringUtils::string_length(DP_EXT, sizeof(DP_EXT)));
+            const FwSizeType fileNameLength = this->m_fileList[file].length();
+            const FwSizeType dpExtLength = Fw::StringUtils::string_length(DP_EXT, sizeof(DP_EXT));
+            const FwSignedSizeType loc =
+                Fw::StringUtils::substring_find_last(this->m_fileList[file].toChar(), fileNameLength, DP_EXT,
+                                                     dpExtLength);
 
-            if (-1 == loc) {
+            // Only accept files whose final suffix is the data product extension
+            if ((-1 == loc) || (static_cast<FwSizeType>(loc) + dpExtLength != fileNameLength)) {
                 continue;
             }
 
@@ -497,14 +501,19 @@ int DpCatalog::processFile(Fw::String fullFile, FwSizeType dir) {
         return 0;
     }
 
+    if (fileSize < Fw::DpContainer::MIN_PACKET_SIZE) {
+        this->log_WARNING_HI_FileReadError(fullFile, Os::File::BAD_SIZE);
+        return 0;
+    }
+
     Os::File::Status stat = dpFile.open(fullFile.toChar(), Os::File::OPEN_READ);
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_FileOpenError(fullFile, stat);
         return 0;
     }
 
-    // Read DP header
-    FwSizeType size = Fw::DpContainer::Header::SIZE;
+    // Read DP header and header hash
+    FwSizeType size = Fw::DpContainer::MIN_PACKET_SIZE;
 
     stat = dpFile.read(dpBuff, size);
     if (stat != Os::File::OP_OK) {
@@ -513,8 +522,8 @@ int DpCatalog::processFile(Fw::String fullFile, FwSizeType dir) {
         return 0;
     }
 
-    // if full header isn't read, something's wrong with the file, so skip
-    if (size != Fw::DpContainer::Header::SIZE) {
+    // if full header and hashes aren't read, something's wrong with the file, so skip
+    if (size != Fw::DpContainer::MIN_PACKET_SIZE) {
         this->log_WARNING_HI_FileReadError(fullFile, Os::File::BAD_SIZE);
         dpFile.close();
         return 0;
@@ -526,10 +535,35 @@ int DpCatalog::processFile(Fw::String fullFile, FwSizeType dir) {
     // give buffer to container instance
     container.setBuffer(hdrBuff);
 
+    // make sure the header metadata matches its stored hash before trusting it
+    Utils::HashBuffer storedHash;
+    Utils::HashBuffer computedHash;
+    Fw::Success::T hashStatus = container.checkHeaderHash(storedHash, computedHash);
+    if (hashStatus != Fw::Success::SUCCESS) {
+        this->log_WARNING_HI_FileHdrError(fullFile, DpHdrField::CRC, computedHash.asBigEndianU32(),
+                                          storedHash.asBigEndianU32());
+        return 0;
+    }
+
     // reset header deserialization in the container
     Fw::SerializeStatus desStat = container.deserializeHeader();
     if (desStat != Fw::FW_SERIALIZE_OK) {
         this->log_WARNING_HI_FileHdrDesError(fullFile, desStat);
+        return 0;
+    }
+
+    const FwSizeType dataSize = container.getDataSize();
+    const FwSizeType expectedDataSize = fileSize - Fw::DpContainer::MIN_PACKET_SIZE;
+    if (dataSize != expectedDataSize) {
+        this->log_WARNING_HI_FileReadError(fullFile, Os::File::BAD_SIZE);
+        return 0;
+    }
+
+    Fw::FileNameString canonicalFileName;
+    canonicalFileName.format(DP_FILENAME_FORMAT, this->m_directories[dir].toChar(), container.getId(),
+                             container.getTimeTag().getSeconds(), container.getTimeTag().getUSeconds());
+    if (canonicalFileName != fullFile) {
+        this->log_WARNING_HI_FileHdrDesError(fullFile, Fw::FW_SERIALIZE_FORMAT_ERROR);
         return 0;
     }
 
@@ -570,11 +604,7 @@ int DpCatalog::processFile(Fw::String fullFile, FwSizeType dir) {
         return -1;
     }
 
-    Fw::FileNameString addedFileName;
-    addedFileName.format(DP_FILENAME_FORMAT, this->m_directories[dir].toChar(), entry.record.get_id(),
-                         entry.record.get_tSec(), entry.record.get_tSub());
-
-    this->log_ACTIVITY_HI_DpFileAdded(addedFileName);
+    this->log_ACTIVITY_HI_DpFileAdded(canonicalFileName);
 
     // Compute relative priority to current exploration node
     // For Handling adding a node to a catalog that has

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -411,9 +411,8 @@ Fw::CmdResponse DpCatalog::fillBinaryTree() {
 
             const FwSizeType fileNameLength = this->m_fileList[file].length();
             const FwSizeType dpExtLength = Fw::StringUtils::string_length(DP_EXT, sizeof(DP_EXT));
-            const FwSignedSizeType loc =
-                Fw::StringUtils::substring_find_last(this->m_fileList[file].toChar(), fileNameLength, DP_EXT,
-                                                     dpExtLength);
+            const FwSignedSizeType loc = Fw::StringUtils::substring_find_last(this->m_fileList[file].toChar(),
+                                                                              fileNameLength, DP_EXT, dpExtLength);
 
             // Only accept files whose final suffix is the data product extension
             if ((-1 == loc) || (static_cast<FwSizeType>(loc) + dpExtLength != fileNameLength)) {

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -562,7 +562,7 @@ int DpCatalog::processFile(Fw::String fullFile, FwSizeType dir) {
     canonicalFileName.format(DP_FILENAME_FORMAT, this->m_directories[dir].toChar(), container.getId(),
                              container.getTimeTag().getSeconds(), container.getTimeTag().getUSeconds());
     if (canonicalFileName != fullFile) {
-        this->log_WARNING_HI_FileHdrDesError(fullFile, Fw::FW_SERIALIZE_FORMAT_ERROR);
+        this->log_WARNING_HI_InvalidFileName(fullFile, canonicalFileName);
         return 0;
     }
 

--- a/Svc/DpCatalog/DpCatalog.fpp
+++ b/Svc/DpCatalog/DpCatalog.fpp
@@ -402,6 +402,16 @@ module Svc {
       id 46 \
       format "Cannot Transmit a Catalog before Building"
 
+    @ DP file name does not match the file's header metadata
+    event InvalidFileName(
+                            file: string size FileNameStringSize @< The invalid file
+                            expected: string size FileNameStringSize @< The expected canonical file
+                          ) \
+      severity warning high \
+      id 47 \
+      format "Invalid DP file name {}. Expected {}" \
+      throttle 10
+
     # ----------------------------------------------------------------------
     # Telemetry
     # ----------------------------------------------------------------------

--- a/Svc/DpCatalog/test/ut/DpCatalogTestMain.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTestMain.cpp
@@ -304,6 +304,21 @@ TEST(OffNominal, ProcessFileInvalidDir) {
     tester.test_ProcessFileInvalidDir();
 }
 
+TEST(OffNominal, TruncatedDpRejected) {
+    Svc::DpCatalogTester tester;
+    tester.test_TruncatedDpRejected();
+}
+
+TEST(OffNominal, NonCanonicalDpRejected) {
+    Svc::DpCatalogTester tester;
+    tester.test_NonCanonicalDpRejected();
+}
+
+TEST(OffNominal, BadHeaderHashRejected) {
+    Svc::DpCatalogTester tester;
+    tester.test_BadHeaderHashRejected();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
@@ -7,6 +7,7 @@
 #include "DpCatalogTester.hpp"
 #include <algorithm>
 #include <cstdlib>
+#include <vector>
 #include "Fw/Dp/DpContainer.hpp"
 #include "Fw/Test/UnitTest.hpp"
 #include "Fw/Types/FileNameString.hpp"
@@ -231,19 +232,25 @@ Fw::String DpCatalogTester::genDP(FwDpIdType id,
                                   bool hdrHashError,
                                   const char* dir) {
     // Fill DP container
-    U8 hdrData[Fw::DpContainer::MIN_PACKET_SIZE];
-    Fw::Buffer hdrBuffer(hdrData, Fw::DpContainer::MIN_PACKET_SIZE);
-    Fw::DpContainer cont(id, hdrBuffer);
+    const FwSizeType packetSize = Fw::DpContainer::getPacketSizeForDataSize(dataSize);
+    std::vector<U8> packetData(packetSize);
+    Fw::Buffer packetBuffer(packetData.data(), packetSize);
+    Fw::DpContainer cont(id, packetBuffer);
     cont.setPriority(prio);
     cont.setTimeTag(time);
     cont.setDpState(dpState);
     cont.setDataSize(dataSize);
-    // serialize file data
-    cont.serializeHeader();
+
     // fill data with ramp
-    U8 dpData[dataSize];
-    for (FwIndexType byte = 0; byte < static_cast<FwIndexType>(dataSize); byte++) {
-        dpData[byte] = byte;
+    U8* const dpData = &packetData[Fw::DpContainer::DATA_OFFSET];
+    for (FwSizeType byte = 0; byte < dataSize; byte++) {
+        dpData[byte] = static_cast<U8>(byte);
+    }
+    // serialize file data and hashes
+    cont.serializeHeader();
+    cont.updateDataHash();
+    if (hdrHashError) {
+        packetData[Fw::DpContainer::HEADER_HASH_OFFSET]++;
     }
     // open file to write data
     Fw::String fileName;
@@ -255,27 +262,15 @@ Fw::String DpCatalogTester::genDP(FwDpIdType id,
         printf("Error opening file %s: status: %d\n", fileName.toChar(), stat);
         return "";
     }
-    FwSizeType size = Fw::DpContainer::Header::SIZE;
-    stat = dpFile.write(hdrData, size);
+    FwSizeType size = packetSize;
+    stat = dpFile.write(packetData.data(), size);
     if (stat != Os::File::Status::OP_OK) {
-        printf("Error writing DP file header %s: status: %d\n", fileName.toChar(), stat);
+        printf("Error writing DP file %s: status: %d\n", fileName.toChar(), stat);
         return "";
     }
-    if (static_cast<FwSizeType>(size) != Fw::DpContainer::Header::SIZE) {
-        printf("Dp file header %s write size didn't match. Req: %" PRI_FwSizeType "Act: %" PRI_FwSizeType "\n",
-               fileName.toChar(), Fw::DpContainer::Header::SIZE, size);
-        return "";
-    }
-    size = dataSize;
-    stat = dpFile.write(dpData, size);
-    if (stat != Os::File::Status::OP_OK) {
-        printf("Error writing DP file data %s: status: %" PRI_FwEnumStoreType "\n", fileName.toChar(),
-               static_cast<FwEnumStoreType>(stat));
-        return "";
-    }
-    if (static_cast<FwSizeType>(size) != dataSize) {
-        printf("Dp file header %s write size didn't match. Req: %" PRI_FwSizeType " Act: %" PRI_FwSizeType "\n",
-               fileName.toChar(), dataSize, size);
+    if (static_cast<FwSizeType>(size) != packetSize) {
+        printf("Dp file %s write size didn't match. Req: %" PRI_FwSizeType "Act: %" PRI_FwSizeType "\n",
+               fileName.toChar(), packetSize, size);
         return "";
     }
     dpFile.close();
@@ -752,6 +747,106 @@ void DpCatalogTester::test_ProcessFileInvalidDir() {
     this->component.configure(dirs, 1, stateFile, 100, alloc);
 
     ASSERT_DEATH_IF_SUPPORTED(this->component.processFile("somefile.dp", DP_MAX_DIRECTORIES), "Assert");
+
+    this->component.shutdown();
+}
+
+void DpCatalogTester::test_TruncatedDpRejected() {
+    Fw::MallocAllocator alloc;
+    Fw::FileNameString dir("./DpTest_TruncatedDpRejected");
+    Fw::FileNameString stateFile("");
+    this->makeDpDir(dir.toChar());
+
+    const FwDpIdType id = 0x123;
+    const FwDpPriorityType priority = 10;
+    Fw::Time time(1000, 100);
+    std::vector<U8> packetData(Fw::DpContainer::MIN_PACKET_SIZE);
+    Fw::Buffer packetBuffer(packetData.data(), Fw::DpContainer::MIN_PACKET_SIZE);
+    Fw::DpContainer container(id, packetBuffer);
+    container.setPriority(priority);
+    container.setTimeTag(time);
+    container.setDpState(Fw::DpState::UNTRANSMITTED);
+    container.setDataSize(0);
+    container.serializeHeader();
+    container.updateDataHash();
+
+    Fw::String fileName;
+    fileName.format(DP_FILENAME_FORMAT, dir.toChar(), id, time.getSeconds(), time.getUSeconds());
+    Os::File dpFile;
+    Os::File::Status stat = dpFile.open(fileName.toChar(), Os::File::Mode::OPEN_CREATE);
+    ASSERT_EQ(stat, Os::File::Status::OP_OK);
+    const FwSizeType headerSize = Fw::DpContainer::Header::SIZE;
+    FwSizeType size = headerSize;
+    stat = dpFile.write(packetData.data(), size);
+    ASSERT_EQ(stat, Os::File::Status::OP_OK);
+    ASSERT_EQ(size, headerSize);
+    dpFile.close();
+
+    this->component.configure(&dir, 1, stateFile, 100, alloc);
+    this->sendCmd_BUILD_CATALOG(0, 10);
+    this->component.doDispatch();
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, DpCatalog::OPCODE_BUILD_CATALOG, 10, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_DpFileAdded_SIZE(0);
+
+    this->sendCmd_START_XMIT_CATALOG(0, 11, Fw::Wait::NO_WAIT, false);
+    this->component.doDispatch();
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_from_fileOut_SIZE(0);
+
+    this->component.shutdown();
+}
+
+void DpCatalogTester::test_NonCanonicalDpRejected() {
+    Fw::MallocAllocator alloc;
+    Fw::FileNameString dir("./DpTest_NonCanonicalDpRejected");
+    Fw::FileNameString stateFile("");
+    this->makeDpDir(dir.toChar());
+
+    Fw::Time time(1000, 100);
+    Fw::String canonicalFile = this->genDP(0x123, 10, time, 16, Fw::DpState::UNTRANSMITTED, false, dir.toChar());
+    ASSERT_STRNE(canonicalFile.toChar(), "");
+
+    Fw::String rogueFile;
+    rogueFile.format("%s/rogue.fdp", dir.toChar());
+    ASSERT_EQ(Os::FileSystem::moveFile(canonicalFile.toChar(), rogueFile.toChar()), Os::FileSystem::OP_OK);
+
+    this->component.configure(&dir, 1, stateFile, 100, alloc);
+    this->sendCmd_BUILD_CATALOG(0, 10);
+    this->component.doDispatch();
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, DpCatalog::OPCODE_BUILD_CATALOG, 10, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_DpFileAdded_SIZE(0);
+
+    this->sendCmd_START_XMIT_CATALOG(0, 11, Fw::Wait::NO_WAIT, false);
+    this->component.doDispatch();
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_from_fileOut_SIZE(0);
+
+    this->component.shutdown();
+}
+
+void DpCatalogTester::test_BadHeaderHashRejected() {
+    Fw::MallocAllocator alloc;
+    Fw::FileNameString dir("./DpTest_BadHeaderHashRejected");
+    Fw::FileNameString stateFile("");
+    this->makeDpDir(dir.toChar());
+
+    Fw::Time time(1000, 100);
+    Fw::String fileName = this->genDP(0x123, 10, time, 16, Fw::DpState::UNTRANSMITTED, true, dir.toChar());
+    ASSERT_STRNE(fileName.toChar(), "");
+
+    this->component.configure(&dir, 1, stateFile, 100, alloc);
+    this->sendCmd_BUILD_CATALOG(0, 10);
+    this->component.doDispatch();
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, DpCatalog::OPCODE_BUILD_CATALOG, 10, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_DpFileAdded_SIZE(0);
+
+    this->sendCmd_START_XMIT_CATALOG(0, 11, Fw::Wait::NO_WAIT, false);
+    this->component.doDispatch();
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_from_fileOut_SIZE(0);
 
     this->component.shutdown();
 }

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
@@ -788,6 +788,8 @@ void DpCatalogTester::test_TruncatedDpRejected() {
     ASSERT_CMD_RESPONSE_SIZE(1);
     ASSERT_CMD_RESPONSE(0, DpCatalog::OPCODE_BUILD_CATALOG, 10, Fw::CmdResponse::OK);
     ASSERT_EVENTS_DpFileAdded_SIZE(0);
+    ASSERT_EVENTS_FileReadError_SIZE(1);
+    ASSERT_EVENTS_FileReadError(0, fileName.toChar(), static_cast<I32>(Os::File::BAD_SIZE));
 
     this->sendCmd_START_XMIT_CATALOG(0, 11, Fw::Wait::NO_WAIT, false);
     this->component.doDispatch();
@@ -817,6 +819,8 @@ void DpCatalogTester::test_NonCanonicalDpRejected() {
     ASSERT_CMD_RESPONSE_SIZE(1);
     ASSERT_CMD_RESPONSE(0, DpCatalog::OPCODE_BUILD_CATALOG, 10, Fw::CmdResponse::OK);
     ASSERT_EVENTS_DpFileAdded_SIZE(0);
+    ASSERT_EVENTS_InvalidFileName_SIZE(1);
+    ASSERT_EVENTS_InvalidFileName(0, rogueFile.toChar(), canonicalFile.toChar());
 
     this->sendCmd_START_XMIT_CATALOG(0, 11, Fw::Wait::NO_WAIT, false);
     this->component.doDispatch();
@@ -842,6 +846,8 @@ void DpCatalogTester::test_BadHeaderHashRejected() {
     ASSERT_CMD_RESPONSE_SIZE(1);
     ASSERT_CMD_RESPONSE(0, DpCatalog::OPCODE_BUILD_CATALOG, 10, Fw::CmdResponse::OK);
     ASSERT_EVENTS_DpFileAdded_SIZE(0);
+    ASSERT_EVENTS_FileHdrError_SIZE(1);
+    ASSERT_EVENTS_FileHdrError(0, fileName.toChar(), DpHdrField::CRC, 635957387, 652734603);
 
     this->sendCmd_START_XMIT_CATALOG(0, 11, Fw::Wait::NO_WAIT, false);
     this->component.doDispatch();

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.hpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.hpp
@@ -149,6 +149,9 @@ class DpCatalogTester : public DpCatalogGTestBase {
     void test_PingIn();
     void test_BadFileDone();
     void test_ProcessFileInvalidDir();
+    void test_TruncatedDpRejected();
+    void test_NonCanonicalDpRejected();
+    void test_BadHeaderHashRejected();
 };
 
 }  // namespace Svc


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5009 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

This change improves `Svc::DpCatalog` validation of data product files discovered during catalog builds.
The catalog now rejects malformed or inconsistent `.fdp` files before adding them to the catalog. Specifically, it now:
- Accepts only files whose final suffix is the data product extension.
- Rejects files smaller than `Fw::DpContainer::MIN_PACKET_SIZE`.
- Reads enough bytes to include the DP header and required hashes.
- Verifies the header hash before trusting header metadata.
- Verifies that the header `dataSize` matches the on-disk file size.
- Verifies that the discovered file path matches the canonical DP filename derived from the header metadata.
The unit test helper was also updated to generate complete DP packets, including payload data and hashes, so tests exercise the same validation path as real data product files.


## Rationale


Previously, `DpCatalog` trusted metadata from any file with a matching `.fdp` extension in a managed directory after reading only the DP header. This allowed truncated or renamed files to be cataloged.
A truncated file could be accepted even though it was smaller than the minimum valid DP packet size. A renamed file could also cause the catalog to scan one path but later transmit a different canonical path reconstructed from untrusted header metadata.
This change ensures that catalog entries are created only from structurally valid DP files whose on-disk path is consistent with the metadata used later for transmission.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Codex