### PR TITLE
Issue 5118 Fix

### DIFF
--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -186,7 +186,7 @@ void TlmPacketizer ::TlmRecv_handler(const FwIndexType portNum,
             this->m_lock.lock();
             this->m_fillBuffers[pkt].updated = true;
             this->m_fillBuffers[pkt].latestTime = timeTag;
-	    if (val.size() <= entry.channelSize){
+	    if (val.getSize() <= entry.channelSize){
             	U8* ptr = &this->m_fillBuffers[pkt].buffer.getBuffAddr()[entry.packetOffset[pkt]];
             	(void)memcpy(ptr, val.getBuffAddr(), static_cast<size_t>(val.getSize()));
 	    }

--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -186,8 +186,10 @@ void TlmPacketizer ::TlmRecv_handler(const FwIndexType portNum,
             this->m_lock.lock();
             this->m_fillBuffers[pkt].updated = true;
             this->m_fillBuffers[pkt].latestTime = timeTag;
-            U8* ptr = &this->m_fillBuffers[pkt].buffer.getBuffAddr()[entry.packetOffset[pkt]];
-            (void)memcpy(ptr, val.getBuffAddr(), static_cast<size_t>(val.getSize()));
+	    if (val.size() <= entry.channelSize){
+            	U8* ptr = &this->m_fillBuffers[pkt].buffer.getBuffAddr()[entry.packetOffset[pkt]];
+            	(void)memcpy(ptr, val.getBuffAddr(), static_cast<size_t>(val.getSize()));
+	    }
             this->m_lock.unLock();
         }
     }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5118  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

TlmPacketizer.cpp  -> TlmRecv_Handler() -> val size check before memcpy()

## Rationale

TlmRecv could overflow buffer into other m_channels corrupting other channels.

## Testing/Review Recommendations

1. Pass in a too large channel size
2. Monitor behavior with other telemetry related objects

## Future Work

* Add precheck for val being passed 
* Add else statement 

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Better understand the code base.
