### PR TITLE
fix(SpacePacketFramer): guard zero-size data at runtime, not only via assert

### DIFF
--- a/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.cpp
@@ -25,14 +25,21 @@ SpacePacketFramer ::~SpacePacketFramer() {}
 // ----------------------------------------------------------------------
 
 void SpacePacketFramer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const ComCfg::FrameContext& context) {
+    // CCSDS Space Packet requires at least 1 data octet (the Packet Data Length
+    // field encodes "number of octets minus 1", so size 0 cannot be represented).
+    // Guard at runtime so the subtraction at packetDataLength never underflows,
+    // even in FW_NO_ASSERT builds.
+    if (data.getSize() == 0) {
+        this->log_WARNING_HI_EmptyDataReceived();
+        this->dataReturnOut_out(0, data, context);
+        return;
+    }
+
     SpacePacketHeader header;
     Fw::SerializeStatus status;
     FwSizeType frameSize = SpacePacketHeader::SERIALIZED_SIZE + data.getSize();
     FW_ASSERT(data.getSize() <= std::numeric_limits<Fw::Buffer::SizeType>::max() - SpacePacketHeader::SERIALIZED_SIZE,
               static_cast<FwAssertArgType>(data.getSize()));
-    FW_ASSERT(
-        data.getSize() > 0,
-        static_cast<FwAssertArgType>(data.getSize()));  // Protocol specifies at least 1 byte of data for a valid packet
 
     // Allocate frame buffer
     Fw::Buffer frameBuffer = this->bufferAllocate_out(0, static_cast<Fw::Buffer::SizeType>(frameSize));

--- a/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.fpp
+++ b/Svc/Ccsds/SpacePacketFramer/SpacePacketFramer.fpp
@@ -20,6 +20,12 @@ module Ccsds {
             format "Failed to allocate a packet buffer: packet dropped" \
             throttle 5
 
+        @ Received a zero-size data buffer; CCSDS Space Packet requires at least 1 data octet
+        event EmptyDataReceived \
+            severity warning high \
+            format "Received empty data buffer: packet dropped (CCSDS requires >= 1 data octet)" \
+            throttle 5
+
         ###############################################################################
         # Standard AC Ports: Required for Channels, Events, Commands, and Parameters  #
         ###############################################################################

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTestMain.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTestMain.cpp
@@ -27,6 +27,11 @@ TEST(SpacePacketFramer, OversizedAllocatorBufferIsTrimmed) {
     tester.testOversizedAllocatorBufferIsTrimmed();
 }
 
+TEST(SpacePacketFramer, EmptyDataDropped) {
+    Svc::Ccsds::SpacePacketFramerTester tester;
+    tester.testEmptyDataDropped();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     STest::Random::seed();

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.cpp
@@ -144,6 +144,23 @@ void SpacePacketFramerTester ::testOversizedAllocatorBufferIsTrimmed() {
     ASSERT_EQ(outBuffer.getSize(), expectedFrameSize);
 }
 
+void SpacePacketFramerTester::testEmptyDataDropped() {
+    Fw::Buffer emptyData(nullptr, 0);
+    ComCfg::FrameContext context;
+    context.set_apid(static_cast<ComCfg::Apid::T>(0x01));
+
+    this->invoke_to_dataIn(0, emptyData, context);
+
+    // No packet should be emitted
+    ASSERT_from_dataOut_SIZE(0);
+    // The original buffer must still be returned to the caller
+    ASSERT_from_dataReturnOut_SIZE(1);
+    // The EmptyDataReceived warning must fire
+    ASSERT_EVENTS_EmptyDataReceived_SIZE(1);
+    // No allocation should have occurred
+    ASSERT_from_bufferAllocate_SIZE(0);
+}
+
 // ----------------------------------------------------------------------
 // Output port handler overrides
 // ----------------------------------------------------------------------

--- a/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
+++ b/Svc/Ccsds/SpacePacketFramer/test/ut/SpacePacketFramerTester.hpp
@@ -47,6 +47,7 @@ class SpacePacketFramerTester final : public SpacePacketFramerGTestBase {
     void testDataReturnPassthrough();
     void testNominalFraming();
     void testOversizedAllocatorBufferIsTrimmed();
+    void testEmptyDataDropped();
 
   private:
     // ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Convert the `FW_ASSERT(data.getSize() > 0)` in `SpacePacketFramer::dataIn_handler` to a
  runtime guard that logs a throttled `EmptyDataReceived` warning and returns the buffer to
  the caller
- The CCSDS Packet Data Length field encodes "octets minus 1", so a zero-octet payload
  cannot be represented; the `static_cast<U16>(data.getSize() - 1)` underflows to 65535
  when the assert is compiled out under `FW_NO_ASSERT`
- Add the `EmptyDataReceived` event to the FPP model with `throttle 5`
- Add unit test `EmptyDataDropped` covering the zero-size path

## Motivation

This is the same defense-in-depth pattern applied in #5585, #5633, #5690, and #5766:
inputs that can be influenced by upstream components or external sources should be
guarded at runtime, not only by assertions that may be compiled out.

## Test plan

- [ ] New `EmptyDataDropped` test: sends a zero-size buffer, asserts no packet emitted,
  buffer returned, warning event fired, no allocation attempted
- [ ] Existing `testNominalFraming` and `testOversizedAllocatorBufferIsTrimmed` pass
  unchanged