### PR TITLE
fix(Fw/Types): use overflow-safe bounds checks in LinearBufferBase serialization

### DIFF
--- a/Fw/Types/Serializable.cpp
+++ b/Fw/Types/Serializable.cpp
@@ -255,7 +255,8 @@ LinearBufferBase::serializeFrom(const U8* buff,
     }
 
     // make sure we have enough space
-    if (this->m_serLoc + length > this->m_capacity) {
+    // Note: m_serLoc <= m_capacity is a class invariant, so this subtraction cannot underflow.
+    if (length > this->m_capacity - this->m_serLoc) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
 
@@ -280,7 +281,9 @@ FW_SERIALIZE_FORCE_INLINE_LBB SerializeStatus LinearBufferBase::serializeFrom(co
 FW_SERIALIZE_FORCE_INLINE_LBB SerializeStatus LinearBufferBase::serializeFrom(const LinearBufferBase& val,
                                                                               Endianness mode) {
     Serializable::SizeType size = val.getSize();
-    if (this->m_serLoc + size + static_cast<Serializable::SizeType>(sizeof(FwSizeStoreType)) > this->m_capacity) {
+    // Note: m_serLoc <= m_capacity is a class invariant, so this subtraction cannot underflow.
+    Serializable::SizeType available = this->m_capacity - this->m_serLoc;
+    if (size > available || static_cast<Serializable::SizeType>(sizeof(FwSizeStoreType)) > available - size) {
         return FW_SERIALIZE_NO_ROOM_LEFT;
     }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5816 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Fixes two unsigned integer overflow vulnerabilities in `Fw/Types/Serializable.cpp` where `serLoc + length > capacity` can wrap to zero and silently pass the bounds check. Uses the subtraction form (`length > capacity - serLoc`) which cannot underflow because `serLoc <= capacity` is a class invariant.

Two sites fixed (+5/-2 lines):
1. `serializeFrom(const U8*, length)` — single subtraction-form check
2. `serializeFrom(const LinearBufferBase&)` — two-step check for `size + sizeof(FwSizeStoreType)` via an `available` intermediate

## Rationale

In unsigned arithmetic, `a + b > max` wraps to a small value when `a + b` overflows, making the guard silently ineffective. The subtraction form `b > max - a` is safe when `a <= max` (the invariant `serLoc <= capacity` holds), and is already the established idiom in this codebase.

## Testing/Review Recommendations

The existing `LinearBufferBase` unit tests cover the affected serialization paths. Behavior is identical for all valid inputs; only the overflow edge case is corrected.

## Future Work

None planned.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude Code was used for codebase search (finding all `serLoc + length > capacity` instances) and fix design.

IAMAI

