### PR TITLE
Backport FileDownlink timeout removal to v3.6

### DIFF
--- a/Ref/Top/RefTopology.cpp
+++ b/Ref/Top/RefTopology.cpp
@@ -48,7 +48,6 @@ NATIVE_INT_TYPE rateGroup3Context[Svc::ActiveRateGroup::CONNECTION_COUNT_MAX] = 
 // A number of constants are needed for construction of the topology. These are specified here.
 enum TopologyConstants {
     CMD_SEQ_BUFFER_SIZE = 5 * 1024,
-    FILE_DOWNLINK_TIMEOUT = 1000,
     FILE_DOWNLINK_COOLDOWN = 1000,
     FILE_DOWNLINK_CYCLE_TIME = 1000,
     FILE_DOWNLINK_FILE_QUEUE_DEPTH = 10,
@@ -82,8 +81,7 @@ void configureTopology() {
     rateGroup3Comp.configure(rateGroup3Context, FW_NUM_ARRAY_ELEMENTS(rateGroup3Context));
 
     // File downlink requires some project-derived properties.
-    fileDownlink.configure(FILE_DOWNLINK_TIMEOUT, FILE_DOWNLINK_COOLDOWN, FILE_DOWNLINK_CYCLE_TIME,
-                           FILE_DOWNLINK_FILE_QUEUE_DEPTH);
+    fileDownlink.configure(FILE_DOWNLINK_COOLDOWN, FILE_DOWNLINK_CYCLE_TIME, FILE_DOWNLINK_FILE_QUEUE_DEPTH);
 
     // Parameter database is configured with a database file name, and that file must be initially read.
     prmDb.configure("PrmDb.dat");

--- a/Svc/FileDownlink/Events.fppi
+++ b/Svc/FileDownlink/Events.fppi
@@ -34,15 +34,6 @@ event DownlinkCanceled(
   format "Canceled downlink of file {} to file {}"
 
 @ The File Downlink component has detected a timeout. Downlink has been canceled.
-event DownlinkTimeout(
-                       sourceFileName: string size 100 @< The source filename
-                       destFileName: string size 100 @< The destination file name
-                     ) \
-  severity warning high \
-  id 0x04 \
-  format "Timeout occurred during downlink of file {} to file {}. Downlink has been canceled."
-
-@ The File Downlink component has detected a timeout. Downlink has been canceled.
 event DownlinkPartialWarning(
                               startOffset: U32 @< Starting file offset in bytes
                               length: U32 @< Number of bytes to downlink

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -12,6 +12,7 @@
 #include <Svc/FileDownlink/FileDownlink.hpp>
 #include <Fw/Types/Assert.hpp>
 #include <FpConfig.hpp>
+#include <Fw/Logger/Logger.hpp>
 #include <Fw/Types/StringUtils.hpp>
 #include <Os/QueueString.hpp>
 #include <limits>
@@ -45,13 +46,23 @@ namespace Svc {
 
   void FileDownlink ::
     configure(
-        U32 timeout,
+        U32 /*timeout*/,
         U32 cooldown,
         U32 cycleTime,
         U32 fileQueueDepth
     )
   {
-    this->m_timeout = timeout;
+    Fw::Logger::log("[WARNING] FileDownlink timeout is unused");
+    configure(cooldown, cycleTime, fileQueueDepth);
+  }
+
+  void FileDownlink ::
+    configure(
+        U32 cooldown,
+        U32 cycleTime,
+        U32 fileQueueDepth
+    )
+  {
     this->m_cooldown = cooldown;
     this->m_cycleTime = cycleTime;
     this->m_configured = true;
@@ -121,15 +132,7 @@ namespace Svc {
         break;
       }
       case Mode::WAIT: {
-        //If current timeout is too-high and we are waiting for a packet, issue a timeout
-        if (this->m_curTimer >= this->m_timeout) {
-          this->m_curTimer = 0;
-          this->log_WARNING_HI_DownlinkTimeout(this->m_file.getSourceName(), this->m_file.getDestName());
-          this->enterCooldown();
-          this->sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR);
-        } else { //Otherwise update the current counter
-          this->m_curTimer += m_cycleTime;
-        }
+        this->m_curTimer += m_cycleTime;
         break;
       }
       default:
@@ -184,16 +187,17 @@ namespace Svc {
         Fw::Buffer &fwBuffer
     )
   {
-	  //If this is a stale buffer (old, timed-out, or both), then ignore its return.
-	  //File downlink actions only respond to the return of the most-recently-sent buffer.
-	  if (this->m_lastBufferId != fwBuffer.getContext() + 1 ||
-	      this->m_mode.get() == Mode::IDLE) {
-		  return;
-	  }
-	  //Non-ignored buffers cannot be returned in "DOWNLINK" and "IDLE" state.  Only in "WAIT", "CANCEL" state.
-	  FW_ASSERT(this->m_mode.get() == Mode::WAIT || this->m_mode.get() == Mode::CANCEL, this->m_mode.get());
+      //If this is a stale buffer (old, timed-out, or both), then ignore its return.
+      //File downlink actions only respond to the return of the most-recently-sent buffer.
+      if (this->m_lastBufferId != fwBuffer.getContext() + 1 ||
+          this->m_mode.get() == Mode::IDLE ||
+          this->m_mode.get() == Mode::COOLDOWN) {
+          return;
+      }
+      //Non-ignored buffers cannot be returned in "DOWNLINK", "IDLE", or "COOLDOWN" state.  Only in "WAIT", "CANCEL" state.
+      FW_ASSERT(this->m_mode.get() == Mode::WAIT || this->m_mode.get() == Mode::CANCEL, this->m_mode.get());
       //If the last packet has been sent (and is returning now) then finish the file
-	  if (this->m_lastCompletedType == Fw::FilePacket::T_END ||
+      if (this->m_lastCompletedType == Fw::FilePacket::T_END ||
           this->m_lastCompletedType == Fw::FilePacket::T_CANCEL) {
           finishHelper(this->m_lastCompletedType == Fw::FilePacket::T_CANCEL);
           return;
@@ -501,7 +505,7 @@ namespace Svc {
           this->sendCancelPacket();
           this->m_lastCompletedType = Fw::FilePacket::T_CANCEL;
       }
-      //If in downlink mode and currently downlinking data then continue with the next packer
+      //If in downlink mode and currently downlinking data then continue with the next packet
       else if (this->m_mode.get() == Mode::DOWNLINK && this->m_lastCompletedType == Fw::FilePacket::T_START) {
           //Send the next packet, or fail doing so
           const Os::File::Status status = this->sendDataPacket(this->m_byteOffset);

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -270,9 +270,18 @@ namespace Svc {
       );
 
       //! Configure FileDownlink component
+      //! Overloaded function for backwards compatibility
       //!
       void configure(
-          U32 timeout, //!< Timeout threshold (milliseconds) while in WAIT state
+          U32 /*timeout*/, //!< Unused timeout argument left for backwards compatibility
+          U32 cooldown, //!< Cooldown (in ms) between finishing a downlink and starting the next file.
+          U32 cycleTime, //!< Rate at which we are running
+          U32 fileQueueDepth //!< Max number of items in file downlink queue
+      );
+
+      //! Configure FileDownlink component
+      //!
+      void configure(
           U32 cooldown, //!< Cooldown (in ms) between finishing a downlink and starting the next file.
           U32 cycleTime, //!< Rate at which we are running
           U32 fileQueueDepth //!< Max number of items in file downlink queue

--- a/Svc/FileDownlink/docs/sdd.md
+++ b/Svc/FileDownlink/docs/sdd.md
@@ -65,10 +65,8 @@ Name | Type | Kind | Purpose
 at component instantiation time:
 
 * *downlinkPacketSize*: The size of the packets to use on downlink.
-* *timeout*: Max amount of time in ms to wait for a buffer return before aborting downlink
 * *cooldown*: The amount of time in ms to wait in a cooldown state before starting next downlink.
-* *cycle time*: Frequency in ms of clock pulses sent to `Run` port, used for timing timeouts and
-  cooldown.
+* *cycle time*: Frequency in ms of clock pulses sent to `Run` port, used for cooldown.
 * *file queue depth*: The maximum number of files that can be held in the internal file downlink
   queue. Attempting to dispatch a SendFile command or port call while the queue is full will result
   in a busy error response.
@@ -123,7 +121,3 @@ Checklist |
 [Design](Checklist/design.xlsx) |
 [Code](Checklist/code.xlsx) |
 [Unit Test](Checklist/unit_test.xls) |
-
-## 6 Unit Testing
-
-TODO

--- a/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
@@ -29,11 +29,6 @@ TEST(FileDownlink, DownlinkPartial) {
   tester.downlinkPartial();
 }
 
-TEST(FileDownlink, DownlinkTimeout) {
-    Svc::FileDownlinkTester tester;
-    tester.timeout();
-}
-
 TEST(FileDownlink, SendFilePort) {
     Svc::FileDownlinkTester tester;
     tester.sendFilePort();

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -18,7 +18,6 @@
 #define CMD_SEQ 0
 #define QUEUE_DEPTH 10
 
-#define TIMEOUT_MS 1000
 #define COOLDOWN_MS 500
 #define CYCLE_MS 100
 #define MAX_ALLOCATED 100
@@ -34,7 +33,7 @@ namespace Svc {
       component("FileDownlink"),
       buffers_index(0)
   {
-    this->component.configure(TIMEOUT_MS, COOLDOWN_MS, CYCLE_MS, 10);
+    this->component.configure(COOLDOWN_MS, CYCLE_MS, 10);
     this->connectPorts();
     this->initComponents();
   }
@@ -269,60 +268,6 @@ namespace Svc {
     this->removeFile(sourceFileName);
 
   }
-
-    void FileDownlinkTester ::
-      timeout()
-    {
-        // Assert idle mode
-        ASSERT_EQ(FileDownlink::Mode::IDLE, this->component.m_mode.get());
-
-        // Create a file
-        const char *const sourceFileName = "source.bin";
-        const char *const destFileName = "dest.bin";
-        U8 data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-        FileBuffer fileBufferOut(data, sizeof(data));
-        fileBufferOut.write(sourceFileName);
-
-        Fw::CmdStringArg sourceCmdStringArg(sourceFileName);
-        Fw::CmdStringArg destCmdStringArg(destFileName);
-        this->sendCmd_SendFile(
-          INSTANCE,
-          CMD_SEQ,
-          sourceCmdStringArg,
-          destCmdStringArg
-        );
-        this->component.doDispatch(); // Dispatch sendfile command
-        this->component.Run_handler(0,0); // Pull file from queue
-
-        // Continue running the component without dispatching the responses
-        for (U32 i = 0; i < TIMEOUT_MS/CYCLE_MS; i++) {
-            this->component.Run_handler(0,0);
-            ASSERT_CMD_RESPONSE_SIZE(0);
-        }
-
-        this->component.Run_handler(0,0);
-        ASSERT_CMD_RESPONSE_SIZE(1);
-        Fw::CmdResponse expResp = FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? Fw::CmdResponse::OK : Fw::CmdResponse::EXECUTION_ERROR;
-        ASSERT_CMD_RESPONSE(0, FileDownlink::OPCODE_SENDFILE, CMD_SEQ, expResp);
-
-        // Assert telemetry
-        ASSERT_TLM_SIZE(1);
-        ASSERT_TLM_PacketsSent_SIZE(1);
-
-        // Assert events
-        ASSERT_EVENTS_SIZE(2);
-        ASSERT_EVENTS_DownlinkTimeout_SIZE(1);
-        ASSERT_EVENTS_SendStarted_SIZE(1);
-//    printTextLogHistory(stdout);
-        ASSERT_EVENTS_SendStarted(0, 10, sourceFileName, destFileName);
-        ASSERT_EVENTS_DownlinkTimeout(0, sourceFileName, destFileName);
-
-        // Assert idle mode
-        ASSERT_EQ(FileDownlink::Mode::COOLDOWN, this->component.m_mode.get());
-
-        // Remove the outgoing file
-        this->removeFile(sourceFileName);
-    }
 
     void FileDownlinkTester ::
     sendFilePort()

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
@@ -126,10 +126,6 @@ namespace Svc {
       //!
       void downlinkPartial();
 
-      //! Timeout
-      //!
-      void timeout();
-
       //! sendFilePort
       //! Test downlinking a file via a port
       //!


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5287 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

This backports the #4555 bugfix to v3.6.x. It also updates `FileDownlink` to handle returned buffers during `COOLDOWN` the same way they are handled during `IDLE` mode, rather than asserting.

## Rationale

Downstream throttling should not cause `FileDownlink` to assert.

## Testing/Review Recommendations

I've tested these `FileDownlink` changes on Linux and the component seems to be operating as expected. Unfortunately, this PR changes the `FileDownlink::configure()` function header, removing the `timeout` argument, which breaks CI builds. Question: Should we change the external test deployments so they build? Should we override `FileDownlink::configure()` so it has a backwards-compatible function header with a dummy `U32` argument where `timeout` used to be?

## Future Work

I propose bringing forward the handling of returned buffers in `COOLDOWN` mode to F Prime `v4`, making `bufferReturn_handler()` handle returns in `COOLDOWN` mode the same way it handles returns in `IDLE` mode.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
