### PR TITLE
Fix undefined behavior in FpySequencer op_mul overflow guard

### DIFF
--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -751,8 +751,8 @@ DirectiveError FpySequencer::op_mul() {
     if ((rhs > 0) && (lhs > 0) && ((std::numeric_limits<I64>::max() / rhs) < lhs)) {
         return DirectiveError::ARITHMETIC_OVERFLOW;
     }
-    // Check the both negative case
-    else if ((rhs < 0) && (lhs < 0) && ((std::numeric_limits<I64>::max() / (-1 * rhs)) < (-1 * lhs))) {
+    // Check the both negative case. Compare without negation: negating a value of min is undefined behavior
+    else if ((rhs < 0) && (lhs < 0) && (lhs < (std::numeric_limits<I64>::max() / rhs))) {
         return DirectiveError::ARITHMETIC_OVERFLOW;
     }
     // Underflow can occur with operands of differing signs and occurs when one operand is less than the minimum value

--- a/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
+++ b/Svc/FpySequencer/test/ut/FpySequencerTestMain.cpp
@@ -1210,6 +1210,51 @@ TEST_F(FpySequencerTester, mul_overflow_neg_neg) {
     tester_push<I64>(-3);
     ASSERT_EQ(tester_op_mul(), DirectiveError::ARITHMETIC_OVERFLOW);
 }
+// I64 min has no positive counterpart, so any negation-based guard misses these cases
+TEST_F(FpySequencerTester, mul_overflow_min_neg_one) {
+    tester_push<I64>(std::numeric_limits<I64>::min());
+    tester_push<I64>(-1);
+    ASSERT_EQ(tester_op_mul(), DirectiveError::ARITHMETIC_OVERFLOW);
+}
+TEST_F(FpySequencerTester, mul_overflow_neg_one_min) {
+    tester_push<I64>(-1);
+    tester_push<I64>(std::numeric_limits<I64>::min());
+    ASSERT_EQ(tester_op_mul(), DirectiveError::ARITHMETIC_OVERFLOW);
+}
+TEST_F(FpySequencerTester, mul_overflow_min_neg_two) {
+    tester_push<I64>(std::numeric_limits<I64>::min());
+    tester_push<I64>(-2);
+    ASSERT_EQ(tester_op_mul(), DirectiveError::ARITHMETIC_OVERFLOW);
+}
+TEST_F(FpySequencerTester, mul_overflow_neg_two_min) {
+    tester_push<I64>(-2);
+    tester_push<I64>(std::numeric_limits<I64>::min());
+    ASSERT_EQ(tester_op_mul(), DirectiveError::ARITHMETIC_OVERFLOW);
+}
+TEST_F(FpySequencerTester, mul_overflow_min_min) {
+    tester_push<I64>(std::numeric_limits<I64>::min());
+    tester_push<I64>(std::numeric_limits<I64>::min());
+    ASSERT_EQ(tester_op_mul(), DirectiveError::ARITHMETIC_OVERFLOW);
+}
+TEST_F(FpySequencerTester, mul_neg_neg_boundary_ok) {
+    // (-3037000499)^2 = 9223372030926249001, the largest both-negative square within I64 max
+    tester_push<I64>(-3037000499LL);
+    tester_push<I64>(-3037000499LL);
+    ASSERT_EQ(tester_op_mul(), DirectiveError::NO_ERROR);
+    ASSERT_EQ(tester_pop<I64>(), 9223372030926249001LL);
+}
+TEST_F(FpySequencerTester, mul_neg_neg_boundary_overflow) {
+    // (-3037000500)^2 = 9223372037000250000, just above I64 max
+    tester_push<I64>(-3037000500LL);
+    tester_push<I64>(-3037000500LL);
+    ASSERT_EQ(tester_op_mul(), DirectiveError::ARITHMETIC_OVERFLOW);
+}
+TEST_F(FpySequencerTester, mul_neg_one_neg_one) {
+    tester_push<I64>(-1);
+    tester_push<I64>(-1);
+    ASSERT_EQ(tester_op_mul(), DirectiveError::NO_ERROR);
+    ASSERT_EQ(tester_pop<I64>(), 1);
+}
 TEST_F(FpySequencerTester, mul_underflow_neg_pos) {
     // lhs negative, rhs positive
     tester_push<I64>(std::numeric_limits<I64>::min());


### PR DESCRIPTION
|                                                         |                                |
| :------------------------------------------------------ | :----------------------------- |
| **_Related Issue(s)_**                                  | Fixes fprime-community/fpy#128 |
| **_Has Unit Tests (y/n)_**                              | y                              |
| **_Documentation Included (y/n)_**                      | n                              |
| **_Generative AI was used in this contribution (y/n)_** | y                              |

---

## Change Description

The both-negative overflow check in `op_mul` negated its operands via `-1 * rhs` and `-1 * lhs`. Negating `I64` min is undefined behavior, so the guard missed the overflow and pushed a silently wrapped product (`I64_MIN * -2` pushed `0`). The check is now `lhs < std::numeric_limits<I64>::max() / rhs`, which evaluates no negation and is algebraically identical to the fpy model's reference guard. Tests add the issue's vectors in both operand orders plus boundary tightness checks.

## Rationale

A flight sequence VM must not contain arithmetic undefined behavior: results were operand order dependent, varied with compiler flags (aborting outright under `-ftrapv`), and diverged from the ground model, which traps correctly on all of these cases.

## Testing/Review Recommendations

Run `fprime-util check` in `Svc/FpySequencer`; the new tests fail on the previous guard and the UBSan build flags the negation. The fix was also differentially verified against `__int128` ground truth and the fpy model guard over millions of vectors with zero mismatches.

## Future Work

fpy#127 (`op_sdiv` rounding) will be proposed separately.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI assisted (Claude Code): defect analysis, the guard rewrite, unit tests, and verification harnesses. All changes reviewed by the submitter, who takes responsibility for every line.
