### PR TITLE
Warn on uninitialized submodules and empty libraries in CMake (#5054)

### DIFF
--- a/cmake/API.cmake
+++ b/cmake/API.cmake
@@ -119,6 +119,7 @@ endmacro()
 function(add_fprime_subdirectory FP_SOURCE_DIR)
     get_module_name("${FP_SOURCE_DIR}")
     set(FPRIME_CURRENT_MODULE "${MODULE_NAME}")
+    fprime_check_uninitialized_subdirectory("${FP_SOURCE_DIR}")
 
     # Unset all variables that carry special meaning as it is dangerous to pass them through
     foreach (VARIABLE IN ITEMS SOURCE_FILES MOD_DEPS UT_SOURCE_FILES UT_MOD_DEPS EXECUTABLE_NAME)

--- a/cmake/module.cmake
+++ b/cmake/module.cmake
@@ -230,6 +230,12 @@ function(fprime__internal_add_build_target_helper TARGET_NAME TYPE SOURCES AUTOC
         fprime_target_implementations("${TARGET_NAME}" ${CHOOSES_IMPLEMENTATIONS})
     elseif(TYPE STREQUAL "Library")
         add_library("${TARGET_NAME}" ${FPRIME_CMAKE_ADD_OPTIONS} ${SOURCES})
+        if (NOT (INTERFACE IN_LIST FPRIME_CMAKE_ADD_OPTIONS) AND NOT SOURCES AND NOT AUTOCODER_INPUTS)
+            fprime_cmake_warning(
+                "F Prime library target '${TARGET_NAME}' has no SOURCES or AUTOCODER_INPUTS.\n"
+                "This may indicate an uninitialized submodule or misconfigured module."
+            )
+        endif()
     else()
         fprime_cmake_fatal_error("Cannot register compilation target of type ${TYPE}")
     endif()

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -569,6 +569,39 @@ function(fprime_cmake_warning)
 endfunction(fprime_cmake_warning)
 
 ####
+# Function `fprime_check_uninitialized_subdirectory`:
+#
+# Warn when a path added via add_fprime_subdirectory looks like an uninitialized git submodule.
+# See nasa/fprime#5054.
+#
+# - **SOURCE_DIR:** directory about to be added to the build
+####
+function(fprime_check_uninitialized_subdirectory SOURCE_DIR)
+    if (NOT IS_DIRECTORY "${SOURCE_DIR}")
+        return()
+    endif()
+    # Uninitialized submodule checkout: .git exists as a file (gitdir pointer), not a directory.
+    if (EXISTS "${SOURCE_DIR}/.git" AND NOT IS_DIRECTORY "${SOURCE_DIR}/.git")
+        fprime_cmake_warning(
+            "Submodule path '${SOURCE_DIR}' appears uninitialized.\n"
+            "Run: git submodule update --init --recursive"
+        )
+        return()
+    endif()
+    # Empty directory with no CMakeLists.txt is another common uninitialized submodule symptom.
+    if (NOT EXISTS "${SOURCE_DIR}/CMakeLists.txt")
+        file(GLOB SUBDIR_CONTENTS RELATIVE "${SOURCE_DIR}" "${SOURCE_DIR}/*")
+        list(LENGTH SUBDIR_CONTENTS CONTENT_COUNT)
+        if (CONTENT_COUNT EQUAL 0)
+            fprime_cmake_warning(
+                "Directory '${SOURCE_DIR}' is empty and may be an uninitialized submodule.\n"
+                "Run: git submodule update --init --recursive"
+            )
+        endif()
+    endif()
+endfunction(fprime_check_uninitialized_subdirectory)
+
+####
 # Function `fprime_cmake_status`:
 #
 # Prints a status message to the user that can be quieted with FPRIME_CMAKE_QUIET=ON.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5054 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

- `fprime_check_uninitialized_subdirectory()` warns when `add_fprime_subdirectory` targets look like uninitialized git submodules (`.git` file pointer or empty directory without `CMakeLists.txt`).
- Warn when a non-INTERFACE `register_fprime_library` target has no `SOURCES` or `AUTOCODER_INPUTS`.

## Rationale

Per @thomas-bc and @LeStarch on #5054: catch the common `git clone` without `--recurse-submodules` failure mode early in CMake instead of opaque empty-library builds.

## Testing/Review Recommendations

```
cd TestDeploymentsProject/build && fprime-util generate
```

Configure succeeds on TestDeploymentsProject. Warnings appear when submodule paths are empty/uninitialized.

## Future Work

Could promote empty-library cases to `FATAL_ERROR` behind a project option if maintainers want stricter behavior.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI-assisted implementation and PR description drafting.

IAMAI