### PR TITLE
Fix FileWorker process abort on zero-length writeIn and report actual bytes written

### DIFF
--- a/Svc/FileWorker/FileWorker.cpp
+++ b/Svc/FileWorker/FileWorker.cpp
@@ -183,7 +183,11 @@ void FileWorker ::writeIn_handler(FwIndexType portNum,
     // failure, permission denied, disk full, partial write) must not be reported
     // to ground as a successful FW_STATUS_DONE_WRITE.
     const FileWorkerStatus writeStatus = isWrite ? FW_STATUS_DONE_WRITE : FW_STATUS_FAILED_TO_WRITE;
-    this->writeDoneOut_out(0, writeStatus, isWrite ? buffer.getSize() : 0);
+    // Report bytes actually written, which excludes the skipped offset. Reporting the full
+    // buffer size over-reports by offsetBytes, and reports a whole buffer for a zero-length
+    // write. offsetBytes <= buffer.getSize() is checked above, so this cannot underflow.
+    const FwSizeType writtenBytes = buffer.getSize() - offsetBytes;
+    this->writeDoneOut_out(0, writeStatus, isWrite ? writtenBytes : 0);
     this->m_state = FW_STATE_IDLE;
     return;
 }
@@ -379,6 +383,28 @@ bool FileWorker ::writeBufferToFile(Fw::Buffer& buffer, const char* fileName, Fw
     FW_ASSERT(fileName != nullptr);
 
     Fw::LogStringArg logStringArg(fileName);
+
+    // Get buffer data and size, then apply offset
+    FwSizeType size = buffer.getSize();
+    U8* const data = reinterpret_cast<U8*>(buffer.getData());
+    FW_ASSERT(data != nullptr);
+    FW_ASSERT(offset <= size);
+    size -= offset;
+
+    // A zero-length write (offset == buffer size, a valid "nothing left to write" boundary
+    // permitted by writeIn_handler's offset check) is a successful no-op. Return before
+    // opening the file: this avoids reaching FW_ASSERT(size > 0) in writeToFile(), and avoids
+    // creating an empty file for a request that writes nothing, since both OPEN_WRITE and
+    // OPEN_APPEND pass O_CREAT. An existing file's contents are not at risk either way here:
+    // OPEN_WRITE overwrites in place and does not truncate; only OPEN_CREATE sets O_TRUNC.
+    if (size == 0) {
+        this->log_ACTIVITY_LO_WriteCompleted(size, logStringArg);
+        return true;
+    }
+
+    U8* const dataFromOffset = reinterpret_cast<U8*>(data + offset);
+    FW_ASSERT(dataFromOffset != nullptr);
+
     Os::File file;
     Os::File::Status stat = Os::File::OP_OK;
 
@@ -393,17 +419,6 @@ bool FileWorker ::writeBufferToFile(Fw::Buffer& buffer, const char* fileName, Fw
         this->log_WARNING_HI_OpenFileError(logStringArg, stat);
         return false;
     }
-
-    // Get buffer data and size
-    FwSizeType size = buffer.getSize();
-    U8* const data = reinterpret_cast<U8*>(buffer.getData());
-    FW_ASSERT(data != nullptr);
-
-    // Apply offset
-    FW_ASSERT(offset <= size);
-    size -= offset;
-    U8* const dataFromOffset = reinterpret_cast<U8*>(data + offset);
-    FW_ASSERT(dataFromOffset != nullptr);
 
     // Write file
     this->log_ACTIVITY_LO_WriteBegin(size, logStringArg);
@@ -438,6 +453,15 @@ void FileWorker ::writeBufferHashToFile(Fw::Buffer& buffer, const char* fileName
     // Apply offset
     FW_ASSERT(offset <= size);
     size -= offset;  // checked by assert
+
+    // A zero-length write changed no file contents, so the hash must not change either. Skip
+    // generation entirely: on the append path this would otherwise trip FW_ASSERT(size > 0) in
+    // getHash(), and on the non-append path it would silently overwrite a valid hash file with
+    // the hash of zero bytes.
+    if (size == 0) {
+        return;
+    }
+
     U8* const dataFromOffset = reinterpret_cast<U8*>(data + offset);
     FW_ASSERT(dataFromOffset != nullptr);
 

--- a/Svc/FileWorker/test/ut/FileWorkerTestMain.cpp
+++ b/Svc/FileWorker/test/ut/FileWorkerTestMain.cpp
@@ -41,6 +41,11 @@ TEST(Nominal, testWritingOffset) {
     tester.testWritingOffset();
 }
 
+TEST(Nominal, testWriteZeroLength) {
+    Svc::FileWorkerTester tester;
+    tester.testWriteZeroLength();
+}
+
 TEST(Nominal, testAppending) {
     Svc::FileWorkerTester tester;
     tester.testAppending();

--- a/Svc/FileWorker/test/ut/FileWorkerTester.cpp
+++ b/Svc/FileWorker/test/ut/FileWorkerTester.cpp
@@ -391,4 +391,60 @@ void FileWorkerTester ::testTimeout() {
     f.close();
 }
 
+void FileWorkerTester ::testWriteZeroLength() {
+    // Regression: a well-formed writeIn with offsetBytes == buffer.getSize() leaves zero
+    // bytes to write. writeIn_handler's `offsetBytes > buffer.getSize()` check accepts this
+    // boundary, and previously the resulting size == 0 tripped FW_ASSERT(size > 0) in
+    // writeToFile(), aborting the process. It must instead be handled as a successful no-op
+    // that leaves the target file's contents alone.
+    const char* fnameChar = "testwritezero.txt";
+    const U8 preserved[] = "PRESERVE-ME";
+    const FwSizeType preservedSize = sizeof(preserved);
+
+    // Pre-seed the target file with known contents that the no-op write must leave intact.
+    Os::File seed;
+    ASSERT_EQ(seed.open(fnameChar, Os::File::OPEN_WRITE), Os::File::OP_OK);
+    FwSizeType seedSize = preservedSize;
+    ASSERT_EQ(seed.write(preserved, seedSize), Os::File::OP_OK);
+    seed.close();
+
+    // Valid, non-empty buffer with the offset pointing exactly at its end (nothing to write).
+    U8 data[1024];
+    for (FwSizeType i = 0; i < sizeof(data); i++) {
+        data[i] = static_cast<U8>(i % 256);
+    }
+    Fw::Buffer buffer(data, sizeof(data));
+    Fw::String fname = fnameChar;
+    FwSizeType offsetBytes = sizeof(data);  // == buffer.getSize()
+
+    // Drive the request. Pre-fix this aborts the process at FW_ASSERT(size > 0).
+    this->invoke_to_writeIn(0, fname, buffer, offsetBytes, false);
+    this->component.doDispatch();
+
+    // The boundary value is valid input, not an error: no InvalidInput, no write/open errors.
+    ASSERT_EVENTS_InvalidInput_SIZE(0);
+    ASSERT_EVENTS_WriteFileError_SIZE(0);
+    ASSERT_EVENTS_OpenFileError_SIZE(0);
+    ASSERT_EVENTS_WriteValidationError_SIZE(0);
+
+    // Reported as a successful write of zero bytes: the count is bytes actually written, so
+    // it must not report the full buffer size when the offset consumed all of it.
+    ASSERT_from_writeDoneOut_SIZE(1);
+    ASSERT_from_writeDoneOut(0, FW_STATUS_DONE_WRITE, 0);
+    ASSERT_EQ(this->component.m_state, FileWorkerState::FW_STATE_IDLE);
+
+    // The existing file's contents must be intact. Note this alone does not prove the file was
+    // never opened: OPEN_WRITE does not set O_TRUNC, so a stray open would leave a file this
+    // short unchanged. The regression it does catch is the pre-fix FW_ASSERT abort above.
+    Os::File check;
+    ASSERT_EQ(check.open(fnameChar, Os::File::OPEN_READ), Os::File::OP_OK);
+    U8 readback[preservedSize];
+    FwSizeType readSize = preservedSize;
+    ASSERT_EQ(check.read(readback, readSize), Os::File::OP_OK);
+    ASSERT_EQ(readSize, preservedSize);
+    ASSERT_EQ(memcmp(readback, preserved, preservedSize), 0);
+    check.close();
+    (void)::remove(fnameChar);
+}
+
 }  // namespace Svc

--- a/Svc/FileWorker/test/ut/FileWorkerTester.hpp
+++ b/Svc/FileWorker/test/ut/FileWorkerTester.hpp
@@ -54,6 +54,7 @@ class FileWorkerTester final : public FileWorkerGTestBase {
     void testTransfer();
     void testWriting();
     void testWritingOffset();
+    void testWriteZeroLength();
     void testAppending();
     void testTimeout();
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| N |
|**_Generative AI was used in this contribution (y/n)_**| Y |

---
## Change Description

This PR contains four related changes in Svc/FileWorker: 

1. A zero-length writeIn no longer aborts, since writeIn_handler's offsetBytes > buffer.getSize() check accepts offsetBytes == buffer.getSize(), leaving size == 0 which reached FW_ASSERT(size > 0) in writeToFile(); writeBufferToFile() now returns a successful no-op before opening the file. 
2. writeBufferHashToFile() got the matching guard, since the append path would trip getHash()'s assert and the non-append path would overwrite a valid hash with the hash of zero bytes. 
3. The offset arithmetic and FW_ASSERT(offset <= size) moved above file.open(). 
4. writeDoneOut reports buffer.getSize() - offsetBytes instead of the full buffer size.

## Rationale

The abort is reachable from input the component already accepted as valid, and since FW_ASSERT aborts in a single-process deployment it takes down the whole image, not just FileWorker. 

## Testing/Review Recommendations
The byte-count change alters the writeDoneOut sizeBytes contract for nonzero-offset callers (no test churn, but a deployment compensating for the old over-report would need updating), and records that OPEN_WRITE maps to O_WRONLY | O_CREAT with no O_TRUNC.

## Future Work
the orphan WriteCompleted with no WriteBegin; the untested no-spurious-creation case; and whether the read path needs the same size-report look.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude Fable 5 used to confirm issue, generate UT and this report. 