### PR TITLE
fix(FileDownlink): set cancel packet buffer to exact serialized size

### DIFF
--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -396,6 +396,15 @@ void FileDownlink ::sendCancelPacket() {
     // Serialize the filePacket content into the buffer
     status = filePacket.toBuffer(offsetBuffer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
+    // Match sendFilePacket(): expose the exact serialized size on the wire.
+    // getBuffer() leaves size at FILEDOWNLINK_INTERNAL_BUFFER_SIZE; leaving that
+    // full size makes receivers that call filePacket.fromBuffer(fwBuffer) fail with
+    // FW_DESERIALIZE_SIZE_MISMATCH on Cancel (Start/Data/End already set size).
+    // See nasa/fprime#5347.
+    const U32 bufferSize = filePacket.bufferSize() + static_cast<U32>(sizeof(FwPacketDescriptorType));
+    FW_ASSERT(buffer.getSize() >= bufferSize, static_cast<FwAssertArgType>(buffer.getSize()),
+              static_cast<FwAssertArgType>(bufferSize));
+    buffer.setSize(bufferSize);
     this->bufferSendOut_out(0, buffer);
     this->m_packetsSent.packetSent();
 }

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -396,11 +396,6 @@ void FileDownlink ::sendCancelPacket() {
     // Serialize the filePacket content into the buffer
     status = filePacket.toBuffer(offsetBuffer);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK);
-    // Match sendFilePacket(): expose the exact serialized size on the wire.
-    // getBuffer() leaves size at FILEDOWNLINK_INTERNAL_BUFFER_SIZE; leaving that
-    // full size makes receivers that call filePacket.fromBuffer(fwBuffer) fail with
-    // FW_DESERIALIZE_SIZE_MISMATCH on Cancel (Start/Data/End already set size).
-    // See nasa/fprime#5347.
     const U32 bufferSize = filePacket.bufferSize() + static_cast<U32>(sizeof(FwPacketDescriptorType));
     FW_ASSERT(buffer.getSize() >= bufferSize, static_cast<FwAssertArgType>(buffer.getSize()),
               static_cast<FwAssertArgType>(bufferSize));

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -540,6 +540,10 @@ void FileDownlinkTester ::validateCancelPacket(const Fw::Buffer& buffer, const U
     const Fw::FilePacket::Header& header = filePacket.asHeader();
     ASSERT_EQ(sequenceIndex, header.m_sequenceIndex);
     ASSERT_EQ(Fw::FilePacket::T_CANCEL, header.m_type);
+    // Cancel buffers must advertise exact payload size (same contract as Start/Data/End).
+    // Full-size internal buffers break strict fromBuffer() consumers (#5347).
+    ASSERT_EQ(filePacket.bufferSize() + sizeof(FwPacketDescriptorType),
+              static_cast<U32>(buffer.getSize()));
 }
 
 }  // namespace Svc

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -542,8 +542,7 @@ void FileDownlinkTester ::validateCancelPacket(const Fw::Buffer& buffer, const U
     ASSERT_EQ(Fw::FilePacket::T_CANCEL, header.m_type);
     // Cancel buffers must advertise exact payload size (same contract as Start/Data/End).
     // Full-size internal buffers break strict fromBuffer() consumers (#5347).
-    ASSERT_EQ(filePacket.bufferSize() + sizeof(FwPacketDescriptorType),
-              static_cast<U32>(buffer.getSize()));
+    ASSERT_EQ(filePacket.bufferSize() + sizeof(FwPacketDescriptorType), static_cast<U32>(buffer.getSize()));
 }
 
 }  // namespace Svc


### PR DESCRIPTION
## Overview
Cancel packets from `Svc::FileDownlink` were leaving the outbound buffer sized at the full internal buffer (`FILEDOWNLINK_INTERNAL_BUFFER_SIZE`) instead of the exact serialized packet length. Start/Data/End already shrink via `sendFilePacket()`; Cancel did not.

Strict consumers that call `Fw::FilePacket::fromBuffer` on the cancel buffer then fail with `FW_DESERIALIZE_SIZE_MISMATCH`, because `CancelPacket::fromSerialBuffer` requires **zero leftover bytes** after the header (cancel is header-only).

## Changes
- After serializing the cancel packet, call `buffer.setSize(filePacket.bufferSize() + sizeof(FwPacketDescriptorType))` — same contract as `sendFilePacket()`.
- Unit test: `validateCancelPacket` asserts the buffer advertises that exact size.

## Testing
- FileDownlink unit tests (`CancelDownlink` path) expected to cover this via `validateCancelPacket`.
- Logic verified against `CancelPacket.cpp` leftover check and side-by-side with `sendFilePacket()`.

## Related issue
Fixes #5347

## Notes
Small, isolated fix. No API changes. Helps any component that deserializes FileDownlink cancel buffers using the official `fromBuffer` path.
