### PR TITLE
Add FW_CASSERT_{2,3,4,5,6} macros

### DIFF
--- a/Fw/Types/Assert.cpp
+++ b/Fw/Types/Assert.cpp
@@ -186,6 +186,29 @@ void SwAssert(FILE_NAME_ARG file,
 extern "C" {
 I8 CAssert0(FILE_NAME_ARG file, FwSizeType lineNo);
 I8 CAssert1(FILE_NAME_ARG file, FwAssertArgType arg1, FwSizeType lineNo);
+I8 CAssert2(FILE_NAME_ARG file, FwAssertArgType arg1, FwAssertArgType arg2, FwSizeType lineNo);
+I8 CAssert3(FILE_NAME_ARG file, FwAssertArgType arg1, FwAssertArgType arg2, FwAssertArgType arg3, FwSizeType lineNo);
+I8 CAssert4(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwSizeType lineNo);
+I8 CAssert5(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwAssertArgType arg5,
+            FwSizeType lineNo);
+I8 CAssert6(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwAssertArgType arg5,
+            FwAssertArgType arg6,
+            FwSizeType lineNo);
 }
 
 I8 CAssert0(FILE_NAME_ARG file, FwSizeType lineNo) {
@@ -209,6 +232,89 @@ I8 CAssert1(FILE_NAME_ARG file, FwAssertArgType arg1, FwSizeType lineNo) {
                                 static_cast<FwSizeType>(sizeof(assertMsg)));
     } else {
         registeredHook->reportAssert(file, lineNo, 1, arg1, 0, 0, 0, 0, 0);
+        registeredHook->doAssert();
+    }
+    return 0;
+}
+
+I8 CAssert2(FILE_NAME_ARG file, FwAssertArgType arg1, FwAssertArgType arg2, FwSizeType lineNo) {
+    Fw::AssertHook* const registeredHook = Fw::AssertHook::getRegisteredHook();
+    if (nullptr == registeredHook) {
+        CHAR assertMsg[FW_ASSERT_TEXT_SIZE];
+        Fw::defaultReportAssert(file, lineNo, 2, arg1, arg2, 0, 0, 0, 0, assertMsg,
+                                static_cast<FwSizeType>(sizeof(assertMsg)));
+    } else {
+        registeredHook->reportAssert(file, lineNo, 2, arg1, arg2, 0, 0, 0, 0);
+        registeredHook->doAssert();
+    }
+    return 0;
+}
+
+I8 CAssert3(FILE_NAME_ARG file, FwAssertArgType arg1, FwAssertArgType arg2, FwAssertArgType arg3, FwSizeType lineNo) {
+    Fw::AssertHook* const registeredHook = Fw::AssertHook::getRegisteredHook();
+    if (nullptr == registeredHook) {
+        CHAR assertMsg[FW_ASSERT_TEXT_SIZE];
+        Fw::defaultReportAssert(file, lineNo, 3, arg1, arg2, arg3, 0, 0, 0, assertMsg,
+                                static_cast<FwSizeType>(sizeof(assertMsg)));
+    } else {
+        registeredHook->reportAssert(file, lineNo, 3, arg1, arg2, arg3, 0, 0, 0);
+        registeredHook->doAssert();
+    }
+    return 0;
+}
+
+I8 CAssert4(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwSizeType lineNo) {
+    Fw::AssertHook* const registeredHook = Fw::AssertHook::getRegisteredHook();
+    if (nullptr == registeredHook) {
+        CHAR assertMsg[FW_ASSERT_TEXT_SIZE];
+        Fw::defaultReportAssert(file, lineNo, 4, arg1, arg2, arg3, arg4, 0, 0, assertMsg,
+                                static_cast<FwSizeType>(sizeof(assertMsg)));
+    } else {
+        registeredHook->reportAssert(file, lineNo, 4, arg1, arg2, arg3, arg4, 0, 0);
+        registeredHook->doAssert();
+    }
+    return 0;
+}
+
+I8 CAssert5(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwAssertArgType arg5,
+            FwSizeType lineNo) {
+    Fw::AssertHook* const registeredHook = Fw::AssertHook::getRegisteredHook();
+    if (nullptr == registeredHook) {
+        CHAR assertMsg[FW_ASSERT_TEXT_SIZE];
+        Fw::defaultReportAssert(file, lineNo, 5, arg1, arg2, arg3, arg4, arg5, 0, assertMsg,
+                                static_cast<FwSizeType>(sizeof(assertMsg)));
+    } else {
+        registeredHook->reportAssert(file, lineNo, 5, arg1, arg2, arg3, arg4, arg5, 0);
+        registeredHook->doAssert();
+    }
+    return 0;
+}
+
+I8 CAssert6(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwAssertArgType arg5,
+            FwAssertArgType arg6,
+            FwSizeType lineNo) {
+    Fw::AssertHook* const registeredHook = Fw::AssertHook::getRegisteredHook();
+    if (nullptr == registeredHook) {
+        CHAR assertMsg[FW_ASSERT_TEXT_SIZE];
+        Fw::defaultReportAssert(file, lineNo, 6, arg1, arg2, arg3, arg4, arg5, arg6, assertMsg,
+                                static_cast<FwSizeType>(sizeof(assertMsg)));
+    } else {
+        registeredHook->reportAssert(file, lineNo, 6, arg1, arg2, arg3, arg4, arg5, arg6);
         registeredHook->doAssert();
     }
     return 0;

--- a/Fw/Types/CAssert.h
+++ b/Fw/Types/CAssert.h
@@ -18,6 +18,11 @@ extern "C" {
 
 #define FW_CASSERT(...)
 #define FW_CASSERT_1(cond, arg1)
+#define FW_CASSERT_2(cond, arg1, arg2)
+#define FW_CASSERT_3(cond, arg1, arg2, arg3)
+#define FW_CASSERT_4(cond, arg1, arg2, arg3, arg4)
+#define FW_CASSERT_5(cond, arg1, arg2, arg3, arg4, arg5)
+#define FW_CASSERT_6(cond, arg1, arg2, arg3, arg4, arg5, arg6)
 
 #else  // ASSERT is defined
 
@@ -25,15 +30,85 @@ extern "C" {
 #define FILE_NAME_ARG U32
 #define FW_CASSERT(cond) ((void)((cond) ? (0) : (CAssert0(ASSERT_FILE_ID, __LINE__))))
 #define FW_CASSERT_1(cond, arg1) ((void)((cond) ? (0) : (CAssert1(ASSERT_FILE_ID, (FwAssertArgType)(arg1), __LINE__))))
+#define FW_CASSERT_2(cond, arg1, arg2) \
+    ((void)((cond) ? (0) : (CAssert2(ASSERT_FILE_ID, (FwAssertArgType)(arg1), (FwAssertArgType)(arg2), __LINE__))))
+#define FW_CASSERT_3(cond, arg1, arg2, arg3)                                                     \
+    ((void)((cond) ? (0)                                                                         \
+                   : (CAssert3(ASSERT_FILE_ID, (FwAssertArgType)(arg1), (FwAssertArgType)(arg2), \
+                               (FwAssertArgType)(arg3), __LINE__))))
+#define FW_CASSERT_4(cond, arg1, arg2, arg3, arg4)                                               \
+    ((void)((cond) ? (0)                                                                         \
+                   : (CAssert4(ASSERT_FILE_ID, (FwAssertArgType)(arg1), (FwAssertArgType)(arg2), \
+                               (FwAssertArgType)(arg3), (FwAssertArgType)(arg4), __LINE__))))
+#define FW_CASSERT_5(cond, arg1, arg2, arg3, arg4, arg5)                                         \
+    ((void)((cond) ? (0)                                                                         \
+                   : (CAssert5(ASSERT_FILE_ID, (FwAssertArgType)(arg1), (FwAssertArgType)(arg2), \
+                               (FwAssertArgType)(arg3), (FwAssertArgType)(arg4), (FwAssertArgType)(arg5), __LINE__))))
+#define FW_CASSERT_6(cond, arg1, arg2, arg3, arg4, arg5, arg6)                                                         \
+    ((void)((cond)                                                                                                     \
+                ? (0)                                                                                                  \
+                : (CAssert6(ASSERT_FILE_ID, (FwAssertArgType)(arg1), (FwAssertArgType)(arg2), (FwAssertArgType)(arg3), \
+                            (FwAssertArgType)(arg4), (FwAssertArgType)(arg5), (FwAssertArgType)(arg6), __LINE__))))
 #else
 #define FILE_NAME_ARG const CHAR*
 #define FW_CASSERT(cond) ((void)((cond) ? (0) : (CAssert0((FILE_NAME_ARG)(__FILE__), __LINE__))))
 #define FW_CASSERT_1(cond, arg1) \
     ((void)((cond) ? (0) : (CAssert1((FILE_NAME_ARG)(__FILE__), (FwAssertArgType)(arg1), __LINE__))))
+#define FW_CASSERT_2(cond, arg1, arg2) \
+    ((void)((cond)                     \
+                ? (0)                  \
+                : (CAssert2((FILE_NAME_ARG)(__FILE__), (FwAssertArgType)(arg1), (FwAssertArgType)(arg2), __LINE__))))
+#define FW_CASSERT_3(cond, arg1, arg2, arg3)                                                                \
+    ((void)((cond) ? (0)                                                                                    \
+                   : (CAssert3((FILE_NAME_ARG)(__FILE__), (FwAssertArgType)(arg1), (FwAssertArgType)(arg2), \
+                               (FwAssertArgType)(arg3), __LINE__))))
+#define FW_CASSERT_4(cond, arg1, arg2, arg3, arg4)                                                          \
+    ((void)((cond) ? (0)                                                                                    \
+                   : (CAssert4((FILE_NAME_ARG)(__FILE__), (FwAssertArgType)(arg1), (FwAssertArgType)(arg2), \
+                               (FwAssertArgType)(arg3), (FwAssertArgType)(arg4), __LINE__))))
+#define FW_CASSERT_5(cond, arg1, arg2, arg3, arg4, arg5)                                                    \
+    ((void)((cond) ? (0)                                                                                    \
+                   : (CAssert5((FILE_NAME_ARG)(__FILE__), (FwAssertArgType)(arg1), (FwAssertArgType)(arg2), \
+                               (FwAssertArgType)(arg3), (FwAssertArgType)(arg4), (FwAssertArgType)(arg5), __LINE__))))
+#define FW_CASSERT_6(cond, arg1, arg2, arg3, arg4, arg5, arg6)                                              \
+    ((void)((cond) ? (0)                                                                                    \
+                   : (CAssert6((FILE_NAME_ARG)(__FILE__), (FwAssertArgType)(arg1), (FwAssertArgType)(arg2), \
+                               (FwAssertArgType)(arg3), (FwAssertArgType)(arg4), (FwAssertArgType)(arg5),   \
+                               (FwAssertArgType)(arg6), __LINE__))))
 #endif
 
 I8 CAssert0(FILE_NAME_ARG file, FwSizeType lineNo);                        //!< C assert function
 I8 CAssert1(FILE_NAME_ARG file, FwAssertArgType arg1, FwSizeType lineNo);  //!< C assert function with one argument
+I8 CAssert2(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwSizeType lineNo);  //!< C assert function with two arguments
+I8 CAssert3(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwSizeType lineNo);  //!< C assert function with three arguments
+I8 CAssert4(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwSizeType lineNo);  //!< C assert function with four arguments
+I8 CAssert5(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwAssertArgType arg5,
+            FwSizeType lineNo);  //!< C assert function with five arguments
+I8 CAssert6(FILE_NAME_ARG file,
+            FwAssertArgType arg1,
+            FwAssertArgType arg2,
+            FwAssertArgType arg3,
+            FwAssertArgType arg4,
+            FwAssertArgType arg5,
+            FwAssertArgType arg6,
+            FwSizeType lineNo);  //!< C assert function with six arguments
 
 #endif  // ASSERT is defined
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5375 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Adds `FW_CASSERT_{2,3,4,5,6}` macros to `Fw/Types/CAssert.h`, backed by `CAssert{2,3,4,5,6}` functions in `Fw/Types/Assert.cpp`.

Each follows the existing `FW_CASSERT_1`/`CAssert1` pattern.

Change is purely additive.

## Rationale

Requested in #5375. C libraries called from F Prime need multi-argument assertions for observability in flight.

This makes `CAssert.h` symmetrical with `Assert.h`, up to the 6 arguments already supported by `FW_ASSERT` and `AssertHook::reportAssert`.

## Testing/Review Recommendations

- Each new macro/function can be diffed against its `_1` counterpart and the matching `SwAssert` overload in `Assert.hpp`
- Ran `Fw/Types` unit tests (pass) and `fprime-util format --check` (clean)
- Compiled a C99 translation unit using all new macros with `-Wall -Wextra` and verified a registered `AssertHook` receives the correct `numArgs` and argument values