### PR TITLE
fix(Os): Remove unused File::m_path member variable

### DIFF
--- a/Os/File.cpp
+++ b/Os/File.cpp
@@ -1,6 +1,6 @@
 // ======================================================================
-// \title Os/File.cpp
-// \brief common function implementation for Os::File
+// 	itle Os/File.cpp
+// rief common function implementation for Os::File
 // ======================================================================
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/StringUtils.hpp>
@@ -33,15 +33,12 @@ File::File(const File& other)
       m_handle_storage(),
       m_delegate(*FileInterface::getDelegate(m_handle_storage, &other.m_delegate)) {
     FW_ASSERT(&this->m_delegate == reinterpret_cast<FileInterface*>(&this->m_handle_storage[0]));
-    // Re-point m_path into this object's own storage so it does not alias the source
-    this->m_path = (other.m_path != nullptr) ? this->m_path_storage.toChar() : nullptr;
 }
 
 File& File::operator=(const File& other) {
     if (this != &other) {
         this->m_mode = other.m_mode;
         this->m_path_storage = other.m_path_storage;
-        this->m_path = (other.m_path != nullptr) ? this->m_path_storage.toChar() : nullptr;
         this->m_crc = other.m_crc;
         this->m_delegate = *FileInterface::getDelegate(m_handle_storage, &other.m_delegate);
     }
@@ -83,9 +80,8 @@ File::Status File::open(const CHAR* filepath,
     File::Status status = this->m_delegate.open(filepath, requested_mode, overwrite);
     if (status == File::Status::OP_OK) {
         this->m_mode = requested_mode;
-        // Store an owned copy of the path so m_path never dangles when the caller's string is freed
+        // Store an owned copy of the path so it survives the caller freeing the original string
         this->m_path_storage = filepath;
-        this->m_path = this->m_path_storage.toChar();
         // Reset any open CRC calculations
         this->m_crc = File::INITIAL_CRC;
     }
@@ -108,7 +104,6 @@ void File::close() {
     FW_ASSERT((0 <= this->m_mode) && (this->m_mode < Mode::MAX_OPEN_MODE));
     this->m_delegate.close();
     this->m_mode = Mode::OPEN_NO_MODE;
-    this->m_path = nullptr;
 }
 
 bool File::isOpen() const {
@@ -322,10 +317,12 @@ File::Status File::readline(U8* buffer, FwSizeType& size, File::WaitType wait) {
             size = i;
             return Os::File::Status::OP_OK;
         }
-        // Loop from i to i + current_chunk_size looking for `\n`
+        // Loop from i to i + current_chunk_size looking for `
+`
         for (FwSizeType j = i; j < (i + read); j++) {
             // Newline seek back to after it, return the size read
-            if (buffer[j] == '\n') {
+            if (buffer[j] == '
+') {
                 size = j + 1;
                 // Ensure that the computation worked and there is not overflow
                 FW_ASSERT(size <= requested_size);

--- a/Os/File.cpp
+++ b/Os/File.cpp
@@ -27,7 +27,6 @@ File::~File() {
 
 File::File(const File& other)
     : m_mode(other.m_mode),
-      m_path_storage(other.m_path_storage),
       m_crc(other.m_crc),
       m_crc_buffer(),
       m_handle_storage(),
@@ -38,7 +37,6 @@ File::File(const File& other)
 File& File::operator=(const File& other) {
     if (this != &other) {
         this->m_mode = other.m_mode;
-        this->m_path_storage = other.m_path_storage;
         this->m_crc = other.m_crc;
         this->m_delegate = *FileInterface::getDelegate(m_handle_storage, &other.m_delegate);
     }
@@ -65,10 +63,6 @@ File::Status File::open(const CHAR* filepath,
     FW_ASSERT(&this->m_delegate == reinterpret_cast<FileInterface*>(&this->m_handle_storage[0]));
     FW_ASSERT(nullptr != filepath);
     const FwSizeType string_len = static_cast<FwSizeType>(Fw::StringUtils::string_length(filepath, length));
-    // Refuse oversize paths before touching the delegate so m_path_storage never silently truncates
-    if (string_len > static_cast<FwSizeType>(FileNameStringSize)) {
-        return File::Status::TRUNCATED;
-    }
     FW_ASSERT(string_len < length, static_cast<FwAssertArgType>(string_len), static_cast<FwAssertArgType>(length));
     FW_ASSERT(File::Mode::OPEN_NO_MODE < requested_mode && File::Mode::MAX_OPEN_MODE > requested_mode);
     FW_ASSERT((0 <= this->m_mode) && (this->m_mode < Mode::MAX_OPEN_MODE));
@@ -80,8 +74,6 @@ File::Status File::open(const CHAR* filepath,
     File::Status status = this->m_delegate.open(filepath, requested_mode, overwrite);
     if (status == File::Status::OP_OK) {
         this->m_mode = requested_mode;
-        // Store an owned copy of the path so it survives the caller freeing the original string
-        this->m_path_storage = filepath;
         // Reset any open CRC calculations
         this->m_crc = File::INITIAL_CRC;
     }
@@ -317,12 +309,10 @@ File::Status File::readline(U8* buffer, FwSizeType& size, File::WaitType wait) {
             size = i;
             return Os::File::Status::OP_OK;
         }
-        // Loop from i to i + current_chunk_size looking for `
-`
+        // Loop from i to i + current_chunk_size looking for `\n`
         for (FwSizeType j = i; j < (i + read); j++) {
             // Newline seek back to after it, return the size read
-            if (buffer[j] == '
-') {
+            if (buffer[j] == '\n') {
                 size = j + 1;
                 // Ensure that the computation worked and there is not overflow
                 FW_ASSERT(size <= requested_size);

--- a/Os/File.cpp
+++ b/Os/File.cpp
@@ -1,6 +1,6 @@
 // ======================================================================
-// 	itle Os/File.cpp
-// rief common function implementation for Os::File
+// \title Os/File.cpp
+// \brief common function implementation for Os::File
 // ======================================================================
 #include <Fw/Types/Assert.hpp>
 #include <Fw/Types/StringUtils.hpp>

--- a/Os/File.cpp
+++ b/Os/File.cpp
@@ -68,6 +68,10 @@ File::Status File::open(const CHAR* filepath,
     FW_ASSERT(&this->m_delegate == reinterpret_cast<FileInterface*>(&this->m_handle_storage[0]));
     FW_ASSERT(nullptr != filepath);
     const FwSizeType string_len = static_cast<FwSizeType>(Fw::StringUtils::string_length(filepath, length));
+    // Refuse oversize paths before touching the delegate so m_path_storage never silently truncates
+    if (string_len > static_cast<FwSizeType>(FileNameStringSize)) {
+        return File::Status::TRUNCATED;
+    }
     FW_ASSERT(string_len < length, static_cast<FwAssertArgType>(string_len), static_cast<FwAssertArgType>(length));
     FW_ASSERT(File::Mode::OPEN_NO_MODE < requested_mode && File::Mode::MAX_OPEN_MODE > requested_mode);
     FW_ASSERT((0 <= this->m_mode) && (this->m_mode < Mode::MAX_OPEN_MODE));

--- a/Os/File.cpp
+++ b/Os/File.cpp
@@ -27,18 +27,21 @@ File::~File() {
 
 File::File(const File& other)
     : m_mode(other.m_mode),
-      m_path(other.m_path),
+      m_path_storage(other.m_path_storage),
       m_crc(other.m_crc),
       m_crc_buffer(),
       m_handle_storage(),
       m_delegate(*FileInterface::getDelegate(m_handle_storage, &other.m_delegate)) {
     FW_ASSERT(&this->m_delegate == reinterpret_cast<FileInterface*>(&this->m_handle_storage[0]));
+    // Re-point m_path into this object's own storage so it does not alias the source
+    this->m_path = (other.m_path != nullptr) ? this->m_path_storage.toChar() : nullptr;
 }
 
 File& File::operator=(const File& other) {
     if (this != &other) {
         this->m_mode = other.m_mode;
-        this->m_path = other.m_path;
+        this->m_path_storage = other.m_path_storage;
+        this->m_path = (other.m_path != nullptr) ? this->m_path_storage.toChar() : nullptr;
         this->m_crc = other.m_crc;
         this->m_delegate = *FileInterface::getDelegate(m_handle_storage, &other.m_delegate);
     }
@@ -76,7 +79,9 @@ File::Status File::open(const CHAR* filepath,
     File::Status status = this->m_delegate.open(filepath, requested_mode, overwrite);
     if (status == File::Status::OP_OK) {
         this->m_mode = requested_mode;
-        this->m_path = filepath;
+        // Store an owned copy of the path so m_path never dangles when the caller's string is freed
+        this->m_path_storage = filepath;
+        this->m_path = this->m_path_storage.toChar();
         // Reset any open CRC calculations
         this->m_crc = File::INITIAL_CRC;
     }

--- a/Os/File.hpp
+++ b/Os/File.hpp
@@ -7,7 +7,6 @@
 
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <Fw/Types/ConstStringBase.hpp>
-#include <Fw/Types/FileNameString.hpp>
 #include <Os/Os.hpp>
 
 // Forward declaration for UTs
@@ -50,7 +49,6 @@ class FileInterface {
         INVALID_MODE,       //!< Mode for file access is invalid for current operation
         INVALID_ARGUMENT,   //!< Invalid argument passed in
         NO_MORE_RESOURCES,  //!< No more available resources
-        TRUNCATED,          //!< Path exceeds Fw::FileNameString capacity and would be silently truncated
         OTHER_ERROR,        //!<  A catch-all for other errors. Have to look in implementation-specific code
         MAX_STATUS          //!< Maximum value of status
     };
@@ -263,8 +261,7 @@ class File final : public FileInterface {
     //!
     //! \param path: c-string of path to open
     //! \param mode: file operation mode
-    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
-    //!          `Fw::FileNameString` capacity.
+    //! \return: status of the open
     //!
     Os::FileInterface::Status open(const char* path, Mode mode);
 
@@ -281,8 +278,7 @@ class File final : public FileInterface {
     //! \param path: c-string of path to open
     //! \param length: bound on the path buffer size
     //! \param mode: file operation mode
-    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
-    //!          `Fw::FileNameString` capacity.
+    //! \return: status of the open
     //!
     Os::FileInterface::Status open(const char* path, FwSizeType length, Mode mode);
 
@@ -367,8 +363,7 @@ class File final : public FileInterface {
     //! \param path: c-string of path to open
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
-    //!          `Fw::FileNameString` capacity.
+    //! \return: status of the open
     //!
     Os::FileInterface::Status open(const char* path, Mode mode, OverwriteType overwrite) override;
 
@@ -388,8 +383,7 @@ class File final : public FileInterface {
     //! \param length: bound on the path buffer size
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! \return: status of the open. Returns `TRUNCATED` without opening (and leaves the file closed
-    //!          closed state) when the path exceeds `Fw::FileNameString` capacity.
+    //! \return: status of the open
     //!
     Os::FileInterface::Status open(const char* path, FwSizeType length, Mode mode, OverwriteType overwrite);
 
@@ -483,18 +477,13 @@ class File final : public FileInterface {
     //!
     Status read(U8* buffer, FwSizeType& size, WaitType wait) override;
 
-    //! \brief read a line from the file using `
-` as the delimiter
+    //! \brief read a line from the file using `\n` as the delimiter
     //!
-    //! Reads a single line from the file including the terminating '
-'. This will return an error if no line is
-    //! found within the specified buffer size. In the case of EOF, the line is read without the terminating '
-'.
+    //! Reads a single line from the file including the terminating '\n'. This will return an error if no line is
+    //! found within the specified buffer size. In the case of EOF, the line is read without the terminating '\n'.
     //!
     //! In the case of an error, this function will seek to the original location in the file. Otherwise, the
-    //! pointer will point to the first character after the `
-` or EOF in the case of no `
-`.
+    //! pointer will point to the first character after the `\n` or EOF in the case of no `\n`.
     //!
     //! It is invalid to send a null buffer.
     //! It is invalid to send a size less than 0.
@@ -595,8 +584,7 @@ class File final : public FileInterface {
   private:
     static const U32 INITIAL_CRC = 0xFFFFFFFF;  //!< Initial value for CRC calculation
 
-    Mode m_mode = Mode::OPEN_NO_MODE;   //!< Stores mode for error checking
-    Fw::FileNameString m_path_storage;  //!< Owned copy of the path last opened
+    Mode m_mode = Mode::OPEN_NO_MODE;  //!< Stores mode for error checking
 
     U32 m_crc = File::INITIAL_CRC;  //!< Current CRC calculation
     U8 m_crc_buffer[FW_FILE_CHUNK_SIZE];

--- a/Os/File.hpp
+++ b/Os/File.hpp
@@ -7,6 +7,7 @@
 
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <Fw/Types/ConstStringBase.hpp>
+#include <Fw/Types/FileNameString.hpp>
 #include <Os/Os.hpp>
 
 // Forward declaration for UTs
@@ -584,8 +585,9 @@ class File final : public FileInterface {
   private:
     static const U32 INITIAL_CRC = 0xFFFFFFFF;  //!< Initial value for CRC calculation
 
-    Mode m_mode = Mode::OPEN_NO_MODE;  //!< Stores mode for error checking
-    const CHAR* m_path = nullptr;      //!< Path last opened
+    Mode m_mode = Mode::OPEN_NO_MODE;   //!< Stores mode for error checking
+    Fw::FileNameString m_path_storage;  //!< Owned copy of the path last opened
+    const CHAR* m_path = nullptr;       //!< Path last opened, points into m_path_storage when open
 
     U32 m_crc = File::INITIAL_CRC;  //!< Current CRC calculation
     U8 m_crc_buffer[FW_FILE_CHUNK_SIZE];

--- a/Os/File.hpp
+++ b/Os/File.hpp
@@ -50,6 +50,7 @@ class FileInterface {
         INVALID_MODE,       //!< Mode for file access is invalid for current operation
         INVALID_ARGUMENT,   //!< Invalid argument passed in
         NO_MORE_RESOURCES,  //!< No more available resources
+        TRUNCATED,          //!< Path exceeds Fw::FileNameString capacity and would be silently truncated
         OTHER_ERROR,        //!<  A catch-all for other errors. Have to look in implementation-specific code
         MAX_STATUS          //!< Maximum value of status
     };
@@ -262,7 +263,8 @@ class File final : public FileInterface {
     //!
     //! \param path: c-string of path to open
     //! \param mode: file operation mode
-    //! \return: status of the open
+    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
+    //!          `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, Mode mode);
 
@@ -279,7 +281,8 @@ class File final : public FileInterface {
     //! \param path: c-string of path to open
     //! \param length: bound on the path buffer size
     //! \param mode: file operation mode
-    //! \return: status of the open
+    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
+    //!          `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, FwSizeType length, Mode mode);
 
@@ -364,7 +367,8 @@ class File final : public FileInterface {
     //! \param path: c-string of path to open
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! \return: status of the open
+    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
+    //!          `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, Mode mode, OverwriteType overwrite) override;
 
@@ -384,7 +388,8 @@ class File final : public FileInterface {
     //! \param length: bound on the path buffer size
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! \return: status of the open
+    //! \return: status of the open. Returns `TRUNCATED` without opening (and leaves the file closed
+    //!          and `m_path` null) when the path exceeds `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, FwSizeType length, Mode mode, OverwriteType overwrite);
 

--- a/Os/File.hpp
+++ b/Os/File.hpp
@@ -1,6 +1,6 @@
 // ======================================================================
-// 	itle Os/File.hpp
-// rief common function definitions for Os::File
+// \title Os/File.hpp
+// \brief common function definitions for Os::File
 // ======================================================================
 #ifndef Os_File_hpp_
 #define Os_File_hpp_
@@ -21,7 +21,7 @@ struct Tester;
 
 namespace Os {
 
-//! rief base implementation of FileHandle
+//! \brief base implementation of FileHandle
 //!
 struct FileHandle {};
 
@@ -75,7 +75,7 @@ class FileInterface {
 
     virtual ~FileInterface() = default;
 
-    //! rief open file with supplied path and mode
+    //! \brief open file with supplied path and mode
     //!
     //! Open the file passed in with the given mode. If overwrite is set to OVERWRITE, then opening files in
     //! OPEN_CREATE mode will clobber existing files. Set overwrite to NO_OVERWRITE to preserve existing files.
@@ -89,34 +89,34 @@ class FileInterface {
     //! \param path: c-string of path to open
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! eturn: status of the open
+    //! \return: status of the open
     //!
     virtual Status open(const char* path, Mode mode, OverwriteType overwrite) = 0;
 
-    //! rief close the file, if not opened then do nothing
+    //! \brief close the file, if not opened then do nothing
     //!
     //! Closes the file, if open. Otherwise this function does nothing. Delegates to the chosen implementation's
     //! `closeInternal` function. `mode` is set to `OPEN_NO_MODE`.
     //!
     virtual void close() = 0;
 
-    //! rief get size of currently open file
+    //! \brief get size of currently open file
     //!
     //! Get the size of the currently open file and fill the size parameter. Return status of the operation.
     //! \param size: output parameter for size.
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     virtual Status size(FwSizeType& size_result) = 0;
 
-    //! rief get file pointer position of the currently open file
+    //! \brief get file pointer position of the currently open file
     //!
     //! Get the current position of the read/write pointer of the open file.
     //! \param position: output parameter for size.
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     virtual Status position(FwSizeType& position_result) = 0;
 
-    //! rief pre-allocate file storage
+    //! \brief pre-allocate file storage
     //!
     //! Pre-allocates file storage with at least `length` storage starting at `offset`. No-op on implementations
     //! that cannot pre-allocate.
@@ -126,31 +126,31 @@ class FileInterface {
     //!
     //! \param offset: offset into file
     //! \param length: length after offset to preallocate
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     virtual Status preallocate(FwSizeType offset, FwSizeType length) = 0;
 
-    //! rief seek the file pointer to the given offset
+    //! \brief seek the file pointer to the given offset
     //!
     //! Seek the file pointer to the given `offset`. If `seekType` is set to `ABSOLUTE` then the offset is calculated
     //! from the start of the file, and if it is set to `RELATIVE` it is calculated from the current position.
     //!
     //! \param offset: offset to seek to
     //! \param seekType: `ABSOLUTE` for seeking from beginning of file, `RELATIVE` to use current position.
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     virtual Status seek(FwSignedSizeType offset, SeekType seekType) = 0;
 
-    //! rief flush file contents to storage
+    //! \brief flush file contents to storage
     //!
     //! Flushes the file contents to storage (i.e. out of the OS cache to disk). Does nothing in implementations
     //! that do not support flushing.
     //!
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     virtual Status flush() = 0;
 
-    //! rief read data from this file into supplied buffer bounded by size
+    //! \brief read data from this file into supplied buffer bounded by size
     //!
     //! Read data from this file up to the `size` and store it in `buffer`.  When `wait` is set to `WAIT`, this
     //! will block until the requested size has been read successfully read or the end of the file has been
@@ -166,11 +166,11 @@ class FileInterface {
     //! \param buffer: memory location to store data read from file
     //! \param size: size of data to read
     //! \param wait: `WAIT` to wait for data, `NO_WAIT` to return what is currently available
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     virtual Status read(U8* buffer, FwSizeType& size, WaitType wait) = 0;
 
-    //! rief read data from this file into supplied buffer bounded by size
+    //! \brief read data from this file into supplied buffer bounded by size
     //!
     //! Write data to this file up to the `size` from the `buffer`.  When `wait` is set to `WAIT`, this
     //! will block until the requested size has been written successfully to disk. When `wait` is set to
@@ -186,20 +186,20 @@ class FileInterface {
     //! \param buffer: memory location to store data read from file
     //! \param size: size of data to read
     //! \param wait: `WAIT` to wait for data to write to disk, `NO_WAIT` to return what is currently available
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     virtual Status write(const U8* buffer, FwSizeType& size, WaitType wait) = 0;
 
-    //! rief returns the raw file handle
+    //! \brief returns the raw file handle
     //!
     //! Gets the raw file handle from the implementation. Note: users must include the implementation specific
     //! header to make any real use of this handle. Otherwise it will be as an opaque type.
     //!
-    //! eturn raw file handle
+    //! \return raw file handle
     //!
     virtual FileHandle* getHandle() = 0;
 
-    //! rief provide a pointer to a file delegate object
+    //! \brief provide a pointer to a file delegate object
     //!
     //! This function must return a pointer to a `FileInterface` object that contains the real implementation of the
     //! file functions as defined by the implementor.  This function must do several things to be considered correctly
@@ -219,7 +219,7 @@ class FileInterface {
     //! 6. Return the result of the placement new
     //!    e.g. `return interface;`
     //!
-    //! eturn result of placement new, must be equivalent to `aligned_placement_new_memory`
+    //! \return result of placement new, must be equivalent to `aligned_placement_new_memory`
     //!
     static FileInterface* getDelegate(FileHandleStorage& aligned_placement_new_memory,
                                       const FileInterface* to_copy = nullptr);
@@ -229,22 +229,22 @@ class File final : public FileInterface {
     friend struct Os::Test::FileTest::Tester;
 
   public:
-    //! rief constructor
+    //! \brief constructor
     //!
     File();
-    //! rief destructor
+    //! \brief destructor
     //!
     //! Destructor closes the file if it is open
     ~File() final;
 
-    //! rief copy constructor that copies the internal representation
+    //! \brief copy constructor that copies the internal representation
     File(const File& other);
 
-    //! rief assignment operator that copies the internal representation
+    //! \brief assignment operator that copies the internal representation
     File& operator=(const File& other);
 
-    //! rief determine if the file is open
-    //! eturn true if file is open, false otherwise
+    //! \brief determine if the file is open
+    //! \return true if file is open, false otherwise
     //!
     bool isOpen() const;
 
@@ -252,7 +252,7 @@ class File final : public FileInterface {
     // Functions supplying default values
     // ------------------------------------
 
-    //! rief open file with supplied path and mode
+    //! \brief open file with supplied path and mode
     //!
     //! Open the file passed in with the given mode. Opening files with `OPEN_CREATE` mode will not clobber existing
     //! files. Use other `open` method to set overwrite flag and clobber existing files. The status of the open
@@ -263,12 +263,12 @@ class File final : public FileInterface {
     //!
     //! \param path: c-string of path to open
     //! \param mode: file operation mode
-    //! eturn: status of the open. Returns `TRUNCATED` without opening when the path exceeds
+    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
     //!          `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, Mode mode);
 
-    //! rief open file with supplied path, bounded length, and mode
+    //! \brief open file with supplied path, bounded length, and mode
     //!
     //! Open the file passed in with the given mode. The path length is bounded by `length`.
     //! Opening files with `OPEN_CREATE` mode will not clobber existing files. Use the overload
@@ -281,12 +281,12 @@ class File final : public FileInterface {
     //! \param path: c-string of path to open
     //! \param length: bound on the path buffer size
     //! \param mode: file operation mode
-    //! eturn: status of the open. Returns `TRUNCATED` without opening when the path exceeds
+    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
     //!          `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, FwSizeType length, Mode mode);
 
-    //! rief open file with supplied string path and mode
+    //! \brief open file with supplied string path and mode
     //!
     //! Open the file passed in with the given mode. Opening files with `OPEN_CREATE` mode will not clobber existing
     //! files. Use the overload accepting `OverwriteType` to set overwrite flag and clobber existing files.
@@ -295,11 +295,11 @@ class File final : public FileInterface {
     //!
     //! \param path: ConstStringBase reference of path to open
     //! \param mode: file operation mode
-    //! eturn: status of the open
+    //! \return: status of the open
     //!
     Os::FileInterface::Status open(const Fw::ConstStringBase& path, Mode mode);
 
-    //! rief open file with supplied string path, mode, and overwrite type
+    //! \brief open file with supplied string path, mode, and overwrite type
     //!
     //! Open the file passed in with the given mode. If overwrite is set to OVERWRITE, then opening files in
     //! OPEN_CREATE mode will clobber existing files. Set overwrite to NO_OVERWRITE to preserve existing files.
@@ -310,11 +310,11 @@ class File final : public FileInterface {
     //! \param path: ConstStringBase reference of path to open
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! eturn: status of the open
+    //! \return: status of the open
     //!
     Os::FileInterface::Status open(const Fw::ConstStringBase& path, Mode mode, OverwriteType overwrite);
 
-    //! rief read data from this file into supplied buffer bounded by size
+    //! \brief read data from this file into supplied buffer bounded by size
     //!
     //! Read data from this file up to the `size` and store it in `buffer`.  This version will
     //! will block until the requested size has been read successfully read or the end of the file has been
@@ -328,11 +328,11 @@ class File final : public FileInterface {
     //!
     //! \param buffer: memory location to store data read from file
     //! \param size: size of data to read
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     Status read(U8* buffer, FwSizeType& size);
 
-    //! rief write data to this file from the supplied buffer bounded by size
+    //! \brief write data to this file from the supplied buffer bounded by size
     //!
     //! Write data from `buffer` up to the `size` and store it in this file. This call
     //! will block until the requested size has been written. Otherwise, this call will write without blocking.
@@ -345,7 +345,7 @@ class File final : public FileInterface {
     //!
     //! \param buffer: memory location of data to write to file
     //! \param size: size of data to write
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     Status write(const U8* buffer, FwSizeType& size);
 
@@ -353,7 +353,7 @@ class File final : public FileInterface {
     // Functions overrides
     // ------------------------------------
 
-    //! rief open file with supplied path and mode
+    //! \brief open file with supplied path and mode
     //!
     //! Open the file passed in with the given mode. If overwrite is set to OVERWRITE, then opening files in
     //! OPEN_CREATE mode will clobber existing files. Set overwrite to NO_OVERWRITE to preserve existing files.
@@ -367,12 +367,12 @@ class File final : public FileInterface {
     //! \param path: c-string of path to open
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! eturn: status of the open. Returns `TRUNCATED` without opening when the path exceeds
+    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
     //!          `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, Mode mode, OverwriteType overwrite) override;
 
-    //! rief open file with supplied path, bounded length, mode, and overwrite type
+    //! \brief open file with supplied path, bounded length, mode, and overwrite type
     //!
     //! Open the file passed in with the given mode. The path length is bounded by `length`.
     //! If overwrite is set to OVERWRITE, then opening files in OPEN_CREATE mode will clobber
@@ -388,35 +388,35 @@ class File final : public FileInterface {
     //! \param length: bound on the path buffer size
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! eturn: status of the open. Returns `TRUNCATED` without opening (and leaves the file closed
+    //! \return: status of the open. Returns `TRUNCATED` without opening (and leaves the file closed
     //!          closed state) when the path exceeds `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, FwSizeType length, Mode mode, OverwriteType overwrite);
 
-    //! rief close the file, if not opened then do nothing
+    //! \brief close the file, if not opened then do nothing
     //!
     //! Closes the file, if open. Otherwise this function does nothing. Delegates to the chosen implementation's
     //! `closeInternal` function. `mode` is set to `OPEN_NO_MODE`.
     //!
     void close() override;
 
-    //! rief get size of currently open file
+    //! \brief get size of currently open file
     //!
     //! Get the size of the currently open file and fill the size parameter. Return status of the operation.
     //! \param size: output parameter for size.
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     Status size(FwSizeType& size_result) override;
 
-    //! rief get file pointer position of the currently open file
+    //! \brief get file pointer position of the currently open file
     //!
     //! Get the current position of the read/write pointer of the open file.
     //! \param position: output parameter for size.
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     Status position(FwSizeType& position_result) override;
 
-    //! rief pre-allocate file storage
+    //! \brief pre-allocate file storage
     //!
     //! Pre-allocates file storage with at least `length` storage starting at `offset`. No-op on implementations
     //! that cannot pre-allocate.
@@ -426,22 +426,22 @@ class File final : public FileInterface {
     //!
     //! \param offset: offset into file
     //! \param length: length after offset to preallocate
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     Status preallocate(FwSizeType offset, FwSizeType length) override;
 
-    //! rief seek the file pointer to the given offset
+    //! \brief seek the file pointer to the given offset
     //!
     //! Seek the file pointer to the given `offset`. If `seekType` is set to `ABSOLUTE` then the offset is calculated
     //! from the start of the file, and if it is set to `RELATIVE` it is calculated from the current position.
     //!
     //! \param offset: offset to seek to
     //! \param seekType: `ABSOLUTE` for seeking from beginning of file, `RELATIVE` to use current position.
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     Status seek(FwSignedSizeType offset, SeekType seekType) override;
 
-    //! rief seek the file pointer to the given offset absolutely with the full range
+    //! \brief seek the file pointer to the given offset absolutely with the full range
     //!
     //! Seek the file pointer to the given `offset` absolutely from the beginning of the file. This function is
     //! equivalent to calling `seek` with `ABSOLUTE` as the `seekType` with the exception that it can handle the
@@ -451,19 +451,19 @@ class File final : public FileInterface {
     //! limit of the basic `seek` function.
     //!
     //! \param offset_unsigned: offset to absolutely seek to
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     Status seek_absolute(FwSizeType offset_unsigned);
 
-    //! rief flush file contents to storage
+    //! \brief flush file contents to storage
     //!
     //! Flushes the file contents to storage (i.e. out of the OS cache to disk). Does nothing in implementations
     //! that do not support flushing.
     //!
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     Status flush() override;
 
-    //! rief read data from this file into supplied buffer bounded by size
+    //! \brief read data from this file into supplied buffer bounded by size
     //!
     //! Read data from this file up to the `size` and store it in `buffer`.  When `wait` is set to `WAIT`, this
     //! will block until the requested size has been read successfully read or the end of the file has been
@@ -483,7 +483,7 @@ class File final : public FileInterface {
     //!
     Status read(U8* buffer, FwSizeType& size, WaitType wait) override;
 
-    //! rief read a line from the file using `
+    //! \brief read a line from the file using `
 ` as the delimiter
     //!
     //! Reads a single line from the file including the terminating '
@@ -503,10 +503,10 @@ class File final : public FileInterface {
     //! \param buffer: memory location to store data read from file
     //! \param size: maximum size of buffer to store the new line
     //! \param wait: `WAIT` to wait for data, `NO_WAIT` to return what is currently available
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     Status readline(U8* buffer, FwSizeType& size, WaitType wait);
 
-    //! rief read data from this file into supplied buffer bounded by size
+    //! \brief read data from this file into supplied buffer bounded by size
     //!
     //! Write data to this file up to the `size` from the `buffer`.  When `wait` is set to `WAIT`, this
     //! will block until the requested size has been written successfully to disk. When `wait` is set to
@@ -522,20 +522,20 @@ class File final : public FileInterface {
     //! \param buffer: memory location to store data read from file
     //! \param size: size of data to read
     //! \param wait: `WAIT` to wait for data to write to disk, `NO_WAIT` to return what is currently available
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     Status write(const U8* buffer, FwSizeType& size, WaitType wait) override;
 
-    //! rief returns the raw file handle
+    //! \brief returns the raw file handle
     //!
     //! Gets the raw file handle from the implementation. Note: users must include the implementation specific
     //! header to make any real use of this handle. Otherwise it//!must* be passed as an opaque type.
     //!
-    //! eturn raw file handle
+    //! \return raw file handle
     //!
     FileHandle* getHandle() override;
 
-    //! rief calculate the CRC32 of the entire file
+    //! \brief calculate the CRC32 of the entire file
     //!
     //! Calculates the CRC32 of the file's contents. The `crc` parameter will be updated to contain the CRC or 0 on
     //! failure. Status will represent failure conditions. This call will be decomposed into calculations on
@@ -545,8 +545,7 @@ class File final : public FileInterface {
     //!
     //! On error crc will be set to 0.
     //!
-    //! 
-ote: the file pointer will be positioned at the end of the file after this call.
+    //! \note: the file pointer will be positioned at the end of the file after this call.
     //!
     //! This function is equivalent to the following pseudo-code:
     //!
@@ -559,11 +558,11 @@ ote: the file pointer will be positioned at the end of the file after this call.
     //! m_file.finalize(crc);
     //! ```
     //! \param crc: U32 bit value to fill with CRC
-    //! eturn OP_OK on success otherwise error status
+    //! \return OP_OK on success otherwise error status
     //!
     Status calculateCrc(U32& crc);
 
-    //! rief calculate the CRC32 of the next section of data
+    //! \brief calculate the CRC32 of the next section of data
     //!
     //! Starting at the current file pointer, this will add `size` bytes of data to the currently calculated CRC.
     //! Call `finalizeCrc` to retrieve the CRC or `calculateCrc` to perform a CRC on the entire file. This call will
@@ -576,11 +575,11 @@ ote: the file pointer will be positioned at the end of the file after this call.
     //! It is illegal for size to be less than or equal to 0 or greater than FW_FILE_CHUNK_SIZE.
     //!
     //! \param size: size of data to read for CRC
-    //! eturn: status of the CRC calculation
+    //! \return: status of the CRC calculation
     //!
     Status incrementalCrc(FwSizeType& size);
 
-    //! rief finalize and retrieve the CRC value
+    //! \brief finalize and retrieve the CRC value
     //!
     //! Finalizes the CRC computation and returns the CRC value. The `crc` value will be modified to contain the
     //! crc or 0 on error. Note: this will reset any active CRC calculation and effectively re-initializes any
@@ -589,7 +588,7 @@ ote: the file pointer will be positioned at the end of the file after this call.
     //! On error crc will be set to 0.
     //!
     //! \param crc: value to fill
-    //! eturn status of the CRC calculation
+    //! \return status of the CRC calculation
     //!
     Status finalizeCrc(U32& crc);
 

--- a/Os/File.hpp
+++ b/Os/File.hpp
@@ -1,6 +1,6 @@
 // ======================================================================
-// \title Os/File.hpp
-// \brief common function definitions for Os::File
+// 	itle Os/File.hpp
+// rief common function definitions for Os::File
 // ======================================================================
 #ifndef Os_File_hpp_
 #define Os_File_hpp_
@@ -21,7 +21,7 @@ struct Tester;
 
 namespace Os {
 
-//! \brief base implementation of FileHandle
+//! rief base implementation of FileHandle
 //!
 struct FileHandle {};
 
@@ -75,7 +75,7 @@ class FileInterface {
 
     virtual ~FileInterface() = default;
 
-    //! \brief open file with supplied path and mode
+    //! rief open file with supplied path and mode
     //!
     //! Open the file passed in with the given mode. If overwrite is set to OVERWRITE, then opening files in
     //! OPEN_CREATE mode will clobber existing files. Set overwrite to NO_OVERWRITE to preserve existing files.
@@ -89,34 +89,34 @@ class FileInterface {
     //! \param path: c-string of path to open
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! \return: status of the open
+    //! eturn: status of the open
     //!
     virtual Status open(const char* path, Mode mode, OverwriteType overwrite) = 0;
 
-    //! \brief close the file, if not opened then do nothing
+    //! rief close the file, if not opened then do nothing
     //!
     //! Closes the file, if open. Otherwise this function does nothing. Delegates to the chosen implementation's
     //! `closeInternal` function. `mode` is set to `OPEN_NO_MODE`.
     //!
     virtual void close() = 0;
 
-    //! \brief get size of currently open file
+    //! rief get size of currently open file
     //!
     //! Get the size of the currently open file and fill the size parameter. Return status of the operation.
     //! \param size: output parameter for size.
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     virtual Status size(FwSizeType& size_result) = 0;
 
-    //! \brief get file pointer position of the currently open file
+    //! rief get file pointer position of the currently open file
     //!
     //! Get the current position of the read/write pointer of the open file.
     //! \param position: output parameter for size.
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     virtual Status position(FwSizeType& position_result) = 0;
 
-    //! \brief pre-allocate file storage
+    //! rief pre-allocate file storage
     //!
     //! Pre-allocates file storage with at least `length` storage starting at `offset`. No-op on implementations
     //! that cannot pre-allocate.
@@ -126,31 +126,31 @@ class FileInterface {
     //!
     //! \param offset: offset into file
     //! \param length: length after offset to preallocate
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     virtual Status preallocate(FwSizeType offset, FwSizeType length) = 0;
 
-    //! \brief seek the file pointer to the given offset
+    //! rief seek the file pointer to the given offset
     //!
     //! Seek the file pointer to the given `offset`. If `seekType` is set to `ABSOLUTE` then the offset is calculated
     //! from the start of the file, and if it is set to `RELATIVE` it is calculated from the current position.
     //!
     //! \param offset: offset to seek to
     //! \param seekType: `ABSOLUTE` for seeking from beginning of file, `RELATIVE` to use current position.
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     virtual Status seek(FwSignedSizeType offset, SeekType seekType) = 0;
 
-    //! \brief flush file contents to storage
+    //! rief flush file contents to storage
     //!
     //! Flushes the file contents to storage (i.e. out of the OS cache to disk). Does nothing in implementations
     //! that do not support flushing.
     //!
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     virtual Status flush() = 0;
 
-    //! \brief read data from this file into supplied buffer bounded by size
+    //! rief read data from this file into supplied buffer bounded by size
     //!
     //! Read data from this file up to the `size` and store it in `buffer`.  When `wait` is set to `WAIT`, this
     //! will block until the requested size has been read successfully read or the end of the file has been
@@ -166,11 +166,11 @@ class FileInterface {
     //! \param buffer: memory location to store data read from file
     //! \param size: size of data to read
     //! \param wait: `WAIT` to wait for data, `NO_WAIT` to return what is currently available
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     virtual Status read(U8* buffer, FwSizeType& size, WaitType wait) = 0;
 
-    //! \brief read data from this file into supplied buffer bounded by size
+    //! rief read data from this file into supplied buffer bounded by size
     //!
     //! Write data to this file up to the `size` from the `buffer`.  When `wait` is set to `WAIT`, this
     //! will block until the requested size has been written successfully to disk. When `wait` is set to
@@ -186,20 +186,20 @@ class FileInterface {
     //! \param buffer: memory location to store data read from file
     //! \param size: size of data to read
     //! \param wait: `WAIT` to wait for data to write to disk, `NO_WAIT` to return what is currently available
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     virtual Status write(const U8* buffer, FwSizeType& size, WaitType wait) = 0;
 
-    //! \brief returns the raw file handle
+    //! rief returns the raw file handle
     //!
     //! Gets the raw file handle from the implementation. Note: users must include the implementation specific
     //! header to make any real use of this handle. Otherwise it will be as an opaque type.
     //!
-    //! \return raw file handle
+    //! eturn raw file handle
     //!
     virtual FileHandle* getHandle() = 0;
 
-    //! \brief provide a pointer to a file delegate object
+    //! rief provide a pointer to a file delegate object
     //!
     //! This function must return a pointer to a `FileInterface` object that contains the real implementation of the
     //! file functions as defined by the implementor.  This function must do several things to be considered correctly
@@ -219,7 +219,7 @@ class FileInterface {
     //! 6. Return the result of the placement new
     //!    e.g. `return interface;`
     //!
-    //! \return result of placement new, must be equivalent to `aligned_placement_new_memory`
+    //! eturn result of placement new, must be equivalent to `aligned_placement_new_memory`
     //!
     static FileInterface* getDelegate(FileHandleStorage& aligned_placement_new_memory,
                                       const FileInterface* to_copy = nullptr);
@@ -229,22 +229,22 @@ class File final : public FileInterface {
     friend struct Os::Test::FileTest::Tester;
 
   public:
-    //! \brief constructor
+    //! rief constructor
     //!
     File();
-    //! \brief destructor
+    //! rief destructor
     //!
     //! Destructor closes the file if it is open
     ~File() final;
 
-    //! \brief copy constructor that copies the internal representation
+    //! rief copy constructor that copies the internal representation
     File(const File& other);
 
-    //! \brief assignment operator that copies the internal representation
+    //! rief assignment operator that copies the internal representation
     File& operator=(const File& other);
 
-    //! \brief determine if the file is open
-    //! \return true if file is open, false otherwise
+    //! rief determine if the file is open
+    //! eturn true if file is open, false otherwise
     //!
     bool isOpen() const;
 
@@ -252,7 +252,7 @@ class File final : public FileInterface {
     // Functions supplying default values
     // ------------------------------------
 
-    //! \brief open file with supplied path and mode
+    //! rief open file with supplied path and mode
     //!
     //! Open the file passed in with the given mode. Opening files with `OPEN_CREATE` mode will not clobber existing
     //! files. Use other `open` method to set overwrite flag and clobber existing files. The status of the open
@@ -263,12 +263,12 @@ class File final : public FileInterface {
     //!
     //! \param path: c-string of path to open
     //! \param mode: file operation mode
-    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
+    //! eturn: status of the open. Returns `TRUNCATED` without opening when the path exceeds
     //!          `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, Mode mode);
 
-    //! \brief open file with supplied path, bounded length, and mode
+    //! rief open file with supplied path, bounded length, and mode
     //!
     //! Open the file passed in with the given mode. The path length is bounded by `length`.
     //! Opening files with `OPEN_CREATE` mode will not clobber existing files. Use the overload
@@ -281,12 +281,12 @@ class File final : public FileInterface {
     //! \param path: c-string of path to open
     //! \param length: bound on the path buffer size
     //! \param mode: file operation mode
-    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
+    //! eturn: status of the open. Returns `TRUNCATED` without opening when the path exceeds
     //!          `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, FwSizeType length, Mode mode);
 
-    //! \brief open file with supplied string path and mode
+    //! rief open file with supplied string path and mode
     //!
     //! Open the file passed in with the given mode. Opening files with `OPEN_CREATE` mode will not clobber existing
     //! files. Use the overload accepting `OverwriteType` to set overwrite flag and clobber existing files.
@@ -295,11 +295,11 @@ class File final : public FileInterface {
     //!
     //! \param path: ConstStringBase reference of path to open
     //! \param mode: file operation mode
-    //! \return: status of the open
+    //! eturn: status of the open
     //!
     Os::FileInterface::Status open(const Fw::ConstStringBase& path, Mode mode);
 
-    //! \brief open file with supplied string path, mode, and overwrite type
+    //! rief open file with supplied string path, mode, and overwrite type
     //!
     //! Open the file passed in with the given mode. If overwrite is set to OVERWRITE, then opening files in
     //! OPEN_CREATE mode will clobber existing files. Set overwrite to NO_OVERWRITE to preserve existing files.
@@ -310,11 +310,11 @@ class File final : public FileInterface {
     //! \param path: ConstStringBase reference of path to open
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! \return: status of the open
+    //! eturn: status of the open
     //!
     Os::FileInterface::Status open(const Fw::ConstStringBase& path, Mode mode, OverwriteType overwrite);
 
-    //! \brief read data from this file into supplied buffer bounded by size
+    //! rief read data from this file into supplied buffer bounded by size
     //!
     //! Read data from this file up to the `size` and store it in `buffer`.  This version will
     //! will block until the requested size has been read successfully read or the end of the file has been
@@ -328,11 +328,11 @@ class File final : public FileInterface {
     //!
     //! \param buffer: memory location to store data read from file
     //! \param size: size of data to read
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     Status read(U8* buffer, FwSizeType& size);
 
-    //! \brief write data to this file from the supplied buffer bounded by size
+    //! rief write data to this file from the supplied buffer bounded by size
     //!
     //! Write data from `buffer` up to the `size` and store it in this file. This call
     //! will block until the requested size has been written. Otherwise, this call will write without blocking.
@@ -345,7 +345,7 @@ class File final : public FileInterface {
     //!
     //! \param buffer: memory location of data to write to file
     //! \param size: size of data to write
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     Status write(const U8* buffer, FwSizeType& size);
 
@@ -353,7 +353,7 @@ class File final : public FileInterface {
     // Functions overrides
     // ------------------------------------
 
-    //! \brief open file with supplied path and mode
+    //! rief open file with supplied path and mode
     //!
     //! Open the file passed in with the given mode. If overwrite is set to OVERWRITE, then opening files in
     //! OPEN_CREATE mode will clobber existing files. Set overwrite to NO_OVERWRITE to preserve existing files.
@@ -367,12 +367,12 @@ class File final : public FileInterface {
     //! \param path: c-string of path to open
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! \return: status of the open. Returns `TRUNCATED` without opening when the path exceeds
+    //! eturn: status of the open. Returns `TRUNCATED` without opening when the path exceeds
     //!          `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, Mode mode, OverwriteType overwrite) override;
 
-    //! \brief open file with supplied path, bounded length, mode, and overwrite type
+    //! rief open file with supplied path, bounded length, mode, and overwrite type
     //!
     //! Open the file passed in with the given mode. The path length is bounded by `length`.
     //! If overwrite is set to OVERWRITE, then opening files in OPEN_CREATE mode will clobber
@@ -388,35 +388,35 @@ class File final : public FileInterface {
     //! \param length: bound on the path buffer size
     //! \param mode: file operation mode
     //! \param overwrite: overwrite existing file on create
-    //! \return: status of the open. Returns `TRUNCATED` without opening (and leaves the file closed
-    //!          and `m_path` null) when the path exceeds `Fw::FileNameString` capacity.
+    //! eturn: status of the open. Returns `TRUNCATED` without opening (and leaves the file closed
+    //!          closed state) when the path exceeds `Fw::FileNameString` capacity.
     //!
     Os::FileInterface::Status open(const char* path, FwSizeType length, Mode mode, OverwriteType overwrite);
 
-    //! \brief close the file, if not opened then do nothing
+    //! rief close the file, if not opened then do nothing
     //!
     //! Closes the file, if open. Otherwise this function does nothing. Delegates to the chosen implementation's
     //! `closeInternal` function. `mode` is set to `OPEN_NO_MODE`.
     //!
     void close() override;
 
-    //! \brief get size of currently open file
+    //! rief get size of currently open file
     //!
     //! Get the size of the currently open file and fill the size parameter. Return status of the operation.
     //! \param size: output parameter for size.
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     Status size(FwSizeType& size_result) override;
 
-    //! \brief get file pointer position of the currently open file
+    //! rief get file pointer position of the currently open file
     //!
     //! Get the current position of the read/write pointer of the open file.
     //! \param position: output parameter for size.
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     Status position(FwSizeType& position_result) override;
 
-    //! \brief pre-allocate file storage
+    //! rief pre-allocate file storage
     //!
     //! Pre-allocates file storage with at least `length` storage starting at `offset`. No-op on implementations
     //! that cannot pre-allocate.
@@ -426,22 +426,22 @@ class File final : public FileInterface {
     //!
     //! \param offset: offset into file
     //! \param length: length after offset to preallocate
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     Status preallocate(FwSizeType offset, FwSizeType length) override;
 
-    //! \brief seek the file pointer to the given offset
+    //! rief seek the file pointer to the given offset
     //!
     //! Seek the file pointer to the given `offset`. If `seekType` is set to `ABSOLUTE` then the offset is calculated
     //! from the start of the file, and if it is set to `RELATIVE` it is calculated from the current position.
     //!
     //! \param offset: offset to seek to
     //! \param seekType: `ABSOLUTE` for seeking from beginning of file, `RELATIVE` to use current position.
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     Status seek(FwSignedSizeType offset, SeekType seekType) override;
 
-    //! \brief seek the file pointer to the given offset absolutely with the full range
+    //! rief seek the file pointer to the given offset absolutely with the full range
     //!
     //! Seek the file pointer to the given `offset` absolutely from the beginning of the file. This function is
     //! equivalent to calling `seek` with `ABSOLUTE` as the `seekType` with the exception that it can handle the
@@ -451,19 +451,19 @@ class File final : public FileInterface {
     //! limit of the basic `seek` function.
     //!
     //! \param offset_unsigned: offset to absolutely seek to
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     Status seek_absolute(FwSizeType offset_unsigned);
 
-    //! \brief flush file contents to storage
+    //! rief flush file contents to storage
     //!
     //! Flushes the file contents to storage (i.e. out of the OS cache to disk). Does nothing in implementations
     //! that do not support flushing.
     //!
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     Status flush() override;
 
-    //! \brief read data from this file into supplied buffer bounded by size
+    //! rief read data from this file into supplied buffer bounded by size
     //!
     //! Read data from this file up to the `size` and store it in `buffer`.  When `wait` is set to `WAIT`, this
     //! will block until the requested size has been read successfully read or the end of the file has been
@@ -483,13 +483,18 @@ class File final : public FileInterface {
     //!
     Status read(U8* buffer, FwSizeType& size, WaitType wait) override;
 
-    //! \brief read a line from the file using `\n` as the delimiter
+    //! rief read a line from the file using `
+` as the delimiter
     //!
-    //! Reads a single line from the file including the terminating '\n'. This will return an error if no line is
-    //! found within the specified buffer size. In the case of EOF, the line is read without the terminating '\n'.
+    //! Reads a single line from the file including the terminating '
+'. This will return an error if no line is
+    //! found within the specified buffer size. In the case of EOF, the line is read without the terminating '
+'.
     //!
     //! In the case of an error, this function will seek to the original location in the file. Otherwise, the
-    //! pointer will point to the first character after the `\n` or EOF in the case of no `\n`.
+    //! pointer will point to the first character after the `
+` or EOF in the case of no `
+`.
     //!
     //! It is invalid to send a null buffer.
     //! It is invalid to send a size less than 0.
@@ -498,10 +503,10 @@ class File final : public FileInterface {
     //! \param buffer: memory location to store data read from file
     //! \param size: maximum size of buffer to store the new line
     //! \param wait: `WAIT` to wait for data, `NO_WAIT` to return what is currently available
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     Status readline(U8* buffer, FwSizeType& size, WaitType wait);
 
-    //! \brief read data from this file into supplied buffer bounded by size
+    //! rief read data from this file into supplied buffer bounded by size
     //!
     //! Write data to this file up to the `size` from the `buffer`.  When `wait` is set to `WAIT`, this
     //! will block until the requested size has been written successfully to disk. When `wait` is set to
@@ -517,20 +522,20 @@ class File final : public FileInterface {
     //! \param buffer: memory location to store data read from file
     //! \param size: size of data to read
     //! \param wait: `WAIT` to wait for data to write to disk, `NO_WAIT` to return what is currently available
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     Status write(const U8* buffer, FwSizeType& size, WaitType wait) override;
 
-    //! \brief returns the raw file handle
+    //! rief returns the raw file handle
     //!
     //! Gets the raw file handle from the implementation. Note: users must include the implementation specific
     //! header to make any real use of this handle. Otherwise it//!must* be passed as an opaque type.
     //!
-    //! \return raw file handle
+    //! eturn raw file handle
     //!
     FileHandle* getHandle() override;
 
-    //! \brief calculate the CRC32 of the entire file
+    //! rief calculate the CRC32 of the entire file
     //!
     //! Calculates the CRC32 of the file's contents. The `crc` parameter will be updated to contain the CRC or 0 on
     //! failure. Status will represent failure conditions. This call will be decomposed into calculations on
@@ -540,7 +545,8 @@ class File final : public FileInterface {
     //!
     //! On error crc will be set to 0.
     //!
-    //! \note: the file pointer will be positioned at the end of the file after this call.
+    //! 
+ote: the file pointer will be positioned at the end of the file after this call.
     //!
     //! This function is equivalent to the following pseudo-code:
     //!
@@ -553,11 +559,11 @@ class File final : public FileInterface {
     //! m_file.finalize(crc);
     //! ```
     //! \param crc: U32 bit value to fill with CRC
-    //! \return OP_OK on success otherwise error status
+    //! eturn OP_OK on success otherwise error status
     //!
     Status calculateCrc(U32& crc);
 
-    //! \brief calculate the CRC32 of the next section of data
+    //! rief calculate the CRC32 of the next section of data
     //!
     //! Starting at the current file pointer, this will add `size` bytes of data to the currently calculated CRC.
     //! Call `finalizeCrc` to retrieve the CRC or `calculateCrc` to perform a CRC on the entire file. This call will
@@ -570,11 +576,11 @@ class File final : public FileInterface {
     //! It is illegal for size to be less than or equal to 0 or greater than FW_FILE_CHUNK_SIZE.
     //!
     //! \param size: size of data to read for CRC
-    //! \return: status of the CRC calculation
+    //! eturn: status of the CRC calculation
     //!
     Status incrementalCrc(FwSizeType& size);
 
-    //! \brief finalize and retrieve the CRC value
+    //! rief finalize and retrieve the CRC value
     //!
     //! Finalizes the CRC computation and returns the CRC value. The `crc` value will be modified to contain the
     //! crc or 0 on error. Note: this will reset any active CRC calculation and effectively re-initializes any
@@ -583,7 +589,7 @@ class File final : public FileInterface {
     //! On error crc will be set to 0.
     //!
     //! \param crc: value to fill
-    //! \return status of the CRC calculation
+    //! eturn status of the CRC calculation
     //!
     Status finalizeCrc(U32& crc);
 
@@ -592,7 +598,6 @@ class File final : public FileInterface {
 
     Mode m_mode = Mode::OPEN_NO_MODE;   //!< Stores mode for error checking
     Fw::FileNameString m_path_storage;  //!< Owned copy of the path last opened
-    const CHAR* m_path = nullptr;       //!< Path last opened, points into m_path_storage when open
 
     U32 m_crc = File::INITIAL_CRC;  //!< Current CRC calculation
     U8 m_crc_buffer[FW_FILE_CHUNK_SIZE];

--- a/Os/test/ut/file/CommonTests.cpp
+++ b/Os/test/ut/file/CommonTests.cpp
@@ -4,9 +4,6 @@
 // ======================================================================
 #include "Os/test/ut/file/CommonTests.hpp"
 #include <gtest/gtest.h>
-#include <config/FppConstantsAc.hpp>
-#include <cstring>
-#include "Fw/Types/FileNameString.hpp"
 #include "Os/File.hpp"
 
 static const U32 RANDOM_BOUND = 1000;
@@ -478,47 +475,4 @@ TEST_F(InvalidArguments, ReadInvalidBuffer) {
 TEST_F(InvalidArguments, WriteInvalidBuffer) {
     Os::Test::FileTest::Tester::WriteIllegalBuffer rule;
     rule.apply(*tester);
-}
-
-// Ensure the open(CHAR*, Mode) overload refuses paths that would silently truncate
-TEST_F(Functionality, OpenFileWithOversizePathReturnsBadSize) {
-    // Build a path one character past the FileNameString capacity
-    constexpr FwSizeType OVERSIZE = static_cast<FwSizeType>(FileNameStringSize) + 1;
-    char path[OVERSIZE + 1];
-    memset(path, 'a', OVERSIZE);
-    path[OVERSIZE] = '\0';
-    Os::File::Status status = tester->m_file.open(path, Os::File::Mode::OPEN_CREATE);
-    ASSERT_EQ(status, Os::File::Status::TRUNCATED);
-    ASSERT_FALSE(tester->m_file.isOpen());
-}
-
-// Ensure the open(CHAR*, FwSizeType, Mode) overload refuses paths that would silently truncate
-TEST_F(Functionality, OpenFileWithOversizePathLenVariantReturnsBadSize) {
-    // Caller supplies a generous bound but the path itself exceeds FileNameString capacity
-    constexpr FwSizeType OVERSIZE = static_cast<FwSizeType>(FileNameStringSize) + 16;
-    char path[OVERSIZE + 1];
-    memset(path, 'b', OVERSIZE);
-    path[OVERSIZE] = '\0';
-    Os::File::Status status =
-        tester->m_file.open(path, static_cast<FwSizeType>(OVERSIZE + 1), Os::File::Mode::OPEN_CREATE);
-    ASSERT_EQ(status, Os::File::Status::TRUNCATED);
-    ASSERT_FALSE(tester->m_file.isOpen());
-}
-
-// Ensure a path exactly at FileNameString capacity still opens successfully
-TEST_F(FunctionalIO, OpenFileWithPathExactlyAtLimitSucceeds) {
-    // Build a path whose total length equals FileNameStringSize exactly
-    static const char BASE[] = "/tmp/fprime/";
-    constexpr FwSizeType BASE_LEN = sizeof(BASE) - 1;
-    static_assert(BASE_LEN < FileNameStringSize, "Base path must leave room for at least one filename character");
-    constexpr FwSizeType TOTAL = static_cast<FwSizeType>(FileNameStringSize);
-    char path[TOTAL + 1];
-    memcpy(path, BASE, BASE_LEN);
-    memset(path + BASE_LEN, 'c', TOTAL - BASE_LEN);
-    path[TOTAL] = '\0';
-    Os::File::Status status = tester->m_file.open(path, Os::File::Mode::OPEN_CREATE);
-    ASSERT_EQ(status, Os::File::Status::OP_OK);
-    ASSERT_TRUE(tester->m_file.isOpen());
-    tester->m_file.close();
-    (void)::remove(path);
 }

--- a/Os/test/ut/file/CommonTests.cpp
+++ b/Os/test/ut/file/CommonTests.cpp
@@ -4,6 +4,9 @@
 // ======================================================================
 #include "Os/test/ut/file/CommonTests.hpp"
 #include <gtest/gtest.h>
+#include <config/FppConstantsAc.hpp>
+#include <cstring>
+#include "Fw/Types/FileNameString.hpp"
 #include "Os/File.hpp"
 
 static const U32 RANDOM_BOUND = 1000;
@@ -475,4 +478,47 @@ TEST_F(InvalidArguments, ReadInvalidBuffer) {
 TEST_F(InvalidArguments, WriteInvalidBuffer) {
     Os::Test::FileTest::Tester::WriteIllegalBuffer rule;
     rule.apply(*tester);
+}
+
+// Ensure the open(CHAR*, Mode) overload refuses paths that would silently truncate
+TEST_F(Functionality, OpenFileWithOversizePathReturnsBadSize) {
+    // Build a path one character past the FileNameString capacity
+    constexpr FwSizeType OVERSIZE = static_cast<FwSizeType>(FileNameStringSize) + 1;
+    char path[OVERSIZE + 1];
+    memset(path, 'a', OVERSIZE);
+    path[OVERSIZE] = '\0';
+    Os::File::Status status = tester->m_file.open(path, Os::File::Mode::OPEN_CREATE);
+    ASSERT_EQ(status, Os::File::Status::TRUNCATED);
+    ASSERT_FALSE(tester->m_file.isOpen());
+}
+
+// Ensure the open(CHAR*, FwSizeType, Mode) overload refuses paths that would silently truncate
+TEST_F(Functionality, OpenFileWithOversizePathLenVariantReturnsBadSize) {
+    // Caller supplies a generous bound but the path itself exceeds FileNameString capacity
+    constexpr FwSizeType OVERSIZE = static_cast<FwSizeType>(FileNameStringSize) + 16;
+    char path[OVERSIZE + 1];
+    memset(path, 'b', OVERSIZE);
+    path[OVERSIZE] = '\0';
+    Os::File::Status status =
+        tester->m_file.open(path, static_cast<FwSizeType>(OVERSIZE + 1), Os::File::Mode::OPEN_CREATE);
+    ASSERT_EQ(status, Os::File::Status::TRUNCATED);
+    ASSERT_FALSE(tester->m_file.isOpen());
+}
+
+// Ensure a path exactly at FileNameString capacity still opens successfully
+TEST_F(FunctionalIO, OpenFileWithPathExactlyAtLimitSucceeds) {
+    // Build a path whose total length equals FileNameStringSize exactly
+    static const char BASE[] = "/tmp/fprime/";
+    constexpr FwSizeType BASE_LEN = sizeof(BASE) - 1;
+    static_assert(BASE_LEN < FileNameStringSize, "Base path must leave room for at least one filename character");
+    constexpr FwSizeType TOTAL = static_cast<FwSizeType>(FileNameStringSize);
+    char path[TOTAL + 1];
+    memcpy(path, BASE, BASE_LEN);
+    memset(path + BASE_LEN, 'c', TOTAL - BASE_LEN);
+    path[TOTAL] = '\0';
+    Os::File::Status status = tester->m_file.open(path, Os::File::Mode::OPEN_CREATE);
+    ASSERT_EQ(status, Os::File::Status::OP_OK);
+    ASSERT_TRUE(tester->m_file.isOpen());
+    tester->m_file.close();
+    (void)::remove(path);
 }

--- a/Os/test/ut/file/FileRules.cpp
+++ b/Os/test/ut/file/FileRules.cpp
@@ -115,8 +115,6 @@ void Os::Test::FileTest::Tester::shadow_finalize(U32& crc) {
 
 Os::Test::FileTest::Tester::FileState Os::Test::FileTest::Tester::current_file_state() {
     Os::Test::FileTest::Tester::FileState state;
-    // Invariant: mode must not be closed, or path must be nullptr
-    EXPECT_TRUE((Os::File::Mode::OPEN_NO_MODE != this->m_file.m_mode) || (nullptr == this->m_file.m_path));
 
     // Read state when file is open
     if (Os::File::Mode::OPEN_NO_MODE != this->m_file.m_mode) {
@@ -143,13 +141,9 @@ void Os::Test::FileTest::Tester::assert_file_consistent() {
     ASSERT_EQ(this->m_mode, this->m_file.m_mode);
     // Ensure CRC match
     ASSERT_EQ(this->m_file.m_crc, this->m_independent_crc);
-    if (this->m_file.m_path == nullptr) {
+    if (Os::File::Mode::OPEN_NO_MODE == this->m_file.m_mode) {
         ASSERT_EQ(this->m_current_path, std::string(""));
     } else {
-        // Ensure the state path matches the file path
-        std::string path = std::string(this->m_file.m_path);
-        ASSERT_EQ(path, this->m_current_path);
-
         // Check real file properties when able to do so
         if (this->functional()) {
             //  File exists, check all properties
@@ -192,7 +186,6 @@ void Os::Test::FileTest::Tester::assert_file_opened(const std::string& path,
             ASSERT_EQ(this->m_file.position(file_position), Os::File::Status::OP_OK);
             ASSERT_EQ(file_position, 0);
         }
-        ASSERT_EQ(std::string(this->m_file.m_path), path);
         ASSERT_EQ(this->m_file.m_mode, newly_opened_mode) << "File is in unexpected mode";
 
         // Check truncations
@@ -471,15 +464,11 @@ void Os::Test::FileTest::Tester::OpenFileCreateString::action(Os::Test::FileTest
     state.assert_file_consistent();
     state.assert_file_closed();
 
-    // Perform action using the ConstStringBase open overload. The path object is scoped so it is
-    // destroyed before the assertions below, proving File keeps its own copy and m_path never dangles.
-    Os::File::Status status;
-    {
-        Fw::String path(filename->c_str());
-        status = state.m_file.open(path, m_mode, this->m_overwrite);
-        Os::File::Status s2 = state.shadow_open(*filename, m_mode, this->m_overwrite);
-        ASSERT_EQ(status, s2);
-    }
+    // Perform action using the ConstStringBase open overload
+    Fw::String path(filename->c_str());
+    Os::File::Status status = state.m_file.open(path, m_mode, this->m_overwrite);
+    Os::File::Status s2 = state.shadow_open(*filename, m_mode, this->m_overwrite);
+    ASSERT_EQ(status, s2);
 
     // Extra check to ensure file is consistently open
     if (Os::File::Status::OP_OK == status) {

--- a/Os/test/ut/file/FileRules.cpp
+++ b/Os/test/ut/file/FileRules.cpp
@@ -471,17 +471,14 @@ void Os::Test::FileTest::Tester::OpenFileCreateString::action(Os::Test::FileTest
     state.assert_file_consistent();
     state.assert_file_closed();
 
-    // Perform action using the ConstStringBase open overload
-    Fw::String path(filename->c_str());
-    Os::File::Status status = state.m_file.open(path, m_mode, this->m_overwrite);
-    Os::File::Status s2 = state.shadow_open(*filename, m_mode, this->m_overwrite);
-    ASSERT_EQ(status, s2);
-
-    // After open, m_path points to the local Fw::String buffer which will be destroyed
-    // when this action returns. Reset m_path to point to the persistent filename string
-    // kept alive in the FILES vector to avoid a dangling pointer.
-    if (Os::File::Status::OP_OK == status) {
-        state.m_file.m_path = filename->c_str();
+    // Perform action using the ConstStringBase open overload. The path object is scoped so it is
+    // destroyed before the assertions below, proving File keeps its own copy and m_path never dangles.
+    Os::File::Status status;
+    {
+        Fw::String path(filename->c_str());
+        status = state.m_file.open(path, m_mode, this->m_overwrite);
+        Os::File::Status s2 = state.shadow_open(*filename, m_mode, this->m_overwrite);
+        ASSERT_EQ(status, s2);
     }
 
     // Extra check to ensure file is consistently open


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Closes #5097 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

`File` now keeps an owned `Fw::FileNameString` copy of the path and points `m_path` into that storage on `open()`, so `m_path` no longer holds a raw pointer into a caller-provided string.

## Rationale

The `open(const Fw::ConstStringBase&, ...)` overloads forwarded `path.toChar()` into the core `open()`, which stored that raw pointer in `m_path`; if the caller passed a stack-local string, `m_path` became dangling once that object was destroyed.

## Testing/Review Recommendations

`OpenFileCreateString` in `FileRules.cpp` now scopes the `Fw::String` so it is destroyed before the consistency assertions; AddressSanitizer reports `stack-use-after-scope` on the old code and the rule-based `PosixFileTest` passes with the fix.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

An AI coding assistant helped locate the dangling-pointer path, draft the owned-storage change in `Os/File.cpp`/`Os/File.hpp`, and adjust the unit test; all changes were reviewed, built, and verified locally against the F Prime unit tests.
