### PR TITLE
Modernize DpCatalog: in-class initializers and =default destructor

### DIFF
--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -21,7 +21,9 @@ static_assert(DP_MAX_FILES > 0, "Configuration DP_MAX_FILES must be positive");
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-DpCatalog ::DpCatalog(const char* const compName) : DpCatalogComponentBase(compName) {}
+DpCatalog ::DpCatalog(const char* const compName) : DpCatalogComponentBase(compName) {
+    // Members are default-initialized via in-class initializers in the header.
+}
 
 void DpCatalog::configure(Fw::FileNameString directories[DP_MAX_DIRECTORIES],
                           FwSizeType numDirs,

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -21,32 +21,7 @@ static_assert(DP_MAX_FILES > 0, "Configuration DP_MAX_FILES must be positive");
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-DpCatalog ::DpCatalog(const char* const compName)
-    : DpCatalogComponentBase(compName),
-      m_initialized(false),
-      m_dpTree(nullptr),
-      m_freeListHead(nullptr),
-      m_currentNode(nullptr),
-      m_currentXmitNode(nullptr),
-      m_numDpSlots(0),
-      m_numDirectories(0),
-      m_stateFileData(nullptr),
-      m_stateFileEntries(0),
-      m_memSize(0),
-      m_memPtr(nullptr),
-      m_allocatorId(0),
-      m_allocator(nullptr),
-      m_catalogBuilt(false),
-      m_xmitInProgress(false),
-      m_xmitCmdWait(false),
-      m_xmitBytes(0),
-      m_xmitOpCode(0),
-      m_xmitCmdSeq(0),
-      m_pendingFiles(0),
-      m_pendingDpBytes(0),
-      m_remainActive(false) {}
-
-DpCatalog ::~DpCatalog() {}
+DpCatalog ::DpCatalog(const char* const compName) : DpCatalogComponentBase(compName) {}
 
 void DpCatalog::configure(Fw::FileNameString directories[DP_MAX_DIRECTORIES],
                           FwSizeType numDirs,

--- a/Svc/DpCatalog/DpCatalog.hpp
+++ b/Svc/DpCatalog/DpCatalog.hpp
@@ -34,7 +34,7 @@ class DpCatalog final : public DpCatalogComponentBase {
     );
 
     /// @brief DpCatalog destructor
-    ~DpCatalog();
+    ~DpCatalog() = default;
 
     /// @brief Configure the DpCatalog
     /// @param maxDpFiles The max number of data product files to track
@@ -243,42 +243,42 @@ class DpCatalog final : public DpCatalogComponentBase {
     // ----------------------------------
     // Private data
     // ----------------------------------
-    bool m_initialized;  //!< set when the component has been initialized
+    bool m_initialized = false;  //!< set when the component has been initialized
 
-    DpBtreeNode* m_dpTree;           //!< The head of the binary tree
-    DpBtreeNode* m_freeListHead;     //!< The head of the free list
-    DpBtreeNode* m_currentNode;      //!< current node for traversing tree
-    DpBtreeNode* m_currentXmitNode;  //!< node being currently transmitted
+    DpBtreeNode* m_dpTree = nullptr;           //!< The head of the binary tree
+    DpBtreeNode* m_freeListHead = nullptr;     //!< The head of the free list
+    DpBtreeNode* m_currentNode = nullptr;      //!< current node for traversing tree
+    DpBtreeNode* m_currentXmitNode = nullptr;  //!< node being currently transmitted
 
-    FwSizeType m_numDpSlots;  //!< Stores the available number of record slots.
+    FwSizeType m_numDpSlots = 0;  //!< Stores the available number of record slots.
 
     Fw::FileNameString m_directories[DP_MAX_DIRECTORIES];  //!< List of supplied DP directories
-    FwSizeType m_numDirectories;                           //!< number of supplied directories
+    FwSizeType m_numDirectories = 0;                       //!< number of supplied directories
     Fw::String m_fileList[DP_MAX_FILES];                   //!< working array of files/directory
 
-    Fw::FileNameString m_stateFile;      //!< file to store transmit state
-    DpDstateFileEntry* m_stateFileData;  //!< DP state loaded from file
-    FwSizeType m_stateFileEntries;       //!< size of state file data
+    Fw::FileNameString m_stateFile;                //!< file to store transmit state
+    DpDstateFileEntry* m_stateFileData = nullptr;  //!< DP state loaded from file
+    FwSizeType m_stateFileEntries = 0;             //!< size of state file data
 
-    FwSizeType m_memSize;           //!< size of allocated buffer
-    void* m_memPtr;                 //!< stored for shutdown
-    FwEnumStoreType m_allocatorId;  //!< stored for shutdown
-    Fw::MemAllocator* m_allocator;  //!< stored for shutdown
+    FwSizeType m_memSize = 0;                 //!< size of allocated buffer
+    void* m_memPtr = nullptr;                 //!< stored for shutdown
+    FwEnumStoreType m_allocatorId = 0;        //!< stored for shutdown
+    Fw::MemAllocator* m_allocator = nullptr;  //!< stored for shutdown
 
-    bool m_catalogBuilt;                    //!< catalog build is complete (can add DPs at runtime)
-    bool m_xmitInProgress;                  //!< set if DP files are in the process of being sent
+    bool m_catalogBuilt = false;            //!< catalog build is complete (can add DPs at runtime)
+    bool m_xmitInProgress = false;          //!< set if DP files are in the process of being sent
     Fw::FileNameString m_currXmitFileName;  //!< current file being transmitted
-    bool m_xmitCmdWait;                     //!< true if waiting for transmission complete to complete xmit command
-    U64 m_xmitBytes;                        //!< bytes transmitted for downlink session
-    FwOpcodeType m_xmitOpCode;              //!< stored xmit command opcode
-    U32 m_xmitCmdSeq;                       //!< stored command sequence id
+    bool m_xmitCmdWait = false;             //!< true if waiting for transmission complete to complete xmit command
+    U64 m_xmitBytes = 0;                    //!< bytes transmitted for downlink session
+    FwOpcodeType m_xmitOpCode = 0;          //!< stored xmit command opcode
+    U32 m_xmitCmdSeq = 0;                   //!< stored command sequence id
 
-    U32 m_pendingFiles;    //!< Pending Files to Transmit
-    U64 m_pendingDpBytes;  //!< Pending Bytes to Transmit
+    U32 m_pendingFiles = 0;    //!< Pending Files to Transmit
+    U64 m_pendingDpBytes = 0;  //!< Pending Bytes to Transmit
 
-    bool m_remainActive;  //!< Does the DpCat resume transmission when
-                          //!< a runtime Dp is received after
-                          //!< the full catalog is sent
+    bool m_remainActive = false;  //!< Does the DpCat resume transmission when
+                                  //!< a runtime Dp is received after
+                                  //!< the full catalog is sent
 };
 
 }  // namespace Svc


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4521 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Migrates the initialization of all scalar/pointer data members of `Svc::DpCatalog` from the constructor's member-initializer list to in-class default member initializers, and converts the empty destructor to `= default`.

The constructor body is now:

```cpp
DpCatalog::DpCatalog(const char* const compName) : DpCatalogComponentBase(compName) {}
```

Object members (`m_directories[]`, `m_fileList[]`, `m_stateFile`, `m_currXmitFileName`) are unchanged because they are default-constructed and were not flagged.

## Rationale

Resolves a cluster of SonarQube findings listed in #4521:

- **22× `cpp:S3230`** — *"Do not use the constructor's initializer list for data member ...; use the in-class initializer instead."* (Medium)
- **1× `cpp:S3490`** — *"Use `=default` instead of the default implementation of this special member function."* (High)

The change is intentionally narrow and self-contained:

- Touches only the `Svc/DpCatalog` constructor/destructor and member declarations.
- Does **not** overlap with the scope of #4964 (clamp `m_directories` loop), #5042 (validate fdp files), or #5043 (`destCapacity` deserialize), all of which target other regions of the same file.

This pattern (in-class member initializers and `= default`) is already used elsewhere in the repo, e.g. `Svc/DpWriter/DpWriter.hpp`, `Svc/SeqDispatcher/SeqDispatcher.hpp`, `Svc/Ccsds/AosFramer/AosFramer.hpp`, `Svc/Ccsds/ApidManager/ApidManager.hpp`.

## Testing/Review Recommendations

Behavior is unchanged — this is a refactor of *where* members are initialized, not *what* they are initialized to:

- The previous initializer list initialized members in declaration order (which it must, by C++ rules). The new in-class initializers initialize members in declaration order. Construction order and values are identical.
- All flagged members were primitive scalars or pointers, all initialized to their natural zero/`nullptr` value. The new defaults match exactly: `bool → false`, integer types → `0`, pointer types → `nullptr`.
- The empty destructor `~DpCatalog() {}` is semantically equivalent to `~DpCatalog() = default;`.

Local validation:

- `clang-format --dry-run --Werror` (clang-format 22) against the repo's `.clang-format` (Chromium, IndentWidth 4, ColumnLimit 120): **passes** with exit 0.
- `cppcheck --enable=warning,style,performance --std=c++17` against `Svc/DpCatalog/DpCatalog.{cpp,hpp}` reports the **same** two pre-existing style findings (`redundantInitialization` on `response` and `stat`) before and after this change, just shifted by 25 lines because of the line delta. **No new findings introduced.**
- Unit tests not modified; this PR introduces no behavior change.

## Future Work

The remaining static analysis findings in #4521 — cognitive complexity in `fillBinaryTree`, nested control flow, `reinterpret_cast` replacements, `std::string` migrations, const-correctness on parameters and helpers, unchecked parameter dereferences, etc. — remain untouched and can be tackled in follow-up PRs.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude Code (Anthropic, model `claude-opus-4-7`) was used as a pair-programming assistant for the following:

- **Scope**: `Svc/DpCatalog/DpCatalog.cpp` and `Svc/DpCatalog/DpCatalog.hpp`.
- **Type of assistance**:
  - Identifying that the S3230 / S3490 findings in #4521 form a cohesive, self-contained cluster that does not collide with the scopes of #4964, #5042, or #5043.
  - Proposing the in-class initializer migration as the minimal mechanical change that resolves all 22 S3230 findings and the S3490 finding at once.
  - Drafting this PR description.
- **Level of modification**: Each generated change was reviewed line-by-line against the original constructor and header, the `.clang-format` config, and existing repo patterns (`Svc/DpWriter`, `Svc/SeqDispatcher`, `Svc/Ccsds/AosFramer`, `Svc/Ccsds/ApidManager`) to confirm style alignment. `clang-format` and `cppcheck` were used to validate the result.
- No AI-generated code was used unverified.