### PR TITLE
Add a regression test for .fppi edits re-running generation

### DIFF
--- a/cmake/test/data/TestDeployment/TestRelative/CMakeLists.txt
+++ b/cmake/test/data/TestDeployment/TestRelative/CMakeLists.txt
@@ -6,3 +6,9 @@ register_fprime_library(
     SOURCES
         ./uses_types.cpp
 )
+
+# Record what CMake will reconfigure for. Rewritten on every configure, so the
+# test suite can both read the list and use the file as a witness that a
+# reconfigure happened.
+get_property(TEST_CONFIGURE_DEPENDS DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/configure-depends.txt" "${TEST_CONFIGURE_DEPENDS}")

--- a/cmake/test/data/TestDeployment/TestRelative/constant2.fpp
+++ b/cmake/test/data/TestDeployment/TestRelative/constant2.fpp
@@ -4,3 +4,5 @@
 # \brief  defines a constant
 # ======================================================================
 constant relative_constant2 = true
+
+include "included.fppi"

--- a/cmake/test/data/TestDeployment/TestRelative/included.fppi
+++ b/cmake/test/data/TestDeployment/TestRelative/included.fppi
@@ -1,0 +1,6 @@
+# ======================================================================
+# \title  included.fppi
+# \brief  constant supplied through an include, used to check that edits
+#         to .fppi files are tracked by the build system
+# ======================================================================
+constant included_constant = true

--- a/cmake/test/data/TestDeployment/TestRelative/uses_types.cpp
+++ b/cmake/test/data/TestDeployment/TestRelative/uses_types.cpp
@@ -6,3 +6,5 @@
 #include <TestDeployment/TestRelative/FppConstantsAc.hpp>
 // Constant definitions will not be defined if the module setup failed
 bool new_constant = (relative_constant1 && relative_constant2);
+// Supplied through an .fppi include rather than the .fpp itself
+bool included_ok = included_constant;

--- a/cmake/test/src/test_autocoder.py
+++ b/cmake/test/src/test_autocoder.py
@@ -1,3 +1,7 @@
+import os
+import time
+from pathlib import Path
+
 from . import cmake
 from . import settings
 
@@ -19,6 +23,7 @@ _ = cmake.get_build(
         "TestTargetAutocoderModule",
         "TestChainedAutocoderModule",
         "TestHeaderAutocoderModule",
+        "TestRelative",
     ],
 )
 
@@ -90,3 +95,49 @@ def test_autocoder_rerun_autocoder(AUTOCODER_BUILD):
     )
     rerun_autocoder_output = build_cache_path / "test-rerun-autocoder.txt"
     assert rerun_autocoder_output.exists(), "Failed to create rerun autocoder output"
+
+
+def _configure_depends(build):
+    """Path of the configure-dependency listing written by TestRelative"""
+    return build / "TestDeployment" / "TestRelative" / "configure-depends.txt"
+
+
+def test_included_fpp_is_tracked(AUTOCODER_BUILD):
+    """Test that an .fppi pulled in by a model file is a configure dependency
+
+    A change to an included file has to re-run generation, so the file must be
+    tracked by CMake rather than only by the generated output's own rule.
+    """
+    cmake.assert_process_success(AUTOCODER_BUILD, targets=["TestRelative"])
+    listing = _configure_depends(AUTOCODER_BUILD["build"])
+    assert listing.exists(), "TestRelative did not record its configure dependencies"
+    assert "included.fppi" in listing.read_text(), (
+        "included.fppi is not a configure dependency, so editing it will not "
+        "re-run generation"
+    )
+
+
+def test_touching_included_fpp_reconfigures(AUTOCODER_BUILD):
+    """Test that editing an .fppi actually triggers a reconfigure
+
+    The listing above is rewritten on every configure, so its timestamp moving
+    is the evidence that touching the include re-ran CMake.
+    """
+    build = AUTOCODER_BUILD["build"]
+    listing = _configure_depends(build)
+    assert listing.exists(), "TestRelative did not record its configure dependencies"
+
+    # Settle first: a build with nothing to do must not move the timestamp.
+    cmake.run_make(build, "TestRelative")
+    settled = listing.stat().st_mtime
+    cmake.run_make(build, "TestRelative")
+    assert listing.stat().st_mtime == settled, "Build is not settled"
+
+    include = Path(AUTOCODER_BUILD["source"]) / "TestRelative" / "included.fppi"
+    os.utime(include, (time.time() + 1, time.time() + 1))
+    return_code, _, _ = cmake.run_make(build, "TestRelative")
+
+    assert return_code == 0, "Build failed after touching the included file"
+    assert (
+        listing.stat().st_mtime != settled
+    ), "Touching included.fppi did not re-run CMake"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #3929 |
|**_Has Unit Tests (y/n)_**| y (the change is tests) |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

#3929 asks for a test that catches it if editing an `.fppi` ever stops re-running generation. This adds one.

`TestRelative` now has an `included.fppi` that `constant2.fpp` pulls in, and `uses_types.cpp` uses the constant from it, so a silent generation failure turns into a compile error — the way that fixture already catches things. The module also writes out its `CMAKE_CONFIGURE_DEPENDS` list, and the two new tests read it: one checks the include is in the list, the other touches the include and checks CMake really re-ran.

## Rationale

It is worth explaining why the test looks like this, because the obvious version of it does not work.

The obvious version is "edit the `.fppi`, rebuild, check the generated output changed". I wrote that one first, and it passes with #3933 reverted — so it would never have caught the bug it exists for. The include is already in `FILE_DEPENDENCIES`, which already reaches the generation command's `DEPENDS`, so content changes flow through with or without the fix.

What #3933 actually added is the `requires_regeneration` call that puts the include into `CMAKE_CONFIGURE_DEPENDS`. That is what makes an edit trigger a re-configure, and it is the part that can regress while nothing looks broken. So that is what these tests assert instead.

For context: #3928 was reported and fixed by #3933 on the same day, in five lines, with no test. #3929 was opened that day to add the test, and has been open since.

## Testing/Review Recommendations

All on `devel` @ `1e91573`, with the toolchain pinned in `requirements.txt`:

- `test_autocoder.py` and `test_feature.py` go from 16 passed to 18. `test_feature.py` is in there because it builds `TestRelative` too, so it sees the fixture change.
- With #3933's five lines reverted, both new tests fail. That is the run I would check first — a test here that still passes without the fix is not doing anything, and my first draft was exactly that.
- I ran the two new tests eight more times on their own, all passing. They compare timestamps, and this repo has seen an intermittent double-configure before (#3533), so one data point did not feel like enough.
- `pytest -s` from `cmake/test`, which is what the CI job runs: 42 passed in 13m32s.

Formatting checked with `black==21.6b0`, the version `python-format.yml` pins.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

I used Claude Code. It helped me work out what #3933 actually changes, wrote the tests, and drafted this description. All of it sits in `cmake/test/` — the test module and the `TestRelative` fixture. No framework code is touched.

The output was heavily modified rather than used as-is. The first version asserted on generated content and passed with the fix reverted, so I dropped it and rewrote the tests around the configure dependency. Every number above comes from a run I did myself.
