### PR TITLE
Add F Prime Reference Projects page, link from Supported Platforms

### DIFF
--- a/docs/user-manual/framework/reference-projects.md
+++ b/docs/user-manual/framework/reference-projects.md
@@ -1,0 +1,56 @@
+# F´ Reference Projects
+
+[Supported Platforms](./supported-platforms.md) lists reference projects tied to a specific
+hardware and OS pair. F´ also has reference projects that are not tied to a particular
+platform, and continuous integration (CI) that exercises repositories under
+[fprime-community](https://github.com/fprime-community) on an ongoing basis. Both are
+listed here.
+
+## Other Reference Projects
+
+Reference repositories under `fprime-community` that are not already covered by a row in the
+[Supported Platforms](./supported-platforms.md#supported-platforms) or
+[Targeted Platforms](./supported-platforms.md#targeted-platforms-planned-support) tables.
+
+| Project | Description |
+| ------- | ----------- |
+| [`fprime-amsat-main-board-reference`](https://github.com/fprime-community/fprime-amsat-main-board-reference) | Port of F´ to the PICO Main Sensor Board for the AMSAT CubeSat Simulator |
+| [`fprime-amsat-reference`](https://github.com/fprime-community/fprime-amsat-reference) | Port of F´ to the C&DH Pi Zero 2 Board for the AMSAT CubeSat Simulator |
+| [`fprime-generic-hub-reference`](https://github.com/fprime-community/fprime-generic-hub-reference) | Reference for applications running with the Hub Pattern |
+| [`fprime-phased-deployment-reference`](https://github.com/fprime-community/fprime-phased-deployment-reference) | Reference deployment demonstrating how to run F´ entirely through phases |
+| [`fprime-pycubed-baremetal-reference`](https://github.com/fprime-community/fprime-pycubed-baremetal-reference) | PyCubed baremetal reference deployment |
+| [`fprime-pycubed-zephyr-reference`](https://github.com/fprime-community/fprime-pycubed-zephyr-reference) | PyCubed Zephyr reference deployment |
+| [`fprime-sensors-reference`](https://github.com/fprime-community/fprime-sensors-reference) | Reference project for the `fprime-sensors` library |
+| [`fprime-stm32h7-zephyr-reference`](https://github.com/fprime-community/fprime-stm32h7-zephyr-reference) | STM32H7 Zephyr reference deployment |
+| [`fprime-yamcs-reference`](https://github.com/fprime-community/fprime-yamcs-reference) | Reference F´ project integrated with YAMCS mission control software |
+| [`fprime_cfs_reference`](https://github.com/fprime-community/fprime_cfs_reference) | cFS reference project using applications built with F´ |
+
+## External Repository CI
+
+`ext-*.yml` workflows in this repository's [CI](https://github.com/nasa/fprime/tree/devel/.github/workflows)
+keep the reference and tutorial repositories above building against `devel`. The trigger
+column matters here: several of these run on a schedule, on release, or only on manual
+dispatch, rather than on every push — without that context their badges can read as stale
+or broken when they are working as intended.
+
+| Workflow | Repository | Trigger | Status |
+| -------- | ---------- | ------- | ------ |
+| External Repo: AArch64 Linux LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | push, pull request | [![External Repo: AArch64 Linux LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker.yml) |
+| Soak Setup: AArch64 Linux LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | on release, manual dispatch | [![Soak Setup: AArch64 Linux LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-setup.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-setup.yml) |
+| Soak Test: AArch64 Linux LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | scheduled | [![Soak Test: AArch64 Linux LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-test.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-test.yml) |
+| Soak Summary: AArch64 Linux LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | manual dispatch | [![Soak Summary: AArch64 Linux LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-summary.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-summary.yml) |
+| External Repo: fprime-examples | [`fprime-examples`](https://github.com/nasa/fprime-examples) | push, pull request | [![External Repo: fprime-examples](https://github.com/nasa/fprime/actions/workflows/ext-build-examples-repo.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-build-examples-repo.yml) |
+| External Repo: fprime-python-reference | [`fprime-python-reference`](https://github.com/fprime-community/fprime-python-reference) | push, pull request | [![External Repo: fprime-python-reference](https://github.com/nasa/fprime/actions/workflows/ext-build-fprime-python-reference.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-build-fprime-python-reference.yml) |
+| External Repo: Tutorial: HelloWorld | [`fprime-tutorial-hello-world`](https://github.com/fprime-community/fprime-tutorial-hello-world) | push, pull request | [![External Repo: Tutorial: HelloWorld](https://github.com/nasa/fprime/actions/workflows/ext-build-hello-world.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-build-hello-world.yml) |
+| External Repo: Tutorial: LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | push, pull request | [![External Repo: Tutorial: LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-build-led-blinker.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-build-led-blinker.yml) |
+| External Repo: Tutorial: MathComponent | [`fprime-tutorial-math-component`](https://github.com/fprime-community/fprime-tutorial-math-component) | push, pull request | [![External Repo: Tutorial: MathComponent](https://github.com/nasa/fprime/actions/workflows/ext-build-math-comp.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-build-math-comp.yml) |
+| External Repo: Cookiecutters Tests | [`fprime-tools`](https://github.com/nasa/fprime-tools), [`fprime-bootstrap`](https://github.com/fprime-community/fprime-bootstrap) | push, pull request | [![External Repo: Cookiecutters Tests](https://github.com/nasa/fprime/actions/workflows/ext-cookiecutters-test.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-cookiecutters-test.yml) |
+| External Repo: cFS Reference | [`fprime_cfs_reference`](https://github.com/fprime-community/fprime_cfs_reference) | push, pull request | [![External Repo: cFS Reference](https://github.com/nasa/fprime/actions/workflows/ext-fprime-cfs-reference.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-cfs-reference.yml) |
+| External Repo: Zephyr Reference (Pico 2) | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | push, pull request | [![External Repo: Zephyr Reference (Pico 2)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-pico2.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-pico2.yml) |
+| External Repo: Zephyr Reference (Teensy 4.1) | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | push, pull request | [![External Repo: Zephyr Reference (Teensy 4.1)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-teensy41.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-teensy41.yml) |
+| External Repo: Generic Hub Reference | [`fprime-generic-hub-reference`](https://github.com/fprime-community/fprime-generic-hub-reference) | push, pull request | [![External Repo: Generic Hub Reference](https://github.com/nasa/fprime/actions/workflows/ext-generic-hub-reference.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-generic-hub-reference.yml) |
+| Soak Setup: Pico 2 Zephyr Reference | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | on release, manual dispatch | [![Soak Setup: Pico 2 Zephyr Reference](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-setup.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-setup.yml) |
+| Soak Test: Pico 2 Zephyr Reference | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | scheduled | [![Soak Test: Pico 2 Zephyr Reference](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-test.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-test.yml) |
+| Soak Summary: Pico 2 Zephyr Reference | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | manual dispatch | [![Soak Summary: Pico 2 Zephyr Reference](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-summary.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-summary.yml) |
+| External Repo: RPI LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | push, pull request | [![External Repo: RPI LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-raspberry-led-blinker.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-raspberry-led-blinker.yml) |
+| External Repo: YAMCS Reference | [`fprime-yamcs-reference`](https://github.com/fprime-community/fprime-yamcs-reference) | push, pull request | [![External Repo: YAMCS Reference](https://github.com/nasa/fprime/actions/workflows/ext-yamcs-reference.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-yamcs-reference.yml) |

--- a/docs/user-manual/framework/reference-projects.md
+++ b/docs/user-manual/framework/reference-projects.md
@@ -1,56 +1,20 @@
 # F´ Reference Projects
 
-[Supported Platforms](./supported-platforms.md) lists reference projects tied to a specific
-hardware and OS pair. F´ also has reference projects that are not tied to a particular
-platform, and continuous integration (CI) that exercises repositories under
-[fprime-community](https://github.com/fprime-community) on an ongoing basis. Both are
-listed here.
+This page lists various reference projects that use F Prime. Those often demonstrate a specific feature or integration by
+showcasing a fully functional reference deployment, and are proven to be functional through Continuous Integration (CI). 
 
-## fprime-community References
+For reference deployments running on specific hardware platforms, see [Supported Platforms](./supported-platforms.md).
 
-Reference repositories under `fprime-community` that are not already covered by a row in the
-[Supported Platforms](./supported-platforms.md#supported-platforms) or
-[Targeted Platforms](./supported-platforms.md#targeted-platforms-planned-support) tables.
+## References
 
 | Project | Description |
 | ------- | ----------- |
-| [`fprime-amsat-main-board-reference`](https://github.com/fprime-community/fprime-amsat-main-board-reference) | Port of F´ to the PICO Main Sensor Board for the AMSAT CubeSat Simulator |
-| [`fprime-amsat-reference`](https://github.com/fprime-community/fprime-amsat-reference) | Port of F´ to the C&DH Pi Zero 2 Board for the AMSAT CubeSat Simulator |
-| [`fprime-generic-hub-reference`](https://github.com/fprime-community/fprime-generic-hub-reference) | Reference for applications running with the Hub Pattern |
-| [`fprime-phased-deployment-reference`](https://github.com/fprime-community/fprime-phased-deployment-reference) | Reference deployment demonstrating how to run F´ entirely through phases |
-| [`fprime-pycubed-baremetal-reference`](https://github.com/fprime-community/fprime-pycubed-baremetal-reference) | PyCubed baremetal reference deployment |
-| [`fprime-pycubed-zephyr-reference`](https://github.com/fprime-community/fprime-pycubed-zephyr-reference) | PyCubed Zephyr reference deployment |
-| [`fprime-sensors-reference`](https://github.com/fprime-community/fprime-sensors-reference) | Reference project for the `fprime-sensors` library |
-| [`fprime-stm32h7-zephyr-reference`](https://github.com/fprime-community/fprime-stm32h7-zephyr-reference) | STM32H7 Zephyr reference deployment |
-| [`fprime-yamcs-reference`](https://github.com/fprime-community/fprime-yamcs-reference) | Reference F´ project integrated with YAMCS mission control software |
+| [`fprime-yamcs-reference`](https://github.com/fprime-community/fprime-yamcs-reference) | Reference F´ project integrated with [YAMCS](https://yamcs.org/) mission control software |
+| [`fprime-python-reference`](https://github.com/fprime-community/fprime-python-reference) | Reference project for writing F´ components in Python |
 | [`fprime_cfs_reference`](https://github.com/fprime-community/fprime_cfs_reference) | cFS reference project using applications built with F´ |
+| [`fprime-generic-hub-reference`](https://github.com/fprime-community/fprime-generic-hub-reference) | Reference for applications running the [Hub Pattern](../design-patterns/hub-pattern.md) |
+| [`fprime-sensors-reference`](https://github.com/fprime-community/fprime-sensors-reference) | Reference project for the `fprime-sensors` library |
+| [`fprime-encryption-reference`](https://github.com/fprime-community/fprime-encryption-reference) | Reference project for encrypting the communications link |
+| [`fprime-phased-deployment-reference`](https://github.com/fprime-community/fprime-phased-deployment-reference) | Reference deployment demonstrating how to run F´ entirely through [FPP phases](https://nasa.github.io/fpp/fpp-users-guide.html#Defining-Component-Instances_Init-Specifiers_Execution-Phases) |
 
-## External Repository Continuous Integration (CI)
-
-`ext-*.yml` workflows in this repository's [CI](https://github.com/nasa/fprime/tree/devel/.github/workflows)
-keep the reference and tutorial repositories above building against `devel`. The trigger
-column matters here: several of these run on a schedule, on release, or only on manual
-dispatch, rather than on every push — without that context their badges can read as stale
-or broken when they are working as intended.
-
-| Workflow | Repository | Trigger | Status |
-| -------- | ---------- | ------- | ------ |
-| External Repo: AArch64 Linux LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | push, pull request | [![External Repo: AArch64 Linux LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker.yml) |
-| Soak Setup: AArch64 Linux LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | on release, manual dispatch | [![Soak Setup: AArch64 Linux LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-setup.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-setup.yml) |
-| Soak Test: AArch64 Linux LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | scheduled | [![Soak Test: AArch64 Linux LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-test.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-test.yml) |
-| Soak Summary: AArch64 Linux LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | manual dispatch | [![Soak Summary: AArch64 Linux LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-summary.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-aarch64-linux-led-blinker-soak-summary.yml) |
-| External Repo: fprime-examples | [`fprime-examples`](https://github.com/nasa/fprime-examples) | push, pull request | [![External Repo: fprime-examples](https://github.com/nasa/fprime/actions/workflows/ext-build-examples-repo.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-build-examples-repo.yml) |
-| External Repo: fprime-python-reference | [`fprime-python-reference`](https://github.com/fprime-community/fprime-python-reference) | push, pull request | [![External Repo: fprime-python-reference](https://github.com/nasa/fprime/actions/workflows/ext-build-fprime-python-reference.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-build-fprime-python-reference.yml) |
-| External Repo: Tutorial: HelloWorld | [`fprime-tutorial-hello-world`](https://github.com/fprime-community/fprime-tutorial-hello-world) | push, pull request | [![External Repo: Tutorial: HelloWorld](https://github.com/nasa/fprime/actions/workflows/ext-build-hello-world.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-build-hello-world.yml) |
-| External Repo: Tutorial: LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | push, pull request | [![External Repo: Tutorial: LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-build-led-blinker.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-build-led-blinker.yml) |
-| External Repo: Tutorial: MathComponent | [`fprime-tutorial-math-component`](https://github.com/fprime-community/fprime-tutorial-math-component) | push, pull request | [![External Repo: Tutorial: MathComponent](https://github.com/nasa/fprime/actions/workflows/ext-build-math-comp.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-build-math-comp.yml) |
-| External Repo: Cookiecutters Tests | [`fprime-tools`](https://github.com/nasa/fprime-tools), [`fprime-bootstrap`](https://github.com/fprime-community/fprime-bootstrap) | push, pull request | [![External Repo: Cookiecutters Tests](https://github.com/nasa/fprime/actions/workflows/ext-cookiecutters-test.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-cookiecutters-test.yml) |
-| External Repo: cFS Reference | [`fprime_cfs_reference`](https://github.com/fprime-community/fprime_cfs_reference) | push, pull request | [![External Repo: cFS Reference](https://github.com/nasa/fprime/actions/workflows/ext-fprime-cfs-reference.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-cfs-reference.yml) |
-| External Repo: Zephyr Reference (Pico 2) | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | push, pull request | [![External Repo: Zephyr Reference (Pico 2)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-pico2.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-pico2.yml) |
-| External Repo: Zephyr Reference (Teensy 4.1) | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | push, pull request | [![External Repo: Zephyr Reference (Teensy 4.1)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-teensy41.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-teensy41.yml) |
-| External Repo: Generic Hub Reference | [`fprime-generic-hub-reference`](https://github.com/fprime-community/fprime-generic-hub-reference) | push, pull request | [![External Repo: Generic Hub Reference](https://github.com/nasa/fprime/actions/workflows/ext-generic-hub-reference.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-generic-hub-reference.yml) |
-| Soak Setup: Pico 2 Zephyr Reference | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | on release, manual dispatch | [![Soak Setup: Pico 2 Zephyr Reference](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-setup.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-setup.yml) |
-| Soak Test: Pico 2 Zephyr Reference | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | scheduled | [![Soak Test: Pico 2 Zephyr Reference](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-test.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-test.yml) |
-| Soak Summary: Pico 2 Zephyr Reference | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | manual dispatch | [![Soak Summary: Pico 2 Zephyr Reference](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-summary.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-pico2-zephyr-reference-soak-summary.yml) |
-| External Repo: RPI LedBlinker | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | push, pull request | [![External Repo: RPI LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-raspberry-led-blinker.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-raspberry-led-blinker.yml) |
-| External Repo: YAMCS Reference | [`fprime-yamcs-reference`](https://github.com/fprime-community/fprime-yamcs-reference) | push, pull request | [![External Repo: YAMCS Reference](https://github.com/nasa/fprime/actions/workflows/ext-yamcs-reference.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-yamcs-reference.yml) |
+For status of the CI on those and other references, please see https://github.com/nasa/fprime/actions

--- a/docs/user-manual/framework/reference-projects.md
+++ b/docs/user-manual/framework/reference-projects.md
@@ -17,4 +17,6 @@ For reference deployments running on specific hardware platforms, see [Supported
 | [`fprime-encryption-reference`](https://github.com/fprime-community/fprime-encryption-reference) | Reference project for encrypting the communications link |
 | [`fprime-phased-deployment-reference`](https://github.com/fprime-community/fprime-phased-deployment-reference) | Reference deployment demonstrating how to run F´ entirely through [FPP phases](https://nasa.github.io/fpp/fpp-users-guide.html#Defining-Component-Instances_Init-Specifiers_Execution-Phases) |
 
-For status of the CI on those and other references, please see https://github.com/nasa/fprime/actions
+For status of the CI on those and other references, please see https://github.com/nasa/fprime/actions.
+
+Other references, examples and useful resources can be found in the [F´ Community GitHub](https://github.com/fprime-community).

--- a/docs/user-manual/framework/reference-projects.md
+++ b/docs/user-manual/framework/reference-projects.md
@@ -6,7 +6,7 @@ platform, and continuous integration (CI) that exercises repositories under
 [fprime-community](https://github.com/fprime-community) on an ongoing basis. Both are
 listed here.
 
-## Other Reference Projects
+## fprime-community References
 
 Reference repositories under `fprime-community` that are not already covered by a row in the
 [Supported Platforms](./supported-platforms.md#supported-platforms) or
@@ -25,7 +25,7 @@ Reference repositories under `fprime-community` that are not already covered by 
 | [`fprime-yamcs-reference`](https://github.com/fprime-community/fprime-yamcs-reference) | Reference F´ project integrated with YAMCS mission control software |
 | [`fprime_cfs_reference`](https://github.com/fprime-community/fprime_cfs_reference) | cFS reference project using applications built with F´ |
 
-## External Repository CI
+## External Repository Continuous Integration (CI)
 
 `ext-*.yml` workflows in this repository's [CI](https://github.com/nasa/fprime/tree/devel/.github/workflows)
 keep the reference and tutorial repositories above building against `devel`. The trigger

--- a/docs/user-manual/framework/supported-platforms.md
+++ b/docs/user-manual/framework/supported-platforms.md
@@ -1,5 +1,8 @@
 # Supported Platforms
 
+This page lists platforms tied to a specific hardware and OS pair. For reference projects
+and CI that aren't tied to a particular platform, see [F´ Reference Projects](./reference-projects.md).
+
 | Hardware         | OS | Architecture   | Reference Project | Build Status |
 | ---------------- | -------------------- | ------------------------------- | ---------------------------------- | ------------ |
 | Apple Silicon    | Darwin    | ARM  | [`F Prime Ref`](https://github.com/nasa/fprime) | [![CI [macOS]](https://github.com/nasa/fprime/actions/workflows/build-test-macos.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/build-test-macos.yml) |

--- a/docs/user-manual/framework/supported-platforms.md
+++ b/docs/user-manual/framework/supported-platforms.md
@@ -10,7 +10,6 @@ and CI that aren't tied to a particular platform, see [F´ Reference Projects](.
 | Feather M4 	   | FreeRTOS  | ARM | [`fprime-featherm4-freertos-reference`](https://github.com/fprime-community/fprime-featherm4-freertos-reference) | N/A |
 | Pi Pico          | Zephyr    | ARMv6-M | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | N/A |
 | Pi Pico 2        | Zephyr    | RISC-V | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | [![External Repo: Zephyr Reference (Pico 2)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-pico2.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-pico2.yml) |
-| PolarFire SoC    | VxWorks 7 | RISC-V | TBD | N/A |
 | PyCubed          | Zephyr    | RISC-V | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | N/A |
 | Raspberry Pi     | Linux     | ARMv8 | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | [![External Repo: RPI LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-raspberry-led-blinker.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-raspberry-led-blinker.yml) |
 | Teensy41         | Zephyr    | ARMv7-M | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | [![External Repo: Zephyr Reference (Teensy 4.1)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-teensy41.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-teensy41.yml) |
@@ -31,6 +30,7 @@ These are platforms that the F Prime community or core team is actively working 
 | Pi Pico  | Baremetal  | ARM | In development |[`fprime-baremetal-reference`](https://github.com/fprime-community/fprime-baremetal-reference) | TBD |
 | Pi Pico 2| Baremetal | RISC-V | In development |[`fprime-baremetal-reference`](https://github.com/fprime-community/fprime-baremetal-reference) | TBD |
 | PolarFire SoC  | Linux | RISC-V | Not started | |TBD|
+| PolarFire SoC  | VxWorks 7 | RISC-V | Not started | |TBD|
 | PyCubed  | Baremetal | RISC-V | In development |[`fprime-baremetal-reference`](https://github.com/fprime-community/fprime-baremetal-reference) | TBD |
 | Snapdragon CoProcessor | Linux | ARM | Not started | |TBD|
 | Vorago | Baremetal | ARM | In development | |TBD|

--- a/docs/user-manual/framework/supported-platforms.md
+++ b/docs/user-manual/framework/supported-platforms.md
@@ -1,8 +1,5 @@
 # Supported Platforms
 
-This page lists platforms tied to a specific hardware and OS pair. For reference projects
-and CI that aren't tied to a particular platform, see [F´ Reference Projects](./reference-projects.md).
-
 | Hardware         | OS | Architecture   | Reference Project | Build Status |
 | ---------------- | -------------------- | ------------------------------- | ---------------------------------- | ------------ |
 | Apple Silicon    | Darwin    | ARM  | [`F Prime Ref`](https://github.com/nasa/fprime) | [![CI [macOS]](https://github.com/nasa/fprime/actions/workflows/build-test-macos.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/build-test-macos.yml) |
@@ -10,6 +7,7 @@ and CI that aren't tied to a particular platform, see [F´ Reference Projects](.
 | Feather M4 	   | FreeRTOS  | ARM | [`fprime-featherm4-freertos-reference`](https://github.com/fprime-community/fprime-featherm4-freertos-reference) | N/A |
 | Pi Pico          | Zephyr    | ARMv6-M | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | N/A |
 | Pi Pico 2        | Zephyr    | RISC-V | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | [![External Repo: Zephyr Reference (Pico 2)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-pico2.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-pico2.yml) |
+| PolarFire SoC    | VxWorks 7 | RISC-V | TBD | N/A |
 | PyCubed          | Zephyr    | RISC-V | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | N/A |
 | Raspberry Pi     | Linux     | ARMv8 | [`fprime-workshop-led-blinker`](https://github.com/fprime-community/fprime-workshop-led-blinker) | [![External Repo: RPI LedBlinker](https://github.com/nasa/fprime/actions/workflows/ext-raspberry-led-blinker.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-raspberry-led-blinker.yml) |
 | Teensy41         | Zephyr    | ARMv7-M | [`fprime-zephyr-reference`](https://github.com/fprime-community/fprime-zephyr-reference) | [![External Repo: Zephyr Reference (Teensy 4.1)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-teensy41.yml/badge.svg)](https://github.com/nasa/fprime/actions/workflows/ext-fprime-zephyr-reference-teensy41.yml) |
@@ -30,7 +28,6 @@ These are platforms that the F Prime community or core team is actively working 
 | Pi Pico  | Baremetal  | ARM | In development |[`fprime-baremetal-reference`](https://github.com/fprime-community/fprime-baremetal-reference) | TBD |
 | Pi Pico 2| Baremetal | RISC-V | In development |[`fprime-baremetal-reference`](https://github.com/fprime-community/fprime-baremetal-reference) | TBD |
 | PolarFire SoC  | Linux | RISC-V | Not started | |TBD|
-| PolarFire SoC  | VxWorks 7 | RISC-V | Not started | |TBD|
 | PyCubed  | Baremetal | RISC-V | In development |[`fprime-baremetal-reference`](https://github.com/fprime-community/fprime-baremetal-reference) | TBD |
 | Snapdragon CoProcessor | Linux | ARM | Not started | |TBD|
 | Vorago | Baremetal | ARM | In development | |TBD|


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Closes #5428 |
|**_Has Unit Tests (y/n)_**| n (documentation only) |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Adds a new `docs/user-manual/framework/reference-projects.md` page with two tables:

- **fprime-community References** — `fprime-community` reference repositories not already covered by a row in the Supported Platforms or Targeted Platforms tables.
- **External Repository Continuous Integration (CI)** — the `ext-*.yml` workflows, the repository each exercises, and its trigger, with build-status badges.

`supported-platforms.md` gets a two-line pointer to the new page near the top, rather than the content itself.

## Rationale

Fixes #5428, following the direction given there. Two prior attempts at this issue:

- #5429 was closed because the issue hadn't gone through CCB yet.
- #5506 (mine) was closed because it added a new section to `supported-platforms.md` instead of a separate page.

The most recent comment on the issue gave the concrete direction this PR follows: "Split into two separate pages. References and then link into supported platforms." I posted a plan comment on the issue before implementing, given the history here.

No navigation config change is needed: `.nav.yml`'s Framework entry points at the whole `docs/user-manual/framework/` directory, and `awesome-nav` auto-discovers files within it.

## Testing/Review Recommendations

Documentation only; no source is modified. Verified mechanically rather than by eye:

- All 10 repositories in the "fprime-community References" table resolve via the GitHub API and are public and non-archived.
- All 19 `ext-*.yml` files referenced exist in `.github/workflows/`; each row's name, target repository, and trigger were read from the workflow file itself, not inferred from the filename.
- Markdown table column counts are consistent across both tables (checked programmatically).
- The two anchor links from the new page into `supported-platforms.md` (`#supported-platforms`, `#targeted-platforms-planned-support`) were verified against Python-Markdown's actual `toc` extension slugify output for those two headings, not assumed.
- Attempted a full local `mkdocs build --strict`. The site's `custom_dir`/`mike`/`open-in-new-tab`/`multirepo` plugin chain isn't runnable standalone outside whatever pipeline builds fprime.jpl.nasa.gov — confirmed no workflow in this repository itself runs `mkdocs build`. Disclosing that rather than claiming a full site-build pass I didn't actually get.

Since opening this, @Specky26846 deployed it against the actual website build and left a few good suggestions, all addressed: renamed the "Other Reference Projects" heading, spelled out "CI", and moved a PolarFire SoC/VxWorks 7 row out of Supported Platforms since its reference project is still TBD.

Three judgment calls worth a maintainer's opinion, same as last time:
1. Repos already named in the platform tables (`fprime-vxworks-reference`, `fprime-featherm4-freertos-reference`, `fprime-zephyr-reference`, `fprime-workshop-led-blinker`, `fprime-baremetal-reference`) were excluded from the new table to avoid duplication.
2. Tutorial repositories (`fprime-tutorial-*`) were excluded from the reference-projects table (they're tutorials, not reference deployments) but their CI is still listed in the External Repository CI table since those workflows exist regardless.
3. For `ext-cookiecutters-test.yml` I listed both `fprime-tools` and `fprime-bootstrap`, since the workflow exercises both.

## Future Work

None anticipated beyond keeping both tables current as new reference repos/workflows are added.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

I worked through this with Claude Code — it pulled the repository and workflow data via the GitHub API and by reading the workflow files directly, drafted the page and the link, and verified the anchor slugs against Python-Markdown's actual behavior rather than assuming them. I reviewed the sourced data against the actual repos/workflows myself before including it, and this is the second attempt at this issue from this account — the first (#5506) was closed for using the wrong page structure, which I corrected here per the maintainer's follow-up direction.
