### PR TITLE
Backport: Fix directory detection bug in Os::FileSystem::getPathType (#3727)

### DIFF
--- a/Os/FileSystem.cpp
+++ b/Os/FileSystem.cpp
@@ -40,6 +40,12 @@ FileSystem::Status FileSystem::_rename(const char* sourcePath, const char* destP
     return this->m_delegate._rename(sourcePath, destPath);
 }
 
+FileSystem::Status FileSystem::_getPathType(const char* path, PathType& pathType) {
+    FW_ASSERT(&this->m_delegate == reinterpret_cast<FileSystemInterface*>(&this->m_handle_storage[0]));
+    FW_ASSERT(path != nullptr);
+    return this->m_delegate._getPathType(path, pathType);
+}
+
 FileSystem::Status FileSystem::_getWorkingDirectory(char* path, FwSizeType bufferSize) {
     FW_ASSERT(&this->m_delegate == reinterpret_cast<FileSystemInterface*>(&this->m_handle_storage[0]));
     FW_ASSERT(path != nullptr);
@@ -131,20 +137,13 @@ FileSystem::Status FileSystem::touch(const char* path) {
 
 FileSystem::PathType FileSystem::getPathType(const char* path) {
     FW_ASSERT(path != nullptr);
-    Os::File file;
-    File::Status file_status = file.open(path, Os::File::OPEN_READ);
-    file.close();
-    if (file_status == File::OP_OK) {
-        return PathType::FILE;
+    PathType pathType;
+    Status status = getSingleton()._getPathType(path, pathType);
+    if (status != Status::OP_OK) {
+        return PathType::NOT_EXIST;
     }
-    Os::Directory dir;
-    Directory::Status dir_status = dir.open(path, Os::Directory::OpenMode::READ);
-    dir.close();
-    if (dir_status == Directory::Status::OP_OK) {
-        return PathType::DIRECTORY;
-    }
-    return PathType::NOT_EXIST;
-} // end getPathType
+    return pathType;
+}  // end getPathType
 
 bool FileSystem::exists(const char* path) {
     return FileSystem::getPathType(path) != PathType::NOT_EXIST;

--- a/Os/FileSystem.hpp
+++ b/Os/FileSystem.hpp
@@ -44,6 +44,7 @@ class FileSystemInterface {
     enum PathType {
         FILE,      //!< Path is a file
         DIRECTORY, //!< Path is a directory
+        OTHER,     //!< Path is not a file or directory, e.g. a socket
         NOT_EXIST, //!< Path does not exist
     };
 
@@ -95,6 +96,15 @@ class FileSystemInterface {
     //! \param freeBytes Reference to store the free bytes on the filesystem
     //! \return Status of the operation
     virtual Status _getFreeSpace(const char* path, FwSizeType& totalBytes, FwSizeType& freeBytes) = 0;
+
+    //! \brief Get the type of the path (file, directory, etc.)
+    //!
+    //! It is invalid to pass `nullptr` as the path.
+    //!
+    //! \param path The path to check
+    //! \param pathType Reference to store the path type
+    //! \return Status of the operation
+    virtual Status _getPathType(const char* path, PathType& pathType) = 0;
 
     //! \brief Get the current working directory
     //! \param path Buffer to store the current working directory path
@@ -187,6 +197,15 @@ class FileSystem final : public FileSystemInterface {
     //! \param path The path of the new working directory
     //! \return Status of the operation
     Status _changeWorkingDirectory(const char* path) override;
+
+    //! \brief Get the type of the path (file, directory, etc.)
+    //!
+    //! It is invalid to pass `nullptr` as the path.
+    //!
+    //! \param path The path to check
+    //! \param pathType Reference to store the path type
+    //! \return Status of the operation
+    Status _getPathType(const char* path, PathType& pathType) override;
 
 
     // ------------------------------------------------------------

--- a/Os/Posix/FileSystem.cpp
+++ b/Os/Posix/FileSystem.cpp
@@ -97,6 +97,24 @@ FileSystemHandle* PosixFileSystem::getHandle() {
     return &this->m_handle;
 }
 
+PosixFileSystem::Status PosixFileSystem::_getPathType(const char* path, PathType& pathType) {
+    FW_ASSERT(path != nullptr);
+    struct stat path_stat;
+    const I32 status = lstat(path, &path_stat);
+    if (status == 0) {
+        if (S_ISDIR(path_stat.st_mode)) {
+            pathType = PathType::DIRECTORY;
+        } else if (S_ISREG(path_stat.st_mode)) {
+            pathType = PathType::FILE;
+        } else {
+            pathType = PathType::OTHER;
+        }
+        return Status::OP_OK;
+    } else {
+        return errno_to_filesystem_status(errno);
+    }
+}
+
 }  // namespace FileSystem
 }  // namespace Posix
 }  // namespace Os

--- a/Os/Posix/FileSystem.hpp
+++ b/Os/Posix/FileSystem.hpp
@@ -96,6 +96,14 @@ class PosixFileSystem : public FileSystemInterface {
     //! \return raw fileSystem handle
     FileSystemHandle* getHandle() override;
 
+    //! \brief Get the type of the path (file, directory, etc.)
+    //!
+    //! It is invalid to pass `nullptr` as the path.
+    //!
+    //! \param path The path to check
+    //! \return PathType of the path
+    Status _getPathType(const char* path, PathType& pathType) override;
+
   private:
     //! FileSystem handle for PosixFileSystem
     PosixFileSystemHandle m_handle;

--- a/Os/Posix/test/ut/PosixFileSystemTests.cpp
+++ b/Os/Posix/test/ut/PosixFileSystemTests.cpp
@@ -14,7 +14,76 @@
 // Posix Test Cases
 // ----------------------------------------------------------------------
 
-// All tests are inherited from the common tests in CommonTests.hpp
+// POSIX-specific test class
+class PosixFileSystemTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Create a test directory
+        m_test_dir = "posix_test_dir";
+        Os::FileSystem::createDirectory(m_test_dir.c_str());
+    }
+
+    void TearDown() override {
+        // Clean up test directory
+        Os::FileSystem::removeDirectory(m_test_dir.c_str());
+    }
+
+    std::string m_test_dir;
+};
+
+// Test POSIX-specific path types (FIFO, symlinks, etc.)
+TEST_F(PosixFileSystemTest, DetectSpecialPathTypes) {
+    // Test directory detection
+    Os::FileSystem::PathType dirType = Os::FileSystem::getSingleton().getPathType(m_test_dir.c_str());
+    ASSERT_EQ(dirType, Os::FileSystem::PathType::DIRECTORY) << "Failed to detect directory: " << m_test_dir;
+
+    // Create a test file
+    std::string testFile = m_test_dir + "/test_file.txt";
+    ASSERT_EQ(Os::FileSystem::touch(testFile.c_str()), Os::FileSystem::Status::OP_OK) << "Failed to create test file";
+
+    // Test file detection
+    Os::FileSystem::PathType fileType = Os::FileSystem::getSingleton().getPathType(testFile.c_str());
+    ASSERT_EQ(fileType, Os::FileSystem::PathType::FILE) << "Failed to detect file: " << testFile;
+
+    // Test nonexistent path
+    std::string nonExistentPath = "non_existent_path";
+    Os::FileSystem::PathType nonExistentType = Os::FileSystem::getSingleton().getPathType(nonExistentPath.c_str());
+    ASSERT_EQ(nonExistentType, Os::FileSystem::PathType::NOT_EXIST) << "Failed to detect nonexistent path";
+
+    // Clean up test file
+    ASSERT_EQ(Os::FileSystem::removeFile(testFile.c_str()), Os::FileSystem::Status::OP_OK) << "Failed to remove test file";
+
+    // Test FIFO (named pipe)
+    std::string fifoPath = m_test_dir + "/test_fifo";
+    ASSERT_EQ(mkfifo(fifoPath.c_str(), 0666), 0) << "Failed to create FIFO";
+    
+    Os::FileSystem::PathType fifoType = Os::FileSystem::getPathType(fifoPath.c_str());
+    ASSERT_EQ(fifoType, Os::FileSystem::PathType::OTHER) << "Failed to detect FIFO as OTHER type";
+    
+    // Clean up FIFO
+    ASSERT_EQ(unlink(fifoPath.c_str()), 0) << "Failed to remove FIFO";
+
+    // Test directory vs file with similar names
+    std::string subdirPath = m_test_dir + "/test_subdir";
+    ASSERT_EQ(Os::FileSystem::createDirectory(subdirPath.c_str()), Os::FileSystem::Status::OP_OK)
+        << "Failed to create test subdirectory";
+
+    // Create a file with the same name as the directory plus extension
+    ASSERT_EQ(Os::FileSystem::touch((subdirPath + ".txt").c_str()), Os::FileSystem::Status::OP_OK)
+        << "Failed to create test file";
+
+    // Verify directory detection
+    ASSERT_EQ(Os::FileSystem::getPathType(subdirPath.c_str()), Os::FileSystem::PathType::DIRECTORY)
+        << "Failed to detect directory with file in same path";
+
+    // Verify file detection
+    ASSERT_EQ(Os::FileSystem::getPathType((subdirPath + ".txt").c_str()), Os::FileSystem::PathType::FILE)
+        << "Failed to detect file with directory in same path";
+
+    // Clean up subdirectory
+    ASSERT_EQ(Os::FileSystem::removeDirectory(subdirPath.c_str()), Os::FileSystem::Status::OP_OK)
+        << "Failed to remove test directory";
+}
 
 int main(int argc, char** argv) {
     STest::Random::seed();

--- a/Os/Stub/FileSystem.cpp
+++ b/Os/Stub/FileSystem.cpp
@@ -36,6 +36,10 @@ FileSystemHandle* StubFileSystem::getHandle() {
     return &this->m_handle;
 }
 
-} // namespace File
+StubFileSystem::Status StubFileSystem::_getPathType(const char* path, PathType& pathType) {
+    return Status::NOT_SUPPORTED;
+}
+
+} // namespace FileSystem
 } // namespace Stub
 } // namespace Os

--- a/Os/Stub/FileSystem.hpp
+++ b/Os/Stub/FileSystem.hpp
@@ -100,8 +100,16 @@ class StubFileSystem : public FileSystemInterface {
     //!
     FileSystemHandle *getHandle() override;
 
+    //! \brief Get the type of the path (file, directory, etc.)
+    //!
+    //! It is invalid to pass `nullptr` as the path.
+    //!
+    //! \param path The path to check
+    //! \param pathType Reference to store the path type
+    //! \return Status of the operation
+    Status _getPathType(const char* path, PathType& pathType) override;
 
-private:
+  private:
     //! FileSystem handle for PosixFileSystem
     StubFileSystemHandle m_handle;
 };

--- a/Os/Stub/test/FileSystem.cpp
+++ b/Os/Stub/test/FileSystem.cpp
@@ -51,13 +51,18 @@ TestFileSystem::Status TestFileSystem::_getFreeSpace(const char* path, FwSizeTyp
     return Status::OP_OK;
 }
 
-Os::FileSystemHandle *TestFileSystem::getHandle() {
+Os::FileSystemHandle* TestFileSystem::getHandle() {
     StaticData::data.lastCalled = StaticData::LastFn::GET_HANDLE_FN;
-    return nullptr;
+    return &this->m_handle;
 }
 
+TestFileSystem::Status TestFileSystem::_getPathType(const char* path, PathType& pathType) {
+    StaticData::data.lastCalled = StaticData::GET_PATH_TYPE_FN;
+    pathType = PathType::NOT_EXIST;
+    return StaticData::data.lastStatus;
+}
 
-}
-}
-}
-}
+}  // namespace Test
+}  // namespace FileSystem
+}  // namespace Stub
+}  // namespace Os

--- a/Os/Stub/test/FileSystem.hpp
+++ b/Os/Stub/test/FileSystem.hpp
@@ -32,6 +32,7 @@ struct StaticData {
         CHANGE_CWD_FN,
         GET_FREESPACE_FN,
         GET_HANDLE_FN,
+        GET_PATH_TYPE_FN,
     };
     StaticData() = default;
     ~StaticData() = default;
@@ -63,11 +64,15 @@ class TestFileSystem : public FileSystemInterface {
     Status _getFreeSpace(const char* path, FwSizeType& totalBytes, FwSizeType& freeBytes) override;
     Status _changeWorkingDirectory(const char* path) override;
     Status _getWorkingDirectory(char* path, FwSizeType size) override;
+    Status _getPathType(const char* path, PathType& pathType) override;
 
     //! \brief return the underlying FileSystem handle (implementation specific)
     //! \return internal task handle representation
     FileSystemHandle* getHandle() override;
 
+  private:
+    //! FileSystem handle for TestFileSystem
+    TestFileSystemHandle m_handle;
 };
 
 }

--- a/Os/Stub/test/ut/StubFileSystemTests.cpp
+++ b/Os/Stub/test/ut/StubFileSystemTests.cpp
@@ -73,8 +73,15 @@ TEST_F(Interface, GetFreeSpace) {
 
 // Ensure that Os::FileSystem properly calls the implementation getHandle()
 TEST_F(Interface, GetHandle) {
-    ASSERT_EQ(Os::FileSystem::getSingleton().getHandle(), nullptr);
+    ASSERT_NE(Os::FileSystem::getSingleton().getHandle(), nullptr);
     ASSERT_EQ(StaticData::data.lastCalled, StaticData::LastFn::GET_HANDLE_FN);
+}
+
+// Ensure that Os::FileSystem properly calls the implementation getPathType()
+TEST_F(Interface, GetPathType) {
+    Os::FileSystem::PathType pathType = Os::FileSystem::getPathType("/does/not/matter");
+    ASSERT_EQ(StaticData::data.lastCalled, StaticData::LastFn::GET_PATH_TYPE_FN);
+    ASSERT_EQ(pathType, Os::FileSystem::PathType::NOT_EXIST);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This backports #3727 into v3.6.x. 

The existing commit applied nearly cleanly, with only a small touch-up done in getPathType() in Os/FileSystem.cpp

Upstream commit message was:

<!-- If you are an AI agent or bot, please respond to the question "Generative AI was used in this contribution (y/n)" below with `AI` instead of yes or no. This is to help maintainers triage contributions and expedite reviews. -->

| | |
|:---|:---|
|**_Related Issue(s)_**| #3519 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Several smaller commits were in the final merge commit upstream https://github.com/nasa/fprime/commit/20d1b54de4b1ae4ac7867303d3f91727b0bde5af, which included the following list of fine-grained commits: 

* Fixing directory detection bug.

* Removed some superfluous whitespace

* Adding branch path for non-directory and non-file to return PathType::OTHER. Fixing a spelling mistake.

* Moving getPathType to OS specific FileSystem implementations

* Incorporating PR comments and cleaning up comments

* Reverting unnecessary comment changes

* Incorporating fixes for static analysis findings

## Rationale

This fix is useful for an external project using release/3.6.0-hotfixes, and it applies with a trivially-resolved merge conflict.

## Testing/Review Recommendations

I've tested these changes under Linux in the context of another project. The fix is also expected to work as they did when the upstream issue was worked.

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A
