### PR TITLE
Add fail-closed sandbox confinement to Svc::FileManager command paths

### DIFF
--- a/Svc/FileManager/Events.fppi
+++ b/Svc/FileManager/Events.fppi
@@ -279,4 +279,5 @@ event PathOutsideSandbox(
                             sandboxDir: string size FileNameStringSize @< The configured sandbox directory
                         ) \
   severity warning high \
+  id 0x23 \
   format "Path {} is outside the configured sandbox directory {}"

--- a/Svc/FileManager/Events.fppi
+++ b/Svc/FileManager/Events.fppi
@@ -272,3 +272,11 @@ event GenerateDpInvalidRange(fileName: string size FileNameStringSize @< The fil
   severity warning high \
   id 0x22 \
   format "Invalid offset range requested for file {}: [{}, {}) with file size {}"
+
+@ A command path argument was rejected by the configured sandbox directory
+event PathOutsideSandbox(
+                            path: string size FileNameStringSize @< The rejected path
+                            sandboxDir: string size FileNameStringSize @< The configured sandbox directory
+                        ) \
+  severity warning high \
+  format "Path {} is outside the configured sandbox directory {}"

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -65,8 +65,9 @@ void FileManager ::configure(const char* sandboxDir) {
     // Ensure trailing '/'
     const FwSizeType resolvedLen = Fw::StringUtils::string_length(resolved, Os::FilePathUtils::MAX_PATH_LENGTH);
     FW_ASSERT(resolvedLen > 0);
-    FW_ASSERT(resolvedLen + 2 <= Os::FilePathUtils::MAX_PATH_LENGTH);
+    FW_ASSERT(resolvedLen < Os::FilePathUtils::MAX_PATH_LENGTH);
     if (resolved[resolvedLen - 1] != '/') {
+        FW_ASSERT(resolvedLen + 2 <= Os::FilePathUtils::MAX_PATH_LENGTH);
         resolved[resolvedLen] = '/';
         resolved[resolvedLen + 1] = '\0';
     }

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -16,7 +16,9 @@
 #include <Fw/FPrimeBasicTypes.hpp>
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
+#include "Fw/Types/StringUtils.hpp"
 #include "Os/Directory.hpp"
+#include "Os/FilePathUtils.hpp"
 #include "Svc/FileManager/FileManager.hpp"
 #include "config/FileManagerConfig.hpp"
 
@@ -31,6 +33,8 @@ FileManager ::FileManager(const char* const compName  //!< The component name
     : FileManagerComponentBase(compName),
       commandCount(0),
       errorCount(0),
+      m_sandboxDir(""),
+      m_sandboxConfigured(false),
       m_listState(IDLE),
       m_totalEntries(0),
       m_currentOpCode(0),
@@ -49,6 +53,54 @@ FileManager ::FileManager(const char* const compName  //!< The component name
 
 FileManager ::~FileManager() {}
 
+void FileManager ::configure(const char* sandboxDir) {
+    FW_ASSERT(sandboxDir != nullptr);
+
+    // Resolve the sandbox directory (relative paths resolve against CWD)
+    char resolved[Os::FilePathUtils::MAX_PATH_LENGTH];
+    const Os::FilePathUtils::Status resolveStatus =
+        Os::FilePathUtils::resolveFromCwd(sandboxDir, resolved, sizeof(resolved));
+    FW_ASSERT(resolveStatus == Os::FilePathUtils::VALID, static_cast<FwAssertArgType>(resolveStatus));
+
+    // Ensure trailing '/'
+    const FwSizeType resolvedLen = Fw::StringUtils::string_length(resolved, Os::FilePathUtils::MAX_PATH_LENGTH);
+    FW_ASSERT(resolvedLen > 0);
+    FW_ASSERT(resolvedLen + 2 <= Os::FilePathUtils::MAX_PATH_LENGTH);
+    if (resolved[resolvedLen - 1] != '/') {
+        resolved[resolvedLen] = '/';
+        resolved[resolvedLen + 1] = '\0';
+    }
+
+    this->m_sandboxDir = resolved;
+    this->m_sandboxConfigured = true;
+}
+
+bool FileManager ::resolveInSandbox(const Fw::CmdStringArg& path,
+                                    Fw::FileNameString& resolved,
+                                    const FwOpcodeType opCode,
+                                    const U32 cmdSeq) {
+    bool accepted = false;
+    if (this->m_sandboxConfigured) {
+        char resolvedBuffer[Os::FilePathUtils::MAX_PATH_LENGTH];
+        const Os::FilePathUtils::Status resolveStatus =
+            Os::FilePathUtils::resolveFromCwd(path.toChar(), resolvedBuffer, sizeof(resolvedBuffer));
+        if ((resolveStatus == Os::FilePathUtils::VALID) &&
+            (Os::FilePathUtils::checkContainment(resolvedBuffer, this->m_sandboxDir.toChar()) ==
+             Os::FilePathUtils::VALID)) {
+            resolved = resolvedBuffer;
+            accepted = true;
+        }
+    }
+    if (!accepted) {
+        this->log_WARNING_HI_PathOutsideSandbox(Fw::LogStringArg(path.toChar()),
+                                                Fw::LogStringArg(this->m_sandboxDir.toChar()));
+        ++this->errorCount;
+        this->tlmWrite_Errors(this->errorCount);
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::VALIDATION_ERROR);
+    }
+    return accepted;
+}
+
 // ----------------------------------------------------------------------
 // Command handler implementations
 // ----------------------------------------------------------------------
@@ -56,10 +108,14 @@ FileManager ::~FileManager() {}
 void FileManager ::CreateDirectory_cmdHandler(const FwOpcodeType opCode,
                                               const U32 cmdSeq,
                                               const Fw::CmdStringArg& dirName) {
+    Fw::FileNameString resolvedDirName;
+    if (!this->resolveInSandbox(dirName, resolvedDirName, opCode, cmdSeq)) {
+        return;
+    }
     Fw::LogStringArg logStringDirName(dirName.toChar());
     this->log_ACTIVITY_HI_CreateDirectoryStarted(logStringDirName);
     bool errorIfDirExists = true;
-    const Os::FileSystem::Status status = Os::FileSystem::createDirectory(dirName.toChar(), errorIfDirExists);
+    const Os::FileSystem::Status status = Os::FileSystem::createDirectory(resolvedDirName.toChar(), errorIfDirExists);
     if (status != Os::FileSystem::OP_OK) {
         this->log_WARNING_HI_DirectoryCreateError(logStringDirName, status);
     } else {
@@ -73,9 +129,13 @@ void FileManager ::RemoveFile_cmdHandler(const FwOpcodeType opCode,
                                          const U32 cmdSeq,
                                          const Fw::CmdStringArg& fileName,
                                          const bool ignoreErrors) {
+    Fw::FileNameString resolvedFileName;
+    if (!this->resolveInSandbox(fileName, resolvedFileName, opCode, cmdSeq)) {
+        return;
+    }
     Fw::LogStringArg logStringFileName(fileName.toChar());
     this->log_ACTIVITY_HI_RemoveFileStarted(logStringFileName);
-    const Os::FileSystem::Status status = Os::FileSystem::removeFile(fileName.toChar());
+    const Os::FileSystem::Status status = Os::FileSystem::removeFile(resolvedFileName.toChar());
     if (status != Os::FileSystem::OP_OK) {
         this->log_WARNING_HI_FileRemoveError(logStringFileName, status);
         if (ignoreErrors == true) {
@@ -95,10 +155,16 @@ void FileManager ::MoveFile_cmdHandler(const FwOpcodeType opCode,
                                        const U32 cmdSeq,
                                        const Fw::CmdStringArg& sourceFileName,
                                        const Fw::CmdStringArg& destFileName) {
+    Fw::FileNameString resolvedSource;
+    Fw::FileNameString resolvedDest;
+    if (!this->resolveInSandbox(sourceFileName, resolvedSource, opCode, cmdSeq) ||
+        !this->resolveInSandbox(destFileName, resolvedDest, opCode, cmdSeq)) {
+        return;
+    }
     Fw::LogStringArg logStringSource(sourceFileName.toChar());
     Fw::LogStringArg logStringDest(destFileName.toChar());
     this->log_ACTIVITY_HI_MoveFileStarted(logStringSource, logStringDest);
-    const Os::FileSystem::Status status = Os::FileSystem::moveFile(sourceFileName.toChar(), destFileName.toChar());
+    const Os::FileSystem::Status status = Os::FileSystem::moveFile(resolvedSource.toChar(), resolvedDest.toChar());
     if (status != Os::FileSystem::OP_OK) {
         this->log_WARNING_HI_FileMoveError(logStringSource, logStringDest, status);
     } else {
@@ -111,9 +177,13 @@ void FileManager ::MoveFile_cmdHandler(const FwOpcodeType opCode,
 void FileManager ::RemoveDirectory_cmdHandler(const FwOpcodeType opCode,
                                               const U32 cmdSeq,
                                               const Fw::CmdStringArg& dirName) {
+    Fw::FileNameString resolvedDirName;
+    if (!this->resolveInSandbox(dirName, resolvedDirName, opCode, cmdSeq)) {
+        return;
+    }
     Fw::LogStringArg logStringDirName(dirName.toChar());
     this->log_ACTIVITY_HI_RemoveDirectoryStarted(logStringDirName);
-    const Os::FileSystem::Status status = Os::FileSystem::removeDirectory(dirName.toChar());
+    const Os::FileSystem::Status status = Os::FileSystem::removeDirectory(resolvedDirName.toChar());
     if (status != Os::FileSystem::OP_OK) {
         this->log_WARNING_HI_DirectoryRemoveError(logStringDirName, status);
     } else {
@@ -127,12 +197,18 @@ void FileManager ::AppendFile_cmdHandler(const FwOpcodeType opCode,
                                          const U32 cmdSeq,
                                          const Fw::CmdStringArg& source,
                                          const Fw::CmdStringArg& target) {
+    Fw::FileNameString resolvedSource;
+    Fw::FileNameString resolvedTarget;
+    if (!this->resolveInSandbox(source, resolvedSource, opCode, cmdSeq) ||
+        !this->resolveInSandbox(target, resolvedTarget, opCode, cmdSeq)) {
+        return;
+    }
     Fw::LogStringArg logStringSource(source.toChar());
     Fw::LogStringArg logStringTarget(target.toChar());
     this->log_ACTIVITY_HI_AppendFileStarted(logStringSource, logStringTarget);
 
     Os::FileSystem::Status status;
-    status = Os::FileSystem::appendFile(source.toChar(), target.toChar(), true);
+    status = Os::FileSystem::appendFile(resolvedSource.toChar(), resolvedTarget.toChar(), true);
     if (status != Os::FileSystem::OP_OK) {
         this->log_WARNING_HI_AppendFileFailed(logStringSource, logStringTarget, status);
     } else {
@@ -144,11 +220,15 @@ void FileManager ::AppendFile_cmdHandler(const FwOpcodeType opCode,
 }
 
 void FileManager ::FileSize_cmdHandler(const FwOpcodeType opCode, const U32 cmdSeq, const Fw::CmdStringArg& fileName) {
+    Fw::FileNameString resolvedFileName;
+    if (!this->resolveInSandbox(fileName, resolvedFileName, opCode, cmdSeq)) {
+        return;
+    }
     Fw::LogStringArg logStringFileName(fileName.toChar());
     this->log_ACTIVITY_HI_FileSizeStarted(logStringFileName);
 
     FwSizeType size_arg;
-    const Os::FileSystem::Status status = Os::FileSystem::getFileSize(fileName.toChar(), size_arg);
+    const Os::FileSystem::Status status = Os::FileSystem::getFileSize(resolvedFileName.toChar(), size_arg);
     if (status != Os::FileSystem::OP_OK) {
         this->log_WARNING_HI_FileSizeError(logStringFileName, status);
     } else {
@@ -169,10 +249,15 @@ void FileManager ::ListDirectory_cmdHandler(const FwOpcodeType opCode,
         return;
     }
 
+    Fw::FileNameString resolvedDirName;
+    if (!this->resolveInSandbox(dirName, resolvedDirName, opCode, cmdSeq)) {
+        return;
+    }
+
     this->log_ACTIVITY_HI_ListDirectoryStarted(dirName);
 
     // Open the directory for reading
-    Os::Directory::Status status = m_currentDir.open(dirName.toChar(), Os::Directory::OpenMode::READ);
+    Os::Directory::Status status = m_currentDir.open(resolvedDirName.toChar(), Os::Directory::OpenMode::READ);
 
     if (status != Os::Directory::OP_OK) {
         this->log_WARNING_HI_ListDirectoryError(dirName, static_cast<U32>(status));
@@ -197,9 +282,13 @@ void FileManager ::ListDirectory_cmdHandler(const FwOpcodeType opCode,
 void FileManager ::CalculateCrc_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdStringArg& filename) {
     Os::File file;
     U32 crcValue = 0;
+    Fw::FileNameString resolvedFilename;
+    if (!this->resolveInSandbox(filename, resolvedFilename, opCode, cmdSeq)) {
+        return;
+    }
     this->log_ACTIVITY_HI_CalculateCrcStarted(filename);
 
-    Os::File::Status status = file.open(filename.toChar(), Os::File::OPEN_READ);
+    Os::File::Status status = file.open(resolvedFilename.toChar(), Os::File::OPEN_READ);
     if (status == Os::File::OP_OK) {
         status = file.calculateCrc(crcValue);
     }
@@ -244,7 +333,12 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
         effectiveChunkSize = FileManagerConfig::GENERATE_DP_MAX_CHUNK_SIZE;
     }
 
-    Os::File::Status status = this->m_dpFile.open(fileName.toChar(), Os::File::OPEN_READ);
+    Fw::FileNameString resolvedFileName;
+    if (!this->resolveInSandbox(fileName, resolvedFileName, opCode, cmdSeq)) {
+        return;
+    }
+
+    Os::File::Status status = this->m_dpFile.open(resolvedFileName.toChar(), Os::File::OPEN_READ);
     if (status != Os::File::OP_OK) {
         this->log_WARNING_HI_GenerateDpFailed(logFileName, FileManager_GenerateDpStage::OPEN, static_cast<U32>(status));
         this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -14,6 +14,7 @@
 #define Svc_FileManager_HPP
 
 #include <atomic>
+#include "Fw/Types/FileNameString.hpp"
 #include "Os/File.hpp"
 #include "Os/FileSystem.hpp"
 #include "Svc/FileManager/FileManagerComponentAc.hpp"
@@ -37,6 +38,17 @@ class FileManager final : public FileManagerComponentBase {
     //! Destroy object FileManager
     //!
     ~FileManager();
+
+    //! Configure the sandbox directory that confines all command path arguments
+    //!
+    //! Restricts every FileManager command to paths inside the given directory.
+    //! Fail-closed: until called, every command is rejected with a PathOutsideSandbox
+    //! event. Configure `/` to allow any path (the FileHandling subtopologies do this
+    //! by default via their configuration modules).
+    //!
+    //! \param sandboxDir: path of the allowed directory (absolute, or relative to CWD)
+    //!
+    void configure(const char* sandboxDir);
 
   private:
     // ----------------------------------------------------------------------
@@ -147,6 +159,21 @@ class FileManager final : public FileManagerComponentBase {
                              const Os::FileSystem::Status status  //!< The status
     );
 
+    //! Resolve a command path argument and check it against the sandbox directory
+    //!
+    //! Resolves the path (relative paths resolve against the current working directory,
+    //! `.` and `..` segments are collapsed) and checks containment in the configured
+    //! sandbox. On rejection, emits PathOutsideSandbox, counts an error, and sends a
+    //! VALIDATION_ERROR command response.
+    //!
+    //! \return true if the path was accepted; resolved holds the canonical path
+    //!
+    bool resolveInSandbox(const Fw::CmdStringArg& path,  //!< The path argument to validate
+                          Fw::FileNameString& resolved,  //!< Output: canonical absolute path
+                          const FwOpcodeType opCode,     //!< Opcode for the rejection response
+                          const U32 cmdSeq               //!< Sequence for the rejection response
+    );
+
   private:
     // ----------------------------------------------------------------------
     // Handler implementations for user-defined internal interfaces
@@ -169,6 +196,14 @@ class FileManager final : public FileManagerComponentBase {
     //! The total number of errors
     //!
     U32 errorCount;
+
+    //! The sandbox directory confining all command path arguments (absolute, trailing '/')
+    //!
+    Fw::FileNameString m_sandboxDir;
+
+    //! Whether configure() has been called
+    //!
+    bool m_sandboxConfigured;
 
     // ----------------------------------------------------------------------
     // Directory listing state machine variables

--- a/Svc/FileManager/docs/sdd.md
+++ b/Svc/FileManager/docs/sdd.md
@@ -7,6 +7,27 @@ It is a wrapper around the OSAL file, filesystem and directory APIs. The compone
 commands, calls the corresponding OSAL operation, and reports the result through events,
 telemetry, and command responses.
 
+## Security Considerations
+
+Every FileManager command takes filesystem paths from ground commands and operates on them
+with the process's full privileges. The component confines those paths with a sandbox
+directory set by `configure(sandboxDir)`:
+
+* The sandbox is **fail-closed**: until `configure` is called, every command is rejected
+  with a `PathOutsideSandbox` warning event and a `VALIDATION_ERROR` command response.
+* Each path argument is canonicalized (`Os::FilePathUtils::resolveFromCwd`: relative paths
+  resolve against the current working directory; `.` and `..` segments are collapsed
+  textually, without following symlinks) and must resolve inside the configured directory
+  (`Os::FilePathUtils::checkContainment`). The canonical path is what reaches the OS call;
+  rejected commands perform no filesystem operation. On rejection the component emits the
+  `PathOutsideSandbox` warning event (carrying the rejected path and the configured
+  directory), increments the `Errors` telemetry channel, and returns `VALIDATION_ERROR`.
+  For two-path commands (`MoveFile`, `AppendFile`) each argument is checked independently.
+* Configuring `"/"` permits any path, matching the component's historical behavior. The
+  `FileHandling` and `FileHandlingCfdp` subtopologies configure `"/"` by default for
+  backwards compatibility; deployments wishing restricted file management must call
+  `configure` again from topology setup code with a restricted directory.
+
 ## Functionality
 
 `Svc::FileManager` supports common filesystem operations. They are currently:
@@ -22,7 +43,31 @@ telemetry, and command responses.
 - GenerateDp
 
 For each command, the component returns success or failure and emits status
-information for operators.
+information for operators. Every path argument is validated against the configured
+sandbox directory before the operation runs (see Security Considerations and
+Configuration); events echo the path as commanded, while the filesystem operation
+acts on the canonical resolved path.
+
+### Configuration
+
+`configure(sandboxDir)` **must be called once during topology setup, before commanding.**
+It sets the directory that confines every command path argument; the component is
+fail-closed and rejects all commands until it is called. `sandboxDir` may be absolute or
+relative to the process working directory, and `"/"` permits any path.
+
+Deployments using the `FileHandling` or `FileHandlingCfdp` subtopology get this call in
+the autocoded `configComponents` phase (open, `"/"`, for backwards compatibility —
+re-configure from topology setup code to restrict). Deployments instantiating
+`Svc.FileManager` directly must add the call themselves:
+
+```cpp
+// e.g. in topology setup code
+fileManager.configure("/data/");   // restrict to /data
+```
+
+Compile-time configuration lives in `config/FileManagerConfig.hpp`
+(`FILES_PER_RATE_TICK`, `CHUNKS_PER_RATE_TICK`, `GENERATE_DP_MAX_CHUNK_SIZE`,
+`DEFAULT_DP_PRIORITY`).
 
 ### Ports
 

--- a/Svc/FileManager/test/ut/FileManagerMain.cpp
+++ b/Svc/FileManager/test/ut/FileManagerMain.cpp
@@ -144,6 +144,26 @@ TEST(Test, generateDpCustomPriority) {
     tester.generateDpCustomPriority();
 }
 
+TEST(Sandbox, rejectsOutsidePaths) {
+    Svc::FileManagerTester tester;
+    tester.sandboxRejectsOutsidePaths();
+}
+
+TEST(Sandbox, failClosed) {
+    Svc::FileManagerTester tester;
+    tester.sandboxFailClosed();
+}
+
+TEST(Sandbox, resolvesPaths) {
+    Svc::FileManagerTester tester;
+    tester.sandboxResolvesPaths();
+}
+
+TEST(Sandbox, openRootIsUnrestricted) {
+    Svc::FileManagerTester tester;
+    tester.sandboxOpenRootIsUnrestricted();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -30,6 +30,9 @@ namespace Svc {
 FileManagerTester ::FileManagerTester() : FileManagerGTestBase("Tester", MAX_HISTORY_SIZE), component("FileManager") {
     this->connectPorts();
     this->initComponents();
+    // The sandbox is fail-closed until configured; open it fully, as the subtopologies do by
+    // default, so the nominal tests exercise unrestricted behavior. Sandbox tests re-configure.
+    this->component.configure("/");
 }
 
 FileManagerTester ::~FileManagerTester() {
@@ -940,6 +943,172 @@ void FileManagerTester ::assertFailure(const FwOpcodeType opcode) const {
     ASSERT_TLM_Errors_SIZE(1);
     ASSERT_TLM_Errors(0, 1);
 }
+void FileManagerTester ::assertSandboxRejection(const FwOpcodeType opcode, const char* const path) {
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, opcode, CMD_SEQ, Fw::CmdResponse::VALIDATION_ERROR);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_PathOutsideSandbox_SIZE(1);
+    ASSERT_STREQ(path, this->eventHistory_PathOutsideSandbox->at(0).path.toChar());
+    ASSERT_TLM_SIZE(1);
+    ASSERT_TLM_Errors_SIZE(1);
+}
+
+void FileManagerTester ::sandboxRejectsOutsidePaths() {
+    // Confine the component to a test directory; anything resolving outside must be rejected
+    // before any filesystem operation happens.
+    this->system("rm -rf sandbox_ut && mkdir -p sandbox_ut/inner");
+    this->component.configure("sandbox_ut");
+
+    // Absolute path outside the sandbox
+    this->clearHistory();
+    this->removeFile("/tmp/fprime_sandbox_ut_target.txt", false);
+    this->assertSandboxRejection(FileManager::OPCODE_REMOVEFILE, "/tmp/fprime_sandbox_ut_target.txt");
+
+    // Relative path escaping via '..'
+    this->clearHistory();
+    this->createDirectory("sandbox_ut/../escaped_dir");
+    this->assertSandboxRejection(FileManager::OPCODE_CREATEDIRECTORY, "sandbox_ut/../escaped_dir");
+    int ret = ::system("test -e escaped_dir");
+    ASSERT_NE(ret, 0) << "directory must not be created outside the sandbox";
+
+    // MoveFile: contained source, escaping destination — nothing may happen
+    this->system("echo data > sandbox_ut/contained.txt");
+    this->clearHistory();
+    this->moveFile("sandbox_ut/contained.txt", "../moved_out.txt");
+    this->assertSandboxRejection(FileManager::OPCODE_MOVEFILE, "../moved_out.txt");
+    ret = ::system("test -f sandbox_ut/contained.txt");
+    ASSERT_EQ(ret, 0) << "source must be untouched when the destination is rejected";
+
+    // AppendFile: escaping source
+    this->clearHistory();
+    this->appendFile("/etc/hostname", "sandbox_ut/contained.txt");
+    this->assertSandboxRejection(FileManager::OPCODE_APPENDFILE, "/etc/hostname");
+
+    // FileSize outside
+    this->clearHistory();
+    Fw::CmdStringArg sizeArg("/etc/hostname");
+    this->sendCmd_FileSize(INSTANCE, CMD_SEQ, sizeArg);
+    this->component.doDispatch();
+    this->assertSandboxRejection(FileManager::OPCODE_FILESIZE, "/etc/hostname");
+
+    // ListDirectory outside
+    this->clearHistory();
+    Fw::CmdStringArg listArg("/etc");
+    this->sendCmd_ListDirectory(INSTANCE, CMD_SEQ, listArg);
+    this->component.doDispatch();
+    this->assertSandboxRejection(FileManager::OPCODE_LISTDIRECTORY, "/etc");
+
+    // CalculateCrc outside
+    this->clearHistory();
+    Fw::CmdStringArg crcArg("/etc/hostname");
+    this->sendCmd_CalculateCrc(INSTANCE, CMD_SEQ, crcArg);
+    this->component.doDispatch();
+    this->assertSandboxRejection(FileManager::OPCODE_CALCULATECRC, "/etc/hostname");
+
+    // RemoveDirectory outside
+    this->clearHistory();
+    this->removeDirectory("/tmp");
+    this->assertSandboxRejection(FileManager::OPCODE_REMOVEDIRECTORY, "/tmp");
+
+    // GenerateDp outside
+    this->clearHistory();
+    Fw::CmdStringArg dpArg("/etc/hostname");
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, dpArg, 0, 0, 0, 0, FileManager_GenerateDpMode::IMMEDIATE);
+    this->component.doDispatch();
+    this->assertSandboxRejection(FileManager::OPCODE_GENERATEDP, "/etc/hostname");
+
+    // A contained command still works
+    this->clearHistory();
+    this->createDirectory("sandbox_ut/new_dir");
+    this->assertSuccess(FileManager::OPCODE_CREATEDIRECTORY);
+    ret = ::system("test -d sandbox_ut/new_dir");
+    ASSERT_EQ(ret, 0);
+
+    this->system("rm -rf sandbox_ut escaped_dir");
+}
+
+void FileManagerTester ::sandboxFailClosed() {
+    // Until configure() is called, every command must be rejected. The tester constructor
+    // configures the component, so reset the flag (friend access) to exercise the
+    // unconfigured state, then restore.
+    ASSERT_TRUE(this->component.m_sandboxConfigured) << "tester component is configured in the constructor";
+    this->component.m_sandboxConfigured = false;
+    this->clearHistory();
+    this->removeFile("any_file.txt", false);
+    this->assertSandboxRejection(FileManager::OPCODE_REMOVEFILE, "any_file.txt");
+    this->component.configure("/");
+}
+
+void FileManagerTester ::sandboxResolvesPaths() {
+    // With the sandbox open ("/", set in the constructor), '..' segments that stay inside
+    // still resolve, and operations act on the canonical path.
+    this->system("rm -rf sandbox_res && mkdir -p sandbox_res/a");
+    this->component.configure("sandbox_res");
+
+    // 'a/../inside.txt' resolves to '<sandbox>/inside.txt': contained, so it is accepted
+    this->clearHistory();
+    this->system("echo hello > sandbox_res/inside.txt");
+    Fw::CmdStringArg sizeArg("sandbox_res/a/../inside.txt");
+    this->sendCmd_FileSize(INSTANCE, CMD_SEQ, sizeArg);
+    this->component.doDispatch();
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_FILESIZE, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_PathOutsideSandbox_SIZE(0);
+    ASSERT_EVENTS_FileSizeSucceeded_SIZE(1);
+
+    this->system("rm -rf sandbox_res");
+    this->component.configure("/");
+}
+
+void FileManagerTester ::sandboxOpenRootIsUnrestricted() {
+    // The FileHandling subtopologies configure the sandbox to "/" by default for backwards
+    // compatibility. This test mirrors the operations from the report that motivated the
+    // sandbox (arbitrary absolute paths under /tmp) and verifies they still succeed with the
+    // open configuration, pinning the compatibility guarantee.
+    this->component.configure("/");
+    this->system("rm -rf /tmp/fprime_sandbox_ut_open");
+
+    // CreateDirectory at an arbitrary absolute path
+    this->clearHistory();
+    this->createDirectory("/tmp/fprime_sandbox_ut_open");
+    this->assertSuccess(FileManager::OPCODE_CREATEDIRECTORY);
+    int ret = ::system("test -d /tmp/fprime_sandbox_ut_open");
+    ASSERT_EQ(ret, 0);
+
+    // FileSize at an arbitrary absolute path
+    this->system("echo -n '0123456789AB' > /tmp/fprime_sandbox_ut_open/file.txt");
+    this->clearHistory();
+    Fw::CmdStringArg sizeArg("/tmp/fprime_sandbox_ut_open/file.txt");
+    this->sendCmd_FileSize(INSTANCE, CMD_SEQ, sizeArg);
+    this->component.doDispatch();
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_FILESIZE, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_PathOutsideSandbox_SIZE(0);
+    ASSERT_EVENTS_FileSizeSucceeded_SIZE(1);
+    ASSERT_EVENTS_FileSizeSucceeded(0, "/tmp/fprime_sandbox_ut_open/file.txt", 12);
+
+    // MoveFile between arbitrary absolute paths (assert response directly: assertSuccess
+    // expects CommandsExecuted == 1, which does not hold on this shared tester instance)
+    this->clearHistory();
+    this->moveFile("/tmp/fprime_sandbox_ut_open/file.txt", "/tmp/fprime_sandbox_ut_open/moved.txt");
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_MOVEFILE, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_PathOutsideSandbox_SIZE(0);
+    ret = ::system("test -f /tmp/fprime_sandbox_ut_open/moved.txt");
+    ASSERT_EQ(ret, 0);
+
+    // RemoveFile at an arbitrary absolute path
+    this->clearHistory();
+    this->removeFile("/tmp/fprime_sandbox_ut_open/moved.txt", false);
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_REMOVEFILE, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_PathOutsideSandbox_SIZE(0);
+    ret = ::system("test -f /tmp/fprime_sandbox_ut_open/moved.txt");
+    ASSERT_NE(ret, 0);
+
+    this->system("rm -rf /tmp/fprime_sandbox_ut_open");
+}
+
 void FileManagerTester ::from_pingOut_handler(const FwIndexType portNum, U32 key) {
     this->pushFromPortEntry_pingOut(key);
 }

--- a/Svc/FileManager/test/ut/FileManagerTester.hpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.hpp
@@ -195,6 +195,28 @@ class FileManagerTester : public FileManagerGTestBase {
     //! Assert failed command execution
     void assertFailure(const FwOpcodeType opcode) const;
 
+    //! Assert that the last command was rejected by the sandbox: PathOutsideSandbox event,
+    //! VALIDATION_ERROR response, error counted, and no other events
+    void assertSandboxRejection(const FwOpcodeType opcode, const char* const path);
+
+  public:
+    // ----------------------------------------------------------------------
+    // Sandbox tests
+    // ----------------------------------------------------------------------
+
+    //! Escaping and absolute-outside paths are rejected by every command; contained paths work
+    void sandboxRejectsOutsidePaths();
+
+    //! An unconfigured FileManager rejects every command (fail-closed)
+    void sandboxFailClosed();
+
+    //! Relative paths and internal '..' segments resolve before containment is checked
+    void sandboxResolvesPaths();
+
+    //! configure("/") — the subtopology default — preserves the historical unrestricted
+    //! behavior: absolute paths anywhere on the filesystem are accepted
+    void sandboxOpenRootIsUnrestricted();
+
     // ----------------------------------------------------------------------
     // Data product test support
     // ----------------------------------------------------------------------

--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -36,7 +36,13 @@ module FileHandling {
         queue size FileHandlingConfig.QueueSizes.fileManager \
         stack size FileHandlingConfig.StackSizes.fileManager \
         priority FileHandlingConfig.Priorities.fileManager \
-        cpu FileHandlingConfig.CpuAffinities.fileManager
+        cpu FileHandlingConfig.CpuAffinities.fileManager \
+    {
+        phase Fpp.ToCpp.Phases.configComponents """
+        // Sandbox for file-management command paths; "/" is unrestricted. Re-configure to restrict.
+        FileHandling::fileManager.configure(FileHandlingConfig::Paths::sandboxDir);
+        """
+    }
 
     instance prmDb: Svc.PrmDb base id FileHandlingConfig.BASE_ID + 0x03000 \
         queue size FileHandlingConfig.QueueSizes.prmDb \

--- a/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandlingConfig/FileHandlingConfig.fpp
@@ -33,7 +33,7 @@ module FileHandlingConfig {
     # File paths used by the subtopology
     module Paths {
         constant prmDbFile = "PrmDb.dat"       # Parameter database storage file
-        constant sandboxDir = "/"              # File-access sandbox for fileUplink, fileDownlink, prmDb ("/" = unrestricted)
+        constant sandboxDir = "/"              # File-access sandbox for fileUplink, fileDownlink, fileManager, prmDb ("/" = unrestricted)
     }
 
     # File downlink configuration constants

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -37,7 +37,7 @@ The **FileHandling subtopology** packages the core file-transfer services common
 > [!WARNING]
 > **This subtopology is not configured to be secure by default.** For backwards compatibility, its
 > `configComponents` phase configures the file-access sandboxes of `fileUplink`, `fileDownlink`,
-> and `prmDb` to `FileHandlingConfig::Paths::sandboxDir`, which defaults to `"/"`. With that
+> `fileManager`, and `prmDb` to `FileHandlingConfig::Paths::sandboxDir`, which defaults to `"/"`. With that
 > default, **any absolute path accessible to the process** may be written, read, or loaded via
 > ground command. (The underlying `Os::SandboxedFile` is fail-closed when left
 > unconfigured; this subtopology deliberately configures it open.)
@@ -46,6 +46,8 @@ The **FileHandling subtopology** packages the core file-transfer services common
 > code (after the autocoded `configComponents` phase runs) with a restricted directory:
 >
 > * `FileHandling::fileUplink.configure(<directory>)` — restrict uplinked file writes.
+> * `FileHandling::fileManager.configure(<directory>)` — restrict file-management command paths
+>   (create/remove/move/append/list/size/CRC/data-product generation).
 > * `FileHandling::fileDownlink.configure(<directory>)` — restrict downlink reads (this is the
 >   `configure(directory)` overload; the `configure(cooldown, cycleTime, fileQueueDepth)`
 >   overload does **not** set a sandbox).

--- a/Svc/Subtopologies/FileHandlingCfdp/FileHandlingCfdp.fpp
+++ b/Svc/Subtopologies/FileHandlingCfdp/FileHandlingCfdp.fpp
@@ -21,7 +21,13 @@ module FileHandlingCfdp {
         queue size FileHandlingCfdpConfig.QueueSizes.fileManager \
         stack size FileHandlingCfdpConfig.StackSizes.fileManager \
         priority FileHandlingCfdpConfig.Priorities.fileManager \
-        cpu FileHandlingCfdpConfig.CpuAffinities.fileManager
+        cpu FileHandlingCfdpConfig.CpuAffinities.fileManager \
+    {
+        phase Fpp.ToCpp.Phases.configComponents """
+        // Sandbox for file-management command paths; "/" is unrestricted. Re-configure to restrict.
+        FileHandlingCfdp::fileManager.configure("/");
+        """
+    }
 
     instance prmDb: Svc.PrmDb base id FileHandlingCfdpConfig.BASE_ID + 0x02000 \
         queue size FileHandlingCfdpConfig.QueueSizes.prmDb \

--- a/Svc/Subtopologies/FileHandlingCfdp/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandlingCfdp/docs/sdd.md
@@ -42,7 +42,9 @@ The **FileHandlingCfdp subtopology** packages CFDP-based file-transfer services 
 > wishing restricted file security **must call `configureSandbox` again** from topology setup
 > code (after the autocoded `configComponents` phase runs):
 > `FileHandlingCfdp::prmDb.configureSandbox(<directory>)`, where the directory contains the store
-> file set by `prmDb.configure(<file name>)` (which is **not** itself a sandbox). Additionally,
+> file set by `prmDb.configure(<file name>)` (which is **not** itself a sandbox). The
+> `fileManager` command-path sandbox is likewise configured to `"/"`; restrict it with
+> `FileHandlingCfdp::fileManager.configure(<directory>)`. Additionally,
 > CFDP file transfers via `cfdpManager` are not sandboxed: ground-commanded transactions may read
 > or write any path accessible to the process.
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5849 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Gives `Svc::FileManager` the same directory-confinement configuration its sibling file components (`FileUplink`, `FileDownlink`, `PrmDb`) already have, per #5849.

- **New `FileManager::configure(const char* sandboxDir)`**, mirroring the `FileUplink`/`Os::SandboxedFile` pattern: **fail-closed** until called; configuring `"/"` permits any path (historical behavior).
- **All ten command path sites confined.** Every path argument (`CreateDirectory`, `RemoveFile`, both args of `MoveFile` and `AppendFile`, `RemoveDirectory`, `FileSize`, `ListDirectory`, `CalculateCrc`, `GenerateDp`) is canonicalized with `Os::FilePathUtils::resolveFromCwd` and checked with `checkContainment` before any OS call, via a single `resolveInSandbox()` helper. The canonical path is what reaches `Os::FileSystem`/`Os::File`/`Os::Directory`; events continue to echo the path as commanded.
- **Rejection is loud and side-effect free**: new `PathOutsideSandbox` (WARNING_HI, carries the rejected path and the configured directory — appended to `Events.fppi` so existing event IDs are unchanged), `Errors` telemetry incremented, `VALIDATION_ERROR` command response, no filesystem operation.
- **Subtopologies configure it open by default** for backwards compatibility: `FileHandling` calls `fileManager.configure(FileHandlingConfig::Paths::sandboxDir)` (default `"/"`; the constant's comment now lists `fileManager`), and `FileHandlingCfdp` calls `fileManager.configure("/")`, matching how each already handles `prmDb`.
- **Docs**: new Security Considerations section in the FileManager SDD; the `FileHandling` and `FileHandlingCfdp` SDD warning blocks now cover `fileManager` and show the restricting call.

## Rationale

FileManager was the only file-handling component with no optional sandbox: a deployment that set `FileHandlingConfig::Paths::sandboxDir` to a restricted directory confined uplink, downlink, and the parameter database — but the file-management command set could still operate on any path the process can reach. Operating on operator-specified paths is FileManager's documented purpose, so the default remains unrestricted through the subtopologies; this change makes confinement *possible* and consistent, and makes an unconfigured (out-of-subtopology) instantiation fail loudly rather than silently unrestricted, matching the fail-closed convention `Os::SandboxedFile` adopted.

## Testing/Review Recommendations

`Svc_FileManager_ut_exe`: 32/32 pass (28 existing + 4 new). Full native framework build passes, which compiles both subtopologies' generated `configComponents` phases.

- `Sandbox.rejectsOutsidePaths` — with the sandbox set to a test directory: absolute-outside and `..`-escaping paths are rejected on every command (including per-argument checks on `MoveFile`/`AppendFile`), with the event/response/telemetry contract asserted and the filesystem verified untouched; a contained command still succeeds.
- `Sandbox.failClosed` — an unconfigured component rejects commands.
- `Sandbox.resolvesPaths` — `..` segments that stay inside the sandbox resolve and the command succeeds on the canonical path.
- `Sandbox.openRootIsUnrestricted` — with `configure("/")` (the subtopology default), the exact operations from the motivating report (create/size/move/remove at arbitrary absolute paths under `/tmp`) still succeed, pinning the backwards-compatibility guarantee.
- Existing tests run with the sandbox configured to `"/"` in the tester constructor (as the subtopologies do) and pass unchanged, demonstrating behavioral compatibility.

Review focus:
- **Fail-closed default**: out-of-tree projects that instantiate `Svc.FileManager` directly (both in-tree instantiations are in the subtopologies, which are wired here) must add a `configure()` call or every command fails with `PathOutsideSandbox`. This is deliberate — it matches `FileUplink` — but it is the migration-visible part of the change.
- Containment is textual (no `realpath`), the same limitation as `Os::SandboxedFile`; symlinks inside the sandbox are out of scope.
- `PathOutsideSandbox` placement at the end of `Events.fppi` (event IDs stable; dictionaries gain one event).

Regression tests derive from the reporter's PoC in the tracking issue.

## Future Work

- Consider a follow-on aligning `Svc::CmdSequencer`/`Svc::DpCatalog` and other path-taking components with the same pattern if desired.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

Claude Code was used to draft the implementation, unit tests, and documentation changes, and to run the unit test suite and framework build. All changes were reviewed by the author.
