### PR TITLE
feat(FileDownlink): sandboxed reads via Os::SandboxedFile

### DIFF
--- a/Svc/FileDownlink/Events.fppi
+++ b/Svc/FileDownlink/Events.fppi
@@ -94,3 +94,11 @@ event FilenameDestinationOverflow() \
   severity warning high \
   id 0x11 \
   format "Commanded destination filename too long"
+
+@ Source file path is outside the configured read sandbox
+event SourceOutOfSandbox(
+                        fileName: string size 100 @< The rejected source file path
+                      ) \
+  severity warning high \
+  id 0x12 \
+  format "Source file {} is outside the configured read sandbox"

--- a/Svc/FileDownlink/File.cpp
+++ b/Svc/FileDownlink/File.cpp
@@ -12,7 +12,6 @@
 
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <Fw/Types/Assert.hpp>
-#include <Os/FileSystem.hpp>
 #include <Svc/FileDownlink/FileDownlink.hpp>
 
 namespace Svc {
@@ -27,24 +26,30 @@ Os::File::Status FileDownlink::File ::open(const Fw::FileNameString& sourceFileN
     Fw::LogStringArg destLogStringArg(destFileName);
     this->m_destName = destLogStringArg;
 
-    // Set size
-    FwSizeType file_size;
-    const Os::FileSystem::Status status = Os::FileSystem::getFileSize(sourceFileName.toChar(), file_size);
-    if (status != Os::FileSystem::OP_OK) {
-        return Os::File::BAD_SIZE;
-    }
-    // If the size does not cast cleanly to the desired U32 type, return size error
-    if (static_cast<FwSizeType>(static_cast<U32>(file_size)) != file_size) {
-        return Os::File::BAD_SIZE;
-    }
-    this->m_size = static_cast<U32>(file_size);
-
     // Initialize checksum
     CFDP::Checksum checksum;
     this->m_checksum = checksum;
 
-    // Open osFile for reading
-    return this->m_osFile.open(sourceFileName.toChar(), Os::File::OPEN_READ);
+    // Open osFile for reading (sandbox path validation happens here)
+    Os::File::Status status = this->m_osFile.open(sourceFileName.toChar(), Os::File::OPEN_READ);
+    if (status != Os::File::OP_OK) {
+        return status;
+    }
+
+    // Query size only after the path passes sandbox checks
+    FwSizeType file_size;
+    status = this->m_osFile.size(file_size);
+    if (status != Os::File::OP_OK) {
+        this->m_osFile.close();
+        return Os::File::BAD_SIZE;
+    }
+    // If the size does not cast cleanly to the desired U32 type, return size error
+    if (static_cast<FwSizeType>(static_cast<U32>(file_size)) != file_size) {
+        this->m_osFile.close();
+        return Os::File::BAD_SIZE;
+    }
+    this->m_size = static_cast<U32>(file_size);
+    return Os::File::OP_OK;
 }
 
 Os::File::Status FileDownlink::File ::read(U8* const data, const U32 byteOffset, const U32 size) {

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -50,6 +50,10 @@ void FileDownlink ::configure(U32 cooldown, U32 cycleTime, U32 fileQueueDepth) {
     FW_ASSERT(stat == Os::Queue::OP_OK, static_cast<FwAssertArgType>(stat));
 }
 
+void FileDownlink ::configure(const char* directory) {
+    this->m_file.configureSandbox(directory);
+}
+
 void FileDownlink ::deinit() {
     this->m_fileQueue.teardown();
     FileDownlinkComponentBase::deinit();
@@ -287,7 +291,11 @@ void FileDownlink ::sendFile(const Fw::FileNameString& sourceFilename,
     // Reject command if error when opening file
     if (status != Os::File::OP_OK) {
         this->m_mode.set(Mode::IDLE);
-        this->m_warnings.fileOpenError();
+        if (status == Os::File::OUTSIDE_SANDBOX) {
+            this->m_warnings.sourceOutOfSandbox();
+        } else {
+            this->m_warnings.fileOpenError();
+        }
         sendResponse(FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR);
         return;
     }

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -15,9 +15,9 @@
 #include <Fw/FilePacket/FilePacket.hpp>
 #include <Fw/Types/FileNameString.hpp>
 #include <Os/File.hpp>
-#include <Os/SandboxedFile.hpp>
 #include <Os/Mutex.hpp>
 #include <Os/Queue.hpp>
+#include <Os/SandboxedFile.hpp>
 #include <Svc/FileDownlink/FileDownlinkComponentAc.hpp>
 #include <config/FileDownlinkCfg.hpp>
 

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -15,6 +15,7 @@
 #include <Fw/FilePacket/FilePacket.hpp>
 #include <Fw/Types/FileNameString.hpp>
 #include <Os/File.hpp>
+#include <Os/SandboxedFile.hpp>
 #include <Os/Mutex.hpp>
 #include <Os/Queue.hpp>
 #include <Svc/FileDownlink/FileDownlinkComponentAc.hpp>
@@ -81,8 +82,8 @@ class FileDownlink final : public FileDownlinkComponentBase {
         //! The destination file name
         Fw::LogStringArg m_destName;
 
-        //! The underlying OS file
-        Os::File m_osFile;
+        //! The underlying OS file (sandboxed to restrict read locations)
+        Os::SandboxedFile m_osFile;
 
         //! The file size
         U32 m_size;
@@ -108,8 +109,11 @@ class FileDownlink final : public FileDownlinkComponentBase {
         //! Get the destination file name
         Fw::LogStringArg& getDestName(void) { return this->m_destName; }
 
+        //! Configure the allowed read directory for sandboxed file opens
+        void configureSandbox(const char* directory) { this->m_osFile.configure(directory); }
+
         //! Get the underlying OS file
-        Os::File& getOsFile(void) { return this->m_osFile; }
+        Os::SandboxedFile& getOsFile(void) { return this->m_osFile; }
 
         //! Get the file size
         U32 getSize(void) { return this->m_size; }
@@ -179,6 +183,9 @@ class FileDownlink final : public FileDownlinkComponentBase {
         //! Issue a Zero-Size File warning
         void zeroSize();
 
+        //! Issue a Source Out Of Sandbox warning
+        void sourceOutOfSandbox();
+
       private:
         //! Record a warning
         void warning() {
@@ -229,6 +236,10 @@ class FileDownlink final : public FileDownlinkComponentBase {
                    U32 cycleTime,      //!< Rate at which we are running
                    U32 fileQueueDepth  //!< Max number of items in file downlink queue
     );
+
+    //! Restrict SendFile / SendPartial reads to paths under the configured directory.
+    //! Mirrors Svc::FileUplink::configure. Default sandbox is unrestricted until called.
+    void configure(const char* directory);
 
     //! Cleans up file queue before dispatching to underlying component
     void deinit();

--- a/Svc/FileDownlink/Warnings.cpp
+++ b/Svc/FileDownlink/Warnings.cpp
@@ -27,4 +27,9 @@ void FileDownlink::Warnings ::zeroSize() {
     this->warning();
 }
 
+void FileDownlink::Warnings ::sourceOutOfSandbox() {
+    this->m_fileDownlink->log_WARNING_HI_SourceOutOfSandbox(this->m_fileDownlink->m_file.getSourceName());
+    this->warning();
+}
+
 }  // namespace Svc

--- a/Svc/FileDownlink/docs/sdd.md
+++ b/Svc/FileDownlink/docs/sdd.md
@@ -37,6 +37,11 @@ of type [`Fw::FilePacket`](../../../Fw/FilePacket/docs/sdd.md).
 3. Both components and operators must be able to enqueue files, necessitating both a `SendFile`
    command and port.
 
+4. File access may optionally be sandboxed to a configured directory via `configure(directory)`.
+   When configured, all commanded source paths are validated against the sandbox directory before reading.
+   By default (no call to `configure`, or sandbox set to `/`), all absolute paths are allowed.
+   This mirrors `Svc::FileUplink` write-side sandboxing.
+
 ### 3.3 Ports
 
 #### 3.3.1 Role Ports

--- a/Svc/FileDownlink/docs/sdd.md
+++ b/Svc/FileDownlink/docs/sdd.md
@@ -38,9 +38,10 @@ of type [`Fw::FilePacket`](../../../Fw/FilePacket/docs/sdd.md).
    command and port.
 
 4. File access may optionally be sandboxed to a configured directory via `configure(directory)`.
-   When configured, all commanded source paths are validated against the sandbox directory before reading.
-   By default (no call to `configure`, or sandbox set to `/`), all absolute paths are allowed.
-   This mirrors `Svc::FileUplink` write-side sandboxing.
+   When configured, all source paths supplied through `SendFile`/`SendPartial` commands or the
+   `SendFile` port are validated against the sandbox directory before reading; rejected paths emit
+   `SourceOutOfSandbox`. By default (no call to `configure`, or sandbox set to `/`), all absolute
+   paths are allowed. This mirrors `Svc::FileUplink` write-side sandboxing.
 
 ### 3.3 Ports
 

--- a/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
@@ -34,6 +34,11 @@ TEST(FileDownlink, SendFilePort) {
     tester.sendFilePort();
 }
 
+TEST(FileDownlink, SourceOutOfSandbox) {
+    Svc::FileDownlinkTester tester;
+    tester.sourceOutOfSandbox();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -11,7 +11,9 @@
 
 #include <unistd.h>
 #include <cerrno>
+#include <cstring>
 
+#include <Os/FilePathUtils.hpp>
 #include "FileDownlinkTester.hpp"
 
 #define INSTANCE 0
@@ -32,6 +34,15 @@ FileDownlinkTester ::FileDownlinkTester()
     this->component.configure(COOLDOWN_MS, CYCLE_MS, 10);
     this->connectPorts();
     this->initComponents();
+    char cwd[Os::FilePathUtils::MAX_PATH_LENGTH];
+    FW_ASSERT(getcwd(cwd, sizeof(cwd)) != nullptr);
+    const FwSizeType cwdLen = std::strlen(cwd);
+    FW_ASSERT(cwdLen + 2 <= sizeof(cwd));
+    if (cwd[cwdLen - 1] != '/') {
+        cwd[cwdLen] = '/';
+        cwd[cwdLen + 1] = '\0';
+    }
+    this->component.configure(cwd);
 }
 
 FileDownlinkTester ::~FileDownlinkTester() {
@@ -109,6 +120,20 @@ void FileDownlinkTester ::fileOpenError() {
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_FileOpenError_SIZE(1);
     //    ASSERT_EVENTS_FileDownlink_FileOpenError(0, sourceFileName);
+}
+
+void FileDownlinkTester ::sourceOutOfSandbox() {
+    const char* const sourceFileName = "/etc/hosts";
+    const char* const destFileName = "dest.bin";
+
+    this->sendFile(sourceFileName, destFileName,
+                   (FILEDOWNLINK_COMMAND_FAILURES_DISABLED) ? Fw::CmdResponse::OK : Fw::CmdResponse::EXECUTION_ERROR);
+
+    ASSERT_TLM_SIZE(1);
+    ASSERT_TLM_Warnings(0, 1);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_SourceOutOfSandbox_SIZE(1);
+    ASSERT_EVENTS_SourceOutOfSandbox(0, sourceFileName);
 }
 
 void FileDownlinkTester ::cancelDownlink() {

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -34,8 +34,9 @@ FileDownlinkTester ::FileDownlinkTester()
     this->component.configure(COOLDOWN_MS, CYCLE_MS, 10);
     this->connectPorts();
     this->initComponents();
-    char cwd[Os::FilePathUtils::MAX_PATH_LENGTH];
-    FW_ASSERT(getcwd(cwd, sizeof(cwd)) != nullptr);
+    char cwd[Os::FilePathUtils::MAX_PATH_LENGTH] = {};
+    const char* cwdResult = getcwd(cwd, sizeof(cwd));
+    FW_ASSERT(cwdResult != nullptr);
     const FwSizeType cwdLen = std::strlen(cwd);
     FW_ASSERT(cwdLen + 2 <= sizeof(cwd));
     if (cwd[cwdLen - 1] != '/') {

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
@@ -107,6 +107,9 @@ class FileDownlinkTester : public FileDownlinkGTestBase {
     //!
     void sendFilePort();
 
+    //! Reject a source path outside the configured read sandbox
+    void sourceOutOfSandbox();
+
   private:
     // ----------------------------------------------------------------------
     // Handlers for from ports


### PR DESCRIPTION
## Summary
- Mirror `Svc::FileUplink` write-side sandboxing on the read path for `Svc::FileDownlink`
- Add `configure(const char* directory)` overload, `SourceOutOfSandbox` event, and unit test coverage
- Opt-in / backward compatible (default sandbox remains unrestricted)

Fixes #5398. Complements #5369 FileDownlink cleanup work.

## Test plan
- [ ] `Svc/FileDownlink/test/ut` — new `SourceOutOfSandbox` test passes
- [ ] Existing FileDownlink unit tests pass with CWD sandbox configured in tester ctor