### PR TITLE
Backport fixes to telemetry, fd/memory leaks, bounds and status returns (#5563)

### DIFF
--- a/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
@@ -209,6 +209,7 @@ Os::File::Status LinuxGpioDriver ::open(const char* device,
     }
     // Check if the GPIO line exists
     if (gpio >= chip_info.lines) {
+        status = Os::File::Status::DOESNT_EXIST;
         this->log_WARNING_HI_OpenPinError(Fw::String(device), gpio, Fw::String("Does Not Exist"),
                                           Os::FileStatus(static_cast<Os::FileStatus::T>(status)));
         return status;

--- a/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
+++ b/Drv/LinuxSpiDriver/LinuxSpiDriverComponentImpl.cpp
@@ -86,8 +86,6 @@ namespace Drv {
             return false;
         }
 
-        this->m_fd = fd;
-
         // Configure:
         /*
          * SPI Mode 0, 1, 2, 3
@@ -116,12 +114,14 @@ namespace Drv {
         ret = ioctl(fd, SPI_IOC_WR_MODE, &mode);
         if (ret == -1) {
             this->log_WARNING_HI_SPI_ConfigError(device,select,ret);
+            (void)::close(fd);
             return false;
         }
 
         ret = ioctl(fd, SPI_IOC_RD_MODE, &mode);
         if (ret == -1) {
             this->log_WARNING_HI_SPI_ConfigError(device,select,ret);
+            (void)::close(fd);
             return false;
         }
 
@@ -132,12 +132,14 @@ namespace Drv {
         ret = ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &bits);
         if (ret == -1) {
             this->log_WARNING_HI_SPI_ConfigError(device,select,ret);
+            (void)::close(fd);
             return false;
         }
 
         ret = ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &bits);
         if (ret == -1) {
             this->log_WARNING_HI_SPI_ConfigError(device,select,ret);
+            (void)::close(fd);
             return false;
         }
 
@@ -147,14 +149,20 @@ namespace Drv {
         ret = ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &clock);
         if (ret == -1) {
             this->log_WARNING_HI_SPI_ConfigError(device,select,ret);
+            (void)::close(fd);
             return false;
         }
 
         ret = ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &clock);
         if (ret == -1) {
            this->log_WARNING_HI_SPI_ConfigError(device,select,ret);
+           (void)::close(fd);
            return false;
         }
+
+        // The device is only published once it is fully configured, so that a failed configuration
+        // leaves the driver closed rather than pointing at a misconfigured device
+        this->m_fd = fd;
 
         return true;
 

--- a/Fw/Trap/TrapHandler.hpp
+++ b/Fw/Trap/TrapHandler.hpp
@@ -7,8 +7,9 @@ namespace Fw {
      * TrapHandler:
      *   A framework class used to handle traps that occur during the execution of the
      * the F' framework. Must be registered with a trap register. The user should
-     * inherit from this class and ensure that the doTrap function is implemented. The
-     * default implementation will be do-nothing.
+     * inherit from this class and implement the doTrap function. There is no default
+     * implementation: doTrap is pure virtual, so a subclass that does not implement it
+     * cannot be instantiated.
      */
     class TrapHandler {
         public:
@@ -16,8 +17,6 @@ namespace Fw {
             virtual ~TrapHandler() {}; //!< destructor
             /**
              * Handles the incoming trap.
-             * Note: if user does not supply an implementer of this
-             *       function, a do-nothing version will be run.
              * \param trap: trap number
              */
             virtual void doTrap(U32 trap) = 0;

--- a/Fw/Types/StringUtils.cpp
+++ b/Fw/Types/StringUtils.cpp
@@ -39,8 +39,8 @@ FwSignedSizeType Fw::StringUtils::substring_find(const CHAR* source_string,
     FW_ASSERT(source_string != nullptr);
     FW_ASSERT(sub_string != nullptr);
 
-    // zero size sub-strings should always match
-    if ((source_size > 0) && (0 == sub_size)) {
+    // zero size sub-strings should always match, including in an empty source
+    if (0 == sub_size) {
         return 0;
     }
 

--- a/Fw/Types/StringUtils.hpp
+++ b/Fw/Types/StringUtils.hpp
@@ -45,7 +45,7 @@ FwSizeType string_length(const CHAR* source, FwSizeType buffer_size);
  * \param source_size: the size of the source string
  * \param substring: string to search for
  * \param sub_size: the size of the string to search for
- * \return index of substring, -1 if not found
+ * \return index of substring, -1 if not found. A zero-size substring always matches at index 0
  */
 FwSignedSizeType substring_find(const CHAR* source_string, FwSizeType source_size, const CHAR* sub_string, FwSizeType sub_size);
 

--- a/Fw/Types/test/ut/TypesTest.cpp
+++ b/Fw/Types/test/ut/TypesTest.cpp
@@ -1354,6 +1354,11 @@ TEST(OffNominal, sub_string_substring_zero_size) {
     ASSERT_EQ(Fw::StringUtils::substring_find(source_string,6,sub_string,0),0);
 }
 
+TEST(OffNominal, sub_string_source_and_substring_zero_size) {
+    const char* source_string = "";
+    const char* sub_string = "";
+    ASSERT_EQ(Fw::StringUtils::substring_find(source_string, 0, sub_string, 0), 0);
+}
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/Os/Darwin/Cpu.cpp
+++ b/Os/Darwin/Cpu.cpp
@@ -9,6 +9,7 @@
 #include <mach/mach_init.h>
 #include <mach/mach_types.h>
 #include <mach/message.h>
+#include <mach/vm_map.h>
 
 namespace Os {
 namespace Darwin {
@@ -20,17 +21,31 @@ namespace Cpu {
 //!
 //! \param cpu_load_info: filled with CPU data
 //! \param cpu_count: filled with CPU count
+//! \param processor_msg_count: filled with the size of the kernel allocation in integer_t units
 //!
 //! \return success/failure using kern_return_t
-kern_return_t cpu_data_helper(processor_cpu_load_info_t& cpu_load_info, FwSizeType& cpu_count) {
+//!
+//! \note on success the kernel allocates cpu_load_info; the caller must release it using
+//!       cpu_data_release once the data has been read
+kern_return_t cpu_data_helper(processor_cpu_load_info_t& cpu_load_info,
+                              FwSizeType& cpu_count,
+                              mach_msg_type_number_t& processor_msg_count) {
     static_assert(std::numeric_limits<FwSizeType>::max() >= std::numeric_limits<natural_t>::max(),
                   "FwSizeType cannot hold natural_t values");
     natural_t cpu_count_natural;
-    mach_msg_type_number_t processor_msg_count;
     kern_return_t stat = host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &cpu_count_natural,
                                              reinterpret_cast<processor_info_array_t*>(&cpu_load_info), &processor_msg_count);
     cpu_count = cpu_count_natural;
     return stat;
+}
+
+//! \brief release the CPU information allocated by the kernel inside cpu_data_helper
+//!
+//! \param cpu_load_info: data filled by a successful cpu_data_helper call
+//! \param processor_msg_count: count filled by that same call
+void cpu_data_release(processor_cpu_load_info_t cpu_load_info, mach_msg_type_number_t processor_msg_count) {
+    (void)vm_deallocate(mach_task_self(), reinterpret_cast<vm_address_t>(cpu_load_info),
+                        processor_msg_count * sizeof(integer_t));
 }
 
 //! \brief Query for a single CPU's ticks information
@@ -47,10 +62,14 @@ kern_return_t cpu_data_helper(processor_cpu_load_info_t& cpu_load_info, FwSizeTy
 kern_return_t cpu_by_index(FwSizeType cpu_index, FwSizeType& used, FwSizeType& total) {
     processor_cpu_load_info_t cpu_load_info;
     FwSizeType cpu_count = 0;
-    kern_return_t status = cpu_data_helper(cpu_load_info, cpu_count);
+    mach_msg_type_number_t processor_msg_count = 0;
+    kern_return_t status = cpu_data_helper(cpu_load_info, cpu_count, processor_msg_count);
 
     // Failure for CPU index
     if (cpu_count <= cpu_index) {
+        if (KERN_SUCCESS == status) {
+            cpu_data_release(cpu_load_info, processor_msg_count);
+        }
         status = KERN_FAILURE;
     } else if (KERN_SUCCESS == status) {
         processor_cpu_load_info per_cpu_info = cpu_load_info[cpu_index];
@@ -61,13 +80,16 @@ kern_return_t cpu_by_index(FwSizeType cpu_index, FwSizeType& used, FwSizeType& t
             total += per_cpu_info.cpu_ticks[i];
         }
         used = total - per_cpu_info.cpu_ticks[CPU_STATE_IDLE];
+        cpu_data_release(cpu_load_info, processor_msg_count);
     }
     return status;
 }
 
 CpuInterface::Status DarwinCpu::_getCount(FwSizeType& cpu_count) {
     processor_cpu_load_info_t cpu_load_info;
-    if (KERN_SUCCESS == cpu_data_helper(cpu_load_info, cpu_count)) {
+    mach_msg_type_number_t processor_msg_count = 0;
+    if (KERN_SUCCESS == cpu_data_helper(cpu_load_info, cpu_count, processor_msg_count)) {
+        cpu_data_release(cpu_load_info, processor_msg_count);
         return Status::OP_OK;
     }
     cpu_count = 0;

--- a/Os/Linux/Cpu.cpp
+++ b/Os/Linux/Cpu.cpp
@@ -49,10 +49,10 @@ CpuInterface::Status getCpuData(FwSizeType cpu_index, ProcCpuData data) {
         FwSignedSizeType read_size = sizeof proc_stat_line - 1;
         Os::File::Status file_status = file.readline(reinterpret_cast<U8*>(proc_stat_line), read_size,
                                                      Os::File::WaitType::NO_WAIT);
-        proc_stat_line[read_size + 1] = '\0'; // Null terminate
         if (file_status != Os::File::Status::OP_OK) {
             return CpuInterface::Status::ERROR;
         }
+        proc_stat_line[read_size] = '\0';  // Null terminate, read_size is at most LINE_SIZE
         // Make sure we've not strayed passed the cpu section
         if (::strncmp(proc_stat_line, "cpu", 3) != 0) {
             return CpuInterface::Status::ERROR;

--- a/Os/Linux/Memory.cpp
+++ b/Os/Linux/Memory.cpp
@@ -23,7 +23,7 @@ MemoryInterface::Status LinuxMemory::_getUsage(Os::Memory::Usage& memory_usage) 
     }
 
     memory_usage.total = info.totalram * info.mem_unit;
-    memory_usage.used = info.freeram * info.mem_unit;
+    memory_usage.used = (info.totalram - info.freeram) * info.mem_unit;
     return Status::OP_OK;
 }
 

--- a/Svc/DpCatalog/DpCatalog.cpp
+++ b/Svc/DpCatalog/DpCatalog.cpp
@@ -101,8 +101,11 @@ namespace Svc {
             (this->m_memSize >= sizeof(DpBtreeNode)) and
             (this->m_memPtr != nullptr)
             ) {
-            // set the number of available record slots based on how much memory we actually got
-            this->m_numDpSlots = this->m_memSize / slotSize; // Step 1.
+            // set the number of available record slots based on how much memory we actually got,
+            // never exceeding the DP_MAX_FILES working arrays even if the allocator returned more
+            // memory than was requested
+            const FwSizeType allocatedSlots = this->m_memSize / slotSize;
+            this->m_numDpSlots = (allocatedSlots < DP_MAX_FILES) ? allocatedSlots : DP_MAX_FILES; // Step 1.
             this->resetBinaryTree(); // Step 2
             // assign pointer for the stack - Step 3
             this->m_traverseStack = reinterpret_cast<DpBtreeNode**>(&this->m_freeListHead[this->m_numDpSlots]);

--- a/Svc/LinuxTimer/LinuxTimerComponentImplTimerFd.cpp
+++ b/Svc/LinuxTimer/LinuxTimerComponentImplTimerFd.cpp
@@ -26,6 +26,10 @@ namespace Svc {
 
       /* Create the timer */
       fd = timerfd_create (CLOCK_MONOTONIC, 0);
+      if (fd == -1) {
+          Fw::Logger::log("timer create error: %s\n", strerror(errno));
+          return;
+      }
 
       itval.it_interval.tv_sec = interval/1000;
       itval.it_interval.tv_nsec = (interval*1000000)%1000000000;
@@ -37,8 +41,11 @@ namespace Svc {
       while (true) {
           unsigned long long missed;
           int ret = static_cast<int>(read (fd, &missed, sizeof (missed)));
-          if (-1 == ret) {
+          if ((-1 == ret) && (errno != EINTR)) {
+              // A non-interrupt read error will not clear itself; stop rather than spin on it
               Fw::Logger::log("timer read error: %s\n", strerror(errno));
+              (void)::close(fd);
+              return;
           }
           this->m_mutex.lock();
           bool quit = this->m_quit;
@@ -50,6 +57,7 @@ namespace Svc {
               itval.it_value.tv_nsec = 0;
 
               timerfd_settime (fd, 0, &itval, nullptr);
+              (void)::close(fd);
               return;
           }
           this->m_rawTime.now();

--- a/cmake/autocoder/scripts/fpp_to_dict_wrapper.py
+++ b/cmake/autocoder/scripts/fpp_to_dict_wrapper.py
@@ -11,6 +11,7 @@ This is required to be able to read the version files and pass them to the fpp-t
 import subprocess
 import argparse
 import json
+import sys
 
 
 def main():
@@ -78,4 +79,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| PR #5563 |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| Y |
|**_Generative AI was used in this contribution (y/n)_**| Y |

---
## Change Description

I have been noticing that an fprime deployment running on macOS slowly builds up memory usage. This was tracked down to `Svc::SystemResources`'s call to `Os::Cpu::getTicks()`, triggered via `Svc::SystemResources::run_handler()` on a rate group.

Fortunately, this was just fixed upstream with the addition of `cpu_data_release()` in `Os/Darwin/Cpu.cpp`, but we would like the fix in v3.6. I went ahead and backported other* changes from #5563 since they seemed all good and relevant to v3.6.

[*] All changes were backported except for changes to `Fw/DataStructures` and `Svc/ActivePhaser` which don't exist in v3.6

## Rationale

`Svc::SystemResources` shouldn't leak memory.

## Testing/Review Recommendations

Testing now with my project's deployment... will report back if any issues.

## Future Work

N/A

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude helped me utilize lldb to find the leaky thread (a rate group). Once I told it Svc::SystemResources or something downstream was the culprit, it immediately identified the bug, as well as the recent patch. AI was not used for code generation or backporting.