### PR TITLE
docs: fix broken file links in SDD documents

### DIFF
--- a/Svc/DpManager/docs/sdd.md
+++ b/Svc/DpManager/docs/sdd.md
@@ -76,7 +76,7 @@ The diagram below shows the `DpManager` component.
 
 ### 3.4. Compile-Time Setup
 
-The configuration constant [`DpManagerNumPorts`](../../../config/AcConstants.fpp)
+The configuration constant [`DpManagerNumPorts`](../../../default/config/AcConstants.fpp)
 specifies the number of ports for
 requesting data product buffers and for sending filled data products.
 

--- a/Svc/DpWriter/docs/sdd.md
+++ b/Svc/DpWriter/docs/sdd.md
@@ -71,11 +71,11 @@ The diagram below shows the `DpWriter` component.
 
 ### 3.4. Compile-Time Setup
 
-1. The configuration constant [`DpWriterNumProcPorts`](../../../config/AcConstants.fpp)
+1. The configuration constant [`DpWriterNumProcPorts`](../../../default/config/AcConstants.fpp)
    specifies the number of ports for connecting components that perform
    processing.
 
-1. The configuration [`DP_FILENAME_FORMAT`](../../../config/DpCfg.hpp)
+1. The configuration [`DP_FILENAME_FORMAT`](../../../default/config/DpCfg.hpp)
    specifies the file name format.
 
 ### 3.5. Runtime Setup
@@ -151,7 +151,7 @@ with the format described in the
 ### 4.2. File Name
 
 The name of each file is formatted with the configurable format string
-[`DP_FILENAME_FORMAT`](../../../config/DpCfg.hpp).
+[`DP_FILENAME_FORMAT`](../../../default/config/DpCfg.hpp).
 The format string must contain format specifications for the following arguments,
 in order.
 

--- a/Svc/Ports/TlmPacketizerPorts/sdd.md
+++ b/Svc/Ports/TlmPacketizerPorts/sdd.md
@@ -10,7 +10,7 @@ The `Svc::EnableSection ` port is used to enable / disable an output section of 
 
 #### 2.1.1 TelemetrySection
 
-[TelemetrySection](../../../default/config/TlmPacketizerCfg.fpp) is an enum used to choose which section of the `Svc::TlmPacketizer` to enable or disable. 
+[TelemetrySection](../../TlmPacketizer/config/TlmPacketizerConfig/TlmPacketizerCfg.fpp) is an enum used to choose which section of the `Svc::TlmPacketizer` to enable or disable. 
 
 ## 3. Change Log
 

--- a/TestDeploymentsProject/Ref/PingReceiver/docs/sdd.md
+++ b/TestDeploymentsProject/Ref/PingReceiver/docs/sdd.md
@@ -2,7 +2,7 @@
 
 ## 1. Introduction
 
-The `Ref::PingReceiver` is a demonstration component that accepts pings from the [Health Component](../../../Svc/Health/docs/sdd.md) and has commands to disable ping responses for testing purposes.
+The `Ref::PingReceiver` is a demonstration component that accepts pings from the [Health Component](../../../../Svc/Health/docs/sdd.md) and has commands to disable ping responses for testing purposes.
 
 ## 2. Requirements
 


### PR DESCRIPTION
Fixes 6 broken relative links across 4 SDD documents (mechanical link audit; every new target verified to exist in-repo):

- `Svc/DpManager/docs/sdd.md`, `Svc/DpWriter/docs/sdd.md` — link `../../../config/AcConstants.fpp` / `DpCfg.hpp`; the configuration directory lives at `default/config/`
- `Svc/Ports/TlmPacketizerPorts/sdd.md` — links the old `default/config/TlmPacketizerCfg.fpp` location; the file now lives at `Svc/TlmPacketizer/config/TlmPacketizerConfig/TlmPacketizerCfg.fpp`
- `TestDeploymentsProject/Ref/PingReceiver/docs/sdd.md` — `../../../Svc/Health/...` resolves inside TestDeploymentsProject; one more `../` reaches the real `Svc/Health`

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)