### PR TITLE
remove platform restriction

### DIFF
--- a/Svc/BufferAccumulator/BufferAccumulator.cpp
+++ b/Svc/BufferAccumulator/BufferAccumulator.cpp
@@ -12,8 +12,6 @@
 
 #include "Svc/BufferAccumulator/BufferAccumulator.hpp"
 
-#include <sys/time.h>
-
 #include <limits>
 #include "Fw/Types/BasicTypes.hpp"
 

--- a/Svc/BufferAccumulator/CMakeLists.txt
+++ b/Svc/BufferAccumulator/CMakeLists.txt
@@ -6,8 +6,6 @@
 #
 # Note: using PROJECT_NAME as EXECUTABLE_NAME
 ####
-restrict_platforms(Linux Darwin) # Uses sys/time
-
 
 register_fprime_module(
   AUTOCODER_INPUTS


### PR DESCRIPTION

| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

Removed platform restriction from BufferAccumulator

## Rationale

BufferAccumulator was added to the DataProducts subtopology, but meant that that subtop was restricted to Linux and Darwin because BufferAccumulator included `#include <sys/time.h>` but that include is now unused. 

## Testing/Review Recommendations

Tested on pfsoc video kit running VxWorks

## Future Work



## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))


