### PR TITLE
Retry IpSocket::recv() on EINTR

### DIFF
--- a/Drv/Ip/IpSocket.cpp
+++ b/Drv/Ip/IpSocket.cpp
@@ -208,6 +208,8 @@ SocketIpStatus IpSocket::recv(const SocketDescriptor& socketDescriptor, U8* data
                 // Connection reset or bad file descriptor.
                 req_read = 0;
                 return SOCK_DISCONNECTED;  // Or a more specific error like SOCK_READ_ERROR
+            } else if (errno == EINTR) {
+                continue;
             } else {
                 // Other socket read error.
                 req_read = 0;

--- a/Drv/Ip/test/ut/TestTcp.cpp
+++ b/Drv/Ip/test/ut/TestTcp.cpp
@@ -9,8 +9,46 @@
 #include <Drv/Ip/test/ut/SocketTestHelper.hpp>
 #include <Fw/Logger/Logger.hpp>
 #include <Os/Console.hpp>
+#include <cerrno>
 
 Os::Console logger;
+
+class InterruptOnceSocket final : public Drv::IpSocket {
+  public:
+    U32 recv_calls = 0;
+
+  private:
+    Drv::SocketIpStatus openProtocol(Drv::SocketDescriptor& fd) override {
+        fd.fd = 0;
+        return Drv::SOCK_SUCCESS;
+    }
+
+    FwSignedSizeType sendProtocol(const Drv::SocketDescriptor&, const U8* const, const FwSizeType size) override {
+        return static_cast<FwSignedSizeType>(size);
+    }
+
+    FwSignedSizeType recvProtocol(const Drv::SocketDescriptor&, U8* const data, const FwSizeType) override {
+        this->recv_calls++;
+        if (this->recv_calls == 1) {
+            errno = EINTR;
+            return -1;
+        }
+        data[0] = 0xA5;
+        return 1;
+    }
+};
+
+TEST(ErrorHandling, TestRecvRetriesEintr) {
+    InterruptOnceSocket socket;
+    Drv::SocketDescriptor fd;
+    U8 data[1] = {0};
+    FwSizeType size = sizeof data;
+
+    EXPECT_EQ(socket.recv(fd, data, size), Drv::SOCK_SUCCESS);
+    EXPECT_EQ(socket.recv_calls, 2u);
+    EXPECT_EQ(size, 1u);
+    EXPECT_EQ(data[0], 0xA5);
+}
 
 void test_with_loop(U32 iterations) {
     Drv::SocketIpStatus status1 = Drv::SOCK_SUCCESS;


### PR DESCRIPTION
| | |
  |:---|:---|
  |**_Related Issue(s)_**| #5337 |
  |**_Has Unit Tests (y/n)_**| y |
  |**_Documentation Included (y/n)_**| n |
  |**_Generative AI was used in this contribution (y/n)_**| y |

  ---
## Change Description

`IpSocket::recv()` now retries when `recvProtocol()` returns `-1` with `errno == EINTR`.

This matches the existing comment and post-loop behavior in the function: the loop is intended to retry interrupted reads up to `SOCKET_MAX_ITERATIONS`, then return `SOCK_INTERRUPTED_TRY_AGAIN` if every attempt was interrupted.

I also added a small TCP unit test that uses a test socket to return `EINTR` once, then verifies the next receive succeeds.

## Rationale

Before this change, `EINTR` fell through to the catch-all socket read error branch and returned `SOCK_READ_ERROR` immediately. That made the retry loop unreachable for the case it was written to handle.

## Testing/Review Recommendations

- Added `ErrorHandling.TestRecvRetriesEintr`
- Ran `clang-format` on the touched files
- Ran `git diff --check`

I set up the repo requirements and `googletest` locally, but this Windows host could not complete the F´ unit-test generation path because the repo does not provide a native Windows platform config for this socket build path. CI/Linux should run the new `Drv_Ip_Tcp_test` normally.

## AI Usage

AI was used to help write this PR description and assist with local testing/debugging notes.