### PR TITLE
Accept VALID and DEFAULT in Comp test getParameter

### DIFF
--- a/FppTestProject/FppTest/topology/components/Comp/Comp.cpp
+++ b/FppTestProject/FppTest/topology/components/Comp/Comp.cpp
@@ -5,6 +5,7 @@
 // ======================================================================
 
 #include "FppTest/topology/components/Comp/Comp.hpp"
+#include "Fw/Prm/ParamValid.hpp"
 
 namespace FppTest {
 
@@ -32,7 +33,7 @@ void Comp ::emitTelemetry(U32 a) {
 U32 Comp ::getParameter() {
     Fw::ParamValid valid;
     U32 out = paramGet_Param(valid);
-    FW_ASSERT(valid == Fw::ParamValid::VALID);
+    FW_ASSERT(FW_PARAM_OK(valid), static_cast<FwAssertArgType>(valid.e));
     return out;
 }
 


### PR DESCRIPTION
The FppTest Comp component's getParameter asserted valid == VALID. With nasa/fpp#1097, the generated parameterLoaded hook calls parameterUpdated for parameters that load as DEFAULT as well as VALID, so this assert must accept both. Use FW_PARAM_OK, matching the pattern in Svc components. Refs nasa/fpp#1097.

| | |
|:---|:---|
|**_Related Issue(s)_**| Refs nasa/fpp#1097 |
|**_Has Unit Tests (y/n)_**| n (covered by existing FppTest special_ports tests) |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

The Comp test component in FppTest asserted valid == Fw::ParamValid::VALID in getParameter(). This updates it to accept both VALID and DEFAULT via FW_PARAM_OK, matching the pattern used in Svc components (e.g. FpySequencer, CfdpManager).

## Rationale

This is the tandem F Prime change for nasa/fpp#1097. That PR makes the generated parameterLoaded hook call parameterUpdated whenever FW_PARAM_OK(valid) holds ie. for parameters that load as DEFAULT as well as VALID. The special-ports topology calls loadParameters() on Comp without setting the parameter, so it loads as DEFAULT; with fpp#1097 this reaches getParameter(), where the old VALID-only assert would fire.

## Testing/Review Recommendations

Verified against the existing FppTest suite both ways: with released FPP v3.3.0 (19/19 unit tests pass) and with the FPP build from fpp#1097 (19/19 pass). The change is backward compatible, so CI stays green independently of the FPP merge.

## Future Work

None. Once this merges, fpp#1097 can be merged.

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

No.