### PR TITLE
fix(Ccsds): reject Space Packet type/APID mismatches in deframer

### DIFF
--- a/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/SpacePacketDeframer.cpp
@@ -28,6 +28,23 @@ bool isValidPacketVersionNumber(const SpacePacketHeader& header) {
     return pvn == static_cast<U16>(ComCfg::Pvn::SPACE_PACKET_PROTOCOL);
 }
 
+bool isValidPacketTypeForApid(const SpacePacketHeader& header) {
+    const U16 packetIdentification = header.get_packetIdentification();
+    const U16 packetType = (packetIdentification & SpacePacketSubfields::PktTypeMask) >> SpacePacketSubfields::PktTypeOffset;
+    const U16 apidValue = packetIdentification & SpacePacketSubfields::ApidMask;
+    if (!ComCfg::Apid::isValid(apidValue)) {
+        return true;
+    }
+    const ComCfg::Apid::T apid = static_cast<ComCfg::Apid::T>(apidValue);
+    if (apid == ComCfg::Apid::FW_PACKET_COMMAND) {
+        return packetType == 1U;
+    }
+    if (apid == ComCfg::Apid::FW_PACKET_TELEM) {
+        return packetType == 0U;
+    }
+    return true;
+}
+
 }  // namespace
 
 // ----------------------------------------------------------------------
@@ -73,6 +90,15 @@ void SpacePacketDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data,
     }
 
     if (!isValidPacketVersionNumber(header)) {
+        this->log_WARNING_HI_InvalidPacket();
+        if (this->isConnected_errorNotify_OutputPort(0)) {
+            this->errorNotify_out(0, Svc::Ccsds::FrameError::SP_INVALID_PACKET);
+        }
+        this->dataReturnOut_out(0, data, context);  // Drop the packet
+        return;
+    }
+
+    if (!isValidPacketTypeForApid(header)) {
         this->log_WARNING_HI_InvalidPacket();
         if (this->isConnected_errorNotify_OutputPort(0)) {
             this->errorNotify_out(0, Svc::Ccsds::FrameError::SP_INVALID_PACKET);

--- a/Svc/Ccsds/SpacePacketDeframer/docs/sdd.md
+++ b/Svc/Ccsds/SpacePacketDeframer/docs/sdd.md
@@ -42,6 +42,7 @@ The `Svc::Ccsds::SpacePacketDeframer` extracts the following fields from the CCS
 | SVC-CCSDS-SPD-002 | The SpacePacketDeframer shall extract the user data field from valid Space Packets. | Unit Test |
 | SVC-CCSDS-SPD-003 | The SpacePacketDeframer shall validate the packet length of a Space Packet Primary Header. | Unit Test |
 | SVC-CCSDS-SPD-010 | The SpacePacketDeframer shall validate the Packet Version Number field and reject packets whose Packet Version Number does not match the CCSDS Space Packet Protocol, emitting `InvalidPacket` and returning the buffer. | Unit Test |
+| SVC-CCSDS-SPD-011 | The SpacePacketDeframer shall validate the Packet Type field against known APIDs and reject mismatched packets, emitting `InvalidPacket` and returning the buffer. | Unit Test |
 | SVC-CCSDS-SPD-009 | The SpacePacketDeframer shall emit an `InvalidLength` event if the packet length token in the header is cannot fit in the received data, and drop the received packet. | Unit Test |
 | SVC-CCSDS-SPD-004 | The SpacePacketDeframer shall receive incoming data containing Space Packets via the `dataIn` port. | Unit Test |
 | SVC-CCSDS-SPD-005 | The SpacePacketDeframer shall output the extracted Space Packet user data via the `dataOut` port. | Unit Test |

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTestMain.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTestMain.cpp
@@ -50,6 +50,11 @@ TEST(SpacePacketDeframer, testInvalidPacketIdentificationControlFields) {
     tester.testInvalidPacketIdentificationControlFields();
 }
 
+TEST(SpacePacketDeframer, testInvalidPacketTypeForApid) {
+    Svc::Ccsds::SpacePacketDeframerTester tester;
+    tester.testInvalidPacketTypeForApid();
+}
+
 TEST(SpacePacketDeframer, testCommandPacketTypeAccepted) {
     Svc::Ccsds::SpacePacketDeframerTester tester;
     tester.testCommandPacketTypeAccepted();

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.cpp
@@ -214,6 +214,26 @@ void SpacePacketDeframerTester ::testInvalidPacketIdentificationControlFields() 
     ASSERT_EVENTS_InvalidPacket_SIZE(1);
 }
 
+void SpacePacketDeframerTester ::testInvalidPacketTypeForApid() {
+    U8 payload[2] = {0xAA, 0xBB};
+    ComCfg::FrameContext nullContext;
+
+    // Telemetry APID with telecommand packet type bit set
+    Fw::Buffer buffer = this->assemblePacketWithControlFields(
+        0x0, 0x1, 0x0, static_cast<U16>(ComCfg::Apid::FW_PACKET_TELEM), 0x3, 0x0012,
+        static_cast<U16>(sizeof(payload) - 1), payload, sizeof(payload));
+
+    this->invoke_to_dataIn(0, buffer, nullContext);
+
+    ASSERT_from_dataOut_SIZE(0);
+    ASSERT_from_validateApidSeqCount_SIZE(0);
+    ASSERT_from_dataReturnOut_SIZE(1);
+    ASSERT_from_errorNotify(0, Svc::Ccsds::FrameError::SP_INVALID_PACKET);
+    ASSERT_FROM_PORT_HISTORY_SIZE(2);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_InvalidPacket_SIZE(1);
+}
+
 void SpacePacketDeframerTester ::testCommandPacketTypeAccepted() {
     this->testControlFieldAccepted(0x0, 0x1, 0x0, ComCfg::Apid::FW_PACKET_COMMAND, 0x3);
 }

--- a/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.hpp
+++ b/Svc/Ccsds/SpacePacketDeframer/test/ut/SpacePacketDeframerTester.hpp
@@ -53,6 +53,7 @@ class SpacePacketDeframerTester final : public SpacePacketDeframerGTestBase {
     void testBufferSmallerThanHeaderSize();
     void testBufferSingleByte();
     void testInvalidPacketIdentificationControlFields();
+    void testInvalidPacketTypeForApid();
     void testCommandPacketTypeAccepted();
     void testSecondaryHeaderFlagAccepted();
     void testSequenceFlagsAccepted();


### PR DESCRIPTION
## Summary
Validates CCSDS Space Packet **Packet Type** against known APIDs (`FW_PACKET_COMMAND` / `FW_PACKET_TELEM`) before forwarding payloads. Extends #5290 beyond packet version number checks.

## Testing
`Svc_Ccsds_SpacePacketDeframer_ut_exe`: 11/11 pass (incl. new `testInvalidPacketTypeForApid`).

Fixes #5290