### PR TITLE
Add option to disable command opcode events

### DIFF
--- a/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
@@ -28,12 +28,18 @@ void CommandDispatcherImpl::compCmdReg_handler(FwIndexType portNum, FwOpcodeType
     if (this->m_entryTable.find(opCode, existingPort) == Fw::Success::SUCCESS) {
         // Opcode already present — must be the same port (re-registration)
         FW_ASSERT(existingPort == portNum, static_cast<FwAssertArgType>(opCode));
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_DIAGNOSTIC_OpCodeReregistered(opCode, portNum);
+#endif
     } else {
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         const I32 slot = static_cast<I32>(this->m_entryTable.getSize());
+#endif
         const Fw::Success status = this->m_entryTable.insert(opCode, portNum);
         FW_ASSERT(status == Fw::Success::SUCCESS, static_cast<FwAssertArgType>(opCode));
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_DIAGNOSTIC_OpCodeRegistered(opCode, portNum, slot);
+#endif
     }
 }
 
@@ -43,11 +49,15 @@ void CommandDispatcherImpl::compCmdStat_handler(FwIndexType portNum,
                                                 const Fw::CmdResponse& response) {
     // check response and log
     if (Fw::CmdResponse::OK == response.e) {
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_COMMAND_OpCodeCompleted(opCode);
+#endif
     } else {
         this->m_numCmdErrors++;
         FW_ASSERT(response.e != Fw::CmdResponse::OK);
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_COMMAND_OpCodeError(opCode, response);
+#endif
     }
     // look for command source
     SequenceTrackerEntry trackedCmd;
@@ -96,7 +106,9 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
 
             // if we couldn't find a slot to track the command, quit
             if (pendingInsertStatus != Fw::Success::SUCCESS) {
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
                 this->log_WARNING_HI_TooManyCommands(cmdPkt.getOpCode());
+#endif
                 if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
                     this->seqCmdStatus_out(portNum, cmdPkt.getOpCode(), context, Fw::CmdResponse::EXECUTION_ERROR);
                 }
@@ -106,12 +118,16 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
         // pass arguments to argument buffer
         this->compCmdSend_out(entryPort, cmdPkt.getOpCode(), this->m_seq, cmdPkt.getArgBuffer());
         // log dispatched command
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_COMMAND_OpCodeDispatched(cmdPkt.getOpCode(), entryPort);
+#endif
 
         // increment command count
         this->m_numCmdsDispatched++;
     } else {
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_WARNING_HI_InvalidCommand(cmdPkt.getOpCode());
+#endif
         this->m_numCmdErrors++;
         // Fail command back to port, if connected
         if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
@@ -160,6 +176,7 @@ void CommandDispatcherImpl::pingIn_handler(FwIndexType portNum, U32 key) {
 }
 
 void CommandDispatcherImpl::seqCmdBuff_overflowHook(FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
     // Extract command opcode
     Fw::CmdPacket cmdPkt;
     Fw::SerializeStatus stat = cmdPkt.deserializeFrom(data);
@@ -169,9 +186,10 @@ void CommandDispatcherImpl::seqCmdBuff_overflowHook(FwIndexType portNum, Fw::Com
         opcode = cmdPkt.getOpCode();
     }
 
-    // Log Cmd Buffer Overflow and increment CommandsDroppedBufOverflow counter
-    this->m_numCmdsDropped++;
     this->log_WARNING_HI_CommandDroppedQueueOverflow(opcode, context);
+#endif
+    // Increment CommandsDroppedBufOverflow counter
+    this->m_numCmdsDropped++;
 }
 
 }  // namespace Svc

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
@@ -28,18 +28,12 @@ void CommandDispatcherImpl::compCmdReg_handler(FwIndexType portNum, FwOpcodeType
     if (this->m_entryTable.find(opCode, existingPort) == Fw::Success::SUCCESS) {
         // Opcode already present — must be the same port (re-registration)
         FW_ASSERT(existingPort == portNum, static_cast<FwAssertArgType>(opCode));
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_DIAGNOSTIC_OpCodeReregistered(opCode, portNum);
-#endif
+        this->log_DIAGNOSTIC_OpCodeReregistered(CmdDispatcherCfg::getEventOpcode(opCode), portNum);
     } else {
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         const I32 slot = static_cast<I32>(this->m_entryTable.getSize());
-#endif
         const Fw::Success status = this->m_entryTable.insert(opCode, portNum);
         FW_ASSERT(status == Fw::Success::SUCCESS, static_cast<FwAssertArgType>(opCode));
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_DIAGNOSTIC_OpCodeRegistered(opCode, portNum, slot);
-#endif
+        this->log_DIAGNOSTIC_OpCodeRegistered(CmdDispatcherCfg::getEventOpcode(opCode), portNum, slot);
     }
 }
 
@@ -49,15 +43,11 @@ void CommandDispatcherImpl::compCmdStat_handler(FwIndexType portNum,
                                                 const Fw::CmdResponse& response) {
     // check response and log
     if (Fw::CmdResponse::OK == response.e) {
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_COMMAND_OpCodeCompleted(opCode);
-#endif
+        this->log_COMMAND_OpCodeCompleted(CmdDispatcherCfg::getEventOpcode(opCode));
     } else {
         this->m_numCmdErrors++;
         FW_ASSERT(response.e != Fw::CmdResponse::OK);
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_COMMAND_OpCodeError(opCode, response);
-#endif
+        this->log_COMMAND_OpCodeError(CmdDispatcherCfg::getEventOpcode(opCode), response);
     }
     // look for command source
     SequenceTrackerEntry trackedCmd;
@@ -106,9 +96,7 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
 
             // if we couldn't find a slot to track the command, quit
             if (pendingInsertStatus != Fw::Success::SUCCESS) {
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-                this->log_WARNING_HI_TooManyCommands(cmdPkt.getOpCode());
-#endif
+                this->log_WARNING_HI_TooManyCommands(CmdDispatcherCfg::getEventOpcode(cmdPkt.getOpCode()));
                 if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
                     this->seqCmdStatus_out(portNum, cmdPkt.getOpCode(), context, Fw::CmdResponse::EXECUTION_ERROR);
                 }
@@ -118,16 +106,12 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
         // pass arguments to argument buffer
         this->compCmdSend_out(entryPort, cmdPkt.getOpCode(), this->m_seq, cmdPkt.getArgBuffer());
         // log dispatched command
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_COMMAND_OpCodeDispatched(cmdPkt.getOpCode(), entryPort);
-#endif
+        this->log_COMMAND_OpCodeDispatched(CmdDispatcherCfg::getEventOpcode(cmdPkt.getOpCode()), entryPort);
 
         // increment command count
         this->m_numCmdsDispatched++;
     } else {
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_WARNING_HI_InvalidCommand(cmdPkt.getOpCode());
-#endif
+        this->log_WARNING_HI_InvalidCommand(CmdDispatcherCfg::getEventOpcode(cmdPkt.getOpCode()));
         this->m_numCmdErrors++;
         // Fail command back to port, if connected
         if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
@@ -176,18 +160,16 @@ void CommandDispatcherImpl::pingIn_handler(FwIndexType portNum, U32 key) {
 }
 
 void CommandDispatcherImpl::seqCmdBuff_overflowHook(FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-    // Extract command opcode
-    Fw::CmdPacket cmdPkt;
-    Fw::SerializeStatus stat = cmdPkt.deserializeFrom(data);
     FwOpcodeType opcode = 0;  // Note: 0 = Reserved opcode
-
-    if (stat == Fw::FW_SERIALIZE_OK) {
-        opcode = cmdPkt.getOpCode();
+    if (CmdDispatcherCfg::IncludeCommandOpcodesInEvents) {
+        Fw::CmdPacket cmdPkt;
+        const Fw::SerializeStatus stat = cmdPkt.deserializeFrom(data);
+        if (stat == Fw::FW_SERIALIZE_OK) {
+            opcode = cmdPkt.getOpCode();
+        }
     }
 
-    this->log_WARNING_HI_CommandDroppedQueueOverflow(opcode, context);
-#endif
+    this->log_WARNING_HI_CommandDroppedQueueOverflow(CmdDispatcherCfg::getEventOpcode(opcode), context);
     // Increment CommandsDroppedBufOverflow counter
     this->m_numCmdsDropped++;
 }

--- a/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.cpp
+++ b/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.cpp
@@ -9,6 +9,7 @@
 #include <Fw/Com/ComPacket.hpp>
 #include <Os/IntervalTimer.hpp>
 #include <Svc/CmdDispatcher/test/ut/CommandDispatcherTester.hpp>
+#include <config/CommandDispatcherImplCfg.hpp>
 
 #include <cstdio>
 
@@ -17,6 +18,12 @@
 
 static_assert(CMD_DISPATCHER_SEQUENCER_TABLE_SIZE + 1 <= std::numeric_limits<U32>::max(),
               "Unit test depends on CMD_DISPATCHER_SEQUENCER_TABLE_SIZE + 1 within range of U32");
+
+namespace {
+constexpr FwOpcodeType getExpectedEventOpcode(const FwOpcodeType opcode) {
+    return Svc::CmdDispatcherCfg::IncludeCommandOpcodesInEvents ? opcode : std::numeric_limits<FwOpcodeType>::max();
+}
+}  // namespace
 
 namespace Svc {
 CommandDispatcherTester::CommandDispatcherTester(Svc::CommandDispatcherImpl& inst)
@@ -74,16 +81,12 @@ void CommandDispatcherTester::registerBuiltinCommands() {
     ASSERT_EQ(port, 1);
 
     // verify event
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
     ASSERT_EVENTS_SIZE(4);
     ASSERT_EVENTS_OpCodeRegistered_SIZE(4);
-    ASSERT_EVENTS_OpCodeRegistered(0, CommandDispatcherImpl::OPCODE_CMD_NO_OP, 1, 0);
-    ASSERT_EVENTS_OpCodeRegistered(1, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING, 1, 1);
-    ASSERT_EVENTS_OpCodeRegistered(2, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1, 1, 2);
-    ASSERT_EVENTS_OpCodeRegistered(3, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING, 1, 3);
-#else
-    ASSERT_EVENTS_SIZE(0);
-#endif
+    ASSERT_EVENTS_OpCodeRegistered(0, getExpectedEventOpcode(CommandDispatcherImpl::OPCODE_CMD_NO_OP), 1, 0);
+    ASSERT_EVENTS_OpCodeRegistered(1, getExpectedEventOpcode(CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING), 1, 1);
+    ASSERT_EVENTS_OpCodeRegistered(2, getExpectedEventOpcode(CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1), 1, 2);
+    ASSERT_EVENTS_OpCodeRegistered(3, getExpectedEventOpcode(CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING), 1, 3);
 }
 
 void CommandDispatcherTester::runNominalDispatch() {
@@ -311,13 +314,9 @@ void CommandDispatcherTester::runInvalidOpcodeDispatch() {
     ASSERT_EQ(port, 0);
 
     // verify registration event
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_OpCodeRegistered_SIZE(1);
-    ASSERT_EVENTS_OpCodeRegistered(0, testOpCode, 0, 4);
-#else
-    ASSERT_EVENTS_SIZE(0);
-#endif
+    ASSERT_EVENTS_OpCodeRegistered(0, getExpectedEventOpcode(testOpCode), 0, 4);
 
     // dispatch a test command with a bad opcode
     U32 testCmdArg = 100;
@@ -334,13 +333,9 @@ void CommandDispatcherTester::runInvalidOpcodeDispatch() {
     ASSERT_EQ(Fw::QueuedComponentBase::MSG_DISPATCH_OK, this->m_impl.doDispatch());
 
     // verify dispatch event
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_InvalidCommand_SIZE(1);
-    ASSERT_EVENTS_InvalidCommand(0u, testOpCode + 1);
-#else
-    ASSERT_EVENTS_SIZE(0);
-#endif
+    ASSERT_EVENTS_InvalidCommand(0u, getExpectedEventOpcode(testOpCode + 1));
 
     // Verify status passed back to port
 

--- a/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.cpp
+++ b/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.cpp
@@ -74,12 +74,16 @@ void CommandDispatcherTester::registerBuiltinCommands() {
     ASSERT_EQ(port, 1);
 
     // verify event
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
     ASSERT_EVENTS_SIZE(4);
     ASSERT_EVENTS_OpCodeRegistered_SIZE(4);
     ASSERT_EVENTS_OpCodeRegistered(0, CommandDispatcherImpl::OPCODE_CMD_NO_OP, 1, 0);
     ASSERT_EVENTS_OpCodeRegistered(1, CommandDispatcherImpl::OPCODE_CMD_NO_OP_STRING, 1, 1);
     ASSERT_EVENTS_OpCodeRegistered(2, CommandDispatcherImpl::OPCODE_CMD_TEST_CMD_1, 1, 2);
     ASSERT_EVENTS_OpCodeRegistered(3, CommandDispatcherImpl::OPCODE_CMD_CLEAR_TRACKING, 1, 3);
+#else
+    ASSERT_EVENTS_SIZE(0);
+#endif
 }
 
 void CommandDispatcherTester::runNominalDispatch() {
@@ -307,9 +311,13 @@ void CommandDispatcherTester::runInvalidOpcodeDispatch() {
     ASSERT_EQ(port, 0);
 
     // verify registration event
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_OpCodeRegistered_SIZE(1);
     ASSERT_EVENTS_OpCodeRegistered(0, testOpCode, 0, 4);
+#else
+    ASSERT_EVENTS_SIZE(0);
+#endif
 
     // dispatch a test command with a bad opcode
     U32 testCmdArg = 100;
@@ -326,9 +334,13 @@ void CommandDispatcherTester::runInvalidOpcodeDispatch() {
     ASSERT_EQ(Fw::QueuedComponentBase::MSG_DISPATCH_OK, this->m_impl.doDispatch());
 
     // verify dispatch event
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_InvalidCommand_SIZE(1);
     ASSERT_EVENTS_InvalidCommand(0u, testOpCode + 1);
+#else
+    ASSERT_EVENTS_SIZE(0);
+#endif
 
     // Verify status passed back to port
 

--- a/Svc/CmdSequencer/CmdSequencerImpl.cpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.cpp
@@ -13,6 +13,7 @@
 #include <Fw/Types/Serializable.hpp>
 #include <Svc/CmdSequencer/CmdSequencerImpl.hpp>
 #include <Utils/Hash/Hash.hpp>
+#include <config/CommandDispatcherImplCfg.hpp>
 
 namespace Svc {
 
@@ -232,10 +233,8 @@ void CmdSequencerComponentImpl::CS_JOIN_WAIT_cmdHandler(const FwOpcodeType opCod
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
     } else {
         m_join_waiting = true;
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         Fw::LogStringArg& logFileName = this->m_sequence->getLogFileName();
-        this->log_ACTIVITY_HI_CS_JoinWaiting(logFileName, m_cmdSeq, m_opCode);
-#endif
+        this->log_ACTIVITY_HI_CS_JoinWaiting(logFileName, m_cmdSeq, CmdDispatcherCfg::getEventOpcode(m_opCode));
         m_cmdSeq = cmdSeq;
         m_opCode = opCode;
     }
@@ -298,9 +297,7 @@ void CmdSequencerComponentImpl ::cmdResponseIn_handler(FwIndexType portNum,
                                                        const Fw::CmdResponse& response) {
     if (this->m_runMode == STOPPED) {
         // Sequencer is not running
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_WARNING_HI_CS_UnexpectedCompletion(opcode);
-#endif
+        this->log_WARNING_HI_CS_UnexpectedCompletion(CmdDispatcherCfg::getEventOpcode(opcode));
     } else {
         // clear command timeout
         this->m_cmdTimeoutTimer.clear();
@@ -423,9 +420,8 @@ bool CmdSequencerComponentImpl::requireRunMode(RunMode mode) {
 }
 
 void CmdSequencerComponentImpl ::commandError(const U32 number, const FwOpcodeType opCode, const U32 error) {
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-    this->log_WARNING_HI_CS_CommandError(this->m_sequence->getLogFileName(), number, opCode, error);
-#endif
+    this->log_WARNING_HI_CS_CommandError(this->m_sequence->getLogFileName(), number,
+                                         CmdDispatcherCfg::getEventOpcode(opCode), error);
     this->error();
 }
 
@@ -476,9 +472,8 @@ void CmdSequencerComponentImpl::sequenceComplete() {
 }
 
 void CmdSequencerComponentImpl::commandComplete(const FwOpcodeType opcode) {
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-    this->log_ACTIVITY_LO_CS_CommandComplete(this->m_sequence->getLogFileName(), this->m_executedCount, opcode);
-#endif
+    this->log_ACTIVITY_LO_CS_CommandComplete(this->m_sequence->getLogFileName(), this->m_executedCount,
+                                             CmdDispatcherCfg::getEventOpcode(opcode));
     ++this->m_executedCount;
     ++this->m_totalExecutedCount;
     this->tlmWrite_CS_CommandsExecuted(this->m_totalExecutedCount);

--- a/Svc/CmdSequencer/CmdSequencerImpl.cpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.cpp
@@ -232,8 +232,10 @@ void CmdSequencerComponentImpl::CS_JOIN_WAIT_cmdHandler(const FwOpcodeType opCod
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
     } else {
         m_join_waiting = true;
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         Fw::LogStringArg& logFileName = this->m_sequence->getLogFileName();
         this->log_ACTIVITY_HI_CS_JoinWaiting(logFileName, m_cmdSeq, m_opCode);
+#endif
         m_cmdSeq = cmdSeq;
         m_opCode = opCode;
     }
@@ -296,7 +298,9 @@ void CmdSequencerComponentImpl ::cmdResponseIn_handler(FwIndexType portNum,
                                                        const Fw::CmdResponse& response) {
     if (this->m_runMode == STOPPED) {
         // Sequencer is not running
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_WARNING_HI_CS_UnexpectedCompletion(opcode);
+#endif
     } else {
         // clear command timeout
         this->m_cmdTimeoutTimer.clear();
@@ -419,7 +423,9 @@ bool CmdSequencerComponentImpl::requireRunMode(RunMode mode) {
 }
 
 void CmdSequencerComponentImpl ::commandError(const U32 number, const FwOpcodeType opCode, const U32 error) {
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
     this->log_WARNING_HI_CS_CommandError(this->m_sequence->getLogFileName(), number, opCode, error);
+#endif
     this->error();
 }
 
@@ -470,7 +476,9 @@ void CmdSequencerComponentImpl::sequenceComplete() {
 }
 
 void CmdSequencerComponentImpl::commandComplete(const FwOpcodeType opcode) {
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
     this->log_ACTIVITY_LO_CS_CommandComplete(this->m_sequence->getLogFileName(), this->m_executedCount, opcode);
+#endif
     ++this->m_executedCount;
     ++this->m_totalExecutedCount;
     this->tlmWrite_CS_CommandsExecuted(this->m_totalExecutedCount);

--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -5,6 +5,7 @@
 // ======================================================================
 
 #include <Svc/FpySequencer/FpySequencer.hpp>
+#include <config/CommandDispatcherImplCfg.hpp>
 #include <new>
 
 namespace Svc {
@@ -294,10 +295,8 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
         // must be a coding error from an outside component (off nom), or due to CANCEL while running a command (nom).
         // because we can't be sure that it wasn't a nominal sequence of events leading to this, don't fail the
         // sequence, just report it
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_WARNING_LO_CmdResponseWhileNotRunningSequence(static_cast<I32>(this->sequencer_getState()), opCode,
-                                                                response);
-#endif
+        this->log_WARNING_LO_CmdResponseWhileNotRunningSequence(static_cast<I32>(this->sequencer_getState()),
+                                                                CmdDispatcherCfg::getEventOpcode(opCode), response);
         return;
     }
 
@@ -318,9 +317,8 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
 
     // if it was from a different sequence:
     if (sequenceIndex != currentSequenceIndex) {
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_WARNING_LO_CmdResponseFromOldSequence(opCode, response, sequenceIndex, currentSequenceIndex);
-#endif
+        this->log_WARNING_LO_CmdResponseFromOldSequence(CmdDispatcherCfg::getEventOpcode(opCode), response,
+                                                        sequenceIndex, currentSequenceIndex);
         return;
     }
 
@@ -329,9 +327,7 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
     // first, make sure we're actually awaiting a statement response
     if (this->sequencer_getState() != State::RUNNING_AWAITING_STATEMENT_RESPONSE) {
         // okay, crap. something from this sequence responded, and we weren't awaiting anything. end it all
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_WARNING_HI_CmdResponseWhileNotAwaiting(opCode, response);
-#endif
+        this->log_WARNING_HI_CmdResponseWhileNotAwaiting(CmdDispatcherCfg::getEventOpcode(opCode), response);
         this->sequencer_sendSignal_stmtResponse_unexpected();
         return;
     }
@@ -339,10 +335,8 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
     if (this->m_runtime.currentStatementOpcode != Fpy::DirectiveId::CONST_CMD &&
         this->m_runtime.currentStatementOpcode != Fpy::DirectiveId::STACK_CMD) {
         // we were not awaiting a cmd response, we were waiting for a directive
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_WARNING_HI_CmdResponseWhileAwaitingDirective(opCode, response,
+        this->log_WARNING_HI_CmdResponseWhileAwaitingDirective(CmdDispatcherCfg::getEventOpcode(opCode), response,
                                                                this->m_runtime.currentStatementOpcode);
-#endif
         this->sequencer_sendSignal_stmtResponse_unexpected();
         return;
     }
@@ -351,9 +345,8 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
     if (opCode != this->m_runtime.currentCmdOpcode) {
         // we were not awaiting this opcode. coding error, likely on the part of the responding component or cmd
         // dispatcher
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_WARNING_HI_WrongCmdResponseOpcode(opCode, response, this->m_runtime.currentCmdOpcode);
-#endif
+        this->log_WARNING_HI_WrongCmdResponseOpcode(CmdDispatcherCfg::getEventOpcode(opCode), response,
+                                                    CmdDispatcherCfg::getEventOpcode(this->m_runtime.currentCmdOpcode));
         this->sequencer_sendSignal_stmtResponse_unexpected();
         return;
     }
@@ -370,9 +363,8 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
 
     if (cmdIndex != currentCmdIndex) {
         // we were not awaiting this exact statement, it was a different one with the same opcode. coding error
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_WARNING_HI_WrongCmdResponseIndex(opCode, response, cmdIndex, currentCmdIndex);
-#endif
+        this->log_WARNING_HI_WrongCmdResponseIndex(CmdDispatcherCfg::getEventOpcode(opCode), response, cmdIndex,
+                                                   currentCmdIndex);
         this->sequencer_sendSignal_stmtResponse_unexpected();
         return;
     }

--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -294,8 +294,10 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
         // must be a coding error from an outside component (off nom), or due to CANCEL while running a command (nom).
         // because we can't be sure that it wasn't a nominal sequence of events leading to this, don't fail the
         // sequence, just report it
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_WARNING_LO_CmdResponseWhileNotRunningSequence(static_cast<I32>(this->sequencer_getState()), opCode,
                                                                 response);
+#endif
         return;
     }
 
@@ -316,7 +318,9 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
 
     // if it was from a different sequence:
     if (sequenceIndex != currentSequenceIndex) {
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_WARNING_LO_CmdResponseFromOldSequence(opCode, response, sequenceIndex, currentSequenceIndex);
+#endif
         return;
     }
 
@@ -325,7 +329,9 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
     // first, make sure we're actually awaiting a statement response
     if (this->sequencer_getState() != State::RUNNING_AWAITING_STATEMENT_RESPONSE) {
         // okay, crap. something from this sequence responded, and we weren't awaiting anything. end it all
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_WARNING_HI_CmdResponseWhileNotAwaiting(opCode, response);
+#endif
         this->sequencer_sendSignal_stmtResponse_unexpected();
         return;
     }
@@ -333,8 +339,10 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
     if (this->m_runtime.currentStatementOpcode != Fpy::DirectiveId::CONST_CMD &&
         this->m_runtime.currentStatementOpcode != Fpy::DirectiveId::STACK_CMD) {
         // we were not awaiting a cmd response, we were waiting for a directive
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_WARNING_HI_CmdResponseWhileAwaitingDirective(opCode, response,
                                                                this->m_runtime.currentStatementOpcode);
+#endif
         this->sequencer_sendSignal_stmtResponse_unexpected();
         return;
     }
@@ -343,7 +351,9 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
     if (opCode != this->m_runtime.currentCmdOpcode) {
         // we were not awaiting this opcode. coding error, likely on the part of the responding component or cmd
         // dispatcher
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_WARNING_HI_WrongCmdResponseOpcode(opCode, response, this->m_runtime.currentCmdOpcode);
+#endif
         this->sequencer_sendSignal_stmtResponse_unexpected();
         return;
     }
@@ -360,7 +370,9 @@ void FpySequencer::cmdResponseIn_handler(FwIndexType portNum,             //!< T
 
     if (cmdIndex != currentCmdIndex) {
         // we were not awaiting this exact statement, it was a different one with the same opcode. coding error
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_WARNING_HI_WrongCmdResponseIndex(opCode, response, cmdIndex, currentCmdIndex);
+#endif
         this->sequencer_sendSignal_stmtResponse_unexpected();
         return;
     }

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -2,6 +2,7 @@
 #include "Fw/Com/ComPacket.hpp"
 #include "Fw/Time/Time.hpp"
 #include "Svc/FpySequencer/FpySequencer.hpp"
+#include <config/CommandDispatcherImplCfg.hpp>
 namespace Svc {
 
 // returns the index of the current statement
@@ -750,10 +751,8 @@ Signal FpySequencer::checkStatementTimeout() {
     if (this->m_runtime.currentStatementOpcode == Fpy::DirectiveId::CONST_CMD ||
         this->m_runtime.currentStatementOpcode == Fpy::DirectiveId::STACK_CMD) {
         // if we were executing a command, warn that the cmd timed out with its opcode
-#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
-        this->log_WARNING_HI_CommandTimedOut(this->m_runtime.currentCmdOpcode, this->currentStatementIdx(),
-                                             this->m_sequenceFilePath);
-#endif
+        this->log_WARNING_HI_CommandTimedOut(CmdDispatcherCfg::getEventOpcode(this->m_runtime.currentCmdOpcode),
+                                             this->currentStatementIdx(), this->m_sequenceFilePath);
     } else {
         this->log_WARNING_HI_DirectiveTimedOut(this->m_runtime.currentStatementOpcode, this->currentStatementIdx(),
                                                this->m_sequenceFilePath);

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -1,8 +1,9 @@
+#include <config/CommandDispatcherImplCfg.hpp>
 #include <new>
 #include "Fw/Com/ComPacket.hpp"
 #include "Fw/Time/Time.hpp"
 #include "Svc/FpySequencer/FpySequencer.hpp"
-#include <config/CommandDispatcherImplCfg.hpp>
+
 namespace Svc {
 
 // returns the index of the current statement

--- a/Svc/FpySequencer/FpySequencerRunState.cpp
+++ b/Svc/FpySequencer/FpySequencerRunState.cpp
@@ -750,8 +750,10 @@ Signal FpySequencer::checkStatementTimeout() {
     if (this->m_runtime.currentStatementOpcode == Fpy::DirectiveId::CONST_CMD ||
         this->m_runtime.currentStatementOpcode == Fpy::DirectiveId::STACK_CMD) {
         // if we were executing a command, warn that the cmd timed out with its opcode
+#if FW_ENABLE_COMMAND_OPCODE_EVENTS == 1
         this->log_WARNING_HI_CommandTimedOut(this->m_runtime.currentCmdOpcode, this->currentStatementIdx(),
                                              this->m_sequenceFilePath);
+#endif
     } else {
         this->log_WARNING_HI_DirectiveTimedOut(this->m_runtime.currentStatementOpcode, this->currentStatementIdx(),
                                                this->m_sequenceFilePath);

--- a/default/config/CommandDispatcherImplCfg.hpp
+++ b/default/config/CommandDispatcherImplCfg.hpp
@@ -8,11 +8,27 @@
 #ifndef CMDDISPATCHER_COMMANDDISPATCHERIMPLCFG_HPP_
 #define CMDDISPATCHER_COMMANDDISPATCHERIMPLCFG_HPP_
 
+#include <Fw/FPrimeBasicTypes.hpp>
+
 // Define configuration values for dispatcher
 
 enum {
     CMD_DISPATCHER_DISPATCH_TABLE_SIZE = 150,  // !< The size of the table holding opcodes to dispatch
     CMD_DISPATCHER_SEQUENCER_TABLE_SIZE = 25,  // !< The size of the table holding commands in progress
 };
+
+namespace Svc {
+namespace CmdDispatcherCfg {
+
+//! Include command opcodes in events when true.
+//! When false, opcode fields are set to the maximum FwOpcodeType value.
+constexpr bool IncludeCommandOpcodesInEvents = true;
+
+constexpr FwOpcodeType getEventOpcode(const FwOpcodeType opcode) {
+    return IncludeCommandOpcodesInEvents ? opcode : std::numeric_limits<FwOpcodeType>::max();
+}
+
+}  // namespace CmdDispatcherCfg
+}  // namespace Svc
 
 #endif /* CMDDISPATCHER_COMMANDDISPATCHERIMPLCFG_HPP_ */

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -126,6 +126,11 @@ extern "C" {
 #define FW_CMD_CHECK_RESIDUAL (1)  //!< Check for leftover command bytes
 #endif
 
+// Enables events that contain command opcodes. Disable when command opcodes must not be downlinked.
+#ifndef FW_ENABLE_COMMAND_OPCODE_EVENTS
+#define FW_ENABLE_COMMAND_OPCODE_EVENTS (1)  //!< Indicates whether events containing command opcodes are emitted
+#endif
+
 // Enables text logging of events as well as data logging. Adds a second logging port for text output.
 // In order to set this to 0, FPRIME_ENABLE_TEXT_LOGGERS must be set to OFF.
 #ifndef FW_ENABLE_TEXT_LOGGING

--- a/default/config/FpConfig.h
+++ b/default/config/FpConfig.h
@@ -126,11 +126,6 @@ extern "C" {
 #define FW_CMD_CHECK_RESIDUAL (1)  //!< Check for leftover command bytes
 #endif
 
-// Enables events that contain command opcodes. Disable when command opcodes must not be downlinked.
-#ifndef FW_ENABLE_COMMAND_OPCODE_EVENTS
-#define FW_ENABLE_COMMAND_OPCODE_EVENTS (1)  //!< Indicates whether events containing command opcodes are emitted
-#endif
-
 // Enables text logging of events as well as data logging. Adds a second logging port for text output.
 // In order to set this to 0, FPRIME_ENABLE_TEXT_LOGGERS must be set to OFF.
 #ifndef FW_ENABLE_TEXT_LOGGING

--- a/docs/user-manual/framework/configuring-fprime.md
+++ b/docs/user-manual/framework/configuring-fprime.md
@@ -348,6 +348,7 @@ Table 47 describes other user settings.
 | Macro                       | Definition                                              | Default | Valid Values     |
 | --------------------------- | --------------------------------------------------------|---------|------------------|
 | FW_CMD_CHECK_RESIDUAL       | Enables command serialization extra bytes check         | 1 (on)  | 0 (off) 1 (on)   |
+| FW_ENABLE_COMMAND_OPCODE_EVENTS | Enables events containing command opcodes           | 1 (on)  | 0 (off) 1 (on)   |
 | FW_AMPCS_COMPATIBLE         | Adds argument sizes to event argument serialization     | 0 (off) | 0 (off) 1 (on)   |
 
 > [!NOTE]

--- a/docs/user-manual/framework/configuring-fprime.md
+++ b/docs/user-manual/framework/configuring-fprime.md
@@ -348,7 +348,6 @@ Table 47 describes other user settings.
 | Macro                       | Definition                                              | Default | Valid Values     |
 | --------------------------- | --------------------------------------------------------|---------|------------------|
 | FW_CMD_CHECK_RESIDUAL       | Enables command serialization extra bytes check         | 1 (on)  | 0 (off) 1 (on)   |
-| FW_ENABLE_COMMAND_OPCODE_EVENTS | Enables events containing command opcodes           | 1 (on)  | 0 (off) 1 (on)   |
 | FW_AMPCS_COMPATIBLE         | Adds argument sizes to event argument serialization     | 0 (off) | 0 (off) 1 (on)   |
 
 > [!NOTE]
@@ -373,6 +372,10 @@ Some components allow users to turn on and off features. If a component does not
 for the user to set.
 
 Users are encouraged to look through the header for the component of interest as they should be self-descriptive.
+
+`CommandDispatcherImplCfg.hpp` provides `Svc::CmdDispatcherCfg::IncludeCommandOpcodesInEvents`. When this setting is
+`false`, events containing command opcodes remain enabled, but their opcode fields are set to the maximum
+`FwOpcodeType` value before downlink.
 
 ## Conclusion
 


### PR DESCRIPTION
| | |
  |:---|:---|
  |**_Related Issue(s)_**| #5594 |
  |**_Has Unit Tests (y/n)_**| y |
  |**_Documentation Included (y/n)_**| y |
  |**_Generative AI was used in this contribution (y/n)_**| y |

  ---
  ## Change Description

  Adds `FW_ENABLE_COMMAND_OPCODE_EVENTS`, enabled by default, to control whether command opcodes are included in events emitted by `CmdDispatcher`, `CmdSequencer`, and `FpySequencer`. Disabling the option suppresses those events without changing command responses.

  ## Rationale

  Projects can disable opcode-bearing event telemetry while preserving the existing default behavior.

  ## Testing/Review Recommendations

  - Built all unit-test targets successfully.
  - Verified the affected component tests with the option enabled.
  - Verified invalid-opcode dispatch with `FW_ENABLE_COMMAND_OPCODE_EVENTS=0`: no event is emitted and the
  `INVALID_OPCODE` response is preserved.
  - Completed the native unit suite; filesystem-heavy tests were run separately on tmpfs because of Docker overlay I/O stalls.

  ## Future Work

  None.

  ## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

  Codex assisted with testing. I did the implementation and reviewed the final changes and results.

Closes #5594