### PR TITLE
fix(Ref): register commands after component and topology configuration

### DIFF
--- a/TestDeploymentsProject/Ref/Top/RefTopology.cpp
+++ b/TestDeploymentsProject/Ref/Top/RefTopology.cpp
@@ -70,8 +70,6 @@ void setupTopology(const TopologyState& state) {
     setBaseIds();
     // Autocoded connection wiring. Function provided by autocoder.
     connectComponents();
-    // Autocoded command registration. Function provided by autocoder.
-    regCommands();
     // Autocoded configuration. Function provided by autocoder.
     configComponents(state);
     if (state.hostname != nullptr && state.port != 0) {
@@ -79,6 +77,8 @@ void setupTopology(const TopologyState& state) {
     }
     // Project-specific component configuration. Function provided above. May be inlined, if desired.
     configureTopology();
+    // Autocoded command registration. Function provided by autocoder.
+    regCommands();
     // Autocoded parameter loading. Function provided by autocoder.
     loadParameters();
     // Autocoded task kick-off (active components). Function provided by autocoder.

--- a/TestDeploymentsProject/Ref/Top/RefTopology.hpp
+++ b/TestDeploymentsProject/Ref/Top/RefTopology.hpp
@@ -27,13 +27,14 @@ namespace Ref {
  *   2. Call the autocoded `setBaseIds()` function to set the base IDs (offset) for each component instance
  *   3. Call the autocoded `connectComponents()` function to wire-together the topology of components
  *   4. Configure components requiring custom configuration
- *   5. Call the autocoded `loadParameters()` function to cause each component to load initial parameter values
- *   6. Call the autocoded `startTasks()` function to start the active component tasks
- *   7. Start tasks not owned by active components
+ *   5. Call the autocoded `regCommands()` function to register commands after configuration has completed
+ *   6. Call the autocoded `loadParameters()` function to cause each component to load initial parameter values
+ *   7. Call the autocoded `startTasks()` function to start the active component tasks
+ *   8. Start tasks not owned by active components
  *
- * Step 4 and step 7 are custom and supplied by the project. The ordering of steps 1, 2, 3, 5, and 6 are critical for
+ * Step 4 and step 8 are custom and supplied by the project. The ordering of steps 1, 2, 3, 5, 6, and 7 are critical for
  * F´ topologies to function. Configuration (step 4) typically assumes a connect but not started topology and is thus
- * inserted between step 3 and 5. Step 7 may come before or after the active component initializations. Since these
+ * inserted between step 3 and 5. Step 8 may come before or after the active component initializations. Since these
  * custom tasks often start radio communication it is convenient to start them last.
  *
  * The state argument carries command line inputs used to setup the topology. For an explanation of the required type


### PR DESCRIPTION
Fixes: #5530
https://github.com/nasa/fprime/issues/5530

## Problem
In `RefTopology`, `regCommands()` was previously called prior to `configComponents()` and `configureTopology()`. 

When `regCommands()` triggers `OpCodeRegistered` events, the event handling framework queries the connected time source port. Because command registration occurred before time provider ports and component configurations were established, event logging could result in uninitialized timestamps or port assertion failures.

## Solution
Moved `regCommands()` after `configComponents()` and `configureTopology()` initialization steps in `RefTopology`. This guarantees that time providers, component configurations, and topology routing are fully established before command registration events are fired.

## Verification
- Built `Ref` deployment cleanly via `fprime-util build`.
- Ran full unit test suite via `fprime-util check` (116/116 tests passed).