### PR TITLE
Drv/Ip: correct SDD and doc comments to match shutdown/close semantics

### DIFF
--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -157,7 +157,7 @@ class IpSocket {
     /**
      * \brief shutdown the socket
      *
-     * Shuts down the socket opened by the open call. In this case of the TcpServer, this does shut down server's
+     * Shuts down the socket opened by the open call. In this case of the TcpServer, this does not shut down server's
      * listening port, but rather shuts down the active client.
      *
      * A shut down begins the termination of communication. The underlying socket will coordinate a clean shutdown, and

--- a/Drv/Ip/IpSocket.hpp
+++ b/Drv/Ip/IpSocket.hpp
@@ -147,7 +147,7 @@ class IpSocket {
     /**
      * \brief closes the socket
      *
-     * Closes the socket opened by the open call. In this case of the TcpServer, this does NOT close server's listening
+     * Closes the socket opened by the open call. In the case of the TcpServer, this does NOT close server's listening
      * port but will close the active client connection.
      *
      * \param socketDescriptor: socket descriptor to close
@@ -157,7 +157,7 @@ class IpSocket {
     /**
      * \brief shutdown the socket
      *
-     * Shuts down the socket opened by the open call. In this case of the TcpServer, this does not shut down server's
+     * Shuts down the socket opened by the open call. In the case of the TcpServer, this does not shut down server's
      * listening port, but rather shuts down the active client.
      *
      * A shut down begins the termination of communication. The underlying socket will coordinate a clean shutdown, and

--- a/Drv/Ip/SocketComponentHelper.hpp
+++ b/Drv/Ip/SocketComponentHelper.hpp
@@ -158,20 +158,20 @@ class SocketComponentHelper {
     /**
      * \brief stop the socket read task and shut down the associated socket.
      *
-     * Called to stop the socket read task. It is an error to call this before the thread has been started using the
-     * start call. This will stop the read task and shut down the client socket.
+     * Called to stop the socket read and reconnect tasks and shut down the client socket. Stopping before start is
+     * permitted but only shuts down the client socket.
      */
     void stop();
 
     void stopReconnect();
 
     /**
-     * \brief joins to the stopping read task to wait for it to close
+     * \brief joins the stopping read and reconnect tasks to wait for them to close
      *
-     * Called to join with the read socket task. This will block and return after the task has been stopped with a call
-     * to the stopSocketTask method.
-     * \param value_ptr: a pointer to fill with data. Passed to the Os::Task::join call. NULL to ignore.
-     * \return: Os::Task::Status passed back from the Os::Task::join call.
+     * Called to join with the read and reconnect tasks. This will block and return after both tasks have been stopped
+     * with a call to the `stop` method.
+     *
+     * \return Os::Task::Status of the read task, or of the reconnect task when the read task joined cleanly
      */
     Os::Task::Status join();
 

--- a/Drv/Ip/SocketComponentHelper.hpp
+++ b/Drv/Ip/SocketComponentHelper.hpp
@@ -156,10 +156,10 @@ class SocketComponentHelper {
     bool runningReconnect();
 
     /**
-     * \brief stop the socket read task and close the associated socket.
+     * \brief stop the socket read task and shut down the associated socket.
      *
      * Called to stop the socket read task. It is an error to call this before the thread has been started using the
-     * startSocketTask call. This will stop the read task and close the client socket.
+     * start call. This will stop the read task and shut down the client socket.
      */
     void stop();
 

--- a/Drv/Ip/TcpServerSocket.hpp
+++ b/Drv/Ip/TcpServerSocket.hpp
@@ -43,12 +43,11 @@ class TcpServerSocket : public IpSocket {
     SocketIpStatus startup(SocketDescriptor& socketDescriptor);
 
     /**
-     * \brief close the server socket created by the `startup` call
+     * \brief shut down and close the server socket created by the `startup` call
      *
-     * Calls the close function on the server socket. No shutdown is performed on the server socket, as that is left to
-     * the individual client sockets.
+     * Calls shutdown, then close, on the server socket.
      *
-     * \param socketDescriptor:  descriptor to close
+     * \param socketDescriptor: descriptor of socket to terminate
      */
     void terminate(const SocketDescriptor& socketDescriptor);
 

--- a/Drv/Ip/docs/sdd.md
+++ b/Drv/Ip/docs/sdd.md
@@ -125,9 +125,9 @@ socket that will listen for incoming connections.  `Drv::TcpServerSocket::startu
 will only close the client connection and does not affect the server from listening for clients, however; it does free
 up the server to accept a new client.
 
-`Drv::TcpServerSocket::shutdown` will close the TCP server from receiving any new clients and effectively releases all
-resources allocated to the server. `Drv::TcpServerSocket::shutdown` implies `Drv::TcpServerSocket::close` and client
-connections will be stopped.
+`Drv::TcpServerSocket::terminate` will shut down and close the TCP server socket, releasing the resources allocated by
+`Drv::TcpServerSocket::startup` and preventing new clients. The shutdown is done first so that a thread waiting in
+`Drv::TcpServerSocket::open` can exit. It does not close an accepted client connection; use `Drv::TcpServerSocket::close`.
 
 ## Example TcpServer Usage
 
@@ -142,10 +142,11 @@ while (chatting) {
     server.send(); // Timeout of 100us
     server.recv(); // Will block
 }
-server.close();
+server.close(); // Close the client connection
 server.open(); // Blocks until a client is available
 ...
-server.shutdown();
+server.close(); // Close the client connection
+server.terminate(); // Shut down and close the server's listening socket
 ```
 
 ## Drv::UdpSocket Class
@@ -200,8 +201,8 @@ in a name, and all arguments to `Os::Task::start` to start the receive and recon
 will determine if this read task will request reconnects to sockets should a disconnect or error occur. Once started, the read task will continue
 until a `Drv::SocketComponentHelper::stop` has been called or an error occurred when started without reconnect set to
 `true`.  Once the socket stop call has been made, the user should call `Drv::SocketComponentHelper::join` in order to
-wait until the full tasks have finished.  `Drv::SocketComponentHelper::stop` will call `Drv::SocketComponentHelper::close` on the
-provided Drv::IpSocket to ensure that any blocking reads exit freeing the thread to completely stop. Normal usage of
+wait until the full tasks have finished.  `Drv::SocketComponentHelper::stop` will call `Drv::SocketComponentHelper::shutdown`
+on the provided Drv::IpSocket to ensure that any blocking reads exit, freeing the thread to completely stop. Normal usage of
 a Drv::SocketComponentHelper derived class is shown below.
 
 ```c++

--- a/Drv/TcpServer/TcpServerComponentImpl.hpp
+++ b/Drv/TcpServer/TcpServerComponentImpl.hpp
@@ -83,9 +83,13 @@ class TcpServerComponentImpl final : public TcpServerComponentBase, public Socke
     SocketIpStatus startup();
 
     /**
-     * \brief terminate the server socket
+     * \brief stop the read task and terminate the server socket
      *
-     * Close the server socket. Should be done after all clients are shutdown and closed.
+     * Stops the read task, then shuts down and closes the server socket so that a task
+     * blocked in `accept` can exit.
+     *
+     * \note This stops the component permanently. It cannot be used to stop accepting new clients
+     * while continuing to service an already-connected one.
      */
     void terminate();
 

--- a/Drv/Udp/docs/sdd.md
+++ b/Drv/Udp/docs/sdd.md
@@ -47,7 +47,7 @@ bool constructApp(bool dump, U32 port_number, char* ipv4_address) {
     if (ipv4_address != nullptr && port_number != 0) {
         Os::TaskString name("ReceiveTask");
         // Needed for receiving only, remove if not configuring to receive
-        comm.startSocketTask(name);
+        comm.start(name);
     }
 }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Updates Drv/Ip documentation which had gotten out of sync with the implementation over time. These inconsistencies were identified while working on #5687.

## Rationale

Documentation needs to match the implementation.

## Testing/Review Recommendations

## Future Work

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude helped port over the documentation changes made for v3.6 in #5687, many of which apply here.