### PR TITLE
fix(FpySequencer): clear breakpoint state on sequence cancel

### DIFF
--- a/Svc/FpySequencer/FpySequencerStateMachine.cpp
+++ b/Svc/FpySequencer/FpySequencerStateMachine.cpp
@@ -88,6 +88,7 @@ void FpySequencer::Svc_FpySequencer_SequencerStateMachine_action_report_seqSucce
 ) {
     this->m_tlm.sequencesSucceeded++;
     this->log_ACTIVITY_HI_SequenceDone(this->m_sequenceFilePath);
+    this->m_sequenceFilePath = NO_SEQ;
     if (this->isConnected_seqDoneOut_OutputPort(0)) {
         // report that the sequence succeeded to internal callers
         this->seqDoneOut_out(0, 0, 0, Fw::CmdResponse::OK);
@@ -103,6 +104,11 @@ void FpySequencer::Svc_FpySequencer_SequencerStateMachine_action_report_seqCance
     Svc_FpySequencer_SequencerStateMachine::Signal signal  //!< The signal
 ) {
     this->m_tlm.sequencesCancelled++;
+    // Clear breakpoint state so it does not leak into the next sequence (#5638)
+    this->m_breakpoint.breakpointInUse = false;
+    this->m_breakpoint.breakpointIndex = 0;
+    this->m_breakpoint.breakOnlyOnceOnBreakpoint = false;
+    this->m_breakpoint.breakBeforeNextLine = false;
     this->log_ACTIVITY_HI_SequenceCancelled(this->m_sequenceFilePath);
     if (this->isConnected_seqDoneOut_OutputPort(0)) {
         // report that the sequence failed to internal callers


### PR DESCRIPTION
## Overview
`m_breakpoint` state is not reset when a sequence is cancelled. After `CANCEL` + `RUN` with a different sequence, a previously set breakpoint can fire unexpectedly if the new statement index happens to match the old `breakpointIndex`.

`resetRuntime()` only reconstructs `m_runtime` via placement-new — it never touches `m_breakpoint`.

## Changes
Resets all four `m_breakpoint` fields in `report_seqCancelled()`, which is the action invoked by all three `cmd_CANCEL` transitions in the state machine. Uses the same field-zeroing pattern as `clearBreakpoint()` (line 343–346 of the same file).

```cpp
this->m_breakpoint.breakpointInUse = false;
this->m_breakpoint.breakpointIndex = 0;
this->m_breakpoint.breakOnlyOnceOnBreakpoint = false;
this->m_breakpoint.breakBeforeNextLine = false;
```

## Testing
Existing sequencer cancel tests cover this action path. The added lines use the same pattern as the existing `clearBreakpoint()`.

Fixes #5638

| | |
|:---|:---|
| AI Used | y |
| AI Usage | Claude Code used for codebase navigation and locating the cancel action path. The fix mirrors clearBreakpoint() already in the same file. |