### PR TITLE
docs: fix two stale relative links in component SDDs

### DIFF
--- a/Fw/Dp/docs/sdd.md
+++ b/Fw/Dp/docs/sdd.md
@@ -10,7 +10,7 @@ For more information on data products and records, see the
 ## 2. Configuration
 
 The following types and constants are configurable via the file
-[`config/DpCfg.fpp`](../../../config/DpCfg.fpp):
+[`config/DpCfg.fpp`](../../../default/config/DpCfg.fpp):
 
 | Name | Kind | Description |
 | ---- | ---- | ---- |

--- a/Svc/FprimeDeframer/docs/sdd.md
+++ b/Svc/FprimeDeframer/docs/sdd.md
@@ -6,7 +6,7 @@ Following the [F Prime Protocol frame specification](../../FprimeProtocol/docs/s
 
 ## Internals
 
-The `Svc::FprimeDeframer` component is an implementation of the [DeframerInterface](../../Interfaces/DeframerInterface.fppi) for the F´ communications protocol. It receives an F´ frame (in a [Fw::Buffer](../../../Fw/Buffer/docs/sdd.md) object) on its `dataIn` input port, modifies the input buffer to remove the header and trailer, and sends it out through its `dataOut` output port. 
+The `Svc::FprimeDeframer` component is an implementation of the [DeframerInterface](../../Interfaces/docs/sdd.md) for the F´ communications protocol. It receives an F´ frame (in a [Fw::Buffer](../../../Fw/Buffer/docs/sdd.md) object) on its `dataIn` input port, modifies the input buffer to remove the header and trailer, and sends it out through its `dataOut` output port. 
 
 Ownership of the buffer is transferred to the component connected to the `dataOut` output port. The input buffer is modified by subtracting the header and trailer size from the buffer's length, and offsetting the buffer's data pointer to point to the start of the packet data.
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| none — same class as #5475 |
|**_Has Unit Tests (y/n)_**| n/a (docs only) |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Two relative links in component SDDs point at paths that do not exist. Both targets verified present in-repo.

- `Fw/Dp/docs/sdd.md:13` — linked `../../../config/DpCfg.fpp`; there is no `config/` at the repo root, the file lives at `default/config/DpCfg.fpp`
- `Svc/FprimeDeframer/docs/sdd.md:9` — linked `../../Interfaces/DeframerInterface.fppi`; `Svc/Interfaces/` holds no `.fppi` files at all. Retargeted to `../../Interfaces/docs/sdd.md`, whose `## Svc/DeframerInterface` section documents this interface and already links back to `../../FprimeDeframer/docs/sdd.md`

Docs only; no code changes.

## Rationale

`Fw/Dp` was missed by #5475, which fixed the same `config/` → `default/config/` drift in `Svc/DpManager` and `Svc/DpWriter`.

Neither link is visible to CI: `.github/actions/markdown-check/mlc-config.json` ignores `.*\.[chf]pp`, which matches both `.fpp` and `.fppi` targets. That is why they survived while `.md` links stayed healthy. The `FprimeDeframer` fix moves that link into the checker's coverage.

The `Fw/Dp` link text still reads `config/DpCfg.fpp` while the target is `default/config/DpCfg.fpp`. That is deliberate — it matches the two places already written that way:

- `docs/user-manual/framework/memory-management/memory-allocation.md:143`
- `Svc/BufferManager/docs/sdd.md:137`

`Svc/FprimeFramer/docs/sdd.md:3` words the same sentence as the corrected `FprimeDeframer` one.

## Testing/Review Recommendations

Swept every relative link in the repo before and after: 920 links across 276 markdown files, excluding `reference/api/**` and `tutorials-*` which the docs build resolves elsewhere. Two broken before, zero after.

Both targets exist on `devel` @ `264bb83`:

```
$ test -e default/config/DpCfg.fpp && echo ok
ok
$ test -e Svc/Interfaces/docs/sdd.md && echo ok
ok
```

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

- **Type of assistance**: repository-wide link audit and drafting this description
- **Scope**: the two `sdd.md` lines above; no source, build or test files touched
- **Tool**: Claude Code
- **Level of modification**: the replacement paths were chosen against existing in-repo conventions rather than accepted as generated, and I ran every check above myself
