### PR TITLE
ci: declare contents: read on the remaining workflows

### DIFF
--- a/.github/workflows/build-test-rhel8.yml
+++ b/.github/workflows/build-test-rhel8.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
+permissions:
+  contents: read
+
 jobs:
   Framework:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -19,6 +19,10 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+
+permissions:
+  contents: read
+
 jobs:
   CMake:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ext-aarch64-linux-led-blinker.yml
+++ b/.github/workflows/ext-aarch64-linux-led-blinker.yml
@@ -25,6 +25,9 @@ env:
   ARM_TOOLS_PATH: /tmp/aarch64-toolchain
   FPRIME_LOCATION: ./lib/fprime
 
+permissions:
+  contents: read
+
 jobs:
   get-branch:
     name: "Get target branch"

--- a/.github/workflows/ext-build-examples-repo.yml
+++ b/.github/workflows/ext-build-examples-repo.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
+permissions:
+  contents: read
+
 jobs:
   get-branch:
     name: "Get target branch"

--- a/.github/workflows/ext-build-hello-world.yml
+++ b/.github/workflows/ext-build-hello-world.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
+permissions:
+  contents: read
+
 jobs:
   get-branch:
     name: "Get target branch"

--- a/.github/workflows/ext-build-led-blinker.yml
+++ b/.github/workflows/ext-build-led-blinker.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
+permissions:
+  contents: read
+
 jobs:
   get-branch:
     name: "Get target branch"

--- a/.github/workflows/ext-build-math-comp.yml
+++ b/.github/workflows/ext-build-math-comp.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
+permissions:
+  contents: read
+
 jobs:
   get-branch:
     name: "Get target branch"

--- a/.github/workflows/ext-cookiecutters-test.yml
+++ b/.github/workflows/ext-cookiecutters-test.yml
@@ -22,6 +22,9 @@ concurrency:
 # a new project, deployment and component and building them
 # This uses the `expect` utility to feed input into the various cookiecutter prompts
 
+permissions:
+  contents: read
+
 jobs:
 
   # -------- Retrieve target branches for fprime-tools and fprime-bootstrap --------

--- a/.github/workflows/ext-fprime-zephyr-reference-pico2.yml
+++ b/.github/workflows/ext-fprime-zephyr-reference-pico2.yml
@@ -17,6 +17,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
+
+permissions:
+  contents: read
+
 jobs:
   get-branch:
     name: "Get target branch"

--- a/.github/workflows/ext-fprime-zephyr-reference-teensy41.yml
+++ b/.github/workflows/ext-fprime-zephyr-reference-teensy41.yml
@@ -17,6 +17,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
+
+permissions:
+  contents: read
+
 jobs:
   get-branch:
     name: "Get target branch"

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -23,6 +23,9 @@ env:
   RPI_TOOLCHAIN_DIR: /tmp/rpi-toolchain
   FPRIME_LOCATION: ./lib/fprime
 
+permissions:
+  contents: read
+
 jobs:
   get-branch:
     name: "Get target branch"

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -12,6 +12,9 @@ on:
       - '.github/actions/spelling/**'
       - '.github/ISSUE_TEMPLATE/**'
 
+permissions:
+  contents: read
+
 jobs:
   cpp-formatting:
     name: C++ Formatting

--- a/.github/workflows/fpp-tests.yml
+++ b/.github/workflows/fpp-tests.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
+permissions:
+  contents: read
+
 jobs:
   fpptest:
     name: Run FppTest

--- a/.github/workflows/fpp-to-json.yml
+++ b/.github/workflows/fpp-to-json.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
+permissions:
+  contents: read
+
 jobs:
   fpp-to-json-ref:
     name: Ref Deployment

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/') }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Build [${{ matrix.runner }}]"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-22.04

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
+permissions:
+  contents: read
+
 jobs:
   format:
       name: Format

--- a/.github/workflows/ref.yml
+++ b/.github/workflows/ref.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/') }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Build [${{ matrix.runner }}]"


### PR DESCRIPTION
Follow-up to #5156 (merged). Per @thomas-bc's ask there:

> I believe that most of our workflow would actually benefit from having only `contents: read`. Would you want to do the update to all of those that don't specify anything yet?

This rolls the workflow-level `permissions: contents: read` block into the 18 remaining workflows that were still relying on the repo default.

### What's in / what's out

Touched (18):

- `build-test-rhel8.yml`, `cmake-test.yml`
- `ext-aarch64-linux-led-blinker.yml`, `ext-build-examples-repo.yml`, `ext-build-hello-world.yml`, `ext-build-led-blinker.yml`, `ext-build-math-comp.yml`, `ext-cookiecutters-test.yml`, `ext-fprime-zephyr-reference-pico2.yml`, `ext-fprime-zephyr-reference-teensy41.yml`, `ext-raspberry-led-blinker.yml`
- `format-check.yml`, `fpp-tests.yml`, `fpp-to-json.yml`, `framework.yml`, `markdown-link-check.yml`, `python-format.yml`, `ref.yml`

Left alone:

- `codeql-jpl-standard.yml`, `codeql-security-scan.yml`, `cppcheck-scan.yml`, `cpplint-scan.yml`, `spelling.yml` already carry per-job permissions (different from `contents: read`) and were called out as intentional in the linked comment.
- `reusable-get-pr-branch.yml`, `reusable-project-builder.yml`, `reusable-project-ci.yml` are `workflow_call` entry points. Declaring `permissions:` on a reusable workflow intersects with what the caller grants and can drop scopes a caller needs (`id-token: write`, etc.), so they should stay implicit.

Also closes #5157 (single-file markdown-link-check, superseded by this PR).

### Why each touched workflow is safe with read-only

None of them call a GitHub API beyond the initial checkout: no comment-on-PR step, no artifact push, no label mutation, no `pull_request_target`. They build, run tests / linters, or hit the markdown link checker, and surface failures via the workflow's own check status.

### Motivation

Standard supply-chain hygiene grounded in CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise): a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Per-workflow caps bound that runtime authority irrespective of repo or org default, give drift protection if the default ever widens, and register with OpenSSF Scorecard's `Token-Permissions` check (which only credits explicit per-workflow declarations).

YAML validated locally with `yaml.safe_load` on each touched file.