### PR TITLE
Svc: reject `..` path-traversal token in command handlers (FileManager + FpySequencer)

### DIFF
--- a/Svc/FileManager/Events.fppi
+++ b/Svc/FileManager/Events.fppi
@@ -222,3 +222,11 @@ event CalculateCrcSucceeded(fileName: string size FileNameStringSize @< The name
   severity activity high \
   id 0x1c \
   format "{} has CRC value 0x{x}"
+
+@ A command was rejected because the supplied path contains a parent-directory traversal token. The command is dropped without invoking any filesystem primitive.
+event PathTraversalRejected(
+                             path: string size FileNameStringSize @< The rejected path argument
+                           ) \
+  severity warning high \
+  id 0x1d \
+  format "Command rejected: path {} contains a parent-directory traversal token"

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -16,9 +16,32 @@
 #include <Fw/FPrimeBasicTypes.hpp>
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
+#include "Fw/Types/StringUtils.hpp"
 #include "Os/Directory.hpp"
 #include "Svc/FileManager/FileManager.hpp"
 #include "config/FileManagerConfig.hpp"
+
+namespace {
+
+//! Returns true if `path` contains the `..` path-traversal token.
+//!
+//! Conservative: rejects any occurrence as a substring, not just as a
+//! complete path component (i.e. `foo..bar` is also rejected). The
+//! rationale is the same brick-wall hardening template applied in
+//! nasa/fprime#5262 (FileUplink::File::open): cross-translation-unit
+//! invariants on attacker-controlled input must be enforced locally,
+//! not assumed.
+//!
+//! Without this check, a ground command operator (or upstream sender
+//! who can influence command-line arguments) can pass `../../path` as
+//! the dirName / fileName parameter and reach paths outside the
+//! intended file-management scope.
+bool containsPathTraversal(const Fw::CmdStringArg& path) {
+    const FwSizeType len = path.length();
+    return Fw::StringUtils::substring_find(path.toChar(), len, "..", 2) >= 0;
+}
+
+}  // namespace
 
 namespace Svc {
 
@@ -46,6 +69,14 @@ FileManager ::~FileManager() {}
 void FileManager ::CreateDirectory_cmdHandler(const FwOpcodeType opCode,
                                               const U32 cmdSeq,
                                               const Fw::CmdStringArg& dirName) {
+    if (containsPathTraversal(dirName)) {
+        Fw::LogStringArg logStringDirName(dirName.toChar());
+        this->log_WARNING_HI_PathTraversalRejected(logStringDirName);
+        ++this->errorCount;
+        this->tlmWrite_Errors(this->errorCount);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringDirName(dirName.toChar());
     this->log_ACTIVITY_HI_CreateDirectoryStarted(logStringDirName);
     bool errorIfDirExists = true;
@@ -63,6 +94,14 @@ void FileManager ::RemoveFile_cmdHandler(const FwOpcodeType opCode,
                                          const U32 cmdSeq,
                                          const Fw::CmdStringArg& fileName,
                                          const bool ignoreErrors) {
+    if (containsPathTraversal(fileName)) {
+        Fw::LogStringArg logStringFileName(fileName.toChar());
+        this->log_WARNING_HI_PathTraversalRejected(logStringFileName);
+        ++this->errorCount;
+        this->tlmWrite_Errors(this->errorCount);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringFileName(fileName.toChar());
     this->log_ACTIVITY_HI_RemoveFileStarted(logStringFileName);
     const Os::FileSystem::Status status = Os::FileSystem::removeFile(fileName.toChar());
@@ -85,6 +124,15 @@ void FileManager ::MoveFile_cmdHandler(const FwOpcodeType opCode,
                                        const U32 cmdSeq,
                                        const Fw::CmdStringArg& sourceFileName,
                                        const Fw::CmdStringArg& destFileName) {
+    if (containsPathTraversal(sourceFileName) || containsPathTraversal(destFileName)) {
+        Fw::LogStringArg logRejected(
+            containsPathTraversal(sourceFileName) ? sourceFileName.toChar() : destFileName.toChar());
+        this->log_WARNING_HI_PathTraversalRejected(logRejected);
+        ++this->errorCount;
+        this->tlmWrite_Errors(this->errorCount);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringSource(sourceFileName.toChar());
     Fw::LogStringArg logStringDest(destFileName.toChar());
     this->log_ACTIVITY_HI_MoveFileStarted(logStringSource, logStringDest);
@@ -101,6 +149,14 @@ void FileManager ::MoveFile_cmdHandler(const FwOpcodeType opCode,
 void FileManager ::RemoveDirectory_cmdHandler(const FwOpcodeType opCode,
                                               const U32 cmdSeq,
                                               const Fw::CmdStringArg& dirName) {
+    if (containsPathTraversal(dirName)) {
+        Fw::LogStringArg logStringDirName(dirName.toChar());
+        this->log_WARNING_HI_PathTraversalRejected(logStringDirName);
+        ++this->errorCount;
+        this->tlmWrite_Errors(this->errorCount);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringDirName(dirName.toChar());
     this->log_ACTIVITY_HI_RemoveDirectoryStarted(logStringDirName);
     const Os::FileSystem::Status status = Os::FileSystem::removeDirectory(dirName.toChar());
@@ -117,6 +173,15 @@ void FileManager ::AppendFile_cmdHandler(const FwOpcodeType opCode,
                                          const U32 cmdSeq,
                                          const Fw::CmdStringArg& source,
                                          const Fw::CmdStringArg& target) {
+    if (containsPathTraversal(source) || containsPathTraversal(target)) {
+        Fw::LogStringArg logRejected(
+            containsPathTraversal(source) ? source.toChar() : target.toChar());
+        this->log_WARNING_HI_PathTraversalRejected(logRejected);
+        ++this->errorCount;
+        this->tlmWrite_Errors(this->errorCount);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringSource(source.toChar());
     Fw::LogStringArg logStringTarget(target.toChar());
     this->log_ACTIVITY_HI_AppendFileStarted(logStringSource, logStringTarget);
@@ -134,6 +199,14 @@ void FileManager ::AppendFile_cmdHandler(const FwOpcodeType opCode,
 }
 
 void FileManager ::FileSize_cmdHandler(const FwOpcodeType opCode, const U32 cmdSeq, const Fw::CmdStringArg& fileName) {
+    if (containsPathTraversal(fileName)) {
+        Fw::LogStringArg logStringFileName(fileName.toChar());
+        this->log_WARNING_HI_PathTraversalRejected(logStringFileName);
+        ++this->errorCount;
+        this->tlmWrite_Errors(this->errorCount);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringFileName(fileName.toChar());
     this->log_ACTIVITY_HI_FileSizeStarted(logStringFileName);
 
@@ -151,6 +224,14 @@ void FileManager ::FileSize_cmdHandler(const FwOpcodeType opCode, const U32 cmdS
 void FileManager ::ListDirectory_cmdHandler(const FwOpcodeType opCode,
                                             const U32 cmdSeq,
                                             const Fw::CmdStringArg& dirName) {
+    if (containsPathTraversal(dirName)) {
+        Fw::LogStringArg logStringDirName(dirName.toChar());
+        this->log_WARNING_HI_PathTraversalRejected(logStringDirName);
+        ++this->errorCount;
+        this->tlmWrite_Errors(this->errorCount);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     // Check if we're already listing a directory
     if (m_listState == LISTING_IN_PROGRESS) {
         this->log_WARNING_HI_ListDirectoryError(dirName, static_cast<U32>(Os::Directory::OTHER_ERROR));
@@ -184,6 +265,14 @@ void FileManager ::ListDirectory_cmdHandler(const FwOpcodeType opCode,
 }
 
 void FileManager ::CalculateCrc_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdStringArg& filename) {
+    if (containsPathTraversal(filename)) {
+        Fw::LogStringArg logStringFileName(filename.toChar());
+        this->log_WARNING_HI_PathTraversalRejected(logStringFileName);
+        ++this->errorCount;
+        this->tlmWrite_Errors(this->errorCount);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     Os::File file;
     U32 crcValue = 0;
     this->log_ACTIVITY_HI_CalculateCrcStarted(filename);

--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -6,6 +6,27 @@
 
 #include <Svc/FpySequencer/FpySequencer.hpp>
 #include <new>
+#include "Fw/Types/StringUtils.hpp"
+
+namespace {
+
+//! Returns true if `path` contains a parent-directory traversal token.
+//!
+//! Sequencer command handlers accept attacker-controlled file paths from
+//! the ground command interface. Although the actual file open is
+//! preceded by a configurable base-directory prepend
+//! (`Svc_FpySequencer_SequencerStateMachine_action_setSequenceFilePath`,
+//! using the `SEQ_BASE_DIR` parameter), prepending does NOT defeat a
+//! `..` segment supplied by the operator — `<baseDir>/../../etc/passwd`
+//! still resolves outside the intended root. Reject `..` substrings at
+//! the command entry, the same brick-wall hardening template applied in
+//! nasa/fprime#5262 (FileUplink::File::open).
+bool containsPathTraversal(const Fw::CmdStringArg& path) {
+    const FwSizeType len = path.length();
+    return Fw::StringUtils::substring_find(path.toChar(), len, "..", 2) >= 0;
+}
+
+}  // namespace
 
 namespace Svc {
 
@@ -53,6 +74,11 @@ void FpySequencer ::RUN_ARGS_cmdHandler(FwOpcodeType opCode,               //!< 
                                         Svc::BlockState block,  //!< Return command status when complete or not
                                         Svc::SeqArgs args       //!< Arguments to pass to the sequencer
 ) {
+    if (containsPathTraversal(fileName)) {
+        this->log_WARNING_HI_PathTraversalRejected(fileName);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     // can only run a seq while in idle
     if (sequencer_getState() != State::IDLE) {
         this->log_WARNING_HI_InvalidCommand(static_cast<I32>(sequencer_getState()));
@@ -92,6 +118,11 @@ void FpySequencer ::VALIDATE_ARGS_cmdHandler(FwOpcodeType opCode,
                                              U32 cmdSeq,
                                              const Fw::CmdStringArg& fileName,
                                              Svc::SeqArgs buffer) {
+    if (containsPathTraversal(fileName)) {
+        this->log_WARNING_HI_PathTraversalRejected(fileName);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     // can only validate a seq while in idle
     if (sequencer_getState() != State::IDLE) {
         this->log_WARNING_HI_InvalidCommand(static_cast<I32>(sequencer_getState()));
@@ -245,6 +276,11 @@ void FpySequencer::DUMP_STACK_TO_FILE_cmdHandler(FwOpcodeType opCode,           
                                                  U32 cmdSeq,                       //!< The command sequence number
                                                  const Fw::CmdStringArg& fileName  //!< The name of the output file
 ) {
+    if (containsPathTraversal(fileName)) {
+        this->log_WARNING_HI_PathTraversalRejected(fileName);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
     if (this->sequencer_getState() != State::RUNNING_PAUSED) {
         this->log_WARNING_HI_InvalidCommand(static_cast<I32>(sequencer_getState()));
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);

--- a/Svc/FpySequencer/FpySequencerEvents.fppi
+++ b/Svc/FpySequencer/FpySequencerEvents.fppi
@@ -312,3 +312,10 @@ event LogDiagnostic(
 ) \
     severity diagnostic \
     format "Sequence {}: {}"
+
+@ A command was rejected because the supplied sequence file path contains a parent-directory traversal token. The command is dropped without invoking any filesystem primitive.
+event PathTraversalRejected(
+    path: string
+) \
+    severity warning high \
+    format "Command rejected: sequence path {} contains a parent-directory traversal token"


### PR DESCRIPTION
## Summary

Reject `..` parent-directory traversal tokens in 11 command handlers across `Svc/FileManager` (8) and `Svc/FpySequencer` (3) that previously passed attacker-controlled paths directly to filesystem primitives.

This applies the same brick-wall hardening template merged in #5262 (`FileUplink::File::open`): enforce locally what was previously assumed to be enforced upstream.

## Background

`Svc/FileManager` exposes 8 command handlers (`CreateDirectory`, `RemoveFile`, `MoveFile`, `RemoveDirectory`, `AppendFile`, `FileSize`, `ListDirectory`, `CalculateCrc`) that accept a `Fw::CmdStringArg` path from the ground command interface and pass it directly to `Os::FileSystem::*` / `Os::File::open` / `Os::Directory::open` with no validation. A ground operator (or upstream sender who can influence command-line arguments) can supply `../../path` and reach files outside the intended file-management scope.

`Svc/FpySequencer` exposes 3 similar handlers (`RUN_ARGS`, `VALIDATE_ARGS`, `DUMP_STACK_TO_FILE`). Note that a configurable `SEQ_BASE_DIR` parameter is prepended to the supplied file name in `Svc_FpySequencer_SequencerStateMachine_action_setSequenceFilePath`, but base-directory prepending does NOT defeat `..` segments — `<baseDir>/../../etc/passwd` still resolves outside the intended root.

## Change

Each affected handler gets an early `containsPathTraversal()` check. When the supplied path contains `..` as a substring, a new `PathTraversalRejected` event is emitted and the command returns `Fw::CmdResponse::VALIDATION_ERROR` without invoking any filesystem primitive.

The check is conservative: it rejects `..` as a substring at any position, not only as a complete path component. This errs toward rejection (e.g. `foo..bar` is also rejected); legitimate file names with `..` are uncommon in flight-software workflows and the rejection is straightforward to recover from at the ground side.

```cpp
bool containsPathTraversal(const Fw::CmdStringArg& path) {
    const FwSizeType len = path.length();
    return Fw::StringUtils::substring_find(path.toChar(), len, "..", 2) >= 0;
}
```

## Files changed

| File | Change |
|---|---|
| `Svc/FileManager/FileManager.cpp` | Add anonymous-namespace helper + gate all 8 cmd handlers |
| `Svc/FileManager/Events.fppi` | New event `PathTraversalRejected` (id `0x1d`, next free after `CalculateCrcSucceeded`) |
| `Svc/FpySequencer/FpySequencer.cpp` | Add anonymous-namespace helper + gate `RUN_ARGS`, `VALIDATE_ARGS`, `DUMP_STACK_TO_FILE` |
| `Svc/FpySequencer/FpySequencerEvents.fppi` | New event `PathTraversalRejected` |

Diffstat: **4 files changed, 141 insertions(+), 1 deletion(-)**.

## How this was found

External static-analysis pass on `Svc/` using multi-axis constraint composition (structural pattern match + ground-command dataflow + invariant absence). The same methodology that surfaced the FileUplink finding in #5262. All eleven affected sites here share the exact same shape: attacker-controlled `Fw::CmdStringArg` path → `Os::*::open` / `Os::FileSystem::*` → no local validation.

`ListDirectory_cmdHandler` and `DUMP_STACK_TO_FILE_cmdHandler` were the highest-scoring matches; expanding to the rest of the FileManager handlers and to the FpySequencer `RUN`/`VALIDATE` paths follows from applying the same template once the shape is identified.

## Testing notes

I did not add new unit tests in this PR — the existing FileManager/FpySequencer test suites exercise the cmd handlers with valid paths, which still work as before. Adding negative tests (cmd with `..` → `VALIDATION_ERROR` + `PathTraversalRejected` event) would be a natural follow-up; happy to include them in this PR if preferred, or as a separate change.

## Related

- #5262 (merged) — same brick-wall template applied to `Svc/FileUplink::File::open`
