### PR TITLE
feat(Os): SandboxedFile deny-by-default (v5.0.0)

### DIFF
--- a/Os/SandboxedFile.cpp
+++ b/Os/SandboxedFile.cpp
@@ -9,7 +9,7 @@
 
 namespace Os {
 
-SandboxedFile::SandboxedFile() : m_file(), m_allowedDirectory("/"), m_configured(true) {}
+SandboxedFile::SandboxedFile() : m_file(), m_allowedDirectory(""), m_configured(false) {}
 
 SandboxedFile::~SandboxedFile() {
     if (m_file.isOpen()) {

--- a/Os/SandboxedFile.hpp
+++ b/Os/SandboxedFile.hpp
@@ -43,9 +43,10 @@ class SandboxedFile {
     SandboxedFile(const SandboxedFile&) = delete;             //!< Non-copyable (owns file handle)
     SandboxedFile& operator=(const SandboxedFile&) = delete;  //!< Non-copy-assignable
 
-    //! \brief Construct a SandboxedFile with default sandbox of `/`
+    //! \brief Construct an unconfigured SandboxedFile (deny-by-default)
     //!
-    //! The default allows any absolute path. Call `configure()` to restrict.
+    //! `open()` returns `OUTSIDE_SANDBOX` until `configure()` is called.
+    //! This is a breaking change from v4.x which defaulted to `/` (permit-all).
     //!
     SandboxedFile();
 

--- a/Os/test/ut/SandboxedFileTest.cpp
+++ b/Os/test/ut/SandboxedFileTest.cpp
@@ -23,7 +23,7 @@ class SandboxedFileTest : public ::testing::Test {
 
 TEST_F(SandboxedFileTest, ConfigureValid) {
     Os::SandboxedFile file;
-    ASSERT_TRUE(file.isConfigured());  // default is "/"
+    ASSERT_FALSE(file.isConfigured());  // deny-by-default (v5.0.0)
     file.configure("/tmp/sandbox_test/");
     ASSERT_TRUE(file.isConfigured());
     ASSERT_STREQ("/tmp/sandbox_test/", file.getSandboxDirectory());
@@ -54,13 +54,12 @@ TEST_F(SandboxedFileTest, TraversalAttackRejected) {
     ASSERT_FALSE(file.isOpen());
 }
 
-TEST_F(SandboxedFileTest, DefaultConfigAllowsAnyAbsolutePath) {
+TEST_F(SandboxedFileTest, UnconfiguredRejectsOpen) {
     Os::SandboxedFile file;
-    // Default sandbox is "/" — any absolute path is allowed
+    // Deny-by-default: open() fails until configure() is called (v5.0.0, #5657)
     auto status = file.open("/tmp/sandbox_test/test_file.bin", Os::File::OPEN_CREATE);
-    ASSERT_EQ(Os::File::OP_OK, status);
-    ASSERT_TRUE(file.isOpen());
-    file.close();
+    ASSERT_EQ(Os::File::OUTSIDE_SANDBOX, status);
+    ASSERT_FALSE(file.isOpen());
 }
 
 TEST_F(SandboxedFileTest, WriteAndRead) {


### PR DESCRIPTION
## Overview
`Os::SandboxedFile` currently defaults to a sandbox of `/`, allowing any absolute path until `configure()` is called. A security review recommended deny-by-default (#5657).

This is the change proposed in #5651 (later reverted), reapplied with the migration path noted.

## Changes
- **SandboxedFile.cpp**: constructor initializes `m_configured(false)` and `m_allowedDirectory("")` instead of `true`/`"/"`
- **SandboxedFile.hpp**: updated doc comment to reflect deny-by-default
- **SandboxedFileTest.cpp**: `ConfigureValid` asserts `!isConfigured()` initially; `DefaultConfigAllowsAnyAbsolutePath` → `UnconfiguredRejectsOpen` (verifies OUTSIDE_SANDBOX)

## Migration (v4 → v5)
Deployments that construct `SandboxedFile` without calling `configure()` must add:
```cpp
sandboxedFile.configure("/");  // restores v4.x permit-all behavior
```
Components using `SandboxedFile` (FileDownlink, FileUplink, CfdpManager) should configure to their intended directory at startup.

## Testing
Updated unit tests verify the new default. Existing tests for configured behavior are unchanged.

Fixes #5657

| | |
|:---|:---|
| AI Used | y |
| AI Usage | Claude Code for tracing SandboxedFile usage and the reverted #5651 history. |