### PR TITLE
PR 5038 - Force Framers to setSize on Fw::Buffer before outputting it

### DIFF
--- a/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
@@ -72,6 +72,9 @@ void SpacePacketFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, c
     status = frameSerializer.serializeFrom(data.getData(), data.getSize(), Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
 
+    // Trim to actual frame size in case allocator returned a larger buffer
+    frameBuffer.setSize(static_cast<Fw::Buffer::SizeType>(frameSize));
+
     this->dataOut_out(0, frameBuffer, context);
     this->dataReturnOut_out(0, data, context);  // return ownership of the original data buffer
 }

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTestMain.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTestMain.cpp
@@ -21,6 +21,11 @@ TEST(SpacePacketFramer, testNominalFraming) {
     tester.testNominalFraming();
 }
 
+TEST(SpacePacketFramer, OversizedAllocatorBufferIsTrimmed) {
+    Svc::Ccsds::SpacePacketFramerTester tester;
+    tester.testOversizedAllocatorBufferIsTrimmed();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
@@ -81,6 +81,33 @@ void SpacePacketFramerTester::testNominalFraming() {
     ASSERT_EQ(this->fromPortHistory_dataReturnOut->at(0).data.getSize(), sizeof(payload));
 }
 
+void SpacePacketFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
+    U8 payload[16];
+    for (U32 i = 0; i < sizeof(payload); ++i) {
+        payload[i] = static_cast<U8>(STest::Random::lowerUpper(0, 0xFF));
+    }
+    Fw::Buffer data(payload, sizeof(payload));
+    ComCfg::FrameContext context;
+    context.set_apid(static_cast<ComCfg::Apid::T>(0x01));
+    this->m_nextSeqCount = 0;
+
+    // Signal the allocator handler to return a larger-than-needed buffer,
+    // simulating a BufferManager bin that is bigger than the exact packet size.
+    this->m_useOversizedAlloc = true;
+    this->invoke_to_dataIn(0, data, context);
+    this->m_useOversizedAlloc = false;
+
+    ASSERT_from_dataOut_SIZE(1);
+    ASSERT_from_dataReturnOut_SIZE(1);
+
+    const FwSizeType expectedFrameSize = sizeof(payload) + SpacePacketHeader::SERIALIZED_SIZE;
+
+    Fw::Buffer outBuffer = this->fromPortHistory_dataOut->at(0).data;
+    // If setSize() is missing from SpacePacketFramer, getSize() returns the
+    // oversized allocation (2 * expectedFrameSize) and this assertion fails.
+    ASSERT_EQ(outBuffer.getSize(), expectedFrameSize);
+}
+
 // ----------------------------------------------------------------------
 // Output port handler overrides
 // ----------------------------------------------------------------------

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
@@ -119,7 +119,8 @@ U16 SpacePacketFramerTester ::from_getApidSeqCount_handler(FwIndexType portNum,
 }
 
 Fw::Buffer SpacePacketFramerTester ::from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) {
-    return Fw::Buffer(this->m_internalDataBuffer, size);
+    FwSizeType allocation = (this->m_useOversizedAlloc) ? sizeof(this->m_internalDataBuffer) : size;
+    return Fw::Buffer(this->m_internalDataBuffer, allocation);
 }
 
 }  // namespace Ccsds

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
@@ -46,6 +46,7 @@ class SpacePacketFramerTester final : public SpacePacketFramerGTestBase {
     void testComStatusPassthrough();
     void testDataReturnPassthrough();
     void testNominalFraming();
+    void testOversizedAllocatorBufferIsTrimmed();
 
   private:
     // ----------------------------------------------------------------------
@@ -80,6 +81,12 @@ class SpacePacketFramerTester final : public SpacePacketFramerGTestBase {
     U8 m_internalDataBuffer[SpacePacketHeader::SERIALIZED_SIZE + MAX_TEST_PACKET_DATA_SIZE];
 
     U16 m_nextSeqCount;  // Sequence count to be returned by getApidSeqCount output port
+
+    // Backing store for the oversized allocation path
+    U8 m_oversizedDataBuffer[512];
+
+    // Flag read by from_bufferAllocate_handler to choose which path to take
+    bool m_useOversizedAlloc = false;
 };
 
 }  // namespace Ccsds

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
@@ -82,9 +82,6 @@ class SpacePacketFramerTester final : public SpacePacketFramerGTestBase {
 
     U16 m_nextSeqCount;  // Sequence count to be returned by getApidSeqCount output port
 
-    // Backing store for the oversized allocation path
-    U8 m_oversizedDataBuffer[512];
-
     // Flag read by from_bufferAllocate_handler to choose which path to take
     bool m_useOversizedAlloc = false;
 };

--- a/Svc/FprimeFramer/FprimeFramer.cpp
+++ b/Svc/FprimeFramer/FprimeFramer.cpp
@@ -55,6 +55,8 @@ void FprimeFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const 
     trailer.set_crcField(hashBuffer.asBigEndianU32());
     status = frameSerializer.serializeFrom(trailer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    // Trim to actual frame size in case allocator returned a larger buffer
+    frameBuffer.setSize(static_cast<Fw::Buffer::SizeType>(frameSize));
 
     // Send the full frame out - this port shall always be connected
     this->dataOut_out(0, frameBuffer, context);

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTestMain.cpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTestMain.cpp
@@ -21,6 +21,11 @@ TEST(Nominal, testNominalFraming) {
     tester.testNominalFraming();
 }
 
+TEST(OffNominal, OversizedAllocatorBufferIsTrimmed) {
+    Svc::FprimeFramerTester tester;
+    tester.testOversizedAllocatorBufferIsTrimmed();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTester.cpp
@@ -85,9 +85,38 @@ void FprimeFramerTester ::testNominalFraming() {
 Fw::Buffer FprimeFramerTester::from_bufferAllocate_handler(FwIndexType portNum, FwSizeType size) {
     this->pushFromPortEntry_bufferAllocate(size);
     this->m_buffer.setData(this->m_buffer_slot);
-    this->m_buffer.setSize(size);
-    ::memset(this->m_buffer.getData(), 0, size);
+    // When m_useOversizedAlloc is set, simulate a pool allocator returning
+    // a larger block than requested — the component must trim it before sending
+    FwSizeType allocatedSize = this->m_useOversizedAlloc ? sizeof(this->m_buffer_slot) : size;
+    this->m_buffer.setSize(allocatedSize);
+    ::memset(this->m_buffer.getData(), 0, allocatedSize);
     return this->m_buffer;
+}
+
+// ----------------------------------------------------------------------
+// Test Harness: Handler oversized output
+// ----------------------------------------------------------------------
+
+void FprimeFramerTester::testOversizedAllocatorBufferIsTrimmed() {
+    U8 bufferData[100];
+    Fw::Buffer buffer(bufferData, sizeof(bufferData));
+    ComCfg::FrameContext context;
+
+    for (U32 i = 0; i < sizeof(bufferData); ++i) {
+        bufferData[i] = static_cast<U8>(i);
+    }
+
+    this->m_useOversizedAlloc = true;
+    this->invoke_to_dataIn(0, buffer, context);
+    this->m_useOversizedAlloc = false;
+
+    ASSERT_from_dataOut_SIZE(1);
+    ASSERT_from_dataReturnOut_SIZE(1);
+
+    Fw::Buffer outputBuffer = this->fromPortHistory_dataOut->at(0).data;
+    FwSizeType expectedSize = sizeof(bufferData) + FprimeProtocol::FrameHeader::SERIALIZED_SIZE +
+                              FprimeProtocol::FrameTrailer::SERIALIZED_SIZE;
+    ASSERT_EQ(outputBuffer.getSize(), expectedSize);
 }
 
 }  // namespace Svc

--- a/Svc/FprimeFramer/test/ut/FprimeFramerTester.hpp
+++ b/Svc/FprimeFramer/test/ut/FprimeFramerTester.hpp
@@ -49,6 +49,9 @@ class FprimeFramerTester final : public FprimeFramerGTestBase {
     //! Test framing of data
     void testNominalFraming();
 
+    //! Test oversized buffer allocation (trimming) of data
+    void testOversizedAllocatorBufferIsTrimmed();
+
   private:
     // ----------------------------------------------------------------------
     // Helper functions
@@ -76,6 +79,9 @@ class FprimeFramerTester final : public FprimeFramerGTestBase {
 
     U8 m_buffer_slot[2048];
     Fw::Buffer m_buffer;  // buffer to be returned by mocked allocate call
+
+    // Flag read by from_bufferAllocate_handler to choose which path to take
+    bool m_useOversizedAlloc = false;
 };
 
 }  // namespace Svc


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| PR 5038 |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| N  |
|**_Generative AI was used in this contribution (y/n)_**| Y |

---
## Change Description

Iadded a single setSize() call in each framer immediately before dataOut_out, trimming the buffer to the exact computed frame size. frameSize is already in scope in both handlers at that point and requires no additional computation.

Svc/FprimeFramer/FprimeFramer.cpp
// Trim to actual frame size in case allocator returned a larger buffer
frameBuffer.setSize(static_cast<Fw::Buffer::SizeType>(frameSize));

Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
// Trim to actual frame size in case allocator returned a larger buffer
frameBuffer.setSize(static_cast<Fw::Buffer::SizeType>(frameSize));

## Rationale

<!-- A rationale for this change. e.g. fixes bug, or most projects need XYZ feature. -->

## Testing/Review Recommendations

This trim any extra data above what is expected. When a memory pool allocator returns a buffer larger than requested — which is common in fixed-block-size allocators — without the setSize trim the framed output would advertise an incorrect (oversized) length to the downstream ComManager, potentially causing it to transmit garbage padding bytes as part of the frame. The change ensures the framed buffer's reported size always exactly matches the true frame size regardless of allocator behavior, making FprimeFramer and SpacePacketFramer more complete, rather than relying on all allocator implementations to return exactly-sized buffers.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude was used to generate unit tests.
