### PR TITLE
Fix FW_NUM_ARRAY_ELEMENTS for FPP array types

### DIFF
--- a/FppTestProject/FppTest/array/ArrayToStringTest.cpp
+++ b/FppTestProject/FppTest/array/ArrayToStringTest.cpp
@@ -20,6 +20,7 @@
 #include "FppTest/array/Uint32ArrayArrayAc.hpp"
 
 #include "FppTest/typed_tests/ArrayTest.hpp"
+#include "Fw/Types/BasicTypes.h"
 
 #include "gtest/gtest.h"
 
@@ -63,6 +64,13 @@ TYPED_TEST(ArrayToStringTest, ToString) {
     Fw::String expected(expectedStream.str().c_str());
 
     ASSERT_STREQ(actualStream.str().c_str(), expected.toChar());
+}
+
+TYPED_TEST(ArrayToStringTest, NumArrayElements) {
+    TypeParam a(this->testVals);
+
+    const auto size = FW_NUM_ARRAY_ELEMENTS(a);
+    ASSERT_EQ(size, static_cast<size_t>(TypeParam::SIZE));
 }
 
 }  // namespace Array

--- a/Fw/Types/BasicTypes.h
+++ b/Fw/Types/BasicTypes.h
@@ -36,6 +36,7 @@ extern "C" {
 #endif
 #include <config/FPrimeNumericalConfig.h>
 #include <inttypes.h>  // Standard integer types and printf macros
+#include <stddef.h>    // size_t
 
 // Compiler checks
 #if defined(__GNUC__) || defined(__llvm__) || defined(PLATFORM_OVERRIDE_GCC_CLANG_CHECK)
@@ -87,7 +88,30 @@ typedef double F64;   //!< 64-bit floating point (double). Required for compiler
 /*----------------------------------------------------------------------------*/
 /* Useful macro definitions                                                   */
 /*----------------------------------------------------------------------------*/
+#ifdef __cplusplus
+}
+
+namespace Fw {
+namespace BasicTypes {
+
+template <typename T, size_t N>
+constexpr size_t fwNumArrayElements(const T (&)[N]) {
+    return N;
+}
+
+template <typename ArrayType>
+constexpr auto fwNumArrayElements(const ArrayType&)
+    -> decltype(ArrayType::SIZE, sizeof(typename ArrayType::ElementType), size_t{}) {
+    return static_cast<size_t>(ArrayType::SIZE);
+}
+
+}  // namespace BasicTypes
+}  // namespace Fw
+
+#define FW_NUM_ARRAY_ELEMENTS(a) (::Fw::BasicTypes::fwNumArrayElements(a))  //!< number of elements in an array
+#else
 #define FW_NUM_ARRAY_ELEMENTS(a) (sizeof(a) / sizeof((a)[0]))  //!< number of elements in an array
+#endif
 // Deprecated: prefer std::max/std::min from <algorithm> in C++ code.
 // Kept for C compatibility only.
 #define FW_MAX(a, b) (((a) > (b)) ? (a) : (b))  //!< MAX macro (deprecated in C++, use std::max)
@@ -102,6 +126,5 @@ typedef double F64;   //!< 64-bit floating point (double). Required for compiler
          //!< Requires -DASSERT_RELATIVE_PATH=path to be set on the compile command line
 
 #ifdef __cplusplus
-}
 #endif
 #endif  // FW_BASIC_TYPES_H


### PR DESCRIPTION
Fixes #5155.

This switches FW_NUM_ARRAY_ELEMENTS to a C++ helper that still handles raw C arrays and also recognizes FPP-generated array types by reading their compile-time SIZE. In C builds the macro still uses sizeof exactly as before.

I added a regression test in FppTestProject/FppTest/array/ArrayToStringTest.cpp that checks FW_NUM_ARRAY_ELEMENTS on several FPP array types.

Verification:
- python3 -m cmake -S . -B build-5155-ut -G "Unix Makefiles" -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
  - fails early in this environment because fprime-version-check is not installed
- python3 -c "<focused compile script>"
  - pass: compiled and ran C++ and C checks against Fw/Types/BasicTypes.h
  - confirmed raw arrays still report element count and FPP-style arrays report SIZE
