### PR TITLE
CfdpManager: Fix Poll Directory Commands

### DIFF
--- a/Svc/Ccsds/CfdpManager/CfdpManager.cpp
+++ b/Svc/Ccsds/CfdpManager/CfdpManager.cpp
@@ -396,6 +396,9 @@ void CfdpManager ::PollDirectory_cmdHandler(FwOpcodeType opCode,
     if (rspStatus == Fw::CmdResponse::OK) {
         rspStatus = this->checkCommandChannelPollIndex(pollId);
     }
+    if (rspStatus == Fw::CmdResponse::OK) {
+        rspStatus = this->checkCommandPollInterval(interval);
+    }
 
     if (rspStatus == Fw::CmdResponse::OK) {
         if (Status::SUCCESS == this->m_engine->startPollDir(channelId, pollId, sourceDirectory, destDirectory,
@@ -562,6 +565,17 @@ Fw::CmdResponse::T CfdpManager ::checkCommandChannelIndex(U8 channelIndex) {
 Fw::CmdResponse::T CfdpManager ::checkCommandChannelPollIndex(U8 pollIndex) {
     if (pollIndex >= MaxPollingDirPerChan) {
         this->log_WARNING_LO_InvalidChannelPoll(pollIndex, MaxPollingDirPerChan);
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    } else {
+        return Fw::CmdResponse::OK;
+    }
+}
+
+Fw::CmdResponse::T CfdpManager ::checkCommandPollInterval(U32 interval) {
+    // A zero interval would arm the poll timer with no time remaining, which is
+    // not a valid polling configuration, so reject it here.
+    if (interval == 0) {
+        this->log_WARNING_LO_InvalidPollInterval(interval);
         return Fw::CmdResponse::VALIDATION_ERROR;
     } else {
         return Fw::CmdResponse::OK;

--- a/Svc/Ccsds/CfdpManager/CfdpManager.cpp
+++ b/Svc/Ccsds/CfdpManager/CfdpManager.cpp
@@ -403,7 +403,7 @@ void CfdpManager ::PollDirectory_cmdHandler(FwOpcodeType opCode,
     if (rspStatus == Fw::CmdResponse::OK) {
         if (Status::SUCCESS == this->m_engine->startPollDir(channelId, pollId, sourceDirectory, destDirectory,
                                                             cfdpClass.e, priority, destId, interval)) {
-            this->log_ACTIVITY_LO_PollDirInitiated(sourceDirectory);
+            this->log_ACTIVITY_LO_PollDirInitiated(sourceDirectory, pollId);
         } else {
             // Failure EVR was already emitted
             rspStatus = Fw::CmdResponse::EXECUTION_ERROR;

--- a/Svc/Ccsds/CfdpManager/CfdpManager.hpp
+++ b/Svc/Ccsds/CfdpManager/CfdpManager.hpp
@@ -425,6 +425,10 @@ class CfdpManager final : public CfdpManagerComponentBase {
     Fw::CmdResponse::T checkCommandChannelPollIndex(U8 pollIndex  //!< The poll index to check
     );
 
+    //! Checks if the requested poll interval is valid (non-zero), and emits an EVR if not
+    Fw::CmdResponse::T checkCommandPollInterval(U32 interval  //!< The poll interval to check
+    );
+
   public:
     // ----------------------------------------------------------------------
     // Parameter helpers used by the CFDP engine

--- a/Svc/Ccsds/CfdpManager/Channel.cpp
+++ b/Svc/Ccsds/CfdpManager/Channel.cpp
@@ -80,6 +80,7 @@ Channel::Channel(Engine* engine,
 
     // Initialize poll directory playback state
     for (U32 i = 0; i < MaxPollingDirPerChan; i++) {
+        m_polldir[i].enabled = Fw::Enabled::DISABLED;
         m_polldir[i].pb.busy = false;
         m_polldir[i].pb.diropen = false;
         m_polldir[i].pb.counted = false;

--- a/Svc/Ccsds/CfdpManager/Channel.cpp
+++ b/Svc/Ccsds/CfdpManager/Channel.cpp
@@ -352,7 +352,6 @@ void Channel::processPollingDirectories() {
     CfdpPollDir* pd;
     U32 i;
     U8 poll_count = 0;
-    Status::T status;
 
     for (i = 0; i < MaxPollingDirPerChan; ++i) {
         pd = &m_polldir[i];
@@ -361,17 +360,16 @@ void Channel::processPollingDirectories() {
             poll_count++;
 
             if ((pd->pb.busy == false) && (pd->pb.num_ts == 0)) {
-                if ((pd->intervalTimer.getStatus() != Timer::Status::RUNNING) && (pd->intervalSec > 0)) {
-                    // timer was not set, so set it now
-                    pd->intervalTimer.setTimer(pd->intervalSec);
-                } else if (pd->intervalTimer.getStatus() == Timer::Status::EXPIRED) {
-                    // the timer has expired
-                    status = m_engine->playbackDirInitiate(&pd->pb, pd->srcDir, pd->dstDir, pd->cfdpClass,
-                                                           Cfdp::Keep::DELETE, m_channelId, pd->priority, pd->destEid);
-                    if (status != Cfdp::Status::SUCCESS) {
-                        // error occurred in playback directory, so reset the timer
-                        // an event is sent when initiating playback directory so there is no reason to
-                        // to have another here
+                if (pd->intervalTimer.getStatus() == Timer::Status::EXPIRED) {
+                    // the timer has expired, so initiate a playback of the directory.
+                    // The return status is intentionally ignored: playbackDirInitiate
+                    // already emits an event on failure and the timer is re-armed
+                    // below regardless so polling retries after the interval.
+                    (void)m_engine->playbackDirInitiate(&pd->pb, pd->srcDir, pd->dstDir, pd->cfdpClass,
+                                                        Cfdp::Keep::DELETE, m_channelId, pd->priority, pd->destEid);
+                    // re-arm the timer for the next interval. The timer only ticks
+                    // down while the playback is not busy.
+                    if (pd->intervalSec > 0) {
                         pd->intervalTimer.setTimer(pd->intervalSec);
                     }
                 } else {

--- a/Svc/Ccsds/CfdpManager/Events.fppi
+++ b/Svc/Ccsds/CfdpManager/Events.fppi
@@ -73,7 +73,13 @@ event InvalidChannelPoll(
     maxPollId: U8 @< Maximum channel index
 ) \
     severity warning low \
-    format "Invalid poll ID {}, maximum poll ID is {}" 
+    format "Invalid poll ID {}, maximum poll ID is {}"
+
+event InvalidPollInterval(
+    interval: U32 @< Requested poll interval in seconds
+) \
+    severity warning low \
+    format "Invalid poll interval {} seconds, must be non-zero"
 
 event FailKeepFileMove(
     srcFile: string size MaxFilePathSize @< Source file being moved

--- a/Svc/Ccsds/CfdpManager/Events.fppi
+++ b/Svc/Ccsds/CfdpManager/Events.fppi
@@ -36,9 +36,10 @@ event PlaybackInitiated(
 
 event PollDirInitiated(
     sourceDirectory: string size MaxFilePathSize @< Source directory being sent
+    pollId: U8 @< Channel poll index
 ) \
     severity activity low \
-    format "Successfully initiated directory poll for {}"
+    format "Successfully initiated directory poll for {} (index {})"
 
 event PollDirStopped(
     channelId: U8 @< Channel index stopped

--- a/Svc/Ccsds/CfdpManager/docs/sdd.md
+++ b/Svc/Ccsds/CfdpManager/docs/sdd.md
@@ -213,6 +213,23 @@ The transmission throttling mechanism works in conjunction with buffer allocatio
 
 Unlike transmit operations that are driven by the periodic `run1Hz` scheduler port, receive operations in CfdpManager are driven by the `dataIn` async input port. Incoming CFDP PDUs arrive via this port and are processed immediately by the component's thread when the port handler is invoked, without per-cycle limits. Receive throttling was implemented in NASA's CF (CFDP) application because CF processes received PDUs during scheduled execution cycles. In contrast, CfdpManager processes incoming PDUs asynchronously as they arrive, so there is no architectural reason to throttle incoming PDUs.
 
+### Directory Playback and Polling
+
+CfdpManager supports two related mechanisms for transferring the contents of a directory:
+
+- **Directory playback** (`PlaybackDirectory` command): a one-shot operation that sends every file currently in the source directory as individual CFDP transactions and completes when the directory has been fully processed.
+- **Directory polling** (`PollDirectory` command): a recurring operation that re-checks the source directory on a fixed interval and automatically sends any new files found. Each channel supports up to `MaxPollingDirPerChan` independent polling slots, identified by a poll index. The file is deleted from the directory after a successful transfer.
+
+**Poll cycle behavior:**
+
+Each polling slot owns an interval timer that is evaluated once per `run1Hz` cycle:
+
+1. A poll slot is armed by the `PollDirectory` command with a non-zero interval (in seconds). A zero interval is rejected at command validation with an `InvalidPollInterval` event.
+2. The interval timer only counts down while the slot's playback is **not** busy. While a directory playback triggered by a previous poll is still in progress (transactions pending or active), the timer is held so polls do not stack up.
+3. When the timer expires, the slot initiates a playback of the source directory and re-arms the timer for the next interval. Re-arming happens regardless of whether the playback started successfully — `playbackDirInitiate` emits its own event on failure, and re-arming ensures the poll retries on the next interval rather than stalling.
+
+Polling continues until stopped with the `StopPollDirectory` command. Stopping is only honored for a slot that is currently enabled; stopping an inactive slot produces a `PollDirNotActive` event.
+
 ## Sequence Diagrams
 
 The following sequence diagrams illustrate the external protocol exchanges between spacecraft and ground systems during CFDP transactions. These diagrams focus on the PDU-level interactions and do not depict the internal state machine transitions or detailed transaction processing logic within the CfdpManager component.
@@ -457,11 +474,12 @@ The CFDP Manager provides comprehensive event reporting covering all aspects of 
 | UnsupportedSendFileArguments | warning low | Invalid send file port request with offset and length |
 | InvalidChannel | warning low | Invalid channel ID, maximum channel ID is specified |
 | PlaybackInitiated | activity low | Successfully initiated directory playback for source directory |
-| PollDirInitiated | activity low | Successfully initiated directory poll for source directory |
+| PollDirInitiated | activity low | Successfully initiated directory poll for source directory (identified by channel poll index) |
 | PollDirStopped | activity low | Successfully stopped directory poll for channel and poll index |
 | PollDirBusy | warning low | Cannot start directory poll - channel poll already in use |
 | PollDirNotActive | warning low | Cannot stop directory poll - channel poll is not active |
 | InvalidChannelPoll | warning low | Invalid poll ID, maximum poll ID is specified |
+| InvalidPollInterval | warning low | Invalid poll interval requested (must be non-zero) |
 | SetFlowState | activity low | Set channel to specified flow state |
 | ResetCounters | activity high | Reset telemetry counters for channel (0xFF indicates all channels) |
 
@@ -564,7 +582,7 @@ The CFDP Manager provides comprehensive event reporting covering all aspects of 
 |---|---|
 | SendFile | Initiates a CFDP file transaction to send a file to a remote entity. Specifies channel, destination entity ID, CFDP class (1 or 2), file retention policy, priority, source filename, and destination filename. |
 | PlaybackDirectory | Starts a directory playback operation to send all files from a source directory to a destination directory on a remote entity. Files are sent sequentially as individual CFDP transactions. Completes when all files in the directory have been processed. |
-| PollDirectory | Establishes a recurring directory poll that periodically checks a source directory for new files and automatically sends them to a destination directory on a remote entity. Poll interval is configurable in seconds. |
+| PollDirectory | Establishes a recurring directory poll that periodically checks a source directory for new files and automatically sends them to a destination directory on a remote entity. Poll interval is configurable in seconds and must be non-zero (a zero interval is rejected with a `VALIDATION_ERROR` response and an `InvalidPollInterval` event). |
 | StopPollDirectory | Stops an active directory poll operation identified by channel ID and poll ID. |
 | SetChannelFlow | Sets the flow control state for a specific CFDP channel. Can freeze (pause) or resume PDU transmission on the channel. |
 | SuspendResumeTransaction | Suspend or resume a transaction. When suspended, the transaction remains in memory but stops making progress (no PDUs sent or processed, no timers tick). Useful during critical spacecraft operations. Takes an action parameter (SUSPEND or RESUME). Transactions are identified by channel ID, transaction sequence number, and entity ID. |

--- a/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerCommandTests.cpp
+++ b/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerCommandTests.cpp
@@ -420,7 +420,7 @@ void CfdpManagerTester::testPollDirectoryNominal() {
     // Verify PollDirInitiated event was emitted
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_PollDirInitiated_SIZE(1);
-    ASSERT_EVENTS_PollDirInitiated(0, srcDir.toChar());
+    ASSERT_EVENTS_PollDirInitiated(0, srcDir.toChar(), pollId);
 
     // Clean up - stop the poll
     this->clearHistory();

--- a/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerCommandTests.cpp
+++ b/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerCommandTests.cpp
@@ -522,6 +522,122 @@ void CfdpManagerTester::testPollDirectoryBusy() {
     Os::FileSystem::removeDirectory(srcDir.toChar());
 }
 
+void CfdpManagerTester::testPollDirectoryInvalidInterval() {
+    // Test that PollDirectory command with a zero interval is rejected with
+    // VALIDATION_ERROR and emits the InvalidPollInterval event.
+    //
+    // A zero interval would arm the poll timer with no time remaining, which is
+    // not a valid polling configuration.
+    //
+    // Event coverage: InvalidPollInterval
+
+    U8 channelId = 0;
+    U8 pollId = 0;
+    EntityId destEid = 2;
+    U32 interval = 0;  // invalid - must be non-zero
+    U8 priority = 0;
+    Fw::String srcDir("test/ut/output/poll_src");
+    Fw::String dstDir("test/ut/output/poll_dst");
+
+    // Clear events
+    this->clearHistory();
+
+    // Send PollDirectory command with a zero interval
+    this->sendCmd_PollDirectory(0,  // Instance
+                                0,  // cmdSeq
+                                channelId, pollId, destEid, Cfdp::Class::CLASS_1, priority, interval, srcDir, dstDir);
+
+    this->component.doDispatch();
+
+    // Verify VALIDATION_ERROR response
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, CfdpManagerComponentBase::OPCODE_POLLDIRECTORY, 0, Fw::CmdResponse::VALIDATION_ERROR);
+
+    // Verify InvalidPollInterval event was emitted with the requested interval
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_InvalidPollInterval_SIZE(1);
+    ASSERT_EVENTS_InvalidPollInterval(0, interval);
+}
+
+void CfdpManagerTester::testPollDirectoryTimerExpiry() {
+    // Test that a polling directory actually fires once its interval timer
+    // expires.
+    //
+    // Observable behavior: the poll timer is armed for `interval` seconds when
+    // the poll is started, and each 1 Hz cycle decrements it by one second.
+    // On the cycle after it reaches zero (EXPIRED) the poll opens the source
+    // directory for playback, which sets the playback state busy. Before the
+    // fix that expired branch was unreachable, so the playback never became
+    // busy no matter how many cycles ran.
+
+    U8 channelId = 0;
+    U8 pollId = 0;
+    EntityId destEid = 2;
+    U32 interval = 3;  // seconds; small so the test only needs a few cycles
+    U8 priority = 0;
+    Fw::String srcDir("test/ut/output/poll_timer_src");
+    Fw::String dstDir("test/ut/output/poll_timer_dst");
+
+    // Create source directory with a single file to be picked up by the poll
+    Os::FileSystem::Status dirStatus = Os::FileSystem::createDirectory(srcDir.toChar());
+    ASSERT_TRUE(dirStatus == Os::FileSystem::OP_OK || dirStatus == Os::FileSystem::ALREADY_EXISTS);
+
+    Fw::String testFilePath(srcDir);
+    testFilePath += "/poll_file.bin";
+    Os::File file;
+    Os::File::Status fileStatus = file.open(testFilePath.toChar(), Os::File::OPEN_CREATE, Os::File::OVERWRITE);
+    ASSERT_EQ(Os::File::OP_OK, fileStatus);
+    U8 testData[64] = {0};
+    FwSizeType bytesToWrite = sizeof(testData);
+    fileStatus = file.write(testData, bytesToWrite);
+    ASSERT_EQ(Os::File::OP_OK, fileStatus);
+    file.close();
+
+    // Clear events
+    this->clearHistory();
+
+    // Start the polling directory
+    this->sendCmd_PollDirectory(0,  // Instance
+                                0,  // cmdSeq
+                                channelId, pollId, destEid, Cfdp::Class::CLASS_1, priority, interval, srcDir, dstDir);
+
+    this->component.doDispatch();
+
+    // Verify start succeeded
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, CfdpManagerComponentBase::OPCODE_POLLDIRECTORY, 0, Fw::CmdResponse::OK);
+
+    // Reach into the engine to observe the poll directory's playback state
+    // (CfdpManagerTester is a friend of Channel/Engine).
+    CfdpPollDir* pollDir = this->component.m_engine->m_channels[channelId]->getPollDir(pollId);
+
+    // The playback is idle while the timer is counting down.
+    ASSERT_FALSE(pollDir->pb.busy) << "Poll playback should be idle before the timer expires";
+
+    // Cycle the engine while the timer counts down. After `interval` cycles the
+    // timer has just reached EXPIRED but the poll has not fired yet.
+    for (U32 i = 0; i < interval; i++) {
+        this->invoke_to_run1Hz(0, 0);
+        this->component.doDispatch();
+    }
+    ASSERT_FALSE(pollDir->pb.busy) << "Poll playback should not fire before the interval elapses";
+
+    // One more cycle: the timer is now EXPIRED, so the poll initiates a
+    // directory playback and the playback state becomes busy.
+    this->invoke_to_run1Hz(0, 0);
+    this->component.doDispatch();
+    ASSERT_TRUE(pollDir->pb.busy) << "Poll should initiate a directory playback once the timer expires";
+
+    // Clean up - stop the poll
+    this->clearHistory();
+    this->sendCmd_StopPollDirectory(0, 0, channelId, pollId);
+    this->component.doDispatch();
+
+    // Clean up files/directory
+    Os::FileSystem::removeFile(testFilePath.toChar());
+    Os::FileSystem::removeDirectory(srcDir.toChar());
+}
+
 // ----------------------------------------------------------------------
 // SetChannelFlow Command Tests
 // ----------------------------------------------------------------------

--- a/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerTestMain.cpp
+++ b/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerTestMain.cpp
@@ -141,6 +141,16 @@ TEST(Command, PollDirectoryBusy) {
     tester.testPollDirectoryBusy();
 }
 
+TEST(Command, PollDirectoryInvalidInterval) {
+    Svc::Ccsds::Cfdp::CfdpManagerTester tester;
+    tester.testPollDirectoryInvalidInterval();
+}
+
+TEST(Command, PollDirectoryTimerExpiry) {
+    Svc::Ccsds::Cfdp::CfdpManagerTester tester;
+    tester.testPollDirectoryTimerExpiry();
+}
+
 TEST(Command, SetChannelFlowNominal) {
     Svc::Ccsds::Cfdp::CfdpManagerTester tester;
     tester.testSetChannelFlowNominal();

--- a/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerTester.hpp
+++ b/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerTester.hpp
@@ -406,6 +406,12 @@ class CfdpManagerTester final : public CfdpManagerGTestBase {
     //! Test PollDirectory command when poll slot is busy
     void testPollDirectoryBusy();
 
+    //! Test PollDirectory command rejects a zero polling interval
+    void testPollDirectoryInvalidInterval();
+
+    //! Test that a polling directory fires once its interval timer expires
+    void testPollDirectoryTimerExpiry();
+
     //! Test SetChannelFlow command with valid channel
     void testSetChannelFlowNominal();
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Updates to the Poll Directory command and Stop Poll command, including events, documentation and unit tests.

## Rationale

- An issue was found with the Poll Directory command where the interval timer logic would always be set without ever starting the transfer of the file in the directory
- If the Poll Directory command "interval" argument was 0, it created issues with the timer logic, so that argument is now validated to be greater than 0.
- There was also an issue with the Stop Poll command checking the wrong status.
- An event was also updated to also show the commanded poll index being used.

## Testing/Review Recommendations

Unit tests where updated and run. I also manually tested by sending the command and moving files into the poll directory.

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Mainly used for unit testing and verification.
