### PR TITLE
ci: pin third-party Actions to commit SHA (CWE-829, 2 sites)

### DIFF
--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           location: ${{ env.FPRIME_LOCATION }}
       - name: "Setup RPI Toolchain"
-        uses: fprime-community/setup-rpi-sysroot@main
+        uses: fprime-community/setup-rpi-sysroot@320798b23716fddfe710cd791f317827e607789d # main (pin to SHA)
       - name: "Generate RPI Build Cache"
         run: |
           fprime-util generate raspberrypi

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@v0.0.26
+        uses: check-spelling/check-spelling@cfb6f7e75bbfc89c71eaa30366d0c166f1bd9c8c # v0.0.26 (pin to SHA)
         with:
           suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
           checkout: true


### PR DESCRIPTION
## Summary

Pins two third-party GitHub Actions to immutable commit SHAs, preserving the human-readable ref in a trailing comment so dependabot / manual review can still drive updates.

|  File | Current | Pinned to |
|---|---|---|
| `.github/workflows/ext-raspberry-led-blinker.yml:58` | `fprime-community/setup-rpi-sysroot@main` | `@320798b2…` (HEAD of `main`) |
| `.github/workflows/spelling.yml:91` | `check-spelling/check-spelling@v0.0.26` | `@cfb6f7e7…` (v0.0.26 tag) |

## Why this matters

A third-party Action pinned to a tag or branch executes whatever the upstream maintainer pushes there at run time. A repo takeover, a maintainer account compromise, or a malicious release that rewrites the tag → CI runs attacker code with all repository secrets in scope. The [tj-actions/changed-files supply-chain attack (March 2025)](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) compromised ~23,000 workflows because they used `@v45` instead of a SHA.

SHA pinning freezes the action contents at exactly the bytes upstream maintainers reviewed at this commit; only an explicit edit (visible in PR diff + git blame) can change it. The comment retains the human-readable version so updates remain ergonomic.

## Other GHA hygiene observations (not in this PR)

The audit also flagged several other repos under `fprime-community/*` referenced as `@main` or `@release` in workflows. They didn't surface as separate findings because they share the same pattern as #1 above — happy to extend this PR or split into per-action commits if preferred.

## Provenance

Findings discovered by [Kulvex Code (KCode)](https://github.com/AstrolexisAI/KCode), a deterministic SAST scanner with an LLM verifier. Full audit on fprime:
- 906 source files scanned
- 668 candidates → 6 confirmed in 114 seconds
- 2 GHA SHA-pinning + 4 `FW_ASSERT` input-validation findings

The 4 `FW_ASSERT` findings are security-class (validation that vanishes in release builds) and will be filed via fprime's [vulnerability report form](https://github.com/nasa/fprime/security/advisories/new) per SECURITY.md, not as a public PR.

Per fprime's AI policy (SECURITY.md): **both finding discovery and fix authoring used AI tooling.** Discovery: KCode (local Gemma + Grok ensemble). Fix: KCode agentic mode (Claude Sonnet 4.5). Each fix is a single-line replacement that preserves indentation. SHA values were resolved via `gh api /repos/{owner}/{repo}/commits/{ref}` immediately before authoring.

IAMAI

---

Signed-off-by: AstroLexis · Kulvex Code <contact@astrolexis.space>