### PR TITLE
Fixed Unguarded FW_ASSERT in CfdpManager (PR #5690)

### DIFF
--- a/Svc/Ccsds/CfdpManager/Chunk.cpp
+++ b/Svc/Ccsds/CfdpManager/Chunk.cpp
@@ -61,6 +61,14 @@ void CfdpChunkList::reset() {
 }
 
 void CfdpChunkList::add(FileSize offset, FileSize size) {
+    // A zero-length chunk covers no bytes and is not a received interval. It also violates the
+    // non-empty invariant assumed downstream by combineNext() (chunk_end > offset), so ignore it
+    // rather than asserting. This value can be derived from incoming protocol data (a FileData PDU
+    // whose payload length equals the encoded offset length), so it must not be treated as a bug.
+    if (size == 0) {
+        return;
+    }
+
     const Chunk chunk = {offset, size};
     const ChunkIdx i = findInsertPosition(&chunk);
 

--- a/Svc/Ccsds/CfdpManager/TransactionRx.cpp
+++ b/Svc/Ccsds/CfdpManager/TransactionRx.cpp
@@ -522,6 +522,14 @@ Status::T Transaction::rProcessFd(const Fw::Buffer& buffer) {
         }
     }
 
+    // A zero-length FileData segment is syntactically valid (payload length equals the encoded
+    // offset length) but carries no bytes. There is nothing to seek to, write, or track as a gap,
+    // so treat it as a successful no-op. This avoids a pointless file I/O round trip and prevents
+    // a zero-size interval from ever reaching the chunk tracker.
+    if ((ret == Cfdp::Status::SUCCESS) && (dataSize == 0)) {
+        return ret;
+    }
+
     // Seek to file offset if needed
     if (ret == Cfdp::Status::SUCCESS) {
         if (this->m_state_data.receive.cached_pos != offset) {

--- a/Svc/Ccsds/CfdpManager/docs/sdd.md
+++ b/Svc/Ccsds/CfdpManager/docs/sdd.md
@@ -2,7 +2,7 @@
 
 ## CFDP Introduction
 
-The CCSDS File Delivery Protocol(CFDP) is a space communication standard designed for reliable, autonomous file transfer in space missions. CFDP provides a robust mechanism for transferring files between ground systems and spacecraft even in environments with long propagation delays, intermittent connectivity, or high error rates.
+The CCSDS File Delivery Protocol (CFDP) is a space communication standard designed for reliable, autonomous file transfer in space missions. CFDP provides a robust mechanism for transferring files between ground systems and spacecraft even in environments with long propagation delays, intermittent connectivity, or high error rates.
 
 CFDP is particularly well-suited for:
 - Spacecraft-to-ground file transfers: Downlinking F' event logs, telemetry data files, science data products, and diagnostic files

--- a/Svc/Ccsds/CfdpManager/docs/sdd.md
+++ b/Svc/Ccsds/CfdpManager/docs/sdd.md
@@ -1,9 +1,8 @@
-#Ccsds::CfdpManager
+# Ccsds::CfdpManager
 
-##CFDP Introduction
+## CFDP Introduction
 
-    The CCSDS File Delivery
-    Protocol(CFDP) is a space communication standard designed for reliable, autonomous file transfer in space missions. CFDP provides a robust mechanism for transferring files between ground systems and spacecraft even in environments with long propagation delays, intermittent connectivity, or high error rates.
+The CCSDS File Delivery Protocol(CFDP) is a space communication standard designed for reliable, autonomous file transfer in space missions. CFDP provides a robust mechanism for transferring files between ground systems and spacecraft even in environments with long propagation delays, intermittent connectivity, or high error rates.
 
 CFDP is particularly well-suited for:
 - Spacecraft-to-ground file transfers: Downlinking F' event logs, telemetry data files, science data products, and diagnostic files

--- a/Svc/Ccsds/CfdpManager/docs/sdd.md
+++ b/Svc/Ccsds/CfdpManager/docs/sdd.md
@@ -1,8 +1,9 @@
-# Ccsds::CfdpManager
+#Ccsds::CfdpManager
 
-## CFDP Introduction
+##CFDP Introduction
 
-The CCSDS File Delivery Protocol (CFDP) is a space communication standard designed for reliable, autonomous file transfer in space missions. CFDP provides a robust mechanism for transferring files between ground systems and spacecraft even in environments with long propagation delays, intermittent connectivity, or high error rates.
+    The CCSDS File Delivery
+    Protocol(CFDP) is a space communication standard designed for reliable, autonomous file transfer in space missions. CFDP provides a robust mechanism for transferring files between ground systems and spacecraft even in environments with long propagation delays, intermittent connectivity, or high error rates.
 
 CFDP is particularly well-suited for:
 - Spacecraft-to-ground file transfers: Downlinking F' event logs, telemetry data files, science data products, and diagnostic files
@@ -131,6 +132,12 @@ CfdpManager follows a layered security architecture where authentication and aut
 CfdpManager accepts destination file paths as specified in incoming CFDP Metadata PDUs without application-layer path validation. This approach is consistent with the CCSDS 727.0-B-5 CFDP standard, which assumes operation over authenticated communication channels.
 
 For mission deployments, ensure radio links employ hardware encryption or cryptographic authentication, ground systems implement proper authentication and authorization controls, and operational procedures include verification of file paths before commanding transfers.
+
+#### Input Robustness
+
+Because CfdpManager processes PDUs received from an external link, it must remain available even when the received bytes are malformed, degenerate, or hostile. The receive path treats structural properties of an incoming PDU as untrusted input and rejects or safely ignores them rather than relying on an `FW_ASSERT`, which would raise a FATAL and remove the deployment from service. Assertions in the CFDP code are reserved for internal invariants that cannot be influenced by received data.
+
+A specific case handled here is a syntactically valid FileData PDU that declares a file offset but carries zero file-data octets (its PDU payload length equals the encoded offset length). Such an empty segment conveys no data: the receive handler treats it as a successful no-op — no file write and no gap-tracking update — so it can never produce a zero-length interval in the chunk tracker. This closes the denial-of-service reported in [GHSA-mh5x-2m6h-8267](https://github.com/nasa/fprime/security/advisories/GHSA-mh5x-2m6h-8267), where a single zero-length Class 2 FileData PDU could reach a gap-tracking assertion and terminate the process. Note that this is an availability hardening measure; it does not by itself remove the need for the authenticated lower layers described above.
 
 ### Main Class Hierarchy
 
@@ -695,4 +702,4 @@ Telemetry is emitted as the `ChannelTelemetry` array, one `ChannelTelemetry` str
 | CFDP-010 | `CfdpManager` shall support configurable file archiving to move completed files instead of deletion | Preserves files for audit trails and operational analysis while managing storage | Unit Test |
 | CFDP-011 | `CfdpManager` shall support both command-initiated and port-initiated file transfers | Allows both ground operators and onboard components to initiate file transfers | Unit Test, System Test |
 | CFDP-012 | `CfdpManager` shall support flow control to freeze and resume channel operations | Provides mechanism to temporarily halt file transfers during critical spacecraft operations | Unit Test |
-
+| CFDP-013 | `CfdpManager` shall process malformed or degenerate received PDUs, including zero-length FileData segments, without raising a FATAL assertion | Preserves deployment availability against untrusted link input and prevents a single crafted PDU from terminating the process ([GHSA-mh5x-2m6h-8267](https://github.com/nasa/fprime/security/advisories/GHSA-mh5x-2m6h-8267)) | Unit Test |

--- a/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerHelperTests.cpp
+++ b/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerHelperTests.cpp
@@ -565,6 +565,27 @@ TEST(ChunkHelper, ComputeGapsZeroTotalHasNoGaps) {
     EXPECT_EQ(0U, chunks.computeGaps(1, 0, 0, nullptr, nullptr));
 }
 
+TEST(ChunkHelper, AddZeroSizeChunkIgnored) {
+    // A zero-length FileData segment (PDU payload length equal to the encoded offset length)
+    // produces add(offset, 0). This carries no bytes and must be ignored rather than tracked;
+    // a zero-size chunk would otherwise reach combineNext() and trip its non-rollover assert
+    // (chunk_end > offset), turning attacker-controlled protocol input into a fatal abort.
+    Chunk chunkMem[4];
+    CfdpChunkList chunks(4, chunkMem);
+
+    chunks.add(0, 0);
+    EXPECT_EQ(0U, chunks.getCount());
+    EXPECT_EQ(nullptr, chunks.getFirstChunk());
+
+    // A zero-size add at a non-zero offset must be ignored the same way
+    chunks.add(4096, 0);
+    EXPECT_EQ(0U, chunks.getCount());
+
+    // A subsequent real chunk is still tracked normally
+    chunks.add(0, 10);
+    EXPECT_EQ(1U, chunks.getCount());
+}
+
 TEST(FileDataPduHelper, TruncatedOffsetRejected) {
     // A PDU truncated in the middle of the file offset must be rejected rather than
     // leaving a stale offset behind

--- a/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerTestMain.cpp
+++ b/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerTestMain.cpp
@@ -91,6 +91,12 @@ TEST(Transaction, Class2RxFileDataOffsetOverflow) {
     tester.testClass2RxFileDataOffsetOverflow();
 }
 
+// Regression test for GHSA-mh5x-2m6h-8267: a zero-length FileData segment must not assert/FATAL
+TEST(Transaction, Class2RxZeroLengthFileData) {
+    Svc::Ccsds::Cfdp::CfdpManagerTester tester;
+    tester.testClass2RxZeroLengthFileData();
+}
+
 TEST(Transaction, MultipleTransactionsInSeries) {
     Svc::Ccsds::Cfdp::CfdpManagerTester tester;
     tester.testMultipleTransactionsInSeries();

--- a/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerTester.cpp
+++ b/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerTester.cpp
@@ -1183,6 +1183,49 @@ void CfdpManagerTester::testClass2RxFileDataOffsetOverflow() {
     cleanupTestFile(txn->m_history->fnames.dst_filename.toChar());
 }
 
+void CfdpManagerTester::testClass2RxZeroLengthFileData() {
+    // Regression test for GHSA-mh5x-2m6h-8267.
+    //
+    // A syntactically valid Class 2 FileData PDU that carries a complete file offset but zero
+    // file-data octets (PDU payload length equal to the encoded offset length) deserializes with
+    // dataSize == 0. Before the fix this reached CfdpChunkList::combineNext(), where a zero-size
+    // chunk violated FW_ASSERT(chunk_end > chunk->offset) and terminated the process via FATAL.
+    //
+    // Received before any metadata, this starts an R2 transaction (bound == FileSize max), so the
+    // offset/size bounds check does not reject it. The engine must instead treat the empty segment
+    // as a harmless no-op: no bytes written, no gap tracked, no fault, and above all no crash.
+    const U8 channelId = 0;
+    const U32 transactionSeq = 502;
+    const FileSize offset = 0;
+    const U16 dataSize = 0;
+    U8 data[1] = {0xA5};  // non-null pointer; zero octets are actually serialized
+
+    // Reaching this call at all after component dispatch proves the assertion no longer fires.
+    sendFileDataPdu(channelId, TEST_GROUND_EID, component.getLocalEidParam(), transactionSeq, offset, dataSize, data,
+                    Cfdp::Class::CLASS_2);
+    component.doDispatch();
+
+    Transaction* txn = findTransaction(channelId, transactionSeq);
+    ASSERT_NE(nullptr, txn) << "R2 transaction should be created for FileData received before metadata";
+    EXPECT_FALSE(txn->m_flags.rx.md_recv);
+
+    // An empty segment is neither out of bounds nor a fault; it is simply ignored.
+    ASSERT_EVENTS_RxFileDataOutOfBounds_SIZE(0);
+    EXPECT_FALSE(TxnStatusIsError(txn->m_history->txn_stat)) << "Empty FileData segment must not fault the transaction";
+
+    // Cycle once so channel telemetry is emitted
+    this->invoke_to_run1Hz(0, 0);
+    this->component.doDispatch();
+
+    ASSERT_GE(this->tlmHistory_ChannelTelemetry->size(), 1u);
+    U32 tlmIndex = static_cast<U32>(this->tlmHistory_ChannelTelemetry->size() - 1);
+    Cfdp::ChannelTelemetryArray tlm = this->tlmHistory_ChannelTelemetry->at(tlmIndex).arg;
+    EXPECT_EQ(0u, tlm[channelId].get_recvFileDataBytes()) << "Empty FileData segment writes no bytes";
+    EXPECT_EQ(0u, tlm[channelId].get_recvErrors()) << "Empty FileData segment must not raise a receive error";
+
+    cleanupTestFile(txn->m_history->fnames.dst_filename.toChar());
+}
+
 // ----------------------------------------------------------------------
 // Port-Based Transaction Tests
 // ----------------------------------------------------------------------

--- a/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerTester.hpp
+++ b/Svc/Ccsds/CfdpManager/test/ut/CfdpManagerTester.hpp
@@ -371,6 +371,9 @@ class CfdpManagerTester final : public CfdpManagerGTestBase {
     //! Test Class 2 RX rejection of a FileData PDU whose offset and length overflow the offset space
     void testClass2RxFileDataOffsetOverflow();
 
+    //! Test Class 2 RX handling of a zero-length FileData segment (GHSA-mh5x-2m6h-8267)
+    void testClass2RxZeroLengthFileData();
+
     //! Test multiple transactions in series
     void testMultipleTransactionsInSeries();
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| PR #5690 |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| Y |
|**_Generative AI was used in this contribution (y/n)_**| Y |

---
## Change Description

Modified Svc/Ccsds/CfdpManager:

Chunk.cpp — CfdpChunkList::add(): early-return when size == 0, so the chunk list enforces its own non-empty-interval invariant instead of asserting on it (protects all callers).

TransactionRx.cpp — rProcessFd(): treat dataSize == 0 as a successful no-op (no seek, no zero-byte write, nothing tracked). 

## Rationale

Prevent a bit-flip and/or bit corruption from causing an FW_ASSERT.  

## Testing/Review Recommendations

Review and execute new unit test that verifies guard. 

## Future Work

None

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude Fable 5 used to implement source code changes, update unit tests and SDD.