### PR TITLE
fix(FpySequencer): reject empty sequence file paths without assert

### DIFF
--- a/Svc/FpySequencer/FpySequencerEvents.fppi
+++ b/Svc/FpySequencer/FpySequencerEvents.fppi
@@ -17,6 +17,10 @@ event FileOpenError(
     severity warning high \
     format "File open error encountered while opening {}: {}"
 
+event EmptySequenceFilePath() \
+    severity warning high \
+    format "Sequence file path is empty"
+
 event FileWriteError(
     writeSize: FwSizeType
     filePath: string

--- a/Svc/FpySequencer/FpySequencerEvents.fppi
+++ b/Svc/FpySequencer/FpySequencerEvents.fppi
@@ -17,10 +17,6 @@ event FileOpenError(
     severity warning high \
     format "File open error encountered while opening {}: {}"
 
-event EmptySequenceFilePath() \
-    severity warning high \
-    format "Sequence file path is empty"
-
 event FileWriteError(
     writeSize: FwSizeType
     filePath: string

--- a/Svc/FpySequencer/FpySequencerValidationState.cpp
+++ b/Svc/FpySequencer/FpySequencerValidationState.cpp
@@ -27,7 +27,8 @@ void FpySequencer::deallocateBuffer(Fw::MemAllocator& allocator) {
 // return SUCCESS if sequence is valid, FAILURE otherwise
 Fw::Success FpySequencer::validate() {
     if (this->m_sequenceFilePath.length() == 0) {
-        this->log_WARNING_HI_EmptySequenceFilePath();
+        this->log_WARNING_HI_FileOpenError(this->m_sequenceFilePath,
+                                           static_cast<I32>(Os::File::INVALID_ARGUMENT));
         return Fw::Success::FAILURE;
     }
 

--- a/Svc/FpySequencer/FpySequencerValidationState.cpp
+++ b/Svc/FpySequencer/FpySequencerValidationState.cpp
@@ -27,8 +27,7 @@ void FpySequencer::deallocateBuffer(Fw::MemAllocator& allocator) {
 // return SUCCESS if sequence is valid, FAILURE otherwise
 Fw::Success FpySequencer::validate() {
     if (this->m_sequenceFilePath.length() == 0) {
-        this->log_WARNING_HI_FileOpenError(this->m_sequenceFilePath,
-                                           static_cast<I32>(Os::File::INVALID_ARGUMENT));
+        this->log_WARNING_HI_FileOpenError(this->m_sequenceFilePath, static_cast<I32>(Os::File::INVALID_ARGUMENT));
         return Fw::Success::FAILURE;
     }
 

--- a/Svc/FpySequencer/FpySequencerValidationState.cpp
+++ b/Svc/FpySequencer/FpySequencerValidationState.cpp
@@ -26,7 +26,10 @@ void FpySequencer::deallocateBuffer(Fw::MemAllocator& allocator) {
 // loads the sequence in memory, and does header/crc/integrity checks.
 // return SUCCESS if sequence is valid, FAILURE otherwise
 Fw::Success FpySequencer::validate() {
-    FW_ASSERT(this->m_sequenceFilePath.length() > 0);
+    if (this->m_sequenceFilePath.length() == 0) {
+        this->log_WARNING_HI_EmptySequenceFilePath();
+        return Fw::Success::FAILURE;
+    }
 
     // crc needs to be initialized with a particular value
     // for the calculation to work

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -3101,7 +3101,9 @@ TEST_F(FpySequencerTester, validate_emptySequenceFilePath) {
     dispatchUntilState(State::VALIDATING);
     dispatchUntilState(State::IDLE);
 
-    ASSERT_EVENTS_EmptySequenceFilePath_SIZE(1);
+    ASSERT_EVENTS_FileOpenError_SIZE(1);
+    ASSERT_EQ(this->eventHistory_FileOpenError->at(0).filePath, Fw::LogStringArg(""));
+    ASSERT_EQ(this->eventHistory_FileOpenError->at(0).errorCode, static_cast<I32>(Os::File::INVALID_ARGUMENT));
     ASSERT_CMD_RESPONSE_SIZE(1);
     ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_VALIDATE(), 0, Fw::CmdResponse::EXECUTION_ERROR);
 }

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -3091,6 +3091,21 @@ TEST_F(FpySequencerTester, seqBaseDir_emptyKeepsRawPath) {
     removeFile("test.bin");
 }
 
+TEST_F(FpySequencerTester, validate_emptySequenceFilePath) {
+    allocMem();
+    paramSet_SEQ_BASE_DIR(Fw::ParamString(""), Fw::ParamValid::VALID);
+    paramSend_SEQ_BASE_DIR(0, 0);
+    this->clearHistory();
+
+    sendCmd_VALIDATE(0, 0, Fw::String(""));
+    dispatchUntilState(State::VALIDATING);
+    dispatchUntilState(State::IDLE);
+
+    ASSERT_EVENTS_EmptySequenceFilePath_SIZE(1);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, Svc::FpySequencerTester::get_OPCODE_VALIDATE(), 0, Fw::CmdResponse::EXECUTION_ERROR);
+}
+
 TEST_F(FpySequencerTester, seqBaseDir_fileOpenLogsResolvedPath) {
     // a base dir that doesn't exist makes file open fail. the FileOpenError
     // event should report the fully resolved path, not the user-supplied one


### PR DESCRIPTION
## Summary
- Replace `FW_ASSERT(m_sequenceFilePath.length() > 0)` with graceful validation failure
- Log existing `FileOpenError` with `Os::File::INVALID_ARGUMENT` when validate/run is called with a zero-length path (no new event)

Fixes #5313

## Test plan
- [x] `validate_emptySequenceFilePath` unit test passes
- [ ] Existing FpySequencer UT suite passes