### PR TITLE
Add zero-sized string integration coverage

### DIFF
--- a/FppTestProject/FppTest/array/alias.fpp
+++ b/FppTestProject/FppTest/array/alias.fpp
@@ -7,8 +7,10 @@ module FppTest {
     array ArrayOfAlias = [3] EA default [ E.A, E.B, E.C ]
 
     type AString = string size 32
+    type AStringZero = string size 0
 
     array AliasString = [3] AString
+    array AliasStringZero = [3] AStringZero
 
     type AliasOfArray = ArrayOfAlias
 

--- a/FppTestProject/FppTest/component/active/fpp_types.fpp
+++ b/FppTestProject/FppTest/component/active/fpp_types.fpp
@@ -3,11 +3,14 @@ enum FormalParamEnum { X, Y, Z }
 array FormalParamArray = [3] U32
 
 array FormalStringArray = [3] string size 3
+array FormalStringZeroArray = [3] string size 0
 
 type FormalAliasString = string size 32
+type FormalAliasStringZero = string size 0
 
-struct FormalParamStruct { x: U32, y: string, z: FormalAliasString }
+struct FormalParamStruct { x: U32, y: string, z: FormalAliasString, z0: FormalAliasStringZero }
 
 array FormalAliasStringArray = [3] FormalAliasString
+array FormalAliasStringZeroArray = [3] FormalAliasStringZero
 type FormalAliasEnum = FormalParamEnum
 type FormalAliasArray = FormalAliasStringArray

--- a/FppTestProject/FppTest/component/active/port_types.fpp
+++ b/FppTestProject/FppTest/component/active/port_types.fpp
@@ -15,6 +15,8 @@ port PrimitiveArgs(
 port StringArgs(
   str80: string @< A string of size 80
   ref str80Ref: string
+  str0: string size 0 @< A string of size 0
+  ref str0Ref: string size 0
   str100: string size 100 @< A string of size 100
   ref str100Ref: string size 100
 )

--- a/FppTestProject/FppTest/component/common/tester.hpp
+++ b/FppTestProject/FppTest/component/common/tester.hpp
@@ -53,6 +53,8 @@ FormalAliasString from_stringAliasReturnOut_handler(FwIndexType portNum,        
 void from_stringArgsOut_handler(const FwIndexType portNum,
                                 const Fw::StringBase& str80,
                                 Fw::StringBase& str80Ref,
+                                const Fw::StringBase& str0,
+                                Fw::StringBase& str0Ref,
                                 const Fw::StringBase& str100,
                                 Fw::StringBase& str100Ref) final;
 

--- a/FppTestProject/FppTest/component/common/typed.cpp
+++ b/FppTestProject/FppTest/component/common/typed.cpp
@@ -161,17 +161,21 @@ U32 TestComponentName ::primitiveReturnSync_handler(const FwIndexType portNum,
 void TestComponentName ::stringArgsGuarded_handler(const FwIndexType portNum,
                                                    const Fw::StringBase& str80,
                                                    Fw::StringBase& str80Ref,
+                                                   const Fw::StringBase& str0,
+                                                   Fw::StringBase& str0Ref,
                                                    const Fw::StringBase& str100,
                                                    Fw::StringBase& str100Ref) {
-    this->stringArgsOut_out(portNum, str80, str80Ref, str100, str100Ref);
+    this->stringArgsOut_out(portNum, str80, str80Ref, str0, str0Ref, str100, str100Ref);
 }
 
 void TestComponentName ::stringArgsSync_handler(const FwIndexType portNum,
                                                 const Fw::StringBase& str80,
                                                 Fw::StringBase& str80Ref,
+                                                const Fw::StringBase& str0,
+                                                Fw::StringBase& str0Ref,
                                                 const Fw::StringBase& str100,
                                                 Fw::StringBase& str100Ref) {
-    this->stringArgsOut_out(portNum, str80, str80Ref, str100, str100Ref);
+    this->stringArgsOut_out(portNum, str80, str80Ref, str0, str0Ref, str100, str100Ref);
 }
 
 void TestComponentName ::structArgsGuarded_handler(const FwIndexType portNum,

--- a/FppTestProject/FppTest/component/common/typed.hpp
+++ b/FppTestProject/FppTest/component/common/typed.hpp
@@ -130,6 +130,8 @@ U32 primitiveReturnSync_handler(FwIndexType portNum,  //!< The port number
 void stringArgsGuarded_handler(FwIndexType portNum,          //!< The port number
                                const Fw::StringBase& str80,  //!< A string of size 80
                                Fw::StringBase& str80Ref,
+                               const Fw::StringBase& str0,  //!< A string of size 0
+                               Fw::StringBase& str0Ref,
                                const Fw::StringBase& str100,  //!< A string of size 100
                                Fw::StringBase& str100Ref) override;
 
@@ -137,6 +139,8 @@ void stringArgsGuarded_handler(FwIndexType portNum,          //!< The port numbe
 void stringArgsSync_handler(FwIndexType portNum,          //!< The port number
                             const Fw::StringBase& str80,  //!< A string of size 80
                             Fw::StringBase& str80Ref,
+                            const Fw::StringBase& str0,  //!< A string of size 0
+                            Fw::StringBase& str0Ref,
                             const Fw::StringBase& str100,  //!< A string of size 100
                             Fw::StringBase& str100Ref) override;
 

--- a/FppTestProject/FppTest/component/common/typed_async.cpp
+++ b/FppTestProject/FppTest/component/common/typed_async.cpp
@@ -39,9 +39,11 @@ void TestComponentName ::structArgsAsync_handler(const FwIndexType portNum,
 void TestComponentName ::stringArgsAsync_handler(const FwIndexType portNum,
                                                  const Fw::StringBase& str80,
                                                  Fw::StringBase& str80Ref,
+                                                 const Fw::StringBase& str0,
+                                                 Fw::StringBase& str0Ref,
                                                  const Fw::StringBase& str100,
                                                  Fw::StringBase& str100Ref) {
-    this->stringArgsOut_out(portNum, str80, str80Ref, str100, str100Ref);
+    this->stringArgsOut_out(portNum, str80, str80Ref, str0, str0Ref, str100, str100Ref);
 }
 
 void TestComponentName ::enumArgsHook_handler(const FwIndexType portNum,

--- a/FppTestProject/FppTest/component/common/typed_async.hpp
+++ b/FppTestProject/FppTest/component/common/typed_async.hpp
@@ -33,6 +33,8 @@ void primitiveArgsAsync_handler(FwIndexType portNum,  //!< The port number
 void stringArgsAsync_handler(FwIndexType portNum,          //!< The port number
                              const Fw::StringBase& str80,  //!< A string of size 80
                              Fw::StringBase& str80Ref,
+                             const Fw::StringBase& str0,  //!< A string of size 0
+                             Fw::StringBase& str0Ref,
                              const Fw::StringBase& str100,  //!< A string of size 100
                              Fw::StringBase& str100Ref) override;
 

--- a/FppTestProject/FppTest/component/tests/PortTests.hpp
+++ b/FppTestProject/FppTest/component/tests/PortTests.hpp
@@ -96,50 +96,50 @@
 // Invoke typed input ports
 // ----------------------------------------------------------------------
 
-#define PORT_TEST_INVOKE_DEFS(PORT_KIND)                                                                              \
-    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::NoParams& port) {                  \
-        ASSERT_TRUE(component.isConnected_noArgsOut_OutputPort(portNum));                                             \
-        ASSERT_TRUE(this->isConnected_to_noArgs##PORT_KIND(portNum));                                                 \
-                                                                                                                      \
-        this->invoke_to_noArgs##PORT_KIND(portNum);                                                                   \
-    }                                                                                                                 \
-                                                                                                                      \
-    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::PrimitiveParams& port) {           \
-        ASSERT_TRUE(component.isConnected_primitiveArgsOut_OutputPort(portNum));                                      \
-        ASSERT_TRUE(this->isConnected_to_primitiveArgs##PORT_KIND(portNum));                                          \
-                                                                                                                      \
-        this->invoke_to_primitiveArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3,             \
-                                                 port.args.val4, port.args.val5, port.args.val6);                     \
-    }                                                                                                                 \
-                                                                                                                      \
-    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::PortStringParams& port) {          \
-        ASSERT_TRUE(component.isConnected_stringArgsOut_OutputPort(portNum));                                         \
-        ASSERT_TRUE(this->isConnected_to_stringArgs##PORT_KIND(portNum));                                             \
-                                                                                                                      \
-        this->invoke_to_stringArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3,                \
-                                              port.args.val4, port.args.val5, port.args.val6);                         \
-    }                                                                                                                 \
-                                                                                                                      \
-    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::EnumParams& port) {                \
-        ASSERT_TRUE(component.isConnected_enumArgsOut_OutputPort(portNum));                                           \
-        ASSERT_TRUE(this->isConnected_to_enumArgs##PORT_KIND(portNum));                                               \
-                                                                                                                      \
-        this->invoke_to_enumArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3, port.args.val4); \
-    }                                                                                                                 \
-                                                                                                                      \
-    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::ArrayParams& port) {               \
-        ASSERT_TRUE(component.isConnected_arrayArgsOut_OutputPort(portNum));                                          \
-        ASSERT_TRUE(this->isConnected_to_arrayArgs##PORT_KIND(portNum));                                              \
-                                                                                                                      \
-        this->invoke_to_arrayArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3, port.args.val4, \
-                                             port.args.val5, port.args.val6);                                         \
-    }                                                                                                                 \
-                                                                                                                      \
-    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::StructParams& port) {              \
-        ASSERT_TRUE(component.isConnected_structArgsOut_OutputPort(portNum));                                         \
-        ASSERT_TRUE(this->isConnected_to_structArgs##PORT_KIND(portNum));                                             \
-                                                                                                                      \
-        this->invoke_to_structArgs##PORT_KIND(portNum, port.args.val1, port.args.val2);                               \
+#define PORT_TEST_INVOKE_DEFS(PORT_KIND)                                                                               \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::NoParams& port) {                   \
+        ASSERT_TRUE(component.isConnected_noArgsOut_OutputPort(portNum));                                              \
+        ASSERT_TRUE(this->isConnected_to_noArgs##PORT_KIND(portNum));                                                  \
+                                                                                                                       \
+        this->invoke_to_noArgs##PORT_KIND(portNum);                                                                    \
+    }                                                                                                                  \
+                                                                                                                       \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::PrimitiveParams& port) {            \
+        ASSERT_TRUE(component.isConnected_primitiveArgsOut_OutputPort(portNum));                                       \
+        ASSERT_TRUE(this->isConnected_to_primitiveArgs##PORT_KIND(portNum));                                           \
+                                                                                                                       \
+        this->invoke_to_primitiveArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3,              \
+                                                 port.args.val4, port.args.val5, port.args.val6);                      \
+    }                                                                                                                  \
+                                                                                                                       \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::PortStringParams& port) {           \
+        ASSERT_TRUE(component.isConnected_stringArgsOut_OutputPort(portNum));                                          \
+        ASSERT_TRUE(this->isConnected_to_stringArgs##PORT_KIND(portNum));                                              \
+                                                                                                                       \
+        this->invoke_to_stringArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3, port.args.val4, \
+                                              port.args.val5, port.args.val6);                                         \
+    }                                                                                                                  \
+                                                                                                                       \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::EnumParams& port) {                 \
+        ASSERT_TRUE(component.isConnected_enumArgsOut_OutputPort(portNum));                                            \
+        ASSERT_TRUE(this->isConnected_to_enumArgs##PORT_KIND(portNum));                                                \
+                                                                                                                       \
+        this->invoke_to_enumArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3, port.args.val4);  \
+    }                                                                                                                  \
+                                                                                                                       \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::ArrayParams& port) {                \
+        ASSERT_TRUE(component.isConnected_arrayArgsOut_OutputPort(portNum));                                           \
+        ASSERT_TRUE(this->isConnected_to_arrayArgs##PORT_KIND(portNum));                                               \
+                                                                                                                       \
+        this->invoke_to_arrayArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3, port.args.val4,  \
+                                             port.args.val5, port.args.val6);                                          \
+    }                                                                                                                  \
+                                                                                                                       \
+    void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::StructParams& port) {               \
+        ASSERT_TRUE(component.isConnected_structArgsOut_OutputPort(portNum));                                          \
+        ASSERT_TRUE(this->isConnected_to_structArgs##PORT_KIND(portNum));                                              \
+                                                                                                                       \
+        this->invoke_to_structArgs##PORT_KIND(portNum, port.args.val1, port.args.val2);                                \
     }
 
 #define PORT_TEST_INVOKE_RETURN_DEFS(PORT_KIND)                                                                       \
@@ -615,43 +615,43 @@
 // Check history of typed output ports
 // ----------------------------------------------------------------------
 
-#define PORT_TEST_CHECK_DEFS(PORT_KIND)                                                                             \
-    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::NoParams& port) {                                      \
-        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                           \
-        ASSERT_from_noArgsOut_SIZE(1);                                                                              \
-    }                                                                                                               \
-                                                                                                                    \
-    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::PrimitiveParams& port) {                               \
-        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                           \
-        ASSERT_from_primitiveArgsOut_SIZE(1);                                                                       \
-        ASSERT_from_primitiveArgsOut(0, port.args.val1, port.args.val2, port.args.val3, port.args.val4,             \
-                                     port.args.val5, port.args.val6);                                               \
-    }                                                                                                               \
-                                                                                                                    \
-    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::PortStringParams& port) {                              \
-        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                           \
-        ASSERT_from_stringArgsOut_SIZE(1);                                                                          \
-        ASSERT_from_stringArgsOut(0, port.args.val1, port.args.val2, port.args.val3, port.args.val4,                 \
-                                  port.args.val5, port.args.val6);                                                   \
-    }                                                                                                               \
-                                                                                                                    \
-    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::EnumParams& port) {                                    \
-        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                           \
-        ASSERT_from_enumArgsOut_SIZE(1);                                                                            \
-        ASSERT_from_enumArgsOut(0, port.args.val1, port.args.val2, port.args.val3, port.args.val4);                 \
-    }                                                                                                               \
-                                                                                                                    \
-    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::ArrayParams& port) {                                   \
-        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                           \
-        ASSERT_from_arrayArgsOut_SIZE(1);                                                                           \
-        ASSERT_from_arrayArgsOut(0, port.args.val1, port.args.val2, port.args.val3, port.args.val4, port.args.val5, \
-                                 port.args.val6);                                                                   \
-    }                                                                                                               \
-                                                                                                                    \
-    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::StructParams& port) {                                  \
-        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                           \
-        ASSERT_from_structArgsOut_SIZE(1);                                                                          \
-        ASSERT_from_structArgsOut(0, port.args.val1, port.args.val2);                                               \
+#define PORT_TEST_CHECK_DEFS(PORT_KIND)                                                                              \
+    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::NoParams& port) {                                       \
+        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                            \
+        ASSERT_from_noArgsOut_SIZE(1);                                                                               \
+    }                                                                                                                \
+                                                                                                                     \
+    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::PrimitiveParams& port) {                                \
+        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                            \
+        ASSERT_from_primitiveArgsOut_SIZE(1);                                                                        \
+        ASSERT_from_primitiveArgsOut(0, port.args.val1, port.args.val2, port.args.val3, port.args.val4,              \
+                                     port.args.val5, port.args.val6);                                                \
+    }                                                                                                                \
+                                                                                                                     \
+    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::PortStringParams& port) {                               \
+        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                            \
+        ASSERT_from_stringArgsOut_SIZE(1);                                                                           \
+        ASSERT_from_stringArgsOut(0, port.args.val1, port.args.val2, port.args.val3, port.args.val4, port.args.val5, \
+                                  port.args.val6);                                                                   \
+    }                                                                                                                \
+                                                                                                                     \
+    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::EnumParams& port) {                                     \
+        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                            \
+        ASSERT_from_enumArgsOut_SIZE(1);                                                                             \
+        ASSERT_from_enumArgsOut(0, port.args.val1, port.args.val2, port.args.val3, port.args.val4);                  \
+    }                                                                                                                \
+                                                                                                                     \
+    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::ArrayParams& port) {                                    \
+        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                            \
+        ASSERT_from_arrayArgsOut_SIZE(1);                                                                            \
+        ASSERT_from_arrayArgsOut(0, port.args.val1, port.args.val2, port.args.val3, port.args.val4, port.args.val5,  \
+                                 port.args.val6);                                                                    \
+    }                                                                                                                \
+                                                                                                                     \
+    void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::StructParams& port) {                                   \
+        ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                            \
+        ASSERT_from_structArgsOut_SIZE(1);                                                                           \
+        ASSERT_from_structArgsOut(0, port.args.val1, port.args.val2);                                                \
     }
 
 #define PORT_TEST_CHECK_RETURN_DEFS(PORT_KIND)                                                            \
@@ -754,10 +754,10 @@
                                                                                              \
         status = this->stringBuf.deserializeTo(str0);                                        \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
-                                                                                              \
+                                                                                             \
         status = this->stringBuf.deserializeTo(str0Ref);                                     \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
-                                                                                              \
+                                                                                             \
         status = this->stringBuf.deserializeTo(str100);                                      \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \

--- a/FppTestProject/FppTest/component/tests/PortTests.hpp
+++ b/FppTestProject/FppTest/component/tests/PortTests.hpp
@@ -117,7 +117,7 @@
         ASSERT_TRUE(this->isConnected_to_stringArgs##PORT_KIND(portNum));                                             \
                                                                                                                       \
         this->invoke_to_stringArgs##PORT_KIND(portNum, port.args.val1, port.args.val2, port.args.val3,                \
-                                              port.args.val4);                                                        \
+                                              port.args.val4, port.args.val5, port.args.val6);                         \
     }                                                                                                                 \
                                                                                                                       \
     void Tester ::test##PORT_KIND##PortInvoke(FwIndexType portNum, FppTest::Types::EnumParams& port) {                \
@@ -467,6 +467,12 @@
         status = buf.serializeFrom(port.args.val4);                                                                 \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
                                                                                                                     \
+        status = buf.serializeFrom(port.args.val5);                                                                 \
+        ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
+                                                                                                                    \
+        status = buf.serializeFrom(port.args.val6);                                                                 \
+        ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                                                     \
+                                                                                                                    \
         this->invoke##PORT_KIND##SerialPort(SerialPortIndex::STRING, buf);                                          \
                                                                                                                     \
         this->checkSerializeStatusSuccess();                                                                        \
@@ -625,7 +631,8 @@
     void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::PortStringParams& port) {                              \
         ASSERT_FROM_PORT_HISTORY_SIZE(1);                                                                           \
         ASSERT_from_stringArgsOut_SIZE(1);                                                                          \
-        ASSERT_from_stringArgsOut(0, port.args.val1, port.args.val2, port.args.val3, port.args.val4);               \
+        ASSERT_from_stringArgsOut(0, port.args.val1, port.args.val2, port.args.val3, port.args.val4,                 \
+                                  port.args.val5, port.args.val6);                                                   \
     }                                                                                                               \
                                                                                                                     \
     void Tester ::test##PORT_KIND##PortCheck(FppTest::Types::EnumParams& port) {                                    \
@@ -736,6 +743,7 @@
     void Tester ::test##PORT_KIND##PortCheckSerial(FppTest::Types::PortStringParams& port) { \
         Fw::SerializeStatus status;                                                          \
         FppTest::Types::String1 str80, str80Ref;                                             \
+        Fw::String str0, str0Ref;                                                            \
         FppTest::Types::String2 str100, str100Ref;                                           \
                                                                                              \
         status = this->stringBuf.deserializeTo(str80);                                       \
@@ -744,6 +752,12 @@
         status = this->stringBuf.deserializeTo(str80Ref);                                    \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
+        status = this->stringBuf.deserializeTo(str0);                                        \
+        ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
+                                                                                              \
+        status = this->stringBuf.deserializeTo(str0Ref);                                     \
+        ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
+                                                                                              \
         status = this->stringBuf.deserializeTo(str100);                                      \
         ASSERT_EQ(status, Fw::FW_SERIALIZE_OK);                                              \
                                                                                              \
@@ -752,8 +766,10 @@
                                                                                              \
         ASSERT_EQ(str80, port.args.val1);                                                    \
         ASSERT_EQ(str80Ref, port.args.val2);                                                 \
-        ASSERT_EQ(str100, port.args.val3);                                                   \
-        ASSERT_EQ(str100Ref, port.args.val4);                                                \
+        ASSERT_EQ(str0, port.args.val3);                                                     \
+        ASSERT_EQ(str0Ref, port.args.val4);                                                  \
+        ASSERT_EQ(str100, port.args.val5);                                                   \
+        ASSERT_EQ(str100Ref, port.args.val6);                                                \
     }                                                                                        \
                                                                                              \
     void Tester ::test##PORT_KIND##PortCheckSerial(FppTest::Types::EnumParams& port) {       \

--- a/FppTestProject/FppTest/component/tests/TesterHandlers.cpp
+++ b/FppTestProject/FppTest/component/tests/TesterHandlers.cpp
@@ -51,9 +51,11 @@ FormalParamEnum Tester ::from_enumReturnOut_handler(const FwIndexType portNum,
 void Tester ::from_stringArgsOut_handler(const FwIndexType portNum,
                                          const Fw::StringBase& str80,
                                          Fw::StringBase& str80Ref,
+                                         const Fw::StringBase& str0,
+                                         Fw::StringBase& str0Ref,
                                          const Fw::StringBase& str100,
                                          Fw::StringBase& str100Ref) {
-    this->pushFromPortEntry_stringArgsOut(str80, str80Ref, str100, str100Ref);
+    this->pushFromPortEntry_stringArgsOut(str80, str80Ref, str0, str0Ref, str100, str100Ref);
 }
 
 Fw::String Tester ::from_stringReturnOut_handler(const FwIndexType portNum,

--- a/FppTestProject/FppTest/component/types/FormalParamTypes.cpp
+++ b/FppTestProject/FppTest/component/types/FormalParamTypes.cpp
@@ -499,8 +499,9 @@ FormalParamStruct getRandomFormalParamStruct() {
 
     Utils::setString(buf, sizeof(buf));
     Fw::StringTemplate<80> str2(buf);
+    Fw::String str0;
 
-    s.set(STest::Pick::any(), str, str2);
+    s.set(STest::Pick::any(), str, str2, str0);
 
     return s;
 }

--- a/FppTestProject/FppTest/component/types/FormalParamTypes.cpp
+++ b/FppTestProject/FppTest/component/types/FormalParamTypes.cpp
@@ -248,8 +248,8 @@ Fw::SerializeStatus PortStringType::deserializeFrom(Fw::SerialBufferBase& buffer
 PortStringTypes::PortStringTypes() {
     setRandomString(val1);
     setRandomString(val2);
-    setRandomString(val3);
-    setRandomString(val4);
+    setRandomString(val5);
+    setRandomString(val6);
 }
 
 Fw::SerializeStatus PortStringTypes::serializeTo(Fw::SerialBufferBase& buffer, Fw::Endianness mode) const {
@@ -257,6 +257,8 @@ Fw::SerializeStatus PortStringTypes::serializeTo(Fw::SerialBufferBase& buffer, F
     buffer.serializeFrom(val2, mode);
     buffer.serializeFrom(val3, mode);
     buffer.serializeFrom(val4, mode);
+    buffer.serializeFrom(val5, mode);
+    buffer.serializeFrom(val6, mode);
     return Fw::SerializeStatus::FW_SERIALIZE_OK;
 }
 

--- a/FppTestProject/FppTest/component/types/FormalParamTypes.hpp
+++ b/FppTestProject/FppTest/component/types/FormalParamTypes.hpp
@@ -195,6 +195,7 @@ struct StructTypes : Fw::Serializable {
 // ----------------------------------------------------------------------
 
 using String1 = Fw::StringTemplate<80>;
+using String0 = Fw::String;
 using String2 = Fw::StringTemplate<100>;
 
 struct PortStringType : Fw::Serializable {
@@ -211,8 +212,10 @@ struct PortStringTypes : Fw::Serializable {
 
     String1 val1;
     String1 val2;
-    String2 val3;
-    String2 val4;
+    String0 val3;
+    String0 val4;
+    String2 val5;
+    String2 val6;
 
     Fw::SerializeStatus serializeTo(Fw::SerialBufferBase& buffer, Fw::Endianness mode) const override;
     Fw::SerializeStatus deserializeFrom(Fw::SerialBufferBase& buffer, Fw::Endianness mode) override;

--- a/FppTestProject/FppTest/sizeof/main.cpp
+++ b/FppTestProject/FppTest/sizeof/main.cpp
@@ -50,7 +50,7 @@ TEST(SizeofTest, Enum) {
 
 TEST(SizeofTest, Struct) {
     ASSERT_EQ(SizeofStruct, TestStruct1::SERIALIZED_SIZE);
-    ASSERT_EQ(SizeofStruct, 94);
+    ASSERT_EQ(SizeofStruct, 100);
     ASSERT_EQ(SizeofStruct2, TestStruct2::SERIALIZED_SIZE);
-    ASSERT_EQ(SizeofStruct2, 338);
+    ASSERT_EQ(SizeofStruct2, 350);
 }

--- a/FppTestProject/FppTest/sizeof/sizeof.fpp
+++ b/FppTestProject/FppTest/sizeof/sizeof.fpp
@@ -14,6 +14,8 @@ type StringDefaultAlias = string
 constant SizeofStringDefaultAlias = sizeof(StringDefaultAlias)
 type StringAlias = string size 100
 constant SizeofStringAlias = sizeof(StringAlias)
+type StringZeroAlias = string size 0
+constant SizeofStringZeroAlias = sizeof(StringZeroAlias)
 
 type U64Alias = U64
 constant SizeofU64Alias = sizeof(U64Alias)
@@ -38,6 +40,7 @@ struct TestStruct1 {
     m2: F64
     m3: [1] EnumAlias
     m4: [3] string size 10
+    m5: [3] string size 0
 }
 constant SizeofStruct = sizeof(TestStruct1)
 

--- a/FppTestProject/FppTest/struct/struct.fpp
+++ b/FppTestProject/FppTest/struct/struct.fpp
@@ -28,16 +28,21 @@ module FppTest {
     }
 
     type StructAliasString = string size 30
+    type StructAliasStringZero = string size 0
 
     struct MultiString {
       mStr_1: string
       mStr_2: string
       mStr50_1: string size 50
       mStr50_2: string size 50
+      mStr0: string size 0
       mStrArr_1: [3] string size 60
       mStrArr_2: [3] string size 60
+      mStrArr0: [3] string size 0
       mStrAlias: StructAliasString
       mStrAlias_2: [3] StructAliasString
+      mStrAlias0: StructAliasStringZero
+      mStrAliasArr0: [3] StructAliasStringZero
     }
 
     passive component C {

--- a/FppTestProject/FppTest/topology/components/Comp/Comp.fpp
+++ b/FppTestProject/FppTest/topology/components/Comp/Comp.fpp
@@ -7,6 +7,10 @@ module FppTest {
     c: string size 10
   }
 
+  struct ZeroSizeData {
+    c: string size 0
+  }
+
   port EmitTelemetry(a: U32)
   port GetParameter() -> U32
 
@@ -48,6 +52,7 @@ module FppTest {
 
     @ A record containing fixed-size data
     product record FixedSizeDataRecord: FixedSizeData id 0x00
+    product record ZeroSizeDataRecord: ZeroSizeData id 0x02
     @ A record containing a variable-size array
     product record F32ArrayRecord: F32 array id 0x01
 

--- a/FppTestProject/FppTest/topology/components/Receiver/Receiver.cpp
+++ b/FppTestProject/FppTest/topology/components/Receiver/Receiver.cpp
@@ -343,11 +343,15 @@ Fw::String Receiver ::stringAliasReturnSync_handler(FwIndexType portNum,
 void Receiver ::stringArgsAsync_handler(FwIndexType portNum,
                                         const Fw::StringBase& str80,
                                         Fw::StringBase& str80Ref,
+                                        const Fw::StringBase& str0,
+                                        Fw::StringBase& str0Ref,
                                         const Fw::StringBase& str100,
                                         Fw::StringBase& str100Ref) {
     m_recv.resetSer();
     str80.serializeTo(m_recv);
     str80Ref.serializeTo(m_recv);
+    str0.serializeTo(m_recv);
+    str0Ref.serializeTo(m_recv);
     str100.serializeTo(m_recv);
     str100Ref.serializeTo(m_recv);
     Fw::Buffer data(m_data, m_recv.getSize());
@@ -357,11 +361,15 @@ void Receiver ::stringArgsAsync_handler(FwIndexType portNum,
 void Receiver ::stringArgsGuarded_handler(FwIndexType portNum,
                                           const Fw::StringBase& str80,
                                           Fw::StringBase& str80Ref,
+                                          const Fw::StringBase& str0,
+                                          Fw::StringBase& str0Ref,
                                           const Fw::StringBase& str100,
                                           Fw::StringBase& str100Ref) {
     m_recv.resetSer();
     str80.serializeTo(m_recv);
     str80Ref.serializeTo(m_recv);
+    str0.serializeTo(m_recv);
+    str0Ref.serializeTo(m_recv);
     str100.serializeTo(m_recv);
     str100Ref.serializeTo(m_recv);
     Fw::Buffer data(m_data, m_recv.getSize());
@@ -371,11 +379,15 @@ void Receiver ::stringArgsGuarded_handler(FwIndexType portNum,
 void Receiver ::stringArgsSync_handler(FwIndexType portNum,
                                        const Fw::StringBase& str80,
                                        Fw::StringBase& str80Ref,
+                                       const Fw::StringBase& str0,
+                                       Fw::StringBase& str0Ref,
                                        const Fw::StringBase& str100,
                                        Fw::StringBase& str100Ref) {
     m_recv.resetSer();
     str80.serializeTo(m_recv);
     str80Ref.serializeTo(m_recv);
+    str0.serializeTo(m_recv);
+    str0Ref.serializeTo(m_recv);
     str100.serializeTo(m_recv);
     str100Ref.serializeTo(m_recv);
     Fw::Buffer data(m_data, m_recv.getSize());

--- a/FppTestProject/FppTest/topology/components/Receiver/Receiver.hpp
+++ b/FppTestProject/FppTest/topology/components/Receiver/Receiver.hpp
@@ -214,6 +214,8 @@ class Receiver final : public ReceiverComponentBase {
     void stringArgsAsync_handler(FwIndexType portNum,          //!< The port number
                                  const Fw::StringBase& str80,  //!< A string of size 80
                                  Fw::StringBase& str80Ref,
+                                 const Fw::StringBase& str0,  //!< A string of size 0
+                                 Fw::StringBase& str0Ref,
                                  const Fw::StringBase& str100,  //!< A string of size 100
                                  Fw::StringBase& str100Ref) override;
 
@@ -221,6 +223,8 @@ class Receiver final : public ReceiverComponentBase {
     void stringArgsGuarded_handler(FwIndexType portNum,          //!< The port number
                                    const Fw::StringBase& str80,  //!< A string of size 80
                                    Fw::StringBase& str80Ref,
+                                   const Fw::StringBase& str0,  //!< A string of size 0
+                                   Fw::StringBase& str0Ref,
                                    const Fw::StringBase& str100,  //!< A string of size 100
                                    Fw::StringBase& str100Ref) override;
 
@@ -228,6 +232,8 @@ class Receiver final : public ReceiverComponentBase {
     void stringArgsSync_handler(FwIndexType portNum,          //!< The port number
                                 const Fw::StringBase& str80,  //!< A string of size 80
                                 Fw::StringBase& str80Ref,
+                                const Fw::StringBase& str0,  //!< A string of size 0
+                                Fw::StringBase& str0Ref,
                                 const Fw::StringBase& str100,  //!< A string of size 100
                                 Fw::StringBase& str100Ref) override;
 

--- a/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
+++ b/FppTestProject/FppTest/topology/components/Sender/Sender.cpp
@@ -75,7 +75,7 @@ void Sender::testPrimitiveArgs(const TestDeploymentPort& portId) {
 void Sender::testStringArgs(const TestDeploymentPort& portId) {
     for (FwIndexType i = 0; i < 3; i++) {
         auto args = initTestCase<Types::PortStringTypes>(i, portId);
-        stringArgsOut_out(m_expectedPortNum, args.val1, args.val2, args.val3, args.val4);
+        stringArgsOut_out(m_expectedPortNum, args.val1, args.val2, args.val3, args.val4, args.val5, args.val6);
         wait();
 
         if (i == 2) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Flask-Compress==1.15
 Flask-RESTful==0.3.10
 fprime-fpl-layout==1.0.4
 fprime-fpl-write-pic==1.0.4
-fprime-fpp==3.3.0a13
+fprime-fpp==3.3.0a14
 fprime-fpy==0.4.0
 fprime-gds==4.2.2a4
 fprime-tools==4.3.0a5


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Companion compiler PR nasa/fpp#1049 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Adds FppTestProject coverage for FPP zero-sized strings across aliases, arrays, structs, ports, component types, sizeof, and data products.

The component and topology tests also send and serialize zero-capacity strings as empty Fw::String values.

Companion compiler PR: https://github.com/nasa/fpp/pull/1049

## Rationale

The FPP compiler now supports zero-sized strings, so the framework integration suite needs coverage for generated types, ports, serialization, and topology behavior.

## Testing/Review Recommendations

- Review the zero-capacity string cases across the generated component and topology fixtures.
- The changed C/C++ files pass the repository's clang-format 20.1.8 check.
- The full GitHub Actions matrix is running against head `41b06fb0`.

## Future Work

None identified.

## AI Usage

OpenAI Codex was used to inspect the CI formatting failure and apply the clang-format-only follow-up. The contributor remains responsible for the complete change and its review.

IAMAI