### PR TITLE
Svc/DpCompressProc: reject buffers smaller than MIN_PACKET_SIZE locally

### DIFF
--- a/Svc/DpCompressProc/DpCompressProc.cpp
+++ b/Svc/DpCompressProc/DpCompressProc.cpp
@@ -53,6 +53,39 @@ void DpCompressProc ::procRequest_handler(FwIndexType portNum, Fw::Buffer& fwBuf
         return;
     }
 
+    // Defense-in-depth: reject buffers smaller than a well-formed DP packet
+    // BEFORE constructing the DpContainer (which asserts the same
+    // invariant via FW_ASSERT). Two motivations, both from the SCJ
+    // brick-wall audit:
+    //
+    //   (1) `Fw::DpContainer::setBuffer` uses FW_ASSERT to enforce
+    //       bufferSize >= MIN_PACKET_SIZE. FW_ASSERT is compiled out at
+    //       lower FW_ASSERT_LEVEL settings; when it is, a caller that
+    //       hands us a buffer of length in [Header::SIZE, MIN_PACKET_SIZE)
+    //       gets past the constructor (deserializeHeader only touches
+    //       the header), and the subsequent
+    //           fwBuffer.getSize() - Fw::DpContainer::MIN_PACKET_SIZE
+    //       below is an unsigned underflow. The resulting `data_buffer`
+    //       has an astronomically-large size and downstream deserializer
+    //       loops walk off the buffer.
+    //
+    //   (2) The invariant is enforced in a different translation unit
+    //       (Fw/Dp/DpContainer.cpp) from where it's *relied on* here.
+    //       Same brick-wall-on-upstream-defense shape as the merged
+    //       nasa/fprime#5262 (FileUplink::File::open, June 2026): a
+    //       future widening of MIN_PACKET_SIZE or refactor of setBuffer
+    //       could silently break this consumer without any diff to
+    //       this file. Adding a local check makes the invariant
+    //       load-bearing on THIS site's own text.
+    if (fwBuffer.getSize() < Fw::DpContainer::MIN_PACKET_SIZE) {
+        // Buffer is too small to be a well-formed DP packet.
+        // Reuse the InvalidHeader EVR; the header is trivially invalid
+        // if the buffer can't even hold the container's minimum.
+        this->log_WARNING_HI_InvalidHeader(fwBuffer.getSize(),
+                                           static_cast<U32>(Fw::FW_DESERIALIZE_SIZE_MISMATCH));
+        return;
+    }
+
     Fw::DpContainer container(0, fwBuffer);
     const Fw::SerializeStatus desStat = container.deserializeHeader();
     if (desStat != Fw::FW_SERIALIZE_OK) {

--- a/Svc/DpCompressProc/DpCompressProc.cpp
+++ b/Svc/DpCompressProc/DpCompressProc.cpp
@@ -53,36 +53,9 @@ void DpCompressProc ::procRequest_handler(FwIndexType portNum, Fw::Buffer& fwBuf
         return;
     }
 
-    // Defense-in-depth: reject buffers smaller than a well-formed DP packet
-    // BEFORE constructing the DpContainer (which asserts the same
-    // invariant via FW_ASSERT). Two motivations, both from the SCJ
-    // brick-wall audit:
-    //
-    //   (1) `Fw::DpContainer::setBuffer` uses FW_ASSERT to enforce
-    //       bufferSize >= MIN_PACKET_SIZE. FW_ASSERT is compiled out at
-    //       lower FW_ASSERT_LEVEL settings; when it is, a caller that
-    //       hands us a buffer of length in [Header::SIZE, MIN_PACKET_SIZE)
-    //       gets past the constructor (deserializeHeader only touches
-    //       the header), and the subsequent
-    //           fwBuffer.getSize() - Fw::DpContainer::MIN_PACKET_SIZE
-    //       below is an unsigned underflow. The resulting `data_buffer`
-    //       has an astronomically-large size and downstream deserializer
-    //       loops walk off the buffer.
-    //
-    //   (2) The invariant is enforced in a different translation unit
-    //       (Fw/Dp/DpContainer.cpp) from where it's *relied on* here.
-    //       Same brick-wall-on-upstream-defense shape as the merged
-    //       nasa/fprime#5262 (FileUplink::File::open, June 2026): a
-    //       future widening of MIN_PACKET_SIZE or refactor of setBuffer
-    //       could silently break this consumer without any diff to
-    //       this file. Adding a local check makes the invariant
-    //       load-bearing on THIS site's own text.
+    // Check that the buffer is large enough to hold a data product packet
     if (fwBuffer.getSize() < Fw::DpContainer::MIN_PACKET_SIZE) {
-        // Buffer is too small to be a well-formed DP packet.
-        // Reuse the InvalidHeader EVR; the header is trivially invalid
-        // if the buffer can't even hold the container's minimum.
-        this->log_WARNING_HI_InvalidHeader(fwBuffer.getSize(),
-                                           static_cast<U32>(Fw::FW_DESERIALIZE_SIZE_MISMATCH));
+        this->log_WARNING_HI_BufferTooSmallForPacket(fwBuffer.getSize(), Fw::DpContainer::MIN_PACKET_SIZE);
         return;
     }
 

--- a/Svc/DpCompressProc/DpCompressProc.fpp
+++ b/Svc/DpCompressProc/DpCompressProc.fpp
@@ -32,6 +32,14 @@ module Svc {
             format "Received buffer of size {}; deserialization of container header failed with error code {}" \
             throttle 10
 
+        @ Received buffer is too small to hold a data product packet
+        event BufferTooSmallForPacket(buffer_size: FwSizeType @< The incoming buffer size
+                                      min_size: FwSizeType @< The minimum required size
+                                      ) \
+            severity warning high \
+            format "Received buffer has size {}; minimum required size is {}" \
+            throttle 10
+
         @ Record ID used to mark compressed records in a data product
         product record CompressionRecord: U8 array
 

--- a/Svc/DpCompressProc/docs/sdd.md
+++ b/Svc/DpCompressProc/docs/sdd.md
@@ -71,6 +71,8 @@ Add requirements in the chart below
 |-----------------------|--------------------------------------------------------------------|
 | CompressionComplete   | DIAGNOSTIC event when DpCompressProc compresses a buffer           |
 | DidNotCompress        | ACTIVITY\_LO event when DpCompressProc can not compress any chunks |
+| InvalidHeader         | WARNING\_HI event when the container header cannot be deserialized |
+| BufferTooSmallForPacket | WARNING\_HI event when the incoming buffer is smaller than `Fw::DpContainer::MIN_PACKET_SIZE` |
 
 
 ## Detailed Documentation

--- a/Svc/DpCompressProc/test/ut/DpCompressProcTestMain.cpp
+++ b/Svc/DpCompressProc/test/ut/DpCompressProcTestMain.cpp
@@ -9,6 +9,14 @@
 #include "STest/STest/Random/Random.hpp"
 #include "Svc/DpCompressProc/test/ut/Rules/Testers.hpp"
 
+//! Off-nominal: a buffer shorter than MIN_PACKET_SIZE must be rejected
+//! before the container is constructed. See
+//! DpCompressProcTester::test_undersized_buffer for the construction
+//! and the failure mode it guards.
+TEST(OffNominal, BufferSmallerThanMinPacketSize) {
+    Svc::Testers::procRequest.testState.test_undersized_buffer();
+}
+
 TEST(Nominal, Compressible) {
     const FwSizeType chunk_size = 4096;
     std::vector<Svc::AbstractState::Chunk> chunks = {Svc::AbstractState::Chunk(Svc::AbstractState::COMPRESSED, 0xA5),

--- a/Svc/DpCompressProc/test/ut/DpCompressProcTestMain.cpp
+++ b/Svc/DpCompressProc/test/ut/DpCompressProcTestMain.cpp
@@ -9,10 +9,6 @@
 #include "STest/STest/Random/Random.hpp"
 #include "Svc/DpCompressProc/test/ut/Rules/Testers.hpp"
 
-//! Off-nominal: a buffer shorter than MIN_PACKET_SIZE must be rejected
-//! before the container is constructed. See
-//! DpCompressProcTester::test_undersized_buffer for the construction
-//! and the failure mode it guards.
 TEST(OffNominal, BufferSmallerThanMinPacketSize) {
     Svc::Testers::procRequest.testState.test_undersized_buffer();
 }

--- a/Svc/DpCompressProc/test/ut/DpCompressProcTester.cpp
+++ b/Svc/DpCompressProc/test/ut/DpCompressProcTester.cpp
@@ -222,6 +222,62 @@ void DpCompressProcTester::test_chunks_helper(const FwSizeStoreType chunk_size,
     abstractState.success_ = true;
 }
 
+void DpCompressProcTester::test_undersized_buffer() {
+    // Every other test here builds a well-formed container via
+    // AbstractState::build_compress_buffer, so none of them reach the
+    // short-buffer branch in procRequest_handler. This drives it.
+    //
+    // Construction: allocate a MIN_PACKET_SIZE + 1 backing array — large
+    // enough that Fw::DpContainer accepts it and can write a well-formed
+    // header with dataSize = 1 — then hand procRequest a *view* of that
+    // same memory whose length is MIN_PACKET_SIZE - 1. Header::SIZE is
+    // well below MIN_PACKET_SIZE, so every header byte is still present
+    // and deserializeHeader() would succeed; the only thing wrong with
+    // the buffer is its length.
+    //
+    // Without the guard, the subsequent
+    //     fwBuffer.getSize() - Fw::DpContainer::MIN_PACKET_SIZE
+    // is an unsigned subtraction that underflows to ~SIZE_MAX and the
+    // chunking loop walks off the end of the allocation. In a
+    // FW_NO_ASSERT build that manifests as a hang in the oversized
+    // deserializer loop; in an assert-enabled build the DpContainer
+    // constructor's own FW_ASSERT aborts the run. With the guard the
+    // handler returns immediately in both configurations.
+    this->clearHistory();
+    this->component.log_WARNING_HI_InvalidHeader_ThrottleClear();
+
+    paramSet_CHUNK_SIZE(4096, Fw::ParamValid::VALID);
+    paramSet_ENABLE(Fw::Enabled::ENABLED, Fw::ParamValid::VALID);
+    this->component.loadParameters();
+
+    const FwSizeType backing_size = Fw::DpContainer::MIN_PACKET_SIZE + 1;
+    U8* mem = new U8[backing_size]();
+
+    Fw::Buffer backing_buf(mem, backing_size);
+    Fw::DpContainer container(0, backing_buf);
+    container.setDataSize(1);
+    container.serializeHeader();
+
+    // One byte short of the minimum — the case the guard rejects.
+    const FwSizeType short_size = Fw::DpContainer::MIN_PACKET_SIZE - 1;
+    Fw::Buffer short_buf(mem, short_size);
+
+    this->invoke_to_procRequest(0, short_buf);
+
+    // Rejected on size, reporting the size we were handed.
+    ASSERT_EVENTS_InvalidHeader_SIZE(1);
+    ASSERT_EVENTS_InvalidHeader(0, short_size, static_cast<U32>(Fw::FW_DESERIALIZE_SIZE_MISMATCH));
+
+    // Nothing forwarded downstream, no completion claimed.
+    ASSERT_from_compressChunk_SIZE(0);
+    ASSERT_EVENTS_CompressionComplete_SIZE(0);
+
+    // Buffer left untouched.
+    ASSERT_EQ(short_buf.getSize(), short_size);
+
+    delete[] mem;
+}
+
 void DpCompressProcTester::test_chunks_disabled(const FwSizeStoreType chunk_size,
                                                 std::vector<AbstractState::Chunk> chunks) {
     Fw::Buffer container_buf = this->abstractState.build_compress_buffer(chunk_size, chunks);

--- a/Svc/DpCompressProc/test/ut/DpCompressProcTester.cpp
+++ b/Svc/DpCompressProc/test/ut/DpCompressProcTester.cpp
@@ -223,28 +223,10 @@ void DpCompressProcTester::test_chunks_helper(const FwSizeStoreType chunk_size,
 }
 
 void DpCompressProcTester::test_undersized_buffer() {
-    // Every other test here builds a well-formed container via
-    // AbstractState::build_compress_buffer, so none of them reach the
-    // short-buffer branch in procRequest_handler. This drives it.
-    //
-    // Construction: allocate a MIN_PACKET_SIZE + 1 backing array — large
-    // enough that Fw::DpContainer accepts it and can write a well-formed
-    // header with dataSize = 1 — then hand procRequest a *view* of that
-    // same memory whose length is MIN_PACKET_SIZE - 1. Header::SIZE is
-    // well below MIN_PACKET_SIZE, so every header byte is still present
-    // and deserializeHeader() would succeed; the only thing wrong with
-    // the buffer is its length.
-    //
-    // Without the guard, the subsequent
-    //     fwBuffer.getSize() - Fw::DpContainer::MIN_PACKET_SIZE
-    // is an unsigned subtraction that underflows to ~SIZE_MAX and the
-    // chunking loop walks off the end of the allocation. In a
-    // FW_NO_ASSERT build that manifests as a hang in the oversized
-    // deserializer loop; in an assert-enabled build the DpContainer
-    // constructor's own FW_ASSERT aborts the run. With the guard the
-    // handler returns immediately in both configurations.
+    // Hand procRequest a view one byte below MIN_PACKET_SIZE into a larger,
+    // well-formed allocation: every header byte is present, only the length is wrong.
     this->clearHistory();
-    this->component.log_WARNING_HI_InvalidHeader_ThrottleClear();
+    this->component.log_WARNING_HI_BufferTooSmallForPacket_ThrottleClear();
 
     paramSet_CHUNK_SIZE(4096, Fw::ParamValid::VALID);
     paramSet_ENABLE(Fw::Enabled::ENABLED, Fw::ParamValid::VALID);
@@ -258,15 +240,16 @@ void DpCompressProcTester::test_undersized_buffer() {
     container.setDataSize(1);
     container.serializeHeader();
 
-    // One byte short of the minimum — the case the guard rejects.
+    // One byte short of the minimum
     const FwSizeType short_size = Fw::DpContainer::MIN_PACKET_SIZE - 1;
     Fw::Buffer short_buf(mem, short_size);
 
     this->invoke_to_procRequest(0, short_buf);
 
-    // Rejected on size, reporting the size we were handed.
-    ASSERT_EVENTS_InvalidHeader_SIZE(1);
-    ASSERT_EVENTS_InvalidHeader(0, short_size, static_cast<U32>(Fw::FW_DESERIALIZE_SIZE_MISMATCH));
+    // Rejected on size, not mistaken for a header deserialization failure
+    ASSERT_EVENTS_BufferTooSmallForPacket_SIZE(1);
+    ASSERT_EVENTS_BufferTooSmallForPacket(0, short_size, Fw::DpContainer::MIN_PACKET_SIZE);
+    ASSERT_EVENTS_InvalidHeader_SIZE(0);
 
     // Nothing forwarded downstream, no completion claimed.
     ASSERT_from_compressChunk_SIZE(0);

--- a/Svc/DpCompressProc/test/ut/DpCompressProcTester.hpp
+++ b/Svc/DpCompressProc/test/ut/DpCompressProcTester.hpp
@@ -42,6 +42,9 @@ class DpCompressProcTester : public DpCompressProcGTestBase {
 
     void test_chunks_disabled(const FwSizeStoreType chunk_size, std::vector<AbstractState::Chunk> chunks);
 
+    //! Drive procRequest with a buffer shorter than MIN_PACKET_SIZE
+    void test_undersized_buffer();
+
   public:
     // ----------------------------------------------------------------------
     // Tests


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| |

---

## Change Description

`DpCompressProc::procRequest_handler` constructed a `Fw::DpContainer` directly from the port-supplied buffer and then computed:

```cpp
Fw::Buffer data_buffer(fwBuffer.getData() + Fw::DpContainer::DATA_OFFSET,
                       fwBuffer.getSize() - Fw::DpContainer::MIN_PACKET_SIZE);
```

The subtraction is unsigned, and nothing in this handler checked the size first.

This adds an early-return guard before the container is constructed, a dedicated event for the rejection, and an off-nominal unit test.

```diff
+    // Check that the buffer is large enough to hold a data product packet
+    if (fwBuffer.getSize() < Fw::DpContainer::MIN_PACKET_SIZE) {
+        this->log_WARNING_HI_BufferTooSmallForPacket(fwBuffer.getSize(), Fw::DpContainer::MIN_PACKET_SIZE);
+        return;
+    }
     Fw::DpContainer container(0, fwBuffer);
```

**New event.** `BufferTooSmallForPacket(buffer_size, min_size)`, `warning high`, `throttle 10`, appended as id 3 so the existing event ids are unchanged. It is named and shaped after the event [`Svc/DpWriter`](https://github.com/nasa/fprime/blob/devel/Svc/DpWriter/DpWriter.fpp#L72) already raises for this identical `< MIN_PACKET_SIZE` check on the calling side — DpCompressProc appears to have been derived from DpWriter and inherited its `InvalidHeader` without the other half of the pair. `InvalidHeader` keeps its own meaning, so the two rejections are distinguishable in downlinked telemetry.

Two small departures from DpWriter, both to match this file rather than that one: snake_case argument names to match `InvalidHeader` directly above, and `FwSizeType` for `min_size` rather than DpWriter's `U32`, since `MIN_PACKET_SIZE` is declared `FwSizeType` and it avoids a cast.

`docs/sdd.md` gains rows for this event and for `InvalidHeader`, which was already missing from that table.

## Rationale

The invariant `getSize() >= MIN_PACKET_SIZE` was enforced only by [`FW_ASSERT` inside `Fw::DpContainer::setBuffer`](https://github.com/nasa/fprime/blob/devel/Fw/Dp/DpContainer.cpp#L128) — a different translation unit from where it is relied on here. With assertions compiled out, a buffer of size in `[Header::SIZE, MIN_PACKET_SIZE)` passes `setBuffer` silently, `deserializeHeader()` succeeds because the header bytes are all present, and the subtraction underflows to near `SIZE_MAX`. `data_buffer` is then constructed with an astronomically large size, and the loop at line 121 walks off the end of the real allocation.

Independently of assert level, this consumer depends structurally on an invariant enforced in another file. A future widening of `MIN_PACKET_SIZE` or a refactor of `setBuffer` could break it with no diff to `DpCompressProc.cpp`. `Svc/DpWriter` already performs this same check locally for the same reason.

## Testing/Review Recommendations

`fprime-util check Svc/DpCompressProc` — 10/10 pass (9 existing plus the new off-nominal case).

`DpCompressProcTester::test_undersized_buffer` allocates a `MIN_PACKET_SIZE + 1` backing array, writes a well-formed header with `dataSize = 1`, then hands `procRequest` a view of that same memory sized `MIN_PACKET_SIZE - 1`. `Header::SIZE` is well below `MIN_PACKET_SIZE`, so every header byte is present and the only defect is the length — which is what makes this the interesting case rather than a malformed-header test. It asserts `BufferTooSmallForPacket` once with both arguments, `InvalidHeader` zero times, zero `compressChunk` calls, zero completion events, and an unchanged buffer size.

Negative control: removing only the guard aborts the suite; restoring it returns 10/10. Under `FW_NO_ASSERT` the same removal instead hangs in the oversized deserializer loop (reproduced by @lntutor).

Event ids confirmed against the generated component base:

```
EVENTID_COMPRESSIONCOMPLETE     = 0x0
EVENTID_DIDNOTCOMPRESS          = 0x1
EVENTID_INVALIDHEADER           = 0x2
EVENTID_BUFFERTOOSMALLFORPACKET = 0x3
```

## Future Work

The new event carries `throttle 10` to match `InvalidHeader` and `DidNotCompress`, but this component declares no commands, so there is no `CLEAR_EVENT_THROTTLE` to reset it. That is the existing behaviour of both current events rather than a regression, but adding a command felt out of scope here.

A requirement row for the new behaviour (`SVC-DPCOMPRESSPROC-004`) could be added to `docs/sdd.md` if wanted; left out to keep the change small.

## Same shape as the previously-merged #5262

[nasa/fprime#5262](https://github.com/nasa/fprime/pull/5262) (`FileUplink::File::open`, merged June 2026) hardened an identical shape: a `memcpy` whose size relied on a `U8` narrowing in a different translation unit. Upstream defenses that live in another file are load-bearing but invisible when reading this one; a local check makes the invariant surface where the arithmetic happens.

## Provenance

Surfaced by the v0.16 scj-hunt `/scan` verb, a geometric anomaly detector run over a fiber bundle of 2959 functions from `Svc/`. `procRequest_handler` ranked #2 of 148 flagged rows. The finding was then read, reproduced and tested by hand before filing.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- -->
