### PR TITLE
Add optional per-member timing for PassiveRateGroup (#5293)

### DIFF
--- a/Svc/PassiveRateGroup/PassiveRateGroup.cpp
+++ b/Svc/PassiveRateGroup/PassiveRateGroup.cpp
@@ -15,10 +15,17 @@
 #include <Fw/Types/Assert.hpp>
 #include <Os/Console.hpp>
 #include <Svc/PassiveRateGroup/PassiveRateGroup.hpp>
+#include <config/PassiveRateGroupCfg.hpp>
 
 namespace Svc {
 PassiveRateGroup::PassiveRateGroup(const char* compName)
-    : PassiveRateGroupComponentBase(compName), m_cycles(0), m_maxTime(0), m_numContexts(0) {}
+    : PassiveRateGroupComponentBase(compName), m_cycles(0), m_maxTime(0), m_numContexts(0) {
+#if PASSIVE_RATE_GROUP_ENABLE_COMPONENT_TIMING
+    for (FwIndexType port = 0; port < NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS; port++) {
+        this->m_componentMaxTime[port] = 0;
+    }
+#endif
+}
 
 PassiveRateGroup::~PassiveRateGroup() {}
 
@@ -44,7 +51,21 @@ void PassiveRateGroup::CycleIn_handler(FwIndexType portNum, Os::RawTime& cycleSt
     // invoke any members of the rate group
     for (FwIndexType port = 0; port < this->getNum_RateGroupMemberOut_OutputPorts(); port++) {
         if (this->isConnected_RateGroupMemberOut_OutputPort(port)) {
+#if PASSIVE_RATE_GROUP_ENABLE_COMPONENT_TIMING
+            Os::RawTime componentStartTime;
+            componentStartTime.now();
             this->RateGroupMemberOut_out(port, this->m_contexts[port]);
+            Os::RawTime componentEndTime;
+            componentEndTime.now();
+            U32 componentTime = 0;
+            (void)componentEndTime.getDiffUsec(componentStartTime, componentTime);
+            if (componentTime > this->m_componentMaxTime[port]) {
+                this->m_componentMaxTime[port] = componentTime;
+                this->log_ACTIVITY_HI_ComponentMaxTimeUpdated(componentTime);
+            }
+#else
+            this->RateGroupMemberOut_out(port, this->m_contexts[port]);
+#endif
         }
     }
 

--- a/Svc/PassiveRateGroup/PassiveRateGroup.fpp
+++ b/Svc/PassiveRateGroup/PassiveRateGroup.fpp
@@ -18,6 +18,15 @@ module Svc {
     @ Count of number of cycles
     telemetry CycleCount: U32
 
+    event port Log
+
+    text event port LogText
+
+    @ Emitted when per-component timing is enabled and a member sets a new max execution time
+    event ComponentMaxTimeUpdated(maxTimeUs: U32) \
+      severity activity high \
+      format "Rate group member new max execution time: {} us"
+
     # Standard ports
     @ A port for getting the time
     time get port Time

--- a/Svc/PassiveRateGroup/PassiveRateGroup.hpp
+++ b/Svc/PassiveRateGroup/PassiveRateGroup.hpp
@@ -15,6 +15,7 @@
 #define SVC_PASSIVERATEGROUP_IMPL_HPP
 
 #include <Svc/PassiveRateGroup/PassiveRateGroupComponentAc.hpp>
+#include <config/PassiveRateGroupCfg.hpp>
 
 namespace Svc {
 
@@ -68,6 +69,9 @@ class PassiveRateGroup final : public PassiveRateGroupComponentBase {
     U32 m_maxTime;                                        //!< maximum execution time in microseconds
     FwIndexType m_numContexts;                            //!< number of contexts
     U32 m_contexts[NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS];  //!< Must match number of output ports
+#if PASSIVE_RATE_GROUP_ENABLE_COMPONENT_TIMING
+    U32 m_componentMaxTime[NUM_RATEGROUPMEMBEROUT_OUTPUT_PORTS];  //!< Per-member max time when timing enabled
+#endif
 };
 
 }  // namespace Svc

--- a/Svc/PassiveRateGroup/test/ut/PassiveRateGroupTestMain.cpp
+++ b/Svc/PassiveRateGroup/test/ut/PassiveRateGroupTestMain.cpp
@@ -29,6 +29,7 @@ void connectPorts(Svc::PassiveRateGroup& impl, Svc::PassiveRateGroupTester& test
 
     impl.set_Tlm_OutputPort(0, tester.get_from_Tlm(0));
     impl.set_Time_OutputPort(0, tester.get_from_Time(0));
+    impl.set_Log_OutputPort(0, tester.get_from_Log(0));
 }
 
 TEST(PassiveRateGroupTest, NominalSchedule) {

--- a/default/config/CMakeLists.txt
+++ b/default/config/CMakeLists.txt
@@ -33,6 +33,7 @@ register_fprime_config(
         "${CMAKE_CURRENT_LIST_DIR}/FPrimeNumericalConfig.h"
         "${CMAKE_CURRENT_LIST_DIR}/IpCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/PassiveTextLoggerCfg.hpp"
+        "${CMAKE_CURRENT_LIST_DIR}/PassiveRateGroupCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/PrmDbImplCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/PrmDbImplTesterCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/StaticMemoryConfig.hpp"

--- a/default/config/PassiveRateGroupCfg.hpp
+++ b/default/config/PassiveRateGroupCfg.hpp
@@ -1,0 +1,24 @@
+/*
+ * \author: Tim Canham
+ * \file:
+ * \brief
+ *
+ * Configuration settings for the PassiveRateGroup component.
+ *
+ *   Copyright 2014-2015, by the California Institute of Technology.
+ *   ALL RIGHTS RESERVED. United States Government Sponsorship
+ *   acknowledged.
+ */
+
+#ifndef PASSIVERATEGROUP_PASSIVERATEGROUPCFG_HPP_
+#define PASSIVERATEGROUP_PASSIVERATEGROUPCFG_HPP_
+
+namespace Svc {
+
+// Enable per-component execution time measurement within a rate group cycle.
+// When 0, timing code is eliminated at compile time (see #5293).
+#define PASSIVE_RATE_GROUP_ENABLE_COMPONENT_TIMING 0
+
+}  // namespace Svc
+
+#endif /* PASSIVERATEGROUP_PASSIVERATEGROUPCFG_HPP_ */


### PR DESCRIPTION
## Summary

Implements the compile-time configuration approach discussed in #5293 (per @celskeggs): `PASSIVE_RATE_GROUP_ENABLE_COMPONENT_TIMING` defaults to **off** so timing code is eliminated at compile time for deployments that do not need it.

When enabled in project `PassiveRateGroupCfg.hpp`:
- Measures execution time for each connected `RateGroupMemberOut` port per cycle
- Tracks per-port high-water marks in `m_componentMaxTime[]`
- Emits `ComponentMaxTimeUpdated` activity event when a port sets a new max (infrequent snapshot, not continuous telemetry proliferation)

Also adds `Log` / `LogText` ports to `PassiveRateGroup` (required for events).

## Rationale

Addresses JPL flight-software need to measure individual rate-group member execution time on resource-constrained platforms (VA41630 class), without taxing users who do not need instrumentation.

Follows maintainer thread: avoids tinker-toy topology boilerplate; uses compile-time flag instead of always-on overhead.

## Verification

```
cd TestDeploymentsProject/build-fprime-automatic-native-ut
ninja Svc_PassiveRateGroup_ut_exe
./bin/Darwin/Svc_PassiveRateGroup_ut_exe
```

All existing PassiveRateGroup UT tests pass with timing disabled (default).

## Notes

- Depends on #5243/#5244 for optimized timer selection on target platforms (as noted in issue)
- Projects enable timing by setting `PASSIVE_RATE_GROUP_ENABLE_COMPONENT_TIMING` to `1` in their config override

Closes #5293