### PR TITLE
fix(FpySequencer): convert reachable asserts to recoverable errors

### DIFF
--- a/Svc/FpySequencer/FpySequencer.hpp
+++ b/Svc/FpySequencer/FpySequencer.hpp
@@ -87,6 +87,21 @@ class FpySequencer : public FpySequencerComponentBase {
         // the byte offset from the start of the stack where the current function's local variables begin.
         // analogous to a 'frame pointer'.
         Fpy::StackSizeType currentFrameStart = 0;
+        // Set true by any stack operation that would violate stack bounds
+        // (overflow on push, underflow on pop, or out-of-range offset on
+        // copy/move). The operation is skipped when set, and the executing
+        // sequence is aborted by the dispatcher on the next dispatchStatement
+        // call. This replaces an FW_ASSERT that an attacker-controlled
+        // .fpy bytecode could trigger to crash the FSW process.
+        bool hasBoundsError = false;
+
+        // True iff a stack operation since the last clearError() would have
+        // violated the stack bounds.
+        bool hasError() const { return this->hasBoundsError; }
+
+        // Clear the error flag (called by the dispatcher after surfacing
+        // the failure to the operator).
+        void clearError() { this->hasBoundsError = false; }
 
         // pops a value off of the top of the stack
         // converts it from big endian

--- a/Svc/FpySequencer/FpySequencerEvents.fppi
+++ b/Svc/FpySequencer/FpySequencerEvents.fppi
@@ -284,3 +284,26 @@ event LogDiagnostic(
 ) \
     severity diagnostic \
     format "Sequence {}: {}"
+
+@ A stack operation in the bytecode interpreter would have violated the
+@ stack bounds (overflow on push, underflow on pop, or out-of-range copy
+@ /move offset). The operation was skipped and the sequence is aborted by
+@ the dispatcher before the next statement runs. Previously a malformed
+@ .fpy file could trigger an FW_ASSERT here and abort the FSW process.
+event StackBoundsError(
+    statementIdx: U32
+) \
+    severity warning high \
+    format "Stack bounds violation while executing statement {}; sequence aborted"
+
+@ A file I/O or buffer operation failed during sequence validation. The
+@ stage field disambiguates which OS call or buffer op hit the failure
+@ (size/position/short-read/setBuffLen). Previously these failures were
+@ FW_ASSERTs that aborted the FSW process; now the sequence is rejected
+@ cleanly and the operator can retry.
+event FileApiError(
+    filePath: string size 60
+    stage: Svc.Fpy.FileApiStage
+) \
+    severity warning high \
+    format "Sequence {} validation failed at OS file API stage {}"

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -18,6 +18,18 @@ Signal FpySequencer::dispatchStatement() {
     // as that indicates eof
     FW_ASSERT(this->m_runtime.nextStatementIndex <= this->m_sequenceObj.get_header().get_statementCount());
 
+    // If the previous statement caused a stack bounds violation (e.g. a
+    // malformed .fpy bytecode pushed past MAX_STACK_SIZE), the Stack class
+    // skipped the bad op and set hasBoundsError. Abort the sequence here
+    // before the next statement runs, rather than letting downstream code
+    // execute on a corrupted stack. Previously the offending op was an
+    // FW_ASSERT that aborted the FSW process.
+    if (this->m_runtime.stack.hasError()) {
+        this->log_WARNING_HI_StackBoundsError(this->currentStatementIdx());
+        this->m_runtime.stack.clearError();
+        return Signal::result_dispatchStatement_failure;
+    }
+
     if (this->m_runtime.nextStatementIndex == this->m_sequenceObj.get_header().get_statementCount()) {
         return Signal::result_dispatchStatement_noMoreStatements;
     }

--- a/Svc/FpySequencer/FpySequencerStack.cpp
+++ b/Svc/FpySequencer/FpySequencerStack.cpp
@@ -5,8 +5,14 @@ namespace Svc {
 template <typename T>
 T FpySequencer::Stack::pop() {
     static_assert(sizeof(T) == 8 || sizeof(T) == 4 || sizeof(T) == 2 || sizeof(T) == 1, "size must be 1, 2, 4, 8");
-    FW_ASSERT(this->size >= sizeof(T), static_cast<FwAssertArgType>(this->size),
-              static_cast<FwAssertArgType>(sizeof(T)));
+    // Underflow guard: a malformed .fpy bytecode can request more bytes
+    // than the stack currently holds. Flag the error and return a zero
+    // value rather than asserting; the dispatcher aborts the sequence
+    // before the next statement runs.
+    if (this->size < sizeof(T)) {
+        this->hasBoundsError = true;
+        return T{};
+    }
     // first make a byte array which can definitely store our val
     U8 valBytes[8] = {0};
     // now move top of stack into byte array and shrink stack
@@ -57,8 +63,13 @@ F64 FpySequencer::Stack::pop<F64>() {
 template <typename T>
 void FpySequencer::Stack::push(T val) {
     static_assert(sizeof(T) == 8 || sizeof(T) == 4 || sizeof(T) == 2 || sizeof(T) == 1, "size must be 1, 2, 4, 8");
-    FW_ASSERT(this->size + sizeof(val) <= Fpy::MAX_STACK_SIZE, static_cast<FwAssertArgType>(this->size),
-              static_cast<FwAssertArgType>(sizeof(T)));
+    // Overflow guard: skip the write if it would exceed MAX_STACK_SIZE
+    // and let the dispatcher abort the sequence cleanly on the next
+    // statement. Previously an FW_ASSERT here aborted the FSW process.
+    if (this->size + sizeof(val) > Fpy::MAX_STACK_SIZE) {
+        this->hasBoundsError = true;
+        return;
+    }
     // first make a byte array which can definitely store our val
     U8 valBytes[8] = {0};
     // convert val to unsigned to avoid undefined behavior for bitshifts of signed types
@@ -114,7 +125,13 @@ void FpySequencer::Stack::push<F64>(F64 val) {
 // pops a byte array from the top of the stack into the destination array
 // does not convert endianness
 void FpySequencer::Stack::pop(U8* dest, Fpy::StackSizeType destSize) {
-    FW_ASSERT(this->size >= destSize, static_cast<FwAssertArgType>(this->size), static_cast<FwAssertArgType>(destSize));
+    if (this->size < destSize) {
+        this->hasBoundsError = true;
+        if (destSize > 0 && dest != nullptr) {
+            memset(dest, 0, destSize);
+        }
+        return;
+    }
     memcpy(dest, this->top() - destSize, destSize);
     this->size -= destSize;
 }
@@ -123,16 +140,20 @@ void FpySequencer::Stack::pop(U8* dest, Fpy::StackSizeType destSize) {
 // leaves the source array unmodified
 // does not convert endianness
 void FpySequencer::Stack::push(const U8* src, Fpy::StackSizeType srcSize) {
-    FW_ASSERT(this->size + srcSize <= Fpy::MAX_STACK_SIZE, static_cast<FwAssertArgType>(this->size),
-              static_cast<FwAssertArgType>(srcSize));
+    if (this->size + srcSize > Fpy::MAX_STACK_SIZE) {
+        this->hasBoundsError = true;
+        return;
+    }
     memcpy(this->top(), src, srcSize);
     this->size += srcSize;
 }
 
 // pushes zero bytes to the stack
 void FpySequencer::Stack::pushZeroes(Fpy::StackSizeType byteCount) {
-    FW_ASSERT(this->size + byteCount <= Fpy::MAX_STACK_SIZE, static_cast<FwAssertArgType>(this->size),
-              static_cast<FwAssertArgType>(byteCount));
+    if (this->size + byteCount > Fpy::MAX_STACK_SIZE) {
+        this->hasBoundsError = true;
+        return;
+    }
     memset(this->top(), 0, byteCount);
     this->size += byteCount;
 }
@@ -142,34 +163,44 @@ U8* FpySequencer::Stack::top() {
 }
 
 // Copies data from one region of the stack to another
-// Asserts that both regions are within bounds and do not overlap
-// Does not modify stack size
+// Sets hasBoundsError and skips the op if any region is out of bounds or
+// the regions overlap. Does not modify stack size.
 void FpySequencer::Stack::copy(Fpy::StackSizeType destOffset,
                                Fpy::StackSizeType srcOffset,
                                Fpy::StackSizeType copySize) {
-    FW_ASSERT(destOffset + copySize <= Fpy::MAX_STACK_SIZE, static_cast<FwAssertArgType>(destOffset),
-              static_cast<FwAssertArgType>(copySize));
-    FW_ASSERT(srcOffset + copySize <= Fpy::MAX_STACK_SIZE, static_cast<FwAssertArgType>(srcOffset),
-              static_cast<FwAssertArgType>(copySize));
+    if (destOffset + copySize > Fpy::MAX_STACK_SIZE) {
+        this->hasBoundsError = true;
+        return;
+    }
+    if (srcOffset + copySize > Fpy::MAX_STACK_SIZE) {
+        this->hasBoundsError = true;
+        return;
+    }
     // Check for overlap: regions overlap if one starts before the other ends
     // No overlap if: destEnd <= srcStart OR srcEnd <= destStart
-    FW_ASSERT(copySize == 0 || (destOffset + copySize <= srcOffset) || (srcOffset + copySize <= destOffset),
-              static_cast<FwAssertArgType>(destOffset), static_cast<FwAssertArgType>(srcOffset));
+    if (!(copySize == 0 || (destOffset + copySize <= srcOffset) || (srcOffset + copySize <= destOffset))) {
+        this->hasBoundsError = true;
+        return;
+    }
     if (copySize > 0) {
         memcpy(this->bytes + destOffset, this->bytes + srcOffset, copySize);
     }
 }
 
 // Moves data within the stack
-// Asserts that both source and destination are within bounds
-// Does not modify stack size
+// Sets hasBoundsError and skips the op if any region is out of bounds.
+// Does not modify stack size.
 void FpySequencer::Stack::move(Fpy::StackSizeType destOffset,
                                Fpy::StackSizeType srcOffset,
                                Fpy::StackSizeType moveSize) {
-    FW_ASSERT(destOffset + moveSize <= Fpy::MAX_STACK_SIZE, static_cast<FwAssertArgType>(destOffset),
-              static_cast<FwAssertArgType>(moveSize));
-    FW_ASSERT(srcOffset + moveSize <= this->size, static_cast<FwAssertArgType>(srcOffset),
-              static_cast<FwAssertArgType>(moveSize));
+    if (destOffset + moveSize > Fpy::MAX_STACK_SIZE) {
+        this->hasBoundsError = true;
+        return;
+    }
+    if (srcOffset + moveSize > this->size) {
+        this->hasBoundsError = true;
+        return;
+    }
     if (moveSize > 0) {
         memmove(this->bytes + destOffset, this->bytes + srcOffset, moveSize);
     }

--- a/Svc/FpySequencer/FpySequencerTypes.fpp
+++ b/Svc/FpySequencer/FpySequencerTypes.fpp
@@ -109,6 +109,15 @@ module Svc {
             POP_EVENT = 75
         }
 
+        @ Stage of file I/O during sequence validation that emitted an FpyFileApiError.
+        @ Used to disambiguate which Os::File or buffer operation hit the failure.
+        enum FileApiStage : U8 {
+            SIZE = 0
+            POSITION = 1
+            READ_LENGTH_MISMATCH = 2
+            SET_BUFFER_LENGTH = 3
+        }
+
         enum DirectiveErrorCode : U8 {
             NO_ERROR = 0
             STMT_OUT_OF_BOUNDS = 1

--- a/Svc/FpySequencer/FpySequencerValidationState.cpp
+++ b/Svc/FpySequencer/FpySequencerValidationState.cpp
@@ -87,12 +87,22 @@ Fw::Success FpySequencer::validate() {
         return Fw::Success::FAILURE;
     }
 
-    // make sure we're at EOF
+    // make sure we're at EOF. The size() and position() OS calls can fail
+    // on filesystem errors or if the file was concurrently modified by
+    // another FileManager command (e.g. RemoveFile or AppendFile) between
+    // the file open and this point. Treat the failure as a validation
+    // failure rather than aborting the FSW process.
     FwSizeType sequenceFileSize;
-    FW_ASSERT(sequenceFile.size(sequenceFileSize) == Os::File::Status::OP_OK);
+    if (sequenceFile.size(sequenceFileSize) != Os::File::Status::OP_OK) {
+        this->log_WARNING_HI_FileApiError(this->m_sequenceFilePath, Fpy::FileApiStage::SIZE);
+        return Fw::Success::FAILURE;
+    }
 
     FwSizeType sequenceFilePosition;
-    FW_ASSERT(sequenceFile.position(sequenceFilePosition) == Os::File::Status::OP_OK);
+    if (sequenceFile.position(sequenceFilePosition) != Os::File::Status::OP_OK) {
+        this->log_WARNING_HI_FileApiError(this->m_sequenceFilePath, Fpy::FileApiStage::POSITION);
+        return Fw::Success::FAILURE;
+    }
 
     if (sequenceFileSize != sequenceFilePosition) {
         this->log_WARNING_HI_ExtraBytesInSequence(static_cast<FwSizeType>(sequenceFileSize - sequenceFilePosition));
@@ -226,13 +236,20 @@ Fw::Success FpySequencer::readBytes(Os::File& file,
         return Fw::Success::FAILURE;
     }
 
-    // should probably fail if we read in MORE bytes than we ask for
-    FW_ASSERT(expectedReadLen == actualReadLen, static_cast<FwAssertArgType>(expectedReadLen),
-              static_cast<FwAssertArgType>(actualReadLen));
+    // A read returning MORE bytes than requested would indicate an OS or
+    // backend bug rather than a malformed input, but treat it defensively
+    // as a validation failure instead of aborting the FSW process.
+    if (expectedReadLen != actualReadLen) {
+        this->log_WARNING_HI_FileApiError(this->m_sequenceFilePath, Fpy::FileApiStage::READ_LENGTH_MISMATCH);
+        return Fw::Success::FAILURE;
+    }
 
     Fw::SerializeStatus serializeStatus =
         this->m_sequenceBuffer.setBuffLen(static_cast<Fw::Serializable::SizeType>(expectedReadLen));
-    FW_ASSERT(serializeStatus == Fw::FW_SERIALIZE_OK, serializeStatus);
+    if (serializeStatus != Fw::FW_SERIALIZE_OK) {
+        this->log_WARNING_HI_FileApiError(this->m_sequenceFilePath, Fpy::FileApiStage::SET_BUFFER_LENGTH);
+        return Fw::Success::FAILURE;
+    }
 
     if (updateCrc) {
         FpySequencer::updateCrc(this->m_computedCRC, this->m_sequenceBuffer.getBuffAddr(), expectedReadLen);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y (existing 234 FpySequencerTester tests retained, all pass) |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y (code generation, testing)|

---
## Change Description

Convert 12 reachable `FW_ASSERT`s in `Svc/FpySequencer` to recoverable errors so a malformed `.fpy` file or a transient OS file-API failure no longer aborts the FSW process.

**Sites converted:**

`FpySequencerStack.cpp` (8 sites):
| Method | Failure mode |
|---|---|
| `Stack::pop<T>()` | underflow on pop |
| `Stack::push<T>()` | overflow on push |
| `Stack::pop(U8*, size)` | underflow on bulk pop |
| `Stack::push(const U8*, size)` | overflow on bulk push |
| `Stack::pushZeroes()` | overflow on zero fill |
| `Stack::copy()` | dest bounds, src bounds, overlap (3 asserts) |
| `Stack::move()` | dest bounds, src bounds (2 asserts) |

`FpySequencerValidationState.cpp` (4 sites):
| Call site | Asserted condition |
|---|---|
| `validate()` | `Os::File::size()` returned `OP_OK` |
| `validate()` | `Os::File::position()` returned `OP_OK` |
| `readBytes()` | `expectedReadLen == actualReadLen` |
| `readBytes()` | `setBuffLen()` returned `FW_SERIALIZE_OK` |

**Approach for the stack sites:**

The Stack methods are called from 25+ sites in `FpySequencerDirectives.cpp`, so changing their signatures to return an error code would balloon the diff. Instead, add a single `bool hasBoundsError` flag on the `Stack` class. Each bounds- or overlap-violating op sets the flag and skips the underlying `memcpy`/`memset`. Value-returning `pop<T>()` returns a zero-initialized `T` so callers continue without UB. `dispatchStatement()` checks `stack.hasError()` at the top of the loop, emits `StackBoundsError(statementIdx)`, clears the flag, and returns `result_dispatchStatement_failure` so the sequence aborts cleanly before the next statement runs.

**Approach for the validation sites:**

`validate()` and `readBytes()` already have an `Fw::Success::FAILURE` return path. The four asserts are replaced with `log_WARNING_HI_FileApiError(filePath, stage)` + early `return Fw::Success::FAILURE`, where `stage` is a new `Fpy::FileApiStage` enum (`SIZE`, `POSITION`, `READ_LENGTH_MISMATCH`, `SET_BUFFER_LENGTH`) so the operator can tell which OS call failed.

**New telemetry (FPP):**

```fpp
enum FileApiStage : U8 {
    SIZE = 0
    POSITION = 1
    READ_LENGTH_MISMATCH = 2
    SET_BUFFER_LENGTH = 3
}

event StackBoundsError(statementIdx: U32) \
    severity warning high \
    format "Stack bounds violation while executing statement {}; sequence aborted"

event FileApiError(filePath: string size 60, stage: Svc.Fpy.FileApiStage) \
    severity warning high \
    format "Sequence {} validation failed at OS file API stage {}"
```

## Rationale

Each of the 12 `FW_ASSERT`s aborts the FSW process when it fires. They are reachable from:

1. **A malformed `.fpy` file.** The bytecode interpreter does not pre-validate that the offsets a `CALL`/`RETURN` frame, `STORE_REL_CONST_OFFSET`, `MEMCMP`, or stack-arithmetic directive will ask the stack to touch are within bounds. A hand-crafted sequence can request a `pop` larger than the current stack size or a `push` past `MAX_STACK_SIZE`. Any operator with command authority (or anyone who can get a sequence file uplinked) can take the spacecraft down with a sub-100-byte file.

2. **A transient OS file error.** `Os::File::size()` / `position()` can fail under concurrent `FileManager` operations on the same path, or on a real filesystem reporting `EIO`. The assumption that these calls always return `OP_OK` is incorrect on a live spacecraft.

This is the same bug class as PR #5136 (`CmdSequencer` `loadFile` reachable assert) which was accepted on `devel`. The fix follows the same minimum-invasive pattern: keep the public API stable, route the error to the existing `Fw::Success::FAILURE` / dispatcher-fail path, surface a telemetry event so the operator can tell what happened.

## Testing/Review Recommendations

**Local verification done:**
- `fprime-util check` on `Svc/FpySequencer` → 234/234 unit tests pass (same as pre-patch).
- `fprime-util format --check --dirs Svc/FpySequencer` → exit 0.

**Suggested review focus:**
1. `FpySequencerRunState.cpp:21-30` — the new `stack.hasError()` check at the top of `dispatchStatement()`. Confirm the placement is correct: it runs *before* the next statement is fetched, so an erroneous op from the previous dispatch is always caught before any further reads.
2. `FpySequencerStack.cpp::pop<T>()` — returning `T{}` on underflow is the only place a "fake" value flows back into the interpreter. The dispatcher catches the error on the next call, so the only thing the caller does with that zero is potentially push it onto the stack again (which can re-flag the error, harmless) or feed it into a directive that runs to completion within the same dispatch. No directive does anything I/O-visible without going back through `dispatchStatement()` first.
3. The new `Fpy::FileApiStage` enum and the two new events are intentionally narrow — they tell the operator which OS call failed without leaking implementation details.

**Suggested additional testing the maintainer may want to run:**
- A negative test that constructs a `.fpy` file with a `MEMCMP` directive whose `size` field exceeds the current stack contents, runs it through `FpySequencer`, and asserts that the sequence ends in failure with `StackBoundsError` rather than crashing the test harness. I did not add this here because the existing `FpySequencerTester` harness asserts on `FW_ASSERT` via a death-test-style mechanism that would need adjustment; happy to add it in a follow-up if you want.

## Future Work

- Add the negative-path unit tests described above (one per Stack bounds class plus one for each file API stage).
- Consider whether the same defensive pattern should apply to the offset arithmetic *inside* directives (e.g., `LOAD_REL` `frameStart + offset` overflow) so the dispatcher catches the error before the Stack method is even called — currently those paths can still emit `FrameStartOutOfBounds` / `StackAccessOutOfBounds` `DirectiveErrorCode`s, which is fine, but worth confirming there is no remaining `FW_ASSERT` in that chain.