### PR TITLE
Add entries to .gitignore that come from generic git repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,6 @@ build-fprime-automatic*
 /ci-logs*
 /ci-Framework-logs*
 /ci-Ref-logs*
-TesterBase.*
-GTestBase.*
 **/DefaultDict/serializable/*
 
 fprime-venv
@@ -94,3 +92,42 @@ Packet-Views
 docs/reference/api/cpp
 docs/reference/api/cmake
 temp_dir/
+
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# FPrime items
+cmake-build-*
+*-template
+*.template.cpp
+*.template.hpp

--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,6 @@ docs/reference/api/cpp
 docs/reference/api/cmake
 temp_dir/
 
-
 # Prerequisites
 *.d
 
@@ -125,9 +124,3 @@ temp_dir/
 *.exe
 *.out
 *.app
-
-# FPrime items
-cmake-build-*
-*-template
-*.template.cpp
-*.template.hpp


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**| N |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

Add entries to .gitignore that come from generic git repos, and some FPrime items I've noticed over time.  Remove two duplicated lines.

## Rationale

A developer might leave build artifacts outside of the usual build-* cache directories and accidentally include them as clutter.

## Testing/Review Recommendations

You might have reasons to want some of these file types in git.
