### PR TITLE
Fix type-limits warning in Svc/Ccsds/TestUtils/TestUtils.cpp

### DIFF
--- a/Svc/Ccsds/TestUtils/TestUtils.cpp
+++ b/Svc/Ccsds/TestUtils/TestUtils.cpp
@@ -27,7 +27,9 @@ ApidOption getRandomApid() {
     // selected index, or we run out of numbers
     SerialType idx = 0;
     SerialType apid = 0;
-    for (SerialType candidateApid = 0; candidateApid <= bound; candidateApid++) {
+    // If bound is the type max then text candidate <= bound causes a type-limits warning
+    // So bound is checked within in the loop
+    for (SerialType candidateApid = 0; bound > 0; candidateApid++) {
         if (ComCfg::Apid::isValid(candidateApid)) {
             // Found a valid APID: store it
             apid = candidateApid;
@@ -40,6 +42,11 @@ ApidOption getRandomApid() {
             // if we run off the end of the 11-bit range
             idx++;
         }
+        // If bound is the type max, its value must be checked before incrementing
+        if (candidateApid == bound) {
+            break;
+        }
+        FW_ASSERT(candidateApid < bound, bound, candidateApid);
     }
     // If the APID we found is not valid, then return NONE
     // This can happen if all of the configured APIDs are out of the 11-bit range

--- a/Svc/Ccsds/TestUtils/TestUtils.cpp
+++ b/Svc/Ccsds/TestUtils/TestUtils.cpp
@@ -27,9 +27,9 @@ ApidOption getRandomApid() {
     // selected index, or we run out of numbers
     SerialType idx = 0;
     SerialType apid = 0;
-    // If bound is the type max then text candidate <= bound causes a type-limits warning
-    // So bound is checked within in the loop
-    for (SerialType candidateApid = 0; bound > 0; candidateApid++) {
+    // Break the loop checking into two operations so that g++ can't report a Wtype-limits warning
+    // when bound is the type max (since neither individual check is always true, but <= would be)
+    for (SerialType candidateApid = 0; candidateApid < bound || candidateApid == bound; candidateApid++) {
         if (ComCfg::Apid::isValid(candidateApid)) {
             // Found a valid APID: store it
             apid = candidateApid;
@@ -42,11 +42,6 @@ ApidOption getRandomApid() {
             // if we run off the end of the 11-bit range
             idx++;
         }
-        // If bound is the type max, its value must be checked before incrementing
-        if (candidateApid == bound) {
-            break;
-        }
-        FW_ASSERT(candidateApid < bound, bound, candidateApid);
     }
     // If the APID we found is not valid, then return NONE
     // This can happen if all of the configured APIDs are out of the 11-bit range


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| No  |
|**_Has Unit Tests (y/n)_**| Yes |
|**_Documentation Included (y/n)_**| N/A  |
|**_Generative AI was used in this contribution (y/n)_**|  y |

---
## Change Description

The flags we're using when compiling unit tests generate an warning message (treated as an error) when compiling Svc/Ccsds/TestUtils/TestUtils.cpp - so the loop was modified 
```
/workspaces/<project>/lib/fprime/Svc/Ccsds/TestUtils/TestUtils.cpp:30:54: error: comparison is always true due to limited range of data type [-Werror=type-limits]
     for (SerialType candidateApid = 0; candidateApid <= bound; candidateApid++) {
                                        ~~~~~~~~~~~~~~^~~~~~~~
```

## Rationale

Our project uses U8 integers for APID (because we're not using CCSDS) and the maximum APID value is 0xFF , so a type-limits is generated when Svc/Ccsds/TestUtils/TestUtils.cpp is compiled (which it is when `fprime-utils build --ut` is run, despite `FPRIME_ENABLE_FRAMEWORK_UTS=OFF` being in settings.ini)
```

-Wtype-limits

    Warn if a comparison is always true or always false due to the limited range of the data type, but do not warn for constant expressions. For example, warn if an unsigned variable is compared against zero with < or >=. This warning is also enabled by -Wextra.
```


## Testing/Review Recommendations

Compile UTs & verify they pass 

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Code review / spelling 