### PR TITLE
Add fused routing paths to DpWriter

### DIFF
--- a/Svc/DpWriter/DpWriter.cpp
+++ b/Svc/DpWriter/DpWriter.cpp
@@ -33,8 +33,6 @@ void DpWriter::configure(const Fw::ConstStringBase& dpFileNamePrefix) {
 
 void DpWriter::bufferSendIn_handler(const FwIndexType portNum, Fw::Buffer& buffer) {
     Fw::Success::T status = Fw::Success::SUCCESS;
-    // portNum is unused
-    (void)portNum;
     // Update num buffers received
     ++this->m_numBuffersReceived;
     // Check that the buffer is valid
@@ -101,13 +99,13 @@ void DpWriter::bufferSendIn_handler(const FwIndexType portNum, Fw::Buffer& buffe
     if (status == Fw::Success::SUCCESS) {
         status = this->writeFile(container, fileName, fileSize);
     }
-    // Send the DpWritten notification
+    // Send the DpWritten notification on the path matching the input port
     if (status == Fw::Success::SUCCESS) {
-        this->sendNotification(container, fileName, fileSize);
+        this->sendNotification(portNum, container, fileName, fileSize);
     }
-    // Deallocate the buffer
+    // Return the buffer on the path matching the input port
     if (buffer.isValid()) {
-        this->deallocBufferSendOut_out(0, buffer);
+        this->deallocBufferSendOut_out(portNum, buffer);
     }
     // Update the error count
     if (status != Fw::Success::SUCCESS) {
@@ -244,13 +242,14 @@ Fw::Success::T DpWriter::writeFile(const Fw::DpContainer& container,
     return status;
 }
 
-void DpWriter::sendNotification(const Fw::DpContainer& container,
+void DpWriter::sendNotification(FwIndexType portNum,
+                                const Fw::DpContainer& container,
                                 const Fw::FileNameString& fileName,
                                 FwSizeType fileSize) {
-    if (isConnected_dpWrittenOut_OutputPort(0)) {
+    if (isConnected_dpWrittenOut_OutputPort(portNum)) {
         // Get the priority
         const FwDpPriorityType priority = container.getPriority();
-        this->dpWrittenOut_out(0, fileName, priority, fileSize);
+        this->dpWrittenOut_out(portNum, fileName, priority, fileSize);
     }
 }
 

--- a/Svc/DpWriter/DpWriter.fpp
+++ b/Svc/DpWriter/DpWriter.fpp
@@ -14,17 +14,17 @@ module Svc {
     # Ports for handling data products
     # ----------------------------------------------------------------------
 
-    @ Port for receiving data products to write to disk
-    async input port bufferSendIn: Fw.BufferSend
+    @ Ports for receiving data products to write to disk
+    async input port bufferSendIn: [DpWriterNumPorts] Fw.BufferSend
 
     @ Port for processing data products
     output port procBufferSendOut: [DpWriterNumProcPorts] Fw.BufferSend
 
-    @ Port for sending DpWritten notifications
-    output port dpWrittenOut: DpWritten
+    @ Ports for sending DpWritten notifications
+    output port dpWrittenOut: [DpWriterNumPorts] DpWritten
 
-    @ Port for deallocating data product buffers
-    output port deallocBufferSendOut: Fw.BufferSend
+    @ Ports for deallocating data product buffers
+    output port deallocBufferSendOut: [DpWriterNumPorts] Fw.BufferSend
 
     # ----------------------------------------------------------------------
     # F' special ports

--- a/Svc/DpWriter/DpWriter.hpp
+++ b/Svc/DpWriter/DpWriter.hpp
@@ -90,9 +90,10 @@ class DpWriter final : public DpWriterComponentBase {
     );
 
     //! Send the DpWritten notification
-    void sendNotification(const Fw::DpContainer& container,    //!< The container
-                          const Fw::FileNameString& fileName,  //!< The file name
-                          FwSizeType packetSize                //!< The packet size
+    void sendNotification(FwIndexType portNum,                   //!< The routing port number
+                          const Fw::DpContainer& container,       //!< The container
+                          const Fw::FileNameString& fileName,     //!< The file name
+                          FwSizeType packetSize                   //!< The packet size
     );
 
   private:

--- a/Svc/DpWriter/DpWriter.hpp
+++ b/Svc/DpWriter/DpWriter.hpp
@@ -93,7 +93,7 @@ class DpWriter final : public DpWriterComponentBase {
     void sendNotification(FwIndexType portNum,                 //!< The routing port number
                           const Fw::DpContainer& container,    //!< The container
                           const Fw::FileNameString& fileName,  //!< The file name
-                          FwSizeType packetSize                //!< The packet size
+                          FwSizeType fileSize                  //!< The file size
     );
 
   private:

--- a/Svc/DpWriter/DpWriter.hpp
+++ b/Svc/DpWriter/DpWriter.hpp
@@ -20,6 +20,14 @@ namespace Svc {
 class DpWriter final : public DpWriterComponentBase {
     friend class DpWriterTester;
 
+    // Keep the generated routing arrays consistent with the forwarding contract.
+    static_assert(DpWriter::NUM_BUFFERSENDIN_INPUT_PORTS == static_cast<FwSizeType>(DpWriterNumPorts),
+                  "Number of buffer send in ports must equal DpWriterNumPorts");
+    static_assert(DpWriter::NUM_DPWRITTENOUT_OUTPUT_PORTS == static_cast<FwSizeType>(DpWriterNumPorts),
+                  "Number of dp written out ports must equal DpWriterNumPorts");
+    static_assert(DpWriter::NUM_DEALLOCBUFFERSENDOUT_OUTPUT_PORTS == static_cast<FwSizeType>(DpWriterNumPorts),
+                  "Number of dealloc buffer send out ports must equal DpWriterNumPorts");
+
   public:
     // ----------------------------------------------------------------------
     // Construction, initialization, and destruction

--- a/Svc/DpWriter/DpWriter.hpp
+++ b/Svc/DpWriter/DpWriter.hpp
@@ -90,10 +90,10 @@ class DpWriter final : public DpWriterComponentBase {
     );
 
     //! Send the DpWritten notification
-    void sendNotification(FwIndexType portNum,                   //!< The routing port number
-                          const Fw::DpContainer& container,       //!< The container
-                          const Fw::FileNameString& fileName,     //!< The file name
-                          FwSizeType packetSize                   //!< The packet size
+    void sendNotification(FwIndexType portNum,                 //!< The routing port number
+                          const Fw::DpContainer& container,    //!< The container
+                          const Fw::FileNameString& fileName,  //!< The file name
+                          FwSizeType packetSize                //!< The packet size
     );
 
   private:

--- a/Svc/DpWriter/docs/sdd.md
+++ b/Svc/DpWriter/docs/sdd.md
@@ -29,13 +29,14 @@ receive this notification and use it to update the data product catalog.
 
 Requirement | Description | Rationale | Verification Method
 ----------- | ----------- | ----------| -------------------
-SVC-DPWRITER-001 | `Svc::DpWriter` shall provide a port for receiving `Fw::Buffer` objects pointing to filled data product containers. | The purpose of `DpWriter` is to write the data products to disk. | Unit Test
+SVC-DPWRITER-001 | `Svc::DpWriter` shall provide an array of ports for receiving `Fw::Buffer` objects pointing to filled data product containers. | The purpose of `DpWriter` is to write the data products to disk and the array permits multiple independent routing paths. | Unit Test
 SVC-DPWRITER-002 | `Svc::DpWriter` shall provide an array of ports for sending `Fw::Buffer` objects for processing. | This requirement supports downstream processing of the data in the buffer. | Unit Test
 SVC-DPWRITER-003 | On receiving a data product container _C_, `Svc::DpWriter` shall use the processing type field of the header of _C_ to select zero or more processing ports to invoke, in port order. | The processing type field is a bit mask. A one in bit `2^n` in the bit mask selects port index `n`. | Unit Test
 SVC-DPWRITER-004 | On receiving an `Fw::Buffer` _B_, and after performing any requested processing on _B_, `Svc::DpWriter` shall write _B_ to disk. | The purpose of `DpWriter` is to write data products to the disk. | Unit Test
-SVC-DPWRITER-005 | `Svc::DpWriter` shall provide a port for notifying other components that data products have been written. | This requirement allows `Svc::DpCatalog` or a similar component to update its catalog in real time. | Unit Test
+SVC-DPWRITER-005 | `Svc::DpWriter` shall provide an array of ports for notifying other components that data products have been written. A notification shall use the same routing port index as the corresponding input buffer. | This requirement allows `Svc::DpCatalog` or a similar component to update its catalog in real time while preserving fused-instance routing. | Unit Test
 SVC-DPWRITER-006 | `Svc::DpManager` shall provide telemetry that reports the number of buffers received, the number of data products written, the number of bytes written, the number of failed writes, and the number of errors. | This requirement establishes the telemetry interface for the component. | Unit test
 SVC-DPWRITER-007 | On receiving an `Fw::Buffer` _B_, and after performing any requested processing on _B_, `Svc::DpWriter` shall re-parse the container header and shrink the size of the product. | Allows processing interfaces to compress data products and communicate that compressed state back to `Svc::DpWriter`. | Unit Test
+SVC-DPWRITER-008 | `Svc::DpWriter` shall return each valid received buffer on the `deallocBufferSendOut` port whose index matches the `bufferSendIn` port that received it. | Matching send and return paths allows a fused `DpWriter` instance to route buffers back toward the correct allocator. | Unit Test
 
 ## 3. Design
 
@@ -52,14 +53,16 @@ The diagram below shows the `DpWriter` component.
 | Kind | Name | Port Type | Usage |
 |------|------|-----------|-------|
 | `async input` | `schedIn` | `Svc.Sched` | Schedule in port |
-| `async input` | `bufferSendIn` | `Fw.BufferSend` | Port for receiving data products to write to disk |
+| `async input` | `bufferSendIn` | `[DpWriterNumPorts] Fw.BufferSend` | Ports for receiving data products to write to disk |
 | `output` | `procBufferSendOut` | `[DpWriterNumProcPorts] Fw.BufferSend` | Port for processing data products |
-| `output` | `dpWrittenOut` | `DpWritten` | Port for sending `DpWritten` notifications |
-| `output` | `deallocBufferSendOut` | `Fw.BufferSend` | Port for deallocating data product buffers |
+| `output` | `dpWrittenOut` | `[DpWriterNumPorts] DpWritten` | Ports for sending `DpWritten` notifications |
+| `output` | `deallocBufferSendOut` | `[DpWriterNumPorts] Fw.BufferSend` | Ports for returning data product buffers |
 | `time get` | `timeGetOut` | `Fw.Time` | Time get port |
 | `telemetry` | `tlmOut` | `Fw.Tlm` | Telemetry port |
 | `event` | `eventOut` | `Fw.Log` | Event port |
 | `text event` | `textEventOut` | `Fw.LogText` | Text event port |
+
+The `bufferSendIn`, `dpWrittenOut`, and `deallocBufferSendOut` arrays form matching routing paths. A buffer received at index _N_ is notified and returned through index _N_.
 
 ### 3.3. State
 
@@ -70,6 +73,11 @@ The diagram below shows the `DpWriter` component.
 1. `numBytes (U64)`: The number of bytes written.
 
 ### 3.4. Compile-Time Setup
+
+1. The configuration constant [`DpWriterNumPorts`](../../../default/config/AcConstants.fpp)
+   specifies the number of matched input, notification, and buffer-return routing paths.
+   Its default value is one, preserving the one-to-one `DpManager` to `DpWriter` pattern.
+   Projects that fuse several logical writer paths into one instance can override this value.
 
 1. The configuration constant [`DpWriterNumProcPorts`](../../../default/config/AcConstants.fpp)
    specifies the number of ports for connecting components that perform
@@ -96,7 +104,7 @@ This handler sends out the state variables as telemetry.
 
 #### 3.6.2. bufferSendIn
 
-This handler receives a mutable reference to a buffer `B`.
+This handler receives a mutable reference to a buffer `B` on routing port _N_.
 It does the following:
 
 1. Check that `B` is valid. If not, emit a warning event.
@@ -122,8 +130,8 @@ It does the following:
       memory pointed to by `B`. Let the resulting bit mask be `M`.
 
    1. Visit the port numbers of `procBufferSendOut` in order.
-      For each port number `N`, if `N` is set in `M`, then invoke
-      `procBufferSendOut` at port number `N`, passing in `B`.
+      For each port number `P`, if `P` is set in `M`, then invoke
+      `procBufferSendOut` at port number `P`, passing in `B`.
       This step updates the memory pointed to by `B` in place.
 
    1. Re-parse the container header pointed to by `B`. If necessary,
@@ -134,10 +142,10 @@ It does the following:
       Format**](#file_format) section. For the time stamp, use the time
       provided by `timeGetOut`.
 
-1. If the file write succeeded and `dpWrittenOut` is connected, then send the
-   file name, priority, and file size out on `dpWrittenOut`.
+1. If the file write succeeded and `dpWrittenOut[N]` is connected, then send the
+   file name, priority, and file size out on `dpWrittenOut[N]`.
 
-1. If `B` is valid, then send `B` on `deallocBufferSendOut`.
+1. If `B` is valid, then send `B` on `deallocBufferSendOut[N]`.
 
 <a name="file_format"></a>
 ## 4. File Format

--- a/Svc/DpWriter/docs/sdd.md
+++ b/Svc/DpWriter/docs/sdd.md
@@ -29,14 +29,14 @@ receive this notification and use it to update the data product catalog.
 
 Requirement | Description | Rationale | Verification Method
 ----------- | ----------- | ----------| -------------------
-SVC-DPWRITER-001 | `Svc::DpWriter` shall provide an array of ports for receiving `Fw::Buffer` objects pointing to filled data product containers. | The purpose of `DpWriter` is to write the data products to disk and the array permits multiple independent routing paths. | Unit Test
+SVC-DPWRITER-001 | `Svc::DpWriter` shall provide an array of ports for receiving `Fw::Buffer` objects pointing to filled data product containers. | The purpose of `DpWriter` is to write the data products to disk. The array permits the fusion of multiple logical writer components with separate routing paths into a single component. This fusion increases resource efficiency (it requires fewer component instances and threads), but it restricts concurrency by forcing sequential execution of all routing paths on the same thread. The component allows developers to manage this tradeoff. | Unit Test
 SVC-DPWRITER-002 | `Svc::DpWriter` shall provide an array of ports for sending `Fw::Buffer` objects for processing. | This requirement supports downstream processing of the data in the buffer. | Unit Test
 SVC-DPWRITER-003 | On receiving a data product container _C_, `Svc::DpWriter` shall use the processing type field of the header of _C_ to select zero or more processing ports to invoke, in port order. | The processing type field is a bit mask. A one in bit `2^n` in the bit mask selects port index `n`. | Unit Test
 SVC-DPWRITER-004 | On receiving an `Fw::Buffer` _B_, and after performing any requested processing on _B_, `Svc::DpWriter` shall write _B_ to disk. | The purpose of `DpWriter` is to write data products to the disk. | Unit Test
-SVC-DPWRITER-005 | `Svc::DpWriter` shall provide an array of ports for notifying other components that data products have been written. A notification shall use the same routing port index as the corresponding input buffer. | This requirement allows `Svc::DpCatalog` or a similar component to update its catalog in real time while preserving fused-instance routing. | Unit Test
+SVC-DPWRITER-005 | `Svc::DpWriter` shall provide an array of ports for notifying other components that data products have been written. A notification shall use the same routing port index as the corresponding input buffer. | The notification output allows `Svc::DpCatalog` or a similar component to update a data product catalog in real time. It is possible to notify a single instance of `Svc::DpCatalog` of all outputs, by connecting all the output ports of `Svc::DpWriter` to that component. It is also possible to notify different components via the different output ports. The array preserves symmetry across the port behaviors of this component (input, buffer return, and notification). | Unit Test
 SVC-DPWRITER-006 | `Svc::DpManager` shall provide telemetry that reports the number of buffers received, the number of data products written, the number of bytes written, the number of failed writes, and the number of errors. | This requirement establishes the telemetry interface for the component. | Unit test
 SVC-DPWRITER-007 | On receiving an `Fw::Buffer` _B_, and after performing any requested processing on _B_, `Svc::DpWriter` shall re-parse the container header and shrink the size of the product. | Allows processing interfaces to compress data products and communicate that compressed state back to `Svc::DpWriter`. | Unit Test
-SVC-DPWRITER-008 | `Svc::DpWriter` shall return each valid received buffer on the `deallocBufferSendOut` port whose index matches the `bufferSendIn` port that received it. | Matching send and return paths allows a fused `DpWriter` instance to route buffers back toward the correct allocator. | Unit Test
+SVC-DPWRITER-008 | `Svc::DpWriter` shall return each valid received buffer on the `deallocBufferSendOut` port whose index matches the `bufferSendIn` port that received it. | Matching send and return paths allows a `DpWriter` instance to route buffers back toward the correct allocator. | Unit Test
 
 ## 3. Design
 
@@ -76,8 +76,8 @@ The `bufferSendIn`, `dpWrittenOut`, and `deallocBufferSendOut` arrays form match
 
 1. The configuration constant [`DpWriterNumPorts`](../../../default/config/AcConstants.fpp)
    specifies the number of matched input, notification, and buffer-return routing paths.
-   Its default value is one, preserving the one-to-one `DpManager` to `DpWriter` pattern.
-   Projects that fuse several logical writer paths into one instance can override this value.
+   Its default value is five, matching the default `DpManagerNumPorts` configuration.
+   Projects can override this value to fit their topology.
 
 1. The configuration constant [`DpWriterNumProcPorts`](../../../default/config/AcConstants.fpp)
    specifies the number of ports for connecting components that perform

--- a/Svc/DpWriter/docs/sdd.md
+++ b/Svc/DpWriter/docs/sdd.md
@@ -62,7 +62,7 @@ The diagram below shows the `DpWriter` component.
 | `event` | `eventOut` | `Fw.Log` | Event port |
 | `text event` | `textEventOut` | `Fw.LogText` | Text event port |
 
-The `bufferSendIn`, `dpWrittenOut`, and `deallocBufferSendOut` arrays form matching routing paths. A buffer received at index _N_ is notified and returned through index _N_.
+The `bufferSendIn`, `dpWrittenOut`, and `deallocBufferSendOut` arrays form matching routing paths. A buffer received at index _N_ is notified and returned through index _N_. Topologies must connect `deallocBufferSendOut[N]` for every connected `bufferSendIn[N]`; the buffer return is unconditional and invoking an unconnected return port asserts. `dpWrittenOut[N]` may be left unconnected.
 
 ### 3.3. State
 
@@ -77,7 +77,9 @@ The `bufferSendIn`, `dpWrittenOut`, and `deallocBufferSendOut` arrays form match
 1. The configuration constant [`DpWriterNumPorts`](../../../default/config/AcConstants.fpp)
    specifies the number of matched input, notification, and buffer-return routing paths.
    Its default value is five, matching the default `DpManagerNumPorts` configuration.
-   Projects can override this value to fit their topology.
+   Projects can override this value to fit their topology. All routing paths share one
+   message queue, so the instance `queue size` must be at least the sum over all connected
+   paths of the maximum buffers that can be in flight on each path; a full queue asserts.
 
 1. The configuration constant [`DpWriterNumProcPorts`](../../../default/config/AcConstants.fpp)
    specifies the number of ports for connecting components that perform

--- a/Svc/DpWriter/docs/sdd.md
+++ b/Svc/DpWriter/docs/sdd.md
@@ -34,7 +34,7 @@ SVC-DPWRITER-002 | `Svc::DpWriter` shall provide an array of ports for sending `
 SVC-DPWRITER-003 | On receiving a data product container _C_, `Svc::DpWriter` shall use the processing type field of the header of _C_ to select zero or more processing ports to invoke, in port order. | The processing type field is a bit mask. A one in bit `2^n` in the bit mask selects port index `n`. | Unit Test
 SVC-DPWRITER-004 | On receiving an `Fw::Buffer` _B_, and after performing any requested processing on _B_, `Svc::DpWriter` shall write _B_ to disk. | The purpose of `DpWriter` is to write data products to the disk. | Unit Test
 SVC-DPWRITER-005 | `Svc::DpWriter` shall provide an array of ports for notifying other components that data products have been written. A notification shall use the same routing port index as the corresponding input buffer. | The notification output allows `Svc::DpCatalog` or a similar component to update a data product catalog in real time. It is possible to notify a single instance of `Svc::DpCatalog` of all outputs, by connecting all the output ports of `Svc::DpWriter` to that component. It is also possible to notify different components via the different output ports. The array preserves symmetry across the port behaviors of this component (input, buffer return, and notification). | Unit Test
-SVC-DPWRITER-006 | `Svc::DpManager` shall provide telemetry that reports the number of buffers received, the number of data products written, the number of bytes written, the number of failed writes, and the number of errors. | This requirement establishes the telemetry interface for the component. | Unit test
+SVC-DPWRITER-006 | `Svc::DpWriter` shall provide telemetry that reports the number of buffers received, the number of data products written, the number of bytes written, the number of failed writes, and the number of errors. | This requirement establishes the telemetry interface for the component. | Unit test
 SVC-DPWRITER-007 | On receiving an `Fw::Buffer` _B_, and after performing any requested processing on _B_, `Svc::DpWriter` shall re-parse the container header and shrink the size of the product. | Allows processing interfaces to compress data products and communicate that compressed state back to `Svc::DpWriter`. | Unit Test
 SVC-DPWRITER-008 | `Svc::DpWriter` shall return each valid received buffer on the `deallocBufferSendOut` port whose index matches the `bufferSendIn` port that received it. | Matching send and return paths allows a `DpWriter` instance to route buffers back toward the correct allocator. | Unit Test
 
@@ -68,9 +68,15 @@ The `bufferSendIn`, `dpWrittenOut`, and `deallocBufferSendOut` arrays form match
 
 `DpWriter` maintains the following state:
 
-1. `numDataProducts (U32)`: The number of data products written.
+| Member | Type | Description |
+| --- | --- | --- |
+| `m_numBuffersReceived` | `U32` | The number of buffers received |
+| `m_numBytesWritten` | `U64` | The number of bytes written |
+| `m_numSuccessfulWrites` | `U32` | The number of successful writes |
+| `m_numFailedWrites` | `U32` | The number of failed writes |
+| `m_numErrors` | `U32` | The number of errors |
 
-1. `numBytes (U64)`: The number of bytes written.
+The component also retains its configured file-name prefix in `m_dpFileNamePrefix`.
 
 ### 3.4. Compile-Time Setup
 
@@ -78,8 +84,11 @@ The `bufferSendIn`, `dpWrittenOut`, and `deallocBufferSendOut` arrays form match
    specifies the number of matched input, notification, and buffer-return routing paths.
    Its default value is five, matching the default `DpManagerNumPorts` configuration.
    Projects can override this value to fit their topology. All routing paths share one
-   message queue, so the instance `queue size` must be at least the sum over all connected
-   paths of the maximum buffers that can be in flight on each path; a full queue asserts.
+   message queue with `schedIn` and the asynchronous `CLEAR_EVENT_THROTTLE` command.
+   Size the queue for the sum of the maximum queued buffers across all connected paths,
+   plus the maximum pending scheduler ticks and commands. If at most one tick and one
+   command can be pending, reserve at least two additional slots; deployments permitting
+   larger bursts must reserve more. A full queue asserts.
 
 1. The configuration constant [`DpWriterNumProcPorts`](../../../default/config/AcConstants.fpp)
    specifies the number of ports for connecting components that perform
@@ -188,18 +197,25 @@ Typically it is a directory path prefix.
 
 | Name | Type | Description |
 |------|------|-------------|
-| `NumDataProducts` | `U32` | The number of data products handled |
-| `NumBytes` | `U64` | The number of bytes handled |
+| `NumBuffersReceived` | `U32` | The number of buffers received |
+| `NumBytesWritten` | `U64` | The number of bytes written |
+| `NumSuccessfulWrites` | `U32` | The number of successful writes |
+| `NumFailedWrites` | `U32` | The number of failed writes |
+| `NumErrors` | `U32` | The number of errors |
 
 ### 5.3. Events
 
 | Name | Severity | Description |
 |------|----------|-------------|
-| `BufferInvalid` | `warning high` | Incoming buffer is invalid |
-| `BufferTooSmall` | `warning high` | Incoming buffer is too small to hold a data product container |
-| `InvalidPacketDescriptor` | `warning high` | Incoming buffer has an invalid packet descriptor |
+| `InvalidBuffer` | `warning high` | Incoming buffer is invalid |
+| `BufferTooSmallForPacket` | `warning high` | Incoming buffer is too small to hold a data product packet |
+| `InvalidHeaderHash` | `warning high` | Incoming buffer has an invalid header hash |
+| `InvalidHeader` | `warning high` | An error occurred while deserializing the packet header |
+| `BufferTooSmallForData` | `warning high` | Buffer is too small for the data size specified in the header |
+| `FileNameFormatError` | `warning high` | An error occurred when formatting a file name |
 | `FileOpenError` | `warning high` | An error occurred when opening a file |
 | `FileWriteError` | `warning high` | An error occurred when writing to a file |
+| `FileWritten` | `activity low` | A data product file was written |
 
 ## 6. Example Uses
 

--- a/Svc/DpWriter/test/ut/AbstractState.hpp
+++ b/Svc/DpWriter/test/ut/AbstractState.hpp
@@ -52,7 +52,9 @@ class AbstractState {
           m_NumSuccessfulWrites(0),
           m_NumErrors(0),
           m_procTypes(0),
-          m_procShrinkDataSizeOpt() {}
+          m_procShrinkDataSizeOpt(),
+          m_dpWrittenOutPortNumOpt(),
+          m_deallocBufferSendOutPortNumOpt() {}
 
   public:
     // ----------------------------------------------------------------------
@@ -136,6 +138,12 @@ class AbstractState {
     Fw::DpCfg::ProcType::SerialType m_procTypes;
 
     Fw::Optional<FwSizeType> m_procShrinkDataSizeOpt;
+
+    //! The last routing port used for DpWritten notification
+    Fw::Optional<FwIndexType> m_dpWrittenOutPortNumOpt;
+
+    //! The last routing port used to return a buffer
+    Fw::Optional<FwIndexType> m_deallocBufferSendOutPortNumOpt;
 };
 
 }  // namespace Svc

--- a/Svc/DpWriter/test/ut/DpWriterTestMain.cpp
+++ b/Svc/DpWriter/test/ut/DpWriterTestMain.cpp
@@ -78,15 +78,6 @@ TEST(BufferSendIn, OK) {
     tester.OK();
 }
 
-TEST(BufferSendIn, RoutingPorts) {
-    COMMENT("Verify fused DpWriter routing paths preserve the input port index.");
-    REQUIREMENT("SVC-DPWRITER-001");
-    REQUIREMENT("SVC-DPWRITER-005");
-    REQUIREMENT("SVC-DPWRITER-008");
-    BufferSendIn::Tester tester;
-    tester.RoutingPorts();
-}
-
 TEST(BufferSendIn, OKProcShrink) {
     COMMENT("Invoke bufferSendIn with nominal input. Shrink the buffer in processing");
     REQUIREMENT("SVC-DPMANAGER-002");
@@ -95,6 +86,15 @@ TEST(BufferSendIn, OKProcShrink) {
     REQUIREMENT("SVC-DPMANAGER-007");
     BufferSendIn::Tester tester;
     tester.OKProcShrink();
+}
+
+TEST(BufferSendIn, RoutingPorts) {
+    COMMENT("Verify fused DpWriter routing paths preserve the input port index.");
+    REQUIREMENT("SVC-DPWRITER-001");
+    REQUIREMENT("SVC-DPWRITER-005");
+    REQUIREMENT("SVC-DPWRITER-008");
+    BufferSendIn::Tester tester;
+    tester.RoutingPorts();
 }
 
 TEST(CLEAR_EVENT_THROTTLE, OK) {

--- a/Svc/DpWriter/test/ut/DpWriterTestMain.cpp
+++ b/Svc/DpWriter/test/ut/DpWriterTestMain.cpp
@@ -78,6 +78,15 @@ TEST(BufferSendIn, OK) {
     tester.OK();
 }
 
+TEST(BufferSendIn, RoutingPorts) {
+    COMMENT("Verify fused DpWriter routing paths preserve the input port index.");
+    REQUIREMENT("SVC-DPWRITER-001");
+    REQUIREMENT("SVC-DPWRITER-005");
+    REQUIREMENT("SVC-DPWRITER-008");
+    BufferSendIn::Tester tester;
+    tester.RoutingPorts();
+}
+
 TEST(BufferSendIn, OKProcShrink) {
     COMMENT("Invoke bufferSendIn with nominal input. Shrink the buffer in processing");
     REQUIREMENT("SVC-DPMANAGER-002");

--- a/Svc/DpWriter/test/ut/DpWriterTester.cpp
+++ b/Svc/DpWriter/test/ut/DpWriterTester.cpp
@@ -46,6 +46,19 @@ void DpWriterTester::from_procBufferSendOut_handler(FwIndexType portNum, Fw::Buf
     }
 }
 
+void DpWriterTester::from_dpWrittenOut_handler(FwIndexType portNum,
+                                               const Fw::FileNameString& fileName,
+                                               FwDpPriorityType priority,
+                                               FwSizeType fileSize) {
+    this->abstractState.m_dpWrittenOutPortNumOpt = Fw::Optional<FwIndexType>(portNum);
+    this->pushFromPortEntry_dpWrittenOut(fileName, priority, fileSize);
+}
+
+void DpWriterTester::from_deallocBufferSendOut_handler(FwIndexType portNum, Fw::Buffer& buffer) {
+    this->abstractState.m_deallocBufferSendOutPortNumOpt = Fw::Optional<FwIndexType>(portNum);
+    this->pushFromPortEntry_deallocBufferSendOut(buffer);
+}
+
 // ----------------------------------------------------------------------
 // Public member functions
 // ----------------------------------------------------------------------

--- a/Svc/DpWriter/test/ut/DpWriterTester.cpp
+++ b/Svc/DpWriter/test/ut/DpWriterTester.cpp
@@ -47,7 +47,7 @@ void DpWriterTester::from_procBufferSendOut_handler(FwIndexType portNum, Fw::Buf
 }
 
 void DpWriterTester::from_dpWrittenOut_handler(FwIndexType portNum,
-                                               const Fw::FileNameString& fileName,
+                                               const Fw::StringBase& fileName,
                                                FwDpPriorityType priority,
                                                FwSizeType fileSize) {
     this->abstractState.m_dpWrittenOutPortNumOpt = Fw::Optional<FwIndexType>(portNum);

--- a/Svc/DpWriter/test/ut/DpWriterTester.hpp
+++ b/Svc/DpWriter/test/ut/DpWriterTester.hpp
@@ -49,6 +49,18 @@ class DpWriterTester : public DpWriterGTestBase {
                                         Fw::Buffer& fwBuffer  //!< The buffer
                                         ) final;
 
+    //! Handler implementation for dpWrittenOut
+    void from_dpWrittenOut_handler(FwIndexType portNum,                 //!< The port number
+                                   const Fw::FileNameString& fileName,  //!< The file name
+                                   FwDpPriorityType priority,           //!< The priority
+                                   FwSizeType fileSize                  //!< The file size
+                                   ) final;
+
+    //! Handler implementation for deallocBufferSendOut
+    void from_deallocBufferSendOut_handler(FwIndexType portNum,  //!< The port number
+                                           Fw::Buffer& buffer    //!< The buffer
+                                           ) final;
+
   public:
     // ----------------------------------------------------------------------
     // Public member functions

--- a/Svc/DpWriter/test/ut/DpWriterTester.hpp
+++ b/Svc/DpWriter/test/ut/DpWriterTester.hpp
@@ -50,10 +50,10 @@ class DpWriterTester : public DpWriterGTestBase {
                                         ) final;
 
     //! Handler implementation for dpWrittenOut
-    void from_dpWrittenOut_handler(FwIndexType portNum,                 //!< The port number
-                                   const Fw::FileNameString& fileName,  //!< The file name
-                                   FwDpPriorityType priority,           //!< The priority
-                                   FwSizeType fileSize                  //!< The file size
+    void from_dpWrittenOut_handler(FwIndexType portNum,             //!< The port number
+                                   const Fw::StringBase& fileName,  //!< The file name
+                                   FwDpPriorityType priority,       //!< The priority
+                                   FwSizeType fileSize              //!< The file size
                                    ) final;
 
     //! Handler implementation for deallocBufferSendOut

--- a/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
+++ b/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
@@ -481,6 +481,7 @@ void TestState::testRoutingPorts() {
 
         ASSERT_from_dpWrittenOut_SIZE(1);
         ASSERT_from_deallocBufferSendOut_SIZE(1);
+        ASSERT_from_deallocBufferSendOut(0, buffer);
         ASSERT_TRUE(this->abstractState.m_dpWrittenOutPortNumOpt.has_value());
         ASSERT_TRUE(this->abstractState.m_deallocBufferSendOutPortNumOpt.has_value());
         ASSERT_EQ(this->abstractState.m_dpWrittenOutPortNumOpt.value(), portNum);

--- a/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
+++ b/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
@@ -16,6 +16,7 @@
 #include "STest/Pick/Pick.hpp"
 #include "Svc/DpWriter/test/ut/Rules/BufferSendIn.hpp"
 #include "Svc/DpWriter/test/ut/Rules/Testers.hpp"
+#include "config/FppConstantsAc.hpp"
 
 namespace Svc {
 
@@ -466,6 +467,27 @@ void TestState ::action__BufferSendIn__FileWriteError() {
 // Non-rule tests
 // ----------------------------------------------------------------------
 
+void TestState::testRoutingPorts() {
+    auto& fileData = Os::Stub::File::Test::StaticData::data;
+    for (FwIndexType portNum = 0; portNum < DpWriterNumPorts; ++portNum) {
+        this->clearHistory();
+        this->abstractState.m_dpWrittenOutPortNumOpt.reset();
+        this->abstractState.m_deallocBufferSendOutPortNumOpt.reset();
+        fileData.pointer = 0;
+
+        Fw::Buffer buffer = this->abstractState.getDpBuffer();
+        this->invoke_to_bufferSendIn(portNum, buffer);
+        this->doDispatch();
+
+        ASSERT_from_dpWrittenOut_SIZE(1);
+        ASSERT_from_deallocBufferSendOut_SIZE(1);
+        ASSERT_TRUE(this->abstractState.m_dpWrittenOutPortNumOpt.has_value());
+        ASSERT_TRUE(this->abstractState.m_deallocBufferSendOutPortNumOpt.has_value());
+        ASSERT_EQ(this->abstractState.m_dpWrittenOutPortNumOpt.value(), portNum);
+        ASSERT_EQ(this->abstractState.m_deallocBufferSendOutPortNumOpt.value(), portNum);
+    }
+}
+
 void TestState ::testFileNameFormatError() {
     // Configure a prefix that fills the file name string, forcing a format overflow
     Fw::FileNameString prefix;
@@ -518,6 +540,11 @@ void Tester::FileOpenError() {
 void Tester::FileWriteError() {
     Testers::fileWriteStatus.ruleError.apply(this->testState);
     this->ruleFileWriteError.apply(this->testState);
+    this->testState.printEvents();
+}
+
+void Tester::RoutingPorts() {
+    this->testState.testRoutingPorts();
     this->testState.printEvents();
 }
 

--- a/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
+++ b/Svc/DpWriter/test/ut/Rules/BufferSendIn.cpp
@@ -467,28 +467,6 @@ void TestState ::action__BufferSendIn__FileWriteError() {
 // Non-rule tests
 // ----------------------------------------------------------------------
 
-void TestState::testRoutingPorts() {
-    auto& fileData = Os::Stub::File::Test::StaticData::data;
-    for (FwIndexType portNum = 0; portNum < DpWriterNumPorts; ++portNum) {
-        this->clearHistory();
-        this->abstractState.m_dpWrittenOutPortNumOpt.reset();
-        this->abstractState.m_deallocBufferSendOutPortNumOpt.reset();
-        fileData.pointer = 0;
-
-        Fw::Buffer buffer = this->abstractState.getDpBuffer();
-        this->invoke_to_bufferSendIn(portNum, buffer);
-        this->doDispatch();
-
-        ASSERT_from_dpWrittenOut_SIZE(1);
-        ASSERT_from_deallocBufferSendOut_SIZE(1);
-        ASSERT_from_deallocBufferSendOut(0, buffer);
-        ASSERT_TRUE(this->abstractState.m_dpWrittenOutPortNumOpt.has_value());
-        ASSERT_TRUE(this->abstractState.m_deallocBufferSendOutPortNumOpt.has_value());
-        ASSERT_EQ(this->abstractState.m_dpWrittenOutPortNumOpt.value(), portNum);
-        ASSERT_EQ(this->abstractState.m_deallocBufferSendOutPortNumOpt.value(), portNum);
-    }
-}
-
 void TestState ::testFileNameFormatError() {
     // Configure a prefix that fills the file name string, forcing a format overflow
     Fw::FileNameString prefix;
@@ -508,6 +486,28 @@ void TestState ::testFileNameFormatError() {
         } else {
             ASSERT_EVENTS_SIZE(0);
         }
+    }
+}
+
+void TestState::testRoutingPorts() {
+    auto& fileData = Os::Stub::File::Test::StaticData::data;
+    for (FwIndexType portNum = 0; portNum < DpWriterNumPorts; ++portNum) {
+        this->clearHistory();
+        this->abstractState.m_dpWrittenOutPortNumOpt.reset();
+        this->abstractState.m_deallocBufferSendOutPortNumOpt.reset();
+        fileData.pointer = 0;
+
+        Fw::Buffer buffer = this->abstractState.getDpBuffer();
+        this->invoke_to_bufferSendIn(portNum, buffer);
+        this->doDispatch();
+
+        ASSERT_from_dpWrittenOut_SIZE(1);
+        ASSERT_from_deallocBufferSendOut_SIZE(1);
+        ASSERT_from_deallocBufferSendOut(0, buffer);
+        ASSERT_TRUE(this->abstractState.m_dpWrittenOutPortNumOpt.has_value());
+        ASSERT_TRUE(this->abstractState.m_deallocBufferSendOutPortNumOpt.has_value());
+        ASSERT_EQ(this->abstractState.m_dpWrittenOutPortNumOpt.value(), portNum);
+        ASSERT_EQ(this->abstractState.m_deallocBufferSendOutPortNumOpt.value(), portNum);
     }
 }
 
@@ -544,11 +544,6 @@ void Tester::FileWriteError() {
     this->testState.printEvents();
 }
 
-void Tester::RoutingPorts() {
-    this->testState.testRoutingPorts();
-    this->testState.printEvents();
-}
-
 void Tester::InvalidBuffer() {
     this->ruleInvalidBuffer.apply(this->testState);
     this->testState.printEvents();
@@ -571,6 +566,11 @@ void Tester::OK() {
 
 void Tester::OKProcShrink() {
     this->ruleOKProcShrink.apply(this->testState);
+    this->testState.printEvents();
+}
+
+void Tester::RoutingPorts() {
+    this->testState.testRoutingPorts();
     this->testState.printEvents();
 }
 

--- a/Svc/DpWriter/test/ut/Rules/BufferSendIn.hpp
+++ b/Svc/DpWriter/test/ut/Rules/BufferSendIn.hpp
@@ -55,6 +55,9 @@ class Tester {
     //! File write error
     void FileWriteError();
 
+    //! Routing ports
+    void RoutingPorts();
+
   public:
     // ----------------------------------------------------------------------
     // Rules

--- a/Svc/DpWriter/test/ut/TestState/TestState.hpp
+++ b/Svc/DpWriter/test/ut/TestState/TestState.hpp
@@ -49,6 +49,9 @@ class TestState : public DpWriterTester {
 
     //! Test the FileNameFormatError event and its throttle
     void testFileNameFormatError();
+
+    //! Test that all fused routing ports preserve the input port index
+    void testRoutingPorts();
 };
 
 }  // namespace Svc

--- a/Svc/Subtopologies/DataProducts/docs/sdd.md
+++ b/Svc/Subtopologies/DataProducts/docs/sdd.md
@@ -29,9 +29,14 @@ The **DataProducts subtopology** packages the standard F´ data product services
 
 * `dpMgr.bufferGetOut -> dpBufferManager.bufferGetCallee` — product buffer allocation.
 * `dpMgr.productSendOut -> dpBufferAccumulator.bufferSendInFill` — filled products enter the accumulator.
-* `dpBufferAccumulator.bufferSendOutDrain -> dpWriter.bufferSendIn` — accumulated products drain to the writer.
-* `dpWriter.deallocBufferSendOut -> dpBufferAccumulator.bufferSendInReturn` and `dpBufferAccumulator.bufferSendOutReturn -> dpBufferManager.bufferSendIn` — written buffers return to the buffer manager.
-* `dpWriter.dpWrittenOut -> dpCat.addToCat` — written products are added to the catalog.
+* `dpBufferAccumulator.bufferSendOutDrain -> dpWriter.bufferSendIn[0]` — accumulated products drain to the writer.
+* `dpWriter.deallocBufferSendOut[0] -> dpBufferAccumulator.bufferSendInReturn` and `dpBufferAccumulator.bufferSendOutReturn -> dpBufferManager.bufferSendIn` — written buffers return to the buffer manager.
+* `dpWriter.dpWrittenOut[0] -> dpCat.addToCat` — written products are added to the catalog.
+
+The default internal wiring uses writer routing index `0`. Custom fused wiring must
+keep each input, buffer-return, and connected notification path on the same index.
+Every connected `bufferSendIn[N]` requires a connected `deallocBufferSendOut[N]`;
+`dpWrittenOut[N]` is optional.
 
 ### 2.3 Configuration Hooks inside the Subtopology
 

--- a/default/config/AcConstants.fpp
+++ b/default/config/AcConstants.fpp
@@ -45,6 +45,9 @@ constant BufferRepeaterOutputPorts = 10
 @ Size of port array for DpManager
 constant DpManagerNumPorts = 5
 
+@ Size of data product routing port arrays for DpWriter
+constant DpWriterNumPorts = 1
+
 @ Size of processing port array for DpWriter
 constant DpWriterNumProcPorts = 5
 

--- a/default/config/AcConstants.fpp
+++ b/default/config/AcConstants.fpp
@@ -46,7 +46,7 @@ constant BufferRepeaterOutputPorts = 10
 constant DpManagerNumPorts = 5
 
 @ Size of data product routing port arrays for DpWriter
-constant DpWriterNumPorts = 1
+constant DpWriterNumPorts = 5
 
 @ Size of processing port array for DpWriter
 constant DpWriterNumProcPorts = 5


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4841 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Add matched routing port arrays to `Svc::DpWriter` so one component instance can support fused data-product paths.

- add `DpWriterNumPorts`, defaulting to 5
- array `bufferSendIn`, `dpWrittenOut`, and `deallocBufferSendOut`
- preserve the incoming port index for write notifications and buffer returns
- document the routing contract and configuration in the DpWriter SDD

## Rationale

`DpManager` can represent multiple logical paths through port arrays, while `DpWriter` previously forced every received buffer and notification through port 0. This implements the CCB direction in #4841 to make the components consistent with a five-path default matching DpManager. Existing topologies may continue to use index zero.

## Testing/Review Recommendations

The default is five matched routing paths. Existing unindexed connections continue to use index zero.

Latest local validation: `fprime-util build --ut`, `fprime-util check` (18 DpWriter tests), formatting, and `git diff --check` passed on macOS. The telemetry and event tables were checked against `DpWriter.fpp`.

The follow-up adds routing-array static assertions, restores test-definition order, clarifies shared queue capacity and default wiring, and updates the state/telemetry/event documentation. Current CI and maintainer re-review remain pending.

## Future Work

Any broader DpManager return-to-sender changes remain separate from this focused routing fix.