### PR TITLE
fix(Drv/Ip): apply the UDP send timeout when no send port is configured

### DIFF
--- a/Drv/Ip/UdpSocket.cpp
+++ b/Drv/Ip/UdpSocket.cpp
@@ -138,6 +138,15 @@ SocketIpStatus UdpSocket::openProtocol(SocketDescriptor& socketDescriptor) {
         return SOCK_FAILED_TO_GET_SOCKET;
     }
 
+    // Apply the configured timeouts. This socket may send even when no send port was
+    // configured, because a send port of 0 means "reply to the source of the last
+    // datagram received", so the timeout must not be tied to `port != 0` below.
+    status = this->setupTimeouts(socketFd);
+    if (status != SOCK_SUCCESS) {
+        (void)::close(socketFd);
+        return status;
+    }
+
     // May not be sending in all cases
     if (port != 0) {
         // Set up the address port and name
@@ -162,12 +171,6 @@ SocketIpStatus UdpSocket::openProtocol(SocketDescriptor& socketDescriptor) {
             return SOCK_FAILED_TO_SET_SOCKET_OPTIONS;
         }
 
-        // Now apply timeouts
-        status = this->setupTimeouts(socketFd);
-        if (status != SOCK_SUCCESS) {
-            (void)::close(socketFd);
-            return status;
-        }
         static_assert(sizeof(m_addr_send) == sizeof(address), "Send address must match the local address structure");
         (void)memcpy(&this->m_addr_send, &address, sizeof(this->m_addr_send));
     }

--- a/Drv/Ip/test/ut/TestUdp.cpp
+++ b/Drv/Ip/test/ut/TestUdp.cpp
@@ -183,6 +183,33 @@ TEST(Ephemeral, TestEphemeralPorts) {
     receiver.close(recv_fd);
 }
 
+#ifndef TGT_OS_TYPE_VXWORKS
+// A send port of 0 means "reply to the source of the last datagram received", so such a
+// socket does send and the configured send timeout has to reach it. It used to be applied
+// only when a non-zero send port was configured.
+TEST(SendTimeout, TestSendTimeoutAppliedWithoutSendPort) {
+    const U32 timeout_seconds = 1;
+    const U32 timeout_microseconds = 0;
+
+    Drv::UdpSocket socket;
+    Drv::SocketDescriptor fd;
+    U16 recv_port = Drv::Test::get_free_port(true);
+    ASSERT_NE(0, recv_port);
+
+    socket.configureRecv("127.0.0.1", recv_port);
+    ASSERT_EQ(socket.configureSend("127.0.0.1", 0, timeout_seconds, timeout_microseconds), Drv::SOCK_SUCCESS);
+    ASSERT_EQ(socket.open(fd), Drv::SOCK_SUCCESS);
+
+    struct timeval timeout = {};
+    socklen_t timeout_size = sizeof(timeout);
+    ASSERT_EQ(::getsockopt(fd.fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, &timeout_size), 0) << std::strerror(errno);
+    EXPECT_EQ(static_cast<U32>(timeout.tv_sec), timeout_seconds);
+    EXPECT_EQ(static_cast<U32>(timeout.tv_usec), timeout_microseconds);
+
+    socket.close(fd);
+}
+#endif
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5591 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

`UdpSocket::openProtocol` applied the configured timeouts inside `if (port != 0)`,
so `SO_SNDTIMEO` was never set on a socket configured the respond-to-sender way.
That configuration is documented in `Drv/Ip/docs/sdd.md`: pass a send port of 0 to
`configureSend` and the socket replies to the source of the last datagram it
received. Such a socket does send, and the timeout the caller passed is stored by
`IpSocket::configure` and then dropped.

This moves the `setupTimeouts` call out of that block so it runs for every socket
the class opens, and adds a unit test that reads the value back with `getsockopt`.

`Drv/Ip/UdpSocket.cpp` +9/-6, `Drv/Ip/test/ut/TestUdp.cpp` +27.

## Rationale

`TcpClientSocket` and `TcpServerSocket` both call `setupTimeouts` unconditionally.
The UDP guard was the odd one out, and it conflated two different questions: "is a
send address configured" and "should this socket's options be set". The first has
nothing to do with the second.

## Testing/Review Recommendations

Built and run locally on macOS (AppleClang) with `fprime-util build --ut` and
`fprime-util check` in `Drv/Ip`. I also built the unpatched file with the new test
in place, to confirm the test really catches the bug:

    without the fix:  [ FAILED ]  SendTimeout.TestSendTimeoutAppliedWithoutSendPort
                      getsockopt reported tv_sec = 0, configured value was 1
                      8 of 9 UDP tests passed

    with the fix:     [   OK   ]  SendTimeout.TestSendTimeoutAppliedWithoutSendPort
                      9 of 9 UDP tests passed, check exited 0

The `Drv/Ip` TCP tests pass in both cases.

Worth knowing while reviewing: `TestEphemeralPorts` already walks this path.
Line 150 configures the receiver with `configureSend("127.0.0.1", 0, 0, 100)` and
that socket goes on to send a reply, but nothing read `SO_SNDTIMEO` back, so the
suite passed over the bug.

The new test is guarded on `TGT_OS_TYPE_VXWORKS`, matching `setupTimeouts`, which
is a no-op there.

## Future Work

`setupSocketOptions` sits behind the same `if (port != 0)` guard, so `SO_REUSEADDR`
is also skipped when the send port is 0 — and that is the case where the socket is
the one that binds, which is what the option is for. I left it out of this PR
because changing it alters bind behaviour for existing receive-only sockets, and
that felt like your call rather than mine. Happy to fold it in here or open a
separate issue, whichever you prefer.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

- **Type of assistance:** code generation, debugging assistance, test authoring
- **Scope:** `Drv/Ip/UdpSocket.cpp` (moving the `setupTimeouts` call out of the
  port guard) and `Drv/Ip/test/ut/TestUdp.cpp` (the new `SendTimeout` test)
- **Tool:** Claude (Anthropic)
- **Level of modification:** reviewed and verified rather than used as-is. I built
  and ran the suite locally, and separately built the unpatched source with the new
  test to confirm it fails without the change.