### PR TITLE
Add GenerateDp command to FileManager

### DIFF
--- a/Svc/FileManager/Commands.fppi
+++ b/Svc/FileManager/Commands.fppi
@@ -49,3 +49,13 @@ async command CalculateCrc(
                               filename: string size FileNameStringSize @< The file to CRC
                             ) \
   opcode 0x08
+
+@ Generate a data product from a file, split into chunks.
+@ Each chunk is emitted as a FileChunkHeaderRecord (file name, offset, data size)
+@ followed by a FileChunkDataRecord containing the chunk bytes, so ground tools
+@ can reassemble the original file regardless of DP buffer sizing.
+async command GenerateDp(
+                          fileName: string size FileNameStringSize @< The file to package as a data product
+                          chunkSize: U32 @< The maximum number of file bytes per chunk
+                        ) \
+  opcode 0x09

--- a/Svc/FileManager/Commands.fppi
+++ b/Svc/FileManager/Commands.fppi
@@ -59,5 +59,7 @@ async command GenerateDp(
                           chunkSize: U32 @< The maximum number of file bytes per chunk
                           beginOffset: U64 @< The offset in the file at which to start
                           endOffset: U64 @< The offset in the file at which to stop, exclusive; 0 means the end of the file
+                          $priority: U32 @< The container priority; 0 means the configured default
+                          mode: Svc.FileManager.GenerateDpMode @< Whether to pace the chunks with the rate group or emit them immediately
                         ) \
   opcode 0x09

--- a/Svc/FileManager/Commands.fppi
+++ b/Svc/FileManager/Commands.fppi
@@ -57,5 +57,7 @@ async command CalculateCrc(
 async command GenerateDp(
                           fileName: string size FileNameStringSize @< The file to package as a data product
                           chunkSize: U32 @< The maximum number of file bytes per chunk
+                          beginOffset: U64 @< The offset in the file at which to start
+                          endOffset: U64 @< The offset in the file at which to stop, exclusive; 0 means the end of the file
                         ) \
   opcode 0x09

--- a/Svc/FileManager/Events.fppi
+++ b/Svc/FileManager/Events.fppi
@@ -233,7 +233,7 @@ event CalculateCrcSucceeded(fileName: string size FileNameStringSize @< The name
   format "{} has CRC value 0x{x}"
 @ File data product generation started
 event GenerateDpStarted(fileName: string size FileNameStringSize @< The file being packaged
-                        fileSize: U64 @< The size of the file in bytes
+                        bytesToWrite: U64 @< The number of file bytes that will be written
                        ) \
   severity activity high \
   id 0x1e \
@@ -249,11 +249,12 @@ event GenerateDpComplete(fileName: string size FileNameStringSize @< The file th
 
 @ File data product generation failed
 event GenerateDpFailed(fileName: string size FileNameStringSize @< The file being packaged
+                       stage: Svc.FileManager.GenerateDpStage @< Where the failure occurred
                        status: U32 @< The error status
                       ) \
   severity warning high \
   id 0x20 \
-  format "Data product generation failed for file {}, status {}"
+  format "Data product generation failed for file {} at stage {}, status {}"
 
 @ Data product container allocation failed
 event GenerateDpBufferFailed(fileName: string size FileNameStringSize @< The file being packaged

--- a/Svc/FileManager/Events.fppi
+++ b/Svc/FileManager/Events.fppi
@@ -261,3 +261,13 @@ event GenerateDpBufferFailed(fileName: string size FileNameStringSize @< The fil
   severity warning high \
   id 0x21 \
   format "Failed to allocate data product buffer for file {}"
+
+@ Invalid offset range requested for data product generation
+event GenerateDpInvalidRange(fileName: string size FileNameStringSize @< The file being packaged
+                             beginOffset: U64 @< The requested begin offset
+                             endOffset: U64 @< The requested end offset
+                             fileSize: U64 @< The size of the file
+                            ) \
+  severity warning high \
+  id 0x22 \
+  format "Invalid offset range requested for file {}: [{}, {}) with file size {}"

--- a/Svc/FileManager/Events.fppi
+++ b/Svc/FileManager/Events.fppi
@@ -231,3 +231,33 @@ event CalculateCrcSucceeded(fileName: string size FileNameStringSize @< The name
   severity activity high \
   id 0x1c \
   format "{} has CRC value 0x{x}"
+@ File data product generation started
+event GenerateDpStarted(fileName: string size FileNameStringSize @< The file being packaged
+                        fileSize: U64 @< The size of the file in bytes
+                       ) \
+  severity activity high \
+  id 0x1e \
+  format "Started data product generation for file {} ({} bytes)"
+
+@ File data product generation completed
+event GenerateDpComplete(fileName: string size FileNameStringSize @< The file that was packaged
+                         chunks: U32 @< The number of chunks emitted
+                        ) \
+  severity activity high \
+  id 0x1f \
+  format "Completed data product generation for file {} in {} chunks"
+
+@ File data product generation failed
+event GenerateDpFailed(fileName: string size FileNameStringSize @< The file being packaged
+                       status: U32 @< The error status
+                      ) \
+  severity warning high \
+  id 0x20 \
+  format "Data product generation failed for file {}, status {}"
+
+@ Data product container allocation failed
+event GenerateDpBufferFailed(fileName: string size FileNameStringSize @< The file being packaged
+                            ) \
+  severity warning high \
+  id 0x21 \
+  format "Failed to allocate data product buffer for file {}"

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -223,14 +223,14 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
     // Reject a second request while one is already running
     if (this->m_dpState != DP_IDLE) {
         this->log_WARNING_HI_GenerateDpFailed(logFileName, 0);
-        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
         return;
     }
 
     // Data products must be available
     if (!this->isConnected_productGetOut_OutputPort(0) || !this->isConnected_productSendOut_OutputPort(0)) {
         this->log_WARNING_HI_GenerateDpBufferFailed(logFileName);
-        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
         return;
     }
 
@@ -243,7 +243,7 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
     Os::File::Status status = this->m_dpFile.open(fileName.toChar(), Os::File::OPEN_READ);
     if (status != Os::File::OP_OK) {
         this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
-        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
         return;
     }
 
@@ -252,7 +252,7 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
     if (status != Os::File::OP_OK) {
         this->m_dpFile.close();
         this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
-        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
         return;
     }
 
@@ -271,7 +271,7 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
         this->m_dpFile.close();
         this->log_WARNING_HI_GenerateDpInvalidRange(logFileName, beginOffset, endOffset,
                                                     static_cast<U64>(fileSize));
-        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
         return;
     }
 
@@ -281,7 +281,7 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
         if (status != Os::File::OP_OK) {
             this->m_dpFile.close();
             this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
-            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
             return;
         }
     }
@@ -301,7 +301,7 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
     // An empty range produces no chunks, so complete immediately
     if (this->m_dpOffset >= this->m_dpEndOffset) {
         this->log_ACTIVITY_HI_GenerateDpComplete(logFileName, this->m_dpChunkCount);
-        this->finishDpGeneration(Fw::CmdResponse::OK);
+        this->finishDpGeneration();
     }
 
     // Otherwise the response is deferred until the last chunk is sent
@@ -319,7 +319,7 @@ void FileManager ::processDpChunks() {
         const FwSizeType remaining = static_cast<FwSizeType>(this->m_dpEndOffset - this->m_dpOffset);
         if (remaining == 0) {
             this->log_ACTIVITY_HI_GenerateDpComplete(logFileName, this->m_dpChunkCount);
-            this->finishDpGeneration(Fw::CmdResponse::OK);
+            this->finishDpGeneration();
             return;
         }
 
@@ -330,7 +330,7 @@ void FileManager ::processDpChunks() {
         Os::File::Status status = this->m_dpFile.read(this->m_dpBuffer, readSize);
         if ((status != Os::File::OP_OK) || (readSize == 0)) {
             this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
-            this->finishDpGeneration(Fw::CmdResponse::EXECUTION_ERROR);
+            this->finishDpGeneration();
             return;
         }
 
@@ -341,7 +341,7 @@ void FileManager ::processDpChunks() {
         const Fw::Success::T dpStatus = this->dpGet_FileDpContainer(dpSize, container);
         if (dpStatus != Fw::Success::SUCCESS) {
             this->log_WARNING_HI_GenerateDpBufferFailed(logFileName);
-            this->finishDpGeneration(Fw::CmdResponse::EXECUTION_ERROR);
+            this->finishDpGeneration();
             return;
         }
 
@@ -355,7 +355,7 @@ void FileManager ::processDpChunks() {
         }
         if (serializeStatus != Fw::FW_SERIALIZE_OK) {
             this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(serializeStatus));
-            this->finishDpGeneration(Fw::CmdResponse::EXECUTION_ERROR);
+            this->finishDpGeneration();
             return;
         }
 
@@ -367,19 +367,21 @@ void FileManager ::processDpChunks() {
         // Last chunk of the requested range
         if (this->m_dpOffset >= this->m_dpEndOffset) {
             this->log_ACTIVITY_HI_GenerateDpComplete(logFileName, this->m_dpChunkCount);
-            this->finishDpGeneration(Fw::CmdResponse::OK);
+            this->finishDpGeneration();
             return;
         }
     }
 }
 
-void FileManager ::finishDpGeneration(Fw::CmdResponse::T response) {
+void FileManager ::finishDpGeneration() {
     this->m_dpFile.close();
     this->m_dpState = DP_IDLE;
     this->m_dpOffset = 0;
     this->m_dpEndOffset = 0;
     this->m_dpFileSize = 0;
-    this->cmdResponse_out(this->m_dpOpCode, this->m_dpCmdSeq, response);
+    // Failures emit a warning event but still respond with OK, so that a bad
+    // file name or a transient resource problem does not stop a whole sequence
+    this->cmdResponse_out(this->m_dpOpCode, this->m_dpCmdSeq, Fw::CmdResponse::OK);
 }
 
 void FileManager ::pingIn_handler(const FwIndexType portNum, U32 key) {

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -35,7 +35,15 @@ FileManager ::FileManager(const char* const compName  //!< The component name
       m_totalEntries(0),
       m_currentOpCode(0),
       m_currentCmdSeq(0),
-      m_runQueued(false) {}
+      m_runQueued(false),
+      m_dpState(DP_IDLE),
+      m_dpFileSize(0),
+      m_dpOffset(0),
+      m_dpChunkSize(0),
+      m_dpChunkCount(0),
+      m_dpOpCode(0),
+      m_dpCmdSeq(0),
+      m_dpBuffer{} {}
 
 FileManager ::~FileManager() {}
 
@@ -203,6 +211,141 @@ void FileManager ::CalculateCrc_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, cons
     file.close();
 }
 
+void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
+                                         U32 cmdSeq,
+                                         const Fw::CmdStringArg& fileName,
+                                         U32 chunkSize) {
+    Fw::LogStringArg logFileName(fileName.toChar());
+
+    // Reject a second request while one is already running
+    if (this->m_dpState != DP_IDLE) {
+        this->log_WARNING_HI_GenerateDpFailed(logFileName, 0);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
+
+    // Data products must be available
+    if (!this->isConnected_productGetOut_OutputPort(0) || !this->isConnected_productSendOut_OutputPort(0)) {
+        this->log_WARNING_HI_GenerateDpBufferFailed(logFileName);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
+
+    // Clamp the requested chunk size to the configured read buffer
+    U32 effectiveChunkSize = chunkSize;
+    if ((effectiveChunkSize == 0) || (effectiveChunkSize > FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE)) {
+        effectiveChunkSize = FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE;
+    }
+
+    Os::File::Status status = this->m_dpFile.open(fileName.toChar(), Os::File::OPEN_READ);
+    if (status != Os::File::OP_OK) {
+        this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
+
+    FwSizeType fileSize = 0;
+    status = this->m_dpFile.size(fileSize);
+    if (status != Os::File::OP_OK) {
+        this->m_dpFile.close();
+        this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
+
+    this->m_dpFileName = Fw::String(fileName.toChar());
+    this->m_dpFileSize = fileSize;
+    this->m_dpOffset = 0;
+    this->m_dpChunkSize = effectiveChunkSize;
+    this->m_dpChunkCount = 0;
+    this->m_dpOpCode = opCode;
+    this->m_dpCmdSeq = cmdSeq;
+    this->m_dpState = DP_IN_PROGRESS;
+
+    this->log_ACTIVITY_HI_GenerateDpStarted(logFileName, static_cast<U64>(fileSize));
+
+    // An empty file produces no chunks, so complete immediately
+    if (fileSize == 0) {
+        this->finishDpGeneration(Fw::CmdResponse::OK);
+    }
+
+    // Otherwise the response is deferred until the last chunk is sent
+}
+
+void FileManager ::processDpChunks() {
+    Fw::LogStringArg logFileName(this->m_dpFileName.toChar());
+
+    for (U32 chunk = 0; chunk < FileManagerConfig::CHUNKS_PER_RATE_TICK; chunk++) {
+        if (this->m_dpState != DP_IN_PROGRESS) {
+            return;
+        }
+
+        // Number of bytes remaining in the file
+        const FwSizeType remaining = this->m_dpFileSize - static_cast<FwSizeType>(this->m_dpOffset);
+        if (remaining == 0) {
+            this->log_ACTIVITY_HI_GenerateDpComplete(logFileName, this->m_dpChunkCount);
+            this->finishDpGeneration(Fw::CmdResponse::OK);
+            return;
+        }
+
+        FwSizeType readSize = (remaining < static_cast<FwSizeType>(this->m_dpChunkSize))
+                                  ? remaining
+                                  : static_cast<FwSizeType>(this->m_dpChunkSize);
+
+        Os::File::Status status = this->m_dpFile.read(this->m_dpBuffer, readSize);
+        if ((status != Os::File::OP_OK) || (readSize == 0)) {
+            this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
+            this->finishDpGeneration(Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
+
+        // Request a container large enough for this chunk's header and data
+        const FwSizeType dpSize = SIZE_OF_FileChunkHeaderRecord_RECORD +
+                                  SIZE_OF_FileChunkDataRecord_RECORD(readSize);
+        DpContainer container;
+        const Fw::Success::T dpStatus = this->dpGet_FileDpContainer(dpSize, container);
+        if (dpStatus != Fw::Success::SUCCESS) {
+            this->log_WARNING_HI_GenerateDpBufferFailed(logFileName);
+            this->finishDpGeneration(Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
+
+        // Each chunk is a metadata record followed by a data record, so that
+        // ground tools can reassemble the file from any number of containers
+        const FileManager_FileChunkHeader header(this->m_dpFileName, this->m_dpOffset,
+                                                 static_cast<U32>(readSize));
+        Fw::SerializeStatus serializeStatus = container.serializeRecord_FileChunkHeaderRecord(header);
+        if (serializeStatus == Fw::FW_SERIALIZE_OK) {
+            serializeStatus = container.serializeRecord_FileChunkDataRecord(this->m_dpBuffer, readSize);
+        }
+        if (serializeStatus != Fw::FW_SERIALIZE_OK) {
+            this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(serializeStatus));
+            this->finishDpGeneration(Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
+
+        this->dpSend(container);
+
+        this->m_dpOffset += static_cast<U64>(readSize);
+        this->m_dpChunkCount++;
+
+        // Last chunk of the file
+        if (static_cast<FwSizeType>(this->m_dpOffset) >= this->m_dpFileSize) {
+            this->log_ACTIVITY_HI_GenerateDpComplete(logFileName, this->m_dpChunkCount);
+            this->finishDpGeneration(Fw::CmdResponse::OK);
+            return;
+        }
+    }
+}
+
+void FileManager ::finishDpGeneration(Fw::CmdResponse::T response) {
+    this->m_dpFile.close();
+    this->m_dpState = DP_IDLE;
+    this->m_dpOffset = 0;
+    this->m_dpFileSize = 0;
+    this->cmdResponse_out(this->m_dpOpCode, this->m_dpCmdSeq, response);
+}
+
 void FileManager ::pingIn_handler(const FwIndexType portNum, U32 key) {
     // return key
     this->pingOut_out(0, key);
@@ -222,6 +365,11 @@ void FileManager ::schedIn_handler(const FwIndexType portNum, U32 context) {
 void FileManager ::run_internalInterfaceHandler() {
     FW_ASSERT(this->m_runQueued);
     this->m_runQueued = false;  // Run is not queued anymore (we are running)
+    // Data product generation is paced the same way as directory listing
+    if (this->m_dpState == DP_IN_PROGRESS) {
+        this->processDpChunks();
+    }
+
     // Only process if we're in the middle of a directory listing
     if (m_listState == LISTING_IN_PROGRESS) {
         // Process multiple files per rate tick based on configuration

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -40,6 +40,7 @@ FileManager ::FileManager(const char* const compName  //!< The component name
       m_dpFileSize(0),
       m_dpOffset(0),
       m_dpChunkSize(0),
+      m_dpEndOffset(0),
       m_dpChunkCount(0),
       m_dpOpCode(0),
       m_dpCmdSeq(0),
@@ -214,7 +215,9 @@ void FileManager ::CalculateCrc_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, cons
 void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
                                          U32 cmdSeq,
                                          const Fw::CmdStringArg& fileName,
-                                         U32 chunkSize) {
+                                         U32 chunkSize,
+                                         U64 beginOffset,
+                                         U64 endOffset) {
     Fw::LogStringArg logFileName(fileName.toChar());
 
     // Reject a second request while one is already running
@@ -253,9 +256,40 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
         return;
     }
 
+    // An end offset of zero, or one past the end of the file, means the end of
+    // the file. Ranges let an operator retransmit part of a file or spread the
+    // downlink over several commands.
+    U64 effectiveEnd = endOffset;
+    if ((effectiveEnd == 0) || (effectiveEnd > static_cast<U64>(fileSize))) {
+        effectiveEnd = static_cast<U64>(fileSize);
+    }
+
+    const bool emptyFile = (fileSize == 0);
+    const bool badRange = (beginOffset > static_cast<U64>(fileSize)) ||
+                          (!emptyFile && (beginOffset >= effectiveEnd));
+    if (badRange) {
+        this->m_dpFile.close();
+        this->log_WARNING_HI_GenerateDpInvalidRange(logFileName, beginOffset, endOffset,
+                                                    static_cast<U64>(fileSize));
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+        return;
+    }
+
+    // Position the file at the start of the requested range
+    if (beginOffset > 0) {
+        status = this->m_dpFile.seek(static_cast<FwSignedSizeType>(beginOffset), Os::File::SeekType::ABSOLUTE);
+        if (status != Os::File::OP_OK) {
+            this->m_dpFile.close();
+            this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
+            this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+            return;
+        }
+    }
+
     this->m_dpFileName = Fw::String(fileName.toChar());
     this->m_dpFileSize = fileSize;
-    this->m_dpOffset = 0;
+    this->m_dpOffset = beginOffset;
+    this->m_dpEndOffset = effectiveEnd;
     this->m_dpChunkSize = effectiveChunkSize;
     this->m_dpChunkCount = 0;
     this->m_dpOpCode = opCode;
@@ -264,8 +298,9 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
 
     this->log_ACTIVITY_HI_GenerateDpStarted(logFileName, static_cast<U64>(fileSize));
 
-    // An empty file produces no chunks, so complete immediately
-    if (fileSize == 0) {
+    // An empty range produces no chunks, so complete immediately
+    if (this->m_dpOffset >= this->m_dpEndOffset) {
+        this->log_ACTIVITY_HI_GenerateDpComplete(logFileName, this->m_dpChunkCount);
         this->finishDpGeneration(Fw::CmdResponse::OK);
     }
 
@@ -280,8 +315,8 @@ void FileManager ::processDpChunks() {
             return;
         }
 
-        // Number of bytes remaining in the file
-        const FwSizeType remaining = this->m_dpFileSize - static_cast<FwSizeType>(this->m_dpOffset);
+        // Number of bytes remaining in the requested range
+        const FwSizeType remaining = static_cast<FwSizeType>(this->m_dpEndOffset - this->m_dpOffset);
         if (remaining == 0) {
             this->log_ACTIVITY_HI_GenerateDpComplete(logFileName, this->m_dpChunkCount);
             this->finishDpGeneration(Fw::CmdResponse::OK);
@@ -329,8 +364,8 @@ void FileManager ::processDpChunks() {
         this->m_dpOffset += static_cast<U64>(readSize);
         this->m_dpChunkCount++;
 
-        // Last chunk of the file
-        if (static_cast<FwSizeType>(this->m_dpOffset) >= this->m_dpFileSize) {
+        // Last chunk of the requested range
+        if (this->m_dpOffset >= this->m_dpEndOffset) {
             this->log_ACTIVITY_HI_GenerateDpComplete(logFileName, this->m_dpChunkCount);
             this->finishDpGeneration(Fw::CmdResponse::OK);
             return;
@@ -342,6 +377,7 @@ void FileManager ::finishDpGeneration(Fw::CmdResponse::T response) {
     this->m_dpFile.close();
     this->m_dpState = DP_IDLE;
     this->m_dpOffset = 0;
+    this->m_dpEndOffset = 0;
     this->m_dpFileSize = 0;
     this->cmdResponse_out(this->m_dpOpCode, this->m_dpCmdSeq, response);
 }

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -41,6 +41,7 @@ FileManager ::FileManager(const char* const compName  //!< The component name
       m_dpOffset(0),
       m_dpChunkSize(0),
       m_dpEndOffset(0),
+      m_dpPriority(0),
       m_dpChunkCount(0),
       m_dpOpCode(0),
       m_dpCmdSeq(0),
@@ -217,12 +218,14 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
                                          const Fw::CmdStringArg& fileName,
                                          U32 chunkSize,
                                          U64 beginOffset,
-                                         U64 endOffset) {
+                                         U64 endOffset,
+                                         U32 priority,
+                                         const FileManager_GenerateDpMode& mode) {
     Fw::LogStringArg logFileName(fileName.toChar());
 
     // Reject a second request while one is already running
     if (this->m_dpState != DP_IDLE) {
-        this->log_WARNING_HI_GenerateDpFailed(logFileName, 0);
+        this->log_WARNING_HI_GenerateDpFailed(logFileName, FileManager_GenerateDpStage::BUSY, 0);
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
         return;
     }
@@ -242,7 +245,7 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
 
     Os::File::Status status = this->m_dpFile.open(fileName.toChar(), Os::File::OPEN_READ);
     if (status != Os::File::OP_OK) {
-        this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
+        this->log_WARNING_HI_GenerateDpFailed(logFileName, FileManager_GenerateDpStage::OPEN, static_cast<U32>(status));
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
         return;
     }
@@ -251,7 +254,7 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
     status = this->m_dpFile.size(fileSize);
     if (status != Os::File::OP_OK) {
         this->m_dpFile.close();
-        this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
+        this->log_WARNING_HI_GenerateDpFailed(logFileName, FileManager_GenerateDpStage::SIZE, static_cast<U32>(status));
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
         return;
     }
@@ -278,7 +281,8 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
         status = this->m_dpFile.seek(static_cast<FwSignedSizeType>(beginOffset), Os::File::SeekType::ABSOLUTE);
         if (status != Os::File::OP_OK) {
             this->m_dpFile.close();
-            this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
+            this->log_WARNING_HI_GenerateDpFailed(logFileName, FileManager_GenerateDpStage::SEEK,
+                                                  static_cast<U32>(status));
             this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
             return;
         }
@@ -292,34 +296,51 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
     this->m_dpChunkCount = 0;
     this->m_dpOpCode = opCode;
     this->m_dpCmdSeq = cmdSeq;
+    // A priority of zero reverts to the configured default
+    this->m_dpPriority = (priority == 0) ? static_cast<FwDpPriorityType>(FileManagerCfg::DEFAULT_DP_PRIORITY)
+                                         : static_cast<FwDpPriorityType>(priority);
     this->m_dpState = DP_IN_PROGRESS;
 
-    this->log_ACTIVITY_HI_GenerateDpStarted(logFileName, static_cast<U64>(fileSize));
+    // Report the number of bytes that will be written, which is the requested
+    // range rather than the size of the whole file
+    this->log_ACTIVITY_HI_GenerateDpStarted(logFileName, this->m_dpEndOffset - this->m_dpOffset);
 
     // An empty range produces no chunks, so complete immediately
     if (this->m_dpOffset >= this->m_dpEndOffset) {
         this->log_ACTIVITY_HI_GenerateDpComplete(logFileName, this->m_dpChunkCount);
         this->finishDpGeneration();
+        return;
     }
 
-    // Otherwise the response is deferred until the last chunk is sent
+    // In immediate mode the whole range is emitted here, so that a project that
+    // wants the file out quickly is not limited by the rate group. In paced
+    // mode the rate group meters the work out and the response is deferred.
+    if (mode == FileManager_GenerateDpMode::IMMEDIATE) {
+        this->processDpChunks(0);
+    }
 }
 
-void FileManager ::processDpChunks() {
+void FileManager ::processDpChunks(U32 chunkLimit) {
     Fw::LogStringArg logFileName(this->m_dpFileName.toChar());
 
-    for (U32 chunk = 0; chunk < FileManagerConfig::CHUNKS_PER_RATE_TICK; chunk++) {
+    // A limit of zero means emit the whole remaining range in this call
+    const bool paced = (chunkLimit > 0);
+
+    for (U32 chunk = 0; !paced || (chunk < chunkLimit); chunk++) {
         // Number of bytes remaining in the requested range. The loop returns as
         // soon as the range is exhausted, so this is always non-zero here.
         const FwSizeType remaining = static_cast<FwSizeType>(this->m_dpEndOffset - this->m_dpOffset);
 
-        FwSizeType readSize = (remaining < static_cast<FwSizeType>(this->m_dpChunkSize))
-                                  ? remaining
-                                  : static_cast<FwSizeType>(this->m_dpChunkSize);
+        const FwSizeType requestedSize = (remaining < static_cast<FwSizeType>(this->m_dpChunkSize))
+                                             ? remaining
+                                             : static_cast<FwSizeType>(this->m_dpChunkSize);
 
-        Os::File::Status status = this->m_dpFile.read(this->m_dpBuffer, readSize);
-        if ((status != Os::File::OP_OK) || (readSize == 0)) {
-            this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(status));
+        // The file size is known, so a short read means the file changed underneath us
+        FwSizeType readSize = requestedSize;
+        const Os::File::Status status = this->m_dpFile.read(this->m_dpBuffer, readSize);
+        if ((status != Os::File::OP_OK) || (readSize != requestedSize)) {
+            this->log_WARNING_HI_GenerateDpFailed(logFileName, FileManager_GenerateDpStage::READ,
+                                                  static_cast<U32>(status));
             this->finishDpGeneration();
             return;
         }
@@ -333,6 +354,7 @@ void FileManager ::processDpChunks() {
             this->finishDpGeneration();
             return;
         }
+        container.setPriority(this->m_dpPriority);
 
         // Each chunk is a metadata record followed by a data record, so that
         // ground tools can reassemble the file from any number of containers
@@ -342,7 +364,8 @@ void FileManager ::processDpChunks() {
             serializeStatus = container.serializeRecord_FileChunkDataRecord(this->m_dpBuffer, readSize);
         }
         if (serializeStatus != Fw::FW_SERIALIZE_OK) {
-            this->log_WARNING_HI_GenerateDpFailed(logFileName, static_cast<U32>(serializeStatus));
+            this->log_WARNING_HI_GenerateDpFailed(logFileName, FileManager_GenerateDpStage::SERIALIZE,
+                                                  static_cast<U32>(serializeStatus));
             this->finishDpGeneration();
             return;
         }
@@ -393,7 +416,7 @@ void FileManager ::run_internalInterfaceHandler() {
     this->m_runQueued = false;  // Run is not queued anymore (we are running)
     // Data product generation is paced the same way as directory listing
     if (this->m_dpState == DP_IN_PROGRESS) {
-        this->processDpChunks();
+        this->processDpChunks(FileManagerConfig::CHUNKS_PER_RATE_TICK);
     }
 
     // Only process if we're in the middle of a directory listing

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -265,12 +265,10 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
     }
 
     const bool emptyFile = (fileSize == 0);
-    const bool badRange = (beginOffset > static_cast<U64>(fileSize)) ||
-                          (!emptyFile && (beginOffset >= effectiveEnd));
+    const bool badRange = (beginOffset > static_cast<U64>(fileSize)) || (!emptyFile && (beginOffset >= effectiveEnd));
     if (badRange) {
         this->m_dpFile.close();
-        this->log_WARNING_HI_GenerateDpInvalidRange(logFileName, beginOffset, endOffset,
-                                                    static_cast<U64>(fileSize));
+        this->log_WARNING_HI_GenerateDpInvalidRange(logFileName, beginOffset, endOffset, static_cast<U64>(fileSize));
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
         return;
     }
@@ -335,8 +333,7 @@ void FileManager ::processDpChunks() {
         }
 
         // Request a container large enough for this chunk's header and data
-        const FwSizeType dpSize = SIZE_OF_FileChunkHeaderRecord_RECORD +
-                                  SIZE_OF_FileChunkDataRecord_RECORD(readSize);
+        const FwSizeType dpSize = SIZE_OF_FileChunkHeaderRecord_RECORD + SIZE_OF_FileChunkDataRecord_RECORD(readSize);
         DpContainer container;
         const Fw::Success::T dpStatus = this->dpGet_FileDpContainer(dpSize, container);
         if (dpStatus != Fw::Success::SUCCESS) {
@@ -347,8 +344,7 @@ void FileManager ::processDpChunks() {
 
         // Each chunk is a metadata record followed by a data record, so that
         // ground tools can reassemble the file from any number of containers
-        const FileManager_FileChunkHeader header(this->m_dpFileName, this->m_dpOffset,
-                                                 static_cast<U32>(readSize));
+        const FileManager_FileChunkHeader header(this->m_dpFileName, this->m_dpOffset, static_cast<U32>(readSize));
         Fw::SerializeStatus serializeStatus = container.serializeRecord_FileChunkHeaderRecord(header);
         if (serializeStatus == Fw::FW_SERIALIZE_OK) {
             serializeStatus = container.serializeRecord_FileChunkDataRecord(this->m_dpBuffer, readSize);

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -309,17 +309,9 @@ void FileManager ::processDpChunks() {
     Fw::LogStringArg logFileName(this->m_dpFileName.toChar());
 
     for (U32 chunk = 0; chunk < FileManagerConfig::CHUNKS_PER_RATE_TICK; chunk++) {
-        if (this->m_dpState != DP_IN_PROGRESS) {
-            return;
-        }
-
-        // Number of bytes remaining in the requested range
+        // Number of bytes remaining in the requested range. The loop returns as
+        // soon as the range is exhausted, so this is always non-zero here.
         const FwSizeType remaining = static_cast<FwSizeType>(this->m_dpEndOffset - this->m_dpOffset);
-        if (remaining == 0) {
-            this->log_ACTIVITY_HI_GenerateDpComplete(logFileName, this->m_dpChunkCount);
-            this->finishDpGeneration();
-            return;
-        }
 
         FwSizeType readSize = (remaining < static_cast<FwSizeType>(this->m_dpChunkSize))
                                   ? remaining

--- a/Svc/FileManager/FileManager.fpp
+++ b/Svc/FileManager/FileManager.fpp
@@ -20,6 +20,29 @@ module Svc {
     output port pingOut: Svc.Ping
 
     # ----------------------------------------------------------------------
+    # Data products
+    # ----------------------------------------------------------------------
+
+    @ Data product ports (synchronous get/send)
+    import Fw.DataProductSync
+
+    @ Metadata for one chunk of a file data product
+    struct FileChunkHeader {
+      fileName: string size FileNameStringSize @< The name of the source file
+      offset: U64 @< The offset of this chunk within the source file
+      dataSize: U32 @< The number of data bytes in this chunk
+    }
+
+    @ Chunk metadata record; each instance is followed by a FileChunkDataRecord
+    product record FileChunkHeaderRecord: FileChunkHeader id 0
+
+    @ Chunk data record; carries the actual file bytes for the preceding header
+    product record FileChunkDataRecord: U8 array id 1
+
+    @ Container for file data products
+    product container FileDpContainer id 0 default priority 10
+
+    # ----------------------------------------------------------------------
     # Special ports
     # ----------------------------------------------------------------------
 

--- a/Svc/FileManager/FileManager.fpp
+++ b/Svc/FileManager/FileManager.fpp
@@ -26,6 +26,30 @@ module Svc {
     @ Data product ports (synchronous get/send)
     import Fw.DataProductSync
 
+    @ Where a data product generation failure occurred
+    enum GenerateDpStage {
+      @ Opening the source file
+      OPEN = 0
+      @ Querying the size of the source file
+      SIZE = 1
+      @ Seeking to the requested begin offset
+      SEEK = 2
+      @ Reading a chunk from the source file
+      READ = 3
+      @ Serializing a chunk into the container
+      SERIALIZE = 4
+      @ A request arrived while another was in progress
+      BUSY = 5
+    }
+
+    @ How the chunks of a file are emitted
+    enum GenerateDpMode {
+      @ Emit one chunk per rate group tick, spreading the work over time
+      PACED = 0
+      @ Emit all chunks in the command handler, completing immediately
+      IMMEDIATE = 1
+    }
+
     @ Metadata for one chunk of a file data product
     struct FileChunkHeader {
       fileName: string size FileNameStringSize @< The name of the source file
@@ -40,7 +64,7 @@ module Svc {
     product record FileChunkDataRecord: U8 array id 1
 
     @ Container for file data products
-    product container FileDpContainer id 0 default priority 10
+    product container FileDpContainer id 0 default priority FileManagerCfg.DEFAULT_DP_PRIORITY
 
     # ----------------------------------------------------------------------
     # Special ports

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -105,12 +105,14 @@ class FileManager final : public FileManagerComponentBase {
 
     //! Implementation for GenerateDp command handler
     //! Package a file into a data product, split into chunks
-    void GenerateDp_cmdHandler(FwOpcodeType opCode,               //!< The opcode
-                               U32 cmdSeq,                        //!< The command sequence number
-                               const Fw::CmdStringArg& fileName,  //!< The file to package as a data product
-                               U32 chunkSize,                     //!< The maximum number of file bytes per chunk
-                               U64 beginOffset,                   //!< The offset in the file at which to start
-                               U64 endOffset                      //!< The offset at which to stop, exclusive
+    void GenerateDp_cmdHandler(FwOpcodeType opCode,                    //!< The opcode
+                               U32 cmdSeq,                             //!< The command sequence number
+                               const Fw::CmdStringArg& fileName,       //!< The file to package as a data product
+                               U32 chunkSize,                          //!< The maximum number of file bytes per chunk
+                               U64 beginOffset,                        //!< The offset in the file at which to start
+                               U64 endOffset,                          //!< The offset at which to stop, exclusive
+                               U32 priority,                           //!< The container priority; 0 means the default
+                               const FileManager_GenerateDpMode& mode  //!< Paced or immediate chunk emission
                                ) override;
 
     //! Handler implementation for pingIn
@@ -237,6 +239,9 @@ class FileManager final : public FileManagerComponentBase {
     //! Offset at which packaging stops, exclusive
     U64 m_dpEndOffset;
 
+    //! Priority to use for the containers of the current request
+    FwDpPriorityType m_dpPriority;
+
     //! Number of chunks emitted so far (for the completion event)
     U32 m_dpChunkCount;
 
@@ -250,8 +255,8 @@ class FileManager final : public FileManagerComponentBase {
     //! dynamic allocation is needed in flight code
     U8 m_dpBuffer[FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE];
 
-    //! Emit up to CHUNKS_PER_RATE_TICK chunks of the current file
-    void processDpChunks();
+    //! Emit chunks of the current file; a limit of zero emits all remaining chunks
+    void processDpChunks(U32 chunkLimit);
 
     //! Close out data product generation and respond to the command
     void finishDpGeneration();

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -105,10 +105,12 @@ class FileManager final : public FileManagerComponentBase {
 
     //! Implementation for GenerateDp command handler
     //! Package a file into a data product, split into chunks
-    void GenerateDp_cmdHandler(FwOpcodeType opCode,                //!< The opcode
-                               U32 cmdSeq,                         //!< The command sequence number
-                               const Fw::CmdStringArg& fileName,   //!< The file to package as a data product
-                               U32 chunkSize                       //!< The maximum number of file bytes per chunk
+    void GenerateDp_cmdHandler(FwOpcodeType opCode,               //!< The opcode
+                               U32 cmdSeq,                        //!< The command sequence number
+                               const Fw::CmdStringArg& fileName,  //!< The file to package as a data product
+                               U32 chunkSize,                     //!< The maximum number of file bytes per chunk
+                               U64 beginOffset,                   //!< The offset in the file at which to start
+                               U64 endOffset                      //!< The offset at which to stop, exclusive
                                ) override;
 
     //! Handler implementation for pingIn
@@ -231,6 +233,9 @@ class FileManager final : public FileManagerComponentBase {
 
     //! Number of file bytes to read per chunk
     U32 m_dpChunkSize;
+
+    //! Offset at which packaging stops, exclusive
+    U64 m_dpEndOffset;
 
     //! Number of chunks emitted so far (for the completion event)
     U32 m_dpChunkCount;

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -14,7 +14,9 @@
 #define Svc_FileManager_HPP
 
 #include <atomic>
+#include "Os/File.hpp"
 #include "Os/FileSystem.hpp"
+#include "config/FileManagerConfig.hpp"
 #include "Svc/FileManager/FileManagerComponentAc.hpp"
 
 namespace Svc {
@@ -100,6 +102,14 @@ class FileManager final : public FileManagerComponentBase {
                                  U32 cmdSeq,                       //!< The command sequence number
                                  const Fw::CmdStringArg& filename  //!< The file to CRC
                                  ) override;
+
+    //! Implementation for GenerateDp command handler
+    //! Package a file into a data product, split into chunks
+    void GenerateDp_cmdHandler(FwOpcodeType opCode,                //!< The opcode
+                               U32 cmdSeq,                         //!< The command sequence number
+                               const Fw::CmdStringArg& fileName,   //!< The file to package as a data product
+                               U32 chunkSize                       //!< The maximum number of file bytes per chunk
+                               ) override;
 
     //! Handler implementation for pingIn
     //!
@@ -189,6 +199,57 @@ class FileManager final : public FileManagerComponentBase {
     U32 m_currentCmdSeq;
 
     std::atomic<bool> m_runQueued;
+
+    // ----------------------------------------------------------------------
+    // Data product generation state machine variables
+    // ----------------------------------------------------------------------
+    // Files are packaged into data products one chunk at a time, paced by
+    // the rate group in the same way as directory listing. This keeps the
+    // work bounded per tick and lets the command succeed regardless of how
+    // large the buffers allocated to data products are.
+
+    //! Data product generation state enumeration
+    enum GenerateDpState {
+        DP_IDLE,       //!< Not currently generating a data product
+        DP_IN_PROGRESS //!< Currently emitting file chunks via rate group
+    };
+
+    //! Current state of data product generation
+    GenerateDpState m_dpState;
+
+    //! File handle for the file being packaged
+    Os::File m_dpFile;
+
+    //! Name of the file being packaged (stored for records and events)
+    Fw::String m_dpFileName;
+
+    //! Total size of the file being packaged
+    FwSizeType m_dpFileSize;
+
+    //! Offset of the next chunk to read from the file
+    U64 m_dpOffset;
+
+    //! Number of file bytes to read per chunk
+    U32 m_dpChunkSize;
+
+    //! Number of chunks emitted so far (for the completion event)
+    U32 m_dpChunkCount;
+
+    //! Command opcode stored for the deferred response
+    FwOpcodeType m_dpOpCode;
+
+    //! Command sequence number stored for the deferred response
+    U32 m_dpCmdSeq;
+
+    //! Read buffer for one chunk; sized by configuration so that no
+    //! dynamic allocation is needed in flight code
+    U8 m_dpBuffer[FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE];
+
+    //! Emit up to CHUNKS_PER_RATE_TICK chunks of the current file
+    void processDpChunks();
+
+    //! Close out data product generation and respond to the command
+    void finishDpGeneration(Fw::CmdResponse::T response);
 };
 
 }  // end namespace Svc

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -254,7 +254,7 @@ class FileManager final : public FileManagerComponentBase {
     void processDpChunks();
 
     //! Close out data product generation and respond to the command
-    void finishDpGeneration(Fw::CmdResponse::T response);
+    void finishDpGeneration();
 };
 
 }  // end namespace Svc

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -16,8 +16,8 @@
 #include <atomic>
 #include "Os/File.hpp"
 #include "Os/FileSystem.hpp"
-#include "config/FileManagerConfig.hpp"
 #include "Svc/FileManager/FileManagerComponentAc.hpp"
+#include "config/FileManagerConfig.hpp"
 
 namespace Svc {
 
@@ -212,8 +212,8 @@ class FileManager final : public FileManagerComponentBase {
 
     //! Data product generation state enumeration
     enum GenerateDpState {
-        DP_IDLE,       //!< Not currently generating a data product
-        DP_IN_PROGRESS //!< Currently emitting file chunks via rate group
+        DP_IDLE,        //!< Not currently generating a data product
+        DP_IN_PROGRESS  //!< Currently emitting file chunks via rate group
     };
 
     //! Current state of data product generation

--- a/Svc/FileManager/docs/sdd.md
+++ b/Svc/FileManager/docs/sdd.md
@@ -27,8 +27,9 @@ information for operators.
 ### GenerateDp
 
 `GenerateDp` packages a file into data products. The command takes the file
-name, a chunk size, and a begin and end offset, and the requested range of the
-file is emitted one chunk at a time. An end offset of zero means the end of the
+name, a chunk size, a begin and end offset, a container priority and an
+emission mode, and the requested range of the file is emitted one chunk at a
+time. An end offset of zero means the end of the
 file, so a begin and end offset of zero packages the whole file. Ranges let an
 operator retransmit part of a file, or spread a downlink over several commands
 when a project cannot fit the whole file into data products at once. Each chunk
@@ -38,9 +39,16 @@ bytes, followed by a `FileChunkDataRecord` holding the chunk bytes. Ground
 tools reassemble the original file from these records, so the command works
 regardless of the size of the buffers allocated to data products.
 
-Chunks are paced by the rate group in the same way as directory listing, one
-chunk per tick by default, and the command response is deferred until the last
-chunk has been sent. The requested chunk size is clamped to
+The emission mode selects how the chunks are written. In `PACED` mode they are
+metered out by the rate group in the same way as directory listing, one chunk
+per tick by default, and the command response is deferred until the last chunk
+has been sent. In `IMMEDIATE` mode the whole range is written in the command
+handler, which suits projects that would rather finish quickly than spread the
+work over time.
+
+A priority of zero uses `Svc::FileManagerCfg::DEFAULT_DP_PRIORITY`, which
+projects can adjust, while a non-zero priority applies to the containers of
+that request only. The requested chunk size is clamped to
 `FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE`, which bounds the read buffer
 held by the component.
 

--- a/Svc/FileManager/docs/sdd.md
+++ b/Svc/FileManager/docs/sdd.md
@@ -42,7 +42,14 @@ Chunks are paced by the rate group in the same way as directory listing, one
 chunk per tick by default, and the command response is deferred until the last
 chunk has been sent. The requested chunk size is clamped to
 `FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE`, which bounds the read buffer
-held by the component. Because each chunk header carries the absolute offset
+held by the component.
+
+Failures during data product generation emit a warning event but still return a
+successful command response. A bad file name or a transient resource problem
+therefore does not stop a command sequence that happens to contain the command,
+while operators still see exactly what went wrong in the event log.
+
+Because each chunk header carries the absolute offset
 within the source file, chunks produced by separate commands reassemble
 correctly on the ground with no extra bookkeeping. The data product ports are
 left for the deployment to

--- a/Svc/FileManager/docs/sdd.md
+++ b/Svc/FileManager/docs/sdd.md
@@ -19,8 +19,27 @@ telemetry, and command responses.
 - AppendFile
 - FileSize
 - CalculateCrc
+- GenerateDp
 
 For each command, the component returns success or failure and emits status
 information for operators.
+
+### GenerateDp
+
+`GenerateDp` packages a file into data products. The command takes the file
+name and a chunk size, and the file is emitted one chunk at a time. Each chunk
+is written as a pair of records: a `FileChunkHeaderRecord` carrying the source
+file name, the offset of the chunk within the file and the number of data
+bytes, followed by a `FileChunkDataRecord` holding the chunk bytes. Ground
+tools reassemble the original file from these records, so the command works
+regardless of the size of the buffers allocated to data products.
+
+Chunks are paced by the rate group in the same way as directory listing, one
+chunk per tick by default, and the command response is deferred until the last
+chunk has been sent. The requested chunk size is clamped to
+`FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE`, which bounds the read buffer
+held by the component. The data product ports are left for the deployment to
+connect; if they are not connected the command fails with an event rather than
+attempting to allocate a container.
 
 

--- a/Svc/FileManager/docs/sdd.md
+++ b/Svc/FileManager/docs/sdd.md
@@ -27,7 +27,11 @@ information for operators.
 ### GenerateDp
 
 `GenerateDp` packages a file into data products. The command takes the file
-name and a chunk size, and the file is emitted one chunk at a time. Each chunk
+name, a chunk size, and a begin and end offset, and the requested range of the
+file is emitted one chunk at a time. An end offset of zero means the end of the
+file, so a begin and end offset of zero packages the whole file. Ranges let an
+operator retransmit part of a file, or spread a downlink over several commands
+when a project cannot fit the whole file into data products at once. Each chunk
 is written as a pair of records: a `FileChunkHeaderRecord` carrying the source
 file name, the offset of the chunk within the file and the number of data
 bytes, followed by a `FileChunkDataRecord` holding the chunk bytes. Ground
@@ -38,7 +42,10 @@ Chunks are paced by the rate group in the same way as directory listing, one
 chunk per tick by default, and the command response is deferred until the last
 chunk has been sent. The requested chunk size is clamped to
 `FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE`, which bounds the read buffer
-held by the component. The data product ports are left for the deployment to
+held by the component. Because each chunk header carries the absolute offset
+within the source file, chunks produced by separate commands reassemble
+correctly on the ground with no extra bookkeeping. The data product ports are
+left for the deployment to
 connect; if they are not connected the command fails with an event rather than
 attempting to allocate a container.
 

--- a/Svc/FileManager/test/ut/FileManagerMain.cpp
+++ b/Svc/FileManager/test/ut/FileManagerMain.cpp
@@ -89,6 +89,26 @@ TEST(Test, listDirectoryWithSubdirs) {
     tester.listDirectoryWithSubdirs();
 }
 
+TEST(Test, generateDpSucceed) {
+    Svc::FileManagerTester tester;
+    tester.generateDpSucceed();
+}
+
+TEST(Test, generateDpFileNotFound) {
+    Svc::FileManagerTester tester;
+    tester.generateDpFileNotFound();
+}
+
+TEST(Test, generateDpEmptyFile) {
+    Svc::FileManagerTester tester;
+    tester.generateDpEmptyFile();
+}
+
+TEST(Test, generateDpChunkSizeClamped) {
+    Svc::FileManagerTester tester;
+    tester.generateDpChunkSizeClamped();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/FileManager/test/ut/FileManagerMain.cpp
+++ b/Svc/FileManager/test/ut/FileManagerMain.cpp
@@ -119,6 +119,21 @@ TEST(Test, generateDpInvalidRange) {
     tester.generateDpInvalidRange();
 }
 
+TEST(Test, generateDpBufferFailure) {
+    Svc::FileManagerTester tester;
+    tester.generateDpBufferFailure();
+}
+
+TEST(Test, generateDpWhileBusy) {
+    Svc::FileManagerTester tester;
+    tester.generateDpWhileBusy();
+}
+
+TEST(Test, generateDpSerializationFailure) {
+    Svc::FileManagerTester tester;
+    tester.generateDpSerializationFailure();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/FileManager/test/ut/FileManagerMain.cpp
+++ b/Svc/FileManager/test/ut/FileManagerMain.cpp
@@ -134,6 +134,16 @@ TEST(Test, generateDpSerializationFailure) {
     tester.generateDpSerializationFailure();
 }
 
+TEST(Test, generateDpImmediateMode) {
+    Svc::FileManagerTester tester;
+    tester.generateDpImmediateMode();
+}
+
+TEST(Test, generateDpCustomPriority) {
+    Svc::FileManagerTester tester;
+    tester.generateDpCustomPriority();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/FileManager/test/ut/FileManagerMain.cpp
+++ b/Svc/FileManager/test/ut/FileManagerMain.cpp
@@ -109,6 +109,16 @@ TEST(Test, generateDpChunkSizeClamped) {
     tester.generateDpChunkSizeClamped();
 }
 
+TEST(Test, generateDpPartialRange) {
+    Svc::FileManagerTester tester;
+    tester.generateDpPartialRange();
+}
+
+TEST(Test, generateDpInvalidRange) {
+    Svc::FileManagerTester tester;
+    tester.generateDpInvalidRange();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -466,8 +466,7 @@ void FileManagerTester ::generateDpChunkSizeClamped() {
     Fw::CmdStringArg cmdStringFile(fileName);
     // A chunk size beyond the configured maximum is clamped, so the 50 byte
     // file still fits in a single chunk
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile,
-                             FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE * 4, 0, 0);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE * 4, 0, 0);
     this->component.doDispatch();
     this->runRateGroupCycles(5);
 

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -381,10 +381,18 @@ void FileManagerTester ::productSend_handler(FwDpIdType id, const Fw::Buffer& bu
     this->m_dpSendCount++;
     this->m_dpBytesSent += buffer.getSize();
 
-    // Recover the priority from the serialized container header
+    // Recover the priority and payload size from the serialized container.
+    // Each container holds one chunk: a FileChunkHeaderRecord followed by a
+    // FileChunkDataRecord, so a non-zero data size confirms the chunk actually
+    // carried header-plus-data content rather than an empty container.
     Fw::DpContainer container(id, buffer);
     if (container.deserializeHeader() == Fw::FW_SERIALIZE_OK) {
         this->m_dpLastPriority = container.getPriority();
+        const FwSizeType dataSize = container.getDataSize();
+        this->m_dpPayloadBytes += dataSize;
+        if ((this->m_dpMinPayloadBytes == 0) || (dataSize < this->m_dpMinPayloadBytes)) {
+            this->m_dpMinPayloadBytes = dataSize;
+        }
     }
 }
 
@@ -407,6 +415,7 @@ void FileManagerTester ::generateDpSucceed() {
 
     // Only the start event so far; the response is deferred
     ASSERT_EVENTS_GenerateDpStarted_SIZE(1);
+    ASSERT_EVENTS_GenerateDpStarted(0, fileName, 100);
     ASSERT_CMD_RESPONSE_SIZE(0);
 
     // Drive the rate group until the file is fully packaged
@@ -418,6 +427,12 @@ void FileManagerTester ::generateDpSucceed() {
     ASSERT_EVENTS_GenerateDpComplete(0, fileName, 4);
     ASSERT_EQ(4u, this->m_dpSendCount);
 
+    // Every container carried a real header-plus-data payload (none empty), and
+    // the total payload exceeds the 100 file bytes by the per-chunk record
+    // overhead, confirming the chunks hold actual content and not just headers
+    ASSERT_GT(this->m_dpMinPayloadBytes, 0u);
+    ASSERT_GT(this->m_dpPayloadBytes, 100u);
+
 #if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
     this->system("rm -f dp_test_file");
 #endif
@@ -426,13 +441,23 @@ void FileManagerTester ::generateDpSucceed() {
 void FileManagerTester ::generateDpFileNotFound() {
     this->resetDpState();
 
-    Fw::CmdStringArg cmdStringFile("no_such_dp_file");
+    const char* const missingName = "no_such_dp_file";
+
+    // Recover the exact open status the component will observe for the missing
+    // file, so the assertion checks the real value rather than a hardcoded one
+    Os::File probeFile;
+    const Os::File::Status openStatus = probeFile.open(missingName, Os::File::OPEN_READ);
+    ASSERT_NE(Os::File::OP_OK, openStatus);
+    probeFile.close();
+
+    Fw::CmdStringArg cmdStringFile(missingName);
     this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0, 0, FileManager_GenerateDpMode::PACED);
     this->component.doDispatch();
 
     ASSERT_CMD_RESPONSE_SIZE(1);
     ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
     ASSERT_EVENTS_GenerateDpFailed_SIZE(1);
+    ASSERT_EVENTS_GenerateDpFailed(0, missingName, FileManager_GenerateDpStage::OPEN, static_cast<U32>(openStatus));
     ASSERT_EQ(0u, this->m_dpSendCount);
 }
 
@@ -538,6 +563,7 @@ void FileManagerTester ::generateDpInvalidRange() {
     ASSERT_CMD_RESPONSE_SIZE(1);
     ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
     ASSERT_EVENTS_GenerateDpInvalidRange_SIZE(1);
+    ASSERT_EVENTS_GenerateDpInvalidRange(0, fileName, 60, 20, 100);
     ASSERT_EQ(0u, this->m_dpSendCount);
 
 #if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
@@ -566,6 +592,7 @@ void FileManagerTester ::generateDpBufferFailure() {
     ASSERT_CMD_RESPONSE_SIZE(1);
     ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
     ASSERT_EVENTS_GenerateDpBufferFailed_SIZE(1);
+    ASSERT_EVENTS_GenerateDpBufferFailed(0, fileName);
     ASSERT_EQ(0u, this->m_dpSendCount);
 
 #if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
@@ -597,9 +624,16 @@ void FileManagerTester ::generateDpWhileBusy() {
     ASSERT_CMD_RESPONSE_SIZE(1);
     ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
     ASSERT_EVENTS_GenerateDpFailed_SIZE(1);
+    ASSERT_EVENTS_GenerateDpFailed(0, fileName, FileManager_GenerateDpStage::BUSY, 0);
 
-    // Let the first generation finish so the component returns to idle
+    // Let the first generation finish so the component returns to idle, and
+    // confirm the busy rejection did not corrupt the in-progress generation
     this->runRateGroupCycles(10);
+
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_CMD_RESPONSE(1, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_GenerateDpComplete_SIZE(1);
+    ASSERT_EVENTS_GenerateDpComplete(0, fileName, 7);
 
 #if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
     this->system("rm -f dp_busy_file");
@@ -627,6 +661,10 @@ void FileManagerTester ::generateDpSerializationFailure() {
     ASSERT_CMD_RESPONSE_SIZE(1);
     ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
     ASSERT_EVENTS_GenerateDpFailed_SIZE(1);
+    // The undersized buffer leaves no room to serialize the chunk, so the
+    // failure status is the serialize error the handler forwards
+    ASSERT_EVENTS_GenerateDpFailed(0, fileName, FileManager_GenerateDpStage::SERIALIZE,
+                                   static_cast<U32>(Fw::FW_SERIALIZE_NO_ROOM_LEFT));
 
 #if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
     this->system("rm -f dp_serialize_fail_file");

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -361,18 +361,20 @@ void FileManagerTester ::resetDpState() {
     this->m_dpGetShouldFail = false;
     this->m_dpGetUndersizedBuffer = false;
     this->m_dpLastPriority = 0;
-    this->m_dpContainerBuffer.setData(this->m_dpContainerData);
-    this->m_dpContainerBuffer.setSize(sizeof this->m_dpContainerData);
+    // Construct the buffer over the backing store: setData adjusts an existing
+    // allocation rather than establishing one, so it cannot initialize a
+    // default-constructed buffer
+    this->m_dpContainerBuffer = Fw::Buffer(this->m_dpContainerData, sizeof this->m_dpContainerData);
 }
 
 Fw::Success::T FileManagerTester ::productGet_handler(FwDpIdType id, FwSizeType size, Fw::Buffer& buffer) {
     if (this->m_dpGetShouldFail || (size > sizeof this->m_dpContainerData)) {
         return Fw::Success::FAILURE;
     }
-    this->m_dpContainerBuffer.setData(this->m_dpContainerData);
     // An undersized buffer lets the serialization failure path be exercised
-    this->m_dpContainerBuffer.setSize(this->m_dpGetUndersizedBuffer ? Fw::DpContainer::MIN_PACKET_SIZE
-                                                                    : sizeof this->m_dpContainerData);
+    const FwSizeType bufferSize =
+        this->m_dpGetUndersizedBuffer ? Fw::DpContainer::MIN_PACKET_SIZE : sizeof this->m_dpContainerData;
+    this->m_dpContainerBuffer = Fw::Buffer(this->m_dpContainerData, bufferSize);
     buffer = this->m_dpContainerBuffer;
     return Fw::Success::SUCCESS;
 }

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -359,6 +359,7 @@ void FileManagerTester ::resetDpState() {
     this->m_dpSendCount = 0;
     this->m_dpBytesSent = 0;
     this->m_dpGetShouldFail = false;
+    this->m_dpGetUndersizedBuffer = false;
     this->m_dpContainerBuffer.setData(this->m_dpContainerData);
     this->m_dpContainerBuffer.setSize(sizeof this->m_dpContainerData);
 }
@@ -368,7 +369,9 @@ Fw::Success::T FileManagerTester ::productGet_handler(FwDpIdType id, FwSizeType 
         return Fw::Success::FAILURE;
     }
     this->m_dpContainerBuffer.setData(this->m_dpContainerData);
-    this->m_dpContainerBuffer.setSize(sizeof this->m_dpContainerData);
+    // An undersized buffer lets the serialization failure path be exercised
+    this->m_dpContainerBuffer.setSize(this->m_dpGetUndersizedBuffer ? Fw::DpContainer::MIN_PACKET_SIZE
+                                                                    : sizeof this->m_dpContainerData);
     buffer = this->m_dpContainerBuffer;
     return Fw::Success::SUCCESS;
 }
@@ -531,6 +534,94 @@ void FileManagerTester ::generateDpInvalidRange() {
 
 #if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
     this->system("rm -f dp_bad_range_file");
+#endif
+}
+
+void FileManagerTester ::generateDpBufferFailure() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    const char* const fileName = "dp_buffer_fail_file";
+    this->system("rm -f dp_buffer_fail_file");
+    this->system("printf '0123456789%.0s' $(seq 1 5) > dp_buffer_fail_file");
+#else
+    SKIP();  // Commands not implemented for this OS
+#endif
+
+    this->resetDpState();
+    this->m_dpGetShouldFail = true;
+
+    Fw::CmdStringArg cmdStringFile(fileName);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0);
+    this->component.doDispatch();
+    this->runRateGroupCycles(5);
+
+    // A container allocation failure is reported but does not fail the command
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_GenerateDpBufferFailed_SIZE(1);
+    ASSERT_EQ(0u, this->m_dpSendCount);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -f dp_buffer_fail_file");
+#endif
+}
+
+void FileManagerTester ::generateDpWhileBusy() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    const char* const fileName = "dp_busy_file";
+    this->system("rm -f dp_busy_file");
+    this->system("printf '0123456789%.0s' $(seq 1 10) > dp_busy_file");
+#else
+    SKIP();  // Commands not implemented for this OS
+#endif
+
+    this->resetDpState();
+
+    Fw::CmdStringArg cmdStringFile(fileName);
+    // Start a generation and leave it in progress by not running the rate group
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0);
+    this->component.doDispatch();
+    ASSERT_CMD_RESPONSE_SIZE(0);
+
+    // A second request while one is in progress is reported and rejected
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0);
+    this->component.doDispatch();
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_GenerateDpFailed_SIZE(1);
+
+    // Let the first generation finish so the component returns to idle
+    this->runRateGroupCycles(10);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -f dp_busy_file");
+#endif
+}
+
+void FileManagerTester ::generateDpSerializationFailure() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    const char* const fileName = "dp_serialize_fail_file";
+    this->system("rm -f dp_serialize_fail_file");
+    this->system("printf '0123456789%.0s' $(seq 1 5) > dp_serialize_fail_file");
+#else
+    SKIP();  // Commands not implemented for this OS
+#endif
+
+    this->resetDpState();
+    this->m_dpGetUndersizedBuffer = true;
+
+    Fw::CmdStringArg cmdStringFile(fileName);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0);
+    this->component.doDispatch();
+    this->runRateGroupCycles(5);
+
+    // A serialization failure is reported but does not fail the command
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_GenerateDpFailed_SIZE(1);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -f dp_serialize_fail_file");
 #endif
 }
 

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -421,7 +421,7 @@ void FileManagerTester ::generateDpFileNotFound() {
     this->component.doDispatch();
 
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
     ASSERT_EVENTS_GenerateDpFailed_SIZE(1);
     ASSERT_EQ(0u, this->m_dpSendCount);
 }
@@ -526,7 +526,7 @@ void FileManagerTester ::generateDpInvalidRange() {
     this->component.doDispatch();
 
     ASSERT_CMD_RESPONSE_SIZE(1);
-    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::VALIDATION_ERROR);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
     ASSERT_EVENTS_GenerateDpInvalidRange_SIZE(1);
     ASSERT_EQ(0u, this->m_dpSendCount);
 

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -355,6 +355,132 @@ void FileManagerTester ::calculateCrcSucceed() {
 #endif
 }
 
+void FileManagerTester ::resetDpState() {
+    this->m_dpSendCount = 0;
+    this->m_dpBytesSent = 0;
+    this->m_dpGetShouldFail = false;
+    this->m_dpContainerBuffer.setData(this->m_dpContainerData);
+    this->m_dpContainerBuffer.setSize(sizeof this->m_dpContainerData);
+}
+
+Fw::Success::T FileManagerTester ::productGet_handler(FwDpIdType id, FwSizeType size, Fw::Buffer& buffer) {
+    if (this->m_dpGetShouldFail || (size > sizeof this->m_dpContainerData)) {
+        return Fw::Success::FAILURE;
+    }
+    this->m_dpContainerBuffer.setData(this->m_dpContainerData);
+    this->m_dpContainerBuffer.setSize(sizeof this->m_dpContainerData);
+    buffer = this->m_dpContainerBuffer;
+    return Fw::Success::SUCCESS;
+}
+
+void FileManagerTester ::productSend_handler(FwDpIdType id, const Fw::Buffer& buffer) {
+    this->m_dpSendCount++;
+    this->m_dpBytesSent += buffer.getSize();
+}
+
+void FileManagerTester ::generateDpSucceed() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    const char* const fileName = "dp_test_file";
+    this->system("rm -f dp_test_file");
+    // 100 bytes of deterministic content
+    this->system("printf '0123456789%.0s' $(seq 1 10) > dp_test_file");
+#else
+    SKIP();  // Commands not implemented for this OS
+#endif
+
+    this->resetDpState();
+
+    Fw::CmdStringArg cmdStringFile(fileName);
+    // 32 byte chunks over a 100 byte file yields 4 chunks (32 + 32 + 32 + 4)
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32);
+    this->component.doDispatch();
+
+    // Only the start event so far; the response is deferred
+    ASSERT_EVENTS_GenerateDpStarted_SIZE(1);
+    ASSERT_CMD_RESPONSE_SIZE(0);
+
+    // Drive the rate group until the file is fully packaged
+    this->runRateGroupCycles(10);
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_GenerateDpComplete_SIZE(1);
+    ASSERT_EVENTS_GenerateDpComplete(0, fileName, 4);
+    ASSERT_EQ(4u, this->m_dpSendCount);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -f dp_test_file");
+#endif
+}
+
+void FileManagerTester ::generateDpFileNotFound() {
+    this->resetDpState();
+
+    Fw::CmdStringArg cmdStringFile("no_such_dp_file");
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32);
+    this->component.doDispatch();
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_EVENTS_GenerateDpFailed_SIZE(1);
+    ASSERT_EQ(0u, this->m_dpSendCount);
+}
+
+void FileManagerTester ::generateDpEmptyFile() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    const char* const fileName = "dp_empty_file";
+    this->system("rm -f dp_empty_file");
+    this->system("touch dp_empty_file");
+#else
+    SKIP();  // Commands not implemented for this OS
+#endif
+
+    this->resetDpState();
+
+    Fw::CmdStringArg cmdStringFile(fileName);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32);
+    this->component.doDispatch();
+
+    // An empty file completes immediately with no chunks
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_GenerateDpStarted_SIZE(1);
+    ASSERT_EQ(0u, this->m_dpSendCount);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -f dp_empty_file");
+#endif
+}
+
+void FileManagerTester ::generateDpChunkSizeClamped() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    const char* const fileName = "dp_clamp_file";
+    this->system("rm -f dp_clamp_file");
+    this->system("printf '0123456789%.0s' $(seq 1 5) > dp_clamp_file");
+#else
+    SKIP();  // Commands not implemented for this OS
+#endif
+
+    this->resetDpState();
+
+    Fw::CmdStringArg cmdStringFile(fileName);
+    // A chunk size beyond the configured maximum is clamped, so the 50 byte
+    // file still fits in a single chunk
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile,
+                             FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE * 4);
+    this->component.doDispatch();
+    this->runRateGroupCycles(5);
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_GenerateDpComplete(0, fileName, 1);
+    ASSERT_EQ(1u, this->m_dpSendCount);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -f dp_clamp_file");
+#endif
+}
+
 void FileManagerTester ::listDirectorySucceed() {
 #if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
     // Remove test_dir and create it with some files
@@ -515,7 +641,8 @@ void FileManagerTester ::listDirectory(const char* const dirName) {
 }
 
 void FileManagerTester ::runRateGroupCycles(const U32 cycles) {
-    // Simulate rate group execution for asynchronous directory listing operations.
+    // Simulate rate group execution for asynchronous operations (directory
+    // listing and data product generation).
     // This method mimics the behavior of Rate Group 2 (0.5Hz) by calling the
     // schedule handler repeatedly until the directory listing operation completes.
     // Each cycle processes one directory entry, ensuring bounded execution time.
@@ -524,8 +651,10 @@ void FileManagerTester ::runRateGroupCycles(const U32 cycles) {
         this->invoke_to_schedIn(0, 0);
         this->component.doDispatch();
 
-        // Check if directory listing operation has completed
-        if (this->component.m_listState != FileManager::LISTING_IN_PROGRESS) {
+        // Check if the asynchronous operation has completed
+        const bool listingActive = (this->component.m_listState == FileManager::LISTING_IN_PROGRESS);
+        const bool dpActive = (this->component.m_dpState == FileManager::DP_IN_PROGRESS);
+        if (!listingActive && !dpActive) {
             // Operation finished, no need to continue cycling
             break;
         }

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -392,7 +392,7 @@ void FileManagerTester ::generateDpSucceed() {
 
     Fw::CmdStringArg cmdStringFile(fileName);
     // 32 byte chunks over a 100 byte file yields 4 chunks (32 + 32 + 32 + 4)
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0);
     this->component.doDispatch();
 
     // Only the start event so far; the response is deferred
@@ -417,7 +417,7 @@ void FileManagerTester ::generateDpFileNotFound() {
     this->resetDpState();
 
     Fw::CmdStringArg cmdStringFile("no_such_dp_file");
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0);
     this->component.doDispatch();
 
     ASSERT_CMD_RESPONSE_SIZE(1);
@@ -438,7 +438,7 @@ void FileManagerTester ::generateDpEmptyFile() {
     this->resetDpState();
 
     Fw::CmdStringArg cmdStringFile(fileName);
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0);
     this->component.doDispatch();
 
     // An empty file completes immediately with no chunks
@@ -467,7 +467,7 @@ void FileManagerTester ::generateDpChunkSizeClamped() {
     // A chunk size beyond the configured maximum is clamped, so the 50 byte
     // file still fits in a single chunk
     this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile,
-                             FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE * 4);
+                             FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE * 4, 0, 0);
     this->component.doDispatch();
     this->runRateGroupCycles(5);
 
@@ -478,6 +478,60 @@ void FileManagerTester ::generateDpChunkSizeClamped() {
 
 #if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
     this->system("rm -f dp_clamp_file");
+#endif
+}
+
+void FileManagerTester ::generateDpPartialRange() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    const char* const fileName = "dp_range_file";
+    this->system("rm -f dp_range_file");
+    this->system("printf '0123456789%.0s' $(seq 1 10) > dp_range_file");
+#else
+    SKIP();  // Commands not implemented for this OS
+#endif
+
+    this->resetDpState();
+
+    Fw::CmdStringArg cmdStringFile(fileName);
+    // Bytes [20, 60) of a 100 byte file with 16 byte chunks yields 3 chunks
+    // (16 + 16 + 8), which lets an operator retransmit part of a file
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 20, 60);
+    this->component.doDispatch();
+    this->runRateGroupCycles(10);
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_GenerateDpComplete(0, fileName, 3);
+    ASSERT_EQ(3u, this->m_dpSendCount);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -f dp_range_file");
+#endif
+}
+
+void FileManagerTester ::generateDpInvalidRange() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    const char* const fileName = "dp_bad_range_file";
+    this->system("rm -f dp_bad_range_file");
+    this->system("printf '0123456789%.0s' $(seq 1 10) > dp_bad_range_file");
+#else
+    SKIP();  // Commands not implemented for this OS
+#endif
+
+    this->resetDpState();
+
+    Fw::CmdStringArg cmdStringFile(fileName);
+    // A begin offset at or past the end offset has nothing to package
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 60, 20);
+    this->component.doDispatch();
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::VALIDATION_ERROR);
+    ASSERT_EVENTS_GenerateDpInvalidRange_SIZE(1);
+    ASSERT_EQ(0u, this->m_dpSendCount);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -f dp_bad_range_file");
 #endif
 }
 

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -360,6 +360,7 @@ void FileManagerTester ::resetDpState() {
     this->m_dpBytesSent = 0;
     this->m_dpGetShouldFail = false;
     this->m_dpGetUndersizedBuffer = false;
+    this->m_dpLastPriority = 0;
     this->m_dpContainerBuffer.setData(this->m_dpContainerData);
     this->m_dpContainerBuffer.setSize(sizeof this->m_dpContainerData);
 }
@@ -379,6 +380,12 @@ Fw::Success::T FileManagerTester ::productGet_handler(FwDpIdType id, FwSizeType 
 void FileManagerTester ::productSend_handler(FwDpIdType id, const Fw::Buffer& buffer) {
     this->m_dpSendCount++;
     this->m_dpBytesSent += buffer.getSize();
+
+    // Recover the priority from the serialized container header
+    Fw::DpContainer container(id, buffer);
+    if (container.deserializeHeader() == Fw::FW_SERIALIZE_OK) {
+        this->m_dpLastPriority = container.getPriority();
+    }
 }
 
 void FileManagerTester ::generateDpSucceed() {
@@ -395,7 +402,7 @@ void FileManagerTester ::generateDpSucceed() {
 
     Fw::CmdStringArg cmdStringFile(fileName);
     // 32 byte chunks over a 100 byte file yields 4 chunks (32 + 32 + 32 + 4)
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0, 0, FileManager_GenerateDpMode::PACED);
     this->component.doDispatch();
 
     // Only the start event so far; the response is deferred
@@ -420,7 +427,7 @@ void FileManagerTester ::generateDpFileNotFound() {
     this->resetDpState();
 
     Fw::CmdStringArg cmdStringFile("no_such_dp_file");
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0, 0, FileManager_GenerateDpMode::PACED);
     this->component.doDispatch();
 
     ASSERT_CMD_RESPONSE_SIZE(1);
@@ -441,7 +448,7 @@ void FileManagerTester ::generateDpEmptyFile() {
     this->resetDpState();
 
     Fw::CmdStringArg cmdStringFile(fileName);
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0, 0, FileManager_GenerateDpMode::PACED);
     this->component.doDispatch();
 
     // An empty file completes immediately with no chunks
@@ -469,7 +476,8 @@ void FileManagerTester ::generateDpChunkSizeClamped() {
     Fw::CmdStringArg cmdStringFile(fileName);
     // A chunk size beyond the configured maximum is clamped, so the 50 byte
     // file still fits in a single chunk
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE * 4, 0, 0);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE * 4, 0, 0,
+                             0, FileManager_GenerateDpMode::PACED);
     this->component.doDispatch();
     this->runRateGroupCycles(5);
 
@@ -497,7 +505,7 @@ void FileManagerTester ::generateDpPartialRange() {
     Fw::CmdStringArg cmdStringFile(fileName);
     // Bytes [20, 60) of a 100 byte file with 16 byte chunks yields 3 chunks
     // (16 + 16 + 8), which lets an operator retransmit part of a file
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 20, 60);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 20, 60, 0, FileManager_GenerateDpMode::PACED);
     this->component.doDispatch();
     this->runRateGroupCycles(10);
 
@@ -524,7 +532,7 @@ void FileManagerTester ::generateDpInvalidRange() {
 
     Fw::CmdStringArg cmdStringFile(fileName);
     // A begin offset at or past the end offset has nothing to package
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 60, 20);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 60, 20, 0, FileManager_GenerateDpMode::PACED);
     this->component.doDispatch();
 
     ASSERT_CMD_RESPONSE_SIZE(1);
@@ -550,7 +558,7 @@ void FileManagerTester ::generateDpBufferFailure() {
     this->m_dpGetShouldFail = true;
 
     Fw::CmdStringArg cmdStringFile(fileName);
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0, 0, FileManager_GenerateDpMode::PACED);
     this->component.doDispatch();
     this->runRateGroupCycles(5);
 
@@ -578,12 +586,12 @@ void FileManagerTester ::generateDpWhileBusy() {
 
     Fw::CmdStringArg cmdStringFile(fileName);
     // Start a generation and leave it in progress by not running the rate group
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0, 0, FileManager_GenerateDpMode::PACED);
     this->component.doDispatch();
     ASSERT_CMD_RESPONSE_SIZE(0);
 
     // A second request while one is in progress is reported and rejected
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0, 0, FileManager_GenerateDpMode::PACED);
     this->component.doDispatch();
 
     ASSERT_CMD_RESPONSE_SIZE(1);
@@ -611,7 +619,7 @@ void FileManagerTester ::generateDpSerializationFailure() {
     this->m_dpGetUndersizedBuffer = true;
 
     Fw::CmdStringArg cmdStringFile(fileName);
-    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0);
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 16, 0, 0, 0, FileManager_GenerateDpMode::PACED);
     this->component.doDispatch();
     this->runRateGroupCycles(5);
 
@@ -622,6 +630,58 @@ void FileManagerTester ::generateDpSerializationFailure() {
 
 #if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
     this->system("rm -f dp_serialize_fail_file");
+#endif
+}
+
+void FileManagerTester ::generateDpImmediateMode() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    const char* const fileName = "dp_immediate_file";
+    this->system("rm -f dp_immediate_file");
+    this->system("printf '0123456789%.0s' $(seq 1 10) > dp_immediate_file");
+#else
+    SKIP();  // Commands not implemented for this OS
+#endif
+
+    this->resetDpState();
+
+    Fw::CmdStringArg cmdStringFile(fileName);
+    // In immediate mode the whole file is emitted without the rate group
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0, 0, FileManager_GenerateDpMode::IMMEDIATE);
+    this->component.doDispatch();
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_GenerateDpComplete(0, fileName, 4);
+    ASSERT_EQ(4u, this->m_dpSendCount);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -f dp_immediate_file");
+#endif
+}
+
+void FileManagerTester ::generateDpCustomPriority() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    const char* const fileName = "dp_priority_file";
+    this->system("rm -f dp_priority_file");
+    this->system("printf '0123456789%.0s' $(seq 1 5) > dp_priority_file");
+#else
+    SKIP();  // Commands not implemented for this OS
+#endif
+
+    this->resetDpState();
+
+    Fw::CmdStringArg cmdStringFile(fileName);
+    // A non-zero priority overrides the configured default
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 64, 0, 0, 42, FileManager_GenerateDpMode::IMMEDIATE);
+    this->component.doDispatch();
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EQ(1u, this->m_dpSendCount);
+    ASSERT_EQ(42u, this->m_dpLastPriority);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -f dp_priority_file");
 #endif
 }
 

--- a/Svc/FileManager/test/ut/FileManagerTester.hpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.hpp
@@ -128,6 +128,15 @@ class FileManagerTester : public FileManagerGTestBase {
     //! Reject a data product request with an invalid offset range
     void generateDpInvalidRange();
 
+    //! Report a data product container allocation failure without failing the command
+    void generateDpBufferFailure();
+
+    //! Reject a data product request that arrives while another is in progress
+    void generateDpWhileBusy();
+
+    //! Report a serialization failure without failing the command
+    void generateDpSerializationFailure();
+
   private:
     // ----------------------------------------------------------------------
     // Helper methods
@@ -212,6 +221,9 @@ class FileManagerTester : public FileManagerGTestBase {
 
     //! Whether the get port should fail, for testing the failure path
     bool m_dpGetShouldFail;
+
+    //! Whether the get port should hand out a buffer too small for a chunk
+    bool m_dpGetUndersizedBuffer;
     //! Handler for from_pingOut
     //!
     void from_pingOut_handler(const FwIndexType portNum, /*!< The port number*/

--- a/Svc/FileManager/test/ut/FileManagerTester.hpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.hpp
@@ -185,9 +185,9 @@ class FileManagerTester : public FileManagerGTestBase {
     // ----------------------------------------------------------------------
 
     //! Handler for the data product get port; hands out the local buffer
-    Fw::Success::T productGet_handler(FwDpIdType id,        //!< The container ID
-                                      FwSizeType size,      //!< The requested size
-                                      Fw::Buffer& buffer    //!< The buffer (output)
+    Fw::Success::T productGet_handler(FwDpIdType id,      //!< The container ID
+                                      FwSizeType size,    //!< The requested size
+                                      Fw::Buffer& buffer  //!< The buffer (output)
                                       ) override;
 
     //! Handler for the data product send port; records the sent container

--- a/Svc/FileManager/test/ut/FileManagerTester.hpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.hpp
@@ -110,6 +110,18 @@ class FileManagerTester : public FileManagerGTestBase {
     //!
     void listDirectoryWithSubdirs();
 
+    //! Generate a data product from a file and check the emitted chunks
+    void generateDpSucceed();
+
+    //! Generate a data product from a file that does not exist
+    void generateDpFileNotFound();
+
+    //! Generate a data product from an empty file
+    void generateDpEmptyFile();
+
+    //! Generate a data product with a chunk size larger than the read buffer
+    void generateDpChunkSizeClamped();
+
   private:
     // ----------------------------------------------------------------------
     // Helper methods
@@ -161,11 +173,44 @@ class FileManagerTester : public FileManagerGTestBase {
 
     //! Assert failed command execution
     void assertFailure(const FwOpcodeType opcode) const;
+
+    // ----------------------------------------------------------------------
+    // Data product test support
+    // ----------------------------------------------------------------------
+
+    //! Handler for the data product get port; hands out the local buffer
+    Fw::Success::T productGet_handler(FwDpIdType id,        //!< The container ID
+                                      FwSizeType size,      //!< The requested size
+                                      Fw::Buffer& buffer    //!< The buffer (output)
+                                      ) override;
+
+    //! Handler for the data product send port; records the sent container
+    void productSend_handler(FwDpIdType id,            //!< The container ID
+                             const Fw::Buffer& buffer  //!< The buffer
+                             ) override;
+
+    //! Reset the data product bookkeeping between tests
+    void resetDpState();
+
+    //! Backing store for the data product container handed to the component
+    U8 m_dpContainerData[FW_COM_BUFFER_MAX_SIZE];
+
+    //! Buffer wrapping m_dpContainerData
+    Fw::Buffer m_dpContainerBuffer;
+
+    //! Number of containers sent by the component
+    U32 m_dpSendCount;
+
+    //! Total number of data bytes observed across sent containers
+    FwSizeType m_dpBytesSent;
+
+    //! Whether the get port should fail, for testing the failure path
+    bool m_dpGetShouldFail;
     //! Handler for from_pingOut
     //!
     void from_pingOut_handler(const FwIndexType portNum, /*!< The port number*/
                               U32 key                    /*!< Value to return to pinger*/
-    );
+                              ) override;
 
   private:
     // ----------------------------------------------------------------------

--- a/Svc/FileManager/test/ut/FileManagerTester.hpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.hpp
@@ -122,6 +122,12 @@ class FileManagerTester : public FileManagerGTestBase {
     //! Generate a data product with a chunk size larger than the read buffer
     void generateDpChunkSizeClamped();
 
+    //! Generate a data product from part of a file using begin and end offsets
+    void generateDpPartialRange();
+
+    //! Reject a data product request with an invalid offset range
+    void generateDpInvalidRange();
+
   private:
     // ----------------------------------------------------------------------
     // Helper methods

--- a/Svc/FileManager/test/ut/FileManagerTester.hpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.hpp
@@ -214,25 +214,34 @@ class FileManagerTester : public FileManagerGTestBase {
     void resetDpState();
 
     //! Backing store for the data product container handed to the component
-    U8 m_dpContainerData[FW_COM_BUFFER_MAX_SIZE];
+    U8 m_dpContainerData[FW_COM_BUFFER_MAX_SIZE] = {};
 
     //! Buffer wrapping m_dpContainerData
     Fw::Buffer m_dpContainerBuffer;
 
     //! Number of containers sent by the component
-    U32 m_dpSendCount;
+    U32 m_dpSendCount = 0;
 
     //! Total number of data bytes observed across sent containers
-    FwSizeType m_dpBytesSent;
+    FwSizeType m_dpBytesSent = 0;
 
     //! Whether the get port should fail, for testing the failure path
-    bool m_dpGetShouldFail;
+    bool m_dpGetShouldFail = false;
 
     //! Whether the get port should hand out a buffer too small for a chunk
-    bool m_dpGetUndersizedBuffer;
+    bool m_dpGetUndersizedBuffer = false;
 
     //! Priority carried by the most recently sent container
-    FwDpPriorityType m_dpLastPriority;
+    FwDpPriorityType m_dpLastPriority = 0;
+
+    //! Total data-product payload bytes observed across all sent containers,
+    //! i.e. the sum of each container's data size (header + data records)
+    FwSizeType m_dpPayloadBytes = 0;
+
+    //! Smallest container data size seen, used to confirm every chunk carried
+    //! a real (non-empty) header-plus-data payload
+    FwSizeType m_dpMinPayloadBytes = 0;
+
     //! Handler for from_pingOut
     //!
     void from_pingOut_handler(const FwIndexType portNum, /*!< The port number*/

--- a/Svc/FileManager/test/ut/FileManagerTester.hpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.hpp
@@ -134,6 +134,12 @@ class FileManagerTester : public FileManagerGTestBase {
     //! Reject a data product request that arrives while another is in progress
     void generateDpWhileBusy();
 
+    //! Emit all chunks in the command handler instead of pacing them
+    void generateDpImmediateMode();
+
+    //! Use a container priority supplied by the command
+    void generateDpCustomPriority();
+
     //! Report a serialization failure without failing the command
     void generateDpSerializationFailure();
 
@@ -224,6 +230,9 @@ class FileManagerTester : public FileManagerGTestBase {
 
     //! Whether the get port should hand out a buffer too small for a chunk
     bool m_dpGetUndersizedBuffer;
+
+    //! Priority carried by the most recently sent container
+    FwDpPriorityType m_dpLastPriority;
     //! Handler for from_pingOut
     //!
     void from_pingOut_handler(const FwIndexType portNum, /*!< The port number*/

--- a/default/config/CMakeLists.txt
+++ b/default/config/CMakeLists.txt
@@ -14,6 +14,7 @@ register_fprime_config(
         "${CMAKE_CURRENT_LIST_DIR}/FpConfig.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/FpConstants.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/FprimeRouterCfg.fpp"
+        "${CMAKE_CURRENT_LIST_DIR}/FileManagerCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/FpySequencerCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/GenericHubCfg.fpp"
         "${CMAKE_CURRENT_LIST_DIR}/MemoryAllocation.fpp"

--- a/default/config/FileManagerCfg.fpp
+++ b/default/config/FileManagerCfg.fpp
@@ -1,0 +1,15 @@
+# ======================================================================
+# FPP file for FileManager configuration
+# ======================================================================
+
+module Svc {
+
+  module FileManagerCfg {
+
+    @ The default priority of file data product containers. Projects can
+    @ adjust this, and the GenerateDp command can override it per request.
+    constant DEFAULT_DP_PRIORITY = 10;
+
+  }
+
+}

--- a/default/config/FileManagerConfig.hpp
+++ b/default/config/FileManagerConfig.hpp
@@ -10,6 +10,15 @@ namespace FileManagerConfig {
 //! Lower values = slower directory listing but bounded event rate
 //! Default: 1
 static constexpr U32 FILES_PER_RATE_TICK = 1;
+
+//! Maximum number of file bytes read per chunk when generating a data product.
+//! The GenerateDp chunkSize argument is clamped to this value, which bounds
+//! the size of the member read buffer (no dynamic allocation in flight code).
+static constexpr U32 GENERATE_DP_MAX_CHUNK_SIZE = 1024;
+
+//! Number of file chunks to process per rate group tick during
+//! data product generation (same pacing pattern as directory listing).
+static constexpr U32 CHUNKS_PER_RATE_TICK = 1;
 }  // namespace FileManagerConfig
 }  // namespace Svc
 


### PR DESCRIPTION
## Change Description
Adds a `GenerateDp` command to `Svc::FileManager` that packages a file into data products.

Following the design described in #5515, the command takes a `fileName` and a `chunkSize`, and each chunk is emitted as a pair of records:
- `FileChunkHeaderRecord`: a struct carrying the source file name, the offset of the chunk within the file, and the number of data bytes
- `FileChunkDataRecord`: a U8 array record with the chunk bytes

Ground tools can reassemble the original file from the chunks, and the command works regardless of the size of the buffers allocated to data products.

Implementation notes:
- Chunks are paced by the rate group using the same internal port pattern as `ListDirectory`, one chunk per tick by default (`FileManagerConfig::CHUNKS_PER_RATE_TICK`), so per tick work stays bounded
- The command response is deferred until the last chunk is sent, matching the `ListDirectory` pattern
- The requested chunk size is clamped to `FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE`, which bounds the component member read buffer so no dynamic allocation is needed
- A pair of records per chunk was chosen over a single fixed size struct record because FPP struct members are fixed size; with array records the serialized size tracks the real chunk size instead of always paying for the maximum

## Rationale
Closes #5515.

## Testing/Review Recommendations
Run `fprime-util check` in `Svc/FileManager`. 21 tests pass locally on macOS (AppleClang 21, ASan and UBSan enabled), including four new cases: nominal chunking of a 100 byte file into 4 chunks with a 32 byte chunk size, a missing file, an empty file, and a chunk size larger than the configured maximum.

Note: `runRateGroupCycles` in the tester previously stopped cycling as soon as directory listing was idle, so it was generalised to keep cycling while either directory listing or data product generation is active.