### PR TITLE
Enhance queue overflow condition check

### DIFF
--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -325,7 +325,8 @@ bool ComQueue::enqueue(const FwIndexType queueNum, QueueType queueType, const U8
         for (FwIndexType i = 0; i < TOTAL_PORT_COUNT; i++) {
             if (this->m_prioritizedList[i].index == queueNum &&
                 this->m_prioritizedList[i].overflowMode == Types::QUEUE_DROP_OLDEST &&
-                queue.getQueueSize() >= this->m_prioritizedList[i].depth) {
+                queue.getQueueSize() >= this->m_prioritizedList[i].depth &&
+                this->m_prioritizedList[i].depth != 0) {
                 // Queue is full and will drop oldest; remove the front entry to return ownership.
                 // popFront() always removes from the front (oldest) regardless of queue mode,
                 // matching the rotate-based removal that Queue::enqueue() uses for DROP_OLDEST.

--- a/Svc/ComQueue/ComQueue.cpp
+++ b/Svc/ComQueue/ComQueue.cpp
@@ -325,8 +325,7 @@ bool ComQueue::enqueue(const FwIndexType queueNum, QueueType queueType, const U8
         for (FwIndexType i = 0; i < TOTAL_PORT_COUNT; i++) {
             if (this->m_prioritizedList[i].index == queueNum &&
                 this->m_prioritizedList[i].overflowMode == Types::QUEUE_DROP_OLDEST &&
-                queue.getQueueSize() >= this->m_prioritizedList[i].depth &&
-                this->m_prioritizedList[i].depth != 0) {
+                queue.getQueueSize() >= this->m_prioritizedList[i].depth && this->m_prioritizedList[i].depth != 0) {
                 // Queue is full and will drop oldest; remove the front entry to return ownership.
                 // popFront() always removes from the front (oldest) regardless of queue mode,
                 // matching the rotate-based removal that Queue::enqueue() uses for DROP_OLDEST.


### PR DESCRIPTION
Add additional check for non-zero depth in queue overflow condition so as to prevent an assertion.

Fixes #5096.

| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Fix #5096 