### PR TITLE
Document FW_ASSERT error handling guidance

### DIFF
--- a/docs/reference/system-functional/system-services.md
+++ b/docs/reference/system-functional/system-services.md
@@ -32,6 +32,8 @@ The Version component tracks and reports version information for the framework, 
 
 The Assert Fatal Adapter intercepts framework-level assertions (FW_ASSERT calls) and converts them into FATAL events within the event system. This bridges the C++ assertion mechanism with the F Prime event architecture, ensuring that assertion failures are captured, logged, and handled through the standard fatal event path.
 
+Assertions are intended to enforce internal invariants and signal unrecoverable conditions, not to replace recoverable error handling. When assertions are compiled out, the condition is not checked at runtime. Components are also not designed to continue safely after a failed assertion if a platform assertion handler returns. Code paths reachable through runtime or external input should validate and handle expected failures explicitly rather than relying on `FW_ASSERT`.
+
 ### Fatal Event Handling
 
 The Fatal Handler component receives fatal event announcements and performs the platform-specific response to unrecoverable errors. The default implementation may log a message and halt. Deployments typically override this with project-specific behavior such as:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5620 |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**| Y |

---
## Change Description

Add `FW_ASSERT` usage guidance to the canonical F´ assertion documentation at `docs/user-manual/framework/assert.md`.

The guidance clarifies that assertions are intended for internal invariants and unrecoverable software conditions, rather than recoverable runtime or externally influenced errors. It also documents the behavior of `FW_NO_ASSERT` for C++ `FW_ASSERT` and C `FW_CASSERT*`, and notes that F Prime components are not engineered to continue safely after a failed assertion if a custom assertion hook returns.

The earlier system-services documentation change has been removed.

## Rationale

Fixes #5620.

This addresses the requested guidance on using assertions for error checking and the maintainer note that F Prime components are not designed to recover from a failed assertion that returns.

## Testing/Review Recommendations

Documentation-only change.

The documented behavior was verified directly against `Fw/Types/Assert.hpp` and `Fw/Types/CAssert.h`. The branch is based on the current `devel` head and changes only the assertion guide.

## Future Work

None.