### PR TITLE
Backport LinuxUartDriver rategroup-driven telemetry

### DIFF
--- a/Drv/LinuxUartDriver/LinuxUartDriver.cpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.cpp
@@ -297,13 +297,18 @@ LinuxUartDriver ::~LinuxUartDriver() {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-Drv::SendStatus LinuxUartDriver ::send_handler(const NATIVE_INT_TYPE portNum, Fw::Buffer& serBuffer) {
+void LinuxUartDriver ::run_handler(FwIndexType portNum, U32 context) {
+    this->tlmWrite_BytesSent(this->m_bytesSent);
+    this->tlmWrite_BytesRecv(this->m_bytesReceived);
+}
+
+Drv::SendStatus LinuxUartDriver ::send_handler(FwIndexType portNum, Fw::Buffer& sendBuffer) {
     Drv::SendStatus status = Drv::SendStatus::SEND_OK;
-    if (this->m_fd == -1 || serBuffer.getData() == nullptr || serBuffer.getSize() == 0) {
+    if (this->m_fd == -1 || sendBuffer.getData() == nullptr || sendBuffer.getSize() == 0) {
         status = Drv::SendStatus::SEND_ERROR;
     } else {
-        unsigned char *data = serBuffer.getData();
-        NATIVE_INT_TYPE xferSize = static_cast<NATIVE_INT_TYPE>(serBuffer.getSize());
+        unsigned char *data = sendBuffer.getData();
+        NATIVE_INT_TYPE xferSize = static_cast<NATIVE_INT_TYPE>(sendBuffer.getSize());
 
         NATIVE_INT_TYPE stat = static_cast<NATIVE_INT_TYPE>(::write(this->m_fd, data, static_cast<size_t>(xferSize)));
 
@@ -313,12 +318,11 @@ Drv::SendStatus LinuxUartDriver ::send_handler(const NATIVE_INT_TYPE portNum, Fw
             status = Drv::SendStatus::SEND_ERROR;
         } else {
             this->m_bytesSent += static_cast<U32>(stat);
-            this->tlmWrite_BytesSent(this->m_bytesSent);
         }
     }
     // Deallocate when necessary
     if (isConnected_deallocate_OutputPort(0)) {
-        deallocate_out(0, serBuffer);
+        deallocate_out(0, sendBuffer);
     }
     return status;
 }
@@ -361,7 +365,6 @@ void LinuxUartDriver ::serialReadTaskEntry(void* ptr) {
             buff.setSize(static_cast<U32>(stat));
             status = RecvStatus::RECV_OK;  // added by m.chase 03.06.2017
             comp->m_bytesReceived += static_cast<U32>(stat);
-            comp->tlmWrite_BytesRecv(comp->m_bytesReceived);
         } else {
             status = RecvStatus::RECV_ERROR; // Simply to return the buffer
         }

--- a/Drv/LinuxUartDriver/LinuxUartDriver.fpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.fpp
@@ -14,6 +14,9 @@ module Drv {
     @ Deallocates buffers passed to the "send" port
     output port deallocate: Fw.BufferSend
 
+    @ The rate group input for sending telemetry
+    sync input port run: Svc.Sched
+
     # ----------------------------------------------------------------------
     # Special ports
     # ----------------------------------------------------------------------

--- a/Drv/LinuxUartDriver/LinuxUartDriver.hpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.hpp
@@ -18,6 +18,7 @@
 #include <Os/Task.hpp>
 
 #include <termios.h>
+#include <atomic>
 
 namespace Drv {
 
@@ -91,14 +92,22 @@ class LinuxUartDriver : public LinuxUartDriverComponentBase {
     // Handler implementations for user-defined typed input ports
     // ----------------------------------------------------------------------
 
+    //! Handler implementation for run
+    //!
+    //! The rate group input for sending telemetry
+    void run_handler(FwIndexType portNum,  //!< The port number
+                     U32 context           //!< The call order
+                     ) override;
+
     //! Handler implementation for serialSend
     //!
-    Drv::SendStatus send_handler(NATIVE_INT_TYPE portNum, /*!< The port number*/
-                                 Fw::Buffer& serBuffer);
+    Drv::SendStatus send_handler(FwIndexType portNum,    //!< The port number
+                                 Fw::Buffer& sendBuffer  //!< Data to send
+                                 ) override;
 
 
     NATIVE_INT_TYPE m_fd;  //!< file descriptor returned for I/O device
-    U32 m_allocationSize; //!< size of allocation request to memory manager
+    U32 m_allocationSize;  //!< size of allocation request to memory manager
     const char* m_device;  //!< original device path
 
     //! This method will be called by the new thread to wait for input on the serial port.
@@ -106,9 +115,9 @@ class LinuxUartDriver : public LinuxUartDriverComponentBase {
 
     Os::Task m_readTask;  //!< task instance for thread to read serial port
 
-    U32 m_bytesSent;        //!< number of bytes sent
-    U32 m_bytesReceived;    //!< number of bytes received
-    bool m_quitReadThread;  //!< flag to quit thread
+    std::atomic<U32> m_bytesSent;      //!< number of bytes sent
+    std::atomic<U32> m_bytesReceived;  //!< number of bytes received
+    bool m_quitReadThread;             //!< flag to quit thread
 };
 
 }  // end namespace Drv


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5120 |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**| N |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

Backported #3980 to v3.6.x, making it so LinuxUartDriver won't spam the telemetry system every time it receives or sends a chunk of bytes. Instead, telemetry updates happen via rate group call.

Also updated the `send_handler()` header to match the existing fpp definition, changing `NATIVE_INT_TYPE` to `FwIndexType`, `serBuffer` to `sendBuffer`, and adding a missing `override` keyword.

## Rationale

Sending an update to the telemetry system every time bytes are sent/received could cause undue load on the telemetry system.

## Testing/Review Recommendations

I have confirmed that a test deployment sends incrementing UART RX/TX byte counts to F Prime GDS every time the rate group fires. It might be worth testing on more deployments / more architectures.

## Future Work

N/A
## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A