### PR TITLE
Fixed size FilePorts file-name args to FileNameStringSize; fix port doc comments; add FileDispatcher boundary test

### DIFF
--- a/Svc/FileDispatcher/test/ut/FileDispatcherTestMain.cpp
+++ b/Svc/FileDispatcher/test/ut/FileDispatcherTestMain.cpp
@@ -11,6 +11,11 @@ TEST(Nominal, DispatchTest) {
     tester.dispatchTest();
 }
 
+TEST(Nominal, DispatchMaxLengthNameTest) {
+    Svc::FileDispatcherTester tester;
+    tester.dispatchMaxLengthNameTest();
+}
+
 TEST(Nominal, DispatchAllDisabledTest) {
     Svc::FileDispatcherTester tester;
     tester.dispatchAllDisabledTest();

--- a/Svc/FileDispatcher/test/ut/FileDispatcherTester.cpp
+++ b/Svc/FileDispatcher/test/ut/FileDispatcherTester.cpp
@@ -6,6 +6,8 @@
 
 #include "FileDispatcherTester.hpp"
 
+#include <cstring>
+
 namespace Svc {
 
 // ----------------------------------------------------------------------
@@ -59,6 +61,45 @@ void FileDispatcherTester ::dispatchTest() {
         ASSERT_from_fileDispatch_SIZE(1);
         ASSERT_from_fileDispatch(0, testFileName);
     }
+}
+
+void FileDispatcherTester ::dispatchMaxLengthNameTest() {
+    Svc::FileDispatcherTable table;
+    this->populateTable(table, true);
+
+    // Build a file name of exactly FileNameStringSize characters that ends in a mapped
+    // extension (".file0"). This verifies that a maximum-length file name round-trips
+    // through the FileAnnounce -> FileDispatch path without truncation, guarding the
+    // `string size FileNameStringSize` sizing of those ports (a smaller port would silently
+    // truncate the name here and the assertions below would fail).
+    const char ext[] = ".file0";
+    const FwSizeType extLen = sizeof(ext) - 1;
+    char nameBuf[FileNameStringSize + 1];
+    const FwSizeType fillLen = static_cast<FwSizeType>(FileNameStringSize) - extLen;
+    (void)::memset(nameBuf, 'a', fillLen);
+    (void)::memcpy(nameBuf + fillLen, ext, extLen);
+    nameBuf[FileNameStringSize] = '\0';
+
+    Fw::String testFileName(nameBuf);
+    ASSERT_EQ(testFileName.length(), static_cast<FwSizeType>(FileNameStringSize));
+
+    this->clearHistory();
+    this->invoke_to_fileAnnounceRecv(0, testFileName);
+    this->component.doDispatch();
+
+    // The full-length name must dispatch to port 0 with the name intact (no truncation).
+    // This is the invariant the FileAnnounce/FileDispatch `string size FileNameStringSize`
+    // sizing guarantees.
+    ASSERT_from_fileDispatch_SIZE(1);
+    ASSERT_from_fileDispatch(0, testFileName);
+
+    // Note: the FileDispatched *event* is intentionally not checked for the full name here.
+    // Although the event declares `file_name: string size FileNameStringSize` (240), F Prime
+    // event string arguments are carried as Fw::LogStringArg (= FW_LOG_STRING_MAX_SIZE, 200),
+    // so any event file name longer than 200 chars is truncated. That is a framework-wide
+    // event-string limit, independent of the FileAnnounce/FileDispatch port sizing this test
+    // exercises.
+    ASSERT_EVENTS_FileDispatched_SIZE(1);
 }
 
 void FileDispatcherTester ::dispatchAllDisabledTest() {

--- a/Svc/FileDispatcher/test/ut/FileDispatcherTester.hpp
+++ b/Svc/FileDispatcher/test/ut/FileDispatcherTester.hpp
@@ -46,6 +46,9 @@ class FileDispatcherTester final : public FileDispatcherGTestBase {
     //! Dispatch test
     void dispatchTest();
 
+    //! Dispatch a maximum-length (FileNameStringSize) file name without truncation
+    void dispatchMaxLengthNameTest();
+
     //! Dispatch disabled test
     void dispatchAllDisabledTest();
 

--- a/Svc/Ports/FilePorts/FileAnnounce.fpp
+++ b/Svc/Ports/FilePorts/FileAnnounce.fpp
@@ -8,6 +8,6 @@ module Svc{
     
     @ Port for announcing new files
     port FileAnnounce(
-             ref file_name: string @< The successfully uplinked file
+             ref file_name: string size FileNameStringSize @< The successfully uplinked file
     )
 }

--- a/Svc/Ports/FilePorts/FileDispatch.fpp
+++ b/Svc/Ports/FilePorts/FileDispatch.fpp
@@ -1,13 +1,13 @@
 #####
 # File dispatch ports:
 #
-# A port setting/getting custom versions per project.
+# A port for dispatching files (e.g., routing an uplinked file to a handler by type).
 #####
 
 module Svc{
-    
+
     @ Port for dispatching files
     port FileDispatch(
-             ref file_name: string @< The file to dispatch
+             ref file_name: string size FileNameStringSize @< The file to dispatch
     )
 }

--- a/Svc/Ports/VersionPorts/VersionPorts.fpp
+++ b/Svc/Ports/VersionPorts/VersionPorts.fpp
@@ -16,6 +16,6 @@ module Svc{
     port Version(
              version_id: VersionCfg.VersionEnum @< The entry to access
              ref version_string: string @< The value to be passed
-             ref status: VersionStatus @< The command response argument
+             ref status: VersionStatus @< Status of the version get/set operation
     )
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| N |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| Y |
|**_Generative AI was used in this contribution (y/n)_**| Y |

---
## Change Description

Three small correctness/robustness fixes in Svc/Ports plus a regression test:

- FileAnnounce.fpp / FileDispatch.fpp: change the file_name argument from an unsized string to string size FileNameStringSize, matching the rest of the file pipeline (FileWorkerPorts, the FileDispatcher events, and the 240-char FileNameStringSize constant).
- FileDispatch.fpp: fix the file header comment, which was a copy-paste of the VersionPorts header ("A port setting/getting custom versions per project") and did not describe file dispatch.
- VersionPorts.fpp: fix the status argument comment ("The command response argument" → "Status of the version get/set operation"); it was a copy-paste leftover — this port is not a command.
- Svc/FileDispatcher UT: add Nominal.DispatchMaxLengthNameTest, dispatching a maximum-length (FileNameStringSize) file name and asserting it round-trips through the FileAnnounce → FileDispatch port path with no truncation.

No behavioral change to compiled logic; the port ABI-relevant change is the file_name serialized capacity (256 → 240 in the default config).

## Rationale

- An unsized FPP string inherits FW_FIXED_LENGTH_STRING_SIZE, coupling the file-name capacity of these ports to an unrelated global rather than to FileNameStringSize, which the rest of the file pipeline uses. Today that global (256) happens to exceed FileNameStringSize (240), so it works by coincidence. If a project lowers FW_FIXED_LENGTH_STRING_SIZE below 240 (a normal footprint optimization), file names would silently truncate at the announce/dispatch ports while the rest of the pipeline preserves them — producing a dispatch on a truncated path (wrong-file or failed-open, a truncation-induced path-confusion class of defect). Sizing these ports to FileNameStringSize removes the coincidental coupling and makes correctness explicit.
- The two comment fixes remove misleading copy-paste text from the interface definitions, which is where integrators read the contract.

## Testing/Review Recommendations

- Full deployment builds cleanly (fprime-util build); the port autocode regenerates and the FileDispatcher consumer recompiles. Verified the generated FileAnnouncePortAc.hpp buffer is now sized to 240 (FileNameStringSize).
- Svc_FileDispatcher_ut_exe passes 6/6 including the new boundary test:
ctest --test-dir build-fprime-automatic-native-ut -R Svc_FileDispatcher_ut_exe --output-on-failure
  (requires -DFPRIME_ENABLE_FRAMEWORK_UTS=ON at generate time.)
- The new test guards the invariant "these ports carry a full-length file name." Reviewer note: in the default config it also passes against the old unsized declaration (256 ≥ 240); its value is as a regression guard against any future sizing below FileNameStringSize.

## Future Work

Separate, pre-existing finding surfaced by the boundary test: the FileDispatched / FileDispatchPortNotConnected events declare file_name: string size FileNameStringSize (240), but F Prime event string arguments are carried as Fw::LogStringArg = FW_LOG_STRING_MAX_SIZE (200), so event file names > 200 chars are silently truncated. This is a framework-wide event-string limit (graceful truncation, not a crash), independent of the port sizing fixed here. Options: reduce the events' declared string size to ≤ FW_LOG_STRING_MAX_SIZE, raise FW_LOG_STRING_MAX_SIZE, or document the event-string cap as a known limitation.
- The Svc/Ports/FilePorts SDD port table documents only FileAnnounce; it omits FileDispatch, FileRead, FileWrite, SignalDone, CancelStatus, and VerifyStatus. Worth completing in a follow-up doc pass.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

AI assistance (Claude) was used drafting code changes and regression test, and writing this description. All changes were built and unit-tested against an unmodified checkout; the generated string sizing and the test outcomes (including the event-truncation finding) were verified in-repo before submission.
