### PR TITLE
Fw: Types, fix serialize size left assert

### DIFF
--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -692,7 +692,8 @@ Serializable::SizeType LinearBufferBase::getDeserializeSizeLeft() const {
 }
 
 Serializable::SizeType LinearBufferBase::getSerializeSizeLeft() const {
-    FW_ASSERT(static_cast<FwAssertArgType>(this->m_serLoc));
+    FW_ASSERT(this->getCapacity() >= this->m_serLoc, static_cast<FwAssertArgType>(this->getCapacity()),
+              static_cast<FwAssertArgType>(this->m_serLoc));
     return this->getCapacity() - this->m_serLoc;
 }
 

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -46,6 +46,18 @@ class SerializeTestBuffer : public Fw::LinearBufferBase {
     U8 m_testBuff[255];
 };
 
+TEST(SerializationTest, SerializeSizeLeftStartsAtCapacity) {
+    SerializeTestBuffer buff;
+
+    ASSERT_EQ(buff.getCapacity(), buff.getSerializeSizeLeft());
+
+    const U8 value = 0xAB;
+    const Fw::SerializeStatus status = buff.serializeFrom(value);
+
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, status);
+    ASSERT_EQ(buff.getCapacity() - sizeof(value), buff.getSerializeSizeLeft());
+}
+
 TEST(SerializationTest, Serialization1) {
     printf("Testing Serialization code\n");
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Fixes #5175 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Updates `LinearBufferBase::getSerializeSizeLeft()` so the guard checks that the current serialization offset is within the buffer capacity before subtracting it. This allows a fresh buffer at offset 0 to report its full remaining capacity.

Adds a unit test covering the initial remaining-size value and the value after serializing one byte.

## Rationale

`getSerializeSizeLeft()` asserted on `m_serLoc` directly, so calling it on a new buffer triggered an assertion even though zero is the expected initial serialization offset. The remaining size should be `capacity - m_serLoc` as long as the offset is not beyond the buffer capacity.

## Testing/Review Recommendations

Ran:

- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/fprime-util build --ut -p Fw/Types`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/fprime-util check -p Fw/Types`
- `.venv/bin/clang-format --dry-run --Werror Fw/Types/Serializable.cpp Fw/Types/test/ut/TypesTest.cpp`
- `git diff --check`

Reviewers may want to focus on whether `getCapacity() >= m_serLoc` is the right invariant for this API.

## Future Work

None planned.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

An OpenAI language model was used to inspect the issue and relevant code path, draft the small fix and regression test, and help prepare the pull request text. The final code was reviewed, formatted, built, and tested locally before submission.

IAMAI
