### PR TITLE
test: cover enum SerialType construction and assignment

### DIFF
--- a/FppTestProject/FppTest/typed_tests/EnumTest.hpp
+++ b/FppTestProject/FppTest/typed_tests/EnumTest.hpp
@@ -83,14 +83,24 @@ TYPED_TEST_P(EnumTest, Default) {
 // Test enum constructors
 TYPED_TEST_P(EnumTest, Constructors) {
     typename TypeParam::T validVal = FppTest::Enum::getValidValue<TypeParam>();
+    typename TypeParam::SerialType serialVal = static_cast<typename TypeParam::SerialType>(validVal);
+    typename TypeParam::SerialType invalidSerialVal =
+        static_cast<typename TypeParam::SerialType>(FppTest::Enum::getInvalidValue<TypeParam>());
 
     // Raw enum value constructor
     TypeParam e1(validVal);
     ASSERT_EQ(e1.e, validVal);
 
-    // Copy constructor
-    TypeParam e2(e1);
+    // Serial representation value constructor
+    TypeParam e2(serialVal);
     ASSERT_EQ(e2.e, validVal);
+
+    // Copy constructor
+    TypeParam e3(e1);
+    ASSERT_EQ(e3.e, validVal);
+
+    // Invalid serial representation value constructor
+    ASSERT_DEATH_IF_SUPPORTED(static_cast<void>(TypeParam{invalidSerialVal}), "");
 }
 
 // Test enum assignment operator
@@ -99,14 +109,24 @@ TYPED_TEST_P(EnumTest, AssignmentOp) {
     TypeParam e2;
 
     typename TypeParam::T validVal = FppTest::Enum::getValidValue<TypeParam>();
+    typename TypeParam::SerialType serialVal = static_cast<typename TypeParam::SerialType>(validVal);
+    typename TypeParam::SerialType invalidSerialVal =
+        static_cast<typename TypeParam::SerialType>(FppTest::Enum::getInvalidValue<TypeParam>());
 
     // Raw enum value assignment
     e1 = validVal;
     ASSERT_EQ(e1.e, validVal);
 
+    // Serial representation value assignment
+    e1 = serialVal;
+    ASSERT_EQ(e1.e, validVal);
+
     // Object assignment
     e2 = e1;
     ASSERT_EQ(e2.e, validVal);
+
+    // Invalid serial representation value assignment
+    ASSERT_DEATH_IF_SUPPORTED(e1 = invalidSerialVal, "");
 }
 
 // Test enum equality and inequality operator


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fpp#1052, nasa/fpp#1045 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Extend the existing typed FppTest enum suite with coverage for generated enum construction and assignment from SerialType values. The tests exercise valid and invalid serialized values across all eight existing enum variants.

## Rationale

This is companion F´ integration coverage for nasa/fpp#1045, requested during maintainer review. It verifies that generated enums accept their serialized representation while preserving the existing validity assertion behavior.

## Testing/Review Recommendations

- Released fprime-fpp 3.3.0a12: focused enum build fails at the new SerialType constructor and assignment expressions, establishing the pre-change behavior.
- Tools built from nasa/fpp#1045: focused enum suite passes all 55 GoogleTests and its CTest target.
- Full FppTest project build completed successfully, including 1,994 additional Ninja actions after the focused build.
- Full serial check passes 135/135 CTest tests.

This branch depends on an FPP release containing nasa/fpp#1045; CI using the current released FPP is expected to remain blocked until that dependency is updated.

## Future Work

Update the FPrime FPP dependency to the maintainer-published release containing nasa/fpp#1045 before merge.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Generative AI assisted with test implementation, command execution, verification, and pull request preparation under human direction. The contributor reviewed the resulting diff and evidence.

IAMAI