### PR TITLE
Fix memcpy without bounds checking (#5118)

### DIFF
--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -187,6 +187,10 @@ void TlmPacketizer ::TlmRecv_handler(const FwIndexType portNum,
             this->m_fillBuffers[pkt].updated = true;
             this->m_fillBuffers[pkt].latestTime = timeTag;
             U8* ptr = &this->m_fillBuffers[pkt].buffer.getBuffAddr()[entry.packetOffset[pkt]];
+            // validate before memcpy
+            FW_ASSERT(val.getSize() <= entry.channelSize, static_cast<FwAssertArgType>(val.getSize()),
+                      static_cast<FwAssertArgType>(entry.channelSize));
+
             (void)memcpy(ptr, val.getBuffAddr(), static_cast<size_t>(val.getSize()));
             this->m_lock.unLock();
         }

--- a/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
+++ b/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
@@ -102,6 +102,7 @@ void TlmPacketizerTester ::pushTlmTest() {
     this->invoke_to_TlmRecv(0, 333, ts, buff);
 
     // second channel
+    buff.resetSer();
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(50)));
     this->invoke_to_TlmRecv(0, 10, ts, buff);
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| PR 5118 |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| N |
|**_Generative AI was used in this contribution (y/n)_**|  N |

---
## Change Description

Added bound check before memcpy

## Rationale

Bounds checking should be performed before a memcpy to avoid a potential buffer overflow.

## Testing/Review Recommendations

Ironically, the existing unit test for TlmPacketizer has a bug where it was overwriting the buffer. Because there was no bound checking, the unit tests erroneously passed. When I implemented this change, the unit test failed (correctly) because it was overflowing the buffer. 

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

No
