### PR TITLE
Svc/Subtopologies: add CPU affinity as overridable config for active instances

### DIFF
--- a/Os/Models/Task.fpp
+++ b/Os/Models/Task.fpp
@@ -4,6 +4,9 @@
 # ======================================================================
 
 module Os {
+@ Sentinel for default task parameters: casts to Os::Task::TASK_DEFAULT
+constant TASK_DEFAULT = -1
+
 @ FPP shadow-enum representing Os::Task::Status
 enum TaskStatus : U8 {
     OP_OK,             @< message sent/received okay

--- a/Svc/Subtopologies/CdhCore/CdhCore.fpp
+++ b/Svc/Subtopologies/CdhCore/CdhCore.fpp
@@ -5,12 +5,14 @@ module CdhCore {
     instance cmdDisp: Svc.CommandDispatcher base id CdhCoreConfig.BASE_ID + 0x00000 \
         queue size CdhCoreConfig.QueueSizes.cmdDisp \
         stack size CdhCoreConfig.StackSizes.cmdDisp \
-        priority CdhCoreConfig.Priorities.cmdDisp
+        priority CdhCoreConfig.Priorities.cmdDisp \
+        cpu CdhCoreConfig.CpuAffinities.cmdDisp
 
     instance events: Svc.EventManager base id CdhCoreConfig.BASE_ID + 0x001000 \
         queue size CdhCoreConfig.QueueSizes.events \
         stack size CdhCoreConfig.StackSizes.events \
-        priority CdhCoreConfig.Priorities.events
+        priority CdhCoreConfig.Priorities.events \
+        cpu CdhCoreConfig.CpuAffinities.events
 
     # ----------------------------------------------------------------------
     # Queued Components

--- a/Svc/Subtopologies/CdhCore/CdhCoreConfig/CdhCoreConfig.fpp
+++ b/Svc/Subtopologies/CdhCore/CdhCoreConfig/CdhCoreConfig.fpp
@@ -23,4 +23,12 @@ module CdhCoreConfig {
         constant tlmSend     = 22
 
     }
+
+    module CpuAffinities {
+        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
+        constant TASK_DEFAULT = -1
+        constant cmdDisp     = TASK_DEFAULT
+        constant events      = TASK_DEFAULT
+        constant tlmSend     = TASK_DEFAULT
+    }
 }

--- a/Svc/Subtopologies/CdhCore/CdhCoreConfig/CdhCoreConfig.fpp
+++ b/Svc/Subtopologies/CdhCore/CdhCoreConfig/CdhCoreConfig.fpp
@@ -25,10 +25,8 @@ module CdhCoreConfig {
     }
 
     module CpuAffinities {
-        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
-        constant TASK_DEFAULT = -1
-        constant cmdDisp     = TASK_DEFAULT
-        constant events      = TASK_DEFAULT
-        constant tlmSend     = TASK_DEFAULT
+        constant cmdDisp     = Os.TASK_DEFAULT
+        constant events      = Os.TASK_DEFAULT
+        constant tlmSend     = Os.TASK_DEFAULT
     }
 }

--- a/Svc/Subtopologies/CdhCore/CdhCoreConfig/CdhCoreTlmConfig.fpp
+++ b/Svc/Subtopologies/CdhCore/CdhCoreConfig/CdhCoreTlmConfig.fpp
@@ -4,12 +4,14 @@ module CdhCore{
         queue size CdhCoreConfig.QueueSizes.tlmSend \
         stack size CdhCoreConfig.StackSizes.tlmSend \
         priority CdhCoreConfig.Priorities.tlmSend \
+        cpu CdhCoreConfig.CpuAffinities.tlmSend \
 
     # Uncomment the following block and comment the above block to use TlmPacketizer instead of TlmChan
     # instance tlmSend: Svc.TlmPacketizer base id CdhCoreConfig.BASE_ID + 0x06000 \
     #    queue size CdhCoreConfig.QueueSizes.tlmSend \
     #    stack size CdhCoreConfig.StackSizes.tlmSend \
     #    priority CdhCoreConfig.Priorities.tlmSend \
+    #    cpu CdhCoreConfig.CpuAffinities.tlmSend \
     # {
     #    # NOTE: The Name Ref is specific to the Reference deployment, Ref
     #    # This name will need to be updated if wishing to use this in a custom deployment

--- a/Svc/Subtopologies/CdhCore/docs/sdd.md
+++ b/Svc/Subtopologies/CdhCore/docs/sdd.md
@@ -14,7 +14,7 @@ The **CdhCore subtopology** provides a reusable bundle of the core flight-softwa
 | SVC-CDHCORE-006 | The subtopology shall provide **assert to fatal handling functionality** to convert `FW_ASSERT`s into `FATAL` events.         | Inspection |
 | SVC-CDHCORE-007 | The subtopology shall provide **fatal-event routing functionality** to forward fatal announcements to a configurable handler. | Inspection |
 | SVC-CDHCORE-008 | The subtopology shall provide **telemetry sending functionality** through a configurable telemetry interface.                 | Inspection |
-| SVC-CDHCORE-009 | The subtopology shall support **configurable instance properties** for IDs, queue sizes, stack sizes, and priorities.         | Inspection |
+| SVC-CDHCORE-009 | The subtopology shall support **configurable instance properties** for IDs, queue sizes, stack sizes, priorities, and CPU affinities.         | Inspection |
 | SVC-CDHCORE-010 | The subtopology shall expose rate-group connection points for any rate-drive components it contains.                          | Inspection |
 
 ## 2. Design & Core Functions

--- a/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
+++ b/Svc/Subtopologies/ComCcsds/ComCcsds.fpp
@@ -17,6 +17,7 @@ module ComCcsds {
         queue size ComCcsdsConfig.QueueSizes.comQueue \
         stack size ComCcsdsConfig.StackSizes.comQueue \
         priority ComCcsdsConfig.Priorities.comQueue \
+        cpu ComCcsdsConfig.CpuAffinities.comQueue \
     {
         phase Fpp.ToCpp.Phases.configComponents """
         using namespace ComCcsds;
@@ -100,7 +101,8 @@ module ComCcsds {
     instance aggregator: Svc.ComAggregator base id ComCcsdsConfig.BASE_ID + 0x06000 \
         queue size ComCcsdsConfig.QueueSizes.aggregator \
         stack size ComCcsdsConfig.StackSizes.aggregator \
-        priority ComCcsdsConfig.Priorities.aggregator
+        priority ComCcsdsConfig.Priorities.aggregator \
+        cpu ComCcsdsConfig.CpuAffinities.aggregator
 
     # NOTE: name 'framer' is used for the framer that connects to the Com Adapter Interface for better subtopology interoperability
     instance framer: Svc.Ccsds.TmFramer base id ComCcsdsConfig.BASE_ID + 0x07000

--- a/Svc/Subtopologies/ComCcsds/ComCcsdsConfig/ComCcsdsConfig.fpp
+++ b/Svc/Subtopologies/ComCcsds/ComCcsdsConfig/ComCcsdsConfig.fpp
@@ -18,10 +18,8 @@ module ComCcsdsConfig {
     }
 
     module CpuAffinities {
-        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
-        constant TASK_DEFAULT = -1
-        constant aggregator = TASK_DEFAULT
-        constant comQueue   = TASK_DEFAULT
+        constant aggregator = Os.TASK_DEFAULT
+        constant comQueue   = Os.TASK_DEFAULT
     }
 
     # Queue configuration constants

--- a/Svc/Subtopologies/ComCcsds/ComCcsdsConfig/ComCcsdsConfig.fpp
+++ b/Svc/Subtopologies/ComCcsds/ComCcsdsConfig/ComCcsdsConfig.fpp
@@ -17,6 +17,13 @@ module ComCcsdsConfig {
         constant comQueue   = 29
     }
 
+    module CpuAffinities {
+        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
+        constant TASK_DEFAULT = -1
+        constant aggregator = TASK_DEFAULT
+        constant comQueue   = TASK_DEFAULT
+    }
+
     # Queue configuration constants
     module QueueDepths {
         constant events      = 200             

--- a/Svc/Subtopologies/ComCcsds/docs/sdd.md
+++ b/Svc/Subtopologies/ComCcsds/docs/sdd.md
@@ -21,7 +21,7 @@ Both variants provide the standard **router + ComQueue + CCSDS framers/deframers
 | SVC-COMCCSDS-003 | Provide an F´ **router** to route deframed packets (e.g., commands/files) into the flight software.            | Inspection |
 | SVC-COMCCSDS-004 | Provide a **subtopology variant that supplies `Svc::ComStub`** designed to connect to a ByteStream driver.     | Inspection |
 | SVC-COMCCSDS-005 | Provide a **subtopology variant that expects an external `Svc::ComInterface`** supplied by the deployment.     | Inspection |
-| SVC-COMCCSDS-006 | Support **configurable instance properties** (IDs, queue sizes, stack sizes, priorities) via `ComCcsdsConfig`. | Inspection |
+| SVC-COMCCSDS-006 | Support **configurable instance properties** (IDs, queue sizes, stack sizes, priorities, CPU affinities) via `ComCcsdsConfig`. | Inspection |
 | SVC-COMCCSDS-007 | Provide **composable layer topologies**: a Space Packet packet layer (`SpacePacketFraming`, `SpacePacket`) and a TM/TC transfer frame layer (`TmTcFraming`), from which the full stack is composed. | Inspection |
 
 ---
@@ -148,6 +148,7 @@ topology Flight {
 * **Queue sizes** — Depths for **`ComQueue`** and any other active/queued elements defined by the subtopology.
 * **Stack sizes** — Task stack allocations for active components (if any beyond `ComQueue`).
 * **Priorities** — RTOS priorities for active/queued components as applicable.
+* **CPU affinities** — Core pinning for active component tasks; defaults to `TASK_DEFAULT` (no pinning).
 
 ### 4.2 Buffer Manager Bin Configuration
 

--- a/Svc/Subtopologies/ComFprime/ComFprime.fpp
+++ b/Svc/Subtopologies/ComFprime/ComFprime.fpp
@@ -16,6 +16,7 @@ module ComFprime {
         queue size ComFprimeConfig.QueueSizes.comQueue \
         stack size ComFprimeConfig.StackSizes.comQueue \
         priority ComFprimeConfig.Priorities.comQueue \
+        cpu ComFprimeConfig.CpuAffinities.comQueue \
     {
         phase Fpp.ToCpp.Phases.configComponents """
         using namespace ComFprime;

--- a/Svc/Subtopologies/ComFprime/ComFprimeConfig/ComFprimeConfig.fpp
+++ b/Svc/Subtopologies/ComFprime/ComFprimeConfig/ComFprimeConfig.fpp
@@ -15,9 +15,7 @@ module ComFprimeConfig {
     }
 
     module CpuAffinities {
-        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
-        constant TASK_DEFAULT = -1
-        constant comQueue   = TASK_DEFAULT
+        constant comQueue   = Os.TASK_DEFAULT
     }
 
     # Queue configuration constants

--- a/Svc/Subtopologies/ComFprime/ComFprimeConfig/ComFprimeConfig.fpp
+++ b/Svc/Subtopologies/ComFprime/ComFprimeConfig/ComFprimeConfig.fpp
@@ -14,6 +14,12 @@ module ComFprimeConfig {
         constant comQueue   = 29
     }
 
+    module CpuAffinities {
+        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
+        constant TASK_DEFAULT = -1
+        constant comQueue   = TASK_DEFAULT
+    }
+
     # Queue configuration constants
     module QueueDepths {
         constant events      = 100            

--- a/Svc/Subtopologies/ComFprime/docs/sdd.md
+++ b/Svc/Subtopologies/ComFprime/docs/sdd.md
@@ -18,7 +18,7 @@ Both variants provide the standard **F´ framer/deframer + router + ComQueue** p
 | SVC-COMFPRIME-003 | Provide an F´ **router** to route deframed packets (e.g., commands/files) into the flight software.             | Inspection |
 | SVC-COMFPRIME-004 | Provide a **subtopology variant that supplies `Svc::ComStub`** designed to connect to a ByteStream driver.      | Inspection |
 | SVC-COMFPRIME-005 | Provide a **subtopology variant that expects an external `Svc::ComInterface`** supplied by the deployment.      | Inspection |
-| SVC-COMFPRIME-006 | Support **configurable instance properties** (IDs, queue sizes, stack sizes, priorities) via `ComFprimeConfig`. | Inspection |
+| SVC-COMFPRIME-006 | Support **configurable instance properties** (IDs, queue sizes, stack sizes, priorities, CPU affinities) via `ComFprimeConfig`. | Inspection |
 
 ---
 
@@ -126,6 +126,7 @@ topology Flight {
 * **Queue sizes** — Depths for **`ComQueue`** and any other active/queued elements defined by the subtopology.
 * **Stack sizes** — Task stack allocations for active components (if any beyond `ComQueue`).
 * **Priorities** — RTOS priorities for active/queued components as applicable.
+* **CPU affinities** — Core pinning for active component tasks; defaults to `TASK_DEFAULT` (no pinning).
 
 ### 4.2 Buffer Manager Bin Configuration
 

--- a/Svc/Subtopologies/ComLoggerTee/ComLoggerTeeConfig/ComLoggerTeeConfig.fpp
+++ b/Svc/Subtopologies/ComLoggerTee/ComLoggerTeeConfig/ComLoggerTeeConfig.fpp
@@ -11,4 +11,10 @@ module ComLoggerTeeConfig {
     module Priorities {
         constant comLog = 18
     }
+
+    module CpuAffinities {
+        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
+        constant TASK_DEFAULT = -1
+        constant comLog = TASK_DEFAULT
+    }
 }

--- a/Svc/Subtopologies/ComLoggerTee/ComLoggerTeeConfig/ComLoggerTeeConfig.fpp
+++ b/Svc/Subtopologies/ComLoggerTee/ComLoggerTeeConfig/ComLoggerTeeConfig.fpp
@@ -13,8 +13,6 @@ module ComLoggerTeeConfig {
     }
 
     module CpuAffinities {
-        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
-        constant TASK_DEFAULT = -1
-        constant comLog = TASK_DEFAULT
+        constant comLog = Os.TASK_DEFAULT
     }
 }

--- a/Svc/Subtopologies/ComLoggerTee/subtopology-template.fppi
+++ b/Svc/Subtopologies/ComLoggerTee/subtopology-template.fppi
@@ -1,7 +1,8 @@
 instance comLog: Svc.ComLogger base id BASE_ID \
     queue size ComLoggerTeeConfig.QueueSizes.comLog \
     stack size ComLoggerTeeConfig.StackSizes.comLog \
-    priority ComLoggerTeeConfig.Priorities.comLog
+    priority ComLoggerTeeConfig.Priorities.comLog \
+    cpu ComLoggerTeeConfig.CpuAffinities.comLog
 
 instance comSplitter: Svc.ComSplitter base id BASE_ID + 0x0100
 

--- a/Svc/Subtopologies/DataProducts/DataProducts.fpp
+++ b/Svc/Subtopologies/DataProducts/DataProducts.fpp
@@ -8,6 +8,7 @@ module DataProducts{
         queue size DataProductsConfig.QueueSizes.dpCat \
         stack size DataProductsConfig.StackSizes.dpCat \
         priority DataProductsConfig.Priorities.dpCat \
+        cpu DataProductsConfig.CpuAffinities.dpCat \
     {
         phase Fpp.ToCpp.Phases.configComponents """
             Fw::FileNameString dpDir(DataProductsConfig::Paths::dpDir);
@@ -21,12 +22,14 @@ module DataProducts{
     instance dpMgr: Svc.DpManager base id DataProductsConfig.BASE_ID + 0x01000 \
         queue size DataProductsConfig.QueueSizes.dpMgr \
         stack size DataProductsConfig.StackSizes.dpMgr \
-        priority DataProductsConfig.Priorities.dpMgr
+        priority DataProductsConfig.Priorities.dpMgr \
+        cpu DataProductsConfig.CpuAffinities.dpMgr
 
     instance dpWriter: Svc.DpWriter base id DataProductsConfig.BASE_ID + 0x02000 \
         queue size DataProductsConfig.QueueSizes.dpWriter \
         stack size DataProductsConfig.StackSizes.dpWriter \
         priority DataProductsConfig.Priorities.dpWriter \
+        cpu DataProductsConfig.CpuAffinities.dpWriter \
     {
         phase Fpp.ToCpp.Phases.configComponents """
             DataProducts::dpWriter.configure(dpDir);
@@ -37,6 +40,7 @@ module DataProducts{
         queue size DataProductsConfig.QueueSizes.dpBufferAccumulator \
         stack size DataProductsConfig.StackSizes.dpBufferAccumulator \
         priority DataProductsConfig.Priorities.dpBufferAccumulator \
+        cpu DataProductsConfig.CpuAffinities.dpBufferAccumulator \
     {
         phase Fpp.ToCpp.Phases.configComponents """
             DataProducts::dpBufferAccumulator.allocateQueue(

--- a/Svc/Subtopologies/DataProducts/DataProductsConfig/DataProductsConfig.fpp
+++ b/Svc/Subtopologies/DataProducts/DataProductsConfig/DataProductsConfig.fpp
@@ -30,12 +30,10 @@ module DataProductsConfig {
     }
 
     module CpuAffinities {
-        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
-        constant TASK_DEFAULT = -1
-        constant dpCat    = TASK_DEFAULT
-        constant dpMgr  = TASK_DEFAULT
-        constant dpWriter   = TASK_DEFAULT
-        constant dpBufferAccumulator = TASK_DEFAULT
+        constant dpCat    = Os.TASK_DEFAULT
+        constant dpMgr  = Os.TASK_DEFAULT
+        constant dpWriter   = Os.TASK_DEFAULT
+        constant dpBufferAccumulator = Os.TASK_DEFAULT
     }
 
     module BufferAccumulator {

--- a/Svc/Subtopologies/DataProducts/DataProductsConfig/DataProductsConfig.fpp
+++ b/Svc/Subtopologies/DataProducts/DataProductsConfig/DataProductsConfig.fpp
@@ -29,6 +29,15 @@ module DataProductsConfig {
         constant dpBufferManager  = 21
     }
 
+    module CpuAffinities {
+        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
+        constant TASK_DEFAULT = -1
+        constant dpCat    = TASK_DEFAULT
+        constant dpMgr  = TASK_DEFAULT
+        constant dpWriter   = TASK_DEFAULT
+        constant dpBufferAccumulator = TASK_DEFAULT
+    }
+
     module BufferAccumulator {
         constant allocatorId   = 301
         constant maxNumBuffers = 10

--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -6,12 +6,14 @@ module FileHandling {
     instance fileUplink: Svc.FileUplink base id FileHandlingConfig.BASE_ID + 0x00000 \
         queue size FileHandlingConfig.QueueSizes.fileUplink \
         stack size FileHandlingConfig.StackSizes.fileUplink \
-        priority FileHandlingConfig.Priorities.fileUplink
+        priority FileHandlingConfig.Priorities.fileUplink \
+        cpu FileHandlingConfig.CpuAffinities.fileUplink
 
     instance fileDownlink: Svc.FileDownlink base id FileHandlingConfig.BASE_ID + 0x01000 \
         queue size FileHandlingConfig.QueueSizes.fileDownlink \
         stack size FileHandlingConfig.StackSizes.fileDownlink \
         priority FileHandlingConfig.Priorities.fileDownlink \
+        cpu FileHandlingConfig.CpuAffinities.fileDownlink \
     {
         phase Fpp.ToCpp.Phases.configComponents """
         FileHandling::fileDownlink.configure(
@@ -25,12 +27,14 @@ module FileHandling {
     instance fileManager: Svc.FileManager base id FileHandlingConfig.BASE_ID + 0x02000 \
         queue size FileHandlingConfig.QueueSizes.fileManager \
         stack size FileHandlingConfig.StackSizes.fileManager \
-        priority FileHandlingConfig.Priorities.fileManager
+        priority FileHandlingConfig.Priorities.fileManager \
+        cpu FileHandlingConfig.CpuAffinities.fileManager
 
     instance prmDb: Svc.PrmDb base id FileHandlingConfig.BASE_ID + 0x03000 \
         queue size FileHandlingConfig.QueueSizes.prmDb \
         stack size FileHandlingConfig.StackSizes.prmDb \
         priority FileHandlingConfig.Priorities.prmDb \
+        cpu FileHandlingConfig.CpuAffinities.prmDb \
     {
         phase Fpp.ToCpp.Phases.readParameters """
             FileHandling::prmDb.readParamFile();

--- a/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
@@ -23,6 +23,15 @@ module FileHandlingConfig {
         constant prmDb         = 21
     }
 
+    module CpuAffinities {
+        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
+        constant TASK_DEFAULT = -1
+        constant fileUplink    = TASK_DEFAULT
+        constant fileDownlink  = TASK_DEFAULT
+        constant fileManager   = TASK_DEFAULT
+        constant prmDb         = TASK_DEFAULT
+    }
+
     # File downlink configuration constants
     module DownlinkConfig {
         constant cooldown       = 1000         # File downlink cooldown in ms  

--- a/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
@@ -24,12 +24,10 @@ module FileHandlingConfig {
     }
 
     module CpuAffinities {
-        # -1 casts to Os::Task::TASK_DEFAULT (no CPU pinning)
-        constant TASK_DEFAULT = -1
-        constant fileUplink    = TASK_DEFAULT
-        constant fileDownlink  = TASK_DEFAULT
-        constant fileManager   = TASK_DEFAULT
-        constant prmDb         = TASK_DEFAULT
+        constant fileUplink    = Os.TASK_DEFAULT
+        constant fileDownlink  = Os.TASK_DEFAULT
+        constant fileManager   = Os.TASK_DEFAULT
+        constant prmDb         = Os.TASK_DEFAULT
     }
 
     # File downlink configuration constants

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -10,7 +10,7 @@ The **FileHandling subtopology** packages the core file-transfer services common
 | SVC-FILEHANDLING-002 | The subtopology shall provide **file downlink functionality** to segment and transmit files to ground.          | Inspection |
 | SVC-FILEHANDLING-003 | The subtopology shall provide **on-board file management functionality** (e.g., list, remove, hash, mkdir).     | Inspection |
 | SVC-FILEHANDLING-004 | The subtopology shall provide **parameter management** via the filesystem.                                      | Inspection |
-| SVC-FILEHANDLING-005 | The subtopology shall support **configurable instance properties** (IDs, queue sizes, stack sizes, priorities). | Inspection |
+| SVC-FILEHANDLING-005 | The subtopology shall support **configurable instance properties** (IDs, queue sizes, stack sizes, priorities, CPU affinities). | Inspection |
 | SVC-FILEHANDLING-006 | The subtopology shall expose **rate-group connection points** for any rate-drive components it contains.        | Inspection |
 
 
@@ -27,7 +27,7 @@ The **FileHandling subtopology** packages the core file-transfer services common
 
 ### 2.2 Configuration Hooks inside the Subtopology
 
-* Uses **instance properties** (IDs, queue sizes, stack sizes, priorities) defined in `FileHandlingConfig` for these static instances (see §4).
+* Uses **instance properties** (IDs, queue sizes, stack sizes, priorities, CPU affinities) defined in `FileHandlingConfig` for these static instances (see §4).
 
 ### 2.3 Required Inputs for Operation
 
@@ -76,6 +76,7 @@ topology Flight {
 * **Queue sizes** — Queue depths for `fileUplink`, `fileDownlink`, `fileManager`.
 * **Stack sizes** — Task stacks for active components (`fileUplink`, `fileDownlink`).
 * **Priorities** — RTOS priorities for the active/queued components as applicable.
+* **CPU affinities** — Core pinning for active component tasks; defaults to `TASK_DEFAULT` (no pinning).
 
 > These knobs tailor runtime footprint and scheduling without modifying the subtopology wiring.
 


### PR DESCRIPTION
|                                                         |                                                           |
| :------------------------------------------------------ | :-------------------------------------------------------- |
| **_Related Issue(s)_**                                  | Fixes #5536, fixes #4535                                  |
| **_Has Unit Tests (y/n)_**                              | n (covered by existing `TestDeploymentsProject` CI build) |
| **_Documentation Included (y/n)_**                      | y                                                         |
| **_Generative AI was used in this contribution (y/n)_** | AI                                                        |

---

## Change Description

Adds a `CpuAffinities` module to each subtopology config (mirroring `Priorities`) and a `cpu` specifier to each of the 15 active instances. The default `TASK_DEFAULT = -1` casts to the unsigned `Os::Task::ParamType` as exactly `Os::Task::TASK_DEFAULT`, so default behavior is unchanged (no pinning). Open to a different constant name if preferred.

**Breaking change / release note:** projects that override subtopology config files (whole-file overrides) must add the new `CpuAffinities` module to their copies, or the subtopology FPP fails to resolve. `fprime-community/fprime-zephyr-reference` overrides `CdhCoreConfig.fpp`, so its CI jobs here will fail until the companion lands (fprime-community/fprime-zephyr-reference#37).

## Rationale

On multicore systems there is no way to pin subtopology tasks to a core without pulling the instances out of the subtopology.

## Testing/Review Recommendations

- Built on macOS arm64 and Linux x86_64 (fpp v3.3.0a14), including the full `TestDeploymentsProject` Ref deployment.
- Runtime check on 8-core Linux: defaults leave all task threads at `Cpus_allowed_list: 0-7`; setting `CpuAffinities.cmdDisp = 1` pins that thread to core 1.
- Note: pinning a task that also requests a priority needs `CAP_SYS_NICE`/root on Linux — the existing Posix `EPERM` fallback drops the whole attribute set (pre-existing behavior).

## Future Work

- Companion PR fprime-community/fprime-zephyr-reference#37 (other reference repos with config overrides may need the same addition).
- Possible follow-up on the Posix fallback: retain affinity and stack size when only the priority request is denied.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Implemented and tested with Claude Code (Claude Fable 5); approach chosen and full diff reviewed by @rvaccone.

IAMAI
