### PR TITLE
Increase history sizes in unit tests

### DIFF
--- a/Drv/TcpServer/test/ut/TcpServerTester.hpp
+++ b/Drv/TcpServer/test/ut/TcpServerTester.hpp
@@ -24,7 +24,7 @@ namespace Drv {
 
 class TcpServerTester : public TcpServerGTestBase {
     // Maximum size of histories storing events, telemetry, and port outputs
-    static const FwSizeType MAX_HISTORY_SIZE = 1000;
+    static const FwSizeType MAX_HISTORY_SIZE = 2000;
     // Instance ID supplied to the component instance under test
     static const FwEnumStoreType TEST_INSTANCE_ID = 0;
     // Queue depth supplied to component instance under test

--- a/Drv/Udp/test/ut/UdpTester.hpp
+++ b/Drv/Udp/test/ut/UdpTester.hpp
@@ -24,7 +24,7 @@ namespace Drv {
 
 class UdpTester : public UdpGTestBase {
     // Maximum size of histories storing events, telemetry, and port outputs
-    static const FwSizeType MAX_HISTORY_SIZE = 1000;
+    static const FwSizeType MAX_HISTORY_SIZE = 2000;
     // Instance ID supplied to the component instance under test
     static const FwEnumStoreType TEST_INSTANCE_ID = 0;
     // Queue depth supplied to component instance under test

--- a/Svc/PassiveRateGroup/test/ut/PassiveRateGroupTester.cpp
+++ b/Svc/PassiveRateGroup/test/ut/PassiveRateGroupTester.cpp
@@ -24,7 +24,7 @@
 namespace Svc {
 
 PassiveRateGroupTester::PassiveRateGroupTester(Svc::PassiveRateGroup& inst)
-    : PassiveRateGroupGTestBase("testerbase", 100), m_impl(inst), m_callOrder(0) {
+    : PassiveRateGroupGTestBase("testerbase", 1000), m_impl(inst), m_callOrder(0) {
     this->clearPortCalls();
 }
 


### PR DESCRIPTION
This PR increases the history sizes in some of the unit tests. It fixes unit test failures observed on Mac OS.