### PR TITLE
Fix settings.ini path comparison through symlinks

### DIFF
--- a/cmake/settings/ini.cmake
+++ b/cmake/settings/ini.cmake
@@ -33,9 +33,14 @@ set(FPRIME_UTIL_CRITICAL_LIST
 function(ini_to_cache)
     set(CALCULATED_INI "${CMAKE_SOURCE_DIR}/settings.ini")
 
-    # Check if settings.ini is defined and is not what is expected
-    if (DEFINED FPRIME_SETTINGS_FILE AND NOT FPRIME_SETTINGS_FILE STREQUAL "${CALCULATED_INI}")
-        message(FATAL_ERROR "Provided settings.ini '${FPRIME_SETTINGS_FILE}' not expected file '${CALCULATED_INI}'")
+    # Check if settings.ini is defined and is not what is expected. Resolve symlinks before comparison so equivalent
+    # paths to the same settings file are accepted.
+    if (DEFINED FPRIME_SETTINGS_FILE)
+        get_filename_component(FPRIME_SETTINGS_FILE_REAL "${FPRIME_SETTINGS_FILE}" REALPATH)
+        get_filename_component(CALCULATED_INI_REAL "${CALCULATED_INI}" REALPATH)
+        if (NOT "${FPRIME_SETTINGS_FILE_REAL}" STREQUAL "${CALCULATED_INI_REAL}")
+            message(FATAL_ERROR "Provided settings.ini '${FPRIME_SETTINGS_FILE}' not expected file '${CALCULATED_INI}'")
+        endif()
     endif()
     # Execute the process
     execute_process(COMMAND ${PYTHON}

--- a/cmake/test/src/test_symlink.py
+++ b/cmake/test/src/test_symlink.py
@@ -24,7 +24,7 @@ _ = cmake.get_build(
     install_directory=tempfile.mkdtemp(),
 )
 
-_ = cmake.get_build(
+_2 = cmake.get_build(
     "SYMLINKED_SETTINGS_BUILD",
     settings.REF_APP_PATH,
     cmake_arguments={

--- a/cmake/test/src/test_symlink.py
+++ b/cmake/test/src/test_symlink.py
@@ -28,9 +28,7 @@ _2 = cmake.get_build(
     "SYMLINKED_SETTINGS_BUILD",
     settings.REF_APP_PATH,
     cmake_arguments={
-        "FPRIME_SETTINGS_FILE": SYMLINK_PATH
-        / "TestDeploymentsProject"
-        / "settings.ini"
+        "FPRIME_SETTINGS_FILE": SYMLINK_PATH / "TestDeploymentsProject" / "settings.ini"
     },
     make_targets=[],
 )
@@ -50,6 +48,4 @@ def test_unittest_run(SYMLINKED_UT_BUILD, symlink_maker):
 
 def test_symlinked_settings_path(SYMLINKED_SETTINGS_BUILD, symlink_maker):
     """Equivalent settings.ini paths through symlinks are accepted"""
-    cmake.assert_process_success(
-        SYMLINKED_SETTINGS_BUILD, errors_ok=True, targets=[]
-    )
+    cmake.assert_process_success(SYMLINKED_SETTINGS_BUILD, errors_ok=True, targets=[])

--- a/cmake/test/src/test_symlink.py
+++ b/cmake/test/src/test_symlink.py
@@ -24,6 +24,17 @@ _ = cmake.get_build(
     install_directory=tempfile.mkdtemp(),
 )
 
+_ = cmake.get_build(
+    "SYMLINKED_SETTINGS_BUILD",
+    settings.REF_APP_PATH,
+    cmake_arguments={
+        "FPRIME_SETTINGS_FILE": SYMLINK_PATH
+        / "TestDeploymentsProject"
+        / "settings.ini"
+    },
+    make_targets=[],
+)
+
 
 @pytest.fixture(scope="session")
 def symlink_maker():
@@ -35,3 +46,10 @@ def symlink_maker():
 def test_unittest_run(SYMLINKED_UT_BUILD, symlink_maker):
     """Basic run test for ref"""
     cmake.assert_process_success(SYMLINKED_UT_BUILD, errors_ok=True)
+
+
+def test_symlinked_settings_path(SYMLINKED_SETTINGS_BUILD, symlink_maker):
+    """Equivalent settings.ini paths through symlinks are accepted"""
+    cmake.assert_process_success(
+        SYMLINKED_SETTINGS_BUILD, errors_ok=True, targets=[]
+    )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Fixes #4605 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

Fix the settings.ini path validation so equivalent filesystem paths through symlinks are accepted.

The existing check compares FPRIME_SETTINGS_FILE and the calculated settings.ini path as literal strings. On systems where the same file can be addressed through different paths, such as /tmp and /private/tmp on macOS or a project accessed through a symlink, this causes configuration to fail even though both paths refer to the same file.

This change:

- resolves both paths with CMake REALPATH before comparing them
- preserves the existing error when the paths actually refer to different settings files
- adds regression coverage to the existing symlink CMake tests

## Rationale

Path identity should be based on the resolved filesystem location rather than the literal path spelling. This allows fprime-util and CMake to work correctly when a project or settings file is accessed through a symlink.

## Testing/Review Recommendations

The regression test configures the real TestDeploymentsProject path while passing the same settings.ini through a symlink. The previous literal-string comparison rejects this case; the updated canonical-path comparison accepts it.

Review focus: the REALPATH comparison in cmake/settings/ini.cmake and the new case in cmake/test/src/test_symlink.py.