### PR TITLE
Fixed error in CFDP UT when running as root

### DIFF
--- a/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerEventTests.cpp
+++ b/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerEventTests.cpp
@@ -5,6 +5,11 @@
 //
 // ======================================================================
 
+// If this is compiled for unix, include unistd to check user id
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
+#include <unistd.h>
+#endif
+
 #include "CfdpManagerTester.hpp"
 #include "Fw/Com/ComPacket.hpp"
 #include "Fw/Types/SerialBuffer.hpp"
@@ -2721,6 +2726,14 @@ void CfdpManagerTester::testFailPollFileMoveEvent() {
     // before the last '/') against each channel PollDir::srcDir slot. We register a
     // slot by writing directly to the channel's CfdpPollDir via getPollDir() (friend
     // access), setting srcDir to the exact directory portion of our source file.
+
+// Skip test if running as root, since root bypasses Unix permission checks and can
+// create the default fail_dir ("/fail") at the filesystem root, making moveFile() succeed.
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
+    if (getuid() == 0) {
+        GTEST_SKIP() << "Test skipped when running as root (permission checks are bypassed)";
+    }
+#endif
 
     U8 channelId = 0;
     const char* srcDirPath = "test/ut/output";


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| No  |
|**_Has Unit Tests (y/n)_**| it is a unit test |
|**_Documentation Included (y/n)_**| No |
|**_Generative AI was used in this contribution (y/n)_**|  No |

---
## Change Description

Updated the CFDP unit test  to skip testFailPollFileMoveEvent when running as root (same type of change as https://github.com/nasa/fprime/pull/5354) 

## Rationale

Done because in UNIX root skips file read/write permission checks and can create files in `/`, so the check in `testFailPollFileMoveEvent`  is invalid. 

## Testing/Review Recommendations

Verify CfdpManager UT still compiles for all targeted OSs & passes when executed as root (I verified in my dev container)

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

No