### PR TITLE
ci: declare contents:read on pip-check workflow

### DIFF
--- a/.github/workflows/pip-check.yml
+++ b/.github/workflows/pip-check.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
+permissions:
+  contents: read
+
 jobs:
   pip-install:
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
Adds a workflow-level `permissions: contents: read` block. The job here only checks out the repository and runs its tests / validation; no GitHub API call beyond the initial checkout is needed.

CVE-2025-30066 (the March 2025 `tj-actions/changed-files` supply-chain compromise) is the canonical motivation: a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Per-workflow caps bound that runtime authority irrespective of repo or org default, give drift protection if the default ever widens, and register with OpenSSF Scorecard's Token-Permissions check (which only credits explicit per-workflow declarations).

YAML validated locally with `yaml.safe_load`.
