### PR TITLE
Backport TcpServer shutdown-hang fix

### DIFF
--- a/Drv/Ip/IpSocket.cpp
+++ b/Drv/Ip/IpSocket.cpp
@@ -104,7 +104,9 @@ SocketIpStatus IpSocket::addressToIp4(const char* address, void* ip4) {
 }
 
 void IpSocket::close(const SocketDescriptor& socketDescriptor) {
-    (void)::close(socketDescriptor.fd);
+    if (socketDescriptor.fd >= 0) {
+        (void)::close(socketDescriptor.fd);
+    }
 }
 
 void IpSocket::shutdown(const SocketDescriptor& socketDescriptor) {

--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -136,7 +136,7 @@ class IpSocket {
     /**
      * \brief closes the socket
      *
-     * Closes the socket opened by the open call. In this case of the TcpServer, this does NOT close server's listening
+     * Closes the socket opened by the open call. In the case of the TcpServer, this does NOT close server's listening
      * port but will close the active client connection.
      * 
      * \param socketDescriptor: socket descriptor to close
@@ -146,7 +146,7 @@ class IpSocket {
     /**
      * \brief shutdown the socket
      *
-     * Shuts down the socket opened by the open call. In this case of the TcpServer, this does not shut down server's
+     * Shuts down the socket opened by the open call. In the case of the TcpServer, this does not shut down server's
      * listening port, but rather shuts down the active client.
      *
      * A shut down begins the termination of communication. The underlying socket will coordinate a clean shutdown, and

--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -146,7 +146,7 @@ class IpSocket {
     /**
      * \brief shutdown the socket
      *
-     * Shuts down the socket opened by the open call. In this case of the TcpServer, this does shut down server's
+     * Shuts down the socket opened by the open call. In this case of the TcpServer, this does not shut down server's
      * listening port, but rather shuts down the active client.
      *
      * A shut down begins the termination of communication. The underlying socket will coordinate a clean shutdown, and

--- a/Drv/Ip/SocketComponentHelper.cpp
+++ b/Drv/Ip/SocketComponentHelper.cpp
@@ -183,8 +183,11 @@ void SocketComponentHelper::readLoop() {
             if (status == SOCK_AUTO_CONNECT_DISABLED) {
                 break;
             }
-            // If the reconnection failed in any other way, warn, wait, and retry
+            // If the reconnection failed in any other way, warn, wait, and retry, or break if no longer running
             else if (status != SOCK_SUCCESS) {
+                if (not this->running()) {
+                    break;
+                }
                 Fw::Logger::log("[WARNING] Failed to open port with status %d and errno %d\n", status, errno);
                 (void)Os::Task::delay(SOCKET_RETRY_INTERVAL);
                 continue;

--- a/Drv/Ip/SocketComponentHelper.hpp
+++ b/Drv/Ip/SocketComponentHelper.hpp
@@ -139,12 +139,15 @@ class SocketComponentHelper {
     bool running();
 
     /**
-     * \brief stop the socket read task and close the associated socket.
+     * \brief stop the socket read task and shut down the associated socket
      *
      * Called to stop the socket read task. It is an error to call this before the thread has been started using the
-     * startSocketTask call. This will stop the read task and close the client socket.
+     * start call. This will stop the read task and shut down the client socket.
+     *
+     * \note Virtual so implementations owning a listening socket may release it here too. Closing the client
+     * socket alone will not wake a read task blocked in `accept`.
      */
-    void stop();
+    virtual void stop();
 
     /**
      * \brief joins to the stopping read task to wait for it to close

--- a/Drv/Ip/SocketComponentHelper.hpp
+++ b/Drv/Ip/SocketComponentHelper.hpp
@@ -141,8 +141,8 @@ class SocketComponentHelper {
     /**
      * \brief stop the socket read task and shut down the associated socket
      *
-     * Called to stop the socket read task. It is an error to call this before the thread has been started using the
-     * start call. This will stop the read task and shut down the client socket.
+     * Called to stop the socket read task and shut down the client socket. Stopping before start is permitted
+     * but only shuts down the client socket.
      *
      * \note Virtual so implementations owning a listening socket may release it here too. Closing the client
      * socket alone will not wake a read task blocked in `accept`.
@@ -153,9 +153,9 @@ class SocketComponentHelper {
      * \brief joins to the stopping read task to wait for it to close
      *
      * Called to join with the read socket task. This will block and return after the task has been stopped with a call
-     * to the stopSocketTask method.
-     * \param value_ptr: a pointer to fill with data. Passed to the Os::Task::join call. NULL to ignore.
-     * \return: Os::Task::Status passed back from the Os::Task::join call.
+     * to the `stop` method.
+     *
+     * \return Os::Task::Status passed back from the Os::Task::join call.
      */
     Os::Task::Status join();
 

--- a/Drv/Ip/TcpServerSocket.cpp
+++ b/Drv/Ip/TcpServerSocket.cpp
@@ -90,7 +90,10 @@ SocketIpStatus TcpServerSocket::startup(SocketDescriptor& socketDescriptor) {
 }
 
 void TcpServerSocket::terminate(const SocketDescriptor& socketDescriptor) {
-    (void)::close(socketDescriptor.serverFd);
+    if (socketDescriptor.serverFd >= 0) {
+        (void)::shutdown(socketDescriptor.serverFd, SHUT_RDWR);  // Shutdown first to avoid hanging "accept" calls
+        (void)::close(socketDescriptor.serverFd);
+    }
 }
 
 SocketIpStatus TcpServerSocket::openProtocol(SocketDescriptor& socketDescriptor) {

--- a/Drv/Ip/TcpServerSocket.hpp
+++ b/Drv/Ip/TcpServerSocket.hpp
@@ -43,12 +43,11 @@ class TcpServerSocket : public IpSocket {
     SocketIpStatus startup(SocketDescriptor& socketDescriptor);
 
     /**
-     * \brief close the server socket created by the `startup` call
+     * \brief shut down and close the server socket created by the `startup` call
      *
-     * Calls the close function on the server socket. No shutdown is performed on the server socket, as that is left to
-     * the individual client sockets.
+     * Calls shutdown, then close, on the server socket.
      *
-     * \param socketDescriptor:  descriptor to close
+     * \param socketDescriptor: descriptor of socket to terminate
      */
     void terminate(const SocketDescriptor& socketDescriptor);
 

--- a/Drv/Ip/docs/sdd.md
+++ b/Drv/Ip/docs/sdd.md
@@ -166,10 +166,11 @@ In order to start the receiving thread a call to the `Drv::SocketComponentHelper
 in a name, and all arguments to `Os::Task::start` to start the task. An optional parameter, reconnect, will determine if
 this read task will reconnect to sockets should a disconnect or error occur. Once started the read task will continue
 until a `Drv::SocketComponentHelper::stop` has been called or an error occurred when started without reconnect set to
-`true`.  Once the socket stop call has been made, the user should call `Drv::SocketComponentHelper::join` in order to
-wait until the full task has finished.  `Drv::SocketComponentHelper::stop` will call `Drv::SocketComponentHelper::close` on the
-provided Drv::IpSocket to ensure that any blocking reads exit freeing the thread to completely stop. Normal usage of
-a Drv::SocketComponentHelper derived class is shown below.
+`true`. Once the socket stop call has been made, the user should call `Drv::SocketComponentHelper::join` in order to
+wait until the full task has finished. `Drv::SocketComponentHelper::stop` will call `Drv::SocketComponentHelper::shutdown`
+on the provided Drv::IpSocket to ensure that any blocking reads exit, freeing the thread to completely stop. Classes owning
+a listening socket may override `stop` to release it too; `Drv::TcpServerComponentImpl` does, as a read task blocked in
+`open` will not exit otherwise. Normal usage of a Drv::SocketComponentHelper derived class is shown below.
 
 ```c++
 Os::TaskString name("ReceiveTask");

--- a/Drv/Ip/docs/sdd.md
+++ b/Drv/Ip/docs/sdd.md
@@ -103,9 +103,9 @@ socket that will listen for incoming connections.  `Drv::TcpServerSocket::startu
 will only close the client connection and does not affect the server from listening for clients, however; it does free
 up the server to accept a new client.
 
-`Drv::TcpServerSocket::shutdown` will close the TCP server from receiving any new clients and effectively releases all
-resources allocated to the server. `Drv::TcpServerSocket::shutdown` implies `Drv::TcpServerSocket::close` and client
-connections will be stopped.
+`Drv::TcpServerSocket::terminate` will shut down and close the TCP server socket, releasing the resources allocated by
+`Drv::TcpServerSocket::startup` and preventing new clients. The shutdown is done first so that a thread waiting in
+`Drv::TcpServerSocket::open` can exit. It does not close an accepted client connection; use `Drv::TcpServerSocket::close`.
 
 ## Example TcpServer Usage
 
@@ -120,10 +120,11 @@ while (chatting) {
     server.send(); // Timeout of 100us
     server.recv(); // Will block
 }
-server.close();
+server.close(); // Close the client connection
 server.open(); // Blocks until a client is available
 ...
-server.shutdown();
+server.close(); // Close the client connection
+server.terminate(); // Shut down and close the server's listening socket
 ```
 
 ## Drv::UdpSocket Class

--- a/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
+++ b/Drv/LinuxGpioDriver/LinuxGpioDriver.cpp
@@ -123,7 +123,9 @@ U32 configuration_to_event_flags(Drv::LinuxGpioDriver::GpioConfiguration configu
 }
 
 LinuxGpioDriver ::~LinuxGpioDriver() {
-    (void) ::close(this->m_fd);
+    if (this->m_fd >= 0) {
+        (void)::close(this->m_fd);
+    }
 }
 
 // ----------------------------------------------------------------------

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -94,6 +94,7 @@ SocketIpStatus TcpServerComponentImpl::startup() {
 }
 
 void TcpServerComponentImpl::terminate() {
+    this->stop();
     Os::ScopeLock scopedLock(this->m_lock);
     this->m_socket.terminate(this->m_descriptor);
     this->m_descriptor.serverFd = -1;

--- a/Drv/TcpServer/TcpServerComponentImpl.cpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.cpp
@@ -93,8 +93,13 @@ SocketIpStatus TcpServerComponentImpl::startup() {
     return status;
 }
 
+void TcpServerComponentImpl::stop() {
+    // The read task blocks in `accept` on the listening socket, so stopping it requires terminating that socket
+    this->terminate();
+}
+
 void TcpServerComponentImpl::terminate() {
-    this->stop();
+    SocketComponentHelper::stop();
     Os::ScopeLock scopedLock(this->m_lock);
     this->m_socket.terminate(this->m_descriptor);
     this->m_descriptor.serverFd = -1;

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -80,6 +80,14 @@ class TcpServerComponentImpl : public TcpServerComponentBase, public SocketCompo
     /**
      * \brief stop the read task and terminate the server socket
      *
+     * Equivalent to `terminate`. The read task blocks in `accept` on the server socket, which the base
+     * implementation does not close; it is terminated here to allow `join` to return.
+     */
+    void stop() override;
+
+    /**
+     * \brief stop the read task and terminate the server socket
+     *
      * Stops the read task, then shuts down and closes the server socket so that a read task
      * blocked in `accept` can exit.
      *

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -78,9 +78,13 @@ class TcpServerComponentImpl : public TcpServerComponentBase, public SocketCompo
     SocketIpStatus startup();
 
     /**
-     * \brief terminate the server socket
+     * \brief stop the read task and terminate the server socket
      *
-     * Close the server socket. Should be done after all clients are shutdown and closed.
+     * Stops the read task, then shuts down and closes the server socket so that a read task
+     * blocked in `accept` can exit.
+     *
+     * \note This stops the component permanently. It cannot be used to stop accepting new clients
+     * while continuing to service an already-connected one.
      */
     void terminate();
 

--- a/Drv/TcpServer/docs/sdd.md
+++ b/Drv/TcpServer/docs/sdd.md
@@ -59,7 +59,9 @@ with automatic connection enabled, which will automatically accept the client co
 `configure` must be called before any data is sent or received. `start` must be called for the component to receive data.
 
 
-Users should call `stop` to stop the receive task and `join` to wait for it to exit.
+Users should call `stop` to stop the receive task and `join` to wait for it to exit. For Drv::TcpServerComponentImpl,
+`stop` is equivalent to `terminate`: the receive task blocks in `accept` on the listening socket, so `stop` shuts down and
+closes that socket along with any active client connection.
 
 Users turning off automatic connection must call `open` to open the connection.
 

--- a/Drv/Udp/docs/sdd.md
+++ b/Drv/Udp/docs/sdd.md
@@ -61,7 +61,7 @@ bool constructApp(bool dump, U32 port_number, char* hostname) {
     if (hostname != nullptr && port_number != 0) {
         Os::TaskString name("ReceiveTask");
         // Needed for receiving only, remove if not configuring to receive
-        comm.startSocketTask(name);
+        comm.start(name);
     }
 }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Backports #5202, #5336 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Backports the TcpServer shutdown-hang fix and the IP `close()` file descriptor guards from `devel` to `release/v3.6.0-hotfixes`, plus a change to TcpServer `stop()` needed to keep the v3.6 teardown API working.

Also removes a delay at shutdown by checking if thread is running before a `delay(SOCKET_RETRY_INTERVAL)`.

Updates documentation of affected functions (note that socket documentation in `devel` is outdated, I will open a separate PR to tackle that).

## Rationale

Currently, v3.6 deployments hang when exiting, if a TcpServer has no active client connection.

## Testing/Review Recommendations

Verified against four teardown scenarios:

| Scenario | Before | After |
|---|---|---|
| Client never connected | `join()` hangs | returns immediately |
| Client connected, then disconnected | `join()` hangs | returns immediately |
| Client still connected | returns | returns |
| Listen port unavailable | returns (~1s) | returns (~1s) |

I tested all 8 iterations of this before/after test on two deployments: an internal project deployment plus a modified `fprime-tutorial-hello-world`. In order to get `fprime-tutorial-hello-world` to demonstrate this fix, I made 3 changes to the v3.6.0 deployment:
* Switched `Drv.TcpClient` to `Drv.TcpServer` in instances.fpp
* Moved `comm.stop()` and `comm.join()` above `stopTasks()` (order matters to keep the deployment from hanging at shutdown, at least in v3.6)
* Added a `Svc.ComQueue` in the downlink path (a different unresolved bug causes a thread sending via TcpServer to hang on `accept()` when no client is connected. Without this ComQueue in the middle, the tlm-generating rategroup sits in `accept()` until it eventually asserts due to full component queue at `TlmChanComponentAc.cpp:483`).

## Future Work

Claude proposed some unit tests, which I did not include, because they would hang indefinitely if failing, which didn't seem ideal. But it may be possible to write unit tests to demonstrate this behavior, if desired.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude helped me compare v3.6 socket components to v4 in order to properly backport this change. It provided some initial documentation and commit message examples which I used as inspiration. Finally, it reviewed my work and provided recommendations before I submitted this PR.