### PR TITLE
fix(CmdSequencer): clear sequence buffer on failed loadFile

### DIFF
--- a/Svc/CmdSequencer/CmdSequencerImpl.cpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.cpp
@@ -236,6 +236,16 @@ bool CmdSequencerComponentImpl ::loadFile(const Fw::ConstStringBase& fileName) {
         this->log_ACTIVITY_LO_CS_SequenceLoaded(logFileName);
         ++this->m_loadCmdCount;
         this->tlmWrite_CS_LoadCommands(this->m_loadCmdCount);
+    } else {
+        // A partial load may have populated m_buffer before an intermediate
+        // validation step (e.g. CRC, time, record structure) failed. Without
+        // an explicit reset, FPrimeSequence::hasMoreRecords() still returns
+        // true because getDeserializeSizeLeft() > 0, so a subsequent CS_START
+        // bypasses the "no sequence active" guard and reaches
+        // FPrimeSequence::nextRecord, which asserts on the failed deserialize
+        // and aborts the FSW. Clearing the sequence on every load failure
+        // closes that window.
+        this->m_sequence->clear();
     }
     return status;
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| (none — newly discovered) |
|**_Has Unit Tests (y/n)_**| n (see Future Work) |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y (code generation, testing)|

---
## Change Description

In `CmdSequencerComponentImpl::loadFile`, call `m_sequence->clear()` when
the underlying `FPrimeSequence::loadFile` returns `false`. Previously the
internal `m_buffer` was left holding the partial, unvalidated bytes from
a failed load (for example, when `readFile` succeeded but a subsequent
CRC, time, or record-structure check failed). A subsequent `CS_START`
then saw `hasMoreRecords()` return `true`, bypassed the
`CS_NoSequenceActive` guard, advanced into `nextRecord`, and aborted the
FSW on `FW_ASSERT(status == Fw::FW_SERIALIZE_OK)` at `FPrimeSequence.cpp:66`.

## Rationale

`CS_RUN` followed by `CS_START` is an operator-reachable sequence — the
FSW must not crash in response. Resetting the buffer on every load
failure restores the contract that `hasMoreRecords()` reflects whether a
*valid* sequence is currently loaded, so the existing guard inside
`CS_START_cmdHandler` can do its job.

## Testing/Review Recommendations

Reproduction on the Ref deployment (vanilla `devel` HEAD before patch):