### PR TITLE
Use generated record size macros in the DP examples

### DIFF
--- a/TestDeploymentsProject/Ref/DpDemo/DpDemo.cpp
+++ b/TestDeploymentsProject/Ref/DpDemo/DpDemo.cpp
@@ -114,15 +114,23 @@ void DpDemo ::Dp_cmdHandler(FwOpcodeType opCode,
         return;
     }
 
-    this->numRecords = 15;  // 15 records in current demo
-    FwSizeType dpSize = DpDemo_StringAlias::SERIALIZED_SIZE + sizeof(DpDemo_BoolAlias) + sizeof(DpDemo_I32Alias) +
-                        sizeof(DpDemo_F64Alias) + DpDemo_U32Array::SERIALIZED_SIZE + DpDemo_F32Array::SERIALIZED_SIZE +
-                        DpDemo_BooleanArray::SERIALIZED_SIZE + DpDemo_EnumArray::SERIALIZED_SIZE +
-                        DpDemo_StringArray::SERIALIZED_SIZE + DpDemo_StructWithEverything::SERIALIZED_SIZE +
-                        DpDemo_StructWithStringMembers::SERIALIZED_SIZE + (DpDemo_StringArray::SERIALIZED_SIZE * 3) +
-                        (DpDemo_StringArray::SERIALIZED_SIZE * 1) +
-                        (DpDemo_StructWithStringMembers::SERIALIZED_SIZE * 2) +
-                        DpDemo_ArrayOfStringArray::SERIALIZED_SIZE + (numRecords * sizeof(FwDpIdType));
+    this->numRecords = 14;  // 14 records in current demo
+
+    // Element counts for the variable length array records serialized below
+    const FwSizeType stringArrayElements = 3;
+    const FwSizeType arrayArrayElements = 1;
+    const FwSizeType structArrayElements = 2;
+
+    // The generated SIZE_OF_*_RECORD constants already account for the record
+    // id, and for array records the serialized length prefix, so the demo no
+    // longer has to reproduce the layout by hand
+    FwSizeType dpSize = SIZE_OF_StringRecord_RECORD + SIZE_OF_BooleanRecord_RECORD + SIZE_OF_I32Record_RECORD +
+                        SIZE_OF_F64Record_RECORD + SIZE_OF_U32ArrayRecord_RECORD + SIZE_OF_F32ArrayRecord_RECORD +
+                        SIZE_OF_BooleanArrayRecord_RECORD + SIZE_OF_EnumArrayRecord_RECORD +
+                        SIZE_OF_StructWithEverythingRecord_RECORD + SIZE_OF_ArrayOfStringArrayRecord_RECORD +
+                        SIZE_OF_ArrayOfStructsRecord_RECORD + SIZE_OF_StringArrayRecord_RECORD(stringArrayElements) +
+                        SIZE_OF_ArrayArrayRecord_RECORD(arrayArrayElements) +
+                        SIZE_OF_StructArrayRecord_RECORD(structArrayElements);
 
     this->dpPriority = static_cast<FwDpPriorityType>(priority);
     this->dpProc = proc;

--- a/TestDeploymentsProject/Ref/SignalGen/SignalGen.cpp
+++ b/TestDeploymentsProject/Ref/SignalGen/SignalGen.cpp
@@ -219,7 +219,7 @@ void SignalGen::Dp_cmdHandler(FwOpcodeType opCode,
 
     // get DP buffer. Use sync or async request depending on
     // requested type
-    FwSizeType dpSize = records * (SignalInfo::SERIALIZED_SIZE + sizeof(FwDpIdType));
+    FwSizeType dpSize = records * SIZE_OF_DataRecord_RECORD;
     this->m_numDps = records;
     this->m_currDp = 0;
     this->m_dpPriority = static_cast<FwDpPriorityType>(priority);


### PR DESCRIPTION
## Change Description

Closes #5614.

`SignalGen` and `DpDemo` computed their data product sizes by hand. Both now use the generated `SIZE_OF_*_RECORD` constants.

**SignalGen** is a direct swap: `records * (SignalInfo::SERIALIZED_SIZE + sizeof(FwDpIdType))` becomes `records * SIZE_OF_DataRecord_RECORD`. The value is identical, only the source of truth moves to the generated constant.

**DpDemo** replaces a sixteen term manual sum with eleven fixed macros and three array macros, passing the element count for the variable length records. While doing so the old sum turned out to be wrong in four places:

- `ArrayOfStructsRecord` is serialized but never appeared in the sum.
- `StringArrayRecord`, `ArrayArrayRecord` and `StructArrayRecord` each need an extra `sizeof(FwSizeStoreType)` for the serialized length prefix, which the sum omitted.
- `StringArrayRecord` was sized as `DpDemo_StringArray::SERIALIZED_SIZE * 3`, but the record is a string array, so the generated macro uses `arraySize * Fw::StringBase::STATIC_SERIALIZED_SIZE(80)`.
- `numRecords` was set to 15 while 14 records are serialized, so the per record id overhead was counted once too many.

Some of these offset each other, which is why the demo works today. The macros make the layout the autocoder generates the single source of truth, which is the point of the examples.

## Rationale

These two components are what people read when learning how to build data products, so they should demonstrate the supported way of sizing a container rather than reproducing the record layout by hand.

## Testing/Review Recommendations

Full `Ref` build is clean. Verified against a running `Ref` through the GDS:

- `Ref.dpDemo.Dp IMMEDIATE 10 PROC_TYPE_NONE` reports `DpMemRequested` 3418 bytes, `DpStarted` 14 records, `DpMemReceived` 3483 bytes, then `DpComplete` with 14 records. No allocation or serialization failure.
- `Ref.SG1.Dp IMMEDIATE 5 10` reports `DpMemRequested` 280 bytes, `DpStarted` 5 records, `DpMemReceived` 345 bytes.

No FPP changes. `DpDemo` has no unit tests and the `SignalGen` unit tests do not assert on data product size, so no test updates were needed. `clang-format` is clean.