### PR TITLE
Bump FPP to v3.3.0a4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Flask-Compress==1.15
 Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.4
 fprime-fpl-write-pic==1.0.4
-fprime-fpp==3.3.0a3
+fprime-fpp==3.3.0a4
 fprime-gds==4.2.0
 fprime-tools==4.2.0
 fprime-visual==1.0.2


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Updates FPP to v3.3.0a4 which makes JSON files output without whitespace by default. This will automatically apply to builds with JSON generation on which will reduce build cache size. To use the old behavior use the new `-f` or `--format` option in `fpp-to-json`.

## Rationale

We use FPP and want to update it

## Testing/Review Recommendations


## Future Work

More FPP updates!

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

None
