### PR TITLE
PR 5084 - Fixed pkt_length integer overflow and replaced ASSERT w/ event

### DIFF
--- a/Svc/Ccsds/SpacePacketDeframer/CMakeLists.txt
+++ b/Svc/Ccsds/SpacePacketDeframer/CMakeLists.txt
@@ -21,9 +21,7 @@ register_fprime_library(
 
 # Allow comparison of a configurable constant with a fixed-width constant that may be "always true" in
 # specific configurations buy may not be true in other configurations. Relates to: FwSizeType
-target_compile_options("${FPRIME_CURRENT_MODULE}" PRIVATE
-    $<$<CXX_COMPILER_ID:Clang>:-Wno-tautological-constant-out-of-range-compare>
-)
+target_compile_options(${FPRIME_CURRENT_MODULE} PRIVATE -Wno-tautological-constant-out-of-range-compare)
 
 ### Unit Tests ###
 register_fprime_ut(

--- a/Svc/Ccsds/SpacePacketDeframer/CMakeLists.txt
+++ b/Svc/Ccsds/SpacePacketDeframer/CMakeLists.txt
@@ -19,6 +19,11 @@ register_fprime_library(
     Svc_Ccsds_Types
 )
 
+# Allow comparison of a configurable constant with a fixed-width constant that may be "always true" in
+# specific configurations buy may not be true in other configurations. Relates to: FwSizeType
+target_compile_options("${FPRIME_CURRENT_MODULE}" PRIVATE
+    $<$<CXX_COMPILER_ID:Clang>:-Wno-tautological-constant-out-of-range-compare>
+)
 
 ### Unit Tests ###
 register_fprime_ut(

--- a/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
@@ -52,12 +52,29 @@ void SpacePacketDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data,
 
     SpacePacketHeader header;
     Fw::SerializeStatus status = data.getDeserializer().deserializeTo(header);
-    // Length is valid, so deserialization here should succeed
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    // Deserialisation can still fail if the buffer is malformed despite passing the size check
+    if (status != Fw::FW_SERIALIZE_OK) {
+        this->log_WARNING_HI_InvalidPacket();
+        if (this->isConnected_errorNotify_OutputPort(0)) {
+            this->errorNotify_out(0, Svc::Ccsds::FrameError::SP_INVALID_PACKET);
+        }
+        this->dataReturnOut_out(0, data, context);  // Drop the packet
+        return;
+    }
 
-    // Space Packet protocol defines the Data Length as number of bytes minus 1
-    // so we need to add 1 to the length to get the actual data size
-    U16 pkt_length = static_cast<U16>(header.get_packetDataLength() + 1);
+    // Widen to U32 before adding 1 to prevent U16 truncation to 0 when packetDataLength == 0xFFFF (max U16 value).
+    // This is a undefined behavior condition in C++.
+    const U32 pkt_length_wide = static_cast<U32>(header.get_packetDataLength()) + 1U;
+    if (pkt_length_wide > static_cast<U32>(data.getSize() - SpacePacketHeader::SERIALIZED_SIZE)) {
+        FwSizeType maxDataAvailable = data.getSize() - SpacePacketHeader::SERIALIZED_SIZE;
+        this->log_WARNING_HI_InvalidLength(static_cast<U16>(pkt_length_wide), maxDataAvailable);
+        if (this->isConnected_errorNotify_OutputPort(0)) {
+            this->errorNotify_out(0, Svc::Ccsds::FrameError::SP_INVALID_LENGTH);
+        }
+        this->dataReturnOut_out(0, data, context);
+        return;
+    }
+    const U16 pkt_length = static_cast<U16>(pkt_length_wide);
     if (pkt_length > data.getSize() - SpacePacketHeader::SERIALIZED_SIZE) {
         FwSizeType maxDataAvailable = data.getSize() - SpacePacketHeader::SERIALIZED_SIZE;
         this->log_WARNING_HI_InvalidLength(pkt_length, maxDataAvailable);

--- a/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
@@ -65,7 +65,8 @@ void SpacePacketDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data,
     // Widen to U32 before adding 1 to prevent U16 truncation to 0 when packetDataLength == 0xFFFF (max U16 value).
     // This is a undefined behavior condition in C++.
     const U32 pkt_length = static_cast<U32>(header.get_packetDataLength()) + 1U;
-    if ((pkt_length > data.getSize() - SpacePacketHeader::SERIALIZED_SIZE) || (pkt_length > std::numeric_limits<FwSizeType>::max())) {
+    if ((pkt_length > data.getSize() - SpacePacketHeader::SERIALIZED_SIZE) ||
+        (pkt_length > std::numeric_limits<FwSizeType>::max())) {
         FwSizeType maxDataAvailable = data.getSize() - SpacePacketHeader::SERIALIZED_SIZE;
         this->log_WARNING_HI_InvalidLength(pkt_length, maxDataAvailable);
         if (this->isConnected_errorNotify_OutputPort(0)) {

--- a/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
@@ -52,7 +52,7 @@ void SpacePacketDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data,
 
     SpacePacketHeader header;
     Fw::SerializeStatus status = data.getDeserializer().deserializeTo(header);
-    // Deserialisation can still fail if the buffer is malformed despite passing the size check
+    // Deserialization can still fail if the buffer is malformed despite passing the size check
     if (status != Fw::FW_SERIALIZE_OK) {
         this->log_WARNING_HI_InvalidPacket();
         if (this->isConnected_errorNotify_OutputPort(0)) {

--- a/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
@@ -64,18 +64,8 @@ void SpacePacketDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data,
 
     // Widen to U32 before adding 1 to prevent U16 truncation to 0 when packetDataLength == 0xFFFF (max U16 value).
     // This is a undefined behavior condition in C++.
-    const U32 pkt_length_wide = static_cast<U32>(header.get_packetDataLength()) + 1U;
-    if (pkt_length_wide > static_cast<U32>(data.getSize() - SpacePacketHeader::SERIALIZED_SIZE)) {
-        FwSizeType maxDataAvailable = data.getSize() - SpacePacketHeader::SERIALIZED_SIZE;
-        this->log_WARNING_HI_InvalidLength(static_cast<U16>(pkt_length_wide), maxDataAvailable);
-        if (this->isConnected_errorNotify_OutputPort(0)) {
-            this->errorNotify_out(0, Svc::Ccsds::FrameError::SP_INVALID_LENGTH);
-        }
-        this->dataReturnOut_out(0, data, context);
-        return;
-    }
-    const U16 pkt_length = static_cast<U16>(pkt_length_wide);
-    if (pkt_length > data.getSize() - SpacePacketHeader::SERIALIZED_SIZE) {
+    const U32 pkt_length = static_cast<U32>(header.get_packetDataLength()) + 1U;
+    if ((pkt_length > data.getSize() - SpacePacketHeader::SERIALIZED_SIZE) || (pkt_length > std::numeric_limits<FwSizeType>::max())) {
         FwSizeType maxDataAvailable = data.getSize() - SpacePacketHeader::SERIALIZED_SIZE;
         this->log_WARNING_HI_InvalidLength(pkt_length, maxDataAvailable);
         if (this->isConnected_errorNotify_OutputPort(0)) {

--- a/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.fpp
+++ b/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.fpp
@@ -17,7 +17,7 @@ module Ccsds {
             format "Malformed packet received refusing to deframe"
 
         @ Deframing received an invalid frame length
-        event InvalidLength(transmitted: U16, actual: FwSizeType) \
+        event InvalidLength(transmitted: FwSizeType, actual: FwSizeType) \
             severity warning high \
             format "Invalid length received. Header specified packet byte size of {} | Actual received data length: {}"
 

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTestMain.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTestMain.cpp
@@ -27,9 +27,7 @@ TEST(SpacePacketDeframer, testPacketDataLengthMaxU16Overflow) {
 }
 
 // ----------------------------------------------------------------------
-// graceful handling of undersized buffers
-// The original FW_ASSERT aborts the FSW on deserialization failure.
-// The fix replaces it with an InvalidPacket EVR and a graceful drop.
+// Tests for graceful handling of undersized buffers
 // ----------------------------------------------------------------------
 
 TEST(SpacePacketDeframer, testBufferExactlyHeaderSize) {

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTestMain.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTestMain.cpp
@@ -22,7 +22,7 @@ TEST(SpacePacketDeframer, testDeframingIncorrectLength) {
 }
 
 // ----------------------------------------------------------------------
-// Finding 1 — U16 overflow in pkt_length calculation
+// U16 overflow in pkt_length calculation
 // packetDataLength=0xFFFF wraps to 0 without the U32-widening fix,
 // causing the length guard to pass and an empty buffer to reach dataOut.
 // ----------------------------------------------------------------------
@@ -33,8 +33,8 @@ TEST(SpacePacketDeframer, testPacketDataLengthMaxU16Overflow) {
 }
 
 // ----------------------------------------------------------------------
-// Finding 3 — graceful handling of undersized buffers
-// The original FW_ASSERT aborts the FSW on deserialisation failure.
+// graceful handling of undersized buffers
+// The original FW_ASSERT aborts the FSW on deserialization failure.
 // The fix replaces it with an InvalidPacket EVR and a graceful drop.
 // ----------------------------------------------------------------------
 

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTestMain.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTestMain.cpp
@@ -21,6 +21,38 @@ TEST(SpacePacketDeframer, testDeframingIncorrectLength) {
     tester.testDeframingIncorrectLength();
 }
 
+// ----------------------------------------------------------------------
+// Finding 1 — U16 overflow in pkt_length calculation
+// packetDataLength=0xFFFF wraps to 0 without the U32-widening fix,
+// causing the length guard to pass and an empty buffer to reach dataOut.
+// ----------------------------------------------------------------------
+
+TEST(SpacePacketDeframer, testPacketDataLengthMaxU16Overflow) {
+    Svc::Ccsds::SpacePacketDeframerTester tester;
+    tester.testPacketDataLengthMaxU16Overflow();
+}
+
+// ----------------------------------------------------------------------
+// Finding 3 — graceful handling of undersized buffers
+// The original FW_ASSERT aborts the FSW on deserialisation failure.
+// The fix replaces it with an InvalidPacket EVR and a graceful drop.
+// ----------------------------------------------------------------------
+
+TEST(SpacePacketDeframer, testBufferExactlyHeaderSize) {
+    Svc::Ccsds::SpacePacketDeframerTester tester;
+    tester.testBufferExactlyHeaderSize();
+}
+
+TEST(SpacePacketDeframer, testBufferSmallerThanHeaderSize) {
+    Svc::Ccsds::SpacePacketDeframerTester tester;
+    tester.testBufferSmallerThanHeaderSize();
+}
+
+TEST(SpacePacketDeframer, testBufferSingleByte) {
+    Svc::Ccsds::SpacePacketDeframerTester tester;
+    tester.testBufferSingleByte();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTestMain.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTestMain.cpp
@@ -21,12 +21,6 @@ TEST(SpacePacketDeframer, testDeframingIncorrectLength) {
     tester.testDeframingIncorrectLength();
 }
 
-// ----------------------------------------------------------------------
-// U16 overflow in pkt_length calculation
-// packetDataLength=0xFFFF wraps to 0 without the U32-widening fix,
-// causing the length guard to pass and an empty buffer to reach dataOut.
-// ----------------------------------------------------------------------
-
 TEST(SpacePacketDeframer, testPacketDataLengthMaxU16Overflow) {
     Svc::Ccsds::SpacePacketDeframerTester tester;
     tester.testPacketDataLengthMaxU16Overflow();

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
@@ -150,7 +150,7 @@ void SpacePacketDeframerTester ::testPacketDataLengthMaxU16Overflow() {
     // maxDataAvailable = bufSize - SERIALIZED_SIZE = 1.
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_InvalidLength_SIZE(1);
-    ASSERT_EVENTS_InvalidLength(0, static_cast<U16>(overflowLengthToken + 1), sizeof(payload));
+    ASSERT_EVENTS_InvalidLength(0, overflowLengthToken + 1, sizeof(payload));
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
@@ -105,10 +105,6 @@ void SpacePacketDeframerTester ::testDeframingIncorrectLength() {
                                 realDataLength);  // Event logs the size in bytes, so add 1 to length token
 }
 
-// ----------------------------------------------------------------------
-// Finding 1 — U16 overflow in pkt_length calculation
-// ----------------------------------------------------------------------
-
 void SpacePacketDeframerTester ::testPacketDataLengthMaxU16Overflow() {
     // This test asserts the correct overflow behavior when all bits of packet
     // length are used.
@@ -141,10 +137,6 @@ void SpacePacketDeframerTester ::testPacketDataLengthMaxU16Overflow() {
     ASSERT_EVENTS_InvalidLength_SIZE(1);
     ASSERT_EVENTS_InvalidLength(0, overflowLengthToken + 1, sizeof(payload));
 }
-
-// ----------------------------------------------------------------------
-// Finding 3 — graceful handling of undersized buffers (no FW_ASSERT)
-// ----------------------------------------------------------------------
 
 void SpacePacketDeframerTester ::testBufferExactlyHeaderSize() {
     U8 rawData[SpacePacketHeader::SERIALIZED_SIZE] = {};
@@ -194,6 +186,10 @@ void SpacePacketDeframerTester ::testBufferSingleByte() {
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_InvalidPacket_SIZE(1);
 }
+
+// ----------------------------------------------------------------------
+// Helper functions
+// ----------------------------------------------------------------------
 
 Fw::Buffer SpacePacketDeframerTester ::assemblePacket(U16 apid,
                                                       U16 seqCount,

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
@@ -110,19 +110,8 @@ void SpacePacketDeframerTester ::testDeframingIncorrectLength() {
 // ----------------------------------------------------------------------
 
 void SpacePacketDeframerTester ::testPacketDataLengthMaxU16Overflow() {
-    // packetDataLength = 0xFFFF is the max U16 value.
-    //
-    // Without the fix:
-    //   pkt_length = static_cast<U16>(0xFFFF + 1) = 0
-    //   length guard: 0 > (bufSize - SERIALIZED_SIZE) = false → PASSES
-    //   → empty buffer (size 0) forwarded to dataOut — silent corruption.
-    //
-    // With the fix (widen to U32 before adding 1):
-    //   pkt_length_wide = 65536
-    //   length guard: 65536 > 1 = true → REJECTED with InvalidLength.
-    //
-    // This test asserts the correct post-fix behavior.  If run against the
-    // unfixed code it will fail, acting as a regression guard.
+    // This test asserts the correct overflow behavior when all bits of packet
+    // length are used.
 
     ComCfg::Apid::T apid = static_cast<ComCfg::Apid::T>(1);
     U16 seqCount = 0;
@@ -158,10 +147,6 @@ void SpacePacketDeframerTester ::testPacketDataLengthMaxU16Overflow() {
 // ----------------------------------------------------------------------
 
 void SpacePacketDeframerTester ::testBufferExactlyHeaderSize() {
-    // A buffer of exactly SERIALIZED_SIZE bytes passes the `>` check in the
-    // original FW_ASSERT version only if the check was `<` — the updated
-    // check uses `<=` so this must be caught and dropped gracefully.
-    // This is the tightest boundary case for the size guard.
     U8 rawData[SpacePacketHeader::SERIALIZED_SIZE] = {};
     Fw::Buffer buffer(rawData, SpacePacketHeader::SERIALIZED_SIZE);
     ComCfg::FrameContext nullContext;

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
@@ -106,8 +106,109 @@ void SpacePacketDeframerTester ::testDeframingIncorrectLength() {
 }
 
 // ----------------------------------------------------------------------
-// Helper functions
+// Finding 1 — U16 overflow in pkt_length calculation
 // ----------------------------------------------------------------------
+
+void SpacePacketDeframerTester ::testPacketDataLengthMaxU16Overflow() {
+    // packetDataLength = 0xFFFF is the max U16 value.
+    //
+    // Without the fix:
+    //   pkt_length = static_cast<U16>(0xFFFF + 1) = 0
+    //   length guard: 0 > (bufSize - SERIALIZED_SIZE) = false → PASSES
+    //   → empty buffer (size 0) forwarded to dataOut — silent corruption.
+    //
+    // With the fix (widen to U32 before adding 1):
+    //   pkt_length_wide = 65536
+    //   length guard: 65536 > 1 = true → REJECTED with InvalidLength.
+    //
+    // This test asserts the correct post-fix behavior.  If run against the
+    // unfixed code it will fail, acting as a regression guard.
+
+    ComCfg::Apid::T apid = static_cast<ComCfg::Apid::T>(1);
+    U16 seqCount = 0;
+    const U16 overflowLengthToken = 0xFFFFU;  // triggers U16 wrap-to-zero without fix
+    U8 payload[1] = {0xAB};                   // 1-byte payload — buffer size will be SERIALIZED_SIZE+1
+
+    Fw::Buffer buffer = this->assemblePacket(apid, seqCount, overflowLengthToken, payload, sizeof(payload));
+    ComCfg::FrameContext nullContext;
+
+    this->invoke_to_dataIn(0, buffer, nullContext);
+
+    // Packet must NOT be forwarded downstream
+    ASSERT_from_dataOut_SIZE(0);
+    // Buffer must be returned (frame dropped)
+    ASSERT_from_dataReturnOut_SIZE(1);
+    ASSERT_from_errorNotify(0, Svc::Ccsds::FrameError::SP_INVALID_LENGTH);
+    ASSERT_FROM_PORT_HISTORY_SIZE(2);  // dataReturnOut + errorNotify
+    // Returned buffer must be the original input
+    ASSERT_EQ(this->fromPortHistory_dataReturnOut->at(0).data.getSize(), buffer.getSize());
+    ASSERT_EQ(this->fromPortHistory_dataReturnOut->at(0).context, nullContext);
+    // InvalidLength event must fire.
+    // The EVR argument for transmitted length is static_cast<U16>(pkt_length_wide)
+    // where pkt_length_wide=65536, so static_cast<U16>(65536)=0 — same result as
+    // static_cast<U16>(overflowLengthToken + 1).
+    // maxDataAvailable = bufSize - SERIALIZED_SIZE = 1.
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_InvalidLength_SIZE(1);
+    ASSERT_EVENTS_InvalidLength(0, static_cast<U16>(overflowLengthToken + 1), sizeof(payload));
+}
+
+// ----------------------------------------------------------------------
+// Finding 3 — graceful handling of undersized buffers (no FW_ASSERT)
+// ----------------------------------------------------------------------
+
+void SpacePacketDeframerTester ::testBufferExactlyHeaderSize() {
+    // A buffer of exactly SERIALIZED_SIZE bytes passes the `>` check in the
+    // original FW_ASSERT version only if the check was `<` — the updated
+    // check uses `<=` so this must be caught and dropped gracefully.
+    // This is the tightest boundary case for the size guard.
+    U8 rawData[SpacePacketHeader::SERIALIZED_SIZE] = {};
+    Fw::Buffer buffer(rawData, SpacePacketHeader::SERIALIZED_SIZE);
+    ComCfg::FrameContext nullContext;
+
+    this->invoke_to_dataIn(0, buffer, nullContext);
+
+    ASSERT_from_dataOut_SIZE(0);
+    ASSERT_from_dataReturnOut_SIZE(1);
+    ASSERT_from_errorNotify(0, Svc::Ccsds::FrameError::SP_INVALID_PACKET);
+    ASSERT_FROM_PORT_HISTORY_SIZE(2);  // dataReturnOut + errorNotify
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_InvalidPacket_SIZE(1);
+}
+
+void SpacePacketDeframerTester ::testBufferSmallerThanHeaderSize() {
+    // A buffer smaller than SERIALIZED_SIZE — cannot hold even the header.
+    // Must be dropped gracefully without asserting.
+    U8 rawData[SpacePacketHeader::SERIALIZED_SIZE - 1] = {};
+    Fw::Buffer buffer(rawData, SpacePacketHeader::SERIALIZED_SIZE - 1);
+    ComCfg::FrameContext nullContext;
+
+    this->invoke_to_dataIn(0, buffer, nullContext);
+
+    ASSERT_from_dataOut_SIZE(0);
+    ASSERT_from_dataReturnOut_SIZE(1);
+    ASSERT_from_errorNotify(0, Svc::Ccsds::FrameError::SP_INVALID_PACKET);
+    ASSERT_FROM_PORT_HISTORY_SIZE(2);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_InvalidPacket_SIZE(1);
+}
+
+void SpacePacketDeframerTester ::testBufferSingleByte() {
+    // Single-byte buffer — most extreme undersize input.
+    // Verifies the size guard fires and no crash occurs.
+    U8 rawData[1] = {0xFF};
+    Fw::Buffer buffer(rawData, sizeof(rawData));
+    ComCfg::FrameContext nullContext;
+
+    this->invoke_to_dataIn(0, buffer, nullContext);
+
+    ASSERT_from_dataOut_SIZE(0);
+    ASSERT_from_dataReturnOut_SIZE(1);
+    ASSERT_from_errorNotify(0, Svc::Ccsds::FrameError::SP_INVALID_PACKET);
+    ASSERT_FROM_PORT_HISTORY_SIZE(2);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_InvalidPacket_SIZE(1);
+}
 
 Fw::Buffer SpacePacketDeframerTester ::assemblePacket(U16 apid,
                                                       U16 seqCount,

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.hpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.hpp
@@ -48,6 +48,19 @@ class SpacePacketDeframerTester final : public SpacePacketDeframerGTestBase {
     void testDeframingIncorrectLength();
     // void testDeframingIncorrectSeqCount();
 
+    // Finding 1 — U16 overflow in pkt_length calculation.
+    // packetDataLength=0xFFFF causes static_cast<U16>(0xFFFF+1)=0 without the
+    // fix, allowing an empty buffer to slip past the length guard and reach
+    // dataOut.  After the fix the packet must be rejected with InvalidLength.
+    void testPacketDataLengthMaxU16Overflow();
+
+    // Finding 3 — graceful handling of undersized buffers instead of FW_ASSERT.
+    // Buffers at or below SERIALIZED_SIZE must emit InvalidPacket and be dropped,
+    // never crash the FSW via an assert.
+    void testBufferExactlyHeaderSize();
+    void testBufferSmallerThanHeaderSize();
+    void testBufferSingleByte();
+
   private:
     // ----------------------------------------------------------------------
     // Helper functions

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.hpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.hpp
@@ -48,15 +48,7 @@ class SpacePacketDeframerTester final : public SpacePacketDeframerGTestBase {
     void testDeframingIncorrectLength();
     // void testDeframingIncorrectSeqCount();
 
-    // Finding 1 — U16 overflow in pkt_length calculation.
-    // packetDataLength=0xFFFF causes static_cast<U16>(0xFFFF+1)=0 without the
-    // fix, allowing an empty buffer to slip past the length guard and reach
-    // dataOut.  After the fix the packet must be rejected with InvalidLength.
     void testPacketDataLengthMaxU16Overflow();
-
-    // Finding 3 — graceful handling of undersized buffers instead of FW_ASSERT.
-    // Buffers at or below SERIALIZED_SIZE must emit InvalidPacket and be dropped,
-    // never crash the FSW via an assert.
     void testBufferExactlyHeaderSize();
     void testBufferSmallerThanHeaderSize();
     void testBufferSingleByte();


### PR DESCRIPTION
…in SpacePacketDeframer + unit tests

| | |
|:---|:---|
|**_Related Issue(s)_**| PR 5084  |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| N |
|**_Generative AI was used in this contribution (y/n)_**| Y |

---
## Change Description

For Issue 1, I added a guard to packetDataLength. The guard widens the arithmetic to U32 before adding 1, ensuring the overflow value 65536 correctly exceeds the available buffer size and the packet is rejected with an InvalidLength event.

For Issue 2, I replaced the ASSERT on the return status of deserializeTo(header). Before, the ASSERT would crash the  flight software if header deserialisation failed on a malformed or truncated incoming buffer. The fix replaces the ASSERT with a graceful check that emits an InvalidPacket warning event, drops the buffer, and returns — keeping the FSW operational.

## Rationale

These changes will improve the robustness of F Prime and make it less brittle to off-nominal conditions.

## Testing/Review Recommendations

Execute new unit tests for off-nominal conditions: 1) testPacketDataLengthMaxU16Overflow 2) testBufferExactlyHeaderSize, 3) testBufferSmallerThanHeaderSize, 4) testBufferSingleByte. 

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude was used to generate new unit tests.
