### PR TITLE
Add sandbox confinement to Svc::FileManager

### DIFF
--- a/Os/FilePathUtils.cpp
+++ b/Os/FilePathUtils.cpp
@@ -172,6 +172,27 @@ Status resolveFromCwd(const char* path, char* resolvedOut, FwSizeType resolvedSi
     return resolvePath(path, "/", resolvedOut, resolvedSize);
 }
 
+Status resolveDirectory(const char* directory, char* resolvedOut, FwSizeType resolvedSize) {
+    const Status resolveStatus = resolveFromCwd(directory, resolvedOut, resolvedSize);
+    if (resolveStatus != VALID) {
+        return resolveStatus;
+    }
+
+    const FwSizeType resolvedLen = Fw::StringUtils::string_length(resolvedOut, resolvedSize);
+    if (!isValidCString(resolvedLen, resolvedSize)) {
+        return INVALID_PATH;
+    }
+    FW_ASSERT(resolvedLen > 0);  // resolveFromCwd always yields at least "/"
+    if (resolvedOut[resolvedLen - 1] != '/') {
+        if (resolvedLen + 2 > resolvedSize) {
+            return TOO_LONG;
+        }
+        resolvedOut[resolvedLen] = '/';
+        resolvedOut[resolvedLen + 1] = '\0';
+    }
+    return VALID;
+}
+
 // Internal containment check on already-resolved paths.
 // Verifies that resolvedPath starts with allowedDirectory as a prefix,
 // and that the match occurs at a `/` boundary.

--- a/Os/FilePathUtils.hpp
+++ b/Os/FilePathUtils.hpp
@@ -68,6 +68,19 @@ Status resolvePath(const Fw::ConstStringBase& path, const Fw::ConstStringBase& b
 //!
 Status resolveFromCwd(const char* path, char* resolvedOut, FwSizeType resolvedSize);
 
+//! \brief Resolve a directory path and ensure it ends with a trailing separator
+//!
+//! Convenience wrapper for configuring a sandbox: resolves the directory via
+//! resolveFromCwd() and appends a trailing `/` if not already present, so the
+//! result can be passed directly as the allowedDirectory argument to checkContainment().
+//!
+//! \param directory: input directory path (may be relative or absolute)
+//! \param resolvedOut: output buffer for the resolved directory (with trailing `/`)
+//! \param resolvedSize: size of the output buffer
+//! \return VALID on success, INVALID_PATH or TOO_LONG on failure
+//!
+Status resolveDirectory(const char* directory, char* resolvedOut, FwSizeType resolvedSize);
+
 //! \brief Check whether an already-resolved path is within an allowed directory
 //!
 //! Both arguments must already be canonical absolute paths (output of resolvePath

--- a/Os/SandboxedFile.cpp
+++ b/Os/SandboxedFile.cpp
@@ -3,9 +3,7 @@
 // \brief Implementation of directory-sandboxed file wrapper
 // ======================================================================
 #include <Fw/Types/Assert.hpp>
-#include <Fw/Types/StringUtils.hpp>
 #include <Os/SandboxedFile.hpp>
-#include <cstring>
 
 namespace Os {
 
@@ -22,20 +20,11 @@ void SandboxedFile::configure(const char* allowedDirectory) {
     FW_ASSERT(allowedDirectory != nullptr);
     FW_ASSERT(!m_file.isOpen());
 
-    // Resolve the allowed directory (relative paths resolve against CWD)
+    // Resolve the allowed directory (relative paths resolve against CWD) and ensure trailing '/'
     char resolved[FilePathUtils::MAX_PATH_LENGTH];
     const FilePathUtils::Status resolveStatus =
-        FilePathUtils::resolveFromCwd(allowedDirectory, resolved, sizeof(resolved));
+        FilePathUtils::resolveDirectory(allowedDirectory, resolved, sizeof(resolved));
     FW_ASSERT(resolveStatus == FilePathUtils::VALID);
-
-    // Ensure trailing '/'
-    const FwSizeType resolvedLen = Fw::StringUtils::string_length(resolved, FilePathUtils::MAX_PATH_LENGTH);
-    FW_ASSERT(resolvedLen > 0);
-    FW_ASSERT(resolvedLen + 2 <= FilePathUtils::MAX_PATH_LENGTH);
-    if (resolved[resolvedLen - 1] != '/') {
-        resolved[resolvedLen] = '/';
-        resolved[resolvedLen + 1] = '\0';
-    }
 
     m_allowedDirectory = resolved;
     m_configured = true;

--- a/Svc/FileManager/Events.fppi
+++ b/Svc/FileManager/Events.fppi
@@ -272,3 +272,11 @@ event GenerateDpInvalidRange(fileName: string size FileNameStringSize @< The fil
   severity warning high \
   id 0x22 \
   format "Invalid offset range requested for file {}: [{}, {}) with file size {}"
+
+@ A ground-supplied path resolved outside the configured sandbox directory
+event PathOutsideSandbox(
+                          path: string size FileNameStringSize @< The path that failed the sandbox check
+                        ) \
+  severity warning high \
+  id 0x23 \
+  format "Path {} is outside the configured sandbox directory"

--- a/Svc/FileManager/FileManager.cpp
+++ b/Svc/FileManager/FileManager.cpp
@@ -31,6 +31,7 @@ FileManager ::FileManager(const char* const compName  //!< The component name
     : FileManagerComponentBase(compName),
       commandCount(0),
       errorCount(0),
+      m_sandboxConfigured(false),
       m_listState(IDLE),
       m_totalEntries(0),
       m_currentOpCode(0),
@@ -49,6 +50,18 @@ FileManager ::FileManager(const char* const compName  //!< The component name
 
 FileManager ::~FileManager() {}
 
+void FileManager ::configure(const char* sandboxDir) {
+    FW_ASSERT(sandboxDir != nullptr);
+
+    char resolved[Os::FilePathUtils::MAX_PATH_LENGTH];
+    const Os::FilePathUtils::Status resolveStatus =
+        Os::FilePathUtils::resolveDirectory(sandboxDir, resolved, sizeof(resolved));
+    FW_ASSERT(resolveStatus == Os::FilePathUtils::VALID, static_cast<FwAssertArgType>(resolveStatus));
+
+    this->m_sandboxDir = resolved;
+    this->m_sandboxConfigured = true;
+}
+
 // ----------------------------------------------------------------------
 // Command handler implementations
 // ----------------------------------------------------------------------
@@ -56,6 +69,11 @@ FileManager ::~FileManager() {}
 void FileManager ::CreateDirectory_cmdHandler(const FwOpcodeType opCode,
                                               const U32 cmdSeq,
                                               const Fw::CmdStringArg& dirName) {
+    if (!this->checkSandbox(dirName.toChar())) {
+        this->emitTelemetry(Os::FileSystem::OTHER_ERROR);
+        this->sendCommandResponse(opCode, cmdSeq, Os::FileSystem::OTHER_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringDirName(dirName.toChar());
     this->log_ACTIVITY_HI_CreateDirectoryStarted(logStringDirName);
     bool errorIfDirExists = true;
@@ -73,6 +91,12 @@ void FileManager ::RemoveFile_cmdHandler(const FwOpcodeType opCode,
                                          const U32 cmdSeq,
                                          const Fw::CmdStringArg& fileName,
                                          const bool ignoreErrors) {
+    // ignoreErrors only waives missing-file errors below; it does not waive the sandbox check
+    if (!this->checkSandbox(fileName.toChar())) {
+        this->emitTelemetry(Os::FileSystem::OTHER_ERROR);
+        this->sendCommandResponse(opCode, cmdSeq, Os::FileSystem::OTHER_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringFileName(fileName.toChar());
     this->log_ACTIVITY_HI_RemoveFileStarted(logStringFileName);
     const Os::FileSystem::Status status = Os::FileSystem::removeFile(fileName.toChar());
@@ -95,6 +119,14 @@ void FileManager ::MoveFile_cmdHandler(const FwOpcodeType opCode,
                                        const U32 cmdSeq,
                                        const Fw::CmdStringArg& sourceFileName,
                                        const Fw::CmdStringArg& destFileName) {
+    // Both legs are checked (rather than short-circuited) so a violation on either side is reported
+    const bool sourceAllowed = this->checkSandbox(sourceFileName.toChar());
+    const bool destAllowed = this->checkSandbox(destFileName.toChar());
+    if (!sourceAllowed || !destAllowed) {
+        this->emitTelemetry(Os::FileSystem::OTHER_ERROR);
+        this->sendCommandResponse(opCode, cmdSeq, Os::FileSystem::OTHER_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringSource(sourceFileName.toChar());
     Fw::LogStringArg logStringDest(destFileName.toChar());
     this->log_ACTIVITY_HI_MoveFileStarted(logStringSource, logStringDest);
@@ -111,6 +143,11 @@ void FileManager ::MoveFile_cmdHandler(const FwOpcodeType opCode,
 void FileManager ::RemoveDirectory_cmdHandler(const FwOpcodeType opCode,
                                               const U32 cmdSeq,
                                               const Fw::CmdStringArg& dirName) {
+    if (!this->checkSandbox(dirName.toChar())) {
+        this->emitTelemetry(Os::FileSystem::OTHER_ERROR);
+        this->sendCommandResponse(opCode, cmdSeq, Os::FileSystem::OTHER_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringDirName(dirName.toChar());
     this->log_ACTIVITY_HI_RemoveDirectoryStarted(logStringDirName);
     const Os::FileSystem::Status status = Os::FileSystem::removeDirectory(dirName.toChar());
@@ -127,6 +164,14 @@ void FileManager ::AppendFile_cmdHandler(const FwOpcodeType opCode,
                                          const U32 cmdSeq,
                                          const Fw::CmdStringArg& source,
                                          const Fw::CmdStringArg& target) {
+    // Both legs are checked (rather than short-circuited) so a violation on either side is reported
+    const bool sourceAllowed = this->checkSandbox(source.toChar());
+    const bool targetAllowed = this->checkSandbox(target.toChar());
+    if (!sourceAllowed || !targetAllowed) {
+        this->emitTelemetry(Os::FileSystem::OTHER_ERROR);
+        this->sendCommandResponse(opCode, cmdSeq, Os::FileSystem::OTHER_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringSource(source.toChar());
     Fw::LogStringArg logStringTarget(target.toChar());
     this->log_ACTIVITY_HI_AppendFileStarted(logStringSource, logStringTarget);
@@ -144,6 +189,11 @@ void FileManager ::AppendFile_cmdHandler(const FwOpcodeType opCode,
 }
 
 void FileManager ::FileSize_cmdHandler(const FwOpcodeType opCode, const U32 cmdSeq, const Fw::CmdStringArg& fileName) {
+    if (!this->checkSandbox(fileName.toChar())) {
+        this->emitTelemetry(Os::FileSystem::OTHER_ERROR);
+        this->sendCommandResponse(opCode, cmdSeq, Os::FileSystem::OTHER_ERROR);
+        return;
+    }
     Fw::LogStringArg logStringFileName(fileName.toChar());
     this->log_ACTIVITY_HI_FileSizeStarted(logStringFileName);
 
@@ -164,6 +214,12 @@ void FileManager ::ListDirectory_cmdHandler(const FwOpcodeType opCode,
     // Check if we're already listing a directory
     if (m_listState == LISTING_IN_PROGRESS) {
         this->log_WARNING_HI_ListDirectoryError(dirName, static_cast<U32>(Os::Directory::OTHER_ERROR));
+        this->emitTelemetry(Os::FileSystem::OTHER_ERROR);
+        this->sendCommandResponse(opCode, cmdSeq, Os::FileSystem::OTHER_ERROR);
+        return;
+    }
+
+    if (!this->checkSandbox(dirName.toChar())) {
         this->emitTelemetry(Os::FileSystem::OTHER_ERROR);
         this->sendCommandResponse(opCode, cmdSeq, Os::FileSystem::OTHER_ERROR);
         return;
@@ -195,6 +251,10 @@ void FileManager ::ListDirectory_cmdHandler(const FwOpcodeType opCode,
 }
 
 void FileManager ::CalculateCrc_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, const Fw::CmdStringArg& filename) {
+    if (!this->checkSandbox(filename.toChar())) {
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::EXECUTION_ERROR);
+        return;
+    }
     Os::File file;
     U32 crcValue = 0;
     this->log_ACTIVITY_HI_CalculateCrcStarted(filename);
@@ -223,6 +283,11 @@ void FileManager ::GenerateDp_cmdHandler(FwOpcodeType opCode,
                                          U32 priority,
                                          const FileManager_GenerateDpMode& mode) {
     Fw::LogStringArg logFileName(fileName.toChar());
+
+    if (!this->checkSandbox(fileName.toChar())) {
+        this->cmdResponse_out(opCode, cmdSeq, Fw::CmdResponse::OK);
+        return;
+    }
 
     // Reject a second request while one is already running
     if (this->m_dpState != DP_IDLE) {
@@ -442,15 +507,22 @@ void FileManager ::run_internalInterfaceHandler() {
                 Fw::String fullPath;
                 Fw::FormatStatus formatStatus = fullPath.format("%s/%s", m_currentDirName.toChar(), filename.toChar());
 
+                // Re-check containment on the constructed entry path: dirName was already
+                // validated when the listing started, but this defends against an entry name
+                // that textually escapes it (e.g. a platform that yields a ".." entry).
+                const bool sandboxOk =
+                    (formatStatus == Fw::FormatStatus::SUCCESS) && this->checkSandbox(fullPath.toChar());
+
                 // Determine entry type
-                Os::FileSystem::PathType pathType = (formatStatus == Fw::FormatStatus::SUCCESS)
-                                                        ? Os::FileSystem::getPathType(fullPath.toChar())
-                                                        : Os::FileSystem::NOT_EXIST;
+                Os::FileSystem::PathType pathType =
+                    sandboxOk ? Os::FileSystem::getPathType(fullPath.toChar()) : Os::FileSystem::NOT_EXIST;
 
                 if (formatStatus != Fw::FormatStatus::SUCCESS) {
                     // Cannot determine the type of an entry whose path did not format
                     this->log_WARNING_HI_FileNameFormatError(filename,
                                                              static_cast<Fw::StringFormatStatus::T>(formatStatus));
+                } else if (!sandboxOk) {
+                    // PathOutsideSandbox was already logged by checkSandbox(); skip this entry
                 } else if (pathType == Os::FileSystem::FILE) {
                     // Regular file: get size and emit file event
                     FwSizeType fileSize;
@@ -501,6 +573,22 @@ void FileManager ::sendCommandResponse(const FwOpcodeType opCode,
                                        const Os::FileSystem::Status status) {
     this->cmdResponse_out(opCode, cmdSeq,
                           (status == Os::FileSystem::OP_OK) ? Fw::CmdResponse::OK : Fw::CmdResponse::EXECUTION_ERROR);
+}
+
+bool FileManager ::checkSandbox(const char* path) {
+    bool allowed = false;
+    if (this->m_sandboxConfigured) {
+        char resolved[Os::FilePathUtils::MAX_PATH_LENGTH];
+        const Os::FilePathUtils::Status resolveStatus =
+            Os::FilePathUtils::resolveFromCwd(path, resolved, sizeof(resolved));
+        allowed = (resolveStatus == Os::FilePathUtils::VALID) &&
+                  (Os::FilePathUtils::checkContainment(resolved, this->m_sandboxDir.toChar()) ==
+                   Os::FilePathUtils::VALID);
+    }
+    if (!allowed) {
+        this->log_WARNING_HI_PathOutsideSandbox(Fw::LogStringArg(path));
+    }
+    return allowed;
 }
 
 }  // namespace Svc

--- a/Svc/FileManager/FileManager.hpp
+++ b/Svc/FileManager/FileManager.hpp
@@ -14,7 +14,9 @@
 #define Svc_FileManager_HPP
 
 #include <atomic>
+#include "Fw/Types/String.hpp"
 #include "Os/File.hpp"
+#include "Os/FilePathUtils.hpp"
 #include "Os/FileSystem.hpp"
 #include "Svc/FileManager/FileManagerComponentAc.hpp"
 #include "config/FileManagerConfig.hpp"
@@ -37,6 +39,15 @@ class FileManager final : public FileManagerComponentBase {
     //! Destroy object FileManager
     //!
     ~FileManager();
+
+    //! Configure the sandbox directory restricting all ground-supplied paths
+    //!
+    //! Fail-closed: until called, every command with a path argument is rejected with a
+    //! PathOutsideSandbox warning. Configure `/` to allow any absolute path.
+    //!
+    //! \param sandboxDir: directory that all FileManager path arguments must resolve within
+    //!
+    void configure(const char* sandboxDir);
 
   private:
     // ----------------------------------------------------------------------
@@ -147,6 +158,16 @@ class FileManager final : public FileManagerComponentBase {
                              const Os::FileSystem::Status status  //!< The status
     );
 
+    //! Validate a ground-supplied path against the configured sandbox
+    //!
+    //! Resolves the path against CWD and checks containment against the configured
+    //! sandbox directory. Emits PathOutsideSandbox on rejection. Fails closed: rejects
+    //! every path if configure() has not been called.
+    //!
+    //! \param path: ground-supplied path to validate
+    //! \return true if the path is allowed
+    bool checkSandbox(const char* path);
+
   private:
     // ----------------------------------------------------------------------
     // Handler implementations for user-defined internal interfaces
@@ -169,6 +190,12 @@ class FileManager final : public FileManagerComponentBase {
     //! The total number of errors
     //!
     U32 errorCount;
+
+    //! Whether configure() has been called; fail-closed (all paths rejected) until true
+    bool m_sandboxConfigured;
+
+    //! The configured sandbox directory (absolute, trailing '/'); valid only when m_sandboxConfigured
+    Fw::String m_sandboxDir;
 
     // ----------------------------------------------------------------------
     // Directory listing state machine variables

--- a/Svc/FileManager/docs/sdd.md
+++ b/Svc/FileManager/docs/sdd.md
@@ -86,4 +86,30 @@ left for the deployment to
 connect; if they are not connected the command fails with an event rather than
 attempting to allocate a container.
 
+### Sandbox
+
+Every ground-supplied path argument — both paths of `MoveFile` and `AppendFile`
+included — is validated against a configured sandbox directory via
+`Os::FilePathUtils::resolvePath`/`checkContainment` before it reaches the OSAL. A
+path that resolves outside the sandbox is rejected with a `PathOutsideSandbox`
+warning instead of being passed to the filesystem.
+
+> [!WARNING]
+> The sandbox is **fail-closed**: until `configure(sandboxDir)` is called, every
+> command with a path argument is rejected with `PathOutsideSandbox` — an
+> unconfigured `FileManager` cannot touch the filesystem at all. A deployment
+> **must** call `configure(sandboxDir)` during topology setup to enable file
+> operations and to select the allowed base directory. Note that the stock
+> `FileHandling` subtopology configures the sandbox to `"/"` for backwards
+> compatibility, which permits operating on **any absolute path accessible to
+> the process**. Security-conscious deployments using that subtopology **must**
+> call `configure(sandboxDir)` again from topology setup code with a restricted
+> directory; paths that resolve outside it — `../` traversal and absolute paths
+> — are then rejected. `RemoveFile`'s `ignoreErrors` argument only waives
+> missing-file errors; it does not waive the sandbox check.
+
+`ListDirectory` re-validates each directory entry's constructed path before
+querying its type, as defense in depth against a platform that yields a `.`/`..`
+entry from `Os::Directory::read()` (the POSIX implementation filters both out).
+
 

--- a/Svc/FileManager/test/ut/FileManagerMain.cpp
+++ b/Svc/FileManager/test/ut/FileManagerMain.cpp
@@ -144,6 +144,46 @@ TEST(Test, generateDpCustomPriority) {
     tester.generateDpCustomPriority();
 }
 
+TEST(Test, sandboxUnconfiguredRejectsCommand) {
+    Svc::FileManagerTester tester;
+    tester.sandboxUnconfiguredRejectsCommand();
+}
+
+TEST(Test, sandboxRejectsEscapingPath) {
+    Svc::FileManagerTester tester;
+    tester.sandboxRejectsEscapingPath();
+}
+
+TEST(Test, sandboxAllowsConfiguredPath) {
+    Svc::FileManagerTester tester;
+    tester.sandboxAllowsConfiguredPath();
+}
+
+TEST(Test, sandboxRejectsMoveFileEitherLeg) {
+    Svc::FileManagerTester tester;
+    tester.sandboxRejectsMoveFileEitherLeg();
+}
+
+TEST(Test, sandboxIgnoreErrorsStillRejected) {
+    Svc::FileManagerTester tester;
+    tester.sandboxIgnoreErrorsStillRejected();
+}
+
+TEST(Test, sandboxRejectsListDirectory) {
+    Svc::FileManagerTester tester;
+    tester.sandboxRejectsListDirectory();
+}
+
+TEST(Test, sandboxRejectsGenerateDp) {
+    Svc::FileManagerTester tester;
+    tester.sandboxRejectsGenerateDp();
+}
+
+TEST(Test, sandboxRejectsCalculateCrc) {
+    Svc::FileManagerTester tester;
+    tester.sandboxRejectsCalculateCrc();
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/Svc/FileManager/test/ut/FileManagerTester.cpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.cpp
@@ -30,6 +30,9 @@ namespace Svc {
 FileManagerTester ::FileManagerTester() : FileManagerGTestBase("Tester", MAX_HISTORY_SIZE), component("FileManager") {
     this->connectPorts();
     this->initComponents();
+    // Unrestricted by default so existing tests exercise real command behavior;
+    // sandbox-specific tests below reconfigure a restricted directory as needed.
+    this->component.configure("/");
 }
 
 FileManagerTester ::~FileManagerTester() {
@@ -835,6 +838,193 @@ void FileManagerTester ::listDirectoryFail() {
 
     // Assert failure
     this->assertFailure(FileManager::OPCODE_LISTDIRECTORY);
+}
+
+// ----------------------------------------------------------------------
+// Sandbox confinement tests
+// ----------------------------------------------------------------------
+
+void FileManagerTester ::sandboxUnconfiguredRejectsCommand() {
+    // Simulate a deployment that never called configure(); the constructor's
+    // configure("/") call is undone directly via friend access.
+    this->component.m_sandboxConfigured = false;
+
+    this->createDirectory("unconfigured_test_dir");
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_CREATEDIRECTORY, CMD_SEQ, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_EVENTS_SIZE(1);  // Only PathOutsideSandbox; the sandbox check runs before the Started event
+    ASSERT_EVENTS_PathOutsideSandbox_SIZE(1);
+    ASSERT_EVENTS_PathOutsideSandbox(0, "unconfigured_test_dir");
+    ASSERT_TLM_Errors_SIZE(1);
+    ASSERT_TLM_Errors(0, 1);
+}
+
+void FileManagerTester ::sandboxRejectsEscapingPath() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+    this->system("mkdir sandbox_root");
+#else
+    FAIL();  // Commands not implemented for this OS
+#endif
+    this->component.configure("sandbox_root");
+
+    // Absolute path outside the configured sandbox
+    this->createDirectory("/tmp/fprime_sandbox_escape_test_dir");
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_CREATEDIRECTORY, CMD_SEQ, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_PathOutsideSandbox_SIZE(1);
+    ASSERT_EVENTS_PathOutsideSandbox(0, "/tmp/fprime_sandbox_escape_test_dir");
+    ASSERT_TLM_Errors_SIZE(1);
+    ASSERT_TLM_Errors(0, 1);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    // The directory must not have been created
+    this->system("! test -e /tmp/fprime_sandbox_escape_test_dir");
+    this->system("rm -rf sandbox_root");
+#endif
+}
+
+void FileManagerTester ::sandboxAllowsConfiguredPath() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+    this->system("mkdir sandbox_root");
+#else
+    FAIL();  // Commands not implemented for this OS
+#endif
+    this->component.configure("sandbox_root");
+
+    // A path inside the configured sandbox still works
+    this->createDirectory("sandbox_root/inner_dir");
+
+    this->assertSuccess(FileManager::OPCODE_CREATEDIRECTORY);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("test -d sandbox_root/inner_dir");
+    this->system("rm -rf sandbox_root");
+#endif
+}
+
+void FileManagerTester ::sandboxRejectsMoveFileEitherLeg() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+    this->system("mkdir sandbox_root");
+#else
+    FAIL();  // Commands not implemented for this OS
+#endif
+    this->component.configure("sandbox_root");
+
+    // Both legs are outside the sandbox; both violations are reported (no short-circuit)
+    this->moveFile("/tmp/fprime_sandbox_escape_src", "/tmp/fprime_sandbox_escape_dest");
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_MOVEFILE, CMD_SEQ, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_EVENTS_SIZE(2);
+    ASSERT_EVENTS_PathOutsideSandbox_SIZE(2);
+    ASSERT_EVENTS_PathOutsideSandbox(0, "/tmp/fprime_sandbox_escape_src");
+    ASSERT_EVENTS_PathOutsideSandbox(1, "/tmp/fprime_sandbox_escape_dest");
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+#endif
+}
+
+void FileManagerTester ::sandboxIgnoreErrorsStillRejected() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+    this->system("mkdir sandbox_root");
+#else
+    FAIL();  // Commands not implemented for this OS
+#endif
+    this->component.configure("sandbox_root");
+
+    // ignoreErrors=true waives missing-file errors, not the sandbox check
+    this->removeFile("/tmp/fprime_sandbox_escape_file", true);
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_REMOVEFILE, CMD_SEQ, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_PathOutsideSandbox(0, "/tmp/fprime_sandbox_escape_file");
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+#endif
+}
+
+void FileManagerTester ::sandboxRejectsListDirectory() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+    this->system("mkdir sandbox_root");
+#else
+    FAIL();  // Commands not implemented for this OS
+#endif
+    this->component.configure("sandbox_root");
+
+    // Outside the sandbox; rejected before the directory is ever opened
+    this->listDirectory("/tmp");
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_LISTDIRECTORY, CMD_SEQ, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_PathOutsideSandbox(0, "/tmp");
+    ASSERT_EQ(FileManager::IDLE, this->component.m_listState);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+#endif
+}
+
+void FileManagerTester ::sandboxRejectsGenerateDp() {
+    this->resetDpState();
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+    this->system("mkdir sandbox_root");
+#else
+    FAIL();  // Commands not implemented for this OS
+#endif
+    this->component.configure("sandbox_root");
+
+    Fw::CmdStringArg cmdStringFile("/tmp/fprime_sandbox_escape_dp_file");
+    this->sendCmd_GenerateDp(INSTANCE, CMD_SEQ, cmdStringFile, 32, 0, 0, 0, FileManager_GenerateDpMode::PACED);
+    this->component.doDispatch();
+
+    // GenerateDp always responds OK per its convention; failures surface via events only
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_GENERATEDP, CMD_SEQ, Fw::CmdResponse::OK);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_PathOutsideSandbox(0, "/tmp/fprime_sandbox_escape_dp_file");
+    ASSERT_EVENTS_GenerateDpStarted_SIZE(0);
+    ASSERT_EQ(0u, this->m_dpSendCount);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+#endif
+}
+
+void FileManagerTester ::sandboxRejectsCalculateCrc() {
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+    this->system("mkdir sandbox_root");
+#else
+    FAIL();  // Commands not implemented for this OS
+#endif
+    this->component.configure("sandbox_root");
+
+    Fw::CmdStringArg cmdStringFile("/tmp/fprime_sandbox_escape_crc_file");
+    this->sendCmd_CalculateCrc(INSTANCE, CMD_SEQ, cmdStringFile);
+    this->component.doDispatch();
+
+    ASSERT_CMD_RESPONSE_SIZE(1);
+    ASSERT_CMD_RESPONSE(0, FileManager::OPCODE_CALCULATECRC, CMD_SEQ, Fw::CmdResponse::EXECUTION_ERROR);
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_PathOutsideSandbox(0, "/tmp/fprime_sandbox_escape_crc_file");
+    ASSERT_EVENTS_CalculateCrcStarted_SIZE(0);
+
+#if defined TGT_OS_TYPE_LINUX || TGT_OS_TYPE_DARWIN
+    this->system("rm -rf sandbox_root");
+#endif
 }
 
 // ----------------------------------------------------------------------

--- a/Svc/FileManager/test/ut/FileManagerTester.hpp
+++ b/Svc/FileManager/test/ut/FileManagerTester.hpp
@@ -143,6 +143,34 @@ class FileManagerTester : public FileManagerGTestBase {
     //! Report a serialization failure without failing the command
     void generateDpSerializationFailure();
 
+    // ----------------------------------------------------------------------
+    // Sandbox confinement tests
+    // ----------------------------------------------------------------------
+
+    //! Reject every path-taking command until configure() has been called
+    void sandboxUnconfiguredRejectsCommand();
+
+    //! Reject a single-path command (CreateDirectory) whose path escapes the sandbox
+    void sandboxRejectsEscapingPath();
+
+    //! A command whose path resolves inside the configured sandbox still succeeds
+    void sandboxAllowsConfiguredPath();
+
+    //! Reject MoveFile if either the source or destination escapes the sandbox
+    void sandboxRejectsMoveFileEitherLeg();
+
+    //! RemoveFile's ignoreErrors flag does not waive the sandbox check
+    void sandboxIgnoreErrorsStillRejected();
+
+    //! Reject ListDirectory before opening a directory outside the sandbox
+    void sandboxRejectsListDirectory();
+
+    //! Reject GenerateDp for a file outside the sandbox, per its always-OK response convention
+    void sandboxRejectsGenerateDp();
+
+    //! Reject CalculateCrc for a file outside the sandbox
+    void sandboxRejectsCalculateCrc();
+
   private:
     // ----------------------------------------------------------------------
     // Helper methods

--- a/Svc/Subtopologies/FileHandling/FileHandling.fpp
+++ b/Svc/Subtopologies/FileHandling/FileHandling.fpp
@@ -36,7 +36,13 @@ module FileHandling {
         queue size FileHandlingConfig.QueueSizes.fileManager \
         stack size FileHandlingConfig.StackSizes.fileManager \
         priority FileHandlingConfig.Priorities.fileManager \
-        cpu FileHandlingConfig.CpuAffinities.fileManager
+        cpu FileHandlingConfig.CpuAffinities.fileManager \
+    {
+        phase Fpp.ToCpp.Phases.configComponents """
+        // Sandbox for FileManager file/directory operations; "/" is unrestricted. Re-configure to restrict.
+        FileHandling::fileManager.configure(FileHandlingConfig::Paths::sandboxDir);
+        """
+    }
 
     instance prmDb: Svc.PrmDb base id FileHandlingConfig.BASE_ID + 0x03000 \
         queue size FileHandlingConfig.QueueSizes.prmDb \

--- a/Svc/Subtopologies/FileHandling/docs/sdd.md
+++ b/Svc/Subtopologies/FileHandling/docs/sdd.md
@@ -37,10 +37,11 @@ The **FileHandling subtopology** packages the core file-transfer services common
 > [!WARNING]
 > **This subtopology is not configured to be secure by default.** For backwards compatibility, its
 > `configComponents` phase configures the file-access sandboxes of `fileUplink`, `fileDownlink`,
-> and `prmDb` to `FileHandlingConfig::Paths::sandboxDir`, which defaults to `"/"`. With that
-> default, **any absolute path accessible to the process** may be written, read, or loaded via
-> ground command. (The underlying `Os::SandboxedFile` is fail-closed when left
-> unconfigured; this subtopology deliberately configures it open.)
+> `fileManager`, and `prmDb` to `FileHandlingConfig::Paths::sandboxDir`, which defaults to `"/"`.
+> With that default, **any absolute path accessible to the process** may be written, read,
+> managed, or loaded via ground command. (The underlying `Os::SandboxedFile` and `FileManager`'s
+> own path check are fail-closed when left unconfigured; this subtopology deliberately configures
+> them open.)
 >
 > Deployments wishing restricted file security **must call `configure` again** from topology setup
 > code (after the autocoded `configComponents` phase runs) with a restricted directory:
@@ -49,12 +50,15 @@ The **FileHandling subtopology** packages the core file-transfer services common
 > * `FileHandling::fileDownlink.configure(<directory>)` — restrict downlink reads (this is the
 >   `configure(directory)` overload; the `configure(cooldown, cycleTime, fileQueueDepth)`
 >   overload does **not** set a sandbox).
+> * `FileHandling::fileManager.configure(<directory>)` — restrict every `FileManager` command's
+>   path argument(s) (`CreateDirectory`, `RemoveFile`, `MoveFile`, `RemoveDirectory`,
+>   `AppendFile`, `FileSize`, `ListDirectory`, `CalculateCrc`, `GenerateDp`).
 > * `FileHandling::prmDb.configureSandbox(<directory>)` — restrict all `prmDb` file access
 >   (startup read, `PRM_SAVE_FILE`, `PRM_LOAD_FILE`); the directory must contain the store file
 >   set by `prmDb.configure(<file name>)`, which is **not** itself a sandbox.
 >
 > Alternatively, override `FileHandlingConfig::Paths::sandboxDir` to apply a single restricted
-> directory to all three components. Paths resolving outside a restricted sandbox — `../`
+> directory to all four components. Paths resolving outside a restricted sandbox — `../`
 > traversal sequences and absolute paths — are rejected before any file is opened. The `Ref`
 > deployment demonstrates the re-configure approach in `RefTopology.cpp`.
 
@@ -101,7 +105,7 @@ topology Flight {
 * **Stack sizes** — Task stacks for active components (`fileUplink`, `fileDownlink`).
 * **Priorities** — RTOS priorities for the active/queued components as applicable.
 * **CPU affinities** — Core pinning for active component tasks; defaults to `TASK_DEFAULT` (no pinning).
-* **Paths** — File paths used by the subtopology; `Paths.prmDbFile` sets the `prmDb` parameter storage file (default `PrmDb.dat`); `Paths.sandboxDir` sets the file-access sandbox for `fileUplink`, `fileDownlink`, and `prmDb` (default `/`, unrestricted — see §2.3).
+* **Paths** — File paths used by the subtopology; `Paths.prmDbFile` sets the `prmDb` parameter storage file (default `PrmDb.dat`); `Paths.sandboxDir` sets the file-access sandbox for `fileUplink`, `fileDownlink`, `fileManager`, and `prmDb` (default `/`, unrestricted — see §2.3).
 
 > These knobs tailor runtime footprint and scheduling without modifying the subtopology wiring.
 

--- a/TestDeploymentsProject/Ref/Top/RefTopology.cpp
+++ b/TestDeploymentsProject/Ref/Top/RefTopology.cpp
@@ -57,6 +57,7 @@ void configureTopology() {
     // Restrict file access to the working directory (where PrmDb.dat lives)
     FileHandling::fileUplink.configure(".");
     FileHandling::fileDownlink.configure(".");
+    FileHandling::fileManager.configure(".");
     FileHandling::prmDb.configureSandbox(".");
 }
 

--- a/TestDeploymentsProject/Ref/test/int/ref_integration_test.py
+++ b/TestDeploymentsProject/Ref/test/int/ref_integration_test.py
@@ -413,3 +413,42 @@ def test_prm_db_sandbox(fprime_test_api):
     fprime_test_api.send_and_assert_command(
         "FileHandling.prmDb.PRM_COMMIT_STAGED", max_delay=5
     )
+
+
+def test_file_manager_sandbox(fprime_test_api):
+    """Test that FileManager file/directory access is confined to its sandbox directory.
+
+    The Ref deployment sandboxes FileManager to "." (the working directory of the
+    flight software process). Operating on a path outside that directory should be
+    rejected with a PathOutsideSandbox event, while a path inside it should succeed.
+    """
+    # --- Creating a directory OUTSIDE the sandbox must be rejected ---
+    fprime_test_api.clear_histories()
+    results = fprime_test_api.send_and_await_event(
+        "FileHandling.fileManager.CreateDirectory",
+        args=["/tmp/evil_ref_dir"],
+        events=["FileHandling.fileManager.PathOutsideSandbox"],
+        timeout=5,
+    )
+    assert len(results) == 1, "Expected PathOutsideSandbox for a path outside the sandbox"
+    fprime_test_api.assert_event_count(
+        0, "FileHandling.fileManager.CreateDirectorySucceeded", timeout=1
+    )
+
+    # --- Creating a directory INSIDE the sandbox must succeed ---
+    fprime_test_api.clear_histories()
+    fprime_test_api.send_and_assert_command(
+        "FileHandling.fileManager.CreateDirectory",
+        args=["ref_sandbox_test_dir"],
+        max_delay=5,
+    )
+    fprime_test_api.assert_event(
+        "FileHandling.fileManager.CreateDirectorySucceeded", timeout=5
+    )
+
+    # Clean up
+    fprime_test_api.send_and_assert_command(
+        "FileHandling.fileManager.RemoveDirectory",
+        args=["ref_sandbox_test_dir"],
+        max_delay=5,
+    )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#5849 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| AI |

---
## Change Description

`Svc::FileManager` was the only file-handling component without optional path confinement. All nine of its command handlers (`CreateDirectory`, `RemoveFile`, `MoveFile`, `RemoveDirectory`, `AppendFile`, `FileSize`, `ListDirectory`, `CalculateCrc`, `GenerateDp`) passed ground-supplied paths straight to `Os::FileSystem`/`Os::File`/`Os::Directory`, and the `FileHandling` subtopology's `sandboxDir` knob did not cover it.

- Added `FileManager::configure(sandboxDir)`, fail-closed like `FileUplink`/`FileDownlink`/`PrmDb`. Since `FileManager` doesn't go through `Os::File` uniformly (most handlers call `Os::FileSystem` statics or `Os::Directory` directly), it validates paths itself via a new private `checkSandbox()` helper built on `Os::FilePathUtils::resolveFromCwd` + `checkContainment`, rather than wrapping `Os::SandboxedFile` (which only covers `Os::File::open`).
- Every path argument is checked, including both legs of `MoveFile`/`AppendFile` (both are checked independently, not short-circuited, so a violation on either side is reported) and the per-entry path `ListDirectory` constructs while walking a directory (defense in depth against a platform that yields a `.`/`..` entry — POSIX's `Os::Directory` already filters these, but the check doesn't assume that). Rejections emit a new `PathOutsideSandbox` warning event. `RemoveFile`'s `ignoreErrors` flag only waives missing-file errors, not the sandbox check.
- Extracted `Os::FilePathUtils::resolveDirectory()` (resolve + ensure trailing `/`) out of `Os::SandboxedFile::configure()` so `FileManager::configure()` doesn't reimplement that logic.
- `FileHandling` now configures `fileManager`'s sandbox to `FileHandlingConfig::Paths::sandboxDir` (`"/"` by default) alongside its siblings, and `Ref` reconfigures it to `"."` like `fileUplink`/`fileDownlink`/`prmDb`.

## Rationale

Fixes #5849. A deployment that sets `FileHandlingConfig::Paths::sandboxDir` (or reconfigures it) to restrict file access could reasonably believe the whole `FileHandling` subtopology is confined, when `FileManager`'s command set — which can create/remove/move/append/CRC any path, and package arbitrary files into data products — was not.

## Testing/Review Recommendations

Added to `Svc/FileManager/test/ut`: fail-closed-by-default rejection, an escaping absolute path rejected on a single-path command, a path inside the configured sandbox still succeeding, both legs of `MoveFile` reported independently when both escape, `ignoreErrors=true` not bypassing the check on `RemoveFile`, and the three structurally distinct code paths (`ListDirectory`'s async open, `GenerateDp`'s always-OK-response convention, `CalculateCrc`'s direct `Os::File` use). Also added `test_file_manager_sandbox` to the `Ref` integration suite, mirroring the existing `test_prm_db_sandbox`.

This dev environment can't natively build F' (no Windows platform support in the CMake build), so I set up WSL Ubuntu to verify:
- `Os_FilePathUtils_Test` (24/24) and `Os_SandboxedFile_Test` (11/11) still pass after extracting `resolveDirectory()`.
- `Svc_FileManager_ut_exe` (36/36, all pre-existing tests plus the 8 new sandbox tests) passes.
- The `Ref` deployment builds and links cleanly end-to-end, which exercises both the `FileHandling.fpp` `configComponents` phase change and the `RefTopology.cpp` wiring (these aren't touched by a component-level `fprime-util check`, so this was the only way to compile-check them).

I did **not** run the new `test_file_manager_sandbox` Ref integration test itself — that needs `fprime-gds`, which isn't set up in this environment. It follows the same pattern as `test_prm_db_sandbox` immediately above it in the same file, which does pass in CI.

## Future Work

None.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

- **Tool**: Claude Code (Claude Opus)
- **Type**: Traced the confinement gap through the sibling components (`FileUplink`, `FileDownlink`, `PrmDb`) and the recent `Os::SandboxedFile` fail-closed rework (#5833), designed and implemented the fix, wrote the unit/integration tests, and verified the build in WSL since this machine can't natively build F'.
- **Scope**: `FileManager`, `Os::FilePathUtils`/`Os::SandboxedFile` (extracted a shared helper, no behavior change there), `FileHandling` subtopology wiring, `Ref` topology/integration test.
- **Level of modification**: I reviewed and take responsibility for every line; verification was via the actual test suite and a full deployment build, not just code reading.

IAMAI