### PR TITLE
FileUplink::File::open: validate destination path length at entry

### DIFF
--- a/Svc/FileUplink/File.cpp
+++ b/Svc/FileUplink/File.cpp
@@ -20,12 +20,7 @@ namespace Svc {
 Os::File::Status FileUplink::File::open(const Fw::FilePacket::StartPacket& startPacket) {
     const U32 length = startPacket.getDestinationPath().getLength();
     char path[Fw::FilePacket::PathName::MAX_LENGTH + 1];
-    // Defensive bound check.  The path length is currently bounded by the
-    // U8 type of PathName::m_length (max 255 <= MAX_LENGTH); this check
-    // makes the FileUplink::File::open contract self-defending — any
-    // future widening of m_length would otherwise turn the memcpy into a
-    // stack overflow without compiler diagnostic.  Matches the
-    // defense-in-depth style of handleDataPacket() in this component.
+    // Ensure that length is not greater that the size of the variable we will copy into
     if (length >= sizeof(path)) {
         return Os::File::Status::BAD_SIZE;
     }

--- a/Svc/FileUplink/File.cpp
+++ b/Svc/FileUplink/File.cpp
@@ -20,6 +20,15 @@ namespace Svc {
 Os::File::Status FileUplink::File::open(const Fw::FilePacket::StartPacket& startPacket) {
     const U32 length = startPacket.getDestinationPath().getLength();
     char path[Fw::FilePacket::PathName::MAX_LENGTH + 1];
+    // Defensive bound check.  The path length is currently bounded by the
+    // U8 type of PathName::m_length (max 255 <= MAX_LENGTH); this check
+    // makes the FileUplink::File::open contract self-defending — any
+    // future widening of m_length would otherwise turn the memcpy into a
+    // stack overflow without compiler diagnostic.  Matches the
+    // defense-in-depth style of handleDataPacket() in this component.
+    if (length >= sizeof(path)) {
+        return Os::File::Status::BAD_SIZE;
+    }
     memcpy(path, startPacket.getDestinationPath().getValue(), length);
     path[length] = 0;
     Fw::LogStringArg logStringArg(path);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5261 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Adds a local `length >= sizeof(path)` bound check at the entry of `FileUplink::File::open`, returning `Os::File::Status::BAD_SIZE` when the supplied destination path length would overflow the 256-byte stack buffer.

## Rationale

The function copies wire-supplied bytes into a fixed 256-byte local buffer using `memcpy(path, ..., length)` with no local comparison between `length` and `sizeof(path)`. Current safety relies on `Fw::FilePacket::PathName::m_length` being declared `U8` (in a different file), capping `length` at 255 ≤ `MAX_LENGTH`. Any future widening of `m_length` to `U16` or `U32` would silently turn this into a remotely-triggerable stack buffer overflow, with no compiler error and no test failure unless someone happened to test with a path longer than 255 bytes.

Defense-in-depth here matches the existing style of `handleDataPacket` in the same component, which performs explicit overflow + bound checks against `byteOffset + dataSize` even though both operands are already `U32`-bounded by their declared types.

Closes #5261.

## Testing/Review Recommendations

- Review the choice of return code (`Os::File::Status::BAD_SIZE` from `Os/File.hpp:45`). `BAD_SIZE` is the closest existing semantic match; `OTHER_ERROR` is the fallback if `BAD_SIZE` is reserved for a different use.
- The change is one defensive comparison + early return; no functional behavior changes on well-formed inputs.
- Existing unit tests in `Svc/FileUplink/test/` should continue to pass since well-formed StartPackets have `length <= 255 < 256 = sizeof(path)`.

A unit test exercising the new error path (a hand-constructed StartPacket whose PathName length would equal or exceed `sizeof(path)`) would be valuable, but constructing such a StartPacket requires loosening the upstream `U8` constraint or going below the public API — happy to add this if the maintainers can advise on the preferred approach.

## Future Work

If the maintainer team is interested, the same defensive style applies to a small handful of other functions in `Svc/CmdSequencer/` and `Svc/FileDownlink/` where path or string fields are similarly memcpy'd into fixed-size buffers relying on upstream type narrowing. Happy to scope a follow-up sweep.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

n/a
