### PR TITLE
refactor(FileDownlink): unify cancel path and handle COOLDOWN returns

### DIFF
--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -143,10 +143,12 @@ void FileDownlink ::pingIn_handler(const FwIndexType portNum, U32 key) {
 void FileDownlink ::bufferReturn_handler(const FwIndexType portNum, Fw::Buffer& fwBuffer) {
     // If this is a stale buffer (old, timed-out, or both), then ignore its return.
     // File downlink actions only respond to the return of the most-recently-sent buffer.
-    if (this->m_lastBufferId != fwBuffer.getContext() + 1 || this->m_mode.get() == Mode::IDLE) {
+    if (this->m_lastBufferId != fwBuffer.getContext() + 1 || this->m_mode.get() == Mode::IDLE ||
+        this->m_mode.get() == Mode::COOLDOWN) {
         return;
     }
-    // Non-ignored buffers cannot be returned in "DOWNLINK" and "IDLE" state.  Only in "WAIT", "CANCEL" state.
+    // Non-ignored buffers cannot be returned in "DOWNLINK", "IDLE", or "COOLDOWN" state.
+    // Only in "WAIT", "CANCEL" state.
     FW_ASSERT(this->m_mode.get() == Mode::WAIT || this->m_mode.get() == Mode::CANCEL,
               static_cast<FwAssertArgType>(this->m_mode.get()));
     // If the last packet has been sent (and is returning now) then finish the file
@@ -316,7 +318,7 @@ void FileDownlink ::sendFile(const Fw::FileNameString& sourceFilename,
     }
 
     // Send file and switch to WAIT mode
-    this->getBuffer(this->m_buffer, FILE_PACKET);
+    this->getBuffer(this->m_buffer);
     this->sendStartPacket();
     this->m_mode.set(Mode::WAIT);
     this->m_sequenceIndex = 1;
@@ -366,28 +368,12 @@ Os::File::Status FileDownlink ::sendDataPacket(U32& byteOffset) {
 }
 
 void FileDownlink ::sendCancelPacket() {
-    Fw::Buffer buffer;
     Fw::FilePacket::CancelPacket cancelPacket;
     cancelPacket.initialize(this->m_sequenceIndex);
 
     Fw::FilePacket filePacket;
     filePacket.fromCancelPacket(cancelPacket);
-    this->getBuffer(buffer, CANCEL_PACKET);
-    FW_ASSERT(buffer.getSize() >= filePacket.bufferSize() + sizeof(FwPacketDescriptorType),
-              static_cast<FwAssertArgType>(buffer.getSize()),
-              static_cast<FwAssertArgType>(filePacket.bufferSize() + sizeof(FwPacketDescriptorType)));
-
-    // Serialize the packet descriptor FW_PACKET_FILE to the buffer
-    Fw::SerializeStatus status =
-        buffer.getSerializer().serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_FILE));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
-    Fw::Buffer offsetBuffer(buffer.getData() + sizeof(FwPacketDescriptorType),
-                            buffer.getSize() - static_cast<Fw::Buffer::SizeType>(sizeof(FwPacketDescriptorType)));
-    // Serialize the filePacket content into the buffer
-    status = filePacket.toBuffer(offsetBuffer);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
-    this->bufferSendOut_out(0, buffer);
-    this->m_packetsSent.packetSent();
+    this->sendFilePacket(filePacket);
 }
 
 void FileDownlink ::sendEndPacket() {
@@ -485,13 +471,9 @@ void FileDownlink ::finishHelper(bool cancel) {
     sendResponse(SendFileStatus::STATUS_OK);
 }
 
-void FileDownlink ::getBuffer(Fw::Buffer& buffer, PacketType type) {
-    // Check type is correct
-    FW_ASSERT(type < COUNT_PACKET_TYPE && type >= 0, static_cast<FwAssertArgType>(type));
-    // Wrap the buffer around our indexed memory.
-    buffer.setData(this->m_memoryStore[type]);
+void FileDownlink ::getBuffer(Fw::Buffer& buffer) {
+    buffer.setData(this->m_memoryStore);
     buffer.setSize(FILEDOWNLINK_INTERNAL_BUFFER_SIZE);
-    // Set a known ID to look for later
     buffer.setContext(m_lastBufferId);
     m_lastBufferId++;
 }

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -209,10 +209,6 @@ class FileDownlink final : public FileDownlinkComponentBase {
         U32 context;          // Context id of request, only set for PORT sources.
     };
 
-    //! Enumeration for packet types
-    //! Each type has a buffer to store it.
-    enum PacketType { FILE_PACKET, CANCEL_PACKET, COUNT_PACKET_TYPE };
-
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction
@@ -328,7 +324,7 @@ class FileDownlink final : public FileDownlinkComponentBase {
     void enterCooldown();
 
     // Function to acquire a buffer internally
-    void getBuffer(Fw::Buffer& buffer, PacketType type);
+    void getBuffer(Fw::Buffer& buffer);
     // Downlink the "next" packet
     void downlinkPacket();
     // Finish the file transfer
@@ -349,8 +345,8 @@ class FileDownlink final : public FileDownlinkComponentBase {
     //! File downlink queue
     Os::Queue m_fileQueue;
 
-    //! Buffer's memory backing
-    U8 m_memoryStore[COUNT_PACKET_TYPE][FILEDOWNLINK_INTERNAL_BUFFER_SIZE];
+    //! Buffer memory backing for outbound file packets
+    U8 m_memoryStore[FILEDOWNLINK_INTERNAL_BUFFER_SIZE];
 
     //! The mode
     Mode m_mode;
@@ -369,9 +365,6 @@ class FileDownlink final : public FileDownlinkComponentBase {
 
     //! The current sequence index
     U32 m_sequenceIndex;
-
-    //! Timeout threshold (milliseconds) while in WAIT state
-    U32 m_timeout;
 
     //! Cooldown (in ms) between finishing a downlink and starting the next file.
     U32 m_cooldown;

--- a/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
@@ -24,6 +24,11 @@ TEST(FileDownlink, CancelInIdleMode) {
     tester.cancelInIdleMode();
 }
 
+TEST(FileDownlink, CooldownBufferReturnIgnored) {
+    Svc::FileDownlinkTester tester;
+    tester.cooldownBufferReturnIgnored();
+}
+
 TEST(FileDownlink, DownlinkPartial) {
     Svc::FileDownlinkTester tester;
     tester.downlinkPartial();

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -151,6 +151,49 @@ void FileDownlinkTester ::cancelDownlink() {
 
     ASSERT_EQ(FileDownlink::Mode::COOLDOWN, this->component.m_mode.get());
 
+    // Cancel packets must use the serialized size, not FILEDOWNLINK_INTERNAL_BUFFER_SIZE (#5347)
+    ASSERT_GE(this->fromPortHistory_bufferSendOut->size(), 1U);
+    const Fw::Buffer& cancelBuffer =
+        this->fromPortHistory_bufferSendOut->at(this->fromPortHistory_bufferSendOut->size() - 1).fwBuffer;
+    Fw::FilePacket cancelFilePacket;
+    validateFilePacket(cancelBuffer, cancelFilePacket);
+    ASSERT_EQ(Fw::FilePacket::T_CANCEL, cancelFilePacket.asHeader().m_type);
+    const U32 expectedCancelSize =
+        cancelFilePacket.bufferSize() + static_cast<U32>(sizeof(FwPacketDescriptorType));
+    ASSERT_EQ(expectedCancelSize, cancelBuffer.getSize());
+
+    this->removeFile(sourceFileName);
+}
+
+void FileDownlinkTester ::cooldownBufferReturnIgnored() {
+    // Create a file
+    const char* const sourceFileName = "source.bin";
+    const char* const destFileName = "dest.bin";
+    U8 data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    FileBuffer fileBufferOut(data, sizeof(data));
+    fileBufferOut.write(sourceFileName);
+
+    Fw::CmdStringArg sourceCmdStringArg(sourceFileName);
+    Fw::CmdStringArg destCmdStringArg(destFileName);
+    this->sendCmd_SendFile(INSTANCE, CMD_SEQ, sourceCmdStringArg, destCmdStringArg);
+    this->sendCmd_Cancel(INSTANCE, CMD_SEQ);
+    this->component.doDispatch();
+    this->component.Run_handler(0, 0);
+    this->component.doDispatch();
+    this->component.doDispatch();
+    this->component.doDispatch();
+
+    ASSERT_EQ(FileDownlink::Mode::COOLDOWN, this->component.m_mode.get());
+
+    // Simulate a late buffer return during COOLDOWN; should be ignored without assert.
+    U8 backing[FILEDOWNLINK_INTERNAL_BUFFER_SIZE];
+    Fw::Buffer lateBuffer;
+    lateBuffer.setData(backing);
+    lateBuffer.setSize(16);
+    lateBuffer.setContext(this->component.m_lastBufferId);
+    this->component.bufferReturn_handler(0, lateBuffer);
+    ASSERT_EQ(FileDownlink::Mode::COOLDOWN, this->component.m_mode.get());
+
     this->removeFile(sourceFileName);
 }
 

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
@@ -96,6 +96,10 @@ class FileDownlinkTester : public FileDownlinkGTestBase {
     //!
     void cancelInIdleMode();
 
+    //! Late buffer returns during COOLDOWN are ignored (no assert)
+    //!
+    void cooldownBufferReturnIgnored();
+
     //! Create a file F
     //! Downlink partial F
     //! Verify that the downlinked file matches F


### PR DESCRIPTION
## Summary
Follow-up to @nathancheek's discussion on #5347 and future work from #5288.

- Route cancel packets through `sendFilePacket()` (fixes #5347 via shared path)
- Single outbound buffer (remove separate `CANCEL_PACKET` store)
- Ignore buffer returns during `COOLDOWN` like `IDLE`
- Remove unused `m_timeout` on devel

## Testing
`Svc_FileDownlink_ut_exe`: 7/7 pass.

Related #5347 #5288