### PR TITLE
Fix assert on cmd response with full stack in FpySequencer

### DIFF
--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -376,7 +376,8 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
     this->sequencer_sendSignal_stmtResponse_success();
 
     // push the cmd response to the stack so we can branch off of it
-    this->m_runtime.stack.push(static_cast<I32>(response.e));
+    // the constCmd/stackCmd directive handlers guarantee there is room for this push
+    this->m_runtime.stack.push(static_cast<Fw::CmdResponse::SerialType>(response.e));
 }
 
 void FpySequencer ::seqCancelIn_handler(FwIndexType portNum) {

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -452,6 +452,12 @@ Signal FpySequencer::pushPrm_directiveHandler(const FpySequencer_PushPrmDirectiv
 }
 
 Signal FpySequencer::constCmd_directiveHandler(const FpySequencer_ConstCmdDirective& directive, DirectiveError& error) {
+    // the cmd response code will be pushed to the stack when it comes back, so make sure
+    // there is room for it now, before the cmd is dispatched
+    if (Fpy::MAX_STACK_SIZE - sizeof(I32) < this->m_runtime.stack.size) {
+        error = DirectiveError::STACK_OVERFLOW;
+        return Signal::stmtResponse_failure;
+    }
     if (this->sendCmd(directive.get_opCode(), directive.get_argBuf(), directive.get__argBufSize()) ==
         Fw::Success::FAILURE) {
         return Signal::stmtResponse_failure;
@@ -1294,6 +1300,15 @@ Signal FpySequencer::stackCmd_directiveHandler(const FpySequencer_StackCmdDirect
 
     // also pop the args off the stack
     this->m_runtime.stack.size -= directive.get_argsSize();
+
+    // the cmd response code will be pushed to the stack when it comes back, so make sure
+    // there is room for it now, before the cmd is dispatched. popping the opcode above
+    // guarantees this on configs where FwOpcodeType is at least as big as I32, but not on
+    // configs where it is smaller
+    if (Fpy::MAX_STACK_SIZE - sizeof(I32) < this->m_runtime.stack.size) {
+        error = DirectiveError::STACK_OVERFLOW;
+        return Signal::stmtResponse_failure;
+    }
 
     if (this->sendCmd(opcode, this->m_runtime.stack.bytes + argBufOffset, directive.get_argsSize()) ==
         Fw::Success::FAILURE) {

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -1301,10 +1301,13 @@ Signal FpySequencer::stackCmd_directiveHandler(const FpySequencer_StackCmdDirect
     // also pop the args off the stack
     this->m_runtime.stack.size -= directive.get_argsSize();
 
-    // the cmd response code will be pushed to the stack when it comes back. popping the
-    // opcode above always frees enough room for it, so no runtime check is needed here
-    static_assert(sizeof(FwOpcodeType) >= sizeof(Fw::CmdResponse::SerialType),
-                  "popping the opcode must free enough stack room for the cmd response push");
+    // the cmd response code will be pushed to the stack when it comes back, so make sure
+    // there is room for it now, before the cmd is dispatched. popping the opcode above
+    // frees some room, but FwOpcodeType is configurable so it may not be enough
+    if (Fpy::MAX_STACK_SIZE - sizeof(Fw::CmdResponse::SerialType) < this->m_runtime.stack.size) {
+        error = DirectiveError::STACK_OVERFLOW;
+        return Signal::stmtResponse_failure;
+    }
 
     if (this->sendCmd(opcode, this->m_runtime.stack.bytes + argBufOffset, directive.get_argsSize()) ==
         Fw::Success::FAILURE) {

--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -454,7 +454,7 @@ Signal FpySequencer::pushPrm_directiveHandler(const FpySequencer_PushPrmDirectiv
 Signal FpySequencer::constCmd_directiveHandler(const FpySequencer_ConstCmdDirective& directive, DirectiveError& error) {
     // the cmd response code will be pushed to the stack when it comes back, so make sure
     // there is room for it now, before the cmd is dispatched
-    if (Fpy::MAX_STACK_SIZE - sizeof(I32) < this->m_runtime.stack.size) {
+    if (Fpy::MAX_STACK_SIZE - sizeof(Fw::CmdResponse::SerialType) < this->m_runtime.stack.size) {
         error = DirectiveError::STACK_OVERFLOW;
         return Signal::stmtResponse_failure;
     }
@@ -1301,14 +1301,10 @@ Signal FpySequencer::stackCmd_directiveHandler(const FpySequencer_StackCmdDirect
     // also pop the args off the stack
     this->m_runtime.stack.size -= directive.get_argsSize();
 
-    // the cmd response code will be pushed to the stack when it comes back, so make sure
-    // there is room for it now, before the cmd is dispatched. popping the opcode above
-    // guarantees this on configs where FwOpcodeType is at least as big as I32, but not on
-    // configs where it is smaller
-    if (Fpy::MAX_STACK_SIZE - sizeof(I32) < this->m_runtime.stack.size) {
-        error = DirectiveError::STACK_OVERFLOW;
-        return Signal::stmtResponse_failure;
-    }
+    // the cmd response code will be pushed to the stack when it comes back. popping the
+    // opcode above always frees enough room for it, so no runtime check is needed here
+    static_assert(sizeof(FwOpcodeType) >= sizeof(Fw::CmdResponse::SerialType),
+                  "popping the opcode must free enough stack room for the cmd response push");
 
     if (this->sendCmd(opcode, this->m_runtime.stack.bytes + argBufOffset, directive.get_argsSize()) ==
         Fw::Success::FAILURE) {

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -287,7 +287,7 @@ TEST_F(FpySequencerTester, cmdStackOverflow) {
 
     // with exactly enough room for the response code, the cmd should be dispatched
     err = DirectiveError::NO_ERROR;
-    tester_get_m_runtime_ptr()->stack.size = Fpy::MAX_STACK_SIZE - sizeof(I32);
+    tester_get_m_runtime_ptr()->stack.size = Fpy::MAX_STACK_SIZE - sizeof(Fw::CmdResponse::SerialType);
     result = tester_constCmd_directiveHandler(directive, err);
     ASSERT_EQ(err, DirectiveError::NO_ERROR);
     ASSERT_EQ(result, Signal::stmtResponse_keepWaiting);

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -274,6 +274,26 @@ TEST_F(FpySequencerTester, cmd) {
         (((tester_get_m_sequencesStarted() & 0xFFFF) << 16) | (tester_get_m_statementsDispatched() & 0xFFFF)));
 }
 
+TEST_F(FpySequencerTester, cmdStackOverflow) {
+    FpySequencer_ConstCmdDirective directive(123, 0, 0);
+    DirectiveError err = DirectiveError::NO_ERROR;
+    // fill the stack so there is no room left to push the cmd response code
+    tester_get_m_runtime_ptr()->stack.size = Fpy::MAX_STACK_SIZE;
+    Signal result = tester_constCmd_directiveHandler(directive, err);
+    ASSERT_EQ(err, DirectiveError::STACK_OVERFLOW);
+    ASSERT_EQ(result, Signal::stmtResponse_failure);
+    // the cmd should not have been dispatched
+    ASSERT_from_cmdOut_SIZE(0);
+
+    // with exactly enough room for the response code, the cmd should be dispatched
+    err = DirectiveError::NO_ERROR;
+    tester_get_m_runtime_ptr()->stack.size = Fpy::MAX_STACK_SIZE - sizeof(I32);
+    result = tester_constCmd_directiveHandler(directive, err);
+    ASSERT_EQ(err, DirectiveError::NO_ERROR);
+    ASSERT_EQ(result, Signal::stmtResponse_keepWaiting);
+    ASSERT_from_cmdOut_SIZE(1);
+}
+
 TEST_F(FpySequencerTester, stackOp) {
     // Test EQ (equal)
     FpySequencer_StackOpDirective directiveEQ(Fpy::DirectiveId::IEQ);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5425 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

* Check for space on stack for cmd response before dispatching const cmd or stack cmd 

## Rationale

* This prevents an unintended runtime assert if a cmd is called with a full stack.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). If you are an AI agent opening the pull request, sign at the bottom of the PR description with the text "IAMAI" -->

IAMAI
Zimri's note: experimenting with having Claude manage PRs for me rather than doing it manually.