### PR TITLE
Fix ApidManager bug validating seqCount when table is full

### DIFF
--- a/Svc/Ccsds/ApidManager/ApidManager.cpp
+++ b/Svc/Ccsds/ApidManager/ApidManager.cpp
@@ -30,8 +30,9 @@ U16 ApidManager ::validateApidSeqCountIn_handler(FwIndexType portNum, const ComC
     if (receivedSeqCount != expectedSequenceCount) {
         // Likely a packet was dropped or out of order
         this->log_WARNING_LO_UnexpectedSequenceCount(receivedSeqCount, expectedSequenceCount);
-        // Sync onboard count with received so counting can keep going. Insert cannot fail:
-        // getAndIncrementSeqCount above already tracked this APID, so this only updates it.
+        // Sync onboard count to what was received so counting can keep going. Insert cannot fail:
+        // getAndIncrementSeqCount above inserted the APID already, we would have returned early
+        // due to SEQUENCE_COUNT_ERROR
         const Fw::Success insertStatus = m_apidSequences.insert(apid, this->calculateNextSeqCount(receivedSeqCount));
         FW_ASSERT(insertStatus == Fw::Success::SUCCESS, static_cast<FwAssertArgType>(apid));
     }

--- a/Svc/Ccsds/ApidManager/ApidManager.cpp
+++ b/Svc/Ccsds/ApidManager/ApidManager.cpp
@@ -22,12 +22,18 @@ ApidManager ::ApidManager(const char* const compName) : ApidManagerComponentBase
 // ----------------------------------------------------------------------
 
 U16 ApidManager ::validateApidSeqCountIn_handler(FwIndexType portNum, const ComCfg::Apid& apid, U16 receivedSeqCount) {
-    U16 expectedSequenceCount = this->getAndIncrementSeqCount(apid);
-    if (receivedSeqCount != expectedSequenceCount && receivedSeqCount != SEQUENCE_COUNT_ERROR) {
+    const U16 expectedSequenceCount = this->getAndIncrementSeqCount(apid);
+    if (expectedSequenceCount == SEQUENCE_COUNT_ERROR) {
+        // APID could not be tracked (table full); nothing to validate or sync against
+        return receivedSeqCount;
+    }
+    if (receivedSeqCount != expectedSequenceCount) {
         // Likely a packet was dropped or out of order
         this->log_WARNING_LO_UnexpectedSequenceCount(receivedSeqCount, expectedSequenceCount);
-        // Synchronize onboard count with received number so that count can keep going
-        this->setNextSeqCount(apid, this->calculateNextSeqCount(receivedSeqCount));
+        // Sync onboard count with received so counting can keep going. Insert cannot fail:
+        // getAndIncrementSeqCount above already tracked this APID, so this only updates it.
+        const Fw::Success insertStatus = m_apidSequences.insert(apid, this->calculateNextSeqCount(receivedSeqCount));
+        FW_ASSERT(insertStatus == Fw::Success::SUCCESS, static_cast<FwAssertArgType>(apid));
     }
     return receivedSeqCount;
 }
@@ -42,23 +48,16 @@ U16 ApidManager ::getApidSeqCountIn_handler(FwIndexType portNum, const ComCfg::A
 
 U16 ApidManager ::getAndIncrementSeqCount(ComCfg::Apid::T apid) {
     U16 seqCount = 0;
-    // Find sequence count if exists, otherwise use 0
+    // Find current sequence count if APID is tracked; otherwise default to 0 (first count for a new APID)
     (void)m_apidSequences.find(apid, seqCount);
-    // Increment sequence count for next call
-    U16 updatedSeqCount = this->calculateNextSeqCount(seqCount);
-
-    Fw::Success insertStatus = m_apidSequences.insert(apid, updatedSeqCount);
-    if (insertStatus == Fw::Success::SUCCESS) {
-        return seqCount;  // Return the current sequence count
+    // Store the next sequence count for this APID. If the APID is not yet tracked, this
+    // also registers it; insert can only fail when registering a new APID into a full table.
+    const Fw::Success insertStatus = m_apidSequences.insert(apid, this->calculateNextSeqCount(seqCount));
+    if (insertStatus != Fw::Success::SUCCESS) {
+        this->log_WARNING_HI_ApidTableFull(apid);
+        return SEQUENCE_COUNT_ERROR;
     }
-
-    this->log_WARNING_HI_ApidTableFull(apid);
-    return SEQUENCE_COUNT_ERROR;
-}
-
-void ApidManager::setNextSeqCount(ComCfg::Apid::T apid, U16 seqCount) {
-    Fw::Success insertStatus = m_apidSequences.insert(apid, seqCount);
-    FW_ASSERT(insertStatus == Fw::Success::SUCCESS, static_cast<FwAssertArgType>(apid));
+    return seqCount;
 }
 
 U16 ApidManager::calculateNextSeqCount(const U16 seqCount) const {

--- a/Svc/Ccsds/ApidManager/ApidManager.hpp
+++ b/Svc/Ccsds/ApidManager/ApidManager.hpp
@@ -68,12 +68,10 @@ class ApidManager final : public ApidManagerComponentBase {
     // ----------------------------------------------------------------------
     // Helpers
     // ----------------------------------------------------------------------
-    //! Get the sequence count for a given APID and increment it for the next
-    //! Wraps around at 14 bits
+    //! Get the sequence count for a given APID and increment it for the next.
+    //! Wraps around at 14 bits. Returns SEQUENCE_COUNT_ERROR (and logs ApidTableFull)
+    //! if the APID is not yet tracked and the table is full.
     U16 getAndIncrementSeqCount(ComCfg::Apid::T apid);
-
-    //! Set the next expected sequence count for a given APID
-    void setNextSeqCount(ComCfg::Apid::T apid, U16 seqCount);
 
     //! Helper function for wrapping around at 14 bits when calculating the next sequence count
     U16 calculateNextSeqCount(const U16 seqCount) const;

--- a/Svc/Ccsds/ApidManager/ApidManager.hpp
+++ b/Svc/Ccsds/ApidManager/ApidManager.hpp
@@ -69,7 +69,7 @@ class ApidManager final : public ApidManagerComponentBase {
     // Helpers
     // ----------------------------------------------------------------------
     //! Get the sequence count for a given APID and increment it for the next.
-    //! Wraps around at 14 bits. Returns SEQUENCE_COUNT_ERROR (and logs ApidTableFull)
+    //! Wraps around at 14 bits. Returns SEQUENCE_COUNT_ERROR and logs ApidTableFull event
     //! if the APID is not yet tracked and the table is full.
     U16 getAndIncrementSeqCount(ComCfg::Apid::T apid);
 

--- a/Svc/Ccsds/ApidManager/test/ut/ApidManagerTestMain.cpp
+++ b/Svc/Ccsds/ApidManager/test/ut/ApidManagerTestMain.cpp
@@ -47,10 +47,11 @@ TEST(ApidManager, ValidateSequenceCountWhenTableFull) {
     ApidManagerTester::ValidateSeqCount__NewTableFull ruleValidateNewTableFull;
     // Apply the NewOk rule until the table is full and the shadow flag flips.
     // The rule itself is responsible for flipping shadow_isTableFull when size has reached MAX.
-    while (!tester.shadow.shadow_isTableFull) {
+    FwIndexType iter_bound = 1000;
+    while (!tester.shadow.shadow_isTableFull && iter_bound-- > 0) {
         ruleGetNewOk.apply(tester);
     }
-    // Now exercise the bug path: validate a count for an untracked APID against a full table
+    // Now exercise the test path: validate a count for an untracked APID against a full table
     ruleValidateNewTableFull.apply(tester);
 }
 

--- a/Svc/Ccsds/ApidManager/test/ut/ApidManagerTestMain.cpp
+++ b/Svc/Ccsds/ApidManager/test/ut/ApidManagerTestMain.cpp
@@ -37,6 +37,23 @@ TEST(ApidManager, ValidateSequenceCounts) {
     ruleValidateFailure.apply(tester);  // validate wrong count; event expected
 }
 
+// Fill the APID table, then validate a count for an untracked APID.
+// Verifies that the component logs ApidTableFull, does NOT log
+// UnexpectedSequenceCount, and does not trip an FW_ASSERT trying to
+// re-sync the (untracked) APID.
+TEST(ApidManager, ValidateSequenceCountWhenTableFull) {
+    ApidManagerTester tester;
+    ApidManagerTester::GetSeqCount__NewOk ruleGetNewOk;
+    ApidManagerTester::ValidateSeqCount__NewTableFull ruleValidateNewTableFull;
+    // Apply the NewOk rule until the table is full and the shadow flag flips.
+    // The rule itself is responsible for flipping shadow_isTableFull when size has reached MAX.
+    while (!tester.shadow.shadow_isTableFull) {
+        ruleGetNewOk.apply(tester);
+    }
+    // Now exercise the bug path: validate a count for an untracked APID against a full table
+    ruleValidateNewTableFull.apply(tester);
+}
+
 // Randomized test: apply rules in a random sequence for a large number of iterations
 TEST(ApidManager, RandomizedTesting) {
     U32 numRulesToApply = 10000;
@@ -46,9 +63,11 @@ TEST(ApidManager, RandomizedTesting) {
     ApidManagerTester::GetSeqCount__NewTableFull ruleGetNewTableFull;
     ApidManagerTester::ValidateSeqCount__Ok ruleValidateOk;
     ApidManagerTester::ValidateSeqCount__Failure ruleValidateFailure;
+    ApidManagerTester::ValidateSeqCount__NewTableFull ruleValidateNewTableFull;
 
     STest::Rule<ApidManagerTester>* rules[] = {
-        &ruleGetExisting, &ruleGetNewOk, &ruleGetNewTableFull, &ruleValidateOk, &ruleValidateFailure,
+        &ruleGetExisting, &ruleGetNewOk,        &ruleGetNewTableFull,
+        &ruleValidateOk,  &ruleValidateFailure, &ruleValidateNewTableFull,
     };
 
     STest::RandomScenario<ApidManagerTester> random("Random Rules", rules, FW_NUM_ARRAY_ELEMENTS(rules));

--- a/Svc/Ccsds/ApidManager/test/ut/ApidManagerTester.hpp
+++ b/Svc/Ccsds/ApidManager/test/ut/ApidManagerTester.hpp
@@ -74,6 +74,7 @@ class ApidManagerTester : public ApidManagerGTestBase {
     //! Rules for the validateApidSeqCountIn port
     FW_RBT_DEFINE_RULE(ApidManagerTester, ValidateSeqCount, Ok);
     FW_RBT_DEFINE_RULE(ApidManagerTester, ValidateSeqCount, Failure);
+    FW_RBT_DEFINE_RULE(ApidManagerTester, ValidateSeqCount, NewTableFull);
 };
 
 }  // namespace Ccsds

--- a/Svc/Ccsds/ApidManager/test/ut/Rules/ValidateSeqCount.cpp
+++ b/Svc/Ccsds/ApidManager/test/ut/Rules/ValidateSeqCount.cpp
@@ -56,6 +56,34 @@ void ApidManagerTester::ValidateSeqCount__Failure__action() {
     ASSERT_EVENTS_UnexpectedSequenceCount(0, wrongCount, correctCount);
 }
 
+// ----------------------------------------------------------------------
+// ValidateSeqCount.NewTableFull
+//
+// Exercises validateApidSeqCountIn with an APID that is not currently
+// tracked while the APID table is full. The component must log
+// ApidTableFull, must NOT log UnexpectedSequenceCount, and must return
+// the received sequence count unchanged (the port is a passthrough).
+// ----------------------------------------------------------------------
+
+bool ApidManagerTester::ValidateSeqCount__NewTableFull__precondition() const {
+    return this->shadow.shadow_isTableFull;
+}
+
+void ApidManagerTester::ValidateSeqCount__NewTableFull__action() {
+    this->clearHistory();
+
+    ComCfg::Apid::T apid = this->shadow.shadow_getRandomUntrackedApid();
+    // Use any plausible 14-bit sequence count
+    constexpr U16 receivedSeqCount = 42;
+    U16 returned = this->invoke_to_validateApidSeqCountIn(0, apid, receivedSeqCount);
+
+    ASSERT_EQ(returned, receivedSeqCount) << "validateApidSeqCountIn must return the received count unchanged";
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_ApidTableFull_SIZE(1);
+    ASSERT_EVENTS_ApidTableFull(0, static_cast<U16>(apid));
+    ASSERT_EVENTS_UnexpectedSequenceCount_SIZE(0);
+}
+
 }  // namespace Ccsds
 
 }  // namespace Svc

--- a/docs/how-to/rule-based-testing.md
+++ b/docs/how-to/rule-based-testing.md
@@ -83,7 +83,6 @@ List the distinct behaviors the component can exhibit. For `ApidManager`, this w
 | Get count for new APID (table is full) | `getApidSeqCountIn` with untracked APID | Returns `SEQUENCE_COUNT_ERROR`, sends `ApidTableFull` event |
 | Validate correct count | `validateApidSeqCountIn` with expected count | No event |
 | Validate wrong count | `validateApidSeqCountIn` with unexpected count | Sends `UnexpectedSequenceCount` event |
-| Validate count for new APID (table is full) | `validateApidSeqCountIn` with untracked APID | Sends `ApidTableFull` event, no `UnexpectedSequenceCount` |
 
 Each row maps to one rule. The internal state of ApidManager is simple and linear: its table goes from empty, to in-filling, to full.  
 For components defining state machines, you would usually have at least one rule per transition, and preconditions naturally check against a specific state of the state machine.

--- a/docs/how-to/rule-based-testing.md
+++ b/docs/how-to/rule-based-testing.md
@@ -83,6 +83,7 @@ List the distinct behaviors the component can exhibit. For `ApidManager`, this w
 | Get count for new APID (table is full) | `getApidSeqCountIn` with untracked APID | Returns `SEQUENCE_COUNT_ERROR`, sends `ApidTableFull` event |
 | Validate correct count | `validateApidSeqCountIn` with expected count | No event |
 | Validate wrong count | `validateApidSeqCountIn` with unexpected count | Sends `UnexpectedSequenceCount` event |
+| Validate count for new APID (table is full) | `validateApidSeqCountIn` with untracked APID | Sends `ApidTableFull` event, no `UnexpectedSequenceCount` |
 
 Each row maps to one rule. The internal state of ApidManager is simple and linear: its table goes from empty, to in-filling, to full.  
 For components defining state machines, you would usually have at least one rule per transition, and preconditions naturally check against a specific state of the state machine.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Fixes a bug in ApidManager where validating a sequence count for a new APID would behave improperly if the Apid table is full.
Adds a test to cover this case.
Reduces complexity and odd code flow that was an artifact of migrating from inline data structures to map + odd choices by past me.