### PR TITLE
Report overlong hash-file names instead of asserting in Utils::CRCChecker and Svc::FileWorker

### DIFF
--- a/Svc/FileWorker/FileWorker.cpp
+++ b/Svc/FileWorker/FileWorker.cpp
@@ -40,6 +40,13 @@ void FileWorker ::readIn_handler(FwIndexType portNum, const Fw::StringBase& path
         this->readDoneOut_out(0, FW_STATUS_INVALID_INPUT, 0);
         return;
     }
+    // The path must leave room for the hash-file extension appended by the CRC helpers; a port
+    // argument can legally be up to FileNameStringSize characters, which is too long.
+    if (!FileWorker::pathFitsWithHashExtension(path)) {
+        this->log_WARNING_HI_InvalidInput(Fw::LogStringArg("readIn"), Fw::LogStringArg("path too long"));
+        this->readDoneOut_out(0, FW_STATUS_INVALID_INPUT, 0);
+        return;
+    }
     if (!buffer.isValid()) {
         this->log_WARNING_HI_InvalidInput(Fw::LogStringArg("readIn"), Fw::LogStringArg("invalid buffer"));
         this->readDoneOut_out(0, FW_STATUS_INVALID_INPUT, 0);
@@ -96,6 +103,13 @@ void FileWorker ::verifyIn_handler(FwIndexType portNum, const Fw::StringBase& pa
         this->verifyDoneOut_out(0, FW_STATUS_INVALID_INPUT, 0);
         return;
     }
+    // The path must leave room for the hash-file extension appended by the CRC helpers; a port
+    // argument can legally be up to FileNameStringSize characters, which is too long.
+    if (!FileWorker::pathFitsWithHashExtension(path)) {
+        this->log_WARNING_HI_InvalidInput(Fw::LogStringArg("verifyIn"), Fw::LogStringArg("path too long"));
+        this->verifyDoneOut_out(0, FW_STATUS_INVALID_INPUT, 0);
+        return;
+    }
 
     const char* const fileName = path.toChar();
     FwSizeType fileSize = 0;
@@ -133,6 +147,13 @@ void FileWorker ::writeIn_handler(FwIndexType portNum,
     // Validate inputs before processing file
     if (path.length() == 0) {
         this->log_WARNING_HI_InvalidInput(Fw::LogStringArg("writeIn"), Fw::LogStringArg("empty path"));
+        this->writeDoneOut_out(0, FW_STATUS_INVALID_INPUT, 0);
+        return;
+    }
+    // The path must leave room for the hash-file extension appended by the CRC helpers; a port
+    // argument can legally be up to FileNameStringSize characters, which is too long.
+    if (!FileWorker::pathFitsWithHashExtension(path)) {
+        this->log_WARNING_HI_InvalidInput(Fw::LogStringArg("writeIn"), Fw::LogStringArg("path too long"));
         this->writeDoneOut_out(0, FW_STATUS_INVALID_INPUT, 0);
         return;
     }
@@ -198,6 +219,11 @@ void FileWorker ::writeIn_handler(FwIndexType portNum,
 // ----------------------------------------------------------------------
 // Helper functions
 // ----------------------------------------------------------------------
+
+bool FileWorker ::pathFitsWithHashExtension(const Fw::StringBase& path) {
+    // Fw::FileNameString holds FileNameStringSize characters plus the terminator
+    return (path.length() + Utils::Hash::getFileExtensionLength()) <= FileNameStringSize;
+}
 
 Svc ::FileWorkerStatus FileWorker ::readBufferFromFile(Fw::Buffer& buffer, const char* const fileName) {
     FW_ASSERT(buffer.getData() != nullptr);
@@ -449,9 +475,15 @@ void FileWorker ::writeBufferHashToFile(Fw::Buffer& buffer, const char* fileName
     // Construct hash file name
     const char* ext = Utils::Hash::getFileExtensionString();
     FW_ASSERT(ext != nullptr);
-    char hashFileName[FileNameStringSize];
-    Fw::FormatStatus status = Fw::stringFormat(hashFileName, sizeof(hashFileName), "%s%s", fileName, ext);
-    FW_ASSERT(status == Fw::FormatStatus::SUCCESS);
+    // Same capacity as the CRC helpers so read, verify, and write agree on the longest legal path
+    Fw::FileNameString hashFileNameString;
+    Fw::FormatStatus status = hashFileNameString.format("%s%s", fileName, ext);
+    if (status != Fw::FormatStatus::SUCCESS) {
+        // writeIn_handler rejects such paths up front; report rather than assert if one gets here
+        this->log_WARNING_HI_InvalidInput(Fw::LogStringArg("writeIn"), Fw::LogStringArg("path too long"));
+        return;
+    }
+    const char* const hashFileName = hashFileNameString.toChar();
 
     // Compute hash
     Utils::HashBuffer hashBuffer;

--- a/Svc/FileWorker/FileWorker.hpp
+++ b/Svc/FileWorker/FileWorker.hpp
@@ -9,6 +9,7 @@
 
 #include <atomic>
 #include "Fw/Types/BasicTypes.hpp"
+#include "Fw/Types/FileNameString.hpp"
 #include "Fw/Types/StringUtils.hpp"
 #include "Os/File.hpp"
 #include "Os/FileSystem.hpp"

--- a/Svc/FileWorker/FileWorker.hpp
+++ b/Svc/FileWorker/FileWorker.hpp
@@ -89,6 +89,8 @@ class FileWorker : public FileWorkerComponentBase {
                  Utils::HashBuffer& hashBuffer,
                  const U8* const data,
                  const FwSizeType size);
+    //! True if path plus the hash-file extension fits in an Fw::FileNameString
+    static bool pathFitsWithHashExtension(const Fw::StringBase& path);
     bool writeBufferToFile(Fw::Buffer& buffer, const char* fileName, FwSizeType offset, bool append);
     void writeBufferHashToFile(Fw::Buffer& buffer, const char* fileName, FwSizeType offset, bool append);
     FwSizeType writeToFile(const U8* data, FwSizeType size, Os::File& file, const char* fileName);

--- a/Svc/FileWorker/docs/sdd.md
+++ b/Svc/FileWorker/docs/sdd.md
@@ -69,13 +69,13 @@ timeout</code></td><td><code>U64</code></td><td></td></tr>
 
 ### 3.4 Functional Description
 
-Each `*In` port handler validates its arguments before performing any file operation. Malformed inputs — such as an empty path, an invalid (null or zero-length) buffer, a write offset past the end of the buffer, or a path too long for the filename buffer — are reported by emitting an `InvalidInput` warning event and returning `INVALID_INPUT` to the client, rather than triggering an `FW_ASSERT`. This ensures that invalid, externally supplied (e.g. ground-commanded) inputs are surfaced to operators as telemetry instead of causing an assertion failure.
+Each `*In` port handler validates its arguments before performing any file operation. Malformed inputs — such as an empty path, an invalid (null or zero-length) buffer, a write offset past the end of the buffer, or a path that leaves no room for the `.CRC32` hash-file extension within `FileNameStringSize` — are reported by emitting an `InvalidInput` warning event and returning `INVALID_INPUT` to the client, rather than triggering an `FW_ASSERT`. This ensures that invalid, externally supplied (e.g. ground-commanded) inputs are surfaced to operators as telemetry instead of causing an assertion failure.
 
 #### 3.4.1 writeIn_handler
 
 Calling component passes in a buffer for writing to file, the file location is *path*, and the offset to start writing at.
 
-1. Validate inputs. If the path is empty, the buffer is invalid, the write offset is past the end of the buffer, or the path is too long for the filename buffer, emit an `InvalidInput` event and return `INVALID_INPUT`
+1. Validate inputs. If the path is empty, the buffer is invalid, the write offset is past the end of the buffer, or the path plus the hash-file extension exceeds `FileNameStringSize`, emit an `InvalidInput` event and return `INVALID_INPUT`
 2. If not in IDLE state, return NOT_IDLE
 3. Set state to WRITING
 4. Open a file at the provided path and write contents of client-provided buffer to it
@@ -86,7 +86,7 @@ Calling component passes in a buffer for writing to file, the file location is *
 
 Calling component passes in a file path *path* to read and a buffer for client to read from
 
-1. Validate inputs. If the path is empty or the buffer is invalid, emit an `InvalidInput` event and return `INVALID_INPUT`
+1. Validate inputs. If the path is empty, the buffer is invalid, or the path plus the hash-file extension exceeds `FileNameStringSize`, emit an `InvalidInput` event and return `INVALID_INPUT`
 2. If not in IDLE state, return NOT_IDLE
 3. Set state to READING
 4. Verify checksum. If checksum fails, return FAILED_CRC and set state to IDLE
@@ -96,7 +96,7 @@ Calling component passes in a file path *path* to read and a buffer for client t
 
 #### 3.4.3 verifyIn_handler
 
-1. Validate the input path. If the path is empty, emit an `InvalidInput` event and return `INVALID_INPUT`
+1. Validate the input path. If the path is empty or the path plus the hash-file extension exceeds `FileNameStringSize`, emit an `InvalidInput` event and return `INVALID_INPUT`
 2. Verify checksum. If checksum fails, return FAILED_CRC
 3. Get file size. If file size fails, return FAILED_FILE_SIZE
 4. Return file size to client

--- a/Svc/FileWorker/test/ut/FileWorkerTestMain.cpp
+++ b/Svc/FileWorker/test/ut/FileWorkerTestMain.cpp
@@ -56,6 +56,11 @@ TEST(Nominal, testTimeout) {
     tester.testTimeout();
 }
 
+TEST(Nominal, testPathTooLong) {
+    Svc::FileWorkerTester tester;
+    tester.testPathTooLong();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/FileWorker/test/ut/FileWorkerTester.cpp
+++ b/Svc/FileWorker/test/ut/FileWorkerTester.cpp
@@ -5,6 +5,11 @@
 // ======================================================================
 
 #include "FileWorkerTester.hpp"
+#include <string>
+
+#include "Os/File.hpp"
+#include "Os/FileSystem.hpp"
+#include "Utils/Hash/Hash.hpp"
 
 namespace Svc {
 
@@ -445,6 +450,82 @@ void FileWorkerTester ::testWriteZeroLength() {
     ASSERT_EQ(memcmp(readback, preserved, preservedSize), 0);
     check.close();
     (void)::remove(fnameChar);
+}
+
+void FileWorkerTester ::testPathTooLong() {
+    // Fw::FileNameString holds FileNameStringSize characters. Appending the hash extension to any
+    // path longer than (FileNameStringSize - extension) overflows it, which used to trip
+    // FW_ASSERT inside Utils::CRCChecker / writeBufferHashToFile. Such paths are valid port
+    // arguments (the port string is also FileNameStringSize), so they must be rejected as
+    // InvalidInput instead.
+    const FwSizeType ext = Utils::Hash::getFileExtensionLength();
+    const FwSizeType longestOk = FileNameStringSize - ext;  // 234 with defaults
+    const FwSizeType lengths[] = {longestOk + 1, FileNameStringSize};
+
+    U8 data[16];
+    for (FwSizeType i = 0; i < sizeof(data); i++) {
+        data[i] = static_cast<U8>(i);
+    }
+
+    for (FwSizeType len : lengths) {
+        std::string longName(static_cast<size_t>(len), 'p');
+        Fw::String fname(longName.c_str());
+        ASSERT_EQ(fname.length(), len);
+
+        // readIn
+        this->clearHistory();
+        Fw::Buffer readBuf(data, sizeof(data));
+        this->invoke_to_readIn(0, fname, readBuf);
+        this->component.doDispatch();
+        ASSERT_EVENTS_InvalidInput_SIZE(1);
+        ASSERT_EVENTS_InvalidInput(0, "readIn", "path too long");
+        ASSERT_from_readDoneOut_SIZE(1);
+        ASSERT_from_readDoneOut(0, FW_STATUS_INVALID_INPUT, 0);
+        ASSERT_EQ(this->component.m_state, FileWorkerState::FW_STATE_IDLE);
+
+        // verifyIn
+        this->clearHistory();
+        this->invoke_to_verifyIn(0, fname, 0);
+        this->component.doDispatch();
+        ASSERT_EVENTS_InvalidInput_SIZE(1);
+        ASSERT_EVENTS_InvalidInput(0, "verifyIn", "path too long");
+        ASSERT_EVENTS_CrcFailed_SIZE(0);
+        ASSERT_from_verifyDoneOut_SIZE(1);
+        ASSERT_from_verifyDoneOut(0, FW_STATUS_INVALID_INPUT, 0);
+
+        // writeIn
+        this->clearHistory();
+        Fw::Buffer writeBuf(data, sizeof(data));
+        this->invoke_to_writeIn(0, fname, writeBuf, 0, false);
+        this->component.doDispatch();
+        ASSERT_EVENTS_InvalidInput_SIZE(1);
+        ASSERT_EVENTS_InvalidInput(0, "writeIn", "path too long");
+        ASSERT_from_writeDoneOut_SIZE(1);
+        ASSERT_from_writeDoneOut(0, FW_STATUS_INVALID_INPUT, 0);
+        ASSERT_EQ(this->component.m_state, FileWorkerState::FW_STATE_IDLE);
+        ASSERT_FALSE(Os::FileSystem::exists(longName.c_str()));
+    }
+
+    // The longest path that still fits is valid input and reaches the file layer. No hash file
+    // exists for it, so verify reports a CRC failure rather than InvalidInput.
+    std::string okName(static_cast<size_t>(longestOk), 'q');
+    Fw::String okFname(okName.c_str());
+    Os::File f;
+    ASSERT_EQ(f.open(okName.c_str(), Os::File::OPEN_CREATE, Os::File::OVERWRITE), Os::File::OP_OK);
+    FwSizeType writeSize = sizeof(data);
+    ASSERT_EQ(f.write(data, writeSize), Os::File::OP_OK);
+    f.close();
+
+    this->clearHistory();
+    this->invoke_to_verifyIn(0, okFname, 0);
+    this->component.doDispatch();
+    ASSERT_EVENTS_InvalidInput_SIZE(0);
+    ASSERT_EVENTS_CrcFailed_SIZE(1);
+    ASSERT_EVENTS_CrcFailed(0, static_cast<U32>(Utils::FAILED_FILE_CRC_OPEN));
+    ASSERT_from_verifyDoneOut_SIZE(1);
+    ASSERT_from_verifyDoneOut(0, FW_STATUS_FAILED_CRC, sizeof(data));
+
+    (void)Os::FileSystem::removeFile(okName.c_str());
 }
 
 }  // namespace Svc

--- a/Svc/FileWorker/test/ut/FileWorkerTester.hpp
+++ b/Svc/FileWorker/test/ut/FileWorkerTester.hpp
@@ -57,6 +57,8 @@ class FileWorkerTester final : public FileWorkerGTestBase {
     void testWriteZeroLength();
     void testAppending();
     void testTimeout();
+    //! Paths that leave no room for the hash extension are rejected as invalid input, not asserted
+    void testPathTooLong();
 
   private:
     // ----------------------------------------------------------------------

--- a/Utils/CRCChecker.cpp
+++ b/Utils/CRCChecker.cpp
@@ -77,9 +77,12 @@ crc_stat_t create_checksum_file(const char* const fname) {
     // generate checksum
     hash.finalize(checksum);
 
-    // open checksum file
+    // open checksum file. The filename is caller-supplied input: an overlong name is a reportable
+    // failure, not a coding error, so it must not assert.
     Fw::FormatStatus formatStatus = hashFilename.format("%s%s", fname, HASH_EXTENSION_STRING);
-    FW_ASSERT(formatStatus == Fw::FormatStatus::SUCCESS);
+    if (formatStatus != Fw::FormatStatus::SUCCESS) {
+        return FAILED_FILE_NAME_TOO_LONG;
+    }
 
     stat = f.open(hashFilename.toChar(), Os::File::OPEN_WRITE);
     if (stat != Os::File::OP_OK) {
@@ -105,9 +108,11 @@ crc_stat_t read_crc32_from_file(const char* const fname, U32& checksum_from_file
     Os::File::Status stat;
     Fw::FileNameString hashFilename;
     FW_ASSERT(fname != nullptr);
-    // open checksum file
+    // open checksum file. See create_checksum_file(): overlong names are reported, not asserted.
     Fw::FormatStatus formatStatus = hashFilename.format("%s%s", fname, HASH_EXTENSION_STRING);
-    FW_ASSERT(formatStatus == Fw::FormatStatus::SUCCESS);
+    if (formatStatus != Fw::FormatStatus::SUCCESS) {
+        return FAILED_FILE_NAME_TOO_LONG;
+    }
 
     stat = f.open(hashFilename.toChar(), Os::File::OPEN_READ);
     if (stat != Os::File::OP_OK) {

--- a/Utils/CRCChecker.hpp
+++ b/Utils/CRCChecker.hpp
@@ -29,7 +29,8 @@ typedef enum {
     FAILED_FILE_CRC_OPEN,
     FAILED_FILE_CRC_READ,
     FAILED_FILE_CRC_WRITE,
-    FAILED_FILE_CRC_CHECK
+    FAILED_FILE_CRC_CHECK,
+    FAILED_FILE_NAME_TOO_LONG  //!< filename + hash extension does not fit in Fw::FileNameString
 } crc_stat_t;
 
 crc_stat_t create_checksum_file(const char* const filename);

--- a/Utils/test/ut/CRCCheckerTester.cpp
+++ b/Utils/test/ut/CRCCheckerTester.cpp
@@ -15,6 +15,7 @@
 #include <STest/STest/Pick/Pick.hpp>
 #include <Utils/CRCChecker.hpp>
 #include <Utils/Hash/Hash.hpp>
+#include <string>
 #include <vector>
 
 namespace {
@@ -186,3 +187,37 @@ TEST_F(CRCCheckerTest, RandomizedSoak) {
 }
 
 }  // namespace
+
+TEST_F(CRCCheckerTest, FileNameTooLong) {
+    // A filename that leaves no room for the hash extension in Fw::FileNameString must be reported
+    // as FAILED_FILE_NAME_TOO_LONG by every helper, never asserted on.
+    const FwSizeType ext = Utils::Hash::getFileExtensionLength();
+    const FwSizeType longestOk = FileNameStringSize - ext;  // Fw::FileNameString holds FileNameStringSize chars
+    const U8 data[] = {'1', '2', '3', '4', '5', '6', '7', '8', '9'};
+
+    for (FwSizeType len : {longestOk + 1, static_cast<FwSizeType>(FileNameStringSize)}) {
+        std::string name(static_cast<size_t>(len), 'x');
+        writeFile(name.c_str(), data, sizeof(data));
+
+        ASSERT_EQ(Utils::create_checksum_file(name.c_str()), Utils::FAILED_FILE_NAME_TOO_LONG) << "len " << len;
+        U32 fromFile = 0;
+        ASSERT_EQ(Utils::read_crc32_from_file(name.c_str(), fromFile), Utils::FAILED_FILE_NAME_TOO_LONG)
+            << "len " << len;
+        U32 expected = 0;
+        U32 actual = 0;
+        ASSERT_EQ(Utils::verify_checksum(name.c_str(), expected, actual), Utils::FAILED_FILE_NAME_TOO_LONG)
+            << "len " << len;
+
+        (void)Os::FileSystem::removeFile(name.c_str());
+    }
+
+    // The longest name that fits round-trips normally
+    std::string okName(static_cast<size_t>(longestOk), 'y');
+    writeFile(okName.c_str(), data, sizeof(data));
+    ASSERT_EQ(Utils::create_checksum_file(okName.c_str()), Utils::PASSED_FILE_CRC_WRITE);
+    U32 expected = 0;
+    U32 actual = 0;
+    ASSERT_EQ(Utils::verify_checksum(okName.c_str(), expected, actual), Utils::PASSED_FILE_CRC_CHECK);
+    ASSERT_EQ(expected, 0xCBF43926u);
+    removeTestFiles(okName.c_str());
+}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5802 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Replaces `FW_ASSERT`-on-format-overflow with reported errors when a file path is too long to have the `.CRC32` hash-file extension appended, and rejects such paths at the `FileWorker` port handlers before any file operation.

- `Utils/CRCChecker.hpp`: new `crc_stat_t` value `FAILED_FILE_NAME_TOO_LONG` (appended, existing values unchanged).
- `Utils/CRCChecker.cpp`: `create_checksum_file` and `read_crc32_from_file` (and therefore `verify_checksum`) return `FAILED_FILE_NAME_TOO_LONG` instead of asserting when `"%s.CRC32"` does not fit in `Fw::FileNameString`.
- `Svc/FileWorker/FileWorker.cpp`:
  - New static helper `pathFitsWithHashExtension()` — `path.length() + Utils::Hash::getFileExtensionLength() <= FileNameStringSize`.
  - `readIn_handler`, `verifyIn_handler`, `writeIn_handler` apply it alongside the existing empty-path check, emitting `InvalidInput(<handler>, "path too long")` and returning `FW_STATUS_INVALID_INPUT`.
  - `writeBufferHashToFile` builds the hash filename in an `Fw::FileNameString` (same capacity as the CRC helpers) and reports `InvalidInput` instead of asserting if the format overflows. The previous `char[FileNameStringSize]` buffer held one character fewer than `Fw::FileNameString`, so read/verify and write disagreed on the longest legal path by one.
- `Svc/FileWorker/docs/sdd.md`: validation text for the three handlers updated.

Note on the boundary: `Fw::FileNameString` holds `FileNameStringSize` (240) characters plus terminator, and the `FileRead`/`FileWrite`/`VerifyStatus` port strings admit the same. With the 6-character extension, paths of 235–240 characters overflow; 234 is the longest that works. #5802 quotes 234–239, which is off by one.

Deliberately out of scope: `Os/ValidatedFile.cpp:22` and `Svc/ComLogger/ComLogger.cpp:140` have the same assert pattern, but their names come from init-time configuration rather than port input; `ValidatedFile`'s assert is also documented as intentional (a truncated hash-file name must never validate the wrong file). Left for a separate change if desired.

## Rationale

The overflow is a correct `OVERFLOWED` return from `stringFormat` on input that is legal for the port type; converting it into a FATAL treats operator-supplied data as a coding error. #5198 already replaced the entry-point assertions in `FileWorker` with `InvalidInput` events for the same reason; this covers the deeper sites that change did not reach.

## Testing/Review Recommendations

- `Utils_ut_exe` — 16/16 pass. New `CRCCheckerTest.FileNameTooLong`: 235- and 240-character names return `FAILED_FILE_NAME_TOO_LONG` from all three helpers; a 234-character name round-trips (`PASSED_FILE_CRC_WRITE` / `PASSED_FILE_CRC_CHECK`).
- `FileWorkerTestNominal` — 10/10, `FileWorkerTestError` — 9/9. New `Nominal.testPathTooLong`: 235- and 240-character paths through `readIn`, `verifyIn`, and `writeIn` each produce exactly one `InvalidInput(..., "path too long")`, an `FW_STATUS_INVALID_INPUT` done-port call, idle state, and no file created; a 234-character path passes validation and reaches the file layer (reports `CrcFailed(FAILED_FILE_CRC_OPEN)` because no hash file exists).
- Review focus: the `<=` in `pathFitsWithHashExtension()` against `Fw::StringBase::BUFFER_SIZE` semantics; enum append position in `crc_stat_t` (any external code switching on it should get a warning for the unhandled value).
- `clang-format` (venv, 20.1.8) applied to all changed C++ files.

## Future Work

- Optional consistency pass over `Os::ValidatedFile` and `Svc::ComLogger` (see above).

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude Code was used to draft the implementation, unit tests, and documentation changes, and to run the unit test suites. All changes were reviewed by the author.
