### PR TITLE
Pass the YAMCS deployment path absolutely so the events processor resolves it

### DIFF
--- a/.github/workflows/ext-yamcs-reference.yml
+++ b/.github/workflows/ext-yamcs-reference.yml
@@ -96,8 +96,7 @@ jobs:
           gds-working-directory: "."
           test-working-directory: "."
           binary: ./build-artifacts/Linux/FprimeYamcsReference_YamcsDeployment/bin/FprimeYamcsReference_YamcsDeployment
-          # Absolute: YAMCS passes this on to the events processor, which runs from its
-          # own working directory and cannot resolve a relative path.
+          # Absolute path needed because YAMCS passes this down to a subprocess
           gds-args: -d ${{ github.workspace }}/build-artifacts/Linux/FprimeYamcsReference_YamcsDeployment
           ready-check: python -c "from yamcs.client import YamcsClient; list(YamcsClient('127.0.0.1:8090').list_instances())"
           ready-timeout: "300"

--- a/.github/workflows/ext-yamcs-reference.yml
+++ b/.github/workflows/ext-yamcs-reference.yml
@@ -96,7 +96,9 @@ jobs:
           gds-working-directory: "."
           test-working-directory: "."
           binary: ./build-artifacts/Linux/FprimeYamcsReference_YamcsDeployment/bin/FprimeYamcsReference_YamcsDeployment
-          gds-args: -d ./build-artifacts/Linux/FprimeYamcsReference_YamcsDeployment
+          # Absolute: YAMCS passes this on to the events processor, which runs from its
+          # own working directory and cannot resolve a relative path.
+          gds-args: -d ${{ github.workspace }}/build-artifacts/Linux/FprimeYamcsReference_YamcsDeployment
           ready-check: python -c "from yamcs.client import YamcsClient; list(YamcsClient('127.0.0.1:8090').list_instances())"
           ready-timeout: "300"
           pytest-args: >-


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| follows #5665 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

#5665 changed the deployment path handed to `fprime-yamcs` from absolute to relative:

```
-d ${PWD}/build-artifacts/Linux/${DEPLOYMENT}                      before
-d ./build-artifacts/Linux/FprimeYamcsReference_YamcsDeployment    now
```

`fprime-yamcs` forwards that value to YAMCS as `FPRIME_DICTIONARY` unmodified — the YAMCS directories beside it are absolutised, the dictionary is not (`fprime_yamcs/__main__.py:395` vs `:400-414`). YAMCS then starts `fprime-yamcs-events` from its own working directory, where the relative path does not resolve.

This restores the absolute path.

## Rationale

From `gds-logs/fprime-yamcs.stdout.log` of [run 31664041913](https://github.com/nasa/fprime/actions/runs/31664041913), every five seconds for the life of the job:

```
[ERROR] Failed to start processor: Dictionary not found:
build-artifacts/Linux/FprimeYamcsReference_YamcsDeployment/dict/YamcsDeploymentTopologyDictionary.json
```

61 of them in [31661045200](https://github.com/nasa/fprime/actions/runs/31661045200) as well — the string in the error is the relative path from `gds-args`, verbatim.

Commands still reach the FSW (`fsw.stdout.log` shows `OpCodeDispatched` for the first test's `RemoveFile`), so the failure does not look like a connection problem. What never arrives is events and telemetry, because the processor that produces them never starts. The first test then waits, and the job ends at pytest's 300 s timeout with exit 124.

Both runs that have reached the `Test` job since #5665 merged failed this way; the third failed earlier, in `Build`, for an unrelated reason.

## Testing/Review Recommendations

I cannot run this workflow locally — the check on this PR is the test. What to look for in its log: `[INFO] Using FPRIME_DICTIONARY:` should now print an absolute path, and `Failed to start processor` should not appear.

`binary:` and `pytest-args` are left relative on purpose: the action does `cd "${GITHUB_WORKSPACE}/${GDS_WORKING_DIR}"` first, so those resolve in the job's own shell. Only the value that gets handed off to YAMCS needs to survive a change of working directory.

## Future Work

The durable fix belongs in `fprime-yamcs`, which should absolutise `FPRIME_DICTIONARY` the way it already does `yamcs.directory` and `yamcs.configurationDirectory`. Happy to open that upstream if you would like it.

Separately, the `ready-check` added in #5665 clears as soon as the HTTP API answers, but `fprime-gds` needs an instance in state `RUNNING` before it can connect (`yamcs_transport.py`, `_discover_instance_and_processor`). Against a stub that starts listening while its instance is still `INITIALIZING`, `list_instances()` returns an empty list and the check passes 8 s early. Not what is failing here, so I have left it alone.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

I used Claude Code, on this CI workflow only. It read the failing job logs and the archived `gds-logs` artifacts, traced the dictionary path through `fprime-yamcs`, and drafted this description.

Level of modification: I had it work back from the logs rather than from the diff. Its first attempt was a different change to this workflow's readiness probe, which #5665 had already superseded while it was being written; the error above only turned up after pulling the artifacts from the runs that failed since.
