### PR TITLE
Make soak tests run every other hour

### DIFF
--- a/.github/workflows/ext-aarch64-linux-reference-soak-test.yml
+++ b/.github/workflows/ext-aarch64-linux-reference-soak-test.yml
@@ -7,7 +7,7 @@ name: "Soak Test: AArch64 Linux Reference"
 on:
   schedule:
     # Staggered against the Pico 2 soak
-    - cron: "0,30 * * * *"
+    - cron: "15 */2 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ext-pico2-zephyr-reference-soak-test.yml
+++ b/.github/workflows/ext-pico2-zephyr-reference-soak-test.yml
@@ -6,8 +6,8 @@ name: "Soak Test: Pico 2 Zephyr Reference"
 
 on:
   schedule:
-    # Staggered against the AArch64 Linux LedBlinker soak 
-    - cron: "15,45 * * * *"
+    # Staggered against the AArch64 Linux LedBlinker soak
+    - cron: "45 */2 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION

| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Soak tests currently run every 30mins, and last for 10 to 25mins. 
This is proposing to run every other hour instead. Note that the aarch64 soak test has been consistently failing for a while.