### PR TITLE
Stop falling back on devel for fprime-gds `pr-xxxx` upgrades

### DIFF
--- a/.github/workflows/ext-aarch64-linux-led-blinker.yml
+++ b/.github/workflows/ext-aarch64-linux-led-blinker.yml
@@ -96,11 +96,12 @@ jobs:
           . venv/bin/activate
           pip install -r requirements.txt
           echo "${PWD}/venv/bin" >> "${GITHUB_PATH}"
-      # Upgrade GDS to devel or pr-xxxx branch if it exists
-      - name: "Upgrade fprime-gds to devel or pr-xxxx"
+      # Upgrade GDS to a matching pr-xxxx branch if it exists; never fall back to devel
+      - name: "Upgrade fprime-gds to pr-xxxx (if it exists)"
         uses: nasa/fprime-actions/upgrade-package@devel
         with:
           repository: nasa/fprime-gds
+          pr-branch-only: true
       - name: "Artifacts Download"
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ext-aarch64-linux-led-blinker.yml
+++ b/.github/workflows/ext-aarch64-linux-led-blinker.yml
@@ -98,6 +98,7 @@ jobs:
           echo "${PWD}/venv/bin" >> "${GITHUB_PATH}"
       # Upgrade GDS to a matching pr-xxxx branch if it exists; never fall back to devel
       - name: "Upgrade fprime-gds to pr-xxxx (if it exists)"
+        if: github.event_name == 'pull_request'
         uses: nasa/fprime-actions/upgrade-package@devel
         with:
           repository: nasa/fprime-gds

--- a/.github/workflows/ext-fprime-cfs-reference.yml
+++ b/.github/workflows/ext-fprime-cfs-reference.yml
@@ -43,11 +43,12 @@ jobs:
           target_repository: fprime-community/fprime_cfs_reference
           fprime_location: ./libs/fprime
           target_ref: ${{ needs.get-branch.outputs.target-branch }}
-      # Upgrade GDS to devel or pr-xxxx branch if it exists
-      - name: "Upgrade fprime-gds to devel or pr-xxxx"
+      # Upgrade GDS to a matching pr-xxxx branch if it exists; never fall back to devel
+      - name: "Upgrade fprime-gds to pr-xxxx (if it exists)"
         uses: nasa/fprime-actions/upgrade-package@devel
         with:
           repository: nasa/fprime-gds
+          pr-branch-only: true
       - name: "Build cFS Reference"
         run: |
           make SIMULATION=native prep

--- a/.github/workflows/ext-fprime-cfs-reference.yml
+++ b/.github/workflows/ext-fprime-cfs-reference.yml
@@ -45,6 +45,7 @@ jobs:
           target_ref: ${{ needs.get-branch.outputs.target-branch }}
       # Upgrade GDS to a matching pr-xxxx branch if it exists; never fall back to devel
       - name: "Upgrade fprime-gds to pr-xxxx (if it exists)"
+        if: github.event_name == 'pull_request'
         uses: nasa/fprime-actions/upgrade-package@devel
         with:
           repository: nasa/fprime-gds

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -92,11 +92,12 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements.txt
           echo "${PWD}/venv/bin" >> "${GITHUB_PATH}"
-      # Upgrade GDS to devel or pr-xxxx branch if it exists
-      - name: "Upgrade fprime-gds to devel or pr-xxxx"
+      # Upgrade GDS to a matching pr-xxxx branch if it exists; never fall back to devel
+      - name: "Upgrade fprime-gds to pr-xxxx (if it exists)"
         uses: nasa/fprime-actions/upgrade-package@devel
         with:
           repository: nasa/fprime-gds
+          pr-branch-only: true
       - name: "Artifacts Download"
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ext-raspberry-led-blinker.yml
+++ b/.github/workflows/ext-raspberry-led-blinker.yml
@@ -94,6 +94,7 @@ jobs:
           echo "${PWD}/venv/bin" >> "${GITHUB_PATH}"
       # Upgrade GDS to a matching pr-xxxx branch if it exists; never fall back to devel
       - name: "Upgrade fprime-gds to pr-xxxx (if it exists)"
+        if: github.event_name == 'pull_request'
         uses: nasa/fprime-actions/upgrade-package@devel
         with:
           repository: nasa/fprime-gds

--- a/.github/workflows/ref.yml
+++ b/.github/workflows/ref.yml
@@ -87,11 +87,12 @@ jobs:
         uses: nasa/fprime-actions/setup@devel
         with:
           location: ${{ github.workspace }}
-      # Upgrade GDS to devel or pr-xxxx branch if it exists
-      - name: "Upgrade fprime-gds to devel or pr-xxxx"
+      # Upgrade GDS to a matching pr-xxxx branch if it exists; never fall back to devel
+      - name: "Upgrade fprime-gds to pr-xxxx (if it exists)"
         uses: nasa/fprime-actions/upgrade-package@devel
         with:
           repository: nasa/fprime-gds
+          pr-branch-only: true
       - name: "Download Build Artifacts"
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ref.yml
+++ b/.github/workflows/ref.yml
@@ -89,6 +89,7 @@ jobs:
           location: ${{ github.workspace }}
       # Upgrade GDS to a matching pr-xxxx branch if it exists; never fall back to devel
       - name: "Upgrade fprime-gds to pr-xxxx (if it exists)"
+        if: github.event_name == 'pull_request'
         uses: nasa/fprime-actions/upgrade-package@devel
         with:
           repository: nasa/fprime-gds

--- a/.github/workflows/reusable-project-ci.yml
+++ b/.github/workflows/reusable-project-ci.yml
@@ -80,11 +80,12 @@ jobs:
           fprime_location: ${{ inputs.fprime_location }}
           target_ref: ${{ inputs.target_ref }}
           stage: int
-      # Upgrade GDS to devel or pr-xxxx branch if it exists
-      - name: "Upgrade fprime-gds to devel or pr-xxxx"
+      # Upgrade GDS to a matching pr-xxxx branch if it exists; never fall back to devel
+      - name: "Upgrade fprime-gds to pr-xxxx (if it exists)"
         uses: nasa/fprime-actions/upgrade-package@devel
         with:
           repository: nasa/fprime-gds
+          pr-branch-only: true
       - name: Pull Archive Results
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/reusable-project-ci.yml
+++ b/.github/workflows/reusable-project-ci.yml
@@ -82,6 +82,7 @@ jobs:
           stage: int
       # Upgrade GDS to a matching pr-xxxx branch if it exists; never fall back to devel
       - name: "Upgrade fprime-gds to pr-xxxx (if it exists)"
+        if: github.event_name == 'pull_request'
         uses: nasa/fprime-actions/upgrade-package@devel
         with:
           repository: nasa/fprime-gds

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ fprime-fpl-layout==1.0.4
 fprime-fpl-write-pic==1.0.4
 fprime-fpp==3.3.0a10
 fprime-fpy==0.4.0
-fprime-gds==4.2.0
+fprime-gds==4.2.2a2
 fprime-tools==4.3.0a5
 fprime-visual==1.0.2
 gcovr==8.2


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Stop upgrading `fprime-gds` to `devel` in CI - this is to let `requirements.txt` be the authoritative source of dependency even in `devel` mode. 
Keep the `pr-xxxx` upgrade in a PR context to make the testing workflow easier. This does mean we'll need to remember to make an alpha when this happens, and update requirements.txt. And CI will fail on `devel` if we don't, which is good.