### PR TITLE
PR-5034 - Fix ground file upload processing of different file size for the same filename

### DIFF
--- a/Svc/FileUplink/CMakeLists.txt
+++ b/Svc/FileUplink/CMakeLists.txt
@@ -27,6 +27,7 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/FileUplink.fpp"
   ${CMAKE_CURRENT_LIST_DIR}/test/ut/FileUplinkTester.cpp
   ${CMAKE_CURRENT_LIST_DIR}/test/ut/FileUplinkMain.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/test/ut/FileUplinkOverwriteTests.cpp
 )
 register_fprime_ut()
 set (UT_TARGET_NAME "${FPRIME_CURRENT_MODULE}_ut_exe")

--- a/Svc/FileUplink/File.cpp
+++ b/Svc/FileUplink/File.cpp
@@ -27,8 +27,7 @@ Os::File::Status FileUplink::File::open(const Fw::FilePacket::StartPacket& start
     this->size = startPacket.getFileSize();
     CFDP::Checksum checksum;
     this->m_checksum = checksum;
-    return this->osFile.open(path, Os::File::OPEN_CREATE,
-                                   Os::File::OverwriteType::OVERWRITE);
+    return this->osFile.open(path, Os::File::OPEN_CREATE, Os::File::OverwriteType::OVERWRITE);
 }
 
 Os::File::Status FileUplink::File::write(const U8* const data, const U32 byteOffset, const U32 length) {

--- a/Svc/FileUplink/File.cpp
+++ b/Svc/FileUplink/File.cpp
@@ -27,7 +27,8 @@ Os::File::Status FileUplink::File::open(const Fw::FilePacket::StartPacket& start
     this->size = startPacket.getFileSize();
     CFDP::Checksum checksum;
     this->m_checksum = checksum;
-    return this->osFile.open(path, Os::File::OPEN_WRITE);
+    return this->osFile.open(path, Os::File::OPEN_CREATE,
+                                   Os::File::OverwriteType::OVERWRITE);
 }
 
 Os::File::Status FileUplink::File::write(const U8* const data, const U32 byteOffset, const U32 length) {

--- a/Svc/FileUplink/test/ut/FileUplinkOverwriteTests.cpp
+++ b/Svc/FileUplink/test/ut/FileUplinkOverwriteTests.cpp
@@ -6,8 +6,8 @@
 // Add to CMakeLists.txt sources alongside the other test .cpp files.
 // ======================================================================
 
-#include "FileUplinkTester.hpp"
 #include <gtest/gtest.h>
+#include "FileUplinkTester.hpp"
 
 namespace Svc {
 

--- a/Svc/FileUplink/test/ut/FileUplinkOverwriteTests.cpp
+++ b/Svc/FileUplink/test/ut/FileUplinkOverwriteTests.cpp
@@ -1,0 +1,32 @@
+// ======================================================================
+// \title  FileUplinkOverwriteTests.cpp
+// \brief  TEST_F entries for overwrite truncation regression tests.
+//
+// Placement: Svc/FileUplink/test/ut/FileUplinkOverwriteTests.cpp
+// Add to CMakeLists.txt sources alongside the other test .cpp files.
+// ======================================================================
+
+#include "FileUplinkTester.hpp"
+#include <gtest/gtest.h>
+
+namespace Svc {
+
+// Fixture — identical pattern to the existing FileUplink fixture.
+class FileUplinkOverwrite : public ::testing::Test {
+  protected:
+    FileUplinkTester tester;
+};
+
+TEST_F(FileUplinkOverwrite, OverwriteWithSmallerFile) {
+    tester.overwriteWithSmallerFile();
+}
+
+TEST_F(FileUplinkOverwrite, OverwriteSameSizeFile) {
+    tester.overwriteSameSizeFile();
+}
+
+TEST_F(FileUplinkOverwrite, OverwriteWithLargerFile) {
+    tester.overwriteWithLargerFile();
+}
+
+}  // namespace Svc

--- a/Svc/FileUplink/test/ut/FileUplinkTester.cpp
+++ b/Svc/FileUplink/test/ut/FileUplinkTester.cpp
@@ -10,9 +10,9 @@
 //
 // ======================================================================
 
+#include <sys/stat.h>
 #include <cerrno>
 #include <cstring>
-#include <sys/stat.h>
 
 #include "FileUplinkTester.hpp"
 #include "Fw/Com/ComPacket.hpp"

--- a/Svc/FileUplink/test/ut/FileUplinkTester.cpp
+++ b/Svc/FileUplink/test/ut/FileUplinkTester.cpp
@@ -12,6 +12,7 @@
 
 #include <cerrno>
 #include <cstring>
+#include <sys/stat.h>
 
 #include "FileUplinkTester.hpp"
 #include "Fw/Com/ComPacket.hpp"
@@ -527,6 +528,144 @@ void FileUplinkTester ::removeFile(const char* const path) {
     if (status != 0) {
         ASSERT_EQ(ENOENT, errno);
     }
+}
+
+void FileUplinkTester ::verifyFileSize(const char* const path, const size_t expectedSize) {
+    struct stat st;
+    ASSERT_EQ(0, ::stat(path, &st)) << "Could not stat " << path;
+    ASSERT_EQ(static_cast<size_t>(st.st_size), expectedSize)
+        << "File has " << st.st_size << " bytes on disk; expected " << expectedSize
+        << ". Os::File::open is likely not truncating stale content.";
+}
+
+// ----------------------------------------------------------------------
+// Overwrite truncation tests
+// Regression coverage for the change in File.cpp:
+//   Os::File::open(path, Os::File::OPEN_CREATE, Os::File::OverwriteType::OVERWRITE)
+// Without truncation, stale bytes from a previously-larger file survive
+// past the new logical EOF and corrupt the uplinked content.
+// ----------------------------------------------------------------------
+
+void FileUplinkTester ::overwriteWithSmallerFile() {
+    const char* const sourcePath = "source.bin";
+    const char* const destPath = "overwrite_test.bin";
+
+    // --- First upload: 4 packets * PACKET_SIZE = 20 bytes of 0xAA ---
+    const U32 numLargePackets = 4;
+    const size_t largeFileSize = numLargePackets * PACKET_SIZE;
+    U8 largeData[largeFileSize];
+    memset(largeData, 0xAA, largeFileSize);
+
+    this->sendStartPacket(sourcePath, destPath, largeFileSize);
+    for (U32 i = 0; i < numLargePackets; ++i) {
+        this->sendDataPacket(i * PACKET_SIZE, &largeData[i * PACKET_SIZE]);
+    }
+    CFDP::Checksum largeChecksum;
+    largeChecksum.update(largeData, 0, largeFileSize);
+    this->sendEndPacket(largeChecksum);
+
+    this->verifyFileData(destPath, largeData, largeFileSize);
+    this->verifyFileSize(destPath, largeFileSize);
+
+    // --- Second upload: 1 packet * PACKET_SIZE = 5 bytes of 0xBB ---
+    const U32 numSmallPackets = 1;
+    const size_t smallFileSize = numSmallPackets * PACKET_SIZE;
+    U8 smallData[smallFileSize];
+    memset(smallData, 0xBB, smallFileSize);
+
+    this->sendStartPacket(sourcePath, destPath, smallFileSize);
+    for (U32 i = 0; i < numSmallPackets; ++i) {
+        this->sendDataPacket(i * PACKET_SIZE, &smallData[i * PACKET_SIZE]);
+    }
+    CFDP::Checksum smallChecksum;
+    smallChecksum.update(smallData, 0, smallFileSize);
+    this->sendEndPacket(smallChecksum);
+
+    // Content must be the new data only — no 0xAA stale tail
+    this->verifyFileData(destPath, smallData, smallFileSize);
+    this->verifyFileSize(destPath, smallFileSize);
+
+    this->removeFile(destPath);
+}
+
+void FileUplinkTester ::overwriteSameSizeFile() {
+    const char* const sourcePath = "source.bin";
+    const char* const destPath = "overwrite_test.bin";
+
+    const U32 numPackets = 2;
+    const size_t fileSize = numPackets * PACKET_SIZE;
+
+    // --- First upload: 0x11 fill ---
+    U8 firstData[fileSize];
+    memset(firstData, 0x11, fileSize);
+
+    this->sendStartPacket(sourcePath, destPath, fileSize);
+    for (U32 i = 0; i < numPackets; ++i) {
+        this->sendDataPacket(i * PACKET_SIZE, &firstData[i * PACKET_SIZE]);
+    }
+    CFDP::Checksum firstChecksum;
+    firstChecksum.update(firstData, 0, fileSize);
+    this->sendEndPacket(firstChecksum);
+
+    this->verifyFileData(destPath, firstData, fileSize);
+
+    // --- Second upload: 0x22 fill, same path and size ---
+    U8 secondData[fileSize];
+    memset(secondData, 0x22, fileSize);
+
+    this->sendStartPacket(sourcePath, destPath, fileSize);
+    for (U32 i = 0; i < numPackets; ++i) {
+        this->sendDataPacket(i * PACKET_SIZE, &secondData[i * PACKET_SIZE]);
+    }
+    CFDP::Checksum secondChecksum;
+    secondChecksum.update(secondData, 0, fileSize);
+    this->sendEndPacket(secondChecksum);
+
+    // All bytes must reflect the new upload
+    this->verifyFileData(destPath, secondData, fileSize);
+    this->verifyFileSize(destPath, fileSize);
+
+    this->removeFile(destPath);
+}
+
+void FileUplinkTester ::overwriteWithLargerFile() {
+    const char* const sourcePath = "source.bin";
+    const char* const destPath = "overwrite_test.bin";
+
+    // --- First upload: 1 packet * PACKET_SIZE = 5 bytes of 0x33 ---
+    const U32 numSmallPackets = 1;
+    const size_t smallFileSize = numSmallPackets * PACKET_SIZE;
+    U8 smallData[smallFileSize];
+    memset(smallData, 0x33, smallFileSize);
+
+    this->sendStartPacket(sourcePath, destPath, smallFileSize);
+    for (U32 i = 0; i < numSmallPackets; ++i) {
+        this->sendDataPacket(i * PACKET_SIZE, &smallData[i * PACKET_SIZE]);
+    }
+    CFDP::Checksum smallChecksum;
+    smallChecksum.update(smallData, 0, smallFileSize);
+    this->sendEndPacket(smallChecksum);
+
+    this->verifyFileData(destPath, smallData, smallFileSize);
+
+    // --- Second upload: 4 packets * PACKET_SIZE = 20 bytes of 0x44 ---
+    const U32 numLargePackets = 4;
+    const size_t largeFileSize = numLargePackets * PACKET_SIZE;
+    U8 largeData[largeFileSize];
+    memset(largeData, 0x44, largeFileSize);
+
+    this->sendStartPacket(sourcePath, destPath, largeFileSize);
+    for (U32 i = 0; i < numLargePackets; ++i) {
+        this->sendDataPacket(i * PACKET_SIZE, &largeData[i * PACKET_SIZE]);
+    }
+    CFDP::Checksum largeChecksum;
+    largeChecksum.update(largeData, 0, largeFileSize);
+    this->sendEndPacket(largeChecksum);
+
+    this->verifyFileData(destPath, largeData, largeFileSize);
+    this->verifyFileSize(destPath, largeFileSize);
+
+    this->removeFile(destPath);
 }
 
 }  // namespace Svc

--- a/Svc/FileUplink/test/ut/FileUplinkTester.hpp
+++ b/Svc/FileUplink/test/ut/FileUplinkTester.hpp
@@ -87,6 +87,18 @@ class FileUplinkTester : public FileUplinkGTestBase {
     //!
     void cancelPacketInDataMode();
 
+    //! Overwrite a larger file with a smaller one; verify no stale bytes remain
+    //!
+    void overwriteWithSmallerFile();
+
+    //! Overwrite a file with one of the same size; verify content changes
+    //!
+    void overwriteSameSizeFile();
+
+    //! Overwrite a smaller file with a larger one; verify full content written
+    //!
+    void overwriteWithLargerFile();
+
   private:
     // ----------------------------------------------------------------------
     // Handlers for from ports
@@ -142,6 +154,10 @@ class FileUplinkTester : public FileUplinkGTestBase {
     //! Verify file data
     //!
     void verifyFileData(const char* const path, const U8* const sentData, const size_t sentDataSize);
+
+    //! Verify on-disk file size equals expectedSize (catches stale tail bytes)
+    //!
+    void verifyFileSize(const char* const path, size_t expectedSize);
 
     //! Remove a file
     //!


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| PR 5034 |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| N  |
|**_Generative AI was used in this contribution (y/n)_**| Y |

---
## Change Description

Added OVERWRITE parameter when opening file in Svc/FileUplink/File::open()
[WAS] this->osFile.open(path, Os::File::OPEN_CREATE)
[IS] this->osFile.open(path, Os::File::OPEN_CREATE, Os::File::OverwriteType::OVERWRITE);

## Rationale

This ensures that opening a file with the same filename with a smaller size than the previous version will not contain any stale data from the old file. Without this change, F Prime was reading in extra data from the previous file. At mimimum this wastes hardware resources. At worse, something can be embedded in this space that may be undesirable. 

## Testing/Review Recommendations

I created a new unit test called FileUplinkOverwriteTests to validate this new functionality. 

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

I used Claude to generate the unit test, but I kinda wish I didn't becuase in the time it took to generate something usefull, I could have done it myself and saved some tokens, electrons and frustration. 