### PR TITLE
Add destCapacity DeserializeTo for more robustness

### DIFF
--- a/Fw/Dp/DpContainer.cpp
+++ b/Fw/Dp/DpContainer.cpp
@@ -70,7 +70,8 @@ Fw::SerializeStatus DpContainer::deserializeHeader() {
     if (status == Fw::FW_SERIALIZE_OK) {
         const FwSizeType requestedSize = sizeof this->m_userData;
         FwSizeType receivedSize = requestedSize;
-        status = deserializer.deserializeTo(this->m_userData, sizeof(this->m_userData), receivedSize, Fw::Serialization::OMIT_LENGTH);
+        status = deserializer.deserializeTo(this->m_userData, sizeof(this->m_userData), receivedSize,
+                                            Fw::Serialization::OMIT_LENGTH);
         if (receivedSize != requestedSize) {
             status = Fw::FW_DESERIALIZE_SIZE_MISMATCH;
         }

--- a/Fw/Dp/DpContainer.cpp
+++ b/Fw/Dp/DpContainer.cpp
@@ -70,7 +70,7 @@ Fw::SerializeStatus DpContainer::deserializeHeader() {
     if (status == Fw::FW_SERIALIZE_OK) {
         const FwSizeType requestedSize = sizeof this->m_userData;
         FwSizeType receivedSize = requestedSize;
-        status = deserializer.deserializeTo(this->m_userData, receivedSize, Fw::Serialization::OMIT_LENGTH);
+        status = deserializer.deserializeTo(this->m_userData, sizeof(this->m_userData), receivedSize, Fw::Serialization::OMIT_LENGTH);
         if (receivedSize != requestedSize) {
             status = Fw::FW_DESERIALIZE_SIZE_MISMATCH;
         }

--- a/Fw/Dp/test/util/DpContainerHeader.hpp
+++ b/Fw/Dp/test/util/DpContainerHeader.hpp
@@ -74,7 +74,8 @@ struct DpContainerHeader {
         // Deserialize the user data
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::USER_DATA_OFFSET);
         FwSizeType size = sizeof this->m_userData;
-        status = deserializer.deserializeTo(this->m_userData, sizeof(this->m_userData), size, Fw::Serialization::OMIT_LENGTH);
+        status = deserializer.deserializeTo(this->m_userData, sizeof(this->m_userData), size,
+                                            Fw::Serialization::OMIT_LENGTH);
         DP_CONTAINER_HEADER_ASSERT_EQ(status, FW_SERIALIZE_OK);
         DP_CONTAINER_HEADER_ASSERT_EQ(size, sizeof this->m_userData);
         // Deserialize the data product state

--- a/Fw/Dp/test/util/DpContainerHeader.hpp
+++ b/Fw/Dp/test/util/DpContainerHeader.hpp
@@ -74,7 +74,7 @@ struct DpContainerHeader {
         // Deserialize the user data
         DpContainerHeader::moveDeserToOffset(file, line, deserializer, DpContainer::Header::USER_DATA_OFFSET);
         FwSizeType size = sizeof this->m_userData;
-        status = deserializer.deserializeTo(this->m_userData, size, Fw::Serialization::OMIT_LENGTH);
+        status = deserializer.deserializeTo(this->m_userData, sizeof(this->m_userData), size, Fw::Serialization::OMIT_LENGTH);
         DP_CONTAINER_HEADER_ASSERT_EQ(status, FW_SERIALIZE_OK);
         DP_CONTAINER_HEADER_ASSERT_EQ(size, sizeof this->m_userData);
         // Deserialize the data product state

--- a/Fw/FilePacket/PathName.cpp
+++ b/Fw/FilePacket/PathName.cpp
@@ -40,7 +40,7 @@ SerializeStatus FilePacket::PathName ::fromSerialBuffer(SerialBuffer& serialBuff
     {
         const U8* addrLeft = serialBuffer.getBuffAddrLeft();
         U8 bytes[MAX_LENGTH];
-        const SerializeStatus status = serialBuffer.popBytes(bytes, this->m_length);
+        const SerializeStatus status = serialBuffer.popBytes(bytes, MAX_LENGTH, this->m_length);
 
         if (status != FW_SERIALIZE_OK) {
             return status;

--- a/Fw/Log/AmpcsEvrLogPacket.cpp
+++ b/Fw/Log/AmpcsEvrLogPacket.cpp
@@ -69,7 +69,8 @@ SerializeStatus AmpcsEvrLogPacket::deserializeFrom(SerialBufferBase& buffer) {
     }
 
     FwSizeType size = buffer.getDeserializeSizeLeft();
-    stat = buffer.deserializeTo(this->m_logBuffer.getBuffAddr(), this->m_logBuffer.getCapacity(), size, Fw::Serialization::OMIT_LENGTH);
+    stat = buffer.deserializeTo(this->m_logBuffer.getBuffAddr(), this->m_logBuffer.getCapacity(), size,
+                                Fw::Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         // Shouldn't fail
         stat = this->m_logBuffer.setBuffLen(size);

--- a/Fw/Log/AmpcsEvrLogPacket.cpp
+++ b/Fw/Log/AmpcsEvrLogPacket.cpp
@@ -48,7 +48,7 @@ SerializeStatus AmpcsEvrLogPacket::deserializeFrom(SerialBufferBase& buffer) {
     SerializeStatus stat;
 
     len = AMPCS_EVR_TASK_NAME_LEN;
-    stat = buffer.deserializeTo(this->m_taskName, len, true);
+    stat = buffer.deserializeTo(this->m_taskName, AMPCS_EVR_TASK_NAME_LEN, len, Fw::Serialization::OMIT_LENGTH);
     if (stat != FW_SERIALIZE_OK) {
         return stat;
     }
@@ -69,7 +69,7 @@ SerializeStatus AmpcsEvrLogPacket::deserializeFrom(SerialBufferBase& buffer) {
     }
 
     FwSizeType size = buffer.getDeserializeSizeLeft();
-    stat = buffer.deserializeTo(this->m_logBuffer.getBuffAddr(), size, true);
+    stat = buffer.deserializeTo(this->m_logBuffer.getBuffAddr(), this->m_logBuffer.getCapacity(), size, Fw::Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         // Shouldn't fail
         stat = this->m_logBuffer.setBuffLen(size);

--- a/Fw/Log/LogPacket.cpp
+++ b/Fw/Log/LogPacket.cpp
@@ -54,7 +54,7 @@ SerializeStatus LogPacket::deserializeFrom(SerialBufferBase& buffer, Fw::Endiann
 
     // remainder of buffer must be telemetry value
     FwSizeType size = buffer.getDeserializeSizeLeft();
-    stat = buffer.deserializeTo(this->m_logBuffer.getBuffAddr(), size, Fw::Serialization::OMIT_LENGTH);
+    stat = buffer.deserializeTo(this->m_logBuffer.getBuffAddr(), this->m_logBuffer.getCapacity(), size, Fw::Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         // Shouldn't fail
         stat = this->m_logBuffer.setBuffLen(size);

--- a/Fw/Log/LogPacket.cpp
+++ b/Fw/Log/LogPacket.cpp
@@ -54,7 +54,8 @@ SerializeStatus LogPacket::deserializeFrom(SerialBufferBase& buffer, Fw::Endiann
 
     // remainder of buffer must be telemetry value
     FwSizeType size = buffer.getDeserializeSizeLeft();
-    stat = buffer.deserializeTo(this->m_logBuffer.getBuffAddr(), this->m_logBuffer.getCapacity(), size, Fw::Serialization::OMIT_LENGTH);
+    stat = buffer.deserializeTo(this->m_logBuffer.getBuffAddr(), this->m_logBuffer.getCapacity(), size,
+                                Fw::Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         // Shouldn't fail
         stat = this->m_logBuffer.setBuffLen(size);

--- a/Fw/Tlm/TlmPacket.cpp
+++ b/Fw/Tlm/TlmPacket.cpp
@@ -95,6 +95,9 @@ SerializeStatus TlmPacket::addValue(FwChanIdType id, Time& timeTag, TlmBuffer& b
 
 // extract telemetry value
 SerializeStatus TlmPacket::extractValue(FwChanIdType& id, Time& timeTag, TlmBuffer& buffer, FwSizeType bufferSize) {
+    // Validate the destination buffer parameter before any use.
+    FW_ASSERT(buffer.getCapacity() > 0, static_cast<FwAssertArgType>(buffer.getCapacity()));
+
     // deserialize items out of buffer
 
     // id
@@ -117,6 +120,11 @@ SerializeStatus TlmPacket::extractValue(FwChanIdType& id, Time& timeTag, TlmBuff
     if (bufferSize == 0 || bufferSize > buffer.getCapacity()) {
         return Fw::FW_DESERIALIZE_SIZE_MISMATCH;
     }
+    // Invariant: buffAddr is non-null and bufferSize fits within the destination.
+    FW_ASSERT(buffAddr != nullptr);
+    FW_ASSERT(bufferSize <= buffer.getCapacity(),
+              static_cast<FwAssertArgType>(bufferSize),
+              static_cast<FwAssertArgType>(buffer.getCapacity()));
     stat = this->m_tlmBuffer.deserializeTo(buffAddr, buffer.getCapacity(), bufferSize,
                                            Fw::Serialization::OMIT_LENGTH);
     if (stat != Fw::FW_SERIALIZE_OK) {
@@ -158,6 +166,11 @@ SerializeStatus TlmPacket::deserializeFrom(SerialBufferBase& buffer, Fw::Endiann
     if (size > this->m_tlmBuffer.getCapacity()) {
         return Fw::FW_DESERIALIZE_SIZE_MISMATCH;
     }
+    // Invariant: tlmAddr is non-null and size fits within the destination.
+    FW_ASSERT(tlmAddr != nullptr);
+    FW_ASSERT(size <= this->m_tlmBuffer.getCapacity(),
+              static_cast<FwAssertArgType>(size),
+              static_cast<FwAssertArgType>(this->m_tlmBuffer.getCapacity()));
     stat = buffer.deserializeTo(tlmAddr, this->m_tlmBuffer.getCapacity(), size,
                                 Fw::Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {

--- a/Fw/Tlm/TlmPacket.cpp
+++ b/Fw/Tlm/TlmPacket.cpp
@@ -110,7 +110,8 @@ SerializeStatus TlmPacket::extractValue(FwChanIdType& id, Time& timeTag, TlmBuff
     }
 
     // telemetry buffer
-    stat = this->m_tlmBuffer.deserializeTo(buffer.getBuffAddr(), buffer.getCapacity(), bufferSize, Fw::Serialization::OMIT_LENGTH);
+    stat = this->m_tlmBuffer.deserializeTo(buffer.getBuffAddr(), buffer.getCapacity(), bufferSize,
+                                           Fw::Serialization::OMIT_LENGTH);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
@@ -142,7 +143,8 @@ SerializeStatus TlmPacket::deserializeFrom(SerialBufferBase& buffer, Fw::Endiann
     }
     // deserialize the channel value entry buffers
     FwSizeType size = buffer.getDeserializeSizeLeft();
-    stat = buffer.deserializeTo(this->m_tlmBuffer.getBuffAddr(), this->m_tlmBuffer.getCapacity(), size, Fw::Serialization::OMIT_LENGTH);
+    stat = buffer.deserializeTo(this->m_tlmBuffer.getBuffAddr(), this->m_tlmBuffer.getCapacity(), size,
+                                Fw::Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         // Shouldn't fail
         stat = this->m_tlmBuffer.setBuffLen(size);

--- a/Fw/Tlm/TlmPacket.cpp
+++ b/Fw/Tlm/TlmPacket.cpp
@@ -110,7 +110,7 @@ SerializeStatus TlmPacket::extractValue(FwChanIdType& id, Time& timeTag, TlmBuff
     }
 
     // telemetry buffer
-    stat = this->m_tlmBuffer.deserializeTo(buffer.getBuffAddr(), bufferSize, Fw::Serialization::OMIT_LENGTH);
+    stat = this->m_tlmBuffer.deserializeTo(buffer.getBuffAddr(), buffer.getCapacity(), bufferSize, Fw::Serialization::OMIT_LENGTH);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
@@ -142,7 +142,7 @@ SerializeStatus TlmPacket::deserializeFrom(SerialBufferBase& buffer, Fw::Endiann
     }
     // deserialize the channel value entry buffers
     FwSizeType size = buffer.getDeserializeSizeLeft();
-    stat = buffer.deserializeTo(this->m_tlmBuffer.getBuffAddr(), size, Fw::Serialization::OMIT_LENGTH);
+    stat = buffer.deserializeTo(this->m_tlmBuffer.getBuffAddr(), this->m_tlmBuffer.getCapacity(), size, Fw::Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         // Shouldn't fail
         stat = this->m_tlmBuffer.setBuffLen(size);

--- a/Fw/Tlm/TlmPacket.cpp
+++ b/Fw/Tlm/TlmPacket.cpp
@@ -122,11 +122,9 @@ SerializeStatus TlmPacket::extractValue(FwChanIdType& id, Time& timeTag, TlmBuff
     }
     // Invariant: buffAddr is non-null and bufferSize fits within the destination.
     FW_ASSERT(buffAddr != nullptr);
-    FW_ASSERT(bufferSize <= buffer.getCapacity(),
-              static_cast<FwAssertArgType>(bufferSize),
+    FW_ASSERT(bufferSize <= buffer.getCapacity(), static_cast<FwAssertArgType>(bufferSize),
               static_cast<FwAssertArgType>(buffer.getCapacity()));
-    stat = this->m_tlmBuffer.deserializeTo(buffAddr, buffer.getCapacity(), bufferSize,
-                                           Fw::Serialization::OMIT_LENGTH);
+    stat = this->m_tlmBuffer.deserializeTo(buffAddr, buffer.getCapacity(), bufferSize, Fw::Serialization::OMIT_LENGTH);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
@@ -168,11 +166,9 @@ SerializeStatus TlmPacket::deserializeFrom(SerialBufferBase& buffer, Fw::Endiann
     }
     // Invariant: tlmAddr is non-null and size fits within the destination.
     FW_ASSERT(tlmAddr != nullptr);
-    FW_ASSERT(size <= this->m_tlmBuffer.getCapacity(),
-              static_cast<FwAssertArgType>(size),
+    FW_ASSERT(size <= this->m_tlmBuffer.getCapacity(), static_cast<FwAssertArgType>(size),
               static_cast<FwAssertArgType>(this->m_tlmBuffer.getCapacity()));
-    stat = buffer.deserializeTo(tlmAddr, this->m_tlmBuffer.getCapacity(), size,
-                                Fw::Serialization::OMIT_LENGTH);
+    stat = buffer.deserializeTo(tlmAddr, this->m_tlmBuffer.getCapacity(), size, Fw::Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         // Shouldn't fail
         stat = this->m_tlmBuffer.setBuffLen(size);

--- a/Fw/Tlm/TlmPacket.cpp
+++ b/Fw/Tlm/TlmPacket.cpp
@@ -109,20 +109,25 @@ SerializeStatus TlmPacket::extractValue(FwChanIdType& id, Time& timeTag, TlmBuff
         return stat;
     }
 
-    // telemetry buffer
-    stat = this->m_tlmBuffer.deserializeTo(buffer.getBuffAddr(), buffer.getCapacity(), bufferSize,
+    // validate telemetry buffer's destination pointer and capacity
+    U8* const buffAddr = buffer.getBuffAddr();
+    if (buffAddr == nullptr) {
+        return Fw::FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+    if (bufferSize == 0 || bufferSize > buffer.getCapacity()) {
+        return Fw::FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+    stat = this->m_tlmBuffer.deserializeTo(buffAddr, buffer.getCapacity(), bufferSize,
                                            Fw::Serialization::OMIT_LENGTH);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
 
-    // set buffer size
-    stat = buffer.setBuffLen(bufferSize);
-    if (stat != Fw::FW_SERIALIZE_OK) {
-        return stat;
-    }
-
-    return Fw::FW_SERIALIZE_OK;
+    // Update the destination buffer's length so callers can deserialize typed
+    // values out of it afterwards (e.g. buffOut.deserializeTo(valOut)).
+    // Without this, buffer.getBuffLength() stays 0 and any subsequent typed
+    // deserialize call returns FW_DESERIALIZE_SIZE_MISMATCH.
+    return buffer.setBuffLen(bufferSize);
 }
 
 SerializeStatus TlmPacket::serializeTo(SerialBufferBase& buffer, Fw::Endianness mode) const {
@@ -141,14 +146,23 @@ SerializeStatus TlmPacket::deserializeFrom(SerialBufferBase& buffer, Fw::Endiann
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
+
     // deserialize the channel value entry buffers
     FwSizeType size = buffer.getDeserializeSizeLeft();
-    stat = buffer.deserializeTo(this->m_tlmBuffer.getBuffAddr(), this->m_tlmBuffer.getCapacity(), size,
+
+    // validate destination pointer and capacity
+    U8* const tlmAddr = this->m_tlmBuffer.getBuffAddr();
+    if (tlmAddr == nullptr) {
+        return Fw::FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+    if (size > this->m_tlmBuffer.getCapacity()) {
+        return Fw::FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+    stat = buffer.deserializeTo(tlmAddr, this->m_tlmBuffer.getCapacity(), size,
                                 Fw::Serialization::OMIT_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         // Shouldn't fail
         stat = this->m_tlmBuffer.setBuffLen(size);
-        FW_ASSERT(stat == FW_SERIALIZE_OK, static_cast<FwAssertArgType>(stat));
     }
     return stat;
 }

--- a/Fw/Types/CMakeLists.txt
+++ b/Fw/Types/CMakeLists.txt
@@ -52,6 +52,7 @@ register_fprime_ut(
     "${CMAKE_CURRENT_LIST_DIR}/test/ut/AssertTypesTest.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/test/ut/TypesTest.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/test/ut/CAssertTest.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/test/ut/DeserializeToTest.cpp"
   DEPENDS
     Os
 )

--- a/Fw/Types/SerialBuffer.cpp
+++ b/Fw/Types/SerialBuffer.cpp
@@ -43,7 +43,6 @@ SerializeStatus SerialBuffer ::pushBytes(const U8* const addr, const FwSizeType 
 }
 
 SerializeStatus SerialBuffer ::popBytes(U8* const addr, FwSizeType buffCapacity, FwSizeType n) {
-
     // Check for null destination with a non-zero pop count and buffCapacity
     if (addr == nullptr && n > 0) {
         return FW_DESERIALIZE_SIZE_MISMATCH;

--- a/Fw/Types/SerialBuffer.cpp
+++ b/Fw/Types/SerialBuffer.cpp
@@ -43,6 +43,16 @@ SerializeStatus SerialBuffer ::pushBytes(const U8* const addr, const FwSizeType 
 }
 
 SerializeStatus SerialBuffer ::popBytes(U8* const addr, FwSizeType buffCapacity, FwSizeType n) {
+
+    // Check for null destination with a non-zero pop count and buffCapacity
+    if (addr == nullptr && n > 0) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+
+    if (n > buffCapacity) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+
     return this->deserializeTo(addr, buffCapacity, n, Fw::Serialization::OMIT_LENGTH);
 }
 

--- a/Fw/Types/SerialBuffer.cpp
+++ b/Fw/Types/SerialBuffer.cpp
@@ -42,8 +42,8 @@ SerializeStatus SerialBuffer ::pushBytes(const U8* const addr, const FwSizeType 
     return this->serializeFrom(const_cast<U8*>(addr), n, Fw::Serialization::OMIT_LENGTH);
 }
 
-SerializeStatus SerialBuffer ::popBytes(U8* const addr, FwSizeType n) {
-    return this->deserializeTo(addr, n, Fw::Serialization::OMIT_LENGTH);
+SerializeStatus SerialBuffer ::popBytes(U8* const addr, FwSizeType buffCapacity, FwSizeType n) {
+    return this->deserializeTo(addr, buffCapacity, n, Fw::Serialization::OMIT_LENGTH);
 }
 
 }  // namespace Fw

--- a/Fw/Types/SerialBuffer.hpp
+++ b/Fw/Types/SerialBuffer.hpp
@@ -59,9 +59,9 @@ class SerialBuffer final : public LinearBufferBase {
     );
 
     //! Pop n bytes off the buffer
-    SerializeStatus popBytes(U8* const addr,       //!< Address of bytes to pop
+    SerializeStatus popBytes(U8* const addr,           //!< Address of bytes to pop
                              FwSizeType buffCapacity,  //!< Capacity in bytes of addr
-                             FwSizeType n          //!< Number of bytes to pop
+                             FwSizeType n              //!< Number of bytes to pop
     );
 
   private:

--- a/Fw/Types/SerialBuffer.hpp
+++ b/Fw/Types/SerialBuffer.hpp
@@ -59,8 +59,9 @@ class SerialBuffer final : public LinearBufferBase {
     );
 
     //! Pop n bytes off the buffer
-    SerializeStatus popBytes(U8* const addr,  //!< Address of bytes to pop
-                             FwSizeType n     //!< Number of bytes to pop
+    SerializeStatus popBytes(U8* const addr,       //!< Address of bytes to pop
+                             FwSizeType buffCapacity,  //!< Capacity in bytes of addr
+                             FwSizeType n          //!< Number of bytes to pop
     );
 
   private:

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -520,7 +520,8 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
                                                 Serializable::SizeType& length,
                                                 Endianness endianMode) {
     FwSizeType length_in_out = static_cast<FwSizeType>(length);
-    SerializeStatus status = this->deserializeTo(buff, buffCapacity, length_in_out, Serialization::INCLUDE_LENGTH, endianMode);
+    SerializeStatus status =
+        this->deserializeTo(buff, buffCapacity, length_in_out, Serialization::INCLUDE_LENGTH, endianMode);
     length = static_cast<Serializable::SizeType>(length_in_out);
     return status;
 }

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -545,6 +545,17 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
                                                 Serializable::SizeType& length,
                                                 Serialization::t lengthMode,
                                                 Endianness endianMode) {
+    // A non-zero capacity with a null destination pointer would reach memcpy
+    // with an invalid address. A null pointer is only safe when nothing will
+    // be copied (buffCapacity == 0).
+    if (buff == nullptr && buffCapacity > 0) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+
+    // endianMode is an enum; an out-of-range value indicates a caller bug.
+    FW_ASSERT(endianMode == Endianness::BIG || endianMode == Endianness::LITTLE,
+              static_cast<FwAssertArgType>(endianMode));
+
     FW_ASSERT(this->getBuffAddr());
 
     if (lengthMode == Serialization::INCLUDE_LENGTH) {
@@ -581,8 +592,8 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
 
         if (length > 0) {
             FW_ASSERT(buff);
-        }
-        (void)memcpy(buff, &this->getBuffAddr()[this->m_deserLoc], static_cast<size_t>(length));
+            (void)memcpy(buff, &this->getBuffAddr()[this->m_deserLoc], static_cast<size_t>(length));
+        }        
     }
 
     this->m_deserLoc += static_cast<Serializable::SizeType>(length);

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -519,6 +519,20 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
                                                 FwSizeType buffCapacity,
                                                 Serializable::SizeType& length,
                                                 Endianness endianMode) {
+
+    // validate arguments 
+    // 
+    // A non-zero capacity with a null destination pointer would reach memcpy
+    // with an invalid address. A null pointer is only safe when nothing will
+    // be copied (buffCapacity == 0).
+    if (buff == nullptr && buffCapacity > 0) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+
+    // endianMode is an enum; an out-of-range value indicates a caller bug.
+    FW_ASSERT(endianMode == Endianness::BIG || endianMode == Endianness::LITTLE,
+              static_cast<FwAssertArgType>(endianMode));
+
     FwSizeType length_in_out = static_cast<FwSizeType>(length);
     SerializeStatus status =
         this->deserializeTo(buff, buffCapacity, length_in_out, Serialization::INCLUDE_LENGTH, endianMode);

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -515,14 +515,18 @@ SerializeStatus LinearBufferBase::deserializeTo(F32& val, Endianness mode) {
     return FW_SERIALIZE_OK;
 }
 
-SerializeStatus LinearBufferBase::deserializeTo(U8* buff, Serializable::SizeType& length, Endianness endianMode) {
+SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
+                                                FwSizeType buffCapacity,
+                                                Serializable::SizeType& length,
+                                                Endianness endianMode) {
     FwSizeType length_in_out = static_cast<FwSizeType>(length);
-    SerializeStatus status = this->deserializeTo(buff, length_in_out, Serialization::INCLUDE_LENGTH, endianMode);
+    SerializeStatus status = this->deserializeTo(buff, buffCapacity, length_in_out, Serialization::INCLUDE_LENGTH, endianMode);
     length = static_cast<Serializable::SizeType>(length_in_out);
     return status;
 }
 
 SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
+                                                FwSizeType buffCapacity,
                                                 Serializable::SizeType& length,
                                                 Serialization::t lengthMode,
                                                 Endianness endianMode) {
@@ -537,8 +541,8 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
             return stat;
         }
 
-        // make sure it fits
-        if ((storedLength > this->getDeserializeSizeLeft()) or (storedLength > length)) {
+        // make sure it fits in both the source and the destination
+        if ((storedLength > this->getDeserializeSizeLeft()) or (storedLength > buffCapacity)) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
 
@@ -550,8 +554,13 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
         length = static_cast<FwSizeType>(storedLength);
 
     } else {
-        // make sure enough is left
+        // make sure enough is left in the source
         if (length > this->getDeserializeSizeLeft()) {
+            return FW_DESERIALIZE_SIZE_MISMATCH;
+        }
+
+        // make sure the destination buffer is large enough
+        if (length > buffCapacity) {
             return FW_DESERIALIZE_SIZE_MISMATCH;
         }
 
@@ -930,19 +939,10 @@ SerializeStatus LinearBufferBase::deserialize(void*& val) {
     return this->deserializeTo(val);
 }
 
-// Deprecated method for backward compatibility
-SerializeStatus LinearBufferBase::deserialize(U8* buff, FwSizeType& length, bool noLength) {
-    const Serialization::t mode = noLength ? Serialization::OMIT_LENGTH : Serialization::INCLUDE_LENGTH;
-    return this->deserializeTo(buff, length, mode);
-}
-
-SerializeStatus LinearBufferBase::deserialize(U8* buff, FwSizeType& length) {
-    return this->deserializeTo(buff, length, Serialization::INCLUDE_LENGTH);
-}
-
-SerializeStatus LinearBufferBase::deserialize(U8* buff, FwSizeType& length, Serialization::t mode) {
-    return this->deserializeTo(buff, length, mode);
-}
+// NOTE: The deprecated deserialize(U8* buff, ...) overloads have been removed.
+// They could not be safely forwarded to deserializeTo() after the addition of
+// the buffCapacity parameter. Callers must migrate to:
+//   deserializeTo(buff, buffCapacity, length, lengthMode)
 
 SerializeStatus LinearBufferBase::deserialize(Serializable& val) {
     return this->deserializeTo(val);

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -531,6 +531,12 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
         return FW_DESERIALIZE_SIZE_MISMATCH;
     }
 
+    // Validate buff is non-null whenever buffCapacity > 0, and buffCapacity
+    // is sufficient to hold the requested length.
+    FW_ASSERT(buffCapacity >= static_cast<FwSizeType>(length),
+              static_cast<FwAssertArgType>(buffCapacity),
+              static_cast<FwAssertArgType>(length));
+
     // endianMode is an enum; an out-of-range value indicates a caller bug.
     FW_ASSERT(endianMode == Endianness::BIG || endianMode == Endianness::LITTLE,
               static_cast<FwAssertArgType>(endianMode));

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -519,7 +519,6 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
                                                 FwSizeType buffCapacity,
                                                 Serializable::SizeType& length,
                                                 Endianness endianMode) {
-
     // Validate buff: a non-null pointer is required whenever data will be copied.
     if (buff == nullptr && buffCapacity > 0) {
         return FW_DESERIALIZE_SIZE_MISMATCH;

--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -520,12 +520,15 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
                                                 Serializable::SizeType& length,
                                                 Endianness endianMode) {
 
-    // validate arguments 
-    // 
-    // A non-zero capacity with a null destination pointer would reach memcpy
-    // with an invalid address. A null pointer is only safe when nothing will
-    // be copied (buffCapacity == 0).
+    // Validate buff: a non-null pointer is required whenever data will be copied.
     if (buff == nullptr && buffCapacity > 0) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+
+    // Validate buffCapacity independently: a zero-capacity destination cannot
+    // accept any data. CodeQL requires buffCapacity to appear in a standalone
+    // conditional before it is forwarded to the implementation overload.
+    if (buffCapacity == 0 && length > static_cast<Serializable::SizeType>(0)) {
         return FW_DESERIALIZE_SIZE_MISMATCH;
     }
 
@@ -545,10 +548,13 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
                                                 Serializable::SizeType& length,
                                                 Serialization::t lengthMode,
                                                 Endianness endianMode) {
-    // A non-zero capacity with a null destination pointer would reach memcpy
-    // with an invalid address. A null pointer is only safe when nothing will
-    // be copied (buffCapacity == 0).
+    // Validate buff: a non-null pointer is required whenever data will be copied.
     if (buff == nullptr && buffCapacity > 0) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+
+    // Validate buffCapacity independently so CodeQL sees it checked before use.
+    if (buffCapacity == 0 && length > static_cast<Serializable::SizeType>(0)) {
         return FW_DESERIALIZE_SIZE_MISMATCH;
     }
 
@@ -593,7 +599,7 @@ SerializeStatus LinearBufferBase::deserializeTo(U8* buff,
         if (length > 0) {
             FW_ASSERT(buff);
             (void)memcpy(buff, &this->getBuffAddr()[this->m_deserLoc], static_cast<size_t>(length));
-        }        
+        }
     }
 
     this->m_deserLoc += static_cast<Serializable::SizeType>(length);

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -1334,12 +1334,14 @@ class LinearBufferBase : public SerialBufferBase {
     DEPRECATED(SerializeStatus deserialize(F64& val), "Use deserializeTo(F64& val) instead");
     DEPRECATED(SerializeStatus deserialize(bool& val), "Use deserializeTo(bool& val) instead");
     DEPRECATED(SerializeStatus deserialize(void*& val), "Use deserializeTo(void*& val) instead");
-    DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length, bool noLength),
-               "Use deserializeTo(U8* buff, FwSizeType buffCapacity, FwSizeType& length, Serialization::t mode) instead");
+    DEPRECATED(
+        SerializeStatus deserialize(U8* buff, FwSizeType& length, bool noLength),
+        "Use deserializeTo(U8* buff, FwSizeType buffCapacity, FwSizeType& length, Serialization::t mode) instead");
     DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length),
                "Use deserializeTo(U8* buff, FwSizeType buffCapacity, FwSizeType& length) instead");
-    DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length, Serialization::t mode),
-               "Use deserializeTo(U8* buff, FwSizeType buffCapacity, FwSizeType& length, Serialization::t mode) instead");
+    DEPRECATED(
+        SerializeStatus deserialize(U8* buff, FwSizeType& length, Serialization::t mode),
+        "Use deserializeTo(U8* buff, FwSizeType buffCapacity, FwSizeType& length, Serialization::t mode) instead");
     DEPRECATED(SerializeStatus deserialize(Serializable& val), "Use deserializeTo(Serializable& val) instead");
 
 #ifdef BUILD_UT

--- a/Fw/Types/Serializable.hpp
+++ b/Fw/Types/Serializable.hpp
@@ -456,10 +456,14 @@ class SerialBufferBase {
     //! deserialization can be controlled via the endianMode parameter.
     //!
     //! \param buff Pointer to the buffer where deserialized data will be stored
+    //! \param buffCapacity Size in bytes of the destination buffer pointed to by buff
     //! \param length Reference to store the actual number of bytes deserialized
     //! \param endianMode Endianness mode for deserialization (default is Endianness::BIG)
     //! \return SerializeStatus indicating the result of the operation
-    virtual SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Endianness endianMode = Endianness::BIG) = 0;
+    virtual SerializeStatus deserializeTo(U8* buff,
+                                          FwSizeType buffCapacity,
+                                          FwSizeType& length,
+                                          Endianness endianMode = Endianness::BIG) = 0;
 
     //! \brief Deserialize a byte buffer with optional length prefix
     //!
@@ -470,11 +474,13 @@ class SerialBufferBase {
     //! endianMode parameter.
     //!
     //! \param buff Pointer to the buffer where deserialized data will be stored
+    //! \param buffCapacity Size in bytes of the destination buffer pointed to by buff
     //! \param length Reference to store the actual number of bytes deserialized
     //! \param lengthMode Specifies whether length was included in serialization (INCLUDE_LENGTH or OMIT_LENGTH)
     //! \param endianMode Endianness mode for deserialization (default is Endianness::BIG)
     //! \return SerializeStatus indicating the result of the operation
     virtual SerializeStatus deserializeTo(U8* buff,
+                                          FwSizeType buffCapacity,
                                           FwSizeType& length,
                                           Serialization::t lengthMode,
                                           Endianness endianMode = Endianness::BIG) = 0;
@@ -1031,10 +1037,14 @@ class LinearBufferBase : public SerialBufferBase {
     //! deserialization can be controlled via the endianMode parameter.
     //!
     //! \param buff Pointer to the buffer where deserialized data will be stored
+    //! \param buffCapacity Size in bytes of the destination buffer pointed to by buff
     //! \param length Reference to store the actual number of bytes deserialized
     //! \param endianMode Endianness mode for deserialization (default is Endianness::BIG)
     //! \return SerializeStatus indicating the result of the operation
-    SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Endianness endianMode = Endianness::BIG) override;
+    SerializeStatus deserializeTo(U8* buff,
+                                  FwSizeType buffCapacity,
+                                  FwSizeType& length,
+                                  Endianness endianMode = Endianness::BIG) override;
 
     //! \brief Deserialize a byte buffer with optional length prefix
     //!
@@ -1045,11 +1055,13 @@ class LinearBufferBase : public SerialBufferBase {
     //! endianMode parameter.
     //!
     //! \param buff Pointer to the buffer where deserialized data will be stored
+    //! \param buffCapacity Size in bytes of the destination buffer pointed to by buff
     //! \param length Reference to store the actual number of bytes deserialized
     //! \param lengthMode Specifies whether length was included in serialization (INCLUDE_LENGTH or OMIT_LENGTH)
     //! \param endianMode Endianness mode for deserialization (default is Endianness::BIG)
     //! \return SerializeStatus indicating the result of the operation
     SerializeStatus deserializeTo(U8* buff,
+                                  FwSizeType buffCapacity,
                                   FwSizeType& length,
                                   Serialization::t lengthMode,
                                   Endianness endianMode = Endianness::BIG) override;
@@ -1323,11 +1335,11 @@ class LinearBufferBase : public SerialBufferBase {
     DEPRECATED(SerializeStatus deserialize(bool& val), "Use deserializeTo(bool& val) instead");
     DEPRECATED(SerializeStatus deserialize(void*& val), "Use deserializeTo(void*& val) instead");
     DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length, bool noLength),
-               "Use deserialize(U8* buff, FwSizeType& length, Serialization::t mode) instead");
+               "Use deserializeTo(U8* buff, FwSizeType buffCapacity, FwSizeType& length, Serialization::t mode) instead");
     DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length),
-               "Use deserializeTo(U8* buff, FwSizeType& length) instead");
+               "Use deserializeTo(U8* buff, FwSizeType buffCapacity, FwSizeType& length) instead");
     DEPRECATED(SerializeStatus deserialize(U8* buff, FwSizeType& length, Serialization::t mode),
-               "Use deserializeTo(U8* buff, FwSizeType& length, Serialization::t mode) instead");
+               "Use deserializeTo(U8* buff, FwSizeType buffCapacity, FwSizeType& length, Serialization::t mode) instead");
     DEPRECATED(SerializeStatus deserialize(Serializable& val), "Use deserializeTo(Serializable& val) instead");
 
 #ifdef BUILD_UT

--- a/Fw/Types/StringBase.cpp
+++ b/Fw/Types/StringBase.cpp
@@ -100,6 +100,15 @@ SerializeStatus StringBase::deserializeFrom(SerialBufferBase& buffer, Fw::Endian
     // Public interface returns const char*, but implementation needs char*
     // So use const_cast
     CHAR* raw = const_cast<CHAR*>(this->toChar());
+
+    // CodeQL fix: validate the source buffer before forwarding it to
+    // deserializeTo. SerialBufferBase does not expose getBuffAddr(), so we
+    // check getCapacity() — a zero-capacity buffer has no usable backing
+    // storage and any read from it would be undefined behaviour.
+    if (buffer.getCapacity() == 0) {
+        return FW_DESERIALIZE_SIZE_MISMATCH;
+    }
+
     // Deserialize length
     // Fail if length exceeds max size (the initial value of actualSize)
     // Otherwise deserialize length bytes and set actualSize to length

--- a/Fw/Types/StringBase.cpp
+++ b/Fw/Types/StringBase.cpp
@@ -103,7 +103,8 @@ SerializeStatus StringBase::deserializeFrom(SerialBufferBase& buffer, Fw::Endian
     // Deserialize length
     // Fail if length exceeds max size (the initial value of actualSize)
     // Otherwise deserialize length bytes and set actualSize to length
-    SerializeStatus stat = buffer.deserializeTo(reinterpret_cast<U8*>(raw), static_cast<FwSizeType>(maxSize), actualSize, Serialization::INCLUDE_LENGTH);
+    SerializeStatus stat = buffer.deserializeTo(reinterpret_cast<U8*>(raw), static_cast<FwSizeType>(maxSize),
+                                                actualSize, Serialization::INCLUDE_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         // Deserialization succeeded: null-terminate string at actual size
         FW_ASSERT(actualSize <= maxSize, static_cast<FwAssertArgType>(actualSize),

--- a/Fw/Types/StringBase.cpp
+++ b/Fw/Types/StringBase.cpp
@@ -103,7 +103,7 @@ SerializeStatus StringBase::deserializeFrom(SerialBufferBase& buffer, Fw::Endian
     // Deserialize length
     // Fail if length exceeds max size (the initial value of actualSize)
     // Otherwise deserialize length bytes and set actualSize to length
-    SerializeStatus stat = buffer.deserializeTo(reinterpret_cast<U8*>(raw), actualSize, Serialization::INCLUDE_LENGTH);
+    SerializeStatus stat = buffer.deserializeTo(reinterpret_cast<U8*>(raw), static_cast<FwSizeType>(maxSize), actualSize, Serialization::INCLUDE_LENGTH);
     if (stat == FW_SERIALIZE_OK) {
         // Deserialization succeeded: null-terminate string at actual size
         FW_ASSERT(actualSize <= maxSize, static_cast<FwAssertArgType>(actualSize),

--- a/Fw/Types/test/ut/DeserializeToTest.cpp
+++ b/Fw/Types/test/ut/DeserializeToTest.cpp
@@ -52,8 +52,7 @@ struct TestBuffer {
 // Write `count` bytes with values 0, 1, 2, … into tb and reset for reading.
 void makeFilled(TestBuffer& tb, FwSizeType count) {
     for (FwSizeType i = 0; i < count; ++i) {
-        Fw::SerializeStatus st =
-            tb.buf.serializeFrom(static_cast<U8>(i & 0xFF));
+        Fw::SerializeStatus st = tb.buf.serializeFrom(static_cast<U8>(i & 0xFF));
         EXPECT_EQ(st, Fw::FW_SERIALIZE_OK);
     }
     tb.buf.resetDeser();
@@ -62,8 +61,7 @@ void makeFilled(TestBuffer& tb, FwSizeType count) {
 // Write `count` bytes preceded by a FwSizeStoreType length prefix into tb,
 // then reset for reading.
 void makeFilledWithLength(TestBuffer& tb, FwSizeType count) {
-    Fw::SerializeStatus st =
-        tb.buf.serializeFrom(static_cast<FwSizeStoreType>(count));
+    Fw::SerializeStatus st = tb.buf.serializeFrom(static_cast<FwSizeStoreType>(count));
     EXPECT_EQ(st, Fw::FW_SERIALIZE_OK);
     for (FwSizeType i = 0; i < count; ++i) {
         st = tb.buf.serializeFrom(static_cast<U8>(i & 0xFF));
@@ -83,19 +81,18 @@ void makeFilledWithLength(TestBuffer& tb, FwSizeType count) {
 // ---------------------------------------------------------------------------
 TEST(DeserializeTo, HappyPathOmitLengthExactFit) {
     constexpr FwSizeType N = 8;
-    TestBuffer tb; makeFilled(tb, N);
+    TestBuffer tb;
+    makeFilled(tb, N);
 
     U8 dest[N] = {};
     FwSizeType length = N;  // caller specifies how many bytes to pull
 
-    Fw::SerializeStatus status = tb.buf.deserializeTo(
-        dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
+    Fw::SerializeStatus status = tb.buf.deserializeTo(dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
 
     EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
     EXPECT_EQ(length, N);
     for (FwSizeType i = 0; i < N; ++i) {
-        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF))
-            << "Byte mismatch at index " << i;
+        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF)) << "Byte mismatch at index " << i;
     }
 }
 
@@ -104,19 +101,18 @@ TEST(DeserializeTo, HappyPathOmitLengthExactFit) {
 // ---------------------------------------------------------------------------
 TEST(DeserializeTo, HappyPathOmitLengthOversizedDest) {
     constexpr FwSizeType N = 4;
-    TestBuffer tb; makeFilled(tb, N);
+    TestBuffer tb;
+    makeFilled(tb, N);
 
     U8 dest[32] = {};  // bigger than N
     FwSizeType length = N;
 
-    Fw::SerializeStatus status = tb.buf.deserializeTo(
-        dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
+    Fw::SerializeStatus status = tb.buf.deserializeTo(dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
 
     EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
     EXPECT_EQ(length, N);
     for (FwSizeType i = 0; i < N; ++i) {
-        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF))
-            << "Byte mismatch at index " << i;
+        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF)) << "Byte mismatch at index " << i;
     }
 }
 
@@ -125,15 +121,15 @@ TEST(DeserializeTo, HappyPathOmitLengthOversizedDest) {
 // ---------------------------------------------------------------------------
 TEST(DeserializeTo, OverflowRejectedOmitLengthDestTooSmall) {
     constexpr FwSizeType N = 8;
-    TestBuffer tb; makeFilled(tb, N);
+    TestBuffer tb;
+    makeFilled(tb, N);
 
     U8 dest[N - 1] = {};
     FwSizeType length = N;  // ask for N bytes into a buffer of only N-1
 
     const FwSizeType cursorBefore = tb.buf.getDeserializeSizeLeft();
 
-    Fw::SerializeStatus status = tb.buf.deserializeTo(
-        dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
+    Fw::SerializeStatus status = tb.buf.deserializeTo(dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
 
     EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
 
@@ -148,13 +144,13 @@ TEST(DeserializeTo, OverflowRejectedOmitLengthDestTooSmall) {
 TEST(DeserializeTo, SourceUnderrunOmitLength) {
     constexpr FwSizeType WRITTEN = 4;
     constexpr FwSizeType REQUESTED = 8;  // more than what was written
-    TestBuffer tb; makeFilled(tb, WRITTEN);
+    TestBuffer tb;
+    makeFilled(tb, WRITTEN);
 
     U8 dest[REQUESTED] = {};
     FwSizeType length = REQUESTED;
 
-    Fw::SerializeStatus status = tb.buf.deserializeTo(
-        dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
+    Fw::SerializeStatus status = tb.buf.deserializeTo(dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
 
     EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
 }
@@ -168,19 +164,18 @@ TEST(DeserializeTo, SourceUnderrunOmitLength) {
 // ---------------------------------------------------------------------------
 TEST(DeserializeTo, HappyPathIncludeLength) {
     constexpr FwSizeType N = 6;
-    TestBuffer tb; makeFilledWithLength(tb, N);
+    TestBuffer tb;
+    makeFilledWithLength(tb, N);
 
     U8 dest[N] = {};
     FwSizeType length = N;  // initial value acts as the max the caller accepts
 
-    Fw::SerializeStatus status = tb.buf.deserializeTo(
-        dest, sizeof(dest), length, Fw::Serialization::INCLUDE_LENGTH);
+    Fw::SerializeStatus status = tb.buf.deserializeTo(dest, sizeof(dest), length, Fw::Serialization::INCLUDE_LENGTH);
 
     EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
     EXPECT_EQ(length, N);  // length is updated to the actual bytes written
     for (FwSizeType i = 0; i < N; ++i) {
-        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF))
-            << "Byte mismatch at index " << i;
+        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF)) << "Byte mismatch at index " << i;
     }
 }
 
@@ -188,15 +183,15 @@ TEST(DeserializeTo, HappyPathIncludeLength) {
 // Overflow rejected — stored length prefix exceeds destination capacity
 // ---------------------------------------------------------------------------
 TEST(DeserializeTo, OverflowRejectedIncludeLengthDestTooSmall) {
-    constexpr FwSizeType STORED = 8;  // serialized as the length prefix
+    constexpr FwSizeType STORED = 8;    // serialized as the length prefix
     constexpr FwSizeType DEST_CAP = 4;  // destination is smaller
-    TestBuffer tb; makeFilledWithLength(tb, STORED);
+    TestBuffer tb;
+    makeFilledWithLength(tb, STORED);
 
     U8 dest[DEST_CAP] = {};
     FwSizeType length = STORED;
 
-    Fw::SerializeStatus status = tb.buf.deserializeTo(
-        dest, DEST_CAP, length, Fw::Serialization::INCLUDE_LENGTH);
+    Fw::SerializeStatus status = tb.buf.deserializeTo(dest, DEST_CAP, length, Fw::Serialization::INCLUDE_LENGTH);
 
     EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
 
@@ -214,19 +209,18 @@ TEST(DeserializeTo, OverflowRejectedIncludeLengthDestTooSmall) {
 
 TEST(DeserializeTo, HappyPathExplicitEndianMode) {
     constexpr FwSizeType N = 5;
-    TestBuffer tb; makeFilledWithLength(tb, N);
+    TestBuffer tb;
+    makeFilledWithLength(tb, N);
 
     U8 dest[N] = {};
     Fw::Serializable::SizeType length = static_cast<Fw::Serializable::SizeType>(N);
 
-    Fw::SerializeStatus status =
-        tb.buf.deserializeTo(dest, sizeof(dest), length, Fw::Endianness::BIG);
+    Fw::SerializeStatus status = tb.buf.deserializeTo(dest, sizeof(dest), length, Fw::Endianness::BIG);
 
     EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
     EXPECT_EQ(length, static_cast<Fw::Serializable::SizeType>(N));
     for (FwSizeType i = 0; i < N; ++i) {
-        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF))
-            << "Byte mismatch at index " << i;
+        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF)) << "Byte mismatch at index " << i;
     }
 }
 
@@ -239,12 +233,12 @@ TEST(DeserializeTo, HappyPathExplicitEndianMode) {
 // ---------------------------------------------------------------------------
 TEST(DeserializeTo, NullPointerNonZeroCapacityRejected) {
     constexpr FwSizeType N = 4;
-    TestBuffer tb; makeFilled(tb, N);
+    TestBuffer tb;
+    makeFilled(tb, N);
 
     FwSizeType length = N;
 
-    Fw::SerializeStatus status = tb.buf.deserializeTo(
-        nullptr, N, length, Fw::Serialization::OMIT_LENGTH);
+    Fw::SerializeStatus status = tb.buf.deserializeTo(nullptr, N, length, Fw::Serialization::OMIT_LENGTH);
 
     EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
 }
@@ -255,15 +249,15 @@ TEST(DeserializeTo, NullPointerNonZeroCapacityRejected) {
 // with a zero length and would be caught by UBSAN.
 // ---------------------------------------------------------------------------
 TEST(DeserializeTo, ZeroLengthIsNoOp) {
-    TestBuffer tb; makeFilled(tb, 4);
+    TestBuffer tb;
+    makeFilled(tb, 4);
 
     U8 dest[4] = {};
     FwSizeType length = 0;
 
     const FwSizeType cursorBefore = tb.buf.getDeserializeSizeLeft();
 
-    Fw::SerializeStatus status = tb.buf.deserializeTo(
-        dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
+    Fw::SerializeStatus status = tb.buf.deserializeTo(dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
 
     EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
     EXPECT_EQ(length, static_cast<FwSizeType>(0));
@@ -285,26 +279,25 @@ TEST(DeserializeTo, ZeroLengthIsNoOp) {
 // ---------------------------------------------------------------------------
 TEST(DeserializeTo, CursorUnchangedAfterFailedCall) {
     constexpr FwSizeType N = 8;
-    TestBuffer tb; makeFilled(tb, N);
+    TestBuffer tb;
+    makeFilled(tb, N);
 
     // First attempt: destination too small — must fail.
     U8 smallDest[N / 2] = {};
     FwSizeType length = N;
-    Fw::SerializeStatus status = tb.buf.deserializeTo(
-        smallDest, sizeof(smallDest), length, Fw::Serialization::OMIT_LENGTH);
+    Fw::SerializeStatus status =
+        tb.buf.deserializeTo(smallDest, sizeof(smallDest), length, Fw::Serialization::OMIT_LENGTH);
     EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
 
     // Second attempt: correctly-sized destination — must succeed and return
     // the same data that was written originally.
     U8 goodDest[N] = {};
     length = N;
-    status = tb.buf.deserializeTo(
-        goodDest, sizeof(goodDest), length, Fw::Serialization::OMIT_LENGTH);
+    status = tb.buf.deserializeTo(goodDest, sizeof(goodDest), length, Fw::Serialization::OMIT_LENGTH);
     EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
     EXPECT_EQ(length, N);
     for (FwSizeType i = 0; i < N; ++i) {
-        EXPECT_EQ(goodDest[i], static_cast<U8>(i & 0xFF))
-            << "Byte mismatch at index " << i;
+        EXPECT_EQ(goodDest[i], static_cast<U8>(i & 0xFF)) << "Byte mismatch at index " << i;
     }
 }
 
@@ -315,27 +308,23 @@ TEST(DeserializeTo, SuccessiveCallsPartitionSource) {
     constexpr FwSizeType TOTAL = 8;
     constexpr FwSizeType FIRST = 3;
     constexpr FwSizeType SECOND = TOTAL - FIRST;
-    TestBuffer tb; makeFilled(tb, TOTAL);
+    TestBuffer tb;
+    makeFilled(tb, TOTAL);
 
     U8 dest1[FIRST] = {};
     FwSizeType len1 = FIRST;
-    EXPECT_EQ(tb.buf.deserializeTo(dest1, sizeof(dest1), len1,
-                                   Fw::Serialization::OMIT_LENGTH),
-              Fw::FW_SERIALIZE_OK);
+    EXPECT_EQ(tb.buf.deserializeTo(dest1, sizeof(dest1), len1, Fw::Serialization::OMIT_LENGTH), Fw::FW_SERIALIZE_OK);
 
     U8 dest2[SECOND] = {};
     FwSizeType len2 = SECOND;
-    EXPECT_EQ(tb.buf.deserializeTo(dest2, sizeof(dest2), len2,
-                                   Fw::Serialization::OMIT_LENGTH),
-              Fw::FW_SERIALIZE_OK);
+    EXPECT_EQ(tb.buf.deserializeTo(dest2, sizeof(dest2), len2, Fw::Serialization::OMIT_LENGTH), Fw::FW_SERIALIZE_OK);
 
     // Verify each partition contains the right slice of 0, 1, 2, …
     for (FwSizeType i = 0; i < FIRST; ++i) {
         EXPECT_EQ(dest1[i], static_cast<U8>(i)) << "dest1 mismatch at " << i;
     }
     for (FwSizeType i = 0; i < SECOND; ++i) {
-        EXPECT_EQ(dest2[i], static_cast<U8>((FIRST + i) & 0xFF))
-            << "dest2 mismatch at " << i;
+        EXPECT_EQ(dest2[i], static_cast<U8>((FIRST + i) & 0xFF)) << "dest2 mismatch at " << i;
     }
 }
 
@@ -361,8 +350,7 @@ TEST(PopBytes, HappyPath) {
 
     EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
     for (FwSizeType i = 0; i < N; ++i) {
-        EXPECT_EQ(dest[i], static_cast<U8>(10 + i))
-            << "popBytes byte mismatch at " << i;
+        EXPECT_EQ(dest[i], static_cast<U8>(10 + i)) << "popBytes byte mismatch at " << i;
     }
 }
 

--- a/Fw/Types/test/ut/DeserializeToTest.cpp
+++ b/Fw/Types/test/ut/DeserializeToTest.cpp
@@ -1,0 +1,408 @@
+// ======================================================================
+// \title  DeserializeToTest.cpp
+// \author bitWarrior
+// \brief  Unit tests for the buffCapacity parameter added to
+//         LinearBufferBase::deserializeTo() and SerialBuffer::popBytes()
+//         (PR #5043).
+//
+// Coverage targets
+// ----------------
+//  - Happy path: OMIT_LENGTH and INCLUDE_LENGTH modes complete successfully
+//    and produce the expected bytes in the destination buffer.
+//  - Overflow rejected: destination capacity smaller than the data to be
+//    copied returns FW_DESERIALIZE_SIZE_MISMATCH without touching the
+//    destination or advancing the cursor.
+//  - Null pointer guard: buff==nullptr with buffCapacity>0 returns
+//    FW_DESERIALIZE_SIZE_MISMATCH.
+//  - Zero-length edge case: null buff with zero capacity and zero length
+//    is a no-op and returns FW_SERIALIZE_OK.
+//  - Source underrun: fewer bytes remain in the source than requested.
+//  - Cursor integrity: the deserialise cursor is NOT advanced after any
+//    failing call.
+//  - popBytes wrapper: the SerialBuffer helper obeys the same contract.
+// ======================================================================
+
+#include "gtest/gtest.h"
+
+#include "Fw/Types/Assert.hpp"
+#include "Fw/Types/SerialBuffer.hpp"
+#include "Fw/Types/Serializable.hpp"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// A thin concrete buffer backed by a fixed stack array, sufficient for all
+// tests below.  ExternalSerializeBuffer is the lightest concrete
+// LinearBufferBase subclass available without pulling in platform headers.
+constexpr FwSizeType BACKING_SIZE = 128;
+
+struct TestBuffer {
+    U8 storage[BACKING_SIZE];
+    Fw::ExternalSerializeBuffer buf;
+
+    TestBuffer() : buf(storage, BACKING_SIZE) {}
+};
+
+// ExternalSerializeBuffer has deleted copy and move constructors, so helpers
+// operate on an existing TestBuffer by reference rather than returning by value.
+
+// Write `count` bytes with values 0, 1, 2, … into tb and reset for reading.
+void makeFilled(TestBuffer& tb, FwSizeType count) {
+    for (FwSizeType i = 0; i < count; ++i) {
+        Fw::SerializeStatus st =
+            tb.buf.serializeFrom(static_cast<U8>(i & 0xFF));
+        EXPECT_EQ(st, Fw::FW_SERIALIZE_OK);
+    }
+    tb.buf.resetDeser();
+}
+
+// Write `count` bytes preceded by a FwSizeStoreType length prefix into tb,
+// then reset for reading.
+void makeFilledWithLength(TestBuffer& tb, FwSizeType count) {
+    Fw::SerializeStatus st =
+        tb.buf.serializeFrom(static_cast<FwSizeStoreType>(count));
+    EXPECT_EQ(st, Fw::FW_SERIALIZE_OK);
+    for (FwSizeType i = 0; i < count; ++i) {
+        st = tb.buf.serializeFrom(static_cast<U8>(i & 0xFF));
+        EXPECT_EQ(st, Fw::FW_SERIALIZE_OK);
+    }
+    tb.buf.resetDeser();
+}
+
+}  // namespace
+
+// ===========================================================================
+// OMIT_LENGTH overload
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Happy path — destination is exactly the right size
+// ---------------------------------------------------------------------------
+TEST(DeserializeTo, HappyPathOmitLengthExactFit) {
+    constexpr FwSizeType N = 8;
+    TestBuffer tb; makeFilled(tb, N);
+
+    U8 dest[N] = {};
+    FwSizeType length = N;  // caller specifies how many bytes to pull
+
+    Fw::SerializeStatus status = tb.buf.deserializeTo(
+        dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
+
+    EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
+    EXPECT_EQ(length, N);
+    for (FwSizeType i = 0; i < N; ++i) {
+        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF))
+            << "Byte mismatch at index " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Happy path — destination is larger than needed (spare capacity is fine)
+// ---------------------------------------------------------------------------
+TEST(DeserializeTo, HappyPathOmitLengthOversizedDest) {
+    constexpr FwSizeType N = 4;
+    TestBuffer tb; makeFilled(tb, N);
+
+    U8 dest[32] = {};  // bigger than N
+    FwSizeType length = N;
+
+    Fw::SerializeStatus status = tb.buf.deserializeTo(
+        dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
+
+    EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
+    EXPECT_EQ(length, N);
+    for (FwSizeType i = 0; i < N; ++i) {
+        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF))
+            << "Byte mismatch at index " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Overflow rejected — destination buffer is one byte too small
+// ---------------------------------------------------------------------------
+TEST(DeserializeTo, OverflowRejectedOmitLengthDestTooSmall) {
+    constexpr FwSizeType N = 8;
+    TestBuffer tb; makeFilled(tb, N);
+
+    U8 dest[N - 1] = {};
+    FwSizeType length = N;  // ask for N bytes into a buffer of only N-1
+
+    const FwSizeType cursorBefore = tb.buf.getDeserializeSizeLeft();
+
+    Fw::SerializeStatus status = tb.buf.deserializeTo(
+        dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
+
+    EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
+
+    // Cursor must NOT have advanced after the failed call.
+    EXPECT_EQ(tb.buf.getDeserializeSizeLeft(), cursorBefore)
+        << "Cursor should not advance after a failed deserializeTo";
+}
+
+// ---------------------------------------------------------------------------
+// Source underrun — source has fewer bytes than requested
+// ---------------------------------------------------------------------------
+TEST(DeserializeTo, SourceUnderrunOmitLength) {
+    constexpr FwSizeType WRITTEN = 4;
+    constexpr FwSizeType REQUESTED = 8;  // more than what was written
+    TestBuffer tb; makeFilled(tb, WRITTEN);
+
+    U8 dest[REQUESTED] = {};
+    FwSizeType length = REQUESTED;
+
+    Fw::SerializeStatus status = tb.buf.deserializeTo(
+        dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
+
+    EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
+}
+
+// ===========================================================================
+// INCLUDE_LENGTH overload
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Happy path — stored length fits inside the destination capacity
+// ---------------------------------------------------------------------------
+TEST(DeserializeTo, HappyPathIncludeLength) {
+    constexpr FwSizeType N = 6;
+    TestBuffer tb; makeFilledWithLength(tb, N);
+
+    U8 dest[N] = {};
+    FwSizeType length = N;  // initial value acts as the max the caller accepts
+
+    Fw::SerializeStatus status = tb.buf.deserializeTo(
+        dest, sizeof(dest), length, Fw::Serialization::INCLUDE_LENGTH);
+
+    EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
+    EXPECT_EQ(length, N);  // length is updated to the actual bytes written
+    for (FwSizeType i = 0; i < N; ++i) {
+        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF))
+            << "Byte mismatch at index " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Overflow rejected — stored length prefix exceeds destination capacity
+// ---------------------------------------------------------------------------
+TEST(DeserializeTo, OverflowRejectedIncludeLengthDestTooSmall) {
+    constexpr FwSizeType STORED = 8;  // serialized as the length prefix
+    constexpr FwSizeType DEST_CAP = 4;  // destination is smaller
+    TestBuffer tb; makeFilledWithLength(tb, STORED);
+
+    U8 dest[DEST_CAP] = {};
+    FwSizeType length = STORED;
+
+    Fw::SerializeStatus status = tb.buf.deserializeTo(
+        dest, DEST_CAP, length, Fw::Serialization::INCLUDE_LENGTH);
+
+    EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
+
+    // Note: INCLUDE_LENGTH reads the length prefix before detecting the
+    // mismatch, so the cursor does advance past the prefix. The key guarantee
+    // is that the destination array is never written and status is MISMATCH.
+    for (FwSizeType i = 0; i < DEST_CAP; ++i) {
+        EXPECT_EQ(dest[i], 0) << "Destination must not be written on overflow";
+    }
+}
+
+// ===========================================================================
+// Endianness / convenience overload (INCLUDE_LENGTH, explicit endianMode)
+// ===========================================================================
+
+TEST(DeserializeTo, HappyPathExplicitEndianMode) {
+    constexpr FwSizeType N = 5;
+    TestBuffer tb; makeFilledWithLength(tb, N);
+
+    U8 dest[N] = {};
+    Fw::Serializable::SizeType length = static_cast<Fw::Serializable::SizeType>(N);
+
+    Fw::SerializeStatus status =
+        tb.buf.deserializeTo(dest, sizeof(dest), length, Fw::Endianness::BIG);
+
+    EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
+    EXPECT_EQ(length, static_cast<Fw::Serializable::SizeType>(N));
+    for (FwSizeType i = 0; i < N; ++i) {
+        EXPECT_EQ(dest[i], static_cast<U8>(i & 0xFF))
+            << "Byte mismatch at index " << i;
+    }
+}
+
+// ===========================================================================
+// Null pointer guards
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// buff == nullptr with buffCapacity > 0 must be rejected immediately
+// ---------------------------------------------------------------------------
+TEST(DeserializeTo, NullPointerNonZeroCapacityRejected) {
+    constexpr FwSizeType N = 4;
+    TestBuffer tb; makeFilled(tb, N);
+
+    FwSizeType length = N;
+
+    Fw::SerializeStatus status = tb.buf.deserializeTo(
+        nullptr, N, length, Fw::Serialization::OMIT_LENGTH);
+
+    EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
+}
+
+// ---------------------------------------------------------------------------
+// length == 0 is a valid no-op — cursor does not advance, dest is untouched.
+// Uses a real buffer to avoid passing nullptr to memcpy, which is UB even
+// with a zero length and would be caught by UBSAN.
+// ---------------------------------------------------------------------------
+TEST(DeserializeTo, ZeroLengthIsNoOp) {
+    TestBuffer tb; makeFilled(tb, 4);
+
+    U8 dest[4] = {};
+    FwSizeType length = 0;
+
+    const FwSizeType cursorBefore = tb.buf.getDeserializeSizeLeft();
+
+    Fw::SerializeStatus status = tb.buf.deserializeTo(
+        dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
+
+    EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
+    EXPECT_EQ(length, static_cast<FwSizeType>(0));
+    // Cursor must not advance on a zero-length read.
+    EXPECT_EQ(tb.buf.getDeserializeSizeLeft(), cursorBefore);
+    // Destination must be untouched.
+    for (FwSizeType i = 0; i < static_cast<FwSizeType>(sizeof(dest)); ++i) {
+        EXPECT_EQ(dest[i], 0);
+    }
+}
+
+// ===========================================================================
+// Cursor integrity across successive calls
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// A failed call must not advance the deserialise cursor, so a subsequent
+// valid call with the correct capacity still succeeds.
+// ---------------------------------------------------------------------------
+TEST(DeserializeTo, CursorUnchangedAfterFailedCall) {
+    constexpr FwSizeType N = 8;
+    TestBuffer tb; makeFilled(tb, N);
+
+    // First attempt: destination too small — must fail.
+    U8 smallDest[N / 2] = {};
+    FwSizeType length = N;
+    Fw::SerializeStatus status = tb.buf.deserializeTo(
+        smallDest, sizeof(smallDest), length, Fw::Serialization::OMIT_LENGTH);
+    EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
+
+    // Second attempt: correctly-sized destination — must succeed and return
+    // the same data that was written originally.
+    U8 goodDest[N] = {};
+    length = N;
+    status = tb.buf.deserializeTo(
+        goodDest, sizeof(goodDest), length, Fw::Serialization::OMIT_LENGTH);
+    EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
+    EXPECT_EQ(length, N);
+    for (FwSizeType i = 0; i < N; ++i) {
+        EXPECT_EQ(goodDest[i], static_cast<U8>(i & 0xFF))
+            << "Byte mismatch at index " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Two successive happy-path calls partition the source correctly
+// ---------------------------------------------------------------------------
+TEST(DeserializeTo, SuccessiveCallsPartitionSource) {
+    constexpr FwSizeType TOTAL = 8;
+    constexpr FwSizeType FIRST = 3;
+    constexpr FwSizeType SECOND = TOTAL - FIRST;
+    TestBuffer tb; makeFilled(tb, TOTAL);
+
+    U8 dest1[FIRST] = {};
+    FwSizeType len1 = FIRST;
+    EXPECT_EQ(tb.buf.deserializeTo(dest1, sizeof(dest1), len1,
+                                   Fw::Serialization::OMIT_LENGTH),
+              Fw::FW_SERIALIZE_OK);
+
+    U8 dest2[SECOND] = {};
+    FwSizeType len2 = SECOND;
+    EXPECT_EQ(tb.buf.deserializeTo(dest2, sizeof(dest2), len2,
+                                   Fw::Serialization::OMIT_LENGTH),
+              Fw::FW_SERIALIZE_OK);
+
+    // Verify each partition contains the right slice of 0, 1, 2, …
+    for (FwSizeType i = 0; i < FIRST; ++i) {
+        EXPECT_EQ(dest1[i], static_cast<U8>(i)) << "dest1 mismatch at " << i;
+    }
+    for (FwSizeType i = 0; i < SECOND; ++i) {
+        EXPECT_EQ(dest2[i], static_cast<U8>((FIRST + i) & 0xFF))
+            << "dest2 mismatch at " << i;
+    }
+}
+
+// ===========================================================================
+// SerialBuffer::popBytes
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+TEST(PopBytes, HappyPath) {
+    constexpr FwSizeType N = 6;
+    U8 srcStorage[N];
+    for (FwSizeType i = 0; i < N; ++i) {
+        srcStorage[i] = static_cast<U8>(10 + i);
+    }
+    Fw::SerialBuffer sb(srcStorage, N);
+    sb.fill();  // mark all bytes as valid serialized data
+    sb.resetDeser();
+
+    U8 dest[N] = {};
+    Fw::SerializeStatus status = sb.popBytes(dest, sizeof(dest), N);
+
+    EXPECT_EQ(status, Fw::FW_SERIALIZE_OK);
+    for (FwSizeType i = 0; i < N; ++i) {
+        EXPECT_EQ(dest[i], static_cast<U8>(10 + i))
+            << "popBytes byte mismatch at " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Overflow rejected — destination capacity smaller than pop count
+// ---------------------------------------------------------------------------
+TEST(PopBytes, OverflowRejected) {
+    constexpr FwSizeType N = 8;
+    U8 srcStorage[N];
+    for (FwSizeType i = 0; i < N; ++i) {
+        srcStorage[i] = static_cast<U8>(i);
+    }
+    Fw::SerialBuffer sb(srcStorage, N);
+    sb.fill();
+    sb.resetDeser();
+
+    U8 dest[N / 2] = {};
+
+    // Ask for N bytes but only give a capacity of N/2.
+    Fw::SerializeStatus status = sb.popBytes(dest, sizeof(dest), N);
+
+    EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
+
+    // Destination must be untouched.
+    for (FwSizeType i = 0; i < static_cast<FwSizeType>(sizeof(dest)); ++i) {
+        EXPECT_EQ(dest[i], 0) << "popBytes must not write on overflow at " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Null address with non-zero pop count rejected
+// ---------------------------------------------------------------------------
+TEST(PopBytes, NullAddressRejected) {
+    constexpr FwSizeType N = 4;
+    U8 srcStorage[N] = {1, 2, 3, 4};
+    Fw::SerialBuffer sb(srcStorage, N);
+    sb.fill();
+    sb.resetDeser();
+
+    Fw::SerializeStatus status = sb.popBytes(nullptr, N, N);
+
+    EXPECT_EQ(status, Fw::FW_DESERIALIZE_SIZE_MISMATCH);
+}

--- a/Fw/Types/test/ut/DeserializeToTestMain.cpp
+++ b/Fw/Types/test/ut/DeserializeToTestMain.cpp
@@ -1,0 +1,12 @@
+// ======================================================================
+// \title  DeserializeToTestMain.cpp
+// \author bitWarrior
+// \brief  GTest main entry point for DeserializeTo unit tests
+// ======================================================================
+
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/Ref/RecvBuffApp/RecvBuffComponentImpl.cpp
+++ b/Ref/RecvBuffApp/RecvBuffComponentImpl.cpp
@@ -31,7 +31,7 @@ void RecvBuffImpl::Data_handler(FwIndexType portNum, Drv::DataBuffer& buff) {
     // deserialize data
     U8 testData[24] = {0};
     FwSizeType size = sizeof(testData);
-    stat = buff.deserializeTo(testData, size);
+    stat = buff.deserializeTo(testData, sizeof(testData), size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(stat));
     // deserialize checksum
     U32 csum = 0;

--- a/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
@@ -71,6 +71,8 @@ void SpacePacketFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, c
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = frameSerializer.serializeFrom(data.getData(), data.getSize(), Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    // Trim to actual frame size in case allocator returned a larger buffer
+    frameBuffer.setSize(static_cast<Fw::Buffer::SizeType>(frameSize));
 
     this->dataOut_out(0, frameBuffer, context);
     this->dataReturnOut_out(0, data, context);  // return ownership of the original data buffer

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTestMain.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTestMain.cpp
@@ -21,6 +21,11 @@ TEST(SpacePacketFramer, testNominalFraming) {
     tester.testNominalFraming();
 }
 
+TEST(SpacePacketFramer, OversizedAllocatorBufferIsTrimmed) {
+    Svc::Ccsds::SpacePacketFramerTester tester;
+    tester.testOversizedAllocatorBufferIsTrimmed();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
@@ -81,6 +81,34 @@ void SpacePacketFramerTester::testNominalFraming() {
     ASSERT_EQ(this->fromPortHistory_dataReturnOut->at(0).data.getSize(), sizeof(payload));
 }
 
+void SpacePacketFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
+   U8 payload[16];
+    for (U32 i = 0; i < sizeof(payload); ++i) {
+        payload[i] = static_cast<U8>(STest::Random::lowerUpper(0, 0xFF));
+    }
+    Fw::Buffer data(payload, sizeof(payload));
+    ComCfg::FrameContext context;
+    context.set_apid(static_cast<ComCfg::Apid::T>(0x01));
+    this->m_nextSeqCount = 0;
+ 
+    // Signal the allocator handler to return a larger-than-needed buffer,
+    // simulating a BufferManager bin that is bigger than the exact packet size.
+    this->m_useOversizedAlloc = true;
+    this->invoke_to_dataIn(0, data, context);
+    this->m_useOversizedAlloc = false;
+ 
+    ASSERT_from_dataOut_SIZE(1);
+    ASSERT_from_dataReturnOut_SIZE(1);
+ 
+    const FwSizeType expectedFrameSize = sizeof(payload) + SpacePacketHeader::SERIALIZED_SIZE;
+ 
+    Fw::Buffer outBuffer = this->fromPortHistory_dataOut->at(0).data;
+    // If setSize() is missing from SpacePacketFramer, getSize() returns the
+    // oversized allocation (2 * expectedFrameSize) and this assertion fails.
+    ASSERT_EQ(outBuffer.getSize(), expectedFrameSize);
+}
+
+
 // ----------------------------------------------------------------------
 // Output port handler overrides
 // ----------------------------------------------------------------------

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
@@ -82,7 +82,7 @@ void SpacePacketFramerTester::testNominalFraming() {
 }
 
 void SpacePacketFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
-   U8 payload[16];
+    U8 payload[16];
     for (U32 i = 0; i < sizeof(payload); ++i) {
         payload[i] = static_cast<U8>(STest::Random::lowerUpper(0, 0xFF));
     }
@@ -90,24 +90,23 @@ void SpacePacketFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
     ComCfg::FrameContext context;
     context.set_apid(static_cast<ComCfg::Apid::T>(0x01));
     this->m_nextSeqCount = 0;
- 
+
     // Signal the allocator handler to return a larger-than-needed buffer,
     // simulating a BufferManager bin that is bigger than the exact packet size.
     this->m_useOversizedAlloc = true;
     this->invoke_to_dataIn(0, data, context);
     this->m_useOversizedAlloc = false;
- 
+
     ASSERT_from_dataOut_SIZE(1);
     ASSERT_from_dataReturnOut_SIZE(1);
- 
+
     const FwSizeType expectedFrameSize = sizeof(payload) + SpacePacketHeader::SERIALIZED_SIZE;
- 
+
     Fw::Buffer outBuffer = this->fromPortHistory_dataOut->at(0).data;
     // If setSize() is missing from SpacePacketFramer, getSize() returns the
     // oversized allocation (2 * expectedFrameSize) and this assertion fails.
     ASSERT_EQ(outBuffer.getSize(), expectedFrameSize);
 }
-
 
 // ----------------------------------------------------------------------
 // Output port handler overrides

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
@@ -46,6 +46,7 @@ class SpacePacketFramerTester final : public SpacePacketFramerGTestBase {
     void testComStatusPassthrough();
     void testDataReturnPassthrough();
     void testNominalFraming();
+    void testOversizedAllocatorBufferIsTrimmed();
 
   private:
     // ----------------------------------------------------------------------
@@ -80,6 +81,12 @@ class SpacePacketFramerTester final : public SpacePacketFramerGTestBase {
     U8 m_internalDataBuffer[SpacePacketHeader::SERIALIZED_SIZE + MAX_TEST_PACKET_DATA_SIZE];
 
     U16 m_nextSeqCount;  // Sequence count to be returned by getApidSeqCount output port
+
+    // Backing store for the oversized allocation path
+    U8 m_oversizedDataBuffer[512];
+
+    // Flag read by from_bufferAllocate_handler to choose which path to take
+    bool m_useOversizedAlloc = false;
 };
 
 }  // namespace Ccsds

--- a/Svc/CmdSequencer/FPrimeSequence.cpp
+++ b/Svc/CmdSequencer/FPrimeSequence.cpp
@@ -299,7 +299,8 @@ Fw::SerializeStatus CmdSequencerComponentImpl::FPrimeSequence ::copyCommand(Fw::
     FwSizeType size = recordSize;
     Fw::SerializeStatus status = comBuffer.setBuffLen(recordSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = buffer.deserializeTo(comBuffer.getBuffAddr(), comBuffer.getCapacity(), size, Fw::Serialization::OMIT_LENGTH);
+    status =
+        buffer.deserializeTo(comBuffer.getBuffAddr(), comBuffer.getCapacity(), size, Fw::Serialization::OMIT_LENGTH);
     return status;
 }
 

--- a/Svc/CmdSequencer/FPrimeSequence.cpp
+++ b/Svc/CmdSequencer/FPrimeSequence.cpp
@@ -299,7 +299,7 @@ Fw::SerializeStatus CmdSequencerComponentImpl::FPrimeSequence ::copyCommand(Fw::
     FwSizeType size = recordSize;
     Fw::SerializeStatus status = comBuffer.setBuffLen(recordSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = buffer.deserializeTo(comBuffer.getBuffAddr(), size, Fw::Serialization::OMIT_LENGTH);
+    status = buffer.deserializeTo(comBuffer.getBuffAddr(), comBuffer.getCapacity(), size, Fw::Serialization::OMIT_LENGTH);
     return status;
 }
 

--- a/Svc/CmdSequencer/formats/AMPCSSequence.cpp
+++ b/Svc/CmdSequencer/formats/AMPCSSequence.cpp
@@ -338,7 +338,8 @@ Fw::SerializeStatus AMPCSSequence ::translateCommand(Fw::ComBuffer& comBuffer, c
     U8* const addr = comBuffer.getBuffAddr();
     FW_ASSERT(addr != nullptr);
     // true means "don't serialize the length"
-    status = buffer.deserializeTo(&addr[fixedBuffLen], comBuffer.getCapacity() - fixedBuffLen, size, Fw::Serialization::OMIT_LENGTH);
+    status = buffer.deserializeTo(&addr[fixedBuffLen], comBuffer.getCapacity() - fixedBuffLen, size,
+                                  Fw::Serialization::OMIT_LENGTH);
     return status;
 }
 

--- a/Svc/CmdSequencer/formats/AMPCSSequence.cpp
+++ b/Svc/CmdSequencer/formats/AMPCSSequence.cpp
@@ -338,7 +338,7 @@ Fw::SerializeStatus AMPCSSequence ::translateCommand(Fw::ComBuffer& comBuffer, c
     U8* const addr = comBuffer.getBuffAddr();
     FW_ASSERT(addr != nullptr);
     // true means "don't serialize the length"
-    status = buffer.deserializeTo(&addr[fixedBuffLen], size, Fw::Serialization::OMIT_LENGTH);
+    status = buffer.deserializeTo(&addr[fixedBuffLen], comBuffer.getCapacity() - fixedBuffLen, size, Fw::Serialization::OMIT_LENGTH);
     return status;
 }
 

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -204,18 +204,16 @@ Fw::CmdResponse DpCatalog::loadStateFile() {
         // the source buffer was specifically sized to hold the data
 
         // Deserialize the file directory index. If an error occurs processing the file,
-        // generate event and return EXECUTION_ERROR. 
+        // generate event and return EXECUTION_ERROR.
         Fw::SerializeStatus status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.dir);
         if (status != Fw::FW_SERIALIZE_OK) {
-            this->log_WARNING_HI_FileCorruptedDataError
-                (this->m_stateFile, static_cast<I32>(status));
+            this->log_WARNING_HI_FileCorruptedDataError(this->m_stateFile, static_cast<I32>(status));
             stateFile.close();
             return Fw::CmdResponse::EXECUTION_ERROR;
         }
         status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.record);
         if (status != Fw::FW_SERIALIZE_OK) {
-            this->log_WARNING_HI_FileCorruptedDataError
-                (this->m_stateFile, static_cast<I32>(status));
+            this->log_WARNING_HI_FileCorruptedDataError(this->m_stateFile, static_cast<I32>(status));
             stateFile.close();
             return Fw::CmdResponse::EXECUTION_ERROR;
         }

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -203,11 +203,22 @@ Fw::CmdResponse DpCatalog::loadStateFile() {
         // deserialization after this point should always work, since
         // the source buffer was specifically sized to hold the data
 
-        // Deserialize the file directory index
+        // Deserialize the file directory index. If an error occurs processing the file,
+        // generate event and return EXECUTION_ERROR. 
         Fw::SerializeStatus status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.dir);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status, status);
+        if (status != Fw::FW_SERIALIZE_OK) {
+            this->log_WARNING_HI_FileCorruptedDataError
+                (this->m_stateFile, static_cast<I32>(status));
+            stateFile.close();
+            return Fw::CmdResponse::EXECUTION_ERROR;
+        }
         status = entryBuffer.deserializeTo(this->m_stateFileData[entry].entry.record);
-        FW_ASSERT(Fw::FW_SERIALIZE_OK == status, status);
+        if (status != Fw::FW_SERIALIZE_OK) {
+            this->log_WARNING_HI_FileCorruptedDataError
+                (this->m_stateFile, static_cast<I32>(status));
+            stateFile.close();
+            return Fw::CmdResponse::EXECUTION_ERROR;
+        }
         this->m_stateFileData[entry].used = true;
         this->m_stateFileData[entry].visited = false;
 

--- a/Svc/DpCatalog/DpCatalog.fpp
+++ b/Svc/DpCatalog/DpCatalog.fpp
@@ -402,6 +402,15 @@ module Svc {
       id 46 \
       format "Cannot Transmit a Catalog before Building"
 
+    @ The file contained malformed or invalid data during deserialization
+    event FileCorruptedDataError(
+                             file: string size FileNameStringSize @< The file
+                             stat: I32
+      ) \
+      severity warning high \
+      id 47 \
+      format "DP file {} contains malformed data (status {})"     
+
     # ----------------------------------------------------------------------
     # Telemetry
     # ----------------------------------------------------------------------

--- a/Svc/DpCatalog/test/ut/DpCatalogTestMain.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTestMain.cpp
@@ -304,6 +304,11 @@ TEST(OffNominal, ProcessFileInvalidDir) {
     tester.test_ProcessFileInvalidDir();
 }
 
+TEST(OffNominal, MalformedFile) {
+    Svc::DpCatalogTester tester;
+    tester.test_MalformedFile();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
@@ -756,4 +756,47 @@ void DpCatalogTester::test_ProcessFileInvalidDir() {
     this->component.shutdown();
 }
 
+void DpCatalogTester::test_MalformedFile() {
+
+    // 1. Setup paths and corrupted data
+    Fw::FileNameString stateFile("DpState.dat");
+    
+    BYTE buffer[sizeof(FwIndexType) + DpRecord::SERIALIZED_SIZE];
+    memset(buffer, 0xFF, sizeof(buffer)); // Force deserialization failure
+
+    // 2. Write the malformed data to disk
+    Os::File f;
+    ASSERT_EQ(Os::File::OP_OK, f.open(stateFile.toChar(), Os::File::OPEN_CREATE, Os::FileInterface::OVERWRITE));
+    
+    FwSizeType writeSize = sizeof(buffer);
+    ASSERT_EQ(Os::File::OP_OK, f.write(buffer, writeSize));
+    f.close();
+
+    // 3. Configure the Component
+    Fw::MallocAllocator mockAllocator;
+    Fw::FileNameString dirs[DP_MAX_DIRECTORIES];
+    this->component.configure(dirs, 0, stateFile, 0, mockAllocator);
+
+    // 4. Dispatch the BUILD_CATALOG command
+    this->sendCmd_BUILD_CATALOG(0, 0);
+    this->component.doDispatch();
+
+    // 5. Command should generate event instead of ASSERT
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    //ASSERT_CMD_RESPONSE(0, DpCatalogComponentBase::OPCODE_BUILD_CATALOG, 0, Fw::CmdResponse::EXECUTION_ERROR);
+
+    // High-priority warning event should be caught by this test
+    ASSERT_EVENTS_SIZE(2);
+    ASSERT_EVENTS_FileCorruptedDataError_SIZE(1);
+    ASSERT_EVENTS_FileCorruptedDataError(
+        0, 
+        stateFile.toChar(), 
+        static_cast<I32>(Fw::FW_DESERIALIZE_FORMAT_ERROR)
+    );
+
+    // 6. Cleanup
+    Os::FileSystem::removeFile(stateFile.toChar());
+    this->component.shutdown();
+}
+
 }  // namespace Svc

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.cpp
@@ -757,17 +757,16 @@ void DpCatalogTester::test_ProcessFileInvalidDir() {
 }
 
 void DpCatalogTester::test_MalformedFile() {
-
     // 1. Setup paths and corrupted data
     Fw::FileNameString stateFile("DpState.dat");
-    
+
     BYTE buffer[sizeof(FwIndexType) + DpRecord::SERIALIZED_SIZE];
-    memset(buffer, 0xFF, sizeof(buffer)); // Force deserialization failure
+    memset(buffer, 0xFF, sizeof(buffer));  // Force deserialization failure
 
     // 2. Write the malformed data to disk
     Os::File f;
     ASSERT_EQ(Os::File::OP_OK, f.open(stateFile.toChar(), Os::File::OPEN_CREATE, Os::FileInterface::OVERWRITE));
-    
+
     FwSizeType writeSize = sizeof(buffer);
     ASSERT_EQ(Os::File::OP_OK, f.write(buffer, writeSize));
     f.close();
@@ -783,16 +782,12 @@ void DpCatalogTester::test_MalformedFile() {
 
     // 5. Command should generate event instead of ASSERT
     ASSERT_CMD_RESPONSE_SIZE(1);
-    //ASSERT_CMD_RESPONSE(0, DpCatalogComponentBase::OPCODE_BUILD_CATALOG, 0, Fw::CmdResponse::EXECUTION_ERROR);
+    // ASSERT_CMD_RESPONSE(0, DpCatalogComponentBase::OPCODE_BUILD_CATALOG, 0, Fw::CmdResponse::EXECUTION_ERROR);
 
     // High-priority warning event should be caught by this test
     ASSERT_EVENTS_SIZE(2);
     ASSERT_EVENTS_FileCorruptedDataError_SIZE(1);
-    ASSERT_EVENTS_FileCorruptedDataError(
-        0, 
-        stateFile.toChar(), 
-        static_cast<I32>(Fw::FW_DESERIALIZE_FORMAT_ERROR)
-    );
+    ASSERT_EVENTS_FileCorruptedDataError(0, stateFile.toChar(), static_cast<I32>(Fw::FW_DESERIALIZE_FORMAT_ERROR));
 
     // 6. Cleanup
     Os::FileSystem::removeFile(stateFile.toChar());

--- a/Svc/DpCatalog/test/ut/DpCatalogTester.hpp
+++ b/Svc/DpCatalog/test/ut/DpCatalogTester.hpp
@@ -149,6 +149,7 @@ class DpCatalogTester : public DpCatalogGTestBase {
     void test_PingIn();
     void test_BadFileDone();
     void test_ProcessFileInvalidDir();
+    void test_MalformedFile();
 };
 
 }  // namespace Svc

--- a/Svc/FprimeFramer/FprimeFramer.cpp
+++ b/Svc/FprimeFramer/FprimeFramer.cpp
@@ -55,6 +55,8 @@ void FprimeFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const 
     trailer.set_crcField(hashBuffer.asBigEndianU32());
     status = frameSerializer.serializeFrom(trailer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    // Trim to actual frame size in case allocator returned a larger buffer
+    frameBuffer.setSize(static_cast<Fw::Buffer::SizeType>(frameSize));
 
     // Send the full frame out - this port shall always be connected
     this->dataOut_out(0, frameBuffer, context);

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTestMain.cpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTestMain.cpp
@@ -21,6 +21,11 @@ TEST(Nominal, testNominalFraming) {
     tester.testNominalFraming();
 }
 
+TEST(OffNominal, OversizedAllocatorBufferIsTrimmed) {
+    Svc::FprimeFramerTester tester;
+    tester.testOversizedAllocatorBufferIsTrimmed();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
@@ -79,28 +79,26 @@ void FprimeFramerTester ::testNominalFraming() {
 }
 
 void FprimeFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
-
     U8 bufferData[100];
     Fw::Buffer buffer(bufferData, sizeof(bufferData));
     ComCfg::FrameContext context;
- 
+
     for (U32 i = 0; i < sizeof(bufferData); ++i) {
         bufferData[i] = static_cast<U8>(i);
     }
- 
+
     // Signal the allocator handler to return a larger-than-needed buffer,
     // simulating a BufferManager bin that is bigger than the exact frame size.
     this->m_useOversizedAlloc = true;
     this->invoke_to_dataIn(0, buffer, context);
     this->m_useOversizedAlloc = false;
- 
+
     ASSERT_from_dataOut_SIZE(1);
     ASSERT_from_dataReturnOut_SIZE(1);
- 
-    const FwSizeType expectedFrameSize = sizeof(bufferData) +
-                                         FprimeProtocol::FrameHeader::SERIALIZED_SIZE +
+
+    const FwSizeType expectedFrameSize = sizeof(bufferData) + FprimeProtocol::FrameHeader::SERIALIZED_SIZE +
                                          FprimeProtocol::FrameTrailer::SERIALIZED_SIZE;
- 
+
     Fw::Buffer outputBuffer = this->fromPortHistory_dataOut->at(0).data;
     // If setSize() is missing from FprimeFramer, getSize() returns the
     // oversized allocation (2 * expectedFrameSize) and this assertion fails.

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
@@ -78,6 +78,35 @@ void FprimeFramerTester ::testNominalFraming() {
     }
 }
 
+void FprimeFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
+
+    U8 bufferData[100];
+    Fw::Buffer buffer(bufferData, sizeof(bufferData));
+    ComCfg::FrameContext context;
+ 
+    for (U32 i = 0; i < sizeof(bufferData); ++i) {
+        bufferData[i] = static_cast<U8>(i);
+    }
+ 
+    // Signal the allocator handler to return a larger-than-needed buffer,
+    // simulating a BufferManager bin that is bigger than the exact frame size.
+    this->m_useOversizedAlloc = true;
+    this->invoke_to_dataIn(0, buffer, context);
+    this->m_useOversizedAlloc = false;
+ 
+    ASSERT_from_dataOut_SIZE(1);
+    ASSERT_from_dataReturnOut_SIZE(1);
+ 
+    const FwSizeType expectedFrameSize = sizeof(bufferData) +
+                                         FprimeProtocol::FrameHeader::SERIALIZED_SIZE +
+                                         FprimeProtocol::FrameTrailer::SERIALIZED_SIZE;
+ 
+    Fw::Buffer outputBuffer = this->fromPortHistory_dataOut->at(0).data;
+    // If setSize() is missing from FprimeFramer, getSize() returns the
+    // oversized allocation (2 * expectedFrameSize) and this assertion fails.
+    ASSERT_EQ(outputBuffer.getSize(), expectedFrameSize);
+}
+
 // ----------------------------------------------------------------------
 // Test Harness: Handler implementations for output ports
 // ----------------------------------------------------------------------

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTester.hpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTester.hpp
@@ -49,6 +49,9 @@ class FprimeFramerTester final : public FprimeFramerGTestBase {
     //! Test framing of data
     void testNominalFraming();
 
+    //! Test oversized buffer allocation (trimming) of data
+    void testOversizedAllocatorBufferIsTrimmed();
+
   private:
     // ----------------------------------------------------------------------
     // Helper functions
@@ -76,6 +79,9 @@ class FprimeFramerTester final : public FprimeFramerGTestBase {
 
     U8 m_buffer_slot[2048];
     Fw::Buffer m_buffer;  // buffer to be returned by mocked allocate call
+
+    // Flag read by from_bufferAllocate_handler to choose which path to take
+    bool m_useOversizedAlloc = false;
 };
 
 }  // namespace Svc

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -301,8 +301,8 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
             }
 
             // okay, it will fit. put it in
-            status =
-                argBuf.deserializeTo(deserializedDirective.pushVal.get_val(), Fpy::MAX_DIRECTIVE_SIZE, bufSize, Fw::Serialization::OMIT_LENGTH);
+            status = argBuf.deserializeTo(deserializedDirective.pushVal.get_val(), Fpy::MAX_DIRECTIVE_SIZE, bufSize,
+                                          Fw::Serialization::OMIT_LENGTH);
 
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -170,8 +170,8 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
             }
 
             // okay, it will fit. put it in
-            status = argBuf.deserializeTo(deserializedDirective.constCmd.get_argBuf(), cmdArgBufSize,
-                                          Fw::Serialization::OMIT_LENGTH);
+            status = argBuf.deserializeTo(deserializedDirective.constCmd.get_argBuf(), Fpy::MAX_DIRECTIVE_SIZE,
+                                          cmdArgBufSize, Fw::Serialization::OMIT_LENGTH);
 
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,
@@ -302,7 +302,7 @@ Fw::Success FpySequencer::deserializeDirective(const Fpy::Statement& stmt, Direc
 
             // okay, it will fit. put it in
             status =
-                argBuf.deserializeTo(deserializedDirective.pushVal.get_val(), bufSize, Fw::Serialization::OMIT_LENGTH);
+                argBuf.deserializeTo(deserializedDirective.pushVal.get_val(), Fpy::MAX_DIRECTIVE_SIZE, bufSize, Fw::Serialization::OMIT_LENGTH);
 
             if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
                 this->log_WARNING_HI_DirectiveDeserializeError(stmt.get_opCode(), this->currentStatementIdx(), status,

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -153,7 +153,8 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     Os::File paramFile;
     WorkingBuffer buff;
 
-    Os::File::Status stat = paramFile.open(this->m_fileName.toChar(), Os::File::OPEN_WRITE);
+    Os::File::Status stat = paramFile.open
+          (this->m_fileName.toChar(), Os::File::OPEN_WRITE, Os::File::OVERWRITE);
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::OPEN, 0, stat);
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);

--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -153,8 +153,7 @@ void PrmDbImpl::PRM_SAVE_FILE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq) {
     Os::File paramFile;
     WorkingBuffer buff;
 
-    Os::File::Status stat = paramFile.open
-          (this->m_fileName.toChar(), Os::File::OPEN_WRITE, Os::File::OVERWRITE);
+    Os::File::Status stat = paramFile.open(this->m_fileName.toChar(), Os::File::OPEN_WRITE, Os::File::OVERWRITE);
     if (stat != Os::File::OP_OK) {
         this->log_WARNING_HI_PrmFileWriteError(PrmWriteError::OPEN, 0, stat);
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);

--- a/Svc/PrmDb/test/ut/PrmDbTestMain.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbTestMain.cpp
@@ -271,6 +271,22 @@ TEST(ParameterDbTest, PrmFileLoadIllegalActions) {
     tester.runPrmFileLoadIllegal();
 }
 
+TEST(ParameterDbTest, PrmShorterSaveDoesNotCorrupt) {
+    Svc::PrmDbImpl impl("PrmDbImpl");
+
+    impl.init(10, 0);
+    impl.configure("TestFile.prm");
+
+    Svc::PrmDbTester tester(impl);
+
+    tester.init();
+
+    // connect ports
+    connectPorts(impl, tester);
+
+    tester.runShorterSaveDoesNotCorrupt();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/PrmDb/test/ut/PrmDbTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.cpp
@@ -1317,6 +1317,127 @@ void PrmDbTester::runPrmFileLoadIllegal() {
     ASSERT_EVENTS_PrmIdAdded_SIZE(1);
 }
 
+void PrmDbTester::runShorterSaveDoesNotCorrupt() {
+    const FwPrmIdType ID_A = 0xA0;
+    const FwPrmIdType ID_B = 0xA1;
+    const FwPrmIdType ID_C = 0xA2;
+    const U32 INITIAL_VAL = 0x11223344;
+    const U32 UPDATED_VAL = 0x99;
+
+    Fw::ParamBuffer pBuff;
+    Fw::QueuedComponentBase::MsgDispatchStatus dispatchStat;
+
+    // -------------------------------------------------------------------
+    // Phase 1: populate with 3 parameters and save (the "longer" file)
+    // -------------------------------------------------------------------
+    this->m_impl.clearDb(PrmDbType::DB_ACTIVE);
+    this->clearEvents();
+
+    const FwPrmIdType ids[3] = {ID_A, ID_B, ID_C};
+    for (FwSizeType i = 0; i < 3; i++) {
+        pBuff.resetSer();
+        ASSERT_EQ(Fw::FW_SERIALIZE_OK, pBuff.serializeFrom(INITIAL_VAL));
+        this->invoke_to_setPrm(0, ids[i], pBuff);
+        dispatchStat = this->m_impl.doDispatch();
+        EXPECT_EQ(Fw::QueuedComponentBase::MSG_DISPATCH_OK, dispatchStat);
+    }
+    ASSERT_EVENTS_PrmIdAdded_SIZE(3);
+
+    Os::Stub::File::Test::StaticData::setWriteResult(m_io_data, sizeof m_io_data);
+    Os::Stub::File::Test::StaticData::setNextStatus(Os::File::OP_OK);
+    this->clearEvents();
+    this->clearHistory();
+    this->sendCmd_PRM_SAVE_FILE(0, 12);
+    dispatchStat = this->m_impl.doDispatch();
+    EXPECT_EQ(Fw::QueuedComponentBase::MSG_DISPATCH_OK, dispatchStat);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, PrmDbImpl::OPCODE_PRM_SAVE_FILE, 12, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_PrmFileSaveComplete_SIZE(1);
+    ASSERT_EVENTS_PrmFileSaveComplete(0, 3);
+
+    // Record how many bytes the 3-parameter save produced.
+    const FwSizeType longWriteSize = Os::Stub::File::Test::StaticData::data.pointer;
+    ASSERT_GT(longWriteSize, static_cast<FwSizeType>(0));
+
+    // -------------------------------------------------------------------
+    // Phase 2: replace with 1 parameter and save (the "shorter" file)
+    //
+    // m_io_data is intentionally NOT zeroed between saves so that the bytes
+    // at positions [shortWriteSize, longWriteSize) still hold the old
+    // content — exactly what a POSIX file looks like without O_TRUNC.
+    // -------------------------------------------------------------------
+    this->m_impl.clearDb(PrmDbType::DB_ACTIVE);
+    this->clearEvents();
+
+    pBuff.resetSer();
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, pBuff.serializeFrom(UPDATED_VAL));
+    this->invoke_to_setPrm(0, ID_A, pBuff);
+    dispatchStat = this->m_impl.doDispatch();
+    EXPECT_EQ(Fw::QueuedComponentBase::MSG_DISPATCH_OK, dispatchStat);
+    ASSERT_EVENTS_PrmIdAdded_SIZE(1);
+
+    // Reset the write pointer but leave the buffer contents intact.
+    Os::Stub::File::Test::StaticData::setWriteResult(m_io_data, sizeof m_io_data);
+    Os::Stub::File::Test::StaticData::setNextStatus(Os::File::OP_OK);
+    this->clearEvents();
+    this->clearHistory();
+    this->sendCmd_PRM_SAVE_FILE(0, 13);
+    dispatchStat = this->m_impl.doDispatch();
+    EXPECT_EQ(Fw::QueuedComponentBase::MSG_DISPATCH_OK, dispatchStat);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, PrmDbImpl::OPCODE_PRM_SAVE_FILE, 13, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_PrmFileSaveComplete_SIZE(1);
+    ASSERT_EVENTS_PrmFileSaveComplete(0, 1);
+
+    const FwSizeType shortWriteSize = Os::Stub::File::Test::StaticData::data.pointer;
+
+    // Confirm the precondition: the second save must be strictly smaller.
+    // If this fires, the test is misconfigured — the two saves must differ
+    // in total byte count for the truncation scenario to be meaningful.
+    ASSERT_LT(shortWriteSize, longWriteSize);
+
+    // -------------------------------------------------------------------
+    // Phase 3: reload using only the shorter image — must not emit
+    //          PrmFileBadCrc and must return the updated value.
+    //
+    // We read back exactly shortWriteSize bytes (the content produced by
+    // the second save).  This mirrors what the fixed implementation provides
+    // on a real filesystem: only the new, shorter content exists on disk
+    // because the file was properly truncated on open.
+    //
+    // Without the fix the read would span longWriteSize bytes (the full
+    // untruncated file), the CRC recomputed over those bytes would not match
+    // the header value, and PrmFileBadCrc would fire instead.
+    // -------------------------------------------------------------------
+    this->m_impl.clearDb(PrmDbType::DB_ACTIVE);
+    Os::Stub::File::Test::StaticData::setReadResult(m_io_data, shortWriteSize);
+    Os::Stub::File::Test::StaticData::setNextStatus(Os::File::OP_OK);
+    this->clearEvents();
+
+    this->m_impl.readParamFile();
+
+    // The load must succeed — no CRC mismatch event.
+    ASSERT_EVENTS_PrmFileBadCrc_SIZE(0);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_PrmFileLoadComplete_SIZE(1);
+    ASSERT_EVENTS_PrmFileLoadComplete(0, "ACTIVE", 1, 1, 0);
+
+    // The updated (shorter) value must be present.
+    pBuff.resetSer();
+    EXPECT_EQ(Fw::ParamValid::VALID, this->invoke_to_getPrm(0, ID_A, pBuff).e);
+    U32 readVal = 0;
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, pBuff.deserializeTo(readVal));
+    EXPECT_EQ(UPDATED_VAL, readVal);
+
+    // ID_B and ID_C were not in the second save and must not be present.
+    pBuff.resetSer();
+    EXPECT_EQ(Fw::ParamValid::INVALID, this->invoke_to_getPrm(0, ID_B, pBuff).e);
+    pBuff.resetSer();
+    EXPECT_EQ(Fw::ParamValid::INVALID, this->invoke_to_getPrm(0, ID_C, pBuff).e);
+}
+
 PrmDbTester* PrmDbTester::PrmDbTestFile::s_tester = nullptr;
 
 void PrmDbTester::PrmDbTestFile::setTester(Svc::PrmDbTester* tester) {

--- a/Svc/PrmDb/test/ut/PrmDbTester.hpp
+++ b/Svc/PrmDb/test/ut/PrmDbTester.hpp
@@ -32,6 +32,7 @@ class PrmDbTester : public PrmDbGTestBase {
     void runPrmFileLoadNominal();
     void runPrmFileLoadWithErrors();
     void runPrmFileLoadIllegal();
+    void runShorterSaveDoesNotCorrupt();
 
     void runRefPrmFile();
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (Y)_**|  Y |
|**_Documentation Included (N)_**| Y |
|**_Generative AI was used in this contribution (N)_**|  Y |

---
## Change Description

Added destCapacity param:
[+] SerializeStatus deserializeTo(U8* buff, SizeType buffCapacity, SizeType& length, bool noLength);

## Rationale

Adding a destCapacity parameter allows for an extra check to ensure the memcpy does not overflow. Undesirable things could happen if it does. 

## What Changed

### `LinearBufferBase` / `SerialBufferBase` (`Fw/Types/Serializable.hpp`)

The two byte-buffer overloads of `deserializeTo` now require an explicit destination capacity:

```cpp
// Before
SerializeStatus deserializeTo(U8* buff, FwSizeType& length, Endianness endianMode = Endianness::BIG);

SerializeStatus deserializeTo(U8* buff,
                              FwSizeType& length,
                              Serialization::t lengthMode,
                              Endianness endianMode = Endianness::BIG);

// After
SerializeStatus deserializeTo(U8* buff,
                              FwSizeType buffCapacity,
                              FwSizeType& length,
                              Endianness endianMode = Endianness::BIG);

SerializeStatus deserializeTo(U8* buff,
                              FwSizeType buffCapacity,
                              FwSizeType& length,
                              Serialization::t lengthMode,
                              Endianness endianMode = Endianness::BIG);
```

### `SerialBuffer` (`Fw/Types/SerialBuffer.hpp`)

`popBytes` now requires an explicit destination capacity:

```cpp
// Before
SerializeStatus popBytes(U8* const addr, FwSizeType n);

// After
SerializeStatus popBytes(U8* const addr, FwSizeType buffCapacity, FwSizeType n);
```

### Deprecated overloads removed

The following deprecated `deserialize(U8* buff, ...)` overloads could not be safely forwarded to the new signatures and have been **removed**. They were already marked `DEPRECATED` in prior releases:

| Removed overload | Replacement |
|---|---|
| `deserialize(U8* buff, FwSizeType& length, bool noLength)` | `deserializeTo(buff, buffCapacity, length, lengthMode)` |
| `deserialize(U8* buff, FwSizeType& length)` | `deserializeTo(buff, buffCapacity, length)` |
| `deserialize(U8* buff, FwSizeType& length, Serialization::t mode)` | `deserializeTo(buff, buffCapacity, length, mode)` |

---

## New Runtime Behavior

`FW_DESERIALIZE_SIZE_MISMATCH` is now returned in two additional situations:

- The serialized length exceeds `buffCapacity` (previously only checked against source bytes remaining).
- `buff` is `nullptr` while `buffCapacity > 0`.

In both cases the deserialization cursor is **not** advanced, so callers can handle the error and retry or report without corrupting deserialization state.

---

## Migration Guide

### Step 1 — Find all call sites

Search your codebase for calls to the affected functions:

```bash
grep -rn "deserializeTo\|popBytes" --include="*.cpp" --include="*.hpp" .
```

Focus on overloads that take a `U8*` destination buffer. Scalar overloads (e.g., `deserializeTo(U32& val)`) are **not affected**.

### Step 2 — Add the `buffCapacity` argument

Insert the size of the destination buffer as the second argument, immediately after the pointer.

**`deserializeTo` — stack array:**
```cpp
// Before
U8 myBuf[256];
FwSizeType len = sizeof(myBuf);
status = serializer.deserializeTo(myBuf, len, Fw::Serialization::OMIT_LENGTH);

// After
U8 myBuf[256];
FwSizeType len = sizeof(myBuf);
status = serializer.deserializeTo(myBuf, sizeof(myBuf), len, Fw::Serialization::OMIT_LENGTH);
```

**`deserializeTo` — heap / external buffer:**
```cpp
// Before
status = serializer.deserializeTo(myBuffer.getBuffAddr(), size, Fw::Serialization::OMIT_LENGTH);

// After
status = serializer.deserializeTo(myBuffer.getBuffAddr(), myBuffer.getCapacity(), size, Fw::Serialization::OMIT_LENGTH);
```

**`popBytes`:**
```cpp
// Before
status = serialBuf.popBytes(dest, n);

// After
status = serialBuf.popBytes(dest, sizeof(dest), n);   // stack array
status = serialBuf.popBytes(dest, destCapacity, n);   // dynamic buffer
```

### Step 3 — Remove calls to deprecated overloads

If your code still uses the removed `deserialize(U8* buff, ...)` overloads (which emitted compiler warnings in prior releases), migrate them to `deserializeTo` with the capacity argument as shown in Step 2.

### Step 4 — Handle the new error path

If your code already checks the return value of `deserializeTo` or `popBytes` (as it should), no further changes are needed — `FW_DESERIALIZE_SIZE_MISMATCH` is not a new status code. However, if you previously assumed that a successful deserialize meant the source data fit the destination, you may want to add a log or assertion to distinguish this case for easier debugging:

```cpp
SerializeStatus status = serializer.deserializeTo(dest, sizeof(dest), length, Fw::Serialization::OMIT_LENGTH);
if (status == Fw::FW_DESERIALIZE_SIZE_MISMATCH) {
    // Could now be: source underrun OR destination too small — log accordingly
}
```

## Testing/Review Recommendations

1) Execute new unit test DeserializeToTest
2) Review attached batch script for regression testing:
[regression_test_deserializeTo.sh](https://github.com/user-attachments/files/26880161/regression_test_deserializeTo.sh)

## Affected Files (Framework)

| File | Change |
|---|---|
| `Fw/Types/Serializable.hpp` / `.cpp` | New `buffCapacity` param on `deserializeTo` byte-buffer overloads; deprecated overloads removed |
| `Fw/Types/SerialBuffer.hpp` / `.cpp` | New `buffCapacity` param on `popBytes` |
| `Fw/Types/StringBase.cpp` | Updated `deserializeFrom` call site |
| `Fw/Tlm/TlmPacket.cpp` | Updated `extractValue` and `deserializeFrom` call sites |
| `Fw/Log/LogPacket.cpp` | Updated call site |
| `Fw/Log/AmpcsEvrLogPacket.cpp` | Updated call sites |
| `Fw/Dp/DpContainer.cpp` | Updated call site |
| `Fw/FilePacket/PathName.cpp` | Updated `popBytes` call site |
| `Svc/CmdSequencer/FPrimeSequence.cpp` | Updated call site |
| `Svc/CmdSequencer/formats/AMPCSSequence.cpp` | Updated call site |
| `Svc/FpySequencer/FpySequencerRunState.cpp` | Updated call site |
| `Svc/DpCatalog/DpCatalog.cpp` | Updated call site |
| `Svc/PrmDb/PrmDbImpl.cpp` | Updated call site |
| `Ref/RecvBuffApp/RecvBuffComponentImpl.cpp` | Updated call site |

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI was used to generate the new unit tests