### PR TITLE
Drop Svc.Ping input ports on overflow so the Health system gets to react

### DIFF
--- a/.github/skills/fprime-component-design-fpp/SKILL.md
+++ b/.github/skills/fprime-component-design-fpp/SKILL.md
@@ -92,7 +92,7 @@ for port definition syntax.
 | Need | Port | Import |
 |---|---|---|
 | Rate-group scheduling | `sync input port run: Svc.Sched` | `import Svc.Sched` |
-| Health ping | `async input port pingIn: Svc.Ping` | `import Svc.Ping` |
+| Health ping | `async input port pingIn: Svc.Ping drop` | `import Svc.Ping` |
 | Time access | `time get port timeCaller` | (special port) |
 | Command handling | `command recv port cmdIn` | (special port) |
 | Event logging | `event port eventOut` | (special port) |

--- a/FppTestProject/FppTest/topology/components/Comp/Comp.fpp
+++ b/FppTestProject/FppTest/topology/components/Comp/Comp.fpp
@@ -22,7 +22,7 @@ module FppTest {
     async input port syncIn: Svc.Sched
     output port syncOut: Svc.Sched
 
-    async input port PingIn: Svc.Ping
+    async input port PingIn: Svc.Ping drop
     output port PingOut: Svc.Ping
 
     async command Start(nRecords: U32)

--- a/FppTestProject/FppTest/topology/components/Framework/Framework.fpp
+++ b/FppTestProject/FppTest/topology/components/Framework/Framework.fpp
@@ -53,7 +53,7 @@ module FppTest {
         output port PingSend: [2] Svc.Ping
 
         @ Ping return port
-        async input port PingReturn: [2] Svc.Ping
+        async input port PingReturn: [2] Svc.Ping drop
 
         output port syncOut: [2] Svc.Sched
         async input port syncIn: [2] Svc.Sched

--- a/Svc/ActiveRateGroup/ActiveRateGroup.fpp
+++ b/Svc/ActiveRateGroup/ActiveRateGroup.fpp
@@ -15,7 +15,7 @@ module Svc {
     output port RateGroupMemberOut: [ActiveRateGroupOutputPorts] Sched
 
     @ Ping input port for health
-    async input port PingIn: Ping
+    async input port PingIn: Ping drop
 
     @ Ping output port for health
     output port PingOut: Ping

--- a/Svc/BufferAccumulator/BufferAccumulator.fpp
+++ b/Svc/BufferAccumulator/BufferAccumulator.fpp
@@ -36,7 +36,7 @@ module Svc {
     text event port eventOutText
 
     @ Ping input port for health
-    async input port pingIn: [1] Svc.Ping
+    async input port pingIn: [1] Svc.Ping drop
 
     @ Ping output port for health
     output port pingOut: [1] Svc.Ping

--- a/Svc/BufferLogger/BufferLogger.fpp
+++ b/Svc/BufferLogger/BufferLogger.fpp
@@ -16,7 +16,7 @@ module Svc {
     async input port comIn: Fw.Com
 
     @ Ping input port
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Ping output port
     output port pingOut: Svc.Ping

--- a/Svc/Ccsds/CfdpManager/CfdpManager.fpp
+++ b/Svc/Ccsds/CfdpManager/CfdpManager.fpp
@@ -23,7 +23,7 @@ module Cfdp {
         async input port run1Hz: Svc.Sched
 
         @ Ping in port
-        async input port pingIn: Svc.Ping
+        async input port pingIn: Svc.Ping drop
 
         @ Ping out port
         output port pingOut: Svc.Ping

--- a/Svc/CmdDispatcher/CmdDispatcher.fpp
+++ b/Svc/CmdDispatcher/CmdDispatcher.fpp
@@ -24,7 +24,7 @@ module Svc {
     async input port seqCmdBuff: [CmdDispatcherSequencePorts] Fw.Com hook
 
     @ Ping input port
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Run port used to emit telemetry
     async input port run: Svc.Sched

--- a/Svc/CmdSequencer/CmdSequencer.fpp
+++ b/Svc/CmdSequencer/CmdSequencer.fpp
@@ -62,7 +62,7 @@ module Svc {
     async input port cmdResponseIn: Fw.CmdResponse
 
     @ Ping in port
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Ping out port
     output port pingOut: Svc.Ping

--- a/Svc/ComLogger/ComLogger.fpp
+++ b/Svc/ComLogger/ComLogger.fpp
@@ -11,7 +11,7 @@ module Svc {
     async input port comIn: Fw.Com
 
     @ Ping input port
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Ping output port
     output port pingOut: Svc.Ping

--- a/Svc/DpCatalog/DpCatalog.fpp
+++ b/Svc/DpCatalog/DpCatalog.fpp
@@ -32,7 +32,7 @@ module Svc {
     # Component specific ports
 
     @ Ping input port
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Ping output port
     output port pingOut: Svc.Ping

--- a/Svc/EventManager/EventManager.fpp
+++ b/Svc/EventManager/EventManager.fpp
@@ -56,7 +56,7 @@ module Svc {
     async input port run: Svc.Sched drop
 
     @ Ping input port
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Ping output port
     output port pingOut: Svc.Ping

--- a/Svc/FileDispatcher/FileDispatcher.fpp
+++ b/Svc/FileDispatcher/FileDispatcher.fpp
@@ -51,7 +51,7 @@ module Svc {
         async input port fileAnnounceRecv: Svc.FileAnnounce
 
         @ Ping in
-        async input port pingIn: Svc.Ping
+        async input port pingIn: Svc.Ping drop
 
         ###############################################################################
         # Output ports                                                                 #

--- a/Svc/FileDownlink/FileDownlink.fpp
+++ b/Svc/FileDownlink/FileDownlink.fpp
@@ -23,7 +23,7 @@ module Svc {
     output port bufferSendOut: Fw.BufferSend
 
     @ Ping input port
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Ping output port
     output port pingOut: Svc.Ping

--- a/Svc/FileManager/FileManager.fpp
+++ b/Svc/FileManager/FileManager.fpp
@@ -8,7 +8,7 @@ module Svc {
     # ----------------------------------------------------------------------
 
     @ Ping input port
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Scheduler input port for rate group operations
     sync input port schedIn: Sched

--- a/Svc/FileUplink/FileUplink.fpp
+++ b/Svc/FileUplink/FileUplink.fpp
@@ -14,7 +14,7 @@ module Svc {
     output port bufferSendOut: Fw.BufferSend
 
     @ Ping in
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Ping out
     output port pingOut: Svc.Ping

--- a/Svc/FpySequencer/FpySequencer.fpp
+++ b/Svc/FpySequencer/FpySequencer.fpp
@@ -33,7 +33,7 @@ module Svc {
 
         @ Ping in port
         # TODO should ping have highest prio? or lowest?
-        async input port pingIn: Svc.Ping priority 10 assert
+        async input port pingIn: Svc.Ping priority 10 drop
 
         @ port to trigger a wakeup or timeout check. increase frequency
         @ to increase temporal resolution of sequencer

--- a/Svc/Health/Health.fpp
+++ b/Svc/Health/Health.fpp
@@ -11,7 +11,7 @@ module Svc {
     output port PingSend: [HealthPingPorts] Svc.Ping
 
     @ Ping return port
-    async input port PingReturn: [HealthPingPorts] Svc.Ping
+    async input port PingReturn: [HealthPingPorts] Svc.Ping drop
 
     @ Run port
     sync input port Run: Svc.Sched

--- a/Svc/Health/Health.fpp
+++ b/Svc/Health/Health.fpp
@@ -11,7 +11,7 @@ module Svc {
     output port PingSend: [HealthPingPorts] Svc.Ping
 
     @ Ping return port
-    async input port PingReturn: [HealthPingPorts] Svc.Ping drop
+    async input port PingReturn: [HealthPingPorts] Svc.Ping
 
     @ Run port
     sync input port Run: Svc.Sched

--- a/Svc/PrmDb/PrmDb.fpp
+++ b/Svc/PrmDb/PrmDb.fpp
@@ -69,7 +69,7 @@ module Svc {
     async input port setPrm: Fw.PrmSet
 
     @ Ping input port
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Ping output port
     output port pingOut: Svc.Ping

--- a/Svc/TlmChan/TlmChan.fpp
+++ b/Svc/TlmChan/TlmChan.fpp
@@ -36,7 +36,7 @@ module Svc {
     output port PktSend: Fw.Com
 
     @ Ping input port
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Ping output port
     output port pingOut: Svc.Ping

--- a/Svc/TlmPacketizer/TlmPacketizer.fpp
+++ b/Svc/TlmPacketizer/TlmPacketizer.fpp
@@ -28,7 +28,7 @@ module Svc {
     async input port controlIn: EnableSection
 
     @ Ping input port
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Ping output port
     output port pingOut: Svc.Ping

--- a/TestDeploymentsProject/Ref/BlockDriver/BlockDriver.fpp
+++ b/TestDeploymentsProject/Ref/BlockDriver/BlockDriver.fpp
@@ -19,7 +19,7 @@ module Ref {
     output port BufferOut: Drv.DataBuffer
 
     @ Input ping port
-    async input port PingIn: Svc.Ping
+    async input port PingIn: Svc.Ping drop
 
     @ Output ping port
     output port PingOut: Svc.Ping

--- a/TestDeploymentsProject/Ref/PingReceiver/PingReceiver.fpp
+++ b/TestDeploymentsProject/Ref/PingReceiver/PingReceiver.fpp
@@ -8,7 +8,7 @@ module Ref {
     # ----------------------------------------------------------------------
 
     @ The ping input port
-    async input port PingIn: Svc.Ping
+    async input port PingIn: Svc.Ping drop
 
     @ The ping input port
     output port PingOut: Svc.Ping

--- a/docs/user-manual/design-patterns/health-checking.md
+++ b/docs/user-manual/design-patterns/health-checking.md
@@ -49,7 +49,7 @@ Implementation of the health checking pattern involves placing a pair of `Svc.Pi
 ```
 active component CriticalComponent {
     @ Ping input port to show responsiveness
-    async input port pingIn: Svc.Ping
+    async input port pingIn: Svc.Ping drop
 
     @ Ping output port for response to the ping
     output port pingOut: Svc.Ping


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| - |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Set Svc.Ping input ports to `drop` rather than `assert`

## Rationale

This ensures the Health system gets to react to the queue overflow at the configured timeout threshold, rather than the assert hook firing & taking down the FSW/making cleanup much more complicated.

## Testing/Review Recommendations

I think in general it'd be good to have some tests into how the system responds when compute is under contention/severely under provisioned to ensure the system fails gracefully where possible, rather than abruptly asserting.

## Future Work

I will likely have more suggestions for changes to overflow behavior in upstream components in subsequent PRs. 

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

The actual changes to the FPrime repo were made in vim w/ the help of ripgrep. However, [the overall topology analysis](https://github.com/Willmac16/fprime-topo-analysis) I'm working on, which reminded me of the "pings should drop" point, is tooling written by AI.
