### PR TITLE
Add parameter validation macro

### DIFF
--- a/Fw/Prm/CMakeLists.txt
+++ b/Fw/Prm/CMakeLists.txt
@@ -11,8 +11,16 @@ register_fprime_module(
     "${CMAKE_CURRENT_LIST_DIR}/Prm.fpp"
   HEADERS
     "${CMAKE_CURRENT_LIST_DIR}/ParamBuffer.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/ParamValid.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/PrmBuffer.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/PrmExternalTypes.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/PrmString.hpp"
 )
 
+### UTs ###
+register_fprime_ut(
+  SOURCES
+    "${CMAKE_CURRENT_LIST_DIR}/test/ut/ParamValidTest.cpp"
+  DEPENDS
+    Fw_Prm
+)

--- a/Fw/Prm/ParamValid.hpp
+++ b/Fw/Prm/ParamValid.hpp
@@ -1,0 +1,24 @@
+// ======================================================================
+// \title  ParamValid.hpp
+// \author F Prime
+// \brief  Helpers for checking parameter validity
+//
+// \copyright
+// Copyright (C) 2026 California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+//
+// ======================================================================
+
+#ifndef FW_PRM_PARAM_VALID_HPP
+#define FW_PRM_PARAM_VALID_HPP
+
+#include <Fw/Prm/ParamValidEnumAc.hpp>
+
+//! Check whether a parameter value is usable
+//!
+//! A parameter value is usable when it was successfully loaded from the
+//! parameter database or when its default value was applied.
+#define FW_PARAM_OK(paramValid) (((paramValid) == Fw::ParamValid::DEFAULT) || ((paramValid) == Fw::ParamValid::VALID))
+
+#endif  // FW_PRM_PARAM_VALID_HPP

--- a/Fw/Prm/test/ut/ParamValidTest.cpp
+++ b/Fw/Prm/test/ut/ParamValidTest.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+#include <Fw/Prm/ParamValid.hpp>
+
+TEST(FwPrmParamValid, ReportsUsableParameterStatuses) {
+    EXPECT_FALSE(FW_PARAM_OK(Fw::ParamValid::UNINIT));
+    EXPECT_TRUE(FW_PARAM_OK(Fw::ParamValid::VALID));
+    EXPECT_FALSE(FW_PARAM_OK(Fw::ParamValid::INVALID));
+    EXPECT_TRUE(FW_PARAM_OK(Fw::ParamValid::DEFAULT));
+}

--- a/Svc/Ccsds/CcsdsSdlsFramer/CcsdsSdlsFramer.cpp
+++ b/Svc/Ccsds/CcsdsSdlsFramer/CcsdsSdlsFramer.cpp
@@ -6,6 +6,8 @@
 
 #include "Svc/Ccsds/CcsdsSdlsFramer/CcsdsSdlsFramer.hpp"
 
+#include <Fw/Prm/ParamValid.hpp>
+
 namespace Svc {
 
 namespace Ccsds {
@@ -42,8 +44,7 @@ void CcsdsSdlsFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, con
     if (saIndex == unsetSaIndex) {
         Fw::ParamValid valid = Fw::ParamValid::INVALID;
         saIndex = this->paramGet_SA_INDEX(valid);
-        FW_ASSERT((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT),
-                  static_cast<FwAssertArgType>(valid.e));
+        FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
     }
 
     // Copy context and record the security association index used for encryption

--- a/Svc/Ccsds/CfdpManager/CfdpManager.cpp
+++ b/Svc/Ccsds/CfdpManager/CfdpManager.cpp
@@ -5,6 +5,7 @@
 // ======================================================================
 
 #include <Fw/Com/ComPacket.hpp>
+#include <Fw/Prm/ParamValid.hpp>
 #include <Os/QueueString.hpp>
 #include <Svc/Ccsds/CfdpManager/CfdpManager.hpp>
 #include <Svc/Ccsds/CfdpManager/Channel.hpp>
@@ -109,8 +110,7 @@ void CfdpManager ::drainFileInQueue() {
         // Look up the per-channel default parameters
         Fw::ParamValid valid;
         U8 channelId = this->paramGet_FileInDefaultChannel(valid);
-        FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-                  static_cast<FwAssertArgType>(valid.e));
+        FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
         // Reject an out-of-range channel parameter rather than letting it assert in Engine::txFile
         if (channelId >= Cfdp::NumChannels) {
@@ -120,20 +120,16 @@ void CfdpManager ::drainFileInQueue() {
         }
 
         EntityId destEid = this->paramGet_FileInDefaultDestEntityId(valid);
-        FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-                  static_cast<FwAssertArgType>(valid.e));
+        FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
         Class::T cfdpClass = this->paramGet_FileInDefaultClass(valid);
-        FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-                  static_cast<FwAssertArgType>(valid.e));
+        FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
         Keep::T keep = this->paramGet_FileInDefaultKeep(valid);
-        FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-                  static_cast<FwAssertArgType>(valid.e));
+        FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
         U8 priorityParam = this->paramGet_FileInDefaultPriority(valid);
-        FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-                  static_cast<FwAssertArgType>(valid.e));
+        FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
         // Initiate the transfer on the active thread
         Status::T txStatus =
@@ -591,8 +587,7 @@ EntityId CfdpManager::getLocalEidParam(void) {
 
     // Check for coding errors as all CFDP parameters must have a default
     EntityId localEid = this->paramGet_LocalEid(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     return localEid;
 }
@@ -602,8 +597,7 @@ U32 CfdpManager::getOutgoingFileChunkSizeParam(void) {
 
     // Check for coding errors as all CFDP parameters must have a default
     U32 chunkSize = this->paramGet_OutgoingFileChunkSize(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     return chunkSize;
 }
@@ -612,8 +606,7 @@ U32 CfdpManager::getRxCrcCalcBytesPerCycleParam(void) {
 
     // Check for coding errors as all CFDP parameters must have a default
     U32 rxSize = this->paramGet_RxCrcCalcBytesPerCycle(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     return rxSize;
 }
@@ -623,8 +616,7 @@ U8 CfdpManager::getPostInactivitySendRetriesParam(void) {
 
     // Check for coding errors as all CFDP parameters must have a default
     U8 retries = this->paramGet_PostInactivitySendRetries(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     return retries;
 }
@@ -637,8 +629,7 @@ Fw::String CfdpManager::getTmpDirParam(U8 channelIndex) {
     // Check for coding errors as all CFDP parameters must have a default
     // Get the array first
     ChannelArrayParams paramArray = paramGet_ChannelConfig(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     // Now get individual parameter
     return paramArray[channelIndex].get_tmp_dir();
@@ -652,8 +643,7 @@ Fw::String CfdpManager::getFailDirParam(U8 channelIndex) {
     // Check for coding errors as all CFDP parameters must have a default
     // Get the array first
     ChannelArrayParams paramArray = paramGet_ChannelConfig(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     // Now get individual parameter
     return paramArray[channelIndex].get_fail_dir();
@@ -667,8 +657,7 @@ U8 CfdpManager::getAckLimitParam(U8 channelIndex) {
     // Check for coding errors as all CFDP parameters must have a default
     // Get the array first
     ChannelArrayParams paramArray = paramGet_ChannelConfig(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     // Now get individual parameter
     return paramArray[channelIndex].get_ack_limit();
@@ -682,8 +671,7 @@ U8 CfdpManager::getNackLimitParam(U8 channelIndex) {
     // Check for coding errors as all CFDP parameters must have a default
     // Get the array first
     ChannelArrayParams paramArray = paramGet_ChannelConfig(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     // Now get individual parameter
     return paramArray[channelIndex].get_nack_limit();
@@ -697,8 +685,7 @@ U32 CfdpManager::getAckTimerParam(U8 channelIndex) {
     // Check for coding errors as all CFDP parameters must have a default
     // Get the array first
     ChannelArrayParams paramArray = paramGet_ChannelConfig(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     // Now get individual parameter
     return paramArray[channelIndex].get_ack_timer();
@@ -712,8 +699,7 @@ U32 CfdpManager::getInactivityTimerParam(U8 channelIndex) {
     // Check for coding errors as all CFDP parameters must have a default
     // Get the array first
     ChannelArrayParams paramArray = paramGet_ChannelConfig(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     // Now get individual parameter
     return paramArray[channelIndex].get_inactivity_timer();
@@ -727,8 +713,7 @@ Fw::Enabled CfdpManager::getDequeueEnabledParam(U8 channelIndex) {
     // Check for coding errors as all CFDP parameters must have a default
     // Get the array first
     ChannelArrayParams paramArray = paramGet_ChannelConfig(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     // Now get individual parameter
     return paramArray[channelIndex].get_dequeue_enabled();
@@ -742,8 +727,7 @@ Fw::String CfdpManager::getMoveDirParam(U8 channelIndex) {
     // Check for coding errors as all CFDP parameters must have a default
     // Get the array first
     ChannelArrayParams paramArray = paramGet_ChannelConfig(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     // Now get individual parameter
     return paramArray[channelIndex].get_move_dir();
@@ -757,8 +741,7 @@ U32 CfdpManager ::getMaxOutgoingPdusPerCycleParam(U8 channelIndex) {
     // Check for coding errors as all CFDP parameters must have a default
     // Get the array first
     ChannelArrayParams paramArray = paramGet_ChannelConfig(valid);
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 
     // Now get individual parameter
     return paramArray[channelIndex].get_max_outgoing_pdus_per_cycle();

--- a/Svc/DpCompressProc/DpCompressProc.cpp
+++ b/Svc/DpCompressProc/DpCompressProc.cpp
@@ -9,6 +9,7 @@
 #include "Svc/DpCompressProc/DpCompressProc.hpp"
 
 #include <Fw/Dp/DpContainer.hpp>
+#include <Fw/Prm/ParamValid.hpp>
 
 namespace Svc {
 
@@ -43,7 +44,7 @@ void DpCompressProc::serializeCompressionHeader(Fw::LinearBufferBase& serializer
 void DpCompressProc ::procRequest_handler(FwIndexType portNum, Fw::Buffer& fwBuffer) {
     Fw::ParamValid param_valid;
     Fw::Enabled en_compression = paramGet_ENABLE(param_valid);
-    FW_ASSERT((param_valid == Fw::ParamValid::DEFAULT) || (param_valid == Fw::ParamValid::VALID), param_valid);
+    FW_ASSERT(FW_PARAM_OK(param_valid), param_valid);
     if (en_compression == Fw::Enabled::DISABLED) {
         // Bypass compression
         return;
@@ -81,7 +82,7 @@ void DpCompressProc ::procRequest_handler(FwIndexType portNum, Fw::Buffer& fwBuf
     }
 
     FwSizeType prm_chunk_size = paramGet_CHUNK_SIZE(param_valid);
-    FW_ASSERT((param_valid == Fw::ParamValid::DEFAULT) || (param_valid == Fw::ParamValid::VALID), param_valid);
+    FW_ASSERT(FW_PARAM_OK(param_valid), param_valid);
 
     if (prm_chunk_size > container.getDataSize()) {
         prm_chunk_size = container.getDataSize();

--- a/Svc/DpZLibCompressor/DpZLibCompressor.cpp
+++ b/Svc/DpZLibCompressor/DpZLibCompressor.cpp
@@ -8,6 +8,8 @@
 
 #include <cstring>
 
+#include <Fw/Prm/ParamValid.hpp>
+
 namespace Svc {
 
 // ----------------------------------------------------------------------
@@ -48,7 +50,7 @@ Svc::CompressionAlgorithm DpZLibCompressor ::compressChunk_handler(FwIndexType p
 
     Fw::ParamValid param_valid;
     const FwSizeType zlib_alloc_size = paramGet_ZLibBufferSize(param_valid);
-    FW_ASSERT(param_valid == Fw::ParamValid::DEFAULT || param_valid == Fw::ParamValid::VALID, param_valid);
+    FW_ASSERT(FW_PARAM_OK(param_valid), param_valid);
 
     ctx.zlib_alloc_buffer = bufferZLibGet_out(0, zlib_alloc_size);
     if (ctx.zlib_alloc_buffer.getSize() == 0) {
@@ -87,7 +89,7 @@ Svc::CompressionAlgorithm DpZLibCompressor ::compressChunk_handler(FwIndexType p
 CompressionAlgorithm DpZLibCompressor::zlibCompressionHelper(ZLibCtx& ctx, const Fw::Buffer& in_buffer) {
     Fw::ParamValid param_valid;
     const I8 compression_level = paramGet_CompressionLevel(param_valid);
-    FW_ASSERT(param_valid == Fw::ParamValid::DEFAULT || param_valid == Fw::ParamValid::VALID, param_valid);
+    FW_ASSERT(FW_PARAM_OK(param_valid), param_valid);
 
     int zlib_ok = 0;
     zlib_ok = deflateInit(&ctx.zlib_stream, compression_level);

--- a/Svc/FpySequencer/FpySequencer.cpp
+++ b/Svc/FpySequencer/FpySequencer.cpp
@@ -4,6 +4,7 @@
 // \brief  cpp file for FpySequencer component implementation class
 // ======================================================================
 
+#include <Fw/Prm/ParamValid.hpp>
 #include <Svc/FpySequencer/FpySequencer.hpp>
 #include <config/CommandDispatcherImplCfg.hpp>
 #include <new>
@@ -514,8 +515,7 @@ void FpySequencer::parameterUpdated(FwPrmIdType id) {
         }
     }
 
-    FW_ASSERT(valid != Fw::ParamValid::INVALID && valid != Fw::ParamValid::UNINIT,
-              static_cast<FwAssertArgType>(valid.e));
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
 }
 
 bool FpySequencer::isRunningState(State state) {

--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
@@ -10,6 +10,7 @@
 
 #include <Fw/Com/ComPacket.hpp>
 #include <Fw/FPrimeBasicTypes.hpp>
+#include <Fw/Prm/ParamValid.hpp>
 #include <Svc/TlmPacketizer/TlmPacketizer.hpp>
 #include <TlmPacketizerConfig/FppConstantsAc.hpp>
 #include <cstring>
@@ -585,7 +586,7 @@ Fw::SerializeStatus TlmPacketizer::deserializeParam(const FwPrmIdType base_id,
                                                     const FwPrmIdType local_id,
                                                     const Fw::ParamValid prmStat,
                                                     Fw::SerialBufferBase& buff) {
-    if ((prmStat == Fw::ParamValid::VALID) || (prmStat == Fw::ParamValid::DEFAULT)) {
+    if (FW_PARAM_OK(prmStat)) {
         switch (local_id) {
             case PARAMID_SECTION_ENABLED:
                 return buff.deserializeTo(this->m_sectionEnabled);


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Closes #5573 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y (API documentation) |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Add `FW_PARAM_OK`, a shared macro that reports whether an `Fw::ParamValid` value is `VALID` or `DEFAULT`. Replace the existing equivalent checks throughout the framework and service components, and add unit coverage for all four parameter-validity states.

## Rationale

Parameter consumers repeatedly spell out the same validity condition. Centralizing it removes boilerplate and gives parameter checks one consistent expression.

## Testing/Review Recommendations

- `fprime-util format --check` on all changed C++ files
- `fprime-util check --all` (129/129 tests passed)
- Review that `FW_PARAM_OK` accepts only `VALID` and `DEFAULT`

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

OpenAI Codex was used to inspect the issue and repository, implement the macro and unit test, refactor existing checks, run formatting and the full test suite, and prepare this pull request. The submitted code and prose were generated by the AI agent and validated against the repository's pinned toolchain.

IAMAI
