### PR TITLE
Require explicit SandboxedFile configuration

### DIFF
--- a/Os/SandboxedFile.cpp
+++ b/Os/SandboxedFile.cpp
@@ -9,7 +9,7 @@
 
 namespace Os {
 
-SandboxedFile::SandboxedFile() : m_file(), m_allowedDirectory("/"), m_configured(true) {}
+SandboxedFile::SandboxedFile() : m_file(), m_allowedDirectory("/"), m_configured(false) {}
 
 SandboxedFile::~SandboxedFile() {
     if (m_file.isOpen()) {

--- a/Os/SandboxedFile.hpp
+++ b/Os/SandboxedFile.hpp
@@ -18,8 +18,8 @@ namespace Os {
 //! path-traversal attacks (e.g., `../../etc/shadow`) from components that accept externally
 //! supplied file paths (such as FileUplink or CFDP receivers).
 //!
-//! By default, the sandbox is set to `/` (root), which allows any absolute path.
-//! Call `configure()` to restrict to a specific directory.
+//! SandboxedFile is unconfigured by default and rejects all calls to `open()` until
+//! `configure()` supplies an allowed directory.
 //!
 //! Threat model assumption: untrusted actors cannot create symlinks inside the sandbox.
 //! Path validation is purely textual (no `realpath()` calls) — it does not follow symlinks.
@@ -43,9 +43,9 @@ class SandboxedFile {
     SandboxedFile(const SandboxedFile&) = delete;             //!< Non-copyable (owns file handle)
     SandboxedFile& operator=(const SandboxedFile&) = delete;  //!< Non-copy-assignable
 
-    //! \brief Construct a SandboxedFile with default sandbox of `/`
+    //! \brief Construct an unconfigured SandboxedFile
     //!
-    //! The default allows any absolute path. Call `configure()` to restrict.
+    //! Calls to `open()` return `OUTSIDE_SANDBOX` until `configure()` succeeds.
     //!
     SandboxedFile();
 
@@ -78,7 +78,8 @@ class SandboxedFile {
     //! \brief Open a file, validating the path against the sandbox directory
     //!
     //! Resolves the path against CWD and checks containment before opening.
-    //! Returns `OUTSIDE_SANDBOX` if the resolved path falls outside the sandbox.
+    //! Returns `OUTSIDE_SANDBOX` if the file is unconfigured or if the resolved path
+    //! falls outside the sandbox.
     //!
     //! \param path: c-string path to open
     //! \param mode: file operation mode

--- a/Os/test/ut/SandboxedFileTest.cpp
+++ b/Os/test/ut/SandboxedFileTest.cpp
@@ -23,7 +23,7 @@ class SandboxedFileTest : public ::testing::Test {
 
 TEST_F(SandboxedFileTest, ConfigureValid) {
     Os::SandboxedFile file;
-    ASSERT_TRUE(file.isConfigured());  // default is "/"
+    ASSERT_FALSE(file.isConfigured());
     file.configure("/tmp/sandbox_test/");
     ASSERT_TRUE(file.isConfigured());
     ASSERT_STREQ("/tmp/sandbox_test/", file.getSandboxDirectory());
@@ -54,13 +54,11 @@ TEST_F(SandboxedFileTest, TraversalAttackRejected) {
     ASSERT_FALSE(file.isOpen());
 }
 
-TEST_F(SandboxedFileTest, DefaultConfigAllowsAnyAbsolutePath) {
+TEST_F(SandboxedFileTest, DefaultUnconfiguredRejectsOpen) {
     Os::SandboxedFile file;
-    // Default sandbox is "/" — any absolute path is allowed
     auto status = file.open("/tmp/sandbox_test/test_file.bin", Os::File::OPEN_CREATE);
-    ASSERT_EQ(Os::File::OP_OK, status);
-    ASSERT_TRUE(file.isOpen());
-    file.close();
+    ASSERT_EQ(Os::File::OUTSIDE_SANDBOX, status);
+    ASSERT_FALSE(file.isOpen());
 }
 
 TEST_F(SandboxedFileTest, WriteAndRead) {

--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -7,7 +7,12 @@ module FileHandling {
         queue size FileHandlingConfig.QueueSizes.fileUplink \
         stack size FileHandlingConfig.StackSizes.fileUplink \
         priority FileHandlingConfig.Priorities.fileUplink \
-        cpu FileHandlingConfig.CpuAffinities.fileUplink
+        cpu FileHandlingConfig.CpuAffinities.fileUplink \
+    {
+        phase Fpp.ToCpp.Phases.configComponents """
+        FileHandling::fileUplink.configure("/");
+        """
+    }
 
     instance fileDownlink: Svc.FileDownlink base id FileHandlingConfig.BASE_ID + 0x01000 \
         queue size FileHandlingConfig.QueueSizes.fileDownlink \
@@ -21,6 +26,7 @@ module FileHandling {
             FileHandlingConfig::DownlinkConfig::cycleTime,
             FileHandlingConfig::DownlinkConfig::fileQueueDepth
         );
+        FileHandling::fileDownlink.configure("/");
         """
     }
 

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -28,6 +28,7 @@ The **FileHandling subtopology** packages the core file-transfer services common
 ### 2.2 Configuration Hooks inside the Subtopology
 
 * Uses **instance properties** (IDs, queue sizes, stack sizes, priorities, CPU affinities) defined in `FileHandlingConfig` for these static instances (see §4).
+* Configures `fileUplink` and `fileDownlink` with `/` to preserve the subtopology's existing unrestricted file-access behavior. Deployments should replace this with a narrower directory when possible.
 
 ### 2.3 Required Inputs for Operation
 
@@ -79,6 +80,10 @@ topology Flight {
 * **CPU affinities** — Core pinning for active component tasks; defaults to `TASK_DEFAULT` (no pinning).
 
 > These knobs tailor runtime footprint and scheduling without modifying the subtopology wiring.
+
+### 4.2 Sandboxed file migration
+
+`Os::SandboxedFile` is unconfigured by default and rejects `open()` until `configure()` succeeds. Deployments that instantiate `Svc::FileUplink` or `Svc::FileDownlink` directly must call `configure(<allowed directory>)` during topology setup. To retain the previous unrestricted behavior explicitly, call `configure("/")`.
 
 ---
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Fixes #5657 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Make `Os::SandboxedFile` deny file opens until an allowed directory is explicitly configured. Update the unit test for the new default and configure the FileHandling reference subtopology with `/` to preserve its existing behavior explicitly.

Document the migration requirement for deployments that instantiate `FileUplink` or `FileDownlink` directly.

## Rationale

An implicit `/` sandbox makes a missed configuration call silently permit every absolute path. Requiring `configure()` makes the safer state the default while still allowing deployments to opt into the previous behavior explicitly.

## Testing/Review Recommendations

Generated the native unit-test build and ran:

```text
Svc_FileDownlink_ut_exe
Svc_FileUplink_ut_exe
Os_SandboxedFile_Test
```

All three tests passed. The `Svc_Subtopologies_FileHandling` target also generated successfully.

Review the compatibility choice in `FileHandling.fpp`: it calls `configure("/")` explicitly so the reusable reference subtopology retains its existing behavior.

## Future Work

Deployments should replace `/` with the narrowest directory appropriate for their file-transfer paths.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

OpenAI Codex was used as an AI coding assistant during implementation and local verification. I reviewed the complete change, validated it against the issue requirements, and take responsibility for the submitted code and documentation. The repository formatter, build system, and relevant unit tests were used to verify the result.

IAMAI
