### PR TITLE
Add settable time context to Svc::PosixTime

### DIFF
--- a/Svc/PosixTime/CMakeLists.txt
+++ b/Svc/PosixTime/CMakeLists.txt
@@ -24,4 +24,6 @@ register_fprime_ut(
   SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/test/ut/PosixTimeTester.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/test/ut/PosixTimeMain.cpp"
+  DEPENDS
+    STest
 )

--- a/Svc/PosixTime/PosixTime.cpp
+++ b/Svc/PosixTime/PosixTime.cpp
@@ -1,5 +1,5 @@
 /*
- * TestCommand1Impl.cpp
+ * PosixTime.cpp
  *
  *  Created on: Mar 28, 2014
  *      Author: tcanham
@@ -11,9 +11,13 @@
 
 namespace Svc {
 
-PosixTime::PosixTime(const char* name) : PosixTimeComponentBase(name) {}
+PosixTime::PosixTime(const char* name) : PosixTimeComponentBase(name), m_timeContext(0) {}
 
 PosixTime::~PosixTime() {}
+
+void PosixTime::setTimeContext(FwTimeContextStoreType timeContext) {
+    this->m_timeContext = timeContext;
+}
 
 void PosixTime::timeGetPort_handler(FwIndexType portNum, /*!< The port number*/
                                     Fw::Time& time       /*!< The U32 cmd argument*/
@@ -24,6 +28,7 @@ void PosixTime::timeGetPort_handler(FwIndexType portNum, /*!< The port number*/
         stime.tv_sec = 0;
         stime.tv_nsec = 0;
     }
-    time.set(TimeBase::TB_WORKSTATION_TIME, 0, static_cast<U32>(stime.tv_sec), static_cast<U32>(stime.tv_nsec / 1000));
+    time.set(TimeBase::TB_WORKSTATION_TIME, this->m_timeContext, static_cast<U32>(stime.tv_sec),
+             static_cast<U32>(stime.tv_nsec / 1000));
 }
 }  // namespace Svc

--- a/Svc/PosixTime/PosixTime.hpp
+++ b/Svc/PosixTime/PosixTime.hpp
@@ -1,5 +1,5 @@
 /*
- * TestTelemRecvImpl.hpp
+ * PosixTime.hpp
  *
  *  Created on: Mar 28, 2014
  *      Author: tcanham
@@ -16,6 +16,7 @@ class PosixTime final : public PosixTimeComponentBase {
   public:
     explicit PosixTime(const char* compName);
     virtual ~PosixTime();
+    void setTimeContext(FwTimeContextStoreType timeContext);
 
   protected:
     void timeGetPort_handler(FwIndexType portNum, /*!< The port number*/
@@ -23,6 +24,7 @@ class PosixTime final : public PosixTimeComponentBase {
     );
 
   private:
+    FwTimeContextStoreType m_timeContext;
 };
 
 }  // namespace Svc

--- a/Svc/PosixTime/docs/sdd.md
+++ b/Svc/PosixTime/docs/sdd.md
@@ -9,6 +9,7 @@ The `Svc::PosixTime` is a component that provides system time on Posix systems. 
 | Requirement        | Description                                                                                                           | Verification |
 |--------------------|-----------------------------------------------------------------------------------------------------------------------|--------------|
 | SVC-POSIX-TIME-001 | `Svc::PosixTime` shall return current system time as an `Fw::Time` objects in response to the `timeGetPort` port call | Unit Test    |
+| SVC-POSIX-TIME-002 | `Svc::PosixTime` shall set the time context of returned `Fw::Time` objects to the value supplied by `setTimeContext`  | Unit Test    |
 
 ## 3. Design
 
@@ -20,10 +21,14 @@ The `Svc::PosixTime` is a component that provides system time on Posix systems. 
 |---------------|------------|-----------|--------------------------------------|
 | `timeGetPort` | sync input | `Fw.Time` | Port returning current system design |
 
+### 3.2 Time Context
+
+Returned `Fw::Time` objects carry a project-specific time context, which is `0` unless changed by a call to `setTimeContext()`. `setTimeContext()` is not synchronized and is intended to be called at startup, before the component is serving `timeGetPort` calls.
+
 ## 7. Change Log
 
 Date | Description
 ---- | -----------
 4/20/2017  | Initial Version
 10/12/2023 | Reworked into `Svc::PosixTime` 
-
+8/14/2026  | Added settable time context

--- a/Svc/PosixTime/test/ut/PosixTimeMain.cpp
+++ b/Svc/PosixTime/test/ut/PosixTimeMain.cpp
@@ -2,6 +2,8 @@
 // Main.cpp
 // ----------------------------------------------------------------------
 
+#include <STest/Random/Random.hpp>
+
 #include "PosixTimeTester.hpp"
 
 TEST(Test, GetTime) {
@@ -9,7 +11,13 @@ TEST(Test, GetTime) {
     tester.getTime();
 }
 
+TEST(Test, GetTimeWithContext) {
+    Svc::PosixTimeTester tester("Tester");
+    tester.getTimeWithContext();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
+    STest::Random::seed();
     return RUN_ALL_TESTS();
 }

--- a/Svc/PosixTime/test/ut/PosixTimeTester.cpp
+++ b/Svc/PosixTime/test/ut/PosixTimeTester.cpp
@@ -4,6 +4,9 @@
 
 #include <strings.h>
 #include <cstdio>
+#include <limits>
+
+#include <STest/Pick/Pick.hpp>
 
 #include "PosixTimeTester.hpp"
 
@@ -31,6 +34,22 @@ PosixTimeTester ::~PosixTimeTester() {}
 void PosixTimeTester ::getTime() {
     Fw::Time time;
     this->invoke_to_timeGetPort(0, time);
+    ASSERT_EQ(time.getTimeBase(), TimeBase::TB_WORKSTATION_TIME);
+    ASSERT_EQ(time.getContext(), 0);
+    ASSERT_GT(time.getSeconds(), 0U);
+    ASSERT_GE(time.getUSeconds(), 0U);
+    ASSERT_LE(time.getUSeconds(), 999999U);
+}
+
+void PosixTimeTester ::getTimeWithContext() {
+    // Pick a nonzero context so that it is distinguishable from the default
+    const U32 upper = std::numeric_limits<FwTimeContextStoreType>::max();
+    const FwTimeContextStoreType context = static_cast<FwTimeContextStoreType>(STest::Pick::lowerUpper(1, upper));
+    this->component.setTimeContext(context);
+    Fw::Time time;
+    this->invoke_to_timeGetPort(0, time);
+    ASSERT_EQ(time.getTimeBase(), TimeBase::TB_WORKSTATION_TIME);
+    ASSERT_EQ(time.getContext(), context);
     ASSERT_GT(time.getSeconds(), 0U);
     ASSERT_GE(time.getUSeconds(), 0U);
     ASSERT_LE(time.getUSeconds(), 999999U);

--- a/Svc/PosixTime/test/ut/PosixTimeTester.hpp
+++ b/Svc/PosixTime/test/ut/PosixTimeTester.hpp
@@ -27,6 +27,8 @@ class PosixTimeTester : public PosixTimeGTestBase {
   public:
     void getTime();
 
+    void getTimeWithContext();
+
     // ----------------------------------------------------------------------
     // The component under test
     // ----------------------------------------------------------------------


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5608 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Adds `setTimeContext()` to `Svc::PosixTime`, allowing a deployment to set the time context returned on `timeGetPort` calls. The context defaults to `0`, so existing deployments are unaffected.

Note: this is ported from `release/v3.6.0-hotfixes`, with docs/UTs added. See #5609 for original v3.6 PR.

## Rationale

`Svc::PosixTime` currently hardcodes `0` as the time context. Making it settable lets a deployment include mission-specific  meaning in timestamps generated by this component.

## Testing/Review Recommendations

Unit test adjusted to confirm default time context is 0. Added a unit test to show that a randomly set time context is successful.

## Future Work

`Svc::ChronoTime` doesn't set time context, so could be similarly updated.

This could be expanded to allow setting time context via input port or a command. Such an expansion would require making `m_timeContext` atomic.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude helped update docs and UTs.