### PR TITLE
 Make Os::SandboxedFile fail-closed and configure file-access sandboxes in FileHandling subtopologies

### DIFF
--- a/Os/SandboxedFile.cpp
+++ b/Os/SandboxedFile.cpp
@@ -9,7 +9,11 @@
 
 namespace Os {
 
-SandboxedFile::SandboxedFile() : m_file(), m_allowedDirectory("/"), m_configured(true) {}
+// Fail-closed by default: an unconfigured sandbox denies every open (open() returns
+// OUTSIDE_SANDBOX while m_configured is false). Callers must configure() an allowed
+// directory before use. This prevents ground-supplied paths from reaching the OS layer
+// unconfined when a deployment omits configuration (CWE-22 / CWE-23).
+SandboxedFile::SandboxedFile() : m_file(), m_allowedDirectory(""), m_configured(false) {}
 
 SandboxedFile::~SandboxedFile() {
     if (m_file.isOpen()) {

--- a/Os/test/ut/SandboxedFileTest.cpp
+++ b/Os/test/ut/SandboxedFileTest.cpp
@@ -23,7 +23,7 @@ class SandboxedFileTest : public ::testing::Test {
 
 TEST_F(SandboxedFileTest, ConfigureValid) {
     Os::SandboxedFile file;
-    ASSERT_TRUE(file.isConfigured());  // default is "/"
+    ASSERT_FALSE(file.isConfigured());  // fail-closed: unconfigured by default
     file.configure("/tmp/sandbox_test/");
     ASSERT_TRUE(file.isConfigured());
     ASSERT_STREQ("/tmp/sandbox_test/", file.getSandboxDirectory());
@@ -54,13 +54,31 @@ TEST_F(SandboxedFileTest, TraversalAttackRejected) {
     ASSERT_FALSE(file.isOpen());
 }
 
-TEST_F(SandboxedFileTest, DefaultConfigAllowsAnyAbsolutePath) {
+// GHSA-g8xv-rf85-4pjp regression: an unconfigured sandbox must deny every open
+// (fail-closed). Previously it defaulted to "/", permitting arbitrary absolute paths.
+TEST_F(SandboxedFileTest, DefaultConfigDeniesAbsolutePath) {
     Os::SandboxedFile file;
-    // Default sandbox is "/" — any absolute path is allowed
     auto status = file.open("/tmp/sandbox_test/test_file.bin", Os::File::OPEN_CREATE);
-    ASSERT_EQ(Os::File::OP_OK, status);
-    ASSERT_TRUE(file.isOpen());
-    file.close();
+    ASSERT_EQ(Os::File::OUTSIDE_SANDBOX, status);
+    ASSERT_FALSE(file.isOpen());
+}
+
+// GHSA-g8xv-rf85-4pjp regression: unconfigured sandbox also denies relative paths.
+TEST_F(SandboxedFileTest, DefaultConfigDeniesRelativePath) {
+    Os::SandboxedFile file;
+    auto status = file.open("test_file.bin", Os::File::OPEN_CREATE);
+    ASSERT_EQ(Os::File::OUTSIDE_SANDBOX, status);
+    ASSERT_FALSE(file.isOpen());
+}
+
+// GHSA-g8xv-rf85-4pjp regression: an absolute traversal target outside the configured
+// sandbox (e.g. the classic ../../etc/passwd read) is rejected.
+TEST_F(SandboxedFileTest, ConfiguredSandboxRejectsAbsoluteEscape) {
+    Os::SandboxedFile file;
+    file.configure("/tmp/sandbox_test/");
+    auto status = file.open("/etc/passwd", Os::File::OPEN_READ);
+    ASSERT_EQ(Os::File::OUTSIDE_SANDBOX, status);
+    ASSERT_FALSE(file.isOpen());
 }
 
 TEST_F(SandboxedFileTest, WriteAndRead) {
@@ -91,7 +109,7 @@ TEST_F(SandboxedFileTest, WriteAndRead) {
 
 TEST_F(SandboxedFileTest, GetSandboxDirectoryDefault) {
     Os::SandboxedFile file;
-    ASSERT_STREQ("/", file.getSandboxDirectory());
+    ASSERT_STREQ("", file.getSandboxDirectory());  // fail-closed: no directory until configure()
 }
 
 TEST_F(SandboxedFileTest, OpenEmptyPathRejected) {

--- a/Svc/FileDownlink/docs/sdd.md
+++ b/Svc/FileDownlink/docs/sdd.md
@@ -42,14 +42,16 @@ of type [`Fw::FilePacket`](../../../Fw/FilePacket/docs/sdd.md).
    `SendFile` port are validated against the sandbox directory before reading; rejected paths emit
    `SourceOutOfSandbox`. This mirrors `Svc::FileUplink` write-side sandboxing.
 
-   > [!WARNING]
-   > The sandbox is **fail-open**: until `configure(directory)` is called, the sandbox defaults to
-   > `/`, which permits reading any absolute path accessible to the process via ground command.
-   > This default is intentionally insecure for backwards compatibility. Security-conscious
-   > deployments **must** call `configure(directory)` during topology setup to restrict file
-   > access. Note that the stock `FileHandling` subtopology and reference topologies do **not**
-   > configure a downlink sandbox: `FileHandling` only calls the
-   > `configure(cooldown, cycleTime, fileQueueDepth)` overload, which does not set a sandbox.
+   > [!IMPORTANT]
+   > The sandbox is **fail-closed**: until `configure(directory)` is called, every source open is
+   > rejected with `OUTSIDE_SANDBOX` (emitting `SourceOutOfSandbox`) — an unconfigured
+   > `FileDownlink` cannot read anything. A deployment **must** call the `configure(directory)`
+   > overload during topology setup to enable downlink reads and select the allowed base
+   > directory. The stock `FileHandling` subtopology does this for you (in addition to the
+   > `configure(cooldown, cycleTime, fileQueueDepth)` overload), confining reads to `"."` (the
+   > deployment working-directory subtree); `../` traversal and absolute paths are rejected. A
+   > deployment that genuinely requires unrestricted read access must opt in explicitly by
+   > configuring the sandbox to `"/"`.
 
 ### 3.3 Ports
 

--- a/Svc/FileUplink/docs/sdd.md
+++ b/Svc/FileUplink/docs/sdd.md
@@ -24,12 +24,15 @@ of type [`Fw::FilePacket`](../../../Fw/FilePacket/docs/sdd.md).
 2. File access is sandboxed to a directory configured via `configure(directory)`.
 All uplinked file paths are validated against the sandbox directory before writing.
 
-   > [!WARNING]
-   > The sandbox is **fail-open**: until `configure(directory)` is called, the sandbox defaults to
-   > `/`, which permits writing to any absolute path accessible to the process. This default is
-   > intentionally insecure for backwards compatibility. Security-conscious deployments **must**
-   > call `configure(directory)` during topology setup to restrict file access. Note that the
-   > stock `FileHandling` subtopology does **not** configure a sandbox.
+   > [!IMPORTANT]
+   > The sandbox is **fail-closed**: until `configure(directory)` is called, every open is
+   > rejected with `OUTSIDE_SANDBOX` — an unconfigured `FileUplink` cannot write anywhere.
+   > A deployment **must** call `configure(directory)` during topology setup to enable uplink
+   > writes and to select the allowed base directory. The stock `FileHandling` subtopology does
+   > this for you, confining writes to `"."` (the deployment working-directory subtree); paths
+   > that resolve outside it — `../` traversal and absolute paths — are rejected. A deployment
+   > that genuinely requires unrestricted write access must opt in explicitly by configuring the
+   > sandbox to `"/"`.
 
 3. In the nominal case of file uplink
 

--- a/Svc/PrmDb/docs/sdd.md
+++ b/Svc/PrmDb/docs/sdd.md
@@ -44,16 +44,19 @@ When the component receives the `PRM_SAVE_FILE` command, it saves the entire tab
 
 The `PRM_LOAD_FILE` command loads a parameter file from an operator-supplied path into the staging database. Paths rejected by the load sandbox emit a `PrmFileReadError` event with an `OPEN` stage.
 
-> [!WARNING]
-> The load sandbox is **fail-open**: if `configureLoadSandbox(directory)` is never called, any path
-> accessible to the process is accepted, permitting arbitrary path access via ground command. This
-> default is intentionally insecure for backwards compatibility. Security-conscious deployments
-> **must** call `configureLoadSandbox(directory)` during topology setup. Note that the stock
-> `FileHandling` and `FileHandlingCfdp` subtopologies and reference topologies do **not** configure
-> a load sandbox: they only call `configure(file)`, which sets the store-file name and is **not** a
-> load sandbox. The load and store paths are distinct: startup `readParamFile` and `PRM_SAVE_FILE`
-> operate on the configured store file without sandboxing; only `PRM_LOAD_FILE` staging loads are
-> gated by the load sandbox.
+> [!IMPORTANT]
+> The load sandbox is **fail-closed**: until `configureLoadSandbox(directory)` is called, every
+> `PRM_LOAD_FILE` open is rejected (emitting `PrmFileReadError` with an `OPEN` stage) — an
+> unconfigured `PrmDb` cannot load parameter files by ground command. A deployment **must** call
+> `configureLoadSandbox(directory)` during topology setup to enable `PRM_LOAD_FILE` and select the
+> allowed base directory. The stock `FileHandling` and `FileHandlingCfdp` subtopologies do this for
+> you, confining loads to `"."` (the deployment working-directory subtree); `../` traversal and
+> absolute paths are rejected.
+> This is distinct from `configure(file)`, which sets the store-file name and is **not** a load
+> sandbox. The load and store paths remain distinct: startup `readParamFile` and `PRM_SAVE_FILE`
+> operate on the configured store file and are not gated by the load sandbox; only `PRM_LOAD_FILE`
+> staging loads are. A deployment that genuinely requires unrestricted load access must opt in
+> explicitly by configuring the load sandbox to `"/"`.
 
 The fields for each parameter value as stored in the parameter file are as follows:
 

--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -7,7 +7,14 @@ module FileHandling {
         queue size FileHandlingConfig.QueueSizes.fileUplink \
         stack size FileHandlingConfig.StackSizes.fileUplink \
         priority FileHandlingConfig.Priorities.fileUplink \
-        cpu FileHandlingConfig.CpuAffinities.fileUplink
+        cpu FileHandlingConfig.CpuAffinities.fileUplink \
+    {
+        phase Fpp.ToCpp.Phases.configComponents """
+        // Confine ground-uplinked file writes to the sandbox directory (see
+        // FileHandlingConfig::FileSystem). "." = deployment working-directory subtree.
+        FileHandling::fileUplink.configure(".");
+        """
+    }
 
     instance fileDownlink: Svc.FileDownlink base id FileHandlingConfig.BASE_ID + 0x01000 \
         queue size FileHandlingConfig.QueueSizes.fileDownlink \
@@ -21,6 +28,9 @@ module FileHandling {
             FileHandlingConfig::DownlinkConfig::cycleTime,
             FileHandlingConfig::DownlinkConfig::fileQueueDepth
         );
+        // Confine ground-commanded file reads (SendFile / SendPartial) to the sandbox
+        // directory (see FileHandlingConfig::FileSystem).
+        FileHandling::fileDownlink.configure(".");
         """
     }
 
@@ -36,6 +46,13 @@ module FileHandling {
         priority FileHandlingConfig.Priorities.prmDb \
         cpu FileHandlingConfig.CpuAffinities.prmDb \
     {
+        phase Fpp.ToCpp.Phases.configComponents """
+        // Confine ground-commanded PRM_LOAD_FILE reads to the sandbox directory (see
+        // FileHandlingConfig::FileSystem). Runs before readParameters; only PRM_LOAD_FILE
+        // (DB_STAGING) is sandboxed, so the boot-time readParamFile() of the configured
+        // store file is unaffected.
+        FileHandling::prmDb.configureLoadSandbox(".");
+        """
         phase Fpp.ToCpp.Phases.readParameters """
             FileHandling::prmDb.readParamFile();
         """

--- a/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
@@ -32,8 +32,18 @@ module FileHandlingConfig {
 
     # File downlink configuration constants
     module DownlinkConfig {
-        constant cooldown       = 1000         # File downlink cooldown in ms  
+        constant cooldown       = 1000         # File downlink cooldown in ms
         constant cycleTime      = 1000         # File downlink cycle time in ms
         constant fileQueueDepth = 10           # File downlink queue depth
     }
+
+    # File-access sandbox base directory.
+    # The value is applied in FileHandling.fpp's configComponents phases (as a C++
+    # string literal, because FPP string constants live in this INTERFACE config
+    # library's unlinked FppConstantsAc.cpp and cannot be referenced from topology
+    # autocode). Keep this comment and the literals in FileHandling.fpp in sync.
+    #   Default "." confines all ground-commanded file reads/writes (FileUplink,
+    #   FileDownlink, PrmDb PRM_LOAD_FILE) to the deployment working-directory subtree,
+    #   rejecting "../" traversal and absolute-path escapes. A deployment that truly
+    #   needs unrestricted access must set the literals to "/" as a deliberate opt-in.
 }

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -35,19 +35,25 @@ The **FileHandling subtopology** packages the core file-transfer services common
 * **PrmDb file name**: Call `FileHandling::prmDb.configure(<file name>)` from your topology setup code before parameters are loaded; the subtopology does not set a file name itself, and `PrmDb` asserts if parameters are read or saved without one.
 * **Communication/Framing Stack**: Wire file-packet ports between FileHandling and your COM/framing subtopology (e.g., `ComCcsds`, `ComFprime`, `FramingFprime`, `FramingCcsds`) to complete uplink/downlink paths.
 
-> [!WARNING]
-> **This subtopology is not configured to be secure by default.** For backwards compatibility, it
-> intentionally does **not** configure the file-access sandboxes of its components, leaving them
-> fail-open: `fileUplink` may write, `fileDownlink` may read, and `prmDb` (`PRM_LOAD_FILE`) may
-> load from **any absolute path accessible to the process** via ground command. Security-conscious
-> deployments **must** call the following from topology setup code:
+> [!IMPORTANT]
+> **This subtopology is secure by default.** In its `configComponents` phase it confines all
+> ground-commanded file access to a sandbox base directory of `"."` (the deployment
+> working-directory subtree), calling:
 >
-> * `FileHandling::fileUplink.configure(<directory>)` — restrict uplinked file writes.
-> * `FileHandling::fileDownlink.configure(<directory>)` — restrict downlink reads (note: the
->   `configure(cooldown, cycleTime, fileQueueDepth)` overload called by this subtopology does
->   **not** set a sandbox).
-> * `FileHandling::prmDb.configureLoadSandbox(<directory>)` — restrict `PRM_LOAD_FILE` reads
->   (note: `prmDb.configure(<file name>)` sets the store-file name and is **not** a load sandbox).
+> * `FileHandling::fileUplink.configure(".")` — restrict uplinked file writes.
+> * `FileHandling::fileDownlink.configure(".")` — restrict downlink reads (this is the
+>   `configure(directory)` overload, in addition to the
+>   `configure(cooldown, cycleTime, fileQueueDepth)` overload).
+> * `FileHandling::prmDb.configureLoadSandbox(".")` — restrict `PRM_LOAD_FILE` reads (distinct
+>   from `prmDb.configure(<file name>)`, which sets the store-file name and is **not** a load
+>   sandbox).
+>
+> Paths that resolve outside the sandbox — `../` traversal sequences and absolute paths — are
+> rejected before any file is opened. The underlying `Os::SandboxedFile` is **fail-closed**: if a
+> component were left unconfigured it would deny all access rather than permit it. To change the
+> allowed directory, edit the string literals in this subtopology's `configComponents` phases
+> (see `FileHandlingConfig::FileSystem` in `FileHandlingConfig.fpp`). A deployment that genuinely
+> requires unrestricted access must opt in explicitly by setting the sandbox to `"/"`.
 
 ### 2.4 Limitations
 

--- a/Svc/Subtopologies/FileHandlingCfdp/FileHandlingCfdp.fpp
+++ b/Svc/Subtopologies/FileHandlingCfdp/FileHandlingCfdp.fpp
@@ -31,6 +31,10 @@ module FileHandlingCfdp {
     {
         phase Fpp.ToCpp.Phases.configComponents """
             FileHandlingCfdp::prmDb.configure("PrmDb.dat");
+            // Confine ground-commanded PRM_LOAD_FILE reads to the sandbox directory.
+            // Os::SandboxedFile is fail-closed, so this must be set or PRM_LOAD_FILE is denied.
+            // "." = deployment working-directory subtree; see FileHandlingConfig::FileSystem.
+            FileHandlingCfdp::prmDb.configureLoadSandbox(".");
         """
         phase Fpp.ToCpp.Phases.readParameters """
             FileHandlingCfdp::prmDb.readParamFile();


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  N/A |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| Y |
|**_Generative AI was used in this contribution (y/n)_**| T |

---
## Change Description

Os::SandboxedFile previously default-constructed as configured with an allowed directory of /, so an unconfigured sandbox permitted any absolute path, and the stock FileHandling subtopology never configured one. As a result, ground-supplied file paths reached the OS layer unconfined (FileUplink writes, FileDownlink reads, PrmDb PRM_LOAD_FILE). This addresses GHSA-g8xv-rf85-4pjp (CWE-22/CWE-23).

- Os::SandboxedFile: default to fail-closed (m_configured = false), so an unconfigured instance denies every open (OUTSIDE_SANDBOX) via the existing guard in open().
- FileHandling / FileHandlingCfdp subtopologies: configure the fileUplink, fileDownlink, and prmDb sandboxes to "." (the deployment working-directory subtree) in the configComponents phase, so the stock deployment is confined by default; ../ traversal and absolute paths are rejected.
- SDDs: updated FileUplink, FileDownlink, PrmDb, and FileHandling docs to describe the fail-closed default and the new stock wiring.
- Compatibility note (breaking): deployments that relied on unrestricted or absolute paths without calling configure() will now be denied. Migration is explicit — call configure("<dir>") for a specific base, or configure("/") to deliberately opt back into unrestricted access.

## Rationale

- Fixing the default covers all three sinks at once. FileUplink, FileDownlink, and PrmDb all share Os::SandboxedFile, so the one-line default change closes the write, read, and parameter-load vectors together, rather than patching each call site.
- Why not inline path checks in the components. An ad-hoc ../absolute check in File.cpp would duplicate existing, more-robust logic, cover only some sinks, and hard-code a policy (reject all absolute paths) that some deployments legitimately need. Configuring the existing sandbox keeps a single, well-tested enforcement point.
- Why "." as the stock default. Normal file transfer in the reference deployment already uses relative paths under the working directory, so confining to "." preserves legitimate behavior while blocking escapes — the least-disruptive secure default. Deployments needing a different root override the literal; those needing unrestricted access set "/" as a conscious choice.
- Defense in depth. The two changes are complementary: the fail-closed default guarantees the security property even if wiring is omitted, and the subtopology wiring keeps the stock deployment functional under that stricter default.

## Testing/Review Recommendations

- Os/test/ut/SandboxedFileTest.cpp updated: three new regression tests (unconfigured sandbox denies absolute and relative opens; configured sandbox rejects absolute escapes) plus corrected contract tests for the fail-closed default. Verified they pass against the fix and fail against the prior fail-open code.
- Run: ctest --test-dir build-fprime-automatic-native-ut -R SandboxedFile --output-on-failure (requires -DFPRIME_ENABLE_FRAMEWORK_UTS=ON).
- Reviewers please confirm the "." default is acceptable for reference deployments, and sanity-check the compatibility impact on downstream topologies that set absolute upload/download paths.

## Future Work

- Consider whether configure("/") opt-out should emit a startup warning event for auditability.
- Emit a WARNING_HI on rejected opens in FileUplink/PrmDb (FileDownlink already emits SourceOutOfSandbox).
- Coordinate advisory/CVE publication for GHSA-g8xv-rf85-4pjp with this merge.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI assistance (Claude) was used for source review/variant analysis, drafting the code and test changes, and writing this description. All changes were built and tested against an unmodified checkout; the version range, affected components, and test outcomes were verified in-repo before submission.