### PR TITLE
fix(uplink): replace 7 FW_ASSERT with guards on untrusted data paths

### DIFF
--- a/Svc/FileUplink/FileUplink.cpp
+++ b/Svc/FileUplink/FileUplink.cpp
@@ -52,7 +52,11 @@ void FileUplink::bufferSendIn_handler(const FwIndexType portNum, Fw::Buffer& buf
     // Read the packet type from the packet buffer
     FwPacketDescriptorType packetType = 0;
     Fw::SerializeStatus status = buffer.getDeserializer().deserializeTo(packetType);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    if (status != Fw::FW_SERIALIZE_OK) {
+        this->log_WARNING_HI_InvalidPacketReceived(Fw::ComPacketType::FW_PACKET_UNKNOWN);
+        this->bufferSendOut_out(0, buffer);
+        return;
+    }
 
     // If packet type is not a file packet, log + deallocate and return
     if (packetType != Fw::ComPacketType::FW_PACKET_FILE) {
@@ -84,7 +88,7 @@ void FileUplink::bufferSendIn_handler(const FwIndexType portNum, Fw::Buffer& buf
                 this->handleCancelPacket();
                 break;
             default:
-                FW_ASSERT(false);
+                this->log_WARNING_HI_InvalidPacketReceived(packetType);
                 break;
         }
     }
@@ -141,7 +145,10 @@ void FileUplink::handleDataPacket(const Fw::FilePacket::DataPacket& dataPacket) 
         this->m_warnings.packetOutOfBounds(sequenceIndex, this->m_file.name);
         return;
     }
-    FW_ASSERT(dataPacket.getData() != nullptr);
+    if (dataPacket.getData() == nullptr) {
+        this->m_warnings.packetOutOfBounds(sequenceIndex, this->m_file.name);
+        return;
+    }
     const Os::File::Status status = this->m_file.write(dataPacket.getData(), byteOffset, dataSize);
     if (status != Os::File::OP_OK) {
         this->m_warnings.fileWrite(this->m_file.name);

--- a/Svc/FprimeDeframer/FprimeDeframer.cpp
+++ b/Svc/FprimeDeframer/FprimeDeframer.cpp
@@ -41,7 +41,11 @@ void FprimeDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, cons
     // Deserialize transmitted header into the header object
     auto deserializer = data.getDeserializer();
     Fw::SerializeStatus status = header.deserializeFrom(deserializer);
-    FW_ASSERT(status == Fw::SerializeStatus::FW_SERIALIZE_OK, status);
+    if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
+        this->log_WARNING_HI_InvalidBufferReceived();
+        this->dataReturnOut_out(0, data, context);
+        return;
+    }
     // Check that deserialized start_word token matches expected value (default start_word value in the FPP object)
     const FprimeProtocol::FrameHeader defaultValue;
     if (header.get_startWord() != defaultValue.get_startWord()) {
@@ -69,7 +73,11 @@ void FprimeDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, cons
         // and let downstream components (e.g. custom router) handle it
         FwPacketDescriptorType packetDescriptor = 0;
         status = deserializer.deserializeTo(packetDescriptor);
-        FW_ASSERT(status == Fw::SerializeStatus::FW_SERIALIZE_OK, status);
+        if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
+            this->log_WARNING_LO_PayloadTooShort();
+            this->dataReturnOut_out(0, data, context);
+            return;
+        }
         // If a valid descriptor is deserialized, set it in the context
         if (ComCfg::Apid::isValid(packetDescriptor)) {
             contextCopy.set_apid(static_cast<ComCfg::Apid::T>(packetDescriptor));
@@ -81,9 +89,17 @@ void FprimeDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, cons
     // ---------------- Validate Frame Trailer ----------------
     // Deserialize transmitted trailer: trailer is at offset = len(header) + len(body)
     status = deserializer.moveDeserToOffset(FprimeProtocol::FrameHeader::SERIALIZED_SIZE + header.get_lengthField());
-    FW_ASSERT(status == Fw::SerializeStatus::FW_SERIALIZE_OK, status);
+    if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
+        this->log_WARNING_HI_InvalidBufferReceived();
+        this->dataReturnOut_out(0, data, context);
+        return;
+    }
     status = trailer.deserializeFrom(deserializer);
-    FW_ASSERT(status == Fw::SerializeStatus::FW_SERIALIZE_OK, status);
+    if (status != Fw::SerializeStatus::FW_SERIALIZE_OK) {
+        this->log_WARNING_HI_InvalidBufferReceived();
+        this->dataReturnOut_out(0, data, context);
+        return;
+    }
     // Compute CRC over the transmitted data (header + body)
     Utils::Hash hash;
     Utils::HashBuffer computedCrc;


### PR DESCRIPTION
Hey team! 👋

This replaces 7 `FW_ASSERT` calls on the uplink deserialization path with graceful guards that log and drop malformed frames instead of crashing.

Fixes #5923

## Changes

**Svc/FprimeDeframer** (4 fixes):
- Header deser failure → `InvalidBufferReceived` + drop frame
- Packet descriptor deser failure → `PayloadTooShort` + drop frame
- Trailer offset seek failure → `InvalidBufferReceived` + drop frame
- Trailer deser failure → `InvalidBufferReceived` + drop frame

**Svc/FileUplink** (3 fixes):
- Packet type deser failure → `InvalidPacketReceived` + drop buffer
- Unknown FilePacket::Type → warning instead of `FW_ASSERT(false)`
- Null data pointer → `packetOutOfBounds` warning + return

Reuses existing events, no new FPP, no SDD changes. No behavior change for valid packets.

CWE-617: the deframer size check catches undersized frames, but content deser failures bypass it.

The 8th uplink-path assertion (DpCatalog:801) is in PR #5797.

Have an amazing day! 🚀🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)