### PR TITLE
Support non-default recordSize and prmId field lengths in PrmDb (#4716)

### DIFF
--- a/Svc/PrmDb/PrmDbImpl.cpp
+++ b/Svc/PrmDb/PrmDbImpl.cpp
@@ -51,7 +51,7 @@ namespace Svc {
     }
 
     void PrmDbImpl::clearDb() {
-        for (I32 entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
+        for (FwPrmIdType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
             this->m_db[entry].used = false;
             this->m_db[entry].id = 0;
         }
@@ -64,7 +64,7 @@ namespace Svc {
         // search for entry
         Fw::ParamValid stat = Fw::ParamValid::INVALID;
 
-        for (I32 entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
+        for (FwPrmIdType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
             if (this->m_db[entry].used) {
                 if (this->m_db[entry].id == id) {
                     val = this->m_db[entry].val;
@@ -91,7 +91,7 @@ namespace Svc {
         bool existingEntry = false;
         bool noSlots = true;
 
-        for (NATIVE_INT_TYPE entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
+        for (FwPrmIdType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
             if ((this->m_db[entry].used) && (id == this->m_db[entry].id)) {
                 this->m_db[entry].val = val;
                 existingEntry = true;
@@ -101,7 +101,7 @@ namespace Svc {
 
         // if there is no existing entry, add one
         if (!existingEntry) {
-            for (I32 entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
+            for (FwPrmIdType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++) {
                 if (!(this->m_db[entry].used)) {
                     this->m_db[entry].val = val;
                     this->m_db[entry].id = id;
@@ -142,7 +142,7 @@ namespace Svc {
 
         U32 numRecords = 0;
 
-        for (NATIVE_UINT_TYPE entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_db); entry++) {
+        for (FwPrmIdType entry = 0; entry < FW_NUM_ARRAY_ELEMENTS(this->m_db); entry++) {
             if (this->m_db[entry].used) {
                 // write delimiter
                 static const U8 delim = PRMDB_ENTRY_DELIMITER;
@@ -164,7 +164,7 @@ namespace Svc {
                     return;
                 }
                 // serialize record size = id field + data
-                U32 recordSize = static_cast<U32>(sizeof(FwPrmIdType) + this->m_db[entry].val.getBuffLength());
+                FwSizeStoreType recordSize = static_cast<FwSizeStoreType>(sizeof(FwPrmIdType) + this->m_db[entry].val.getBuffLength());
 
                 // reset buffer
                 buff.resetSer();
@@ -268,7 +268,7 @@ namespace Svc {
 
         this->clearDb();
 
-        for (NATIVE_INT_TYPE entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++)  {
+        for (FwPrmIdType entry = 0; entry < PRMDB_NUM_DB_ENTRIES; entry++)  {
 
             U8 delimiter;
             FwSignedSizeType readSize = static_cast<FwSignedSizeType>(sizeof(delimiter));
@@ -296,7 +296,7 @@ namespace Svc {
                 return;
             }
 
-            U32 recordSize = 0;
+            FwSizeStoreType recordSize = 0;
             // read record size
             readSize = sizeof(recordSize);
 
@@ -321,7 +321,7 @@ namespace Svc {
 
             // sanity check value. It can't be larger than the maximum parameter buffer size + id
             // or smaller than the record id
-            if ((recordSize > FW_PARAM_BUFFER_MAX_SIZE + sizeof(U32)) or (recordSize < sizeof(U32))) {
+            if ((recordSize > FW_PARAM_BUFFER_MAX_SIZE + sizeof(FwPrmIdType)) or (recordSize < sizeof(FwPrmIdType))) {
                 this->log_WARNING_HI_PrmFileReadError(PrmReadError::RECORD_SIZE_VALUE,static_cast<I32>(recordNum),static_cast<I32>(recordSize));
                 return;
             }
@@ -361,7 +361,7 @@ namespace Svc {
                 this->log_WARNING_HI_PrmFileReadError(PrmReadError::PARAMETER_VALUE,static_cast<I32>(recordNum),fStat);
                 return;
             }
-            if (static_cast<U32>(readSize) != recordSize-sizeof(parameterId)) {
+            if (static_cast<FwSizeStoreType>(readSize) != recordSize-sizeof(parameterId)) {
                 this->log_WARNING_HI_PrmFileReadError(PrmReadError::PARAMETER_VALUE_SIZE,static_cast<I32>(recordNum),static_cast<I32>(readSize));
                 return;
             }

--- a/Svc/PrmDb/docs/sdd.md
+++ b/Svc/PrmDb/docs/sdd.md
@@ -46,8 +46,8 @@ The fields for each parameter value as stored in the parameter file are as follo
 
 Description | Size (in bytes) | Value
 ----------- | ---- | -----
-Entry Delimiter | 1 | 0xA5
-Record Size | 4 | Id type size + number of bytes in parameter value
+Entry Delimiter | 1 | Configurable by setting `PRMDB_ENTRY_DELIMITER` (default 0xA5)
+Record Size | Size of FwSizeStoreType | Id type size + number of bytes in parameter value
 Parameter ID | Size of FwPrmIdType | Value of parameter ID
 Parameter value | number of bytes in parameter | serialized bytes of value
 

--- a/Svc/PrmDb/test/ut/PrmDbImplTester.cpp
+++ b/Svc/PrmDb/test/ut/PrmDbImplTester.cpp
@@ -372,7 +372,7 @@ namespace Svc {
                     size += 1;
                     break;
                 case FILE_DATA_ERROR:
-                    buffer[0] += 1;
+                    buffer[0] += 0x81;
                     break;
                 default:
                     break;
@@ -424,11 +424,11 @@ namespace Svc {
                     break;
                 case 1:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
-                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::RECORD_SIZE_SIZE, 0, sizeof(U32) + 1);
+                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::RECORD_SIZE_SIZE, 0, sizeof(FwSizeStoreType) + 1);
                     break;
                 case 2:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
-                    ASSERT_EVENTS_PrmFileReadError(0,PrmReadError::PARAMETER_ID_SIZE, 0, sizeof(FwPrmIdType) + 1);
+                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::PARAMETER_ID_SIZE, 0, sizeof(FwPrmIdType) + 1);
                     break;
                 case 3:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
@@ -489,14 +489,15 @@ namespace Svc {
             switch (i) {
                 case 0:
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
-                    // Parameter read error caused by adding one to the expected read
-                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER_VALUE, 0, PRMDB_ENTRY_DELIMITER + 1);
+                    // Parameter read error caused by adding 0x81 to the expected read
+                    ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::DELIMITER_VALUE, 0, static_cast<U8>(PRMDB_ENTRY_DELIMITER + 0x81));
                     break;
                 case 1: {
-                    // Data in this test is corrupted by adding 1 to the first data byte read. Since data is stored in
-                    // big-endian format the highest order byte of the record size (U32) must have one added to it.
-                    // Expected result of '8' inherited from original design of test.
-                    U32 expected_error_value = 8 + (1 << ((sizeof(U32) - 1) * 8));
+                    // This test corrupts the recordSize by adding 0x81 to the first byte read after the delimiter. Since data is stored
+                    // in big-endian format, the highest order byte of the record size (FwSizeStoreType) must have 0x81 added to it.
+                    // The 0x81 value was chosen to still give an improbably large buffer size even when FwSizeStoreType == U16.
+                    // Expected result of 'sizeof(FwPrmIdType) + sizeof(U32)' inherited from original design of test.
+                    FwSizeStoreType expected_error_value = sizeof(FwPrmIdType) + sizeof(U32) + (0x81 << ((sizeof(FwSizeStoreType) - 1) * 8));
                     ASSERT_EVENTS_PrmFileReadError_SIZE(1);
                     ASSERT_EVENTS_PrmFileReadError(0, PrmReadError::RECORD_SIZE_VALUE, 0, expected_error_value);
                     break;
@@ -548,7 +549,7 @@ namespace Svc {
                     break;
                 case 1:
                     ASSERT_EVENTS_PrmFileWriteError_SIZE(1);
-                    ASSERT_EVENTS_PrmFileWriteError(0, PrmWriteError::RECORD_SIZE_SIZE, 0, sizeof(U32) + 1);
+                    ASSERT_EVENTS_PrmFileWriteError(0, PrmWriteError::RECORD_SIZE_SIZE, 0, sizeof(FwSizeStoreType) + 1);
                     break;
                 case 2:
                     ASSERT_EVENTS_PrmFileWriteError_SIZE(1);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4716 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Updated PrmDbImpl to use configurable types `FwSizeStoreType` and `FwPrmIdType` when handling `recordSize` and `prmId` fields.

Updated unit tests to support these configurable types.  The `PrmFileReadError` test was specifically updated to successfully test the `PrmReadError::RECORD_SIZE_VALUE` scenario for both `U16` and `U32` `FwPrmIdType` cases.

## Rationale

Some projects have unique sizing requirements that differ from the standard F Prime configuration. `FwSizeStoreType` and `FwPrmIdType` should be used where relevant.

## Testing/Review Recommendations

These changes have been tested on macOS. Unit tests were confirmed to pass with `FwPrmIdType` configured as both `U16` and `U32`. It might be worth testing on more deployments / more architectures.

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A