### PR TITLE
doc: add build status badges for reference projects

### DIFF
--- a/docs/user-manual/framework/supported-platforms.md
+++ b/docs/user-manual/framework/supported-platforms.md
@@ -1,17 +1,17 @@
 # Supported Platforms
 
-| Hardware         | OS | Architecture   | Reference Project |
-| ---------------- | -------------------- | -------------- | ---------------------------------- |
-| Apple Silicon    | Darwin    | ARM  | [`F Prime Ref`](https://github.com/nasa/fprime) |
-| BeagleBone Black | VxWorks 7 | ARMv7 | [`fprime-vxworks-reference`](https://github.com/fprime-community/fprime-vxworks-reference) |
-| Feather M4 	   | FreeRTOS  | ARM | [`fprime-featherm4-freertos-reference`](https://github.com/fprime-community/fprime-featherm4-freertos-reference) |
-| Pi Pico          | Zephyr    | ARMv6-M | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) |
-| Pi Pico 2        | Zephyr    | RISC-V | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) |
-| PolarFire SoC    | VxWorks 7 | RISC-V | TBD |
-| PyCubed          | Zephyr    | RISC-V | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) |
-| Raspberry Pi     | Linux     | ARMv8 | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) |
-| Teensy41         | Zephyr    | ARMv7-M | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) |
-| x86              | Linux     | x86\_64 | [`F Prime Ref`](https://github.com/nasa/fprime) |
+| Hardware         | OS | Architecture   | Reference Project | Build Status |
+| ---------------- | -------------------- | ------------------------------- | ---------------------------------- | ------------ |
+| Apple Silicon    | Darwin    | ARM  | [`F Prime Ref`](https://github.com/nasa/fprime) | [![CI [macOS]](https://github.com/nasa/fprime/actions/workflows/build-test-macos.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/build-test-macos.yml) |
+| BeagleBone Black | VxWorks 7 | ARMv7 | [`fprime-vxworks-reference`](https://github.com/fprime-community/fprime-vxworks-reference) | N/A |
+| Feather M4 	   | FreeRTOS  | ARM | [`fprime-featherm4-freertos-reference`](https://github.com/fprime-community/fprime-featherm4-freertos-reference) | N/A |
+| Pi Pico          | Zephyr    | ARMv6-M | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | N/A |
+| Pi Pico 2        | Zephyr    | RISC-V | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | [![External Repo: Zephyr Reference (Pico 2)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-pico2.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-pico2.yml) |
+| PolarFire SoC    | VxWorks 7 | RISC-V | TBD | N/A |
+| PyCubed          | Zephyr    | RISC-V | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | N/A |
+| Raspberry Pi     | Linux     | ARMv8 | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | [![External Repo: RPI LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-raspberry-led-blinker.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-raspberry-led-blinker.yml) |
+| Teensy41         | Zephyr    | ARMv7-M | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | [![External Repo: Zephyr Reference (Teensy 4.1)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-teensy41.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-teensy41.yml) |
+| x86              | Linux     | x86\_64 | [`F Prime Ref`](https://github.com/nasa/fprime) | [![CI [ubuntu]](https://github.com/nasa/fprime/actions/workflows/build-test.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/build-test.yml) [![CI [RHEL8]](https://github.com/nasa/fprime/actions/workflows/build-test-rhel8.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/build-test-rhel8.yml) |
 
 ## Targeted Platforms (Planned Support)
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4401 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

I've started working on cross-referencing the supported platforms with their respective CI workflows. Based on my initial search through the .github/workflows directory, I was able to map and add status badges for the following:

Apple Silicon: Linked to build-test-macos.yml

x86: Linked to build-test.yml (Ubuntu) and build-test-rhel8.yml (RHEL8)

Teensy 4.1 & Pi Pico 2: Linked to ext-fprime-zephyr-reference-pico2.yml and ext-fprime-zephyr-reference-teensy41.yml.
Raspberry Pi: Linked to ext-raspberry-led-blinker.yml.

For the remaining platforms currently marked as N/A, I couldn't find a direct workflow file starting with ext- in the main repository.

## Rationale

Fixes #4401.

## Testing/Review Recommendations

This was previously reviewed and approved by @thomas-bc on my fork.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None.
