### PR TITLE
Remove hardcoded PrmDb file name from FileHandling subtopology

### DIFF
--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -32,9 +32,6 @@ module FileHandling {
         stack size FileHandlingConfig.StackSizes.prmDb \
         priority FileHandlingConfig.Priorities.prmDb \
     {
-        phase Fpp.ToCpp.Phases.configComponents """
-            FileHandling::prmDb.configure("PrmDb.dat");
-        """
         phase Fpp.ToCpp.Phases.readParameters """
             FileHandling::prmDb.readParamFile();
         """

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -32,6 +32,7 @@ The **FileHandling subtopology** packages the core file-transfer services common
 ### 2.3 Required Inputs for Operation
 
 * **Rate Groups**: Connect scheduler outputs to the **Run** (scheduling) ports of `fileDownlink`.
+* **PrmDb file name**: Call `FileHandling::prmDb.configure(<file name>)` from your topology setup code before parameters are loaded; the subtopology does not set a file name itself, and `PrmDb` asserts if parameters are read or saved without one.
 * **Communication/Framing Stack**: Wire file-packet ports between FileHandling and your COM/framing subtopology (e.g., `ComCcsds`, `ComFprime`, `FramingFprime`, `FramingCcsds`) to complete uplink/downlink paths.
 
 ### 2.4 Limitations

--- a/TestDeploymentsProject/Ref/Top/RefTopology.cpp
+++ b/TestDeploymentsProject/Ref/Top/RefTopology.cpp
@@ -56,6 +56,9 @@ void configureTopology() {
 
     // Restrict uplinked files to a sandbox directory to prevent path-traversal writes
     FileHandling::fileUplink.configure("/tmp/uplink/");
+
+    // PrmDb file name must be supplied by the using topology
+    FileHandling::prmDb.configure("PrmDb.dat");
 }
 
 // Public functions for use in main program are namespaced with deployment name Ref

--- a/docs/reference/system-functional/subtopology-file-handling.md
+++ b/docs/reference/system-functional/subtopology-file-handling.md
@@ -25,12 +25,12 @@ The File Handling subtopology packages the core file-transfer and file-managemen
 - Rate group connections to drive File Downlink's send cycle.
 - Communication stack connections for file packet exchange (wire to a ComFprime or ComCcsds subtopology's file ports).
 - Parameter connections from all components that use parameters.
+- A parameter-file name for `prmDb`: call `FileHandling.prmDb.configure()` during topology setup, before parameters are loaded.
 
 ### Configuration
 
 - Base IDs, queue sizes, stack sizes, and priorities via FileHandlingConfig.
 - The File Downlink send rate is determined by the connected rate group frequency.
-- The Parameter Database file path is configured at deployment time.
 
 ### Limitations
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Fixes #4425 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Removes the hardcoded `FileHandling::prmDb.configure("PrmDb.dat")` call from the FileHandling subtopology's `configComponents` phase. The using topology now supplies the file name by calling `configure()` in its own setup code. Ref does this in `configureTopology()`, next to its existing `FileHandling::fileUplink.configure()` call. The `readParameters` phase (`readParamFile()`) is unchanged. Both subtopology docs list the file name as a required input.

## Rationale

Fixes #4425 as recommended: remove the line and require the call from the using topology. Supersedes #5490, which moved the name into `FileHandlingConfig` instead.

Note for upgrading projects: deployments that relied on the implicit `PrmDb.dat` must now call `configure()` during topology setup, before parameters are loaded. `PrmDb` asserts if parameters are read or saved with no file name set. Projects already calling `configure()` themselves are unaffected.

I kept `readParamFile()` in the subtopology, reading "remove that line" as the configure call only. Happy to move it as well if preferred.

## Testing/Review Recommendations

Built and ran the Ref deployment. The generated topology code contains no `prmDb.configure` call, and `strings` shows the binary's file name comes only from `RefTopology.cpp`. Runtime behavior is unchanged.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude (AI agent) drafted the change and ran the Ref build checks, under human direction and review.

IAMAI
