### PR TITLE
ComCfg: add FW_PACKET_PARAM APID for parameter values

### DIFF
--- a/default/config/ComCfg.fpp
+++ b/default/config/ComCfg.fpp
@@ -37,6 +37,7 @@ module ComCfg {
         FW_PACKET_PACKETIZED_TLM = 0x0004  @< Packetized telemetry packet type
         FW_PACKET_DP             = 0x0005  @< Data Product packet type
         FW_PACKET_IDLE           = 0x0006  @< F Prime idle
+        FW_PACKET_PARAM          = 0x0007  @< Parameter value type - outgoing
         FW_PACKET_HAND           = 0x00FE  @< F Prime handshake
         FW_PACKET_UNKNOWN        = 0x00FF  @< F Prime unknown packet
         SPP_IDLE_PACKET          = 0x07FF  @< Per Space Packet Standard, all 1s (11bits) is reserved for Idle Packets


### PR DESCRIPTION
Adds `FW_PACKET_PARAM = 0x0007` to the `ComCfg.Apid` enum. Closes #5516.

The value continues the reserved F Prime block, which runs from `FW_PACKET_COMMAND` (0x0000) to `FW_PACKET_IDLE` (0x0006) before jumping to `FW_PACKET_HAND` (0x00FE). The enum is the single definition point for these descriptors: `Fw::ComPacketType` in `Fw/Com/ComPacket.hpp` is an alias for `ComCfg::Apid::T`, so there is no parallel C++ list to update. No document mirrors the enum values, so the `@<` annotation is the descriptor's documentation.

Scope is the descriptor only, per the issue discussion. Flight side support in PrmDb and ground side support in the GDS are separate issues. Happy to open a follow-up issue for defining the packet structure if that would be useful.

## Testing

Full build clean, 817 of 817 targets. Verified the generated `ApidEnumAc.hpp` contains `FW_PACKET_PARAM = 7` in the correct position between `FW_PACKET_IDLE = 6` and `FW_PACKET_HAND = 254`.