### PR TITLE
Avoid CommandDispatcher sequence ID collisions on wraparound

### DIFF
--- a/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.cpp
@@ -23,6 +23,24 @@ CommandDispatcherImpl::CommandDispatcherImpl(const char* name)
 
 CommandDispatcherImpl::~CommandDispatcherImpl() {}
 
+U32 CommandDispatcherImpl::allocateSequenceNumber() {
+    SequenceTrackerEntry trackedCmd;
+    const FwSizeType numTrackedCommands = this->m_sequenceTracker.getSize();
+
+    // At most numTrackedCommands keys can collide. If all of them do, the next
+    // key is necessarily free because the tracker holds fewer than 2^32 keys.
+    for (FwSizeType i = 0; i < numTrackedCommands; ++i) {
+        if (this->m_sequenceTracker.find(this->m_seq, trackedCmd) != Fw::Success::SUCCESS) {
+            break;
+        }
+        ++this->m_seq;
+    }
+
+    const U32 sequenceNumber = this->m_seq;
+    ++this->m_seq;
+    return sequenceNumber;
+}
+
 void CommandDispatcherImpl::compCmdReg_handler(FwIndexType portNum, FwOpcodeType opCode) {
     FwIndexType existingPort;
     if (this->m_entryTable.find(opCode, existingPort) == Fw::Success::SUCCESS) {
@@ -85,6 +103,8 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
     FwIndexType entryPort;
     Fw::Success findStatus = this->m_entryTable.find(cmdPkt.getOpCode(), entryPort);
     if (findStatus == Fw::Success::SUCCESS and this->isConnected_compCmdSend_OutputPort(entryPort)) {
+        const U32 sequenceNumber = this->allocateSequenceNumber();
+
         // register command in command tracker only if response port is connect
         if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
             SequenceTrackerEntry pendingCmd;
@@ -92,7 +112,7 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
             pendingCmd.context = context;
             pendingCmd.callerPort = portNum;
 
-            const Fw::Success pendingInsertStatus = this->m_sequenceTracker.insert(this->m_seq, pendingCmd);
+            const Fw::Success pendingInsertStatus = this->m_sequenceTracker.insert(sequenceNumber, pendingCmd);
 
             // if we couldn't find a slot to track the command, quit
             if (pendingInsertStatus != Fw::Success::SUCCESS) {
@@ -104,7 +124,7 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
             }
         }  // end if status port connected
         // pass arguments to argument buffer
-        this->compCmdSend_out(entryPort, cmdPkt.getOpCode(), this->m_seq, cmdPkt.getArgBuffer());
+        this->compCmdSend_out(entryPort, cmdPkt.getOpCode(), sequenceNumber, cmdPkt.getArgBuffer());
         // log dispatched command
         this->log_COMMAND_OpCodeDispatched(CmdDispatcherCfg::getEventOpcode(cmdPkt.getOpCode()), entryPort);
 
@@ -117,10 +137,9 @@ void CommandDispatcherImpl::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffe
         if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
             this->seqCmdStatus_out(portNum, cmdPkt.getOpCode(), context, Fw::CmdResponse::INVALID_OPCODE);
         }
+        // Preserve the existing behavior of consuming a sequence number for an invalid opcode.
+        ++this->m_seq;
     }
-
-    // increment sequence number
-    this->m_seq++;
 }
 
 void CommandDispatcherImpl ::run_handler(FwIndexType portNum, U32 context) {

--- a/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
+++ b/Svc/CmdDispatcher/CommandDispatcherImpl.hpp
@@ -144,6 +144,13 @@ class CommandDispatcherImpl final : public CommandDispatcherComponentBase {
     //!  \param context call value defined by user
     void seqCmdBuff_overflowHook(FwIndexType portNum, Fw::ComBuffer& data, U32 context) override;
 
+    //! \brief Select an unused command sequence number and advance m_seq
+    //!
+    //! Search the active sequence tracker starting at m_seq. This avoids reusing
+    //! a sequence number that is still associated with an outstanding command
+    //! after the U32 sequence counter wraps.
+    U32 allocateSequenceNumber();
+
     //! \brief map from opcode to output port index
     //!
     //! Maps each registered command opcode to the output port index of the

--- a/Svc/CmdDispatcher/test/ut/CommandDispatcherTestMain.cpp
+++ b/Svc/CmdDispatcher/test/ut/CommandDispatcherTestMain.cpp
@@ -5,6 +5,8 @@
  *      Author: tcanham
  */
 
+#include <limits>
+
 #include <gtest/gtest.h>
 #include <Fw/Obj/SimpleObjRegistry.hpp>
 #include <Fw/Test/UnitTest.hpp>
@@ -225,6 +227,25 @@ TEST(CmdDispTestOffNominal, CommandQueueOverflow) {
     connectPorts(impl, tester);
 
     tester.runCommandQueueOverflow();
+}
+
+TEST(CmdDispTestOffNominal, SequenceNumberWrapSkipsTrackedIds) {
+    TEST_CASE(102.2.6, "Sequence Number Wraparound");
+    COMMENT("Verify sequence number allocation skips IDs that are still tracked across U32 wraparound.");
+
+    Svc::CommandDispatcherImpl impl("CmdDispImpl");
+    impl.init(10, 0);
+
+    Svc::CommandDispatcherTester tester(impl);
+    tester.init();
+
+    const U32 maxSequenceNumber = std::numeric_limits<U32>::max();
+    ASSERT_TRUE(tester.trackSequenceNumber(maxSequenceNumber));
+    ASSERT_TRUE(tester.trackSequenceNumber(0));
+    tester.setSequenceNumber(maxSequenceNumber);
+
+    EXPECT_EQ(1U, tester.allocateSequenceNumber());
+    EXPECT_EQ(2U, tester.getSequenceNumber());
 }
 
 #ifndef TGT_OS_TYPE_VXWORKS

--- a/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.hpp
+++ b/Svc/CmdDispatcher/test/ut/CommandDispatcherTester.hpp
@@ -31,6 +31,17 @@ class CommandDispatcherTester : public CommandDispatcherGTestBase {
 
     void registerBuiltinCommands();
 
+    void setSequenceNumber(U32 sequenceNumber) { this->m_impl.m_seq = sequenceNumber; }
+
+    U32 getSequenceNumber() const { return this->m_impl.m_seq; }
+
+    U32 allocateSequenceNumber() { return this->m_impl.allocateSequenceNumber(); }
+
+    bool trackSequenceNumber(U32 sequenceNumber) {
+        CommandDispatcherImpl::SequenceTrackerEntry entry = {};
+        return this->m_impl.m_sequenceTracker.insert(sequenceNumber, entry) == Fw::Success::SUCCESS;
+    }
+
   private:
     Svc::CommandDispatcherImpl& m_impl;
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5082 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Avoid reusing an active CommandDispatcher sequence ID when the U32 sequence counter wraps.

- add a bounded allocator that scans the active sequence tracker for a free key
- use the selected key consistently for tracking and command dispatch
- preserve sequence advancement for invalid opcodes
- add a regression test that marks both `UINT32_MAX` and `0` active and verifies the next selected ID is `1`

## Rationale

A wrapped sequence counter can collide with an outstanding command ID. Selecting a free key prevents an active tracker entry from being overwritten and follows the CCB direction in #5082 to search for a free key.

## Testing/Review Recommendations

The added unit test exercises the wraparound collision directly. Please run the CmdDispatcher unit-test target and standard repository CI.

## Future Work

None.