### PR TITLE
Fixed Svc/FileWorker: report FW_STATUS_FAILED_TO_WRITE when writeIn's…

### DIFF
--- a/Svc/FileWorker/FileWorker.cpp
+++ b/Svc/FileWorker/FileWorker.cpp
@@ -174,12 +174,16 @@ void FileWorker ::writeIn_handler(FwIndexType portNum,
     fileName[sizeof(fileName) - 1] = 0;  // guarantee termination
 
     // Write
-    bool isWrite = this->writeBufferToFile(buffer, fileName, offsetBytes, append);
+    const bool isWrite = this->writeBufferToFile(buffer, fileName, offsetBytes, append);
     if (isWrite) {
         this->writeBufferHashToFile(buffer, fileName, offsetBytes, append);
     }
 
-    this->writeDoneOut_out(0, FW_STATUS_DONE_WRITE, buffer.getSize());
+    // Report the actual outcome of the write. A failed writeBufferToFile (open
+    // failure, permission denied, disk full, partial write) must not be reported
+    // to ground as a successful FW_STATUS_DONE_WRITE.
+    const FileWorkerStatus writeStatus = isWrite ? FW_STATUS_DONE_WRITE : FW_STATUS_FAILED_TO_WRITE;
+    this->writeDoneOut_out(0, writeStatus, isWrite ? buffer.getSize() : 0);
     this->m_state = FW_STATE_IDLE;
     return;
 }
@@ -288,6 +292,11 @@ Svc ::FileWorkerReadStatus FileWorker ::readFileBytes(Fw::Buffer& buffer,
         Os::File::Status ret = file.read(buffer.getData() + bytesRead, readAmtActual);
 
         if (Os::File::OP_OK != ret || readAmt != readAmtActual) {
+            // Count the bytes actually transferred so ReadError telemetry reports
+            // the true amount. A short read stays an error on purpose: FileWorker
+            // reads a fixed, caller-specified size and must not silently accept a
+            // file shorter than expected (e.g. truncated mid-read).
+            bytesRead += readAmtActual;
             return FileWorkerReadStatus::FW_READ_ERROR;
         }
 

--- a/Svc/FileWorker/test/ut/FileWorkerErrTestMain.cpp
+++ b/Svc/FileWorker/test/ut/FileWorkerErrTestMain.cpp
@@ -21,6 +21,11 @@ TEST(Nominal, testWriteErr) {
     tester.testWriteErr();
 }
 
+TEST(Nominal, testWriteErrStatusReported) {
+    Svc::FileWorkerTester tester;
+    tester.testWriteErrStatusReported();
+}
+
 TEST(Nominal, testWriteHashErr) {
     Svc::FileWorkerTester tester;
     tester.testWriteHashErr();

--- a/Svc/FileWorker/test/ut/FileWorkerErrTester.cpp
+++ b/Svc/FileWorker/test/ut/FileWorkerErrTester.cpp
@@ -148,6 +148,35 @@ void FileWorkerTester ::testWriteErr() {
     fTest.setOpen(Os::FileInterface::OP_OK);
 }
 
+// Regression test: when the underlying write fails, writeIn must report a
+// failure status on writeDoneOut rather than FW_STATUS_DONE_WRITE. Drives the
+// full writeIn port handler (not just the writeBufferToFile helper) so the
+// status-propagation path is exercised.
+void FileWorkerTester ::testWriteErrStatusReported() {
+    FwSizeType dataSize = 1024;
+    U8 data[dataSize];
+    for (FwSizeType i = 0; i < dataSize; i++) {
+        data[i] = static_cast<U8>(i % 256);
+    }
+    Fw::Buffer buffer(data, dataSize);
+    Fw::String fname = "testwrite.txt";
+    FwSizeType offsetBytes = 0;
+
+    // Force the write's open() to fail so writeBufferToFile returns false.
+    this->clearHistory();
+    fTest.setOpen(Os::FileInterface::INVALID_MODE);
+
+    this->invoke_to_writeIn(0, fname, buffer, offsetBytes, false);
+    this->component.doDispatch();
+
+    // The write failed, so ground must be told it failed.
+    ASSERT_from_writeDoneOut_SIZE(1);
+    ASSERT_from_writeDoneOut(0, FileWorkerStatus::FW_STATUS_FAILED_TO_WRITE, 0);
+    ASSERT_EQ(this->component.m_state, FileWorkerState::FW_STATE_IDLE);
+
+    fTest.setOpen(Os::FileInterface::OP_OK);
+}
+
 void FileWorkerTester ::testWriteHashErr() {
     FwSizeType offsetBytes = 0;
     const char* fnameChar = "testfile.txt";

--- a/Svc/FileWorker/test/ut/FileWorkerErrTester.hpp
+++ b/Svc/FileWorker/test/ut/FileWorkerErrTester.hpp
@@ -50,6 +50,7 @@ class FileWorkerTester final : public FileWorkerGTestBase {
     void testReadErr();
     void testVerifyErr();
     void testWriteErr();
+    void testWriteErrStatusReported();
     void testWriteHashErr();
 
     // Input-validation paths (assert -> event/return-status conversions)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| PR-5397 |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| N |
|**_Generative AI was used in this contribution (y/n)_**| Y |

---
## Change Description

Two independent correctness fixes in `Svc/FileWorker`, one commit each:

1. **`writeIn_handler` status propagation.** `writeIn_handler` emitted
   `FW_STATUS_DONE_WRITE` on `writeDoneOut` unconditionally, even when
   `writeBufferToFile` returned `false` (open failure, permission denied, disk
   full, partial write). The return value only gated the hash sidecar write, not
   the reported status. It now reports `FW_STATUS_FAILED_TO_WRITE` (existing
   enumerator in `FileWorkerTypes.hpp`) with `0` bytes on failure. Adds
   `testWriteErrStatusReported` to the error harness, which drives the full
   `writeIn` port handler with an injected open failure and asserts the failure
   status on `writeDoneOut`.

2. **`readFileBytes` partial-read telemetry.** On a short read, the partially
   transferred bytes were not added to `bytesRead` before returning
   `FW_READ_ERROR`, so the `ReadError` event undercounted the amount actually
   read. `bytesRead` is now incremented by the real transferred count on that
   path. A short read remains an error (FileWorker reads a fixed, caller-specified
   size and must not silently accept a truncated file) — only the reported count
   is corrected.

## Rationale

Both are status/telemetry-reporting correctness bugs. For (1), a downstream
consumer or ground operator keying on the `writeDoneOut` status is told a write
succeeded when it did not, so the reported status and the on-disk state diverge —
an operationally significant gap during incident investigation. The existing
`testWriteErr` covered the `writeBufferToFile` helper's return value and events
but never exercised the handler's `writeDoneOut` status, which is why this
slipped through. For (2), the corrected byte count makes `ReadError` telemetry
reflect what was actually transferred.

## Testing/Review Recommendations

- `fprime-util check` on `Svc/FileWorker`.
- `testWriteErrStatusReported` is a genuine regression test: it fails against the
  pre-fix source (handler reports `DONE_WRITE`) and passes with the fix. Run it
  once before and once after applying commit 1 to confirm.
- Reviewer decision point: commit 1 reports `0` bytes on the failure path
  (`isWrite ? buffer.getSize() : 0`). If retaining `buffer.getSize()` for
  diagnostics is preferred, the handler and the test's third assertion argument
  change together.
- Fix (2) is telemetry-accuracy only and has no dedicated new test; it affects
  the `bytesRead` value passed to the existing `ReadError` event and nothing else.

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude was used to update the unit tests and to draft this PR.