### PR TITLE
Os: add Os::Task::TASK_PRIORITY_OTHER to support non-realtime priorit…

### DIFF
--- a/Os/Models/Task.fpp
+++ b/Os/Models/Task.fpp
@@ -8,6 +8,9 @@ module Os {
 @ CPU affinities must be a valid core index (< CPU_SETSIZE) or TASK_DEFAULT; others assert at startup
 constant TASK_DEFAULT = -1
 
+@ Sentinel for non-realtime / standard priority: casts to Os::Task::TASK_PRIORITY_OTHER
+constant TASK_PRIORITY_OTHER = -2
+
 @ FPP shadow-enum representing Os::Task::Status
 enum TaskStatus : U8 {
     OP_OK,             @< message sent/received okay

--- a/Os/Posix/Task.cpp
+++ b/Os/Posix/Task.cpp
@@ -77,6 +77,20 @@ int set_stack_size(pthread_attr_t& attributes, const Os::Task::Arguments& argume
 }
 
 int set_priority_params(pthread_attr_t& attributes, const Os::Task::Arguments& arguments) {
+    if (arguments.m_priority == Os::Task::TASK_PRIORITY_OTHER) {
+        int status = pthread_attr_setschedpolicy(&attributes, SCHED_OTHER);
+        if (status == PosixTaskHandle::SUCCESS) {
+            status = pthread_attr_setinheritsched(&attributes, PTHREAD_EXPLICIT_SCHED);
+        }
+        if (status == PosixTaskHandle::SUCCESS) {
+            sched_param schedParam;
+            (void)memset(&schedParam, 0, sizeof(sched_param));
+            schedParam.sched_priority = 0;
+            status = pthread_attr_setschedparam(&attributes, &schedParam);
+        }
+        return status;
+    }
+
     const FwSizeType min_priority = static_cast<FwSizeType>(sched_get_priority_min(SCHED_POLICY));
     const FwSizeType max_priority = static_cast<FwSizeType>(sched_get_priority_max(SCHED_POLICY));
     int status = PosixTaskHandle::SUCCESS;
@@ -162,7 +176,8 @@ Os::Task::Status PosixTask::create(const Os::Task::Arguments& arguments,
     if ((arguments.m_stackSize != Os::Task::TASK_DEFAULT) && (pthread_status == PosixTaskHandle::SUCCESS)) {
         pthread_status = set_stack_size(attributes, arguments);
     }
-    if ((arguments.m_priority != Os::Task::TASK_PRIORITY_DEFAULT) && (expect_permission) &&
+    if ((arguments.m_priority != Os::Task::TASK_PRIORITY_DEFAULT) &&
+        (arguments.m_priority == Os::Task::TASK_PRIORITY_OTHER || expect_permission) &&
         (pthread_status == PosixTaskHandle::SUCCESS)) {
         pthread_status = set_priority_params(attributes, arguments);
     }

--- a/Os/Task.hpp
+++ b/Os/Task.hpp
@@ -46,6 +46,12 @@ class TaskInterface {
     //! that is valid for the target platform.
     static constexpr FwTaskPriorityType TASK_PRIORITY_DEFAULT = std::numeric_limits<FwTaskPriorityType>::max();
 
+    //! Sentinel value to use a non-realtime / standard priority for the task (e.g. SCHED_OTHER in POSIX).
+    //!
+    //! Implementations of TaskInterface::start() should place the task in the platform's standard,
+    //! non-realtime time-sharing scheduler.
+    static constexpr FwTaskPriorityType TASK_PRIORITY_OTHER = std::numeric_limits<FwTaskPriorityType>::max() - 1;
+
     enum Status {
         OP_OK,             //!< message sent/received okay
         INVALID_HANDLE,    //!< Task handle invalid

--- a/Os/test/ut/task/CommonTests.cpp
+++ b/Os/test/ut/task/CommonTests.cpp
@@ -241,3 +241,22 @@ TEST(Functionality, RandomizedTesting) {
     const U32 numSteps = bounded.run(tester);
     printf("Ran %u steps.\n", numSteps);
 }
+
+// Ensure that a task can start with TASK_PRIORITY_OTHER
+TEST(Functionality, StartTaskPriorityOther) {
+    Os::Test::Task::Tester tester;
+    std::shared_ptr<Os::Test::Task::TestTaskInfo> new_task = std::make_shared<Os::Test::Task::TestTaskInfo>();
+    new_task->m_state = Os::Task::State::STARTING;
+    tester.m_tasks.push_back(new_task);
+
+    Fw::String name("OtherPriorityTask");
+    Os::Task::Arguments args(name, &Os::Test::Task::TestTaskInfo::standard_task, new_task.get(),
+                             Os::Task::TASK_PRIORITY_OTHER);
+    Os::Test::Task::TestTaskInfo::s_task_count += 1;
+    Os::Task::Status status = new_task->m_task.start(args);
+    ASSERT_EQ(status, Os::Task::Status::OP_OK);
+    ASSERT_EQ(tester.m_last_task, &new_task->m_task) << "New task not registered";
+    new_task->signal();
+    wait_for_state_with_timeout(*new_task, Os::Test::Task::TestTaskInfo::MIDDLE, 100);
+    new_task->stop();
+}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #5855 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |


---
## Change Description

- Added `Os::Task::TASK_PRIORITY_OTHER` sentinel (`std::numeric_limits<FwTaskPriorityType>::max() - 1`) to `Os::TaskInterface` in `Os/Task.hpp`.
- Added `constant TASK_PRIORITY_OTHER = -2` to `Os/Models/Task.fpp` for FPP topologies and active component instances.
- Updated `Os::Posix::Task` (`Os/Posix/Task.cpp`):
  - `set_priority_params()` sets `SCHED_OTHER` policy with priority `0` when `TASK_PRIORITY_OTHER` is provided.
  - `PosixTask::create()` allows `TASK_PRIORITY_OTHER` without requiring elevated real-time permissions (`CAP_SYS_NICE`).
- Added unit test `TEST(Functionality, StartTaskPriorityOther)` to `Os/test/ut/task/CommonTests.cpp`.

## Rationale

Currently, all active components with configured priorities under `Os::Posix::Tasks` are placed into real-time scheduling (`SCHED_RR`). For tasks performing heavy file I/O or background processing (such as `DpWriter`, `FileManager`, `SystemResources`), running under real-time priority can cause priority inversions or unnecessary real-time thread overhead. This change provides a sentinel allowing components to explicitly select standard time-sharing (`SCHED_OTHER`).

## Testing/Review Recommendations

1. Run unit test suite: `fprime-util check` (specifically `PosixTaskTest`).
2. Verify that creating a task with `Os::Task::TASK_PRIORITY_OTHER` assigns `SCHED_OTHER` with `priority 0`.

