### PR TITLE
Document FpySequencer directive dispatch functions

### DIFF
--- a/Svc/FpySequencer/FpySequencerDirectives.cpp
+++ b/Svc/FpySequencer/FpySequencerDirectives.cpp
@@ -987,12 +987,14 @@ Signal FpySequencer::stackOp_directiveHandler(const FpySequencer_StackOpDirectiv
               static_cast<FwAssertArgType>(directive.get__op()));
 
     switch (directive.get__op()) {
+        // Logical operations
         case Fpy::DirectiveId::OR:
             error = this->op_or();
             break;
         case Fpy::DirectiveId::AND:
             error = this->op_and();
             break;
+        // Integer comparisons (equality, unsigned, signed)
         case Fpy::DirectiveId::IEQ:
             error = this->op_ieq();
             break;
@@ -1023,6 +1025,7 @@ Signal FpySequencer::stackOp_directiveHandler(const FpySequencer_StackOpDirectiv
         case Fpy::DirectiveId::SGE:
             error = this->op_sge();
             break;
+        // Floating-point comparisons
         case Fpy::DirectiveId::FEQ:
             error = this->op_feq();
             break;
@@ -1041,9 +1044,11 @@ Signal FpySequencer::stackOp_directiveHandler(const FpySequencer_StackOpDirectiv
         case Fpy::DirectiveId::FGE:
             error = this->op_fge();
             break;
+        // Logical negation
         case Fpy::DirectiveId::NOT:
             error = this->op_not();
             break;
+        // Floating-point/integer conversions
         case Fpy::DirectiveId::FPEXT:
             error = this->op_fpext();
             break;
@@ -1062,6 +1067,7 @@ Signal FpySequencer::stackOp_directiveHandler(const FpySequencer_StackOpDirectiv
         case Fpy::DirectiveId::UITOFP:
             error = this->op_uitofp();
             break;
+        // Integer arithmetic
         case Fpy::DirectiveId::ADD:
             error = this->op_add();
             break;
@@ -1083,6 +1089,7 @@ Signal FpySequencer::stackOp_directiveHandler(const FpySequencer_StackOpDirectiv
         case Fpy::DirectiveId::SMOD:
             error = this->op_smod();
             break;
+        // Floating-point arithmetic
         case Fpy::DirectiveId::FADD:
             error = this->op_fadd();
             break;
@@ -1104,6 +1111,7 @@ Signal FpySequencer::stackOp_directiveHandler(const FpySequencer_StackOpDirectiv
         case Fpy::DirectiveId::FMOD:
             error = this->op_fmod();
             break;
+        // Integer width conversions (sign/zero extension, truncation)
         case Fpy::DirectiveId::SIEXT_8_64:
             error = this->op_siext_8_64();
             break;

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -499,6 +499,7 @@ void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy:
             FW_ASSERT(false);
             return;
         }
+        // Sequence control and timing directives
         case Fpy::DirectiveId::WAIT_REL: {
             this->directive_waitRel_internalInterfaceInvoke(directive.waitRel);
             return;
@@ -519,6 +520,7 @@ void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy:
             this->directive_noOp_internalInterfaceInvoke(directive.noOp);
             return;
         }
+        // Directives that push FSW state (telemetry, parameters) or run commands
         case Fpy::DirectiveId::PUSH_TLM_VAL: {
             this->directive_pushTlmVal_internalInterfaceInvoke(directive.pushTlmVal);
             return;
@@ -536,6 +538,8 @@ void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy:
             return;
         }
         // fallthrough on purpose
+        // Stack operations (logical, comparison, arithmetic, conversion),
+        // delegated to stackOp_directiveHandler
         case Fpy::DirectiveId::OR:
         case Fpy::DirectiveId::AND:
         case Fpy::DirectiveId::IEQ:
@@ -587,6 +591,7 @@ void FpySequencer::dispatchDirective(const DirectiveUnion& directive, const Fpy:
             this->directive_stackOp_internalInterfaceInvoke(directive.stackOp);
             return;
         }
+        // Remaining directives, each dispatched to its own handler
         case Fpy::DirectiveId::EXIT: {
             this->directive_exit_internalInterfaceInvoke(directive.exit);
             return;


### PR DESCRIPTION
## Change Description
Adds brief section comments to the two large switch-based dispatchers flagged by CodeQL (`cpp/poorly-documented-function`): `stackOp_directiveHandler` in `FpySequencerDirectives.cpp` (grouped as logical, comparison, arithmetic, and conversion operations) and `dispatchDirective` in `FpySequencerRunState.cpp`. Comments only — no functional changes. `deserializeDirective` was intentionally left untouched as it was not flagged.

## Rationale
Closes #5482. Satisfies the CodeQL comment-ratio rule and helps readers navigate the ~40-case directive switches.

## Testing/Review Recommendations
Comments-only change; verified `fprime-util build --ut` still compiles in `Svc/FpySequencer`.