### PR TITLE
Add settable time context to Svc::PosixTime

### DIFF
--- a/Svc/PosixTime/PosixTime.cpp
+++ b/Svc/PosixTime/PosixTime.cpp
@@ -1,5 +1,5 @@
 /*
- * TestCommand1Impl.cpp
+ * PosixTime.cpp
  *
  *  Created on: Mar 28, 2014
  *      Author: tcanham
@@ -11,11 +11,15 @@
 
 namespace Svc {
 
-    PosixTime::PosixTime(const char* name) : PosixTimeComponentBase(name)
+    PosixTime::PosixTime(const char* name) : PosixTimeComponentBase(name), m_timeContext(0)
     {
     }
 
     PosixTime::~PosixTime() {
+    }
+
+    void PosixTime::setTimeContext(FwTimeContextStoreType timeContext) {
+        this->m_timeContext = timeContext;
     }
 
     void PosixTime::timeGetPort_handler(
@@ -24,6 +28,6 @@ namespace Svc {
         ) {
         timespec stime;
         (void)clock_gettime(CLOCK_REALTIME,&stime);
-        time.set(TB_WORKSTATION_TIME,0, static_cast<U32>(stime.tv_sec), static_cast<U32>(stime.tv_nsec/1000));
+        time.set(TB_WORKSTATION_TIME, this->m_timeContext, static_cast<U32>(stime.tv_sec), static_cast<U32>(stime.tv_nsec/1000));
     }
 }

--- a/Svc/PosixTime/PosixTime.hpp
+++ b/Svc/PosixTime/PosixTime.hpp
@@ -1,5 +1,5 @@
 /*
- * TestTelemRecvImpl.hpp
+ * PosixTime.hpp
  *
  *  Created on: Mar 28, 2014
  *      Author: tcanham
@@ -16,12 +16,14 @@ class PosixTime: public PosixTimeComponentBase {
     public:
         explicit PosixTime(const char* compName);
         virtual ~PosixTime();
+        void setTimeContext(FwTimeContextStoreType timeContext);
     protected:
         void timeGetPort_handler(
                 NATIVE_INT_TYPE portNum, /*!< The port number*/
                 Fw::Time &time /*!< The U32 cmd argument*/
             );
     private:
+    FwTimeContextStoreType m_timeContext;
 };
 
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5608 |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**| N |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

Adds `setTimeContext()` to `Svc::PosixTime` to allow passing a specific time context to other components.

## Rationale

Currently PosixTime just hardcodes `0` as the time context, but this allows us to provide a non-zero time context to components when they request the current time.

## Testing/Review Recommendations

Tested calling `posixTime.setTimeContext(58);` within `setupTopology()` in a test deployment. Ran deployment alongside fprime-gds and reviewed the GDS `channel.log` output. The provided time context shows up successfully in the log:`(2(58)-1786049221:841479)`.

This PR assumes the use case of setting the time context once at startup in Topology.cpp. It might be safer to make `m_timeContext` be of type `std::atomic<FwTimeContextStoreType>`.

## Future Work

This can probably be applied to F Prime v4 as well, if desired.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

N/A