### PR TITLE
Assert on matching channel size for duplicate channel IDs in TlmPacke…

### DIFF
--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -72,22 +72,31 @@ void TlmPacketizer::setPacketList(const TlmPacketizerPacketList& packetList,
         // add up entries for each defined packet
         for (FwChanIdType tlmEntry = 0; tlmEntry < packetList.list[pktEntry]->numEntries; tlmEntry++) {
             FwChanIdType id = packetList.list[pktEntry]->list[tlmEntry].id;
+            const FwSizeType channelSize = packetList.list[pktEntry]->list[tlmEntry].size;
             FwSizeType entryIndex = 0;
             if (this->m_channelIndices.find(id, entryIndex) != Fw::Success::SUCCESS) {
                 // New channel - allocate a slot and initialize offsets to -1 (not in any packet)
                 entryIndex = this->m_numChannels++;
                 this->m_channels[entryIndex].id = id;
                 this->m_channels[entryIndex].hasValue = false;
+                this->m_channels[entryIndex].channelSize = channelSize;
                 for (FwChanIdType pktOffsetEntry = 0; pktOffsetEntry < MAX_PACKETIZER_PACKETS; pktOffsetEntry++) {
                     this->m_channels[entryIndex].packetOffset[pktOffsetEntry] = -1;
                 }
                 const Fw::Success insertStatus = this->m_channelIndices.insert(id, entryIndex);
                 FW_ASSERT(insertStatus == Fw::Success::SUCCESS, static_cast<FwAssertArgType>(insertStatus));
+            } else {
+                // Existing channel - a channel ID may repeat across packets, but its definition (size) must match.
+                // A conflicting size would corrupt the packet offsets computed from the earlier definition and
+                // overflow the fill buffer during TlmRecv/TlmGet copies, so reject the misconfiguration here.
+                FW_ASSERT(this->m_channels[entryIndex].channelSize == channelSize, static_cast<FwAssertArgType>(id),
+                          static_cast<FwAssertArgType>(channelSize),
+                          static_cast<FwAssertArgType>(this->m_channels[entryIndex].channelSize));
             }
             // not ignored channel - update entry in place via reference
             TlmEntry& entry = this->m_channels[entryIndex];
             entry.ignored = false;
-            entry.channelSize = packetList.list[pktEntry]->list[tlmEntry].size;
+            entry.channelSize = channelSize;
             // the offset into the buffer will be the current packet length
             // the offset must fit within FwSignedSizeType to allow for negative values
             FW_ASSERT(packetLen <= static_cast<FwSizeType>(std::numeric_limits<FwSignedSizeType>::max()),

--- a/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
+++ b/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.cpp
@@ -1852,6 +1852,52 @@ void TlmPacketizerTester::setLevelInvalidTest() {
     ASSERT_from_PktSend_SIZE(1 * Svc::TelemetrySection::NUM_SECTIONS);
 }
 
+// A channel ID may appear in more than one packet as long as the definition
+// (serialized size) is identical.  Channel 10 (size 4) is shared by both
+// packets below, matching the semantics that identical duplicates are allowed.
+namespace {
+TlmPacketizerChannelEntry dupMatchPacketAList[] = {{10, 4}, {100, 2}};
+TlmPacketizerChannelEntry dupMatchPacketBList[] = {{10, 4}, {200, 2}};
+TlmPacketizerPacket dupMatchPacketA = {dupMatchPacketAList, 4, 1, FW_NUM_ARRAY_ELEMENTS(dupMatchPacketAList)};
+TlmPacketizerPacket dupMatchPacketB = {dupMatchPacketBList, 8, 1, FW_NUM_ARRAY_ELEMENTS(dupMatchPacketBList)};
+TlmPacketizerPacketList dupMatchPacketList = {{&dupMatchPacketA, &dupMatchPacketB}, 2};
+
+// Channel 10 is declared with size 4 in packet A and size 6 in packet B. This
+// conflicting definition would corrupt the packet offsets and overflow the
+// fill buffer, so setPacketList must assert.
+TlmPacketizerChannelEntry dupConflictPacketAList[] = {{10, 4}, {100, 2}};
+TlmPacketizerChannelEntry dupConflictPacketBList[] = {{10, 6}, {200, 2}};
+TlmPacketizerPacket dupConflictPacketA = {dupConflictPacketAList, 4, 1, FW_NUM_ARRAY_ELEMENTS(dupConflictPacketAList)};
+TlmPacketizerPacket dupConflictPacketB = {dupConflictPacketBList, 8, 1, FW_NUM_ARRAY_ELEMENTS(dupConflictPacketBList)};
+TlmPacketizerPacketList dupConflictPacketList = {{&dupConflictPacketA, &dupConflictPacketB}, 2};
+}  // namespace
+
+void TlmPacketizerTester::duplicateChannelIdMatchingSizeTest() {
+    this->stockConfiguration();
+    // Identical channel definition across packets is permitted and must not assert.
+    this->component.setPacketList(dupMatchPacketList, IGNORE_OMIT_LIST, 1);
+
+    Fw::Time ts;
+    Fw::TlmBuffer buff;
+
+    // Push the shared channel and confirm it lands in both packets without overflow.
+    ASSERT_EQ(Fw::FW_SERIALIZE_OK, buff.serializeFrom(static_cast<U32>(20)));
+    this->invoke_to_TlmRecv(0, 10, ts, buff);
+
+    this->invoke_to_Run(0, 0);
+    this->component.doDispatch();
+
+    // Both packets carry channel 10, so both are emitted once per section.
+    ASSERT_from_PktSend_SIZE(2 * Svc::TelemetrySection::NUM_SECTIONS);
+}
+
+void TlmPacketizerTester::duplicateChannelIdConflictingSizeTest() {
+    this->stockConfiguration();
+    // Conflicting size for the same channel ID must trip the configuration-time assert.
+    ASSERT_DEATH_IF_SUPPORTED(this->component.setPacketList(dupConflictPacketList, IGNORE_OMIT_LIST, 1),
+                              "TlmPacketizer.cpp");
+}
+
 // ----------------------------------------------------------------------
 // Handlers for typed from ports
 // ----------------------------------------------------------------------

--- a/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.hpp
+++ b/Svc/TlmPacketizer/test/ut/TlmPacketizerTester.hpp
@@ -98,6 +98,12 @@ class TlmPacketizerTester : public TlmPacketizerGTestBase {
     //! Commanding test: verify SET_LEVEL invalid-level returns VALIDATION_ERROR
     void setLevelInvalidTest(void);
 
+    //! Duplicate channel ID across packets with identical size is accepted
+    void duplicateChannelIdMatchingSizeTest(void);
+
+    //! Duplicate channel ID across packets with conflicting size asserts
+    void duplicateChannelIdConflictingSizeTest(void);
+
     //! Helper to set the component into a stock-configuration regardless of default config
     //!
     void stockConfiguration();

--- a/Svc/TlmPacketizer/test/ut/main.cpp
+++ b/Svc/TlmPacketizer/test/ut/main.cpp
@@ -68,6 +68,18 @@ TEST(TestOffNominal, SetLevelInvalidTest) {
     tester.setLevelInvalidTest();
 }
 
+TEST(TestNominal, DuplicateChannelIdMatchingSizeTest) {
+    TEST_CASE(100.1.13, "Duplicate channel ID across packets with identical size");
+    Svc::TlmPacketizerTester tester;
+    tester.duplicateChannelIdMatchingSizeTest();
+}
+
+TEST(TestOffNominal, DuplicateChannelIdConflictingSizeTest) {
+    TEST_CASE(100.2.3, "Duplicate channel ID across packets with conflicting size");
+    Svc::TlmPacketizerTester tester;
+    tester.duplicateChannelIdConflictingSizeTest();
+}
+
 TEST(TestNominal, TlmGetTest) {
     TEST_CASE(100.1.8, "Get telemetry channel");
     Svc::TlmPacketizerTester tester;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5132 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

TlmPacketizer's `setPacketList` stores each channel's serialized size in a single `TlmEntry.channelSize`. When the same channel ID appears in more than one packet, the loop overwrote that size with the last-seen value, so the earlier packet's buffer offsets (computed from the original size) no longer matched. The runtime `memcpy` in `TlmRecv_handler`/`TlmGet_handler` could then read or write past the channel's slot and overflow the fill buffer.

This stamps the size on the first sighting of a channel ID and `FW_ASSERT`s that any later sighting has the same size, mirroring the duplicate detection assert already present in the ignore-list loop. Identical-definition duplicates across packets behave exactly as before; a conflicting definition trips a configuration-time assert before any buffer is used.

## Rationale

Fixes #5132. Per @LeStarch's clarification on the issue, a channel ID may repeat across packets as long as its definition is identical, so this allows matching duplicates and rejects only conflicting sizes.

## Testing/Review Recommendations

Two unit tests added in `Svc/TlmPacketizer/test/ut`: `DuplicateChannelIdMatchingSizeTest` confirms an identical-size duplicate across two packets is accepted and both packets emit; `DuplicateChannelIdConflictingSizeTest` confirms a conflicting size trips the assert via `ASSERT_DEATH_IF_SUPPORTED`. I could not build locally (no C++ toolchain), so please rely on CI for the compile and unit-test run.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

No