### PR TITLE
split Verson's config function so events and tlm can be sent later in the startup process

### DIFF
--- a/Svc/Subtopologies/CdhCore/CdhCore.fpp
+++ b/Svc/Subtopologies/CdhCore/CdhCore.fpp
@@ -42,6 +42,10 @@ module CdhCore {
         // Startup TLM and Config verbosity for Versions
         CdhCore::version.config(true);
         """
+        phase Fpp.ToCpp.Phases.startTasks """
+        // Startup TLM and EVENTS
+        CdhCore::version.start();
+        """
     }
 
     instance textLogger: Svc.PassiveTextLogger base id CdhCoreConfig.BASE_ID + 0x004000

--- a/Svc/Subtopologies/CdhCore/docs/sdd.md
+++ b/Svc/Subtopologies/CdhCore/docs/sdd.md
@@ -35,7 +35,7 @@ The **CdhCore subtopology** provides a reusable bundle of the core flight-softwa
 ### 2.2 Configuration Hooks inside the Subtopology
 
 * **Health**: Configures `$health` with a ping table (`ConfigObjects.CdhCore_health::pingEntries`).
-* **Version**: Calls `version.config(true)` so version/config reporting is enabled at startup.
+* **Version**: Calls `version.config(true)` so version/config reporting is enabled at startup. Calls `version.start()` to send initial version events and telemetry. 
 
 ### 2.3 Internal Wiring
 

--- a/Svc/Version/Version.cpp
+++ b/Svc/Version/Version.cpp
@@ -34,7 +34,7 @@ void Version::config(bool enable) {
 }
 
 void Version::start() {
-    // Semd startup TLM and EVENTS
+    // Send startup TLM and EVENTS
     this->fwVersion_tlm();
     this->projectVersion_tlm();
     this->libraryVersion_tlm();

--- a/Svc/Version/Version.cpp
+++ b/Svc/Version/Version.cpp
@@ -31,8 +31,10 @@ Version ::~Version() {}
 void Version::config(bool enable) {
     // Set Verbosity for custom versions
     this->m_enable = enable;
+}
 
-    // Setup and send startup TLM
+void Version::start() {
+    // Semd startup TLM and EVENTS
     this->fwVersion_tlm();
     this->projectVersion_tlm();
     this->libraryVersion_tlm();

--- a/Svc/Version/Version.hpp
+++ b/Svc/Version/Version.hpp
@@ -24,8 +24,11 @@ class Version final : public VersionComponentBase {
     //! Destroy Version object
     ~Version();
 
-    //! configure version's verbosity and startup
+    //! configure version's verbosity
     void config(bool enable);
+
+    //! send initial version tlm and events
+    void start();
 
   private:
     // ----------------------------------------------------------------------

--- a/Svc/Version/docs/sdd.md
+++ b/Svc/Version/docs/sdd.md
@@ -24,9 +24,10 @@ Tracks versions for framework,project, libraries and user defined project specif
 
 ## Emitting Versions on Start-Up
 
-The version component can emit versions on startup by calling `version.config(true);` during component configuration.
+The version component can emit versions on startup by calling `version.start();` during start tasks.
 
 ## Change Log
 | Date | Description |
 |---|---|
 |---| Initial Draft |
+| 07/30/26 | Added `start()` information |

--- a/Svc/Version/test/ut/VersionTester.cpp
+++ b/Svc/Version/test/ut/VersionTester.cpp
@@ -61,18 +61,17 @@ void VersionTester ::test_startup() {
     this->component.config(true);
     ASSERT_TLM_FrameworkVersion_SIZE(0);
     this->component.start();
-    
+
     ASSERT_TLM_FrameworkVersion(0, Project::Version::FRAMEWORK_VERSION);
     ASSERT_TLM_ProjectVersion(0, Project::Version::PROJECT_VERSION);
     ASSERT_EVENTS_FrameworkVersion_SIZE(1);
     ASSERT_EVENTS_FrameworkVersion(0, Project::Version::FRAMEWORK_VERSION);
     ASSERT_EVENTS_ProjectVersion_SIZE(1);
-    ASSERT_EVENTS_ProjectVersion(0, Project::Version::FRAMEWORK_VERSION);
+    ASSERT_EVENTS_ProjectVersion(0, Project::Version::PROJECT_VERSION);
     // Library versions currently set to a null pointer
     // TODO: Need to figure out how to put in artificial sets to test them
     ASSERT_EVENTS_LibraryVersions_SIZE(12);
     ASSERT_EVENTS_LibraryVersions(0, "blah0 @ blah0");
-    
 }
 
 // ----------------------------------------------------------------------
@@ -129,9 +128,9 @@ void VersionTester ::test_versions() {
     this->sendCmd_VERSION(0, cmd_seq, Svc::VersionType::PROJECT);
     ASSERT_CMD_RESPONSE(0, 1, 9, Fw::CmdResponse::OK);
     ASSERT_TLM_ProjectVersion_SIZE(1);
-    ASSERT_TLM_ProjectVersion(0, Project::Version::FRAMEWORK_VERSION);
+    ASSERT_TLM_ProjectVersion(0, Project::Version::PROJECT_VERSION);
     ASSERT_EVENTS_ProjectVersion_SIZE(1);
-    ASSERT_EVENTS_ProjectVersion(0, Project::Version::FRAMEWORK_VERSION);
+    ASSERT_EVENTS_ProjectVersion(0, Project::Version::PROJECT_VERSION);
 
     this->clear_all();
     this->sendCmd_VERSION(0, cmd_seq, Svc::VersionType::LIBRARY);
@@ -224,7 +223,7 @@ void VersionTester ::test_versions() {
     ASSERT_EVENTS_FrameworkVersion_SIZE(1);
     ASSERT_EVENTS_FrameworkVersion(0, Project::Version::FRAMEWORK_VERSION);
     ASSERT_EVENTS_ProjectVersion_SIZE(1);
-    ASSERT_EVENTS_ProjectVersion(0, Project::Version::FRAMEWORK_VERSION);
+    ASSERT_EVENTS_ProjectVersion(0, Project::Version::PROJECT_VERSION);
     ASSERT_EVENTS_CustomVersions_SIZE(10);
     ASSERT_EVENTS_LibraryVersions_SIZE(12);
 }

--- a/Svc/Version/test/ut/VersionTester.cpp
+++ b/Svc/Version/test/ut/VersionTester.cpp
@@ -58,11 +58,10 @@ void VersionTester ::clear_all() {
 // Test STARTUP
 // ----------------------------------------------------------------------
 void VersionTester ::test_startup() {
-    // this->invoke_to_run(0,0); //No longer running version on a scheduler but invoked after startTasks() in
-    // RefTopology.cpp ASSERT_EVENTS_STARTUP_EVR_SIZE(1);
-    // ASSERT_EVENTS_STARTUP_EVR(0,Project::Version::FRAMEWORK_VERSION,Project::Version::PROJECT_VERSION);
     this->component.config(true);
-    /*
+    ASSERT_TLM_FrameworkVersion_SIZE(0);
+    this->component.start();
+    
     ASSERT_TLM_FrameworkVersion(0, Project::Version::FRAMEWORK_VERSION);
     ASSERT_TLM_ProjectVersion(0, Project::Version::PROJECT_VERSION);
     ASSERT_EVENTS_FrameworkVersion_SIZE(1);
@@ -73,7 +72,7 @@ void VersionTester ::test_startup() {
     // TODO: Need to figure out how to put in artificial sets to test them
     ASSERT_EVENTS_LibraryVersions_SIZE(12);
     ASSERT_EVENTS_LibraryVersions(0, "blah0 @ blah0");
-    */
+    
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/Version/test/ut/version.cpp
+++ b/Svc/Version/test/ut/version.cpp
@@ -7,7 +7,7 @@
 namespace Project {
 
 const char* const Version::FRAMEWORK_VERSION = "v3.4.3-107-gf80da30ba";
-const char* const Version::PROJECT_VERSION = "v3.4.3-107-gf80da30ba";
+const char* const Version::PROJECT_VERSION = "v3.4.4-107-gf80da30ba";
 const FwIndexType Version::LIBRARY_VERSIONS_COUNT = 12;
 const char* const Version::LIBRARY_VERSIONS[] = {
     "blah0 @ blah0", "blah1 @ blah1", "blah2 @ blah2", "blah3 @ blah3", "blah4 @ blah4",   "blah5 @ blah5",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

Deployments that require topology to be configured before `time` can be used could not use CdhCore subtopology because Version's config function sent events and telemetry. Sending events and telemetry involves a time call.

## Rationale

This PR splits Version's config function in to `config()`, which is called in `configComponents` and `start()`, which can be called later in the startup process to output events and tlm, `startTasks` in this case

## Testing/Review Recommendations

Tested on pfsoc video kit hardware

## Future Work


## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

