### PR TITLE
Svc/FileDownlink: add Reset command and stall warning to recover from a wedged downlink

### DIFF
--- a/Svc/FileDownlink/Commands.fppi
+++ b/Svc/FileDownlink/Commands.fppi
@@ -17,3 +17,11 @@ async command SendPartial(
                            length: U32 @< Number of bytes to send from starting offset. Length of 0 implies until the end of the file
                          ) \
   opcode 0x02
+
+@ Force-complete the active downlink and drain queued requests with error responses, without
+@ waiting on outstanding buffer returns. Unlike Cancel, this breaks the buffer flow-control
+@ protocol: use it only to recover when the downstream component will never return the
+@ outstanding buffer. If that component later revives and reads the buffer, it may emit stale
+@ packet data.
+async command Reset \
+  opcode 0x03

--- a/Svc/FileDownlink/Commands.fppi
+++ b/Svc/FileDownlink/Commands.fppi
@@ -18,8 +18,9 @@ async command SendPartial(
                          ) \
   opcode 0x02
 
-@ Force-complete the active downlink and drain queued requests with error responses, without
-@ waiting on outstanding buffer returns. Unlike Cancel, this breaks the buffer flow-control
+@ Force-complete the active downlink and drain queued requests, without waiting on outstanding
+@ buffer returns. Port clients receive STATUS_ERROR for every affected request; command responses
+@ follow FILEDOWNLINK_COMMAND_FAILURES_DISABLED. Unlike Cancel, this breaks the buffer flow-control
 @ protocol: use it only to recover when the downstream component will never return the
 @ outstanding buffer. If that component later revives and reads the buffer, it may emit stale
 @ packet data.

--- a/Svc/FileDownlink/Events.fppi
+++ b/Svc/FileDownlink/Events.fppi
@@ -110,3 +110,13 @@ event DownlinkReset(
   severity activity high \
   id 0x13 \
   format "File downlink reset; dropped {} queued downlink requests"
+
+@ A downlink has been waiting longer than the configured stall timeout for a buffer to be returned. The downstream component may be failing to return buffers; the Reset command recovers the component if the buffer never comes back.
+event DownlinkStalled(
+                       sourceFileName: string size 100 @< The source file name
+                       destFileName: string size 100 @< The destination file name
+                       waitTimeMs: U32 @< Time in milliseconds spent waiting for a buffer return
+                     ) \
+  severity warning high \
+  id 0x14 \
+  format "Downlink of file {} to file {} has waited {} ms for a buffer return"

--- a/Svc/FileDownlink/Events.fppi
+++ b/Svc/FileDownlink/Events.fppi
@@ -102,3 +102,11 @@ event SourceOutOfSandbox(
   severity warning high \
   id 0x12 \
   format "Source file {} is outside the configured read sandbox"
+
+@ The File Downlink component was reset by command. Queued downlink requests are dropped with error responses.
+event DownlinkReset(
+                     queuedFilesDropped: U32 @< Number of queued downlink requests dropped
+                   ) \
+  severity activity high \
+  id 0x13 \
+  format "File downlink reset; dropped {} queued downlink requests"

--- a/Svc/FileDownlink/Events.fppi
+++ b/Svc/FileDownlink/Events.fppi
@@ -103,7 +103,7 @@ event SourceOutOfSandbox(
   id 0x12 \
   format "Source file {} is outside the configured read sandbox"
 
-@ The File Downlink component was reset by command. Queued downlink requests are dropped with error responses.
+@ The File Downlink component was reset by command. The active and queued downlink requests are dropped: port clients receive STATUS_ERROR, command responses follow FILEDOWNLINK_COMMAND_FAILURES_DISABLED.
 event DownlinkReset(
                      queuedFilesDropped: U32 @< Number of queued downlink requests dropped
                    ) \

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -31,7 +31,6 @@ FileDownlink ::FileDownlink(const char* const name)
       m_warnings(this),
       m_sequenceIndex(0),
       m_curTimer(0),
-      m_bufferSize(0),
       m_byteOffset(0),
       m_endOffset(0),
       m_lastCompletedType(Fw::FilePacket::T_NONE),

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -31,6 +31,7 @@ FileDownlink ::FileDownlink(const char* const name)
       m_warnings(this),
       m_sequenceIndex(0),
       m_curTimer(0),
+      m_stallTimeout(0),
       m_fileQueueDepth(0),
       m_byteOffset(0),
       m_endOffset(0),
@@ -39,9 +40,10 @@ FileDownlink ::FileDownlink(const char* const name)
       m_curEntry(),
       m_cntxId(0) {}
 
-void FileDownlink ::configure(U32 cooldown, U32 cycleTime, U32 fileQueueDepth) {
+void FileDownlink ::configure(U32 cooldown, U32 cycleTime, U32 fileQueueDepth, U32 stallTimeout) {
     this->m_cooldown = cooldown;
     this->m_cycleTime = cycleTime;
+    this->m_stallTimeout = stallTimeout;
     this->m_fileQueueDepth = fileQueueDepth;
     this->m_configured = true;
 
@@ -96,8 +98,17 @@ void FileDownlink ::Run_handler(const FwIndexType portNum, U32 context) {
             }
             break;
         }
+        // A pending cancellation waits on the same buffer return, so it can stall the same way
+        case Mode::CANCEL:
         case Mode::WAIT: {
+            const U32 previous = this->m_curTimer;
             this->m_curTimer += m_cycleTime;
+            // Warn once per wait, on the cycle that crosses the stall timeout
+            if ((this->m_stallTimeout != 0) && (previous < this->m_stallTimeout) &&
+                (this->m_curTimer >= this->m_stallTimeout)) {
+                this->log_WARNING_HI_DownlinkStalled(this->m_file.getSourceName(), this->m_file.getDestName(),
+                                                     this->m_curTimer);
+            }
             break;
         }
         default:
@@ -243,6 +254,9 @@ void FileDownlink ::Cancel_cmdHandler(const FwOpcodeType opCode, const U32 cmdSe
     // Must be able to cancel in both downlink and waiting states
     if (this->m_mode.get() == Mode::DOWNLINK || this->m_mode.get() == Mode::WAIT) {
         this->m_mode.set(Mode::CANCEL);
+        // The cancellation begins a new wait on the buffer return; restart the stall timer so a
+        // cancellation that also stalls is warned about
+        this->m_curTimer = 0;
     }
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -31,6 +31,7 @@ FileDownlink ::FileDownlink(const char* const name)
       m_warnings(this),
       m_sequenceIndex(0),
       m_curTimer(0),
+      m_fileQueueDepth(0),
       m_byteOffset(0),
       m_endOffset(0),
       m_lastCompletedType(Fw::FilePacket::T_NONE),
@@ -41,6 +42,7 @@ FileDownlink ::FileDownlink(const char* const name)
 void FileDownlink ::configure(U32 cooldown, U32 cycleTime, U32 fileQueueDepth) {
     this->m_cooldown = cooldown;
     this->m_cycleTime = cycleTime;
+    this->m_fileQueueDepth = fileQueueDepth;
     this->m_configured = true;
 
     Os::Queue::Status stat =
@@ -245,6 +247,26 @@ void FileDownlink ::Cancel_cmdHandler(const FwOpcodeType opCode, const U32 cmdSe
     this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
 }
 
+void FileDownlink ::Reset_cmdHandler(const FwOpcodeType opCode, const U32 cmdSeq) {
+    const Mode::Type mode = this->m_mode.get();
+    // Force-complete any active transfer without waiting on the outstanding buffer return
+    if (mode == Mode::DOWNLINK || mode == Mode::WAIT || mode == Mode::CANCEL) {
+        // Best effort: skip a duplicate cancel packet when one is known to be outstanding.
+        // finishHelper() below clears m_lastCompletedType, so this only covers a cancel packet
+        // emitted by the normal Cancel path.
+        if (this->m_lastCompletedType != Fw::FilePacket::T_CANCEL) {
+            this->sendCancelPacket();
+        }
+        this->finishHelper(true);
+    }
+    // Advance past all handed-out buffer IDs so a late return of an outstanding buffer is
+    // dropped as stale rather than driving the state machine
+    this->m_lastBufferId++;
+    const U32 drained = this->drainFileQueue();
+    this->log_ACTIVITY_HI_DownlinkReset(drained);
+    this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
+}
+
 // ----------------------------------------------------------------------
 // Private helper methods
 // ----------------------------------------------------------------------
@@ -269,17 +291,44 @@ Fw::CmdResponse FileDownlink ::statusToCmdResp(SendFileStatus status) {
 }
 
 void FileDownlink ::sendResponse(SendFileStatus resp) {
-    FW_ASSERT(this->m_curEntry.source == FileDownlink::COMMAND || this->m_curEntry.source == FileDownlink::PORT,
-              static_cast<FwAssertArgType>(this->m_curEntry.source));
-    if (this->m_curEntry.source == FileDownlink::COMMAND) {
-        this->cmdResponse_out(this->m_curEntry.opCode, this->m_curEntry.cmdSeq, statusToCmdResp(resp));
+    this->sendResponse(this->m_curEntry, resp);
+}
+
+void FileDownlink ::sendResponse(const FileEntry& entry, SendFileStatus resp) {
+    FW_ASSERT(entry.source == FileDownlink::COMMAND || entry.source == FileDownlink::PORT,
+              static_cast<FwAssertArgType>(entry.source));
+    if (entry.source == FileDownlink::COMMAND) {
+        this->cmdResponse_out(entry.opCode, entry.cmdSeq, statusToCmdResp(resp));
     } else {
         for (FwIndexType i = 0; i < this->getNum_FileComplete_OutputPorts(); i++) {
             if (this->isConnected_FileComplete_OutputPort(i)) {
-                this->FileComplete_out(i, Svc::SendFileResponse(resp, this->m_curEntry.context));
+                this->FileComplete_out(i, Svc::SendFileResponse(resp, entry.context));
             }
         }
     }
+}
+
+U32 FileDownlink ::drainFileQueue() {
+    // Bound the loop by the queue depth rather than a live message count: delivering an error
+    // response can re-enter SendFile_handler on the caller's thread and enqueue again, and
+    // Os::Queue::getMessagesAvailable() is not serialized against that enqueue.
+    U32 drained = 0;
+    struct FileEntry entry;
+    FwSizeType real_size = 0;
+    FwQueuePriorityType prio = 0;
+    for (U32 i = 0; i < this->m_fileQueueDepth; i++) {
+        if (m_fileQueue.receive(reinterpret_cast<U8*>(&entry), static_cast<FwSizeType>(sizeof(entry)),
+                                Os::Queue::BlockingType::NONBLOCKING, real_size, prio) != Os::Queue::Status::OP_OK) {
+            break;
+        }
+        // The queue is created with this fixed message size; a short read would silently strand
+        // the request's caller without a response
+        FW_ASSERT(sizeof(entry) == real_size, static_cast<FwAssertArgType>(real_size));
+        this->sendResponse(
+            entry, FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR);
+        drained++;
+    }
+    return drained;
 }
 
 void FileDownlink ::sendFile(const Fw::FileNameString& sourceFilename,

--- a/Svc/FileDownlink/FileDownlink.cpp
+++ b/Svc/FileDownlink/FileDownlink.cpp
@@ -167,7 +167,7 @@ void FileDownlink ::bufferReturn_handler(const FwIndexType portNum, Fw::Buffer& 
               static_cast<FwAssertArgType>(this->m_mode.get()));
     // If the last packet has been sent (and is returning now) then finish the file
     if (this->m_lastCompletedType == Fw::FilePacket::T_END || this->m_lastCompletedType == Fw::FilePacket::T_CANCEL) {
-        finishHelper(this->m_lastCompletedType == Fw::FilePacket::T_CANCEL);
+        finishHelper(this->m_lastCompletedType == Fw::FilePacket::T_CANCEL, SendFileStatus::STATUS_OK);
         return;
     }
     // If waiting and a buffer is in-bound, then switch to downlink mode
@@ -263,7 +263,8 @@ void FileDownlink ::Cancel_cmdHandler(const FwOpcodeType opCode, const U32 cmdSe
 
 void FileDownlink ::Reset_cmdHandler(const FwOpcodeType opCode, const U32 cmdSeq) {
     const Mode::Type mode = this->m_mode.get();
-    // Force-complete any active transfer without waiting on the outstanding buffer return
+    // Force-complete any active transfer without waiting on the outstanding buffer return. The
+    // transfer did not complete, so its requester is answered with the abort status.
     if (mode == Mode::DOWNLINK || mode == Mode::WAIT || mode == Mode::CANCEL) {
         // Best effort: skip a duplicate cancel packet when one is known to be outstanding.
         // finishHelper() below clears m_lastCompletedType, so this only covers a cancel packet
@@ -271,7 +272,7 @@ void FileDownlink ::Reset_cmdHandler(const FwOpcodeType opCode, const U32 cmdSeq
         if (this->m_lastCompletedType != Fw::FilePacket::T_CANCEL) {
             this->sendCancelPacket();
         }
-        this->finishHelper(true);
+        this->finishHelper(true, this->abortStatus(this->m_curEntry));
     }
     // Advance past all handed-out buffer IDs so a late return of an outstanding buffer is
     // dropped as stale rather than driving the state machine
@@ -302,6 +303,13 @@ Fw::CmdResponse FileDownlink ::statusToCmdResp(SendFileStatus status) {
 
     // It's impossible to reach this, but added to suppress gcc missing return warning
     return Fw::CmdResponse::EXECUTION_ERROR;
+}
+
+SendFileStatus FileDownlink ::abortStatus(const FileEntry& entry) const {
+    if (entry.source == FileDownlink::PORT) {
+        return SendFileStatus::STATUS_ERROR;
+    }
+    return FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR;
 }
 
 void FileDownlink ::sendResponse(SendFileStatus resp) {
@@ -338,8 +346,7 @@ U32 FileDownlink ::drainFileQueue() {
         // The queue is created with this fixed message size; a short read would silently strand
         // the request's caller without a response
         FW_ASSERT(sizeof(entry) == real_size, static_cast<FwAssertArgType>(real_size));
-        this->sendResponse(
-            entry, FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR);
+        this->sendResponse(entry, this->abortStatus(entry));
         drained++;
     }
     return drained;
@@ -559,7 +566,7 @@ void FileDownlink ::downlinkPacket() {
     this->m_curTimer = 0;
 }
 
-void FileDownlink ::finishHelper(bool cancel) {
+void FileDownlink ::finishHelper(bool cancel, SendFileStatus response) {
     // Complete command and switch to IDLE
     if (not cancel) {
         this->m_filesSent.fileSent();
@@ -568,7 +575,7 @@ void FileDownlink ::finishHelper(bool cancel) {
         this->log_ACTIVITY_HI_DownlinkCanceled(this->m_file.getSourceName(), this->m_file.getDestName());
     }
     this->enterCooldown();
-    sendResponse(SendFileStatus::STATUS_OK);
+    sendResponse(response);
 }
 
 void FileDownlink ::getBuffer(Fw::Buffer& buffer, PacketType type) {

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -304,6 +304,12 @@ class FileDownlink final : public FileDownlinkComponentBase {
                            const U32 cmdSeq            //!< The command sequence number
     );
 
+    //! Implementation for FileDownlink_Reset command handler
+    //!
+    void Reset_cmdHandler(const FwOpcodeType opCode,  //!< The opcode
+                          const U32 cmdSeq            //!< The command sequence number
+    );
+
     //! Implementation for FILE_DWN_SEND_PARTIAL command handler
     //!
     void SendPartial_cmdHandler(
@@ -345,8 +351,12 @@ class FileDownlink final : public FileDownlinkComponentBase {
     void finishHelper(bool is_cancel);
     // Convert internal status enum to a command response
     Fw::CmdResponse statusToCmdResp(SendFileStatus status);
-    // Send response after completing file downlink
+    // Send response for the current file downlink
     void sendResponse(SendFileStatus resp);
+    // Send response for a given file downlink request
+    void sendResponse(const FileEntry& entry, SendFileStatus resp);
+    // Drain the file queue, responding to each request with an error. Returns the number drained.
+    U32 drainFileQueue();
 
   private:
     // ----------------------------------------------------------------------
@@ -388,6 +398,9 @@ class FileDownlink final : public FileDownlinkComponentBase {
 
     //! rate (milliseconds) at which we are running
     U32 m_cycleTime;
+
+    //! Max number of items in the file downlink queue
+    U32 m_fileQueueDepth;
 
     ////! Buffer for sending file data
     Fw::Buffer m_buffer;

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -335,7 +335,6 @@ class FileDownlink final : public FileDownlinkComponentBase {
     void sendFilePacket(const Fw::FilePacket& filePacket);
 
     // State-helper functions
-    void exitFileTransfer();
     void enterCooldown();
 
     // Function to acquire a buffer internally
@@ -381,9 +380,6 @@ class FileDownlink final : public FileDownlinkComponentBase {
     //! The current sequence index
     U32 m_sequenceIndex;
 
-    //! Timeout threshold (milliseconds) while in WAIT state
-    U32 m_timeout;
-
     //! Cooldown (in ms) between finishing a downlink and starting the next file.
     U32 m_cooldown;
 
@@ -395,9 +391,6 @@ class FileDownlink final : public FileDownlinkComponentBase {
 
     ////! Buffer for sending file data
     Fw::Buffer m_buffer;
-
-    //! Buffer size for file data
-    U32 m_bufferSize;
 
     //! Current byte offset in file
     U32 m_byteOffset;

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -349,10 +349,14 @@ class FileDownlink final : public FileDownlinkComponentBase {
     void getBuffer(Fw::Buffer& buffer, PacketType type);
     // Downlink the "next" packet
     void downlinkPacket();
-    // Finish the file transfer
-    void finishHelper(bool is_cancel);
+    // Finish the file transfer, responding to its requester with the given status
+    void finishHelper(bool is_cancel, SendFileStatus response);
     // Convert internal status enum to a command response
     Fw::CmdResponse statusToCmdResp(SendFileStatus status);
+    // Status reported for a request the component abandons without completing it (Reset). Port
+    // clients always receive STATUS_ERROR so that they do not treat an unsent file as delivered;
+    // command responses honor FILEDOWNLINK_COMMAND_FAILURES_DISABLED.
+    SendFileStatus abortStatus(const FileEntry& entry) const;
     // Send response for the current file downlink
     void sendResponse(SendFileStatus resp);
     // Send response for a given file downlink request

--- a/Svc/FileDownlink/FileDownlink.hpp
+++ b/Svc/FileDownlink/FileDownlink.hpp
@@ -232,9 +232,11 @@ class FileDownlink final : public FileDownlinkComponentBase {
 
     //! Configure FileDownlink component
     //!
-    void configure(U32 cooldown,       //!< Cooldown (in ms) between finishing a downlink and starting the next file.
-                   U32 cycleTime,      //!< Rate at which we are running
-                   U32 fileQueueDepth  //!< Max number of items in file downlink queue
+    void configure(
+        U32 cooldown,         //!< Cooldown (in ms) between finishing a downlink and starting the next file.
+        U32 cycleTime,        //!< Rate at which we are running
+        U32 fileQueueDepth,   //!< Max number of items in file downlink queue
+        U32 stallTimeout = 0  //!< Time (in ms) waiting on a buffer return before a DownlinkStalled warning. 0 disables.
     );
 
     //! Restrict SendFile / SendPartial reads to paths under the configured directory.
@@ -398,6 +400,9 @@ class FileDownlink final : public FileDownlinkComponentBase {
 
     //! rate (milliseconds) at which we are running
     U32 m_cycleTime;
+
+    //! Time (in ms) waiting on a buffer return before a DownlinkStalled warning. 0 disables the warning.
+    U32 m_stallTimeout;
 
     //! Max number of items in the file downlink queue
     U32 m_fileQueueDepth;

--- a/Svc/FileDownlink/docs/sdd.md
+++ b/Svc/FileDownlink/docs/sdd.md
@@ -48,7 +48,7 @@ of type [`Fw::FilePacket`](../../../Fw/FilePacket/docs/sdd.md).
    > rejected with `OUTSIDE_SANDBOX` (emitting `SourceOutOfSandbox`) — an unconfigured
    > `FileDownlink` cannot read anything. A deployment **must** call the `configure(directory)`
    > overload during topology setup to enable downlink reads and select the allowed base
-   > directory (the `configure(cooldown, cycleTime, fileQueueDepth)` overload does **not** set a
+   > directory (the `configure(cooldown, cycleTime, fileQueueDepth, stallTimeout)` overload does **not** set a
    > sandbox). Note that the stock `FileHandling` subtopology configures the sandbox to `"/"` for
    > backwards compatibility, which permits reading **any absolute path accessible to the
    > process** via ground command. Security-conscious deployments using that subtopology **must**

--- a/Svc/FileDownlink/docs/sdd.md
+++ b/Svc/FileDownlink/docs/sdd.md
@@ -146,17 +146,20 @@ Reset is an asynchronous command that recovers the component when the downstream
 never returns the outstanding buffer. It force-completes the active downlink, if any, without
 waiting on the buffer return: `FileDownlink` sends a cancel packet, emits `DownlinkCanceled`,
 responds to the originating command or port request, and enters COOLDOWN. It then drains the
-file queue, responding to each queued request with an error, and emits `DownlinkReset` with the
-number of requests dropped. A single Reset drops at most *file queue depth* requests; if
-delivering a drop response causes a client to synchronously submit another request, that request
-may be dropped by the same Reset. As with all downlink failure responses,
-`FILEDOWNLINK_COMMAND_FAILURES_DISABLED` maps these error responses to OK; the `DownlinkReset`
-count is then the only indication that queued requests were dropped. Port clients therefore see
-`SendFileStatus::STATUS_OK` for requests that were dropped without a single packet being sent:
-`Svc::DpCatalog`, for example, will mark the data product TRANSMITTED and remove it from the
-catalog. Deployments that cannot tolerate that must set `FILEDOWNLINK_COMMAND_FAILURES_DISABLED`
-to false, which makes both the drain and the pre-existing failure paths report `STATUS_ERROR`. Late returns of buffers that were outstanding at the time of the
-Reset are ignored.
+file queue, responding to each queued request, and emits `DownlinkReset` with the number of
+requests dropped. A single Reset drops at most *file queue depth* requests; if delivering a drop
+response causes a client to synchronously submit another request, that request may be dropped by
+the same Reset. Late returns of buffers that were outstanding at the time of the Reset are
+ignored.
+
+Reset never completes a transfer, so every request it drops, active or queued, is reported to
+port clients as `SendFileStatus::STATUS_ERROR` regardless of
+`FILEDOWNLINK_COMMAND_FAILURES_DISABLED`; a port client such as `Svc::DpCatalog` therefore keeps
+the product for a later retry. Command responses follow the flag as elsewhere: `OK` when it is
+set, `EXECUTION_ERROR` otherwise. This differs from Cancel: a cancellation that completes on its
+own still reports `STATUS_OK` to port clients, as do the pre-existing failure paths (file open
+error, zero-size file, offset past end of file, read error) when the flag is set, so those paths
+can still lead a port client to treat an unsent file as delivered.
 
 > [!WARNING]
 > Reset breaks the buffer flow-control protocol: the internal packet buffers are eligible for

--- a/Svc/FileDownlink/docs/sdd.md
+++ b/Svc/FileDownlink/docs/sdd.md
@@ -22,6 +22,7 @@ FD-001 | `FileDownlink` shall queue up a list of files to downlink | The require
 FD-002 | `FileDownlink` shall read a file from non-volatile storage, partition the file into packets, and send out the packets. | This requirement provides the capability to downlink files from the spacecraft. | Test
 FD-003 | `FileDownlink` shall wait for a cooldown after completing a file downlink before starting another file downlink | Allows a saturated link to process a backlog that may have built up during a file downlink | Test
 FD-004 | `FileDownlink` shall issue a warning if a file with zero size is encountered | Ensures that operators are aware of invalid file sizes | Test
+FD-005 | `FileDownlink` shall provide a command that force-completes the active downlink and drains the file queue without waiting on outstanding buffer returns | Allows operators to recover the component when a downstream component never returns a buffer | Test
 
 ## 3 Design
 
@@ -134,6 +135,37 @@ failure.
 Cancel is an asynchronous command.
 If *mode* = DOWNLINK or *mode* = WAIT, it sets *mode* to CANCEL.
 Otherwise it does nothing.
+On the return of the outstanding buffer, `FileDownlink` sends a cancel packet; when that cancel
+packet's own buffer is in turn returned, it emits `DownlinkCanceled` and enters COOLDOWN. Cancel therefore follows
+the normal buffer flow-control protocol and cannot complete if the downstream component never
+returns the outstanding buffer. Use Reset to recover from that condition.
+
+#### 3.5.3 Reset
+
+Reset is an asynchronous command that recovers the component when the downstream component
+never returns the outstanding buffer. It force-completes the active downlink, if any, without
+waiting on the buffer return: `FileDownlink` sends a cancel packet, emits `DownlinkCanceled`,
+responds to the originating command or port request, and enters COOLDOWN. It then drains the
+file queue, responding to each queued request with an error, and emits `DownlinkReset` with the
+number of requests dropped. A single Reset drops at most *file queue depth* requests; if
+delivering a drop response causes a client to synchronously submit another request, that request
+may be dropped by the same Reset. As with all downlink failure responses,
+`FILEDOWNLINK_COMMAND_FAILURES_DISABLED` maps these error responses to OK; the `DownlinkReset`
+count is then the only indication that queued requests were dropped. Port clients therefore see
+`SendFileStatus::STATUS_OK` for requests that were dropped without a single packet being sent:
+`Svc::DpCatalog`, for example, will mark the data product TRANSMITTED and remove it from the
+catalog. Deployments that cannot tolerate that must set `FILEDOWNLINK_COMMAND_FAILURES_DISABLED`
+to false, which makes both the drain and the pre-existing failure paths report `STATUS_ERROR`. Late returns of buffers that were outstanding at the time of the
+Reset are ignored.
+
+> [!WARNING]
+> Reset breaks the buffer flow-control protocol: the internal packet buffers are eligible for
+> reuse while a downstream component may still hold references to them. Issue Reset only when
+> the downstream component has been written off. If that component later revives and reads a
+> held buffer, it may emit stale packet data. In particular the file-packet store is re-wrapped
+> by the very next `SendFile` after a Reset, so a downstream component that revives mid-transfer
+> may read bytes `FileDownlink` is concurrently rewriting; nothing in the component delays a
+> follow-on downlink.
 
 ## 4 Checklists
 

--- a/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
@@ -49,6 +49,11 @@ TEST(FileDownlink, ResetInIdleMode) {
     tester.resetInIdleMode();
 }
 
+TEST(FileDownlink, DownlinkStallWarning) {
+    Svc::FileDownlinkTester tester;
+    tester.downlinkStallWarning();
+}
+
 TEST(FileDownlink, DownlinkPartial) {
     Svc::FileDownlinkTester tester;
     tester.downlinkPartial();

--- a/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkMain.cpp
@@ -24,6 +24,31 @@ TEST(FileDownlink, CancelInIdleMode) {
     tester.cancelInIdleMode();
 }
 
+TEST(FileDownlink, ResetWedgedDownlink) {
+    Svc::FileDownlinkTester tester;
+    tester.resetWedgedDownlink();
+}
+
+TEST(FileDownlink, ResetDrainsQueue) {
+    Svc::FileDownlinkTester tester;
+    tester.resetDrainsQueue();
+}
+
+TEST(FileDownlink, ResetWithCancelPacketOutstanding) {
+    Svc::FileDownlinkTester tester;
+    tester.resetWithCancelPacketOutstanding();
+}
+
+TEST(FileDownlink, ResetDrainBounded) {
+    Svc::FileDownlinkTester tester;
+    tester.resetDrainBounded();
+}
+
+TEST(FileDownlink, ResetInIdleMode) {
+    Svc::FileDownlinkTester tester;
+    tester.resetInIdleMode();
+}
+
 TEST(FileDownlink, DownlinkPartial) {
     Svc::FileDownlinkTester tester;
     tester.downlinkPartial();

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -20,6 +20,7 @@
 #define INSTANCE 0
 #define CMD_SEQ 0
 #define QUEUE_DEPTH 10
+#define FILE_QUEUE_DEPTH 10
 
 #define COOLDOWN_MS 500
 #define CYCLE_MS 100
@@ -31,8 +32,13 @@ namespace Svc {
 // ----------------------------------------------------------------------
 
 FileDownlinkTester ::FileDownlinkTester()
-    : FileDownlinkGTestBase("Tester", MAX_HISTORY_SIZE), component("FileDownlink"), buffers_index(0) {
-    this->component.configure(COOLDOWN_MS, CYCLE_MS, 10);
+    : FileDownlinkGTestBase("Tester", MAX_HISTORY_SIZE),
+      component("FileDownlink"),
+      buffers_index(0),
+      m_returnBuffers(true),
+      m_heldCount(0),
+      m_reenqueueOnFileComplete(false) {
+    this->component.configure(COOLDOWN_MS, CYCLE_MS, FILE_QUEUE_DEPTH);
     this->connectPorts();
     this->initComponents();
     char cwd[Os::FilePathUtils::MAX_PATH_LENGTH] = {};
@@ -189,6 +195,239 @@ void FileDownlinkTester ::cancelInIdleMode() {
     this->cancel(Fw::CmdResponse::OK);
 
     this->component.Run_handler(0, 0);
+    // Assert idle mode
+    ASSERT_EQ(FileDownlink::Mode::IDLE, this->component.m_mode.get());
+}
+
+void FileDownlinkTester ::resetWedgedDownlink() {
+    // Create a file
+    const char* const sourceFileName = "source.bin";
+    const char* const destFileName = "dest.bin";
+    U8 data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    FileBuffer fileBufferOut(data, sizeof(data));
+    fileBufferOut.write(sourceFileName);
+
+    // Simulate a downstream component that never returns buffers
+    this->m_returnBuffers = false;
+
+    // Start a downlink; the start packet buffer is sent and never returned
+    Fw::CmdStringArg sourceCmdStringArg(sourceFileName);
+    Fw::CmdStringArg destCmdStringArg(destFileName);
+    this->sendCmd_SendFile(INSTANCE, CMD_SEQ, sourceCmdStringArg, destCmdStringArg);
+    this->component.doDispatch();       // Dispatch send file command
+    this->component.Run_handler(0, 0);  // Dequeue and start processing file
+    ASSERT_EQ(FileDownlink::Mode::WAIT, this->component.m_mode.get());
+    ASSERT_EQ(1u, this->m_heldCount);
+
+    // With no buffer return the component stays in WAIT indefinitely
+    for (U32 i = 0; i < 5; i++) {
+        this->component.Run_handler(0, 0);
+    }
+    ASSERT_EQ(FileDownlink::Mode::WAIT, this->component.m_mode.get());
+
+    // Cancel follows the flow-control protocol, so it cannot complete either
+    this->sendCmd_Cancel(INSTANCE, CMD_SEQ);
+    this->component.doDispatch();  // Dispatch cancel command
+    ASSERT_EQ(FileDownlink::Mode::CANCEL, this->component.m_mode.get());
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileDownlink::OPCODE_CANCEL, CMD_SEQ, Fw::CmdResponse::OK);
+    this->cmdResponseHistory->clear();
+
+    // Reset must recover the component without the outstanding buffer coming back
+    this->sendCmd_Reset(INSTANCE, CMD_SEQ);
+    this->component.doDispatch();  // Dispatch reset command
+    ASSERT_EQ(FileDownlink::Mode::COOLDOWN, this->component.m_mode.get());
+    ASSERT_EQ(2u, this->m_heldCount);  // The cancel packet was sent (and is also never returned)
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_CMD_RESPONSE(0, FileDownlink::OPCODE_SENDFILE, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(1, FileDownlink::OPCODE_RESET, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_DownlinkCanceled_SIZE(1);
+    ASSERT_EVENTS_DownlinkReset_SIZE(1);
+    ASSERT_EVENTS_DownlinkReset(0, 0);
+
+    // Reset must put a cancel packet on the wire, not an end packet: an end packet would tell the
+    // ground that the truncated file completed successfully
+    History<Fw::FilePacket::DataPacket> dataPackets(MAX_HISTORY_SIZE);
+    CFDP::Checksum checksum;
+    validatePacketHistory(*this->fromPortHistory_bufferSendOut, dataPackets, Fw::FilePacket::T_CANCEL, 2, checksum, 0);
+
+    // The wedged buffers finally coming back must be ignored as stale
+    this->returnHeldBuffers();
+    ASSERT_EQ(FileDownlink::Mode::COOLDOWN, this->component.m_mode.get());
+
+    // Ride out the cooldown
+    while (this->component.m_mode.get() == FileDownlink::Mode::COOLDOWN) {
+        this->component.Run_handler(0, 0);
+    }
+    ASSERT_EQ(FileDownlink::Mode::IDLE, this->component.m_mode.get());
+
+    // A new downlink must now succeed, with buffers flowing normally again
+    this->m_returnBuffers = true;
+    this->clearHistory();
+    this->sendFile(sourceFileName, destFileName, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_FileSent_SIZE(1);
+
+    this->removeFile(sourceFileName);
+}
+
+void FileDownlinkTester ::resetDrainsQueue() {
+    // Create a file
+    const char* const sourceFileName = "source.bin";
+    const char* const destFileName = "dest.bin";
+    U8 data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    FileBuffer fileBufferOut(data, sizeof(data));
+    fileBufferOut.write(sourceFileName);
+
+    // Simulate a downstream component that never returns buffers
+    this->m_returnBuffers = false;
+
+    // Start a downlink via the port; the start packet buffer is sent and never returned
+    Fw::String srcFileArg(sourceFileName);
+    Fw::String destFileArg(destFileName);
+    Svc::SendFileResponse resp = this->invoke_to_SendFile(0, srcFileArg, destFileArg, 0, 0);
+    ASSERT_EQ(SendFileStatus::STATUS_OK, resp.get_status());
+    const U32 activeContext = resp.get_context();
+    this->component.Run_handler(0, 0);  // Dequeue and start processing file
+    ASSERT_EQ(FileDownlink::Mode::WAIT, this->component.m_mode.get());
+
+    // Queue two more requests behind the wedged transfer: one command, one port request
+    Fw::CmdStringArg sourceCmdStringArg(sourceFileName);
+    Fw::CmdStringArg destCmdStringArg(destFileName);
+    this->sendCmd_SendFile(INSTANCE, CMD_SEQ, sourceCmdStringArg, destCmdStringArg);
+    this->component.doDispatch();  // Dispatch send file command: the request queues with no response yet
+    resp = this->invoke_to_SendFile(0, srcFileArg, destFileArg, 0, 0);
+    ASSERT_EQ(SendFileStatus::STATUS_OK, resp.get_status());
+    const U32 queuedContext = resp.get_context();
+    ASSERT_CMD_RESPONSE_SIZE(0);
+
+    // Reset: the active transfer is canceled and both queued requests receive responses
+    this->sendCmd_Reset(INSTANCE, CMD_SEQ);
+    this->component.doDispatch();  // Dispatch reset command
+    ASSERT_EQ(FileDownlink::Mode::COOLDOWN, this->component.m_mode.get());
+    ASSERT_EVENTS_DownlinkCanceled_SIZE(1);
+    ASSERT_EVENTS_DownlinkReset_SIZE(1);
+    ASSERT_EVENTS_DownlinkReset(0, 2);
+
+    // The active port request completes with the cancel status, the queued one with an error
+    const SendFileStatus::T queuedStatus =
+        FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR;
+    ASSERT_from_FileComplete_SIZE(2);
+    ASSERT_from_FileComplete(0, Svc::SendFileResponse(SendFileStatus(SendFileStatus::STATUS_OK), activeContext));
+    ASSERT_from_FileComplete(1, Svc::SendFileResponse(SendFileStatus(queuedStatus), queuedContext));
+
+    // The queued command receives an error response; the reset command succeeds
+    const Fw::CmdResponse queuedResp =
+        FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? Fw::CmdResponse::OK : Fw::CmdResponse::EXECUTION_ERROR;
+    ASSERT_CMD_RESPONSE_SIZE(2);
+    ASSERT_CMD_RESPONSE(0, FileDownlink::OPCODE_SENDFILE, CMD_SEQ, queuedResp);
+    ASSERT_CMD_RESPONSE(1, FileDownlink::OPCODE_RESET, CMD_SEQ, Fw::CmdResponse::OK);
+
+    // Ride out the cooldown; the queue is empty so the component stays idle
+    this->returnHeldBuffers();
+    while (this->component.m_mode.get() == FileDownlink::Mode::COOLDOWN) {
+        this->component.Run_handler(0, 0);
+    }
+    ASSERT_EQ(FileDownlink::Mode::IDLE, this->component.m_mode.get());
+    this->component.Run_handler(0, 0);
+    ASSERT_EQ(FileDownlink::Mode::IDLE, this->component.m_mode.get());
+
+    this->removeFile(sourceFileName);
+}
+
+void FileDownlinkTester ::resetWithCancelPacketOutstanding() {
+    // Create a file
+    const char* const sourceFileName = "source.bin";
+    const char* const destFileName = "dest.bin";
+    U8 data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    FileBuffer fileBufferOut(data, sizeof(data));
+    fileBufferOut.write(sourceFileName);
+
+    // Simulate a downstream component that never returns buffers
+    this->m_returnBuffers = false;
+
+    // Start a downlink and cancel it while the start packet is outstanding
+    Fw::CmdStringArg sourceCmdStringArg(sourceFileName);
+    Fw::CmdStringArg destCmdStringArg(destFileName);
+    this->sendCmd_SendFile(INSTANCE, CMD_SEQ, sourceCmdStringArg, destCmdStringArg);
+    this->component.doDispatch();       // Dispatch send file command
+    this->component.Run_handler(0, 0);  // Dequeue and start processing file
+    this->sendCmd_Cancel(INSTANCE, CMD_SEQ);
+    this->component.doDispatch();  // Dispatch cancel command
+    ASSERT_EQ(FileDownlink::Mode::CANCEL, this->component.m_mode.get());
+
+    // Return the start packet buffer: the cancel packet goes out and is itself never returned
+    this->invoke_to_bufferReturn(0, this->m_heldBuffers[0]);
+    this->component.doDispatch();  // Process return of start packet buffer, send cancel packet
+    ASSERT_EQ(FileDownlink::Mode::WAIT, this->component.m_mode.get());
+    ASSERT_from_bufferSendOut_SIZE(2);  // Start packet and cancel packet
+
+    // Reset must not send a second cancel packet into the memory the downstream still holds
+    this->sendCmd_Reset(INSTANCE, CMD_SEQ);
+    this->component.doDispatch();  // Dispatch reset command
+    ASSERT_EQ(FileDownlink::Mode::COOLDOWN, this->component.m_mode.get());
+    ASSERT_from_bufferSendOut_SIZE(2);
+    ASSERT_EVENTS_DownlinkCanceled_SIZE(1);
+
+    // The outstanding cancel packet buffer finally coming back must be ignored as stale
+    this->invoke_to_bufferReturn(0, this->m_heldBuffers[1]);
+    this->component.doDispatch();
+    ASSERT_EQ(FileDownlink::Mode::COOLDOWN, this->component.m_mode.get());
+
+    this->removeFile(sourceFileName);
+}
+
+void FileDownlinkTester ::resetDrainBounded() {
+    // Create a file
+    const char* const sourceFileName = "source.bin";
+    const char* const destFileName = "dest.bin";
+    U8 data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    FileBuffer fileBufferOut(data, sizeof(data));
+    fileBufferOut.write(sourceFileName);
+
+    // Simulate a downstream component that never returns buffers
+    this->m_returnBuffers = false;
+
+    // Start a downlink and queue one port request behind it
+    Fw::CmdStringArg sourceCmdStringArg(sourceFileName);
+    Fw::CmdStringArg destCmdStringArg(destFileName);
+    this->sendCmd_SendFile(INSTANCE, CMD_SEQ, sourceCmdStringArg, destCmdStringArg);
+    this->component.doDispatch();       // Dispatch send file command
+    this->component.Run_handler(0, 0);  // Dequeue and start processing file
+    ASSERT_EQ(FileDownlink::Mode::WAIT, this->component.m_mode.get());
+    Fw::String srcFileArg(sourceFileName);
+    Fw::String destFileArg(destFileName);
+    Svc::SendFileResponse resp = this->invoke_to_SendFile(0, srcFileArg, destFileArg, 0, 0);
+    ASSERT_EQ(SendFileStatus::STATUS_OK, resp.get_status());
+
+    // Every drained request's error response enqueues another one. The drain must still terminate,
+    // bounded by the queue depth, rather than following the requests indefinitely.
+    this->m_reenqueueOnFileComplete = true;
+    this->sendCmd_Reset(INSTANCE, CMD_SEQ);
+    this->component.doDispatch();  // Dispatch reset command
+    this->m_reenqueueOnFileComplete = false;
+
+    ASSERT_EQ(FileDownlink::Mode::COOLDOWN, this->component.m_mode.get());
+    ASSERT_EVENTS_DownlinkReset_SIZE(1);
+    ASSERT_EVENTS_DownlinkReset(0, FILE_QUEUE_DEPTH);
+    ASSERT_from_FileComplete_SIZE(FILE_QUEUE_DEPTH);
+
+    this->removeFile(sourceFileName);
+}
+
+void FileDownlinkTester ::resetInIdleMode() {
+    // Assert idle mode
+    ASSERT_EQ(FileDownlink::Mode::IDLE, this->component.m_mode.get());
+
+    // Send a reset command
+    this->sendCmd_Reset(INSTANCE, CMD_SEQ);
+    this->component.doDispatch();
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileDownlink::OPCODE_RESET, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_DownlinkReset_SIZE(1);
+    ASSERT_EVENTS_DownlinkReset(0, 0);
+    ASSERT_EVENTS_DownlinkCanceled_SIZE(0);
+    ASSERT_from_bufferSendOut_SIZE(0);
+
     // Assert idle mode
     ASSERT_EQ(FileDownlink::Mode::IDLE, this->component.m_mode.get());
 }
@@ -392,7 +631,14 @@ void FileDownlinkTester ::from_bufferSendOut_handler(const FwIndexType portNum, 
     ::memcpy(data, buffer.getData(), buffer.getSize());
     Fw::Buffer buffer_new(data, buffer.getSize(), buffer.getContext());
     pushFromPortEntry_bufferSendOut(buffer_new);
-    invoke_to_bufferReturn(0, buffer);
+    if (this->m_returnBuffers) {
+        invoke_to_bufferReturn(0, buffer);
+    } else {
+        // Simulate a wedged downstream component: hold the buffer for a possible late return
+        ASSERT_LT(this->m_heldCount, FW_NUM_ARRAY_ELEMENTS(this->m_heldBuffers));
+        this->m_heldBuffers[this->m_heldCount] = buffer;
+        this->m_heldCount++;
+    }
 }
 
 void FileDownlinkTester ::from_pingOut_handler(const FwIndexType portNum, U32 key) {
@@ -402,6 +648,12 @@ void FileDownlinkTester ::from_pingOut_handler(const FwIndexType portNum, U32 ke
 void FileDownlinkTester ::from_FileComplete_handler(const FwIndexType portNum, /*!< The port number*/
                                                     const Svc::SendFileResponse& response) {
     pushFromPortEntry_FileComplete(response);
+    if (this->m_reenqueueOnFileComplete) {
+        // Simulate a client that reacts to every completion by immediately requesting another file
+        Fw::String srcFileArg("source.bin");
+        Fw::String destFileArg("dest.bin");
+        (void)this->invoke_to_SendFile(0, srcFileArg, destFileArg, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -511,6 +763,14 @@ void FileDownlinkTester ::removeFile(const char* const name) {
         // OK if file is not there
         ASSERT_EQ(ENOENT, errno);
     }
+}
+
+void FileDownlinkTester ::returnHeldBuffers() {
+    for (U32 i = 0; i < this->m_heldCount; i++) {
+        this->invoke_to_bufferReturn(0, this->m_heldBuffers[i]);
+        this->component.doDispatch();
+    }
+    this->m_heldCount = 0;
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -238,8 +238,11 @@ void FileDownlinkTester ::resetWedgedDownlink() {
     this->component.doDispatch();  // Dispatch reset command
     ASSERT_EQ(FileDownlink::Mode::COOLDOWN, this->component.m_mode.get());
     ASSERT_EQ(2u, this->m_heldCount);  // The cancel packet was sent (and is also never returned)
+    // The wedged command did not complete; its response follows FILEDOWNLINK_COMMAND_FAILURES_DISABLED
+    const Fw::CmdResponse activeResp =
+        FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? Fw::CmdResponse::OK : Fw::CmdResponse::EXECUTION_ERROR;
     ASSERT_CMD_RESPONSE_SIZE(2);
-    ASSERT_CMD_RESPONSE(0, FileDownlink::OPCODE_SENDFILE, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_CMD_RESPONSE(0, FileDownlink::OPCODE_SENDFILE, CMD_SEQ, activeResp);
     ASSERT_CMD_RESPONSE(1, FileDownlink::OPCODE_RESET, CMD_SEQ, Fw::CmdResponse::OK);
     ASSERT_EVENTS_DownlinkCanceled_SIZE(1);
     ASSERT_EVENTS_DownlinkReset_SIZE(1);
@@ -308,14 +311,14 @@ void FileDownlinkTester ::resetDrainsQueue() {
     ASSERT_EVENTS_DownlinkReset_SIZE(1);
     ASSERT_EVENTS_DownlinkReset(0, 2);
 
-    // The active port request completes with the cancel status, the queued one with an error
-    const SendFileStatus::T queuedStatus =
-        FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? SendFileStatus::STATUS_OK : SendFileStatus::STATUS_ERROR;
+    // Reset never completes a transfer: both port requests, active and queued, receive STATUS_ERROR
+    // regardless of FILEDOWNLINK_COMMAND_FAILURES_DISABLED, so a port client such as DpCatalog
+    // keeps the file for a retry instead of treating it as delivered
     ASSERT_from_FileComplete_SIZE(2);
-    ASSERT_from_FileComplete(0, Svc::SendFileResponse(SendFileStatus(SendFileStatus::STATUS_OK), activeContext));
-    ASSERT_from_FileComplete(1, Svc::SendFileResponse(SendFileStatus(queuedStatus), queuedContext));
+    ASSERT_from_FileComplete(0, Svc::SendFileResponse(SendFileStatus(SendFileStatus::STATUS_ERROR), activeContext));
+    ASSERT_from_FileComplete(1, Svc::SendFileResponse(SendFileStatus(SendFileStatus::STATUS_ERROR), queuedContext));
 
-    // The queued command receives an error response; the reset command succeeds
+    // The queued command's response follows the flag; the reset command succeeds
     const Fw::CmdResponse queuedResp =
         FILEDOWNLINK_COMMAND_FAILURES_DISABLED ? Fw::CmdResponse::OK : Fw::CmdResponse::EXECUTION_ERROR;
     ASSERT_CMD_RESPONSE_SIZE(2);
@@ -410,6 +413,10 @@ void FileDownlinkTester ::resetDrainBounded() {
     ASSERT_EVENTS_DownlinkReset_SIZE(1);
     ASSERT_EVENTS_DownlinkReset(0, FILE_QUEUE_DEPTH);
     ASSERT_from_FileComplete_SIZE(FILE_QUEUE_DEPTH);
+    // Every drained port request is reported as an error, not as delivered
+    for (U32 i = 0; i < FILE_QUEUE_DEPTH; i++) {
+        ASSERT_EQ(SendFileStatus::STATUS_ERROR, this->fromPortHistory_FileComplete->at(i).resp.get_status());
+    }
 
     this->removeFile(sourceFileName);
 }

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.cpp
@@ -21,9 +21,9 @@
 #define CMD_SEQ 0
 #define QUEUE_DEPTH 10
 #define FILE_QUEUE_DEPTH 10
-
 #define COOLDOWN_MS 500
 #define CYCLE_MS 100
+#define STALL_TIMEOUT_MS 500
 #define MAX_ALLOCATED 100
 namespace Svc {
 
@@ -38,7 +38,7 @@ FileDownlinkTester ::FileDownlinkTester()
       m_returnBuffers(true),
       m_heldCount(0),
       m_reenqueueOnFileComplete(false) {
-    this->component.configure(COOLDOWN_MS, CYCLE_MS, FILE_QUEUE_DEPTH);
+    this->component.configure(COOLDOWN_MS, CYCLE_MS, FILE_QUEUE_DEPTH, STALL_TIMEOUT_MS);
     this->connectPorts();
     this->initComponents();
     char cwd[Os::FilePathUtils::MAX_PATH_LENGTH] = {};
@@ -430,6 +430,73 @@ void FileDownlinkTester ::resetInIdleMode() {
 
     // Assert idle mode
     ASSERT_EQ(FileDownlink::Mode::IDLE, this->component.m_mode.get());
+}
+
+void FileDownlinkTester ::downlinkStallWarning() {
+    // Create a file
+    const char* const sourceFileName = "source.bin";
+    const char* const destFileName = "dest.bin";
+    U8 data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    FileBuffer fileBufferOut(data, sizeof(data));
+    fileBufferOut.write(sourceFileName);
+
+    // Simulate a downstream component that never returns buffers
+    this->m_returnBuffers = false;
+
+    // Start a downlink; the start packet buffer is sent and never returned
+    Fw::CmdStringArg sourceCmdStringArg(sourceFileName);
+    Fw::CmdStringArg destCmdStringArg(destFileName);
+    this->sendCmd_SendFile(INSTANCE, CMD_SEQ, sourceCmdStringArg, destCmdStringArg);
+    this->component.doDispatch();       // Dispatch send file command
+    this->component.Run_handler(0, 0);  // Dequeue and start processing file
+    ASSERT_EQ(FileDownlink::Mode::WAIT, this->component.m_mode.get());
+
+    // No warning before the stall timeout elapses
+    for (U32 i = 0; i < (STALL_TIMEOUT_MS / CYCLE_MS) - 1; i++) {
+        this->component.Run_handler(0, 0);
+    }
+    ASSERT_EVENTS_DownlinkStalled_SIZE(0);
+
+    // The warning fires on the cycle that crosses the timeout, exactly once
+    this->component.Run_handler(0, 0);
+    ASSERT_EVENTS_DownlinkStalled_SIZE(1);
+    ASSERT_EVENTS_DownlinkStalled(0, sourceFileName, destFileName, STALL_TIMEOUT_MS);
+    for (U32 i = 0; i < 5; i++) {
+        this->component.Run_handler(0, 0);
+    }
+    ASSERT_EVENTS_DownlinkStalled_SIZE(1);
+
+    // Recover and start a second downlink
+    this->sendCmd_Reset(INSTANCE, CMD_SEQ);
+    this->component.doDispatch();  // Dispatch reset command
+    this->returnHeldBuffers();
+    while (this->component.m_mode.get() == FileDownlink::Mode::COOLDOWN) {
+        this->component.Run_handler(0, 0);
+    }
+    this->clearHistory();
+    this->sendCmd_SendFile(INSTANCE, CMD_SEQ, sourceCmdStringArg, destCmdStringArg);
+    this->component.doDispatch();       // Dispatch send file command
+    this->component.Run_handler(0, 0);  // Dequeue and start processing file
+    ASSERT_EQ(FileDownlink::Mode::WAIT, this->component.m_mode.get());
+
+    // Let the warning fire, then cancel: the cancellation begins a new wait on the same
+    // missing buffer return, so the stall timer restarts and the warning must fire again
+    for (U32 i = 0; i < STALL_TIMEOUT_MS / CYCLE_MS; i++) {
+        this->component.Run_handler(0, 0);
+    }
+    ASSERT_EVENTS_DownlinkStalled_SIZE(1);
+    this->sendCmd_Cancel(INSTANCE, CMD_SEQ);
+    this->component.doDispatch();  // Dispatch cancel command
+    ASSERT_EQ(FileDownlink::Mode::CANCEL, this->component.m_mode.get());
+    for (U32 i = 0; i < (STALL_TIMEOUT_MS / CYCLE_MS) - 1; i++) {
+        this->component.Run_handler(0, 0);
+    }
+    ASSERT_EVENTS_DownlinkStalled_SIZE(1);
+    this->component.Run_handler(0, 0);
+    ASSERT_EVENTS_DownlinkStalled_SIZE(2);
+    ASSERT_EVENTS_DownlinkStalled(1, sourceFileName, destFileName, STALL_TIMEOUT_MS);
+
+    this->removeFile(sourceFileName);
 }
 
 void FileDownlinkTester ::downlinkPartial() {

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
@@ -17,7 +17,7 @@
 #include <Svc/FileDownlink/FileDownlink.hpp>
 #include "FileDownlinkGTestBase.hpp"
 
-#define MAX_HISTORY_SIZE 10
+#define MAX_HISTORY_SIZE 20
 #define FILE_BUFFER_CAPACITY 100
 
 namespace Svc {
@@ -116,6 +116,22 @@ class FileDownlinkTester : public FileDownlinkGTestBase {
     //! Reject a source path outside the configured read sandbox
     void sourceOutOfSandbox();
 
+    //! Reset a downlink whose outstanding buffer is never returned,
+    //! then verify the component recovers
+    void resetWedgedDownlink();
+
+    //! Reset with queued downlink requests and verify each receives an error response
+    void resetDrainsQueue();
+
+    //! Reset while a cancel packet is outstanding must not send a second cancel packet
+    void resetWithCancelPacketOutstanding();
+
+    //! A request enqueued while Reset drains the queue is retained, not drained
+    void resetDrainBounded();
+
+    //! Send a reset command in idle mode
+    void resetInIdleMode();
+
   private:
     // ----------------------------------------------------------------------
     // Handlers for from ports
@@ -175,6 +191,9 @@ class FileDownlinkTester : public FileDownlinkGTestBase {
     //!
     void removeFile(const char* const name  //!< The file name
     );
+
+    //! Return all held buffers to the component and dispatch each
+    void returnHeldBuffers();
 
     // ----------------------------------------------------------------------
     // Private static methods
@@ -242,6 +261,19 @@ class FileDownlinkTester : public FileDownlinkGTestBase {
     //! The current sequence index
     //!
     U32 sequenceIndex;
+
+    //! Whether from_bufferSendOut_handler returns buffers to the component.
+    //! Set to false to simulate a downstream component that never returns them.
+    bool m_returnBuffers;
+
+    //! Buffers held while m_returnBuffers is false, available for late return
+    Fw::Buffer m_heldBuffers[4];
+
+    //! Number of buffers held
+    U32 m_heldCount;
+
+    //! When true, every FileComplete response triggers another SendFile port request
+    bool m_reenqueueOnFileComplete;
 };
 
 }  // end namespace Svc

--- a/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
+++ b/Svc/FileDownlink/test/ut/FileDownlinkTester.hpp
@@ -132,6 +132,9 @@ class FileDownlinkTester : public FileDownlinkGTestBase {
     //! Send a reset command in idle mode
     void resetInIdleMode();
 
+    //! Warn when a downlink waits too long on a buffer return, in WAIT and in CANCEL mode
+    void downlinkStallWarning();
+
   private:
     // ----------------------------------------------------------------------
     // Handlers for from ports

--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -25,7 +25,8 @@ module FileHandling {
         FileHandling::fileDownlink.configure(
             FileHandlingConfig::DownlinkConfig::cooldown,
             FileHandlingConfig::DownlinkConfig::cycleTime,
-            FileHandlingConfig::DownlinkConfig::fileQueueDepth
+            FileHandlingConfig::DownlinkConfig::fileQueueDepth,
+            FileHandlingConfig::DownlinkConfig::stallTimeout
         );
         // Sandbox for downlinked file reads; "/" is unrestricted. Re-configure to restrict.
         FileHandling::fileDownlink.configure(FileHandlingConfig::Paths::sandboxDir);

--- a/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
@@ -41,5 +41,6 @@ module FileHandlingConfig {
         constant cooldown       = 1000         # File downlink cooldown in ms
         constant cycleTime      = 1000         # File downlink cycle time in ms
         constant fileQueueDepth = 10           # File downlink queue depth
+        constant stallTimeout   = 0            # DownlinkStalled warning threshold in ms; 0 disables
     }
 }

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -47,7 +47,7 @@ The **FileHandling subtopology** packages the core file-transfer services common
 >
 > * `FileHandling::fileUplink.configure(<directory>)` — restrict uplinked file writes.
 > * `FileHandling::fileDownlink.configure(<directory>)` — restrict downlink reads (this is the
->   `configure(directory)` overload; the `configure(cooldown, cycleTime, fileQueueDepth)`
+>   `configure(directory)` overload; the `configure(cooldown, cycleTime, fileQueueDepth, stallTimeout)`
 >   overload does **not** set a sandbox).
 > * `FileHandling::prmDb.configureSandbox(<directory>)` — restrict all `prmDb` file access
 >   (startup read, `PRM_SAVE_FILE`, `PRM_LOAD_FILE`); the directory must contain the store file


### PR DESCRIPTION
|                                                         |             |
| :------------------------------------------------------ | :---------- |
| **_Related Issue(s)_**                                  | Fixes #5447 |
| **_Has Unit Tests (y/n)_**                              | y           |
| **_Documentation Included (y/n)_**                      | y           |
| **_Generative AI was used in this contribution (y/n)_** | AI          |

---

## Change Description

A downlink whose buffer is never returned wedges `FileDownlink` in `WAIT` until reboot.
`Cancel` can't clear it because it waits on the same return, and `Svc::Health` can't see it
because `pingIn` still answers.

Per @bocchino's review, `Cancel` is unchanged — the protocol break is a new command:

- **`Reset` (0x03)** completes the active transfer without waiting on the buffer return, then
  drains the file queue, answering each dropped request rather than discarding it
  (`ComQueue.FLUSH_QUEUE` pattern, except entries here carry caller context). Emits
  `DownlinkReset` (0x13) with the drop count.
- Reset reports `STATUS_ERROR` to port clients for every request it drops, regardless of
  `FILEDOWNLINK_COMMAND_FAILURES_DISABLED`, so `DpCatalog` keeps the product for a retry.
  Command responses keep the flag mapping.
- **`DownlinkStalled` (0x14)** warns once per wait when a downlink sits too long on a buffer
  return. Optional `stallTimeout` on `configure()`, default off, wired through
  `FileHandlingConfig`. Observation only, no automatic action.
- Dead `m_timeout` / `m_bufferSize` / `exitFileTransfer` removed; SDD §3.5.2 corrected.

## Testing/Review Recommendations

15 UTs (6 new), green under ASan/UBSan; all 4 commits build and pass individually.

Two calls worth a look: the drain is bounded by queue depth rather than a live
`getMessagesAvailable()` count, which isn't serialized against a concurrent enqueue; and
`DownlinkStalled` is intentionally not throttled, since a count throttle only clears at
transfer start and a slow link could exhaust it, then go silent through the actual wedge.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Written with Claude Code and reviewed by me.

IAMAI

