### PR TITLE
Add null check for buffer in toString method

### DIFF
--- a/Fw/Port/PortBase.cpp
+++ b/Fw/Port/PortBase.cpp
@@ -81,6 +81,7 @@ const char* PortBase::getToStringFormatString() {
 
 void PortBase::toString(char* buffer, FwSizeType size) {
     FW_ASSERT(size > 0);
+    FW_ASSERT(buffer != nullptr);
     // Get the port-custom format string
     const char* formatString = this->getToStringFormatString();
     // Determine this port object name (or use "UNKNOWN")


### PR DESCRIPTION

| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Fix a missing buffer check.

## Rationale

Assert on non-null buffers.

## Testing/Review Recommendations

CI

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

HUMAN DO FIX.  HUMAN GOOD.  