### PR TITLE
Remove backwards-compatibility platform search patterns

### DIFF
--- a/cmake/platform/platform.cmake
+++ b/cmake/platform/platform.cmake
@@ -105,11 +105,9 @@ endfunction()
 #
 # Priority order:
 #   1. PROJECT_SOURCE_DIR/cmake/platform/        (project-level direct)
-#   2. FPRIME_PROJECT_ROOT/cmake/platform/       (backwards compat — project root differs from PROJECT_SOURCE_DIR)
-#   3. PROJECT_SOURCE_DIR/lib/*/cmake/platform/  (project libraries)
-#   4. PROJECT_SOURCE_DIR/*/cmake/platform/      (project subdirectories)
-#   5. FPRIME_LIBRARY_LOCATIONS/cmake/platform/  (backwards compat — explicit library locations)
-#   6. FPRIME_FRAMEWORK_PATH/cmake/platform/     (framework fallback)
+#   2. PROJECT_SOURCE_DIR/lib/*/cmake/platform/  (project libraries)
+#   3. PROJECT_SOURCE_DIR/*/cmake/platform/      (project subdirectories)
+#   4. FPRIME_FRAMEWORK_PATH/cmake/platform/     (framework fallback)
 #
 # Results are cached in FPRIME_CACHED_PLATFORM_FILE to avoid re-searching.
 #
@@ -128,36 +126,8 @@ function(fprime_find_platform_file)
     # fprime_glob_ordered (utilities.cmake) so earlier patterns take priority over later ones.
     set(_PLATFORM_GLOBS
         "${PROJECT_SOURCE_DIR}/cmake/platform/${FPRIME_PLATFORM}.cmake"
-    )
-
-    # ---- BACKWARDS COMPATIBILITY ----
-    # The following patterns support older project structures that place platform files relative to
-    # FPRIME_PROJECT_ROOT or FPRIME_LIBRARY_LOCATIONS rather than PROJECT_SOURCE_DIR. These exist
-    # to avoid breaking existing projects during the transition to convention-based discovery.
-    # TODO: Remove these patterns once all projects have migrated to the standard layout.
-    if (DEFINED FPRIME_PROJECT_ROOT AND NOT "${FPRIME_PROJECT_ROOT}" STREQUAL ""
-            AND NOT "${FPRIME_PROJECT_ROOT}" STREQUAL "${PROJECT_SOURCE_DIR}")
-        list(APPEND _PLATFORM_GLOBS
-            "${FPRIME_PROJECT_ROOT}/cmake/platform/${FPRIME_PLATFORM}.cmake"
-        )
-    endif()
-    # ---- END BACKWARDS COMPATIBILITY (project root) ----
-
-    list(APPEND _PLATFORM_GLOBS
         "${PROJECT_SOURCE_DIR}/lib/*/cmake/platform/${FPRIME_PLATFORM}.cmake"
         "${PROJECT_SOURCE_DIR}/*/cmake/platform/${FPRIME_PLATFORM}.cmake"
-    )
-
-    # ---- BACKWARDS COMPATIBILITY ----
-    # TODO: Remove these patterns once all projects have migrated to the standard layout.
-    if (DEFINED FPRIME_LIBRARY_LOCATIONS AND NOT "${FPRIME_LIBRARY_LOCATIONS}" STREQUAL "")
-        foreach(LIBRARY_DIR IN LISTS FPRIME_LIBRARY_LOCATIONS)
-            list(APPEND _PLATFORM_GLOBS "${LIBRARY_DIR}/cmake/platform/${FPRIME_PLATFORM}.cmake")
-        endforeach()
-    endif()
-    # ---- END BACKWARDS COMPATIBILITY (library locations) ----
-
-    list(APPEND _PLATFORM_GLOBS
         "${FPRIME_FRAMEWORK_PATH}/cmake/platform/${FPRIME_PLATFORM}.cmake"
     )
 

--- a/cmake/test/data/TestPlatformResolution/CMakeLists.txt
+++ b/cmake/test/data/TestPlatformResolution/CMakeLists.txt
@@ -1,0 +1,17 @@
+####
+# TestPlatformResolution/CMakeLists.txt:
+#
+# Minimal project used to exercise `fprime_find_platform_file` from platform.cmake.
+####
+cmake_minimum_required(VERSION 3.16)
+project(TestPlatformResolution C CXX)
+
+if (NOT DEFINED FPRIME_FRAMEWORK_PATH)
+    message(FATAL_ERROR "FPRIME_FRAMEWORK_PATH must be set")
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${FPRIME_FRAMEWORK_PATH}/cmake")
+include(platform/platform)
+
+fprime_find_platform_file()
+message(STATUS "[test] PLATFORM_FILE=${FPRIME_CACHED_PLATFORM_FILE}")

--- a/cmake/test/data/TestPlatformResolution/TestSubdirectory/cmake/platform/ProjectSubdirectory.cmake
+++ b/cmake/test/data/TestPlatformResolution/TestSubdirectory/cmake/platform/ProjectSubdirectory.cmake
@@ -1,0 +1,1 @@
+# Test platform discovered under a PROJECT_SOURCE_DIR subdirectory.

--- a/cmake/test/data/TestPlatformResolution/cmake/platform/ProjectDirect.cmake
+++ b/cmake/test/data/TestPlatformResolution/cmake/platform/ProjectDirect.cmake
@@ -1,0 +1,1 @@
+# Test platform discovered directly under PROJECT_SOURCE_DIR.

--- a/cmake/test/data/TestPlatformResolution/lib/TestLibrary/cmake/platform/ProjectLibrary.cmake
+++ b/cmake/test/data/TestPlatformResolution/lib/TestLibrary/cmake/platform/ProjectLibrary.cmake
@@ -1,0 +1,1 @@
+# Test platform discovered under PROJECT_SOURCE_DIR/lib/*.

--- a/cmake/test/src/test_platform.py
+++ b/cmake/test/src/test_platform.py
@@ -1,0 +1,99 @@
+####
+# test_platform.py:
+#
+# Tests for `fprime_find_platform_file` (cmake/platform/platform.cmake).
+#
+####
+import re
+import shutil
+import tempfile
+from pathlib import Path
+
+from . import cmake
+from . import settings
+
+SOURCE_DIRECTORY = settings.DATA_DIR / "TestPlatformResolution"
+PLATFORM_PATTERN = re.compile(r"\[test\] PLATFORM_FILE=(.+)")
+
+
+def run_platform_case(platform, options=None):
+    """Run CMake generation and return the selected platform file, if any."""
+    build_directory = Path(tempfile.mkdtemp())
+    cmake_options = {
+        "FPRIME_FRAMEWORK_PATH": str(settings.FRAMEWORK_PATH),
+        "FPRIME_PLATFORM": platform,
+    }
+    if options:
+        cmake_options.update(options)
+    try:
+        return_code, stdout, _ = cmake.run_cmake(
+            SOURCE_DIRECTORY, build_directory, cmake_options
+        )
+        matches = [PLATFORM_PATTERN.search(line) for line in stdout]
+        platform_files = [Path(match.group(1)).resolve() for match in matches if match]
+        return return_code, platform_files[0] if platform_files else None
+    finally:
+        shutil.rmtree(build_directory, ignore_errors=True)
+
+
+def test_platform_project_direct():
+    """A project-level cmake/platform file is discovered first."""
+    return_code, platform_file = run_platform_case("ProjectDirect")
+    expected = (SOURCE_DIRECTORY / "cmake/platform/ProjectDirect.cmake").resolve()
+    assert return_code == 0, "CMake generation failed"
+    assert platform_file == expected
+
+
+def test_platform_project_library():
+    """A platform file under PROJECT_SOURCE_DIR/lib/* is discovered."""
+    return_code, platform_file = run_platform_case("ProjectLibrary")
+    expected = (
+        SOURCE_DIRECTORY / "lib/TestLibrary/cmake/platform/ProjectLibrary.cmake"
+    ).resolve()
+    assert return_code == 0, "CMake generation failed"
+    assert platform_file == expected
+
+
+def test_platform_project_subdirectory():
+    """A platform file under a project subdirectory is discovered."""
+    return_code, platform_file = run_platform_case("ProjectSubdirectory")
+    expected = (
+        SOURCE_DIRECTORY
+        / "TestSubdirectory/cmake/platform/ProjectSubdirectory.cmake"
+    ).resolve()
+    assert return_code == 0, "CMake generation failed"
+    assert platform_file == expected
+
+
+def test_platform_framework_fallback():
+    """The framework platform directory remains the final fallback."""
+    return_code, platform_file = run_platform_case("Linux")
+    expected = (settings.FRAMEWORK_PATH / "cmake/platform/Linux.cmake").resolve()
+    assert return_code == 0, "CMake generation failed"
+    assert platform_file == expected
+
+
+def test_platform_ignores_fprime_project_root():
+    """FPRIME_PROJECT_ROOT is no longer searched for platform files."""
+    with tempfile.TemporaryDirectory() as legacy_root:
+        legacy_file = Path(legacy_root) / "cmake/platform/LegacyProjectRoot.cmake"
+        legacy_file.parent.mkdir(parents=True)
+        legacy_file.write_text("# legacy platform\n", encoding="utf-8")
+        return_code, platform_file = run_platform_case(
+            "LegacyProjectRoot", {"FPRIME_PROJECT_ROOT": legacy_root}
+        )
+    assert return_code != 0, "Legacy project root should not resolve a platform"
+    assert platform_file is None
+
+
+def test_platform_ignores_fprime_library_locations():
+    """FPRIME_LIBRARY_LOCATIONS is no longer searched for platform files."""
+    with tempfile.TemporaryDirectory() as legacy_library:
+        legacy_file = Path(legacy_library) / "cmake/platform/LegacyLibrary.cmake"
+        legacy_file.parent.mkdir(parents=True)
+        legacy_file.write_text("# legacy platform\n", encoding="utf-8")
+        return_code, platform_file = run_platform_case(
+            "LegacyLibrary", {"FPRIME_LIBRARY_LOCATIONS": legacy_library}
+        )
+    assert return_code != 0, "Legacy library location should not resolve a platform"
+    assert platform_file is None


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5207 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n (CMake docstring updated) |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Removes the obsolete platform discovery fallbacks based on `FPRIME_PROJECT_ROOT` and `FPRIME_LIBRARY_LOCATIONS` from `fprime_find_platform_file`.

Platform resolution now searches only the supported locations, in order:

1. `PROJECT_SOURCE_DIR/cmake/platform`
2. `PROJECT_SOURCE_DIR/lib/*/cmake/platform`
3. `PROJECT_SOURCE_DIR/*/cmake/platform`
4. `FPRIME_FRAMEWORK_PATH/cmake/platform`

Adds focused CMake tests covering each supported resolution path and verifying that the two legacy variables no longer contribute platform locations.

## Rationale

The compatibility search paths were intentionally retained during the convention-based platform-discovery transition and are now obsolete. Removing them completes #5207 and makes platform resolution depend only on the documented project and framework layouts.

## Testing/Review Recommendations

- Added `cmake/test/src/test_platform.py` with six platform-resolution cases.
- The cases cover the three project locations, framework fallback, and both removed compatibility paths.
- The branch is a single commit based directly on the current `devel` head.
- Run `pytest cmake/test/src/test_platform.py` and standard repository CI on the PR branch.

## Future Work

None for this issue.