### PR TITLE
Fix GitHub Actions for v3.6.x Branch

### DIFF
--- a/.github/workflows/build-test-rpi.yml
+++ b/.github/workflows/build-test-rpi.yml
@@ -52,7 +52,7 @@ jobs:
         retention-days: 5
 
   RPI-Integration:
-    runs-on: self-hosted
+    runs-on: raspberrypi
     needs: RPI
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -68,7 +68,7 @@ jobs:
 
   RPI-integration:
     name: "RPI Integration Tests"
-    runs-on: self-hosted
+    runs-on: raspberrypi
     needs: cross-compilation
     steps:
       - name: "Checkout F´ Repository"
@@ -91,12 +91,6 @@ jobs:
           mkdir -p ci-logs
           chmod +x ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker
           fprime-gds --ip-client -d ./build-artifacts/raspberrypi/LedBlinker --logs ./ci-logs &
-          echo "PWD=$(pwd)"
-          find ./build-artifacts -maxdepth 4 | sort
-          stat ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker || true
-          file ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker || true
-          readlink -f ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker || true
-          ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker --help || true
           sleep 10
           pytest --dictionary ./build-artifacts/raspberrypi/LedBlinker/dict/LedBlinkerTopologyDictionary.json ./int/led_integration_tests.py
       - name: 'Archive logs'

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           submodules: false
           repository: fprime-community/fprime-workshop-led-blinker
-          ref: ${{ needs.get-branch.outputs.target-branch }}
+          ref: v3.6.0
       - name: "Overlay current F´ revision"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -91,6 +91,12 @@ jobs:
           mkdir -p ci-logs
           chmod +x ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker
           fprime-gds --ip-client -d ./build-artifacts/raspberrypi/LedBlinker --logs ./ci-logs &
+          echo "PWD=$(pwd)"
+          find ./build-artifacts -maxdepth 4 | sort
+          stat ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker || true
+          file ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker || true
+          readlink -f ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker || true
+          ./build-artifacts/raspberrypi/LedBlinker/bin/LedBlinker --help || true
           sleep 10
           pytest --dictionary ./build-artifacts/raspberrypi/LedBlinker/dict/LedBlinkerTopologyDictionary.json ./int/led_integration_tests.py
       - name: 'Archive logs'

--- a/.github/workflows/pip-check.yml
+++ b/.github/workflows/pip-check.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         # macos-13 is the last Intel-family runner; macos-latest is ARM
-        runner: [macos-13, macos-latest, ubuntu-22.04, ubuntu-latest]
+        runner: [macos-15-intel, macos-latest, ubuntu-22.04, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| no |
|**_Documentation Included (y/n)_**| no |
|**_Generative AI was used in this contribution (y/n)_**| no |

---
## Change Description

Pin the external RPI LED Blinker testing to v3.6.0 to avoid breaking changes with this branch.  Update macos pip dependency check to match `devel` branch.

## Rationale

Update baseline GitHub Actions for v3.6.5 hotfix release.

## Testing/Review Recommendations

All actions should pass successfully.

## Future Work

There are many Node version warnings, similar to `devel`.  Action versions should probably be updated.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI was not used to generate changes for this PR.
