### PR TITLE
Move PrmDb filename in FileHandling subtopology into FileHandlingConfig

### DIFF
--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -33,7 +33,7 @@ module FileHandling {
         priority FileHandlingConfig.Priorities.prmDb \
     {
         phase Fpp.ToCpp.Phases.configComponents """
-            FileHandling::prmDb.configure("PrmDb.dat");
+            FileHandling::prmDb.configure(FileHandlingConfig::Paths::prmDbFile);
         """
         phase Fpp.ToCpp.Phases.readParameters """
             FileHandling::prmDb.readParamFile();

--- a/Svc/Subtopologies/FileHandling/FileHandlingConfig/CMakeLists.txt
+++ b/Svc/Subtopologies/FileHandling/FileHandlingConfig/CMakeLists.txt
@@ -2,5 +2,4 @@ register_fprime_config(
     EXCLUDE_FROM_ALL
     AUTOCODER_INPUTS
         "${CMAKE_CURRENT_LIST_DIR}/FileHandlingConfig.fpp"
-    INTERFACE
 )

--- a/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
@@ -29,4 +29,9 @@ module FileHandlingConfig {
         constant cycleTime      = 1000         # File downlink cycle time in ms
         constant fileQueueDepth = 10           # File downlink queue depth
     }
+
+    # File paths
+    module Paths {
+        constant prmDbFile = "PrmDb.dat"       # Parameter database file
+    }
 }

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -75,6 +75,7 @@ topology Flight {
 * **Queue sizes** — Queue depths for `fileUplink`, `fileDownlink`, `fileManager`.
 * **Stack sizes** — Task stacks for active components (`fileUplink`, `fileDownlink`).
 * **Priorities** — RTOS priorities for the active/queued components as applicable.
+* **Paths** — File name for the `prmDb` parameter database.
 
 > These knobs tailor runtime footprint and scheduling without modifying the subtopology wiring.
 

--- a/docs/reference/system-functional/subtopology-file-handling.md
+++ b/docs/reference/system-functional/subtopology-file-handling.md
@@ -30,7 +30,7 @@ The File Handling subtopology packages the core file-transfer and file-managemen
 
 - Base IDs, queue sizes, stack sizes, and priorities via FileHandlingConfig.
 - The File Downlink send rate is determined by the connected rate group frequency.
-- The Parameter Database file path is configured at deployment time.
+- The Parameter Database file name via FileHandlingConfig.Paths.prmDbFile.
 
 ### Limitations
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Fixes #4425 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Moves the PrmDb file name out of the FileHandling subtopology's `configComponents` phase, where it was hardcoded as `"PrmDb.dat"`, into a new `FileHandlingConfig.Paths.prmDbFile` constant (default unchanged), following the `Paths` pattern from `DataProductsConfig`. Updates the two related doc pages.

This exposed a second issue: `FileHandlingConfig` was registered `INTERFACE` in CMake, so the FPP-generated `FppConstantsAc.cpp` — which defines the string constant out of line — was never compiled and Ref failed to link. Dropped `INTERFACE`, matching the other subtopology config modules that carry string constants (DataProducts, ComFprime, ComCcsds, DpCompression).

## Rationale

Resolves #4425: the file name is project configuration and belongs in config. The default is unchanged, so existing deployments keep writing `PrmDb.dat`. Note for projects overriding `FileHandlingConfig.fpp` via `CONFIGURATION_OVERRIDES`: the new constant must be added to the override copy, as with any constant added to a config module.

## Testing/Review Recommendations

- Built and ran the Ref deployment (instantiates this subtopology): generated topology code passes `FileHandlingConfig::Paths::prmDbFile` to `prmDb.configure()`, with `"PrmDb.dat"` in the binary as before.
- The pre-fix `INTERFACE` registration reproduces the undefined-reference link failure; dropping it fixes the link.
- Override check: setting the constant to a different name and rebuilding shows the new name in the binary; reverting restores the default.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude (AI agent) drafted the change and ran the Ref build and override checks, under human direction and review.

IAMAI
