### PR TITLE
codeql: add FprimeUnguardedUnsignedSubtraction query

### DIFF
--- a/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/FprimeUnguardedUnsignedSubtraction.expected
+++ b/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/FprimeUnguardedUnsignedSubtraction.expected
@@ -2,3 +2,6 @@
 | test.cpp:78:34:78:75 | ... - ... | Unsigned subtraction from getSize() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
 | test.cpp:106:32:106:73 | ... - ... | Unsigned subtraction from getSize() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
 | test.cpp:124:22:124:61 | ... - ... | Unsigned subtraction from getDataSize() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
+| test.cpp:136:28:136:69 | ... - ... | Unsigned subtraction from getSize() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
+| test.cpp:146:28:146:69 | ... - ... | Unsigned subtraction from getSize() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
+| test.cpp:155:28:155:69 | ... - ... | Unsigned subtraction from getSize() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |

--- a/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/FprimeUnguardedUnsignedSubtraction.expected
+++ b/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/FprimeUnguardedUnsignedSubtraction.expected
@@ -1,0 +1,4 @@
+| test.cpp:30:28:30:69 | ... - ... | Unsigned subtraction from getSize() with no run-time check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
+| test.cpp:38:28:38:69 | ... - ... | Unsigned subtraction from getSize() with no run-time check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
+| test.cpp:90:32:90:73 | ... - ... | Unsigned subtraction from getSize() with no run-time check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
+| test.cpp:108:22:108:61 | ... - ... | Unsigned subtraction from getDataSize() with no run-time check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |

--- a/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/FprimeUnguardedUnsignedSubtraction.expected
+++ b/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/FprimeUnguardedUnsignedSubtraction.expected
@@ -1,4 +1,4 @@
-| test.cpp:30:28:30:69 | ... - ... | Unsigned subtraction from getSize() with no run-time check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
-| test.cpp:38:28:38:69 | ... - ... | Unsigned subtraction from getSize() with no run-time check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
-| test.cpp:90:32:90:73 | ... - ... | Unsigned subtraction from getSize() with no run-time check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
-| test.cpp:108:22:108:61 | ... - ... | Unsigned subtraction from getDataSize() with no run-time check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
+| test.cpp:30:28:30:69 | ... - ... | Unsigned subtraction from getSize() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
+| test.cpp:78:34:78:75 | ... - ... | Unsigned subtraction from getSize() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
+| test.cpp:106:32:106:73 | ... - ... | Unsigned subtraction from getSize() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |
+| test.cpp:124:22:124:61 | ... - ... | Unsigned subtraction from getDataSize() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small. |

--- a/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/FprimeUnguardedUnsignedSubtraction.qlref
+++ b/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/FprimeUnguardedUnsignedSubtraction.qlref
@@ -1,0 +1,1 @@
+FprimeUnguardedUnsignedSubtraction.ql

--- a/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/test.cpp
+++ b/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/test.cpp
@@ -123,3 +123,45 @@ FwSizeType plainArithmetic(FwSizeType value) {
 void unguardedDataSize(const Container& c) {
     consume(nullptr, c.getDataSize() - Container::DATA_OFFSET);
 }
+
+// Violation: the only size comparison in the function is on a different
+// object, so nothing here constrains `buf`. This is the shape that let
+// nasa/fprime#5518 through a passing test suite: `procRequest_handler` is
+// ~330 lines and compares `compression_buffer` and `data_reser`, never the
+// port-supplied `fwBuffer`. The bound is computed at run time, which the
+// query must keep accepting for same-object checks -- so only the receiver
+// separates this from `checkedAgainstComputedBound` above.
+void checkOnOtherObject(const Buffer& buf, const Buffer& other) {
+    const FwSizeType limit = requiredSize();
+    consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+    FW_ASSERT(other.getSize() <= limit);
+}
+
+// Violation: the bound is a constant and is strong enough, but it is
+// checked on a different object. Isolates receiver identity from bound
+// arithmetic: a fix that only tightened the bound handling passes the case
+// above and fails this one.
+void checkOnOtherObjectConstantBound(const Buffer& buf, const Buffer& other) {
+    FW_ASSERT(other.getSize() >= Container::MIN_PACKET_SIZE);
+    consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+}
+
+// Violation: the check is on a local copy of a *different* object's size.
+// The receiver has to be carried out through the local-copy form as well as
+// the direct call; a fix that matches receivers only on direct calls still
+// misses this. DpCompressProc has exactly this second, independent path.
+void checkOnLocalCopyOfOtherObject(const Buffer& buf, const Buffer& other) {
+    const FwSizeType otherSize = other.getSize();
+    consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+    FW_ASSERT(otherSize >= Container::MIN_PACKET_SIZE);
+}
+
+// Compliant: `buf` is checked, even though the function also compares a
+// different buffer. One sufficient check is enough -- receiver matching
+// must not degrade into requiring every comparison to be on the subtracted
+// object.
+void checkedAmongOtherObjectChecks(const Buffer& buf, const Buffer& other) {
+    FW_ASSERT(other.getSize() > 0);
+    FW_ASSERT(buf.getSize() >= Container::MIN_PACKET_SIZE);
+    consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+}

--- a/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/test.cpp
+++ b/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/test.cpp
@@ -1,0 +1,109 @@
+namespace Fw {
+void SwAssert(int line);
+}
+#define FW_ASSERT(cond) ((cond) ? static_cast<void>(0) : Fw::SwAssert(__LINE__))
+
+typedef unsigned long FwSizeType;
+typedef unsigned char U8;
+
+// Minimal stand-ins for the F Prime buffer/container shapes.
+class Buffer {
+  public:
+    FwSizeType getSize() const;
+    U8* getData() const;
+};
+
+class Container {
+  public:
+    static const FwSizeType MIN_PACKET_SIZE = 40;
+    static const FwSizeType DATA_OFFSET = 24;
+    FwSizeType getDataSize() const;
+};
+
+void consume(U8* data, FwSizeType size);
+
+// Violation of cpp/fprime/unguarded-unsigned-subtraction (CWE-191):
+// the buffer size comes from the caller and is never checked against
+// MIN_PACKET_SIZE, so a short buffer underflows to near SIZE_MAX.
+// This is the shape fixed in nasa/fprime#5518.
+void unguarded(const Buffer& buf) {
+    consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+}
+
+// Violation: the only check is inside an FW_ASSERT. Assertions may be
+// compiled out at lower FW_ASSERT_LEVEL settings, so this does not
+// protect the subtraction in a release build.
+void guardedOnlyByAssert(const Buffer& buf) {
+    FW_ASSERT(buf.getSize() >= Container::MIN_PACKET_SIZE);
+    consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+}
+
+// Compliant: an explicit run-time check that survives with assertions
+// disabled.
+void guardedByEarlyReturn(const Buffer& buf) {
+    if (buf.getSize() < Container::MIN_PACKET_SIZE) {
+        return;
+    }
+    consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+}
+
+// Compliant: the same check written the other way round.
+void guardedByIf(const Buffer& buf) {
+    if (buf.getSize() >= Container::MIN_PACKET_SIZE) {
+        consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+    }
+}
+
+// Compliant: an FW_ASSERT is present, but a real run-time check is too.
+// Belt-and-braces code should not be reported.
+void assertAndRuntimeCheck(const Buffer& buf) {
+    FW_ASSERT(buf.getSize() >= Container::MIN_PACKET_SIZE);
+    if (buf.getSize() < Container::MIN_PACKET_SIZE) {
+        return;
+    }
+    consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+}
+
+// Compliant: `> 0` is the idiomatic guard for a `- 1` subtraction. The
+// guard constant (0) is one less than the subtrahend (1), which is
+// exactly strong enough. An earlier version of this query compared the
+// two constants for equality and reported this, which was a false
+// positive -- this case pins the fix.
+void guardedByGreaterThanZero(const Buffer& buf) {
+    if (buf.getSize() > 0) {
+        consume(buf.getData(), buf.getSize() - 1);
+    }
+}
+
+// Compliant: a guard stronger than required is still a guard.
+void guardedByStrongerBound(const Buffer& buf) {
+    if (buf.getSize() < Container::MIN_PACKET_SIZE + 8) {
+        return;
+    }
+    consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+}
+
+// Violation: a guard that is too weak to cover the subtraction. Checking
+// against 2 says nothing about whether the size reaches MIN_PACKET_SIZE.
+void guardedTooWeakly(const Buffer& buf) {
+    if (buf.getSize() > 2) {
+        consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+    }
+}
+
+// Compliant: subtracting a variable rather than a compile-time constant
+// is out of scope -- too common and too often intentional.
+void variableSubtrahend(const Buffer& buf, FwSizeType n) {
+    consume(buf.getData(), buf.getSize() - n);
+}
+
+// Compliant: not a size accessor, so the query says nothing about intent.
+FwSizeType plainArithmetic(FwSizeType value) {
+    return value - Container::MIN_PACKET_SIZE;
+}
+
+// Violation: the accessor is a different one from the guarded family,
+// and it is unchecked here.
+void unguardedDataSize(const Container& c) {
+    consume(nullptr, c.getDataSize() - Container::DATA_OFFSET);
+}

--- a/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/test.cpp
+++ b/.github/codeql/fprime-queries-tests/FprimeUnguardedUnsignedSubtraction/test.cpp
@@ -30,10 +30,9 @@ void unguarded(const Buffer& buf) {
     consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
 }
 
-// Violation: the only check is inside an FW_ASSERT. Assertions may be
-// compiled out at lower FW_ASSERT_LEVEL settings, so this does not
-// protect the subtraction in a release build.
-void guardedOnlyByAssert(const Buffer& buf) {
+// Compliant: FW_ASSERT is a valid check in F Prime. Projects choose their
+// own assert level; a site that asserts the invariant is not unchecked.
+void checkedByAssert(const Buffer& buf) {
     FW_ASSERT(buf.getSize() >= Container::MIN_PACKET_SIZE);
     consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
 }
@@ -54,14 +53,31 @@ void guardedByIf(const Buffer& buf) {
     }
 }
 
-// Compliant: an FW_ASSERT is present, but a real run-time check is too.
-// Belt-and-braces code should not be reported.
-void assertAndRuntimeCheck(const Buffer& buf) {
-    FW_ASSERT(buf.getSize() >= Container::MIN_PACKET_SIZE);
-    if (buf.getSize() < Container::MIN_PACKET_SIZE) {
-        return;
-    }
+// Compliant: the check is written on a local copy of the size. This is the
+// Fw::DpContainer::setBuffer shape.
+void checkedOnLocalCopy(const Buffer& buf) {
+    const FwSizeType size = buf.getSize();
+    FW_ASSERT(size >= Container::MIN_PACKET_SIZE);
     consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+}
+
+FwSizeType requiredSize();
+
+// Compliant: the bound is computed at run time, so the query cannot show it
+// is too small. This is the Svc::FileDownlink::sendFilePacket shape.
+void checkedAgainstComputedBound(const Buffer& buf) {
+    const FwSizeType needed = requiredSize() + Container::MIN_PACKET_SIZE;
+    FW_ASSERT(buf.getSize() >= needed);
+    consume(buf.getData(), buf.getSize() - Container::MIN_PACKET_SIZE);
+}
+
+// Violation: the only comparison of the size is unrelated to the subtraction
+// and far too weak to cover it. This is the shape of the FW_ASSERT that
+// follows the subtraction in DpCompressProc; it must keep being reported.
+void unrelatedCheckAfterSubtraction(const Buffer& buf) {
+    const FwSizeType remaining = buf.getSize() - Container::MIN_PACKET_SIZE;
+    FW_ASSERT(buf.getSize() > 0);
+    consume(buf.getData(), remaining);
 }
 
 // Compliant: `> 0` is the idiomatic guard for a `- 1` subtraction. The

--- a/.github/codeql/fprime-queries/FprimeUnguardedUnsignedSubtraction.ql
+++ b/.github/codeql/fprime-queries/FprimeUnguardedUnsignedSubtraction.ql
@@ -1,0 +1,100 @@
+/**
+ * @name Unguarded unsigned subtraction from a run-time size
+ * @description Subtracting a compile-time constant from a size obtained at run time underflows to a very large value, rather than going negative, when the size is smaller than the constant. A comparison that appears only inside an FW_ASSERT does not count as a guard, because assertions may be compiled out.
+ * @kind problem
+ * @id cpp/fprime/unguarded-unsigned-subtraction
+ * @problem.severity warning
+ * @tags correctness
+ *       security
+ *       external/cwe/cwe-191
+ */
+
+import cpp
+import FprimeAssertions
+
+/*
+ * Motivated by the defect fixed in nasa/fprime#5518, where
+ * `DpCompressProc::procRequest_handler` computed
+ *
+ *     fwBuffer.getSize() - Fw::DpContainer::MIN_PACKET_SIZE
+ *
+ * on a port-supplied buffer. The invariant `getSize() >= MIN_PACKET_SIZE`
+ * was enforced only by an `FW_ASSERT` inside `Fw::DpContainer::setBuffer`,
+ * in a different translation unit. With assertions compiled out, a short
+ * buffer underflowed the subtraction to a value near `SIZE_MAX` and the
+ * downstream chunking loop walked off the allocation.
+ *
+ * The query is deliberately conservative in three ways, to keep it usable
+ * as a CI gate rather than a research tool:
+ *
+ *   1. The subtrahend must be a compile-time constant. Variable-minus-
+ *      variable subtraction is far more common and far more often
+ *      intentional, so it is out of scope here.
+ *
+ *   2. The minuend must come from a known size accessor. A bare integer
+ *      subtraction says nothing about intent; `getSize() - K` says the
+ *      author is reasoning about a buffer.
+ *
+ *   3. Guard recognition is direction-agnostic and does no dominance
+ *      analysis: any relational comparison in the same function between
+ *      the accessor and a sufficiently large constant is accepted,
+ *      whether it is written `size < K` (early return) or `size >= K`
+ *      (positive form). That admits false negatives -- a check on a path
+ *      that does not actually reach the subtraction -- in exchange for a
+ *      low false-positive rate.
+ *
+ * On the guard threshold: a comparison against constant `C` is accepted
+ * as guarding `accessor - K` when `C >= K - 1`. The `- 1` matters. It
+ * makes `if (size > 0)` count as a guard for `size - 1`, which is the
+ * idiomatic way to write that check and would otherwise be reported.
+ * Comparing `C` and `K` for exact equality (an earlier version of this
+ * query) rejects that guard and produces a false positive. A weaker
+ * check such as `if (size > 2)` guarding `size - 8` still fails the
+ * threshold and is still reported, which is the desired behaviour.
+ */
+
+/**
+ * A call returning a size or length determined at run time, rather than
+ * one the calling function chose itself.
+ */
+predicate isSizeAccessor(Call c) {
+  c.getTarget().getName() =
+    [
+      "getSize", "getBuffLength", "getDataSize", "getBuffCapacity",
+      "getDeserializeSizeLeft", "getSerializeSizeLeft"
+    ]
+}
+
+/** Holds if `e` appears inside the condition of an `FW_ASSERT`. */
+predicate inFwAssert(Expr e) { exists(FwAssert a | e.getParent*() = a.getAsserted()) }
+
+/**
+ * Holds if `f` compares the result of a size accessor named `name`
+ * against a constant of at least `k - 1`, outside any `FW_ASSERT` --
+ * that is, a guard that still runs when assertions are disabled and
+ * that is strong enough to make `accessor - k` safe.
+ */
+bindingset[k]
+predicate hasRuntimeGuard(Function f, string name, float k) {
+  exists(RelationalOperation rop, Call acc, Expr bound |
+    rop.getEnclosingFunction() = f and
+    not inFwAssert(rop) and
+    acc.getParent*() = rop and
+    isSizeAccessor(acc) and
+    acc.getTarget().getName() = name and
+    bound.getParent*() = rop and
+    bound.getValue().toFloat() >= k - 1.0
+  )
+}
+
+from SubExpr sub, Call minuend, Expr subtrahend, float k
+where
+  sub.getUnspecifiedType().(IntegralType).isUnsigned() and
+  minuend.getParent*() = sub.getLeftOperand() and
+  isSizeAccessor(minuend) and
+  subtrahend = sub.getRightOperand() and
+  k = subtrahend.getValue().toFloat() and
+  not hasRuntimeGuard(sub.getEnclosingFunction(), minuend.getTarget().getName(), k)
+select sub,
+  "Unsigned subtraction from " + minuend.getTarget().getName() +
+    "() with no run-time check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small."

--- a/.github/codeql/fprime-queries/FprimeUnguardedUnsignedSubtraction.ql
+++ b/.github/codeql/fprime-queries/FprimeUnguardedUnsignedSubtraction.ql
@@ -25,6 +25,12 @@ import cpp
  * accessor, and check recognition is direction-agnostic with no dominance
  * analysis. A bound of `C` is accepted for `accessor - K` when `C >= K - 1`,
  * so `if (size > 0)` credits `size - 1`; `test.cpp` pins that case.
+ *
+ * A check only counts when it reads the size of the *same object* that the
+ * subtraction reads. Without that, any comparison of any object's size
+ * anywhere in the enclosing function suppresses the finding, which is how
+ * the original #5518 defect escaped: `procRequest_handler` is ~330 lines and
+ * compares the sizes of three other buffers, never `fwBuffer`.
  */
 
 /**
@@ -40,38 +46,81 @@ predicate isSizeAccessor(Call c) {
 }
 
 /**
- * Holds if `e` reads the size accessor `name`: either a direct call, or an
- * access to a local variable whose initializer is that call. The local-copy
- * form is idiomatic -- `const FwSizeType n = buf.getSize();` then a check on
- * `n` -- and a check written that way is still a check.
+ * Gets the object that the size accessor call `c` reads from, identified by
+ * the declaration its receiver resolves to: the variable or field accessed,
+ * or the enclosing class when the call is on `this`. Comparing declarations
+ * rather than expressions makes `this->m_buffer.getSize()` in a check match
+ * `this->m_buffer.getSize()` in a subtraction.
+ *
+ * Has no result when the receiver is not one of those shapes, for example
+ * `getBuffer().getSize()`.
  */
-predicate readsSize(Expr e, string name) {
-  isSizeAccessor(e.(Call)) and name = e.(Call).getTarget().getName()
-  or
-  exists(LocalScopeVariable v, Call acc |
-    e = v.getAnAccess() and
-    acc = v.getInitializer().getExpr() and
-    isSizeAccessor(acc) and
-    name = acc.getTarget().getName()
+Declaration sizeAccessorReceiver(Call c) {
+  isSizeAccessor(c) and
+  exists(Expr recv | recv = c.getQualifier() |
+    result = recv.(VariableAccess).getTarget()
+    or
+    recv instanceof ThisExpr and
+    result = c.getTarget().(MemberFunction).getDeclaringType()
   )
 }
 
 /**
- * Holds if `f` compares a read of the size accessor `name` against a bound
- * that is not demonstrably too small for `accessor - k`. An `FW_ASSERT`
- * condition counts: it is an ordinary comparison in the AST, and F Prime
- * treats an assertion as a valid check -- projects choose their own assert
- * level. A bound with no constant value is accepted, since the query cannot
- * show it is too small.
+ * Holds if the size accessor calls `a` and `b` read from the same object.
+ *
+ * When neither receiver resolves to a declaration the calls are treated as
+ * matching. That keeps the previous name-only behaviour for shapes this
+ * query cannot reason about, rather than reporting them.
+ */
+predicate sameReceiver(Call a, Call b) {
+  sizeAccessorReceiver(a) = sizeAccessorReceiver(b)
+  or
+  not exists(sizeAccessorReceiver(a)) and
+  not exists(sizeAccessorReceiver(b)) and
+  isSizeAccessor(a) and
+  isSizeAccessor(b)
+}
+
+/**
+ * Holds if `read` reads the same size, from the same object, as the accessor
+ * call `minuend`: either a direct call, or an access to a local variable
+ * whose initializer is such a call. The local-copy form is idiomatic --
+ * `const FwSizeType n = buf.getSize();` then a check on `n` -- and a check
+ * written that way is still a check; `Fw::DpContainer::setBuffer` does
+ * exactly this.
+ */
+predicate readsSameSize(Expr read, Call minuend) {
+  exists(Call acc |
+    acc = read.(Call)
+    or
+    exists(LocalScopeVariable v |
+      read = v.getAnAccess() and
+      acc = v.getInitializer().getExpr()
+    )
+  |
+    isSizeAccessor(acc) and
+    acc.getTarget().getName() = minuend.getTarget().getName() and
+    sameReceiver(acc, minuend)
+  )
+}
+
+/**
+ * Holds if the function containing `minuend` compares the size that
+ * `minuend` reads -- same accessor, same object -- against a bound that is
+ * not demonstrably too small for `minuend - k`. An `FW_ASSERT` condition
+ * counts: it is an ordinary comparison in the AST, and F Prime treats an
+ * assertion as a valid check -- projects choose their own assert level. A
+ * bound with no constant value is accepted, since the query cannot show it
+ * is too small.
  */
 bindingset[k]
-predicate hasCheck(Function f, string name, float k) {
+predicate hasCheck(Call minuend, float k) {
   exists(RelationalOperation rop, Expr sizeSide, Expr bound |
-    rop.getEnclosingFunction() = f and
+    rop.getEnclosingFunction() = minuend.getEnclosingFunction() and
     sizeSide = rop.getAnOperand() and
     bound = rop.getAnOperand() and
     bound != sizeSide and
-    exists(Expr read | read = sizeSide.getAChild*() and readsSize(read, name)) and
+    exists(Expr read | read = sizeSide.getAChild*() and readsSameSize(read, minuend)) and
     (
       not exists(bound.getValue())
       or
@@ -87,7 +136,7 @@ where
   isSizeAccessor(minuend) and
   subtrahend = sub.getRightOperand() and
   k = subtrahend.getValue().toFloat() and
-  not hasCheck(sub.getEnclosingFunction(), minuend.getTarget().getName(), k)
+  not hasCheck(minuend, k)
 select sub,
   "Unsigned subtraction from " + minuend.getTarget().getName() +
     "() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small."

--- a/.github/codeql/fprime-queries/FprimeUnguardedUnsignedSubtraction.ql
+++ b/.github/codeql/fprime-queries/FprimeUnguardedUnsignedSubtraction.ql
@@ -1,56 +1,30 @@
 /**
  * @name Unguarded unsigned subtraction from a run-time size
- * @description Subtracting a compile-time constant from a size obtained at run time underflows to a very large value, rather than going negative, when the size is smaller than the constant. A comparison that appears only inside an FW_ASSERT does not count as a guard, because assertions may be compiled out.
+ * @description Subtracting a compile-time constant from a size obtained at
+ *              run time underflows to a very large value, rather than going
+ *              negative, when the size is smaller than the constant. A check
+ *              may be a condition or an FW_ASSERT; this reports sites with
+ *              neither.
  * @kind problem
  * @id cpp/fprime/unguarded-unsigned-subtraction
  * @problem.severity warning
  * @tags correctness
- *       security
+ *       reliability
  *       external/cwe/cwe-191
  */
 
 import cpp
-import FprimeAssertions
 
 /*
- * Motivated by the defect fixed in nasa/fprime#5518, where
- * `DpCompressProc::procRequest_handler` computed
+ * Motivated by nasa/fprime#5518, where `DpCompressProc::procRequest_handler`
+ * computed `fwBuffer.getSize() - Fw::DpContainer::MIN_PACKET_SIZE` on a
+ * port-supplied buffer with no check of any kind in the handler.
  *
- *     fwBuffer.getSize() - Fw::DpContainer::MIN_PACKET_SIZE
- *
- * on a port-supplied buffer. The invariant `getSize() >= MIN_PACKET_SIZE`
- * was enforced only by an `FW_ASSERT` inside `Fw::DpContainer::setBuffer`,
- * in a different translation unit. With assertions compiled out, a short
- * buffer underflowed the subtraction to a value near `SIZE_MAX` and the
- * downstream chunking loop walked off the allocation.
- *
- * The query is deliberately conservative in three ways, to keep it usable
- * as a CI gate rather than a research tool:
- *
- *   1. The subtrahend must be a compile-time constant. Variable-minus-
- *      variable subtraction is far more common and far more often
- *      intentional, so it is out of scope here.
- *
- *   2. The minuend must come from a known size accessor. A bare integer
- *      subtraction says nothing about intent; `getSize() - K` says the
- *      author is reasoning about a buffer.
- *
- *   3. Guard recognition is direction-agnostic and does no dominance
- *      analysis: any relational comparison in the same function between
- *      the accessor and a sufficiently large constant is accepted,
- *      whether it is written `size < K` (early return) or `size >= K`
- *      (positive form). That admits false negatives -- a check on a path
- *      that does not actually reach the subtraction -- in exchange for a
- *      low false-positive rate.
- *
- * On the guard threshold: a comparison against constant `C` is accepted
- * as guarding `accessor - K` when `C >= K - 1`. The `- 1` matters. It
- * makes `if (size > 0)` count as a guard for `size - 1`, which is the
- * idiomatic way to write that check and would otherwise be reported.
- * Comparing `C` and `K` for exact equality (an earlier version of this
- * query) rejects that guard and produces a false positive. A weaker
- * check such as `if (size > 2)` guarding `size - 8` still fails the
- * threshold and is still reported, which is the desired behaviour.
+ * Deliberately conservative, to be usable as a CI gate: the subtrahend must
+ * be a compile-time constant, the minuend must come from a known size
+ * accessor, and check recognition is direction-agnostic with no dominance
+ * analysis. A bound of `C` is accepted for `accessor - K` when `C >= K - 1`,
+ * so `if (size > 0)` credits `size - 1`; `test.cpp` pins that case.
  */
 
 /**
@@ -65,25 +39,44 @@ predicate isSizeAccessor(Call c) {
     ]
 }
 
-/** Holds if `e` appears inside the condition of an `FW_ASSERT`. */
-predicate inFwAssert(Expr e) { exists(FwAssert a | e.getParent*() = a.getAsserted()) }
+/**
+ * Holds if `e` reads the size accessor `name`: either a direct call, or an
+ * access to a local variable whose initializer is that call. The local-copy
+ * form is idiomatic -- `const FwSizeType n = buf.getSize();` then a check on
+ * `n` -- and a check written that way is still a check.
+ */
+predicate readsSize(Expr e, string name) {
+  isSizeAccessor(e.(Call)) and name = e.(Call).getTarget().getName()
+  or
+  exists(LocalScopeVariable v, Call acc |
+    e = v.getAnAccess() and
+    acc = v.getInitializer().getExpr() and
+    isSizeAccessor(acc) and
+    name = acc.getTarget().getName()
+  )
+}
 
 /**
- * Holds if `f` compares the result of a size accessor named `name`
- * against a constant of at least `k - 1`, outside any `FW_ASSERT` --
- * that is, a guard that still runs when assertions are disabled and
- * that is strong enough to make `accessor - k` safe.
+ * Holds if `f` compares a read of the size accessor `name` against a bound
+ * that is not demonstrably too small for `accessor - k`. An `FW_ASSERT`
+ * condition counts: it is an ordinary comparison in the AST, and F Prime
+ * treats an assertion as a valid check -- projects choose their own assert
+ * level. A bound with no constant value is accepted, since the query cannot
+ * show it is too small.
  */
 bindingset[k]
-predicate hasRuntimeGuard(Function f, string name, float k) {
-  exists(RelationalOperation rop, Call acc, Expr bound |
+predicate hasCheck(Function f, string name, float k) {
+  exists(RelationalOperation rop, Expr sizeSide, Expr bound |
     rop.getEnclosingFunction() = f and
-    not inFwAssert(rop) and
-    acc.getParent*() = rop and
-    isSizeAccessor(acc) and
-    acc.getTarget().getName() = name and
-    bound.getParent*() = rop and
-    bound.getValue().toFloat() >= k - 1.0
+    sizeSide = rop.getAnOperand() and
+    bound = rop.getAnOperand() and
+    bound != sizeSide and
+    exists(Expr read | read = sizeSide.getAChild*() and readsSize(read, name)) and
+    (
+      not exists(bound.getValue())
+      or
+      bound.getValue().toFloat() >= k - 1.0
+    )
   )
 }
 
@@ -94,7 +87,7 @@ where
   isSizeAccessor(minuend) and
   subtrahend = sub.getRightOperand() and
   k = subtrahend.getValue().toFloat() and
-  not hasRuntimeGuard(sub.getEnclosingFunction(), minuend.getTarget().getName(), k)
+  not hasCheck(sub.getEnclosingFunction(), minuend.getTarget().getName(), k)
 select sub,
   "Unsigned subtraction from " + minuend.getTarget().getName() +
-    "() with no run-time check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small."
+    "() with no check that it is at least the subtracted constant; this underflows instead of going negative when the size is too small."


### PR DESCRIPTION
Draft — opening this for a design question before polishing (see **Open question** at the end), since the answer may change what the query reports.

## What it finds

Unsigned subtraction of a compile-time constant from a run-time size, where nothing in the same function establishes that the size is large enough. Because the operands are unsigned, an undersized value doesn't go negative — it wraps to near `SIZE_MAX`, and downstream length arithmetic walks off the buffer.

The rule that makes this worth its own query, rather than being covered by a stock CWE-191 check: **a comparison that appears only inside `FW_ASSERT` does not count as a guard.** `FW_ASSERT` is compiled out at lower `FW_ASSERT_LEVEL` settings, so code that reads as protected in review can be unprotected in a flight build.

That's the same concern the four existing `FprimeUseOfAssertions*` queries address, and this one reuses their `FprimeAssertions.qll`.

## Results on this repository

Measured against a build-traced CodeQL database of `devel` (11,266 defined functions, googletest excluded). **Six results:**

| Location | Function | Situation |
|---|---|---|
| `Fw/Dp/DpContainer.cpp:132` | `setBuffer` | assert-only guarded |
| `Svc/Ccsds/AosFramer.cpp:103` | `compute_and_inject_fecf` | **no guard of any kind** |
| `Svc/Ccsds/SpacePacketFramer.cpp:62` | `dataIn_handler` | assert-only guarded |
| `Svc/DpCompressProc/DpCompressProc.cpp:79` | `procRequest_handler` | **the defect under review in #5518** |
| `Svc/FileDownlink/FileDownlink.cpp:395` | `sendCancelPacket` | assert-only guarded |
| `Svc/FileDownlink/FileDownlink.cpp:436` | `sendFilePacket` | assert-only guarded |

Two of these are worth calling out together. `DpCompressProc.cpp:79` is the bug in #5518; `DpContainer.cpp:132` is the *upstream half of the same issue* — the `FW_ASSERT` that #5518 was relying on across a translation-unit boundary. The query found both ends independently.

`AosFramer.cpp:103` subtracts `AOSTrailer::SERIALIZED_SIZE` from a frame buffer size with no check at all, not even an assertion. I haven't traced whether that frame buffer can ever be shorter than the trailer in practice.

## Design choices

Deliberately conservative in three ways, to be usable as a CI gate:

1. **Subtrahend must be a compile-time constant.** Variable-minus-variable is far more common and far more often intentional.
2. **Minuend must come from a known size accessor** (`getSize`, `getDataSize`, `getDeserializeSizeLeft`, …). A bare integer subtraction says nothing about intent; `getSize() - K` says the author is reasoning about a buffer.
3. **Guard recognition is direction-agnostic with no dominance analysis.** Any relational comparison in the same function between the accessor and a large-enough constant is accepted, whether written as an early return (`size < K`) or positively (`size >= K`). This admits false negatives — a check on a path that doesn't actually reach the subtraction — in exchange for a low false-positive rate.

On the threshold: a comparison against constant `C` is accepted for `accessor - K` when `C >= K - 1`. The `- 1` matters — it credits the idiomatic `if (size > 0)` guard for `size - 1`. An earlier revision compared the two constants for equality and produced a false positive on exactly that shape; `test.cpp` pins the fix. A too-weak `if (size > 2)` guarding `size - MIN_PACKET_SIZE` is still reported.

## Testing

`test.cpp` covers six cases, following the existing pack convention:

- reported: unguarded; assert-only guarded; a second accessor; a too-weak guard
- silent: `> 0` guarding `- 1`; a stronger-than-required guard

Verified locally with `codeql test run --additional-packs=.` — passing. Note I ran CLI 2.26.2 while this workflow pins 2.26.1, so please regenerate `.expected` with `--learn` if that one-patch difference matters.

## Open question

**Four of the six results say "you're relying on `FW_ASSERT` here."** That may well be intentional in F Prime, in which case this query is too noisy as written and should only report sites with no check at all — a one-line change that would reduce this to `AosFramer` plus `DpCompressProc`.

I don't think that call is mine to make. If assert-only reliance is a deliberate and accepted pattern, say so and I'll narrow it. If it's something you'd want visibility on, the current form gives you that.

Happy to also split `AosFramer.cpp:103` into its own issue if you'd rather track the unguarded case separately from the query itself.
