### PR TITLE
docs: clarify FW_ASSERT error-handling guidance

### DIFF
--- a/docs/user-manual/framework/assert.md
+++ b/docs/user-manual/framework/assert.md
@@ -6,6 +6,26 @@ unless there is a software or processor error. Assert.hpp defines macros
 to declare an assertion in C++ code. CAssert.hpp defines macros to
 declare an assertion in C code.
 
+## Assertion Usage Guidance
+
+Assertions are intended to enforce internal invariants and signal
+unrecoverable software conditions. They should not be used as the only
+validation or error-handling mechanism for conditions that can occur during
+normal operation, including conditions influenced by runtime or external
+input. Such conditions should be checked explicitly and handled through the
+appropriate error path.
+
+Assertion behavior is configurable. With `FW_ASSERT_LEVEL` set to
+`FW_NO_ASSERT`, a failed assertion does not report an error or terminate the
+program. In C++, `FW_ASSERT` still evaluates its condition and discards the
+result; the C `FW_CASSERT*` macros are compiled away. Code correctness must
+therefore not depend on assertion failure behavior being enabled.
+
+F Prime components are not engineered to continue safely after a failed
+assertion. A custom assertion hook may technically return from an assertion,
+but code following the failed assertion must not assume that component state
+remains valid.
+
 The definition for the framework assert is found in Fw/Types/Assert.hpp.
 The user calls the `FW_ASSERT(cond, arg1, ...)` macro with up to six arguments. The
 arguments can consist of any basic types shown below.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5620 |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**| Y |
|**_Generative AI was used in this contribution (y/n)_**| Y |

---
## Change Description

Add `FW_ASSERT` usage guidance to the canonical F´ assertion documentation in `docs/user-manual/framework/assert.md`.

The guidance clarifies that assertions are intended to enforce internal invariants and unrecoverable software conditions. Conditions that can occur during normal operation, including those influenced by runtime or external input, should instead be validated explicitly and handled through the appropriate error path.

It also documents the disabled-assert behavior accurately: with `FW_ASSERT_LEVEL` set to `FW_NO_ASSERT`, C++ `FW_ASSERT` still evaluates its condition and discards the result, while the C `FW_CASSERT*` macros are compiled away. Finally, it records the maintainer-requested constraint that F Prime components are not engineered to continue safely after a failed assertion if a custom assertion hook returns.

This supersedes #5746, where the guidance was placed in the system-services documentation rather than the dedicated assertions guide.

## Rationale

Fixes #5620.

This directly addresses the requested guidance on using `FW_ASSERT` for error checking and the maintainer note that F Prime components are not designed to recover from returning after a failed assertion.

## Testing/Review Recommendations

Documentation-only change; no unit tests are applicable.

The documented behavior was verified directly against `Fw/Types/Assert.hpp`, `Fw/Types/CAssert.h`, and `Fw/Types/Assert.cpp`. The branch is based on the current `devel` head and changes only the assertion guide.

## Future Work

None.

## AI Usage

- **Tool:** AI
- **Type of assistance:** AI was used to assist with documentation.