### PR TITLE
fix(BufferManager): guard allocation size loop against integer overflow

### DIFF
--- a/Svc/BufferManager/BufferManagerComponentImpl.cpp
+++ b/Svc/BufferManager/BufferManagerComponentImpl.cpp
@@ -143,10 +143,16 @@ void BufferManagerComponentImpl::setup(U16 mgrId,                    //!< manage
     // walk through bins and add up the sizes
     for (U16 bin = 0; bin < BUFFERMGR_MAX_NUM_BINS; bin++) {
         if (this->m_bufferBins.bins[bin].numBuffers) {
-            memorySize += (this->m_bufferBins.bins[bin].bufferSize *
-                           this->m_bufferBins.bins[bin].numBuffers) +  // allocate each set of buffer memory
-                          (static_cast<FwSizeType>(sizeof(AllocatedBuffer)) *
-                           this->m_bufferBins.bins[bin].numBuffers);  // allocate the structs to track the buffers
+            const FwSizeType bufferSize = this->m_bufferBins.bins[bin].bufferSize;
+            const FwSizeType numBuffers = static_cast<FwSizeType>(this->m_bufferBins.bins[bin].numBuffers);
+            const FwSizeType perBuffer = bufferSize + static_cast<FwSizeType>(sizeof(AllocatedBuffer));
+
+            FW_ASSERT(perBuffer >= bufferSize);  // addition didn't wrap
+            FW_ASSERT(perBuffer <= std::numeric_limits<FwSizeType>::max() / numBuffers);  // multiply safe
+            const FwSizeType binTotal = perBuffer * numBuffers;
+            FW_ASSERT(memorySize <= std::numeric_limits<FwSizeType>::max() - binTotal);  // accumulate safe
+            memorySize += binTotal;
+
             // Total structures is bounded by U16 maximum value to fit in half of context (U32)
             FW_ASSERT((std::numeric_limits<U16>::max() - this->m_numStructs) >=
                       this->m_bufferBins.bins[bin].numBuffers);

--- a/Svc/BufferManager/BufferManagerComponentImpl.cpp
+++ b/Svc/BufferManager/BufferManagerComponentImpl.cpp
@@ -147,7 +147,7 @@ void BufferManagerComponentImpl::setup(U16 mgrId,                    //!< manage
             const FwSizeType numBuffers = static_cast<FwSizeType>(this->m_bufferBins.bins[bin].numBuffers);
             const FwSizeType perBuffer = bufferSize + static_cast<FwSizeType>(sizeof(AllocatedBuffer));
 
-            FW_ASSERT(perBuffer >= bufferSize);  // addition didn't wrap
+            FW_ASSERT(perBuffer >= bufferSize);                                           // addition didn't wrap
             FW_ASSERT(perBuffer <= std::numeric_limits<FwSizeType>::max() / numBuffers);  // multiply safe
             const FwSizeType binTotal = perBuffer * numBuffers;
             FW_ASSERT(memorySize <= std::numeric_limits<FwSizeType>::max() - binTotal);  // accumulate safe

--- a/Svc/BufferManager/test/ut/BufferManagerTestMain.cpp
+++ b/Svc/BufferManager/test/ut/BufferManagerTestMain.cpp
@@ -24,6 +24,11 @@ TEST(Nominal, BufferSizeTrimmed) {
     tester.bufferSizeTrimmed();
 }
 
+TEST(OffNominal, SetupSizeOverflowAsserts) {
+    Svc::BufferManagerTester tester;
+    tester.setupSizeOverflowAsserts();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/BufferManager/test/ut/BufferManagerTester.cpp
+++ b/Svc/BufferManager/test/ut/BufferManagerTester.cpp
@@ -14,6 +14,7 @@
 #include <Fw/Test/UnitTest.hpp>
 #include <Fw/Types/MallocAllocator.hpp>
 #include <cstdlib>
+#include <limits>
 
 #define INSTANCE 0
 #define MAX_HISTORY_SIZE 100
@@ -478,6 +479,36 @@ void BufferManagerTester::bufferSizeTrimmed() {
     ASSERT_FALSE(this->component.m_buffers[0].allocated);
 
     this->component.cleanup();
+}
+
+void BufferManagerTester::setupSizeOverflowAsserts() {
+    // setup() adds up bufferSize + sizeof(AllocatedBuffer) per buffer, times numBuffers, across
+    // bins, and hands the total to the allocator. Each step is now checked before it can wrap;
+    // without the checks the total wrapped silently and the buffer structures were carved into
+    // an allocation far smaller than the manager believed it had.
+    const FwSizeType maxSize = std::numeric_limits<FwSizeType>::max();
+    BufferManagerComponentImpl::BufferBins bins;
+    TestAllocator alloc;
+
+    // bufferSize + sizeof(AllocatedBuffer) wraps
+    memset(&bins, 0, sizeof(bins));
+    bins.bins[0].bufferSize = maxSize;
+    bins.bins[0].numBuffers = 1;
+    ASSERT_DEATH_IF_SUPPORTED(this->component.setup(MGR_ID, MEM_ID, alloc, bins), "Assert: ");
+
+    // per-buffer size times numBuffers wraps
+    memset(&bins, 0, sizeof(bins));
+    bins.bins[0].bufferSize = maxSize / 2;
+    bins.bins[0].numBuffers = 3;
+    ASSERT_DEATH_IF_SUPPORTED(this->component.setup(MGR_ID, MEM_ID, alloc, bins), "Assert: ");
+
+    // the running total across bins wraps
+    memset(&bins, 0, sizeof(bins));
+    bins.bins[0].bufferSize = maxSize / 2;
+    bins.bins[0].numBuffers = 1;
+    bins.bins[1].bufferSize = maxSize / 2;
+    bins.bins[1].numBuffers = 1;
+    ASSERT_DEATH_IF_SUPPORTED(this->component.setup(MGR_ID, MEM_ID, alloc, bins), "Assert: ");
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/BufferManager/test/ut/BufferManagerTester.hpp
+++ b/Svc/BufferManager/test/ut/BufferManagerTester.hpp
@@ -51,6 +51,9 @@ class BufferManagerTester : public BufferManagerGTestBase {
     //! Requested buffer size is preserved when allocating from a larger bin
     void bufferSizeTrimmed();
 
+    //! Bin sizes whose byte count would wrap are refused by setup before any allocation
+    void setupSizeOverflowAsserts();
+
   private:
     // ----------------------------------------------------------------------
     // Helper methods


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5817 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

Fixes integer overflow in `BufferManagerComponentImpl::setup()` where the memory size accumulation loop can silently wrap, leading to undersized allocation and subsequent buffer overruns. Factors `(bufferSize + sizeof(AllocatedBuffer)) * numBuffers` into a single `perBuffer` term and guards three overflow points with `FW_ASSERT`: addition wrap, multiply overflow, and accumulate overflow (+10/-4 lines).

## Rationale

Before this fix, large `bufferSize * numBuffers` products could silently wrap, causing `memorySize` to reflect a much smaller value than actually needed. The subsequent `allocate()` call would succeed with insufficient memory, and later buffer accesses would write past the allocated region. Factoring the expression algebraically reduces guard count from what a naïve approach would require and uses the subtraction form (`x <= MAX - y`) consistent with the idiom in `Fw/Types/Serializable`.

## Testing/Review Recommendations

`BufferManagerTester::setupSizeOverflowAsserts` with three ASSERT_DEATH cases (6713a08), run as `OffNominal.SetupSizeOverflowAsserts`. Without the guards the cases report "failed to die" (silent wrap), with them all pass. Formatting applied with the command from the review.

## Future Work

None planned.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude Code was used for codebase navigation (finding the accumulation loop) and algebraic simplification of the guard expression.

IAMAI

