### PR TITLE
Fix ComStub queue deadlock after driver send failures

### DIFF
--- a/Drv/ByteStreamDriverModel/ByteStreamDriverModel.fpp
+++ b/Drv/ByteStreamDriverModel/ByteStreamDriverModel.fpp
@@ -24,4 +24,7 @@ module Drv {
     @ Signal indicating the driver is ready to send and received data
     port ByteStreamReady()
 
+    @ Request that the driver reinitialize and signal readiness when done
+    port ByteStreamReinitialize()
+
 }

--- a/Drv/Interfaces/ByteStreamDriver.fpp
+++ b/Drv/Interfaces/ByteStreamDriver.fpp
@@ -14,6 +14,9 @@ module Drv {
         @ Status is returned, and ownership of the buffer is retained by the caller
         guarded input port $send: Drv.ByteStreamSend
 
+        @ Request driver reinitialization after a send failure
+        guarded input port reinitializationRequestIn: Drv.ByteStreamReinitialize
+
         @ Port receiving back ownership of data sent out on $recv port
         guarded input port recvReturnIn: Fw.BufferSend
     }
@@ -37,5 +40,8 @@ module Drv {
 
         @ Send (write) data to the driver
         output port drvSendOut: Drv.ByteStreamSend
+
+        @ Request driver reinitialization after a send failure
+        output port drvReinitializationRequestOut: Drv.ByteStreamReinitialize
     }
 }

--- a/Drv/LinuxUartDriver/LinuxUartDriver.cpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.cpp
@@ -327,6 +327,12 @@ void LinuxUartDriver::recvReturnIn_handler(FwIndexType portNum, Fw::Buffer& fwBu
     this->deallocate_out(0, fwBuffer);
 }
 
+void LinuxUartDriver::reinitializationRequestIn_handler(const FwIndexType portNum) {
+    if (this->isConnected_ready_OutputPort(0)) {
+        this->ready_out(0);
+    }
+}
+
 void LinuxUartDriver ::serialReadTaskEntry(void* ptr) {
     FW_ASSERT(ptr != nullptr);
     Drv::ByteStreamStatus status = ByteStreamStatus::OTHER_ERROR;  // added by m.chase 03.06.2017

--- a/Drv/LinuxUartDriver/LinuxUartDriver.hpp
+++ b/Drv/LinuxUartDriver/LinuxUartDriver.hpp
@@ -115,6 +115,8 @@ class LinuxUartDriver final : public LinuxUartDriverComponentBase {
                               Fw::Buffer& fwBuffer  //!< The buffer
                               ) override;
 
+    void reinitializationRequestIn_handler(const FwIndexType portNum) override;
+
     int m_fd;                     //!< file descriptor returned for I/O device
     FwSizeType m_allocationSize;  //!< size of allocation request to memory manager
     const char* m_device;         //!< original device path

--- a/Drv/TcpClient/TcpClientComponentImpl.cpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.cpp
@@ -89,4 +89,8 @@ void TcpClientComponentImpl::recvReturnIn_handler(FwIndexType portNum, Fw::Buffe
     this->deallocate_out(0, fwBuffer);
 }
 
+void TcpClientComponentImpl::reinitializationRequestIn_handler(const FwIndexType portNum) {
+    this->connected();
+}
+
 }  // end namespace Drv

--- a/Drv/TcpClient/TcpClientComponentImpl.hpp
+++ b/Drv/TcpClient/TcpClientComponentImpl.hpp
@@ -138,6 +138,8 @@ class TcpClientComponentImpl final : public TcpClientComponentBase, public Socke
                               Fw::Buffer& fwBuffer  //!< The buffer
                               ) override;
 
+    void reinitializationRequestIn_handler(const FwIndexType portNum) override;
+
     Drv::TcpClientSocket m_socket;  //!< Socket implementation
 
     // Member variable to store the buffer size

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -137,4 +137,8 @@ void TcpServerComponentImpl::recvReturnIn_handler(FwIndexType portNum, Fw::Buffe
     this->deallocate_out(0, fwBuffer);
 }
 
+void TcpServerComponentImpl::reinitializationRequestIn_handler(const FwIndexType portNum) {
+    this->connected();
+}
+
 }  // end namespace Drv

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -172,6 +172,8 @@ class TcpServerComponentImpl final : public TcpServerComponentBase, public Socke
                               Fw::Buffer& fwBuffer  //!< The buffer
                               ) override;
 
+    void reinitializationRequestIn_handler(const FwIndexType portNum) override;
+
     Drv::TcpServerSocket m_socket;  //!< Socket implementation
 
     FwSizeType m_allocation_size;  //!< Member variable to store the buffer size

--- a/Drv/Udp/UdpComponentImpl.cpp
+++ b/Drv/Udp/UdpComponentImpl.cpp
@@ -100,4 +100,8 @@ void UdpComponentImpl::recvReturnIn_handler(FwIndexType portNum, Fw::Buffer& fwB
     this->deallocate_out(0, fwBuffer);
 }
 
+void UdpComponentImpl::reinitializationRequestIn_handler(const FwIndexType portNum) {
+    this->connected();
+}
+
 }  // end namespace Drv

--- a/Drv/Udp/UdpComponentImpl.hpp
+++ b/Drv/Udp/UdpComponentImpl.hpp
@@ -162,6 +162,8 @@ class UdpComponentImpl : public UdpComponentBase, public SocketComponentHelper {
                               Fw::Buffer& fwBuffer  //!< The buffer
                               ) override;
 
+    void reinitializationRequestIn_handler(const FwIndexType portNum) override;
+
     Drv::UdpSocket m_socket;  //!< Socket implementation
 
     FwSizeType m_allocation_size;  //!< Member variable to store the buffer size

--- a/Svc/ComStub/ComStub.cpp
+++ b/Svc/ComStub/ComStub.cpp
@@ -70,7 +70,8 @@ void ComStub::drvAsyncSendReturnIn_handler(FwIndexType portNum,   //!< The port 
         this->m_reinitialize = (sendStatus.e != Drv::ByteStreamStatus::OP_OK);
         this->m_retry_count = 0;  // Reset retry count
         if (sendStatus.e == Drv::ByteStreamStatus::OP_OK) {
-            this->comStatusOut_out(0, Fw::Success::SUCCESS);
+            Fw::Success comSuccess = Fw::Success::SUCCESS;
+            this->comStatusOut_out(0, comSuccess);
         } else {
             this->requestDriverReinitialization();
         }
@@ -132,7 +133,8 @@ void ComStub::handleAsyncRetry(Fw::Buffer& fwBuffer) {
     } else {
         // Exceeded retry limit - drop the stale packet and keep the queue moving
         this->dataReturnOut_out(0, fwBuffer, this->m_storedContext);
-        this->comStatusOut_out(0, Fw::Success::SUCCESS);
+        Fw::Success comSuccess = Fw::Success::SUCCESS;
+        this->comStatusOut_out(0, comSuccess);
         Fw::Logger::log("ComStub RETRY_LIMIT exceeded, skipped sending data");
         this->m_retry_count = 0;  // Reset retry count
     }

--- a/Svc/ComStub/ComStub.cpp
+++ b/Svc/ComStub/ComStub.cpp
@@ -69,10 +69,11 @@ void ComStub::drvAsyncSendReturnIn_handler(FwIndexType portNum,   //!< The port 
         this->dataReturnOut_out(0, fwBuffer, this->m_storedContext);
         this->m_reinitialize = (sendStatus.e != Drv::ByteStreamStatus::OP_OK);
         this->m_retry_count = 0;  // Reset retry count
-        // Send Com status
-        Fw::Success comSuccess =
-            (sendStatus.e == Drv::ByteStreamStatus::OP_OK) ? Fw::Success::SUCCESS : Fw::Success::FAILURE;
-        this->comStatusOut_out(0, comSuccess);
+        if (sendStatus.e == Drv::ByteStreamStatus::OP_OK) {
+            this->comStatusOut_out(0, Fw::Success::SUCCESS);
+        } else {
+            this->requestDriverReinitialization();
+        }
     }
 }
 
@@ -83,6 +84,12 @@ void ComStub ::dataReturnIn_handler(FwIndexType portNum, Fw::Buffer& fwBuffer, c
 // ----------------------------------------------------------------------
 // Helper method implementations
 // ----------------------------------------------------------------------
+
+void ComStub::requestDriverReinitialization() {
+    if (this->isConnected_drvReinitializationRequestOut_OutputPort(0)) {
+        this->drvReinitializationRequestOut_out(0);
+    }
+}
 
 void ComStub::handleSynchronousSend(Fw::Buffer& sendBuffer, const ComCfg::FrameContext& context) {
     Drv::ByteStreamStatus sendStatus = Drv::ByteStreamStatus::SEND_RETRY;
@@ -98,14 +105,18 @@ void ComStub::handleSynchronousSend(Fw::Buffer& sendBuffer, const ComCfg::FrameC
         comSuccess = Fw::Success::SUCCESS;
     } else if (sendStatus == Drv::ByteStreamStatus::SEND_RETRY) {
         Fw::Logger::log("ComStub RETRY_LIMIT exceeded, skipped sending data");
+        comSuccess = Fw::Success::SUCCESS;
     } else {
-        // Other error - need to reinitialize
+        // Other error - wait for the driver to reinitialize before unblocking the queue
         this->m_reinitialize = true;
+        this->requestDriverReinitialization();
     }
 
-    // Return buffer and send status
+    // Return buffer ownership
     this->dataReturnOut_out(0, sendBuffer, context);
-    this->comStatusOut_out(0, comSuccess);
+    if (sendStatus == Drv::ByteStreamStatus::OP_OK || sendStatus == Drv::ByteStreamStatus::SEND_RETRY) {
+        this->comStatusOut_out(0, comSuccess);
+    }
 }
 
 void ComStub::handleAsynchronousSend(Fw::Buffer& sendBuffer, const ComCfg::FrameContext& context) {
@@ -119,10 +130,9 @@ void ComStub::handleAsyncRetry(Fw::Buffer& fwBuffer) {
         this->m_retry_count++;
         this->drvAsyncSendOut_out(0, fwBuffer);
     } else {
-        // Exceeded retry limit - return buffer and notify failure
+        // Exceeded retry limit - drop the stale packet and keep the queue moving
         this->dataReturnOut_out(0, fwBuffer, this->m_storedContext);
-        Fw::Success comStatus = Fw::Success::FAILURE;
-        this->comStatusOut_out(0, comStatus);
+        this->comStatusOut_out(0, Fw::Success::SUCCESS);
         Fw::Logger::log("ComStub RETRY_LIMIT exceeded, skipped sending data");
         this->m_retry_count = 0;  // Reset retry count
     }

--- a/Svc/ComStub/ComStub.hpp
+++ b/Svc/ComStub/ComStub.hpp
@@ -81,6 +81,9 @@ class ComStub final : public ComStubComponentBase {
     //! Handle retry logic for asynchronous sends
     void handleAsyncRetry(Fw::Buffer& fwBuffer);
 
+    //! Ask the driver to reinitialize and signal readiness when done
+    void requestDriverReinitialization();
+
     // ----------------------------------------------------------------------
     // Member variables
     // ----------------------------------------------------------------------

--- a/Svc/ComStub/test/ut/ComStubTestMain.cpp
+++ b/Svc/ComStub/test/ut/ComStubTestMain.cpp
@@ -43,6 +43,11 @@ TEST(Sync, RetryReset) {
     tester.test_retry_reset_sync();
 }
 
+TEST(Sync, ErrorReinitialization) {
+    Svc::ComStubTester tester(Svc::ComStubTester::TestMode::SYNC);
+    tester.test_error_reinitialization();
+}
+
 TEST(Async, Retry) {
     Svc::ComStubTester tester(Svc::ComStubTester::TestMode::ASYNC);
     tester.test_retry_async();

--- a/Svc/ComStub/test/ut/ComStubTester.cpp
+++ b/Svc/ComStub/test/ut/ComStubTester.cpp
@@ -85,8 +85,10 @@ void ComStubTester ::test_fail() {
     if (this->m_test_mode == TestMode::SYNC) {
         this->m_sync_send_status = Drv::ByteStreamStatus::OTHER_ERROR;
         invoke_to_dataIn(0, buffer, context);
-        ASSERT_from_drvSendOut_SIZE(1);     // no retry on error (only one send)
-        ASSERT_from_dataReturnOut_SIZE(1);  // no drvSendOut sent when failure
+        ASSERT_from_drvSendOut_SIZE(1);
+        ASSERT_from_dataReturnOut_SIZE(1);
+        ASSERT_from_drvReinitializationRequestOut_SIZE(1);
+        ASSERT_from_comStatusOut_SIZE(0);
     } else if (this->m_test_mode == TestMode::ASYNC) {
         invoke_to_dataIn(0, buffer, context);
         ASSERT_from_drvAsyncSendOut_SIZE(1);
@@ -126,6 +128,8 @@ void ComStubTester ::test_retry_async() {
     ASSERT_from_drvAsyncSendOut_SIZE(
         static_cast<U32>(this->component.RETRY_LIMIT));  // no drvAsyncSendOut sent when SEND_RETRY
     ASSERT_from_dataReturnOut_SIZE(1);                   // buffer ownership was returned
+    ASSERT_from_comStatusOut_SIZE(1);
+    ASSERT_from_comStatusOut(0, Fw::Success::SUCCESS);
     ASSERT_EQ(this->component.m_retry_count, 0);
 }
 
@@ -144,7 +148,24 @@ void ComStubTester ::test_retry_sync() {
     ASSERT_from_dataReturnOut_SIZE(1);
     ASSERT_from_dataReturnOut(0, buffer, context);
     ASSERT_from_comStatusOut_SIZE(1);
-    ASSERT_from_comStatusOut(0, Fw::Success::FAILURE);
+    ASSERT_from_comStatusOut(0, Fw::Success::SUCCESS);
+}
+
+void ComStubTester ::test_error_reinitialization() {
+    this->test_initial();
+    U8 storage[8];
+    Fw::Buffer buffer(storage, sizeof(storage));
+    this->fill(buffer);
+    ComCfg::FrameContext context;
+
+    this->m_sync_send_status = Drv::ByteStreamStatus::OTHER_ERROR;
+    invoke_to_dataIn(0, buffer, context);
+    ASSERT_from_drvReinitializationRequestOut_SIZE(1);
+    ASSERT_from_comStatusOut_SIZE(0);
+
+    invoke_to_drvConnected(0);
+    ASSERT_from_comStatusOut_SIZE(1);
+    ASSERT_from_comStatusOut(0, Fw::Success::SUCCESS);
 }
 
 void ComStubTester ::test_retry_reset_sync() {
@@ -234,6 +255,7 @@ void ComStubTester ::connectPortsWithTestMode(TestMode mode) {
     this->component.set_dataOut_OutputPort(0, this->get_from_dataOut(0));
     this->component.set_dataReturnOut_OutputPort(0, this->get_from_dataReturnOut(0));
     this->component.set_drvReceiveReturnOut_OutputPort(0, this->get_from_drvReceiveReturnOut(0));
+    this->component.set_drvReinitializationRequestOut_OutputPort(0, this->get_from_drvReinitializationRequestOut(0));
     if (mode == TestMode::SYNC) {
         // Connect synchronous send port
         this->component.set_drvSendOut_OutputPort(0, this->get_from_drvSendOut(0));
@@ -258,6 +280,10 @@ Drv::ByteStreamStatus ComStubTester ::from_drvSendOut_handler(const FwIndexType 
         return Drv::ByteStreamStatus::OP_OK;  // if limit exceeded and no retry fail, return success
     }
     return this->m_sync_send_status;
+}
+
+void ComStubTester ::from_drvReinitializationRequestOut_handler(const FwIndexType portNum) {
+    this->pushFromPortEntry_drvReinitializationRequestOut();
 }
 
 }  // end namespace Svc

--- a/Svc/ComStub/test/ut/ComStubTester.hpp
+++ b/Svc/ComStub/test/ut/ComStubTester.hpp
@@ -67,6 +67,10 @@ class ComStubTester : public ComStubGTestBase {
     //!
     void test_buffer_return();
 
+    //! Tests driver reinitialization after a send error
+    //!
+    void test_error_reinitialization();
+
   private:
     // ----------------------------------------------------------------------
     // Handlers for typed from ports (test harness)
@@ -74,6 +78,9 @@ class ComStubTester : public ComStubGTestBase {
 
     //! Handler for from_drvSendOut
     Drv::ByteStreamStatus from_drvSendOut_handler(const FwIndexType portNum, Fw::Buffer& sendBuffer);
+
+    //! Handler for from_drvReinitializationRequestOut
+    void from_drvReinitializationRequestOut_handler(const FwIndexType portNum);
 
   private:
     // ----------------------------------------------------------------------

--- a/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
+++ b/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
@@ -237,6 +237,9 @@ module ComCcsds {
         @ Input port receiving the ready signal when the ByteStream driver has connected
         port drvConnected        = comStub.drvConnected
 
+        @ Output port requesting driver reinitialization after a send failure
+        port drvReinitializationRequestOut = comStub.drvReinitializationRequestOut
+
         # Buffer management for ComDriver
         @ Input port for requesting (allocating) a new Fw::Buffer from the comms buffer pool
         port commsBufferGetCallee = commsBufferManager.bufferGetCallee

--- a/Svc/Subtopologies/ComFprime/ComFprime.fpp
+++ b/Svc/Subtopologies/ComFprime/ComFprime.fpp
@@ -202,6 +202,9 @@ module ComFprime {
         @ Input port receiving the ready signal when the ByteStream driver has connected
         port drvConnected        = comStub.drvConnected
 
+        @ Output port requesting driver reinitialization after a send failure
+        port drvReinitializationRequestOut = comStub.drvReinitializationRequestOut
+
         # Buffer management for ComDriver
         @ Input port for requesting (allocating) a new Fw::Buffer from the comms buffer pool
         port commsBufferGetCallee = commsBufferManager.bufferGetCallee

--- a/TestDeploymentsProject/Ref/Top/topology.fpp
+++ b/TestDeploymentsProject/Ref/Top/topology.fpp
@@ -123,6 +123,7 @@ module Ref {
       # ComStub <-> ComDriver (Downlink)
       ComCcsds.Subtopology.drvSendOut -> comDriver.$send
       comDriver.ready                 -> ComCcsds.Subtopology.drvConnected
+      ComCcsds.Subtopology.drvReinitializationRequestOut -> comDriver.reinitializationRequestIn
     }
 
     connections Ref {


### PR DESCRIPTION
## Summary

- Add `Drv.ByteStreamReinitialize` and wire `drvReinitializationRequestOut` from `ComStub` to drivers.
- On real send errors, request driver reinitialization and defer `comStatus` SUCCESS until `drvConnected`.
- On retry-limit exhaustion, return `Fw::Success::SUCCESS` so `comQueue` can continue with the next packet.
- Update UDP/TCP/UART drivers and ComStub unit tests.

Fixes #5234

## Test plan

- [ ] `fprime-util build --ut` in `Svc/ComStub` (requires F Prime build environment)
- [x] Updated `ComStub` unit tests cover reinitialization and retry-limit behavior


Made with [Cursor](https://cursor.com)