### PR TITLE
Fix CommandDispatcher sequence number wraparound error

### DIFF
--- a/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
@@ -121,6 +121,9 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
 
     // increment sequence number
     this->m_seq++;
+    if (this->m_seq >= CMD_SEQ_GUARD) {
+        this->m_seq = 0;
+    }
 }
 
 void CommandDispatcherImpl ::run_handler(FwIndexType portNum, U32 context) {

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
@@ -166,6 +166,10 @@ class CommandDispatcherImpl final : public CommandDispatcherComponentBase {
     //! \brief map from command sequence number to pending command state
     Fw::ArrayMap<U32, SequenceTrackerEntry, CMD_DISPATCHER_SEQUENCER_TABLE_SIZE> m_sequenceTracker;
 
+    //!< Guard for wrap-around
+    static constexpr U32 CMD_SEQ_GUARD =
+    std::numeric_limits<U32>::max() - CMD_DISPATCHER_SEQUENCER_TABLE_SIZE;
+
     U32 m_seq;  //!< current command sequence number
 
     U32 m_numCmdsDispatched;  //!< number of commands dispatched


### PR DESCRIPTION
Resolves #5082

| | |
|:---|:---|
|**_Related Issue(s)_**|  #5082 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

  This PR addresses the sequence number wraparound error in CommandDispatcherImpl as described in #5082.
  
## Rationale

  Fixes a bug where the command dispatcher can become deadlocked if m_seq wraps around to 0 and attempts to insert into m_sequenceTracker when an entry from the previous cycle remains. By resetting m_seq before it reaches the maximum U32 value minus the table size, we guarantee that duplicate sequence key collisions are avoided.
  
## Testing/Review Recommendations

All existing unit tests in Svc/CmdDispatcher pass locally (fprime-util build --ut and fprime-util check). 

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Use AI (gemini) to help familiarize myself with the codebase. 
