### PR TITLE
TcDeframer: propagate received VCID in FrameContext

### DIFF
--- a/Svc/Ccsds/TcDeframer/TcDeframer.cpp
+++ b/Svc/Ccsds/TcDeframer/TcDeframer.cpp
@@ -115,7 +115,11 @@ void TcDeframer ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const Co
     // Shrink size to that of the encapsulated data field ( header | data | trailer )
     data.setSize(total_frame_length - TCHeader::SERIALIZED_SIZE - TCTrailer::SERIALIZED_SIZE);
 
-    this->dataOut_out(0, data, context);
+    // Propagate the received VCID so downstream components (e.g. a router) can dispatch on it
+    ComCfg::FrameContext contextCopy = context;
+    contextCopy.set_vcId(vc_id);
+
+    this->dataOut_out(0, data, contextCopy);
 }
 
 void TcDeframer ::dataReturnIn_handler(FwIndexType portNum, Fw::Buffer& fwBuffer, const ComCfg::FrameContext& context) {

--- a/Svc/Ccsds/TcDeframer/docs/sdd.md
+++ b/Svc/Ccsds/TcDeframer/docs/sdd.md
@@ -20,6 +20,10 @@ void configure(U16 vcId, U16 spacecraftId, bool acceptAllVcid);
 - `spacecraftId`: The spacecraft ID to accept.
 - `acceptAllVcid`: If `true`, the deframer accepts all VCIDs. If `false`, it only accepts the `vcId` specified.
 
+## Virtual Channel dispatching
+
+The TcDeframer does not route on the VCID itself. Instead, the VCID read from the TC frame header is written into the `vcId` field of the `ComCfg::FrameContext` emitted on `dataOut` alongside the deframed payload; all other context fields are passed through unchanged. Projects that need to direct frames received on different Virtual Channels to different uplink pipelines can accept all VCIDs and connect `dataOut` to a router that dispatches on `context.vcId`.
+
 ## Port Descriptions
 
 | Kind | Name | Port Type | Description |
@@ -53,3 +57,4 @@ void configure(U16 vcId, U16 spacecraftId, bool acceptAllVcid);
 | SVC-CCSDS-TC-DEFRAMER-008 | The TcDeframer shall log an `InvalidCrc` event if a frame fails the CRC check. | Unit Test |
 | SVC-CCSDS-TC-DEFRAMER-009 | The TcDeframer shall provide an input port (`dataIn`) to receive framed data, and emit deframed data packets on its `dataOut` output port. | Unit Test |
 | SVC-CCSDS-TC-DEFRAMER-010 | The TcDeframer shall emit notifications on its `errorNotify` port when deframing errors occur. | Unit Test |
+| SVC-CCSDS-TC-DEFRAMER-011 | The TcDeframer shall set the `vcId` field of the `FrameContext` emitted on `dataOut` to the Virtual Channel ID of the received frame. | Unit Test |

--- a/Svc/Ccsds/TcDeframer/test/ut/TcDeframerTestMain.cpp
+++ b/Svc/Ccsds/TcDeframer/test/ut/TcDeframerTestMain.cpp
@@ -16,6 +16,11 @@ TEST(TcDeframer, testNominalDeframing) {
     tester.testNominalDeframing();
 }
 
+TEST(TcDeframer, testVcIdPropagation) {
+    Svc::Ccsds::TcDeframerTester tester;
+    tester.testVcIdPropagation();
+}
+
 TEST(TcDeframer, testInvalidScId) {
     Svc::Ccsds::TcDeframerTester tester;
     tester.testInvalidScId();

--- a/Svc/Ccsds/TcDeframer/test/ut/TcDeframerTester.cpp
+++ b/Svc/Ccsds/TcDeframer/test/ut/TcDeframerTester.cpp
@@ -67,6 +67,10 @@ void TcDeframerTester::testNominalDeframing() {
     for (FwIndexType i = 0; i < payloadLength; i++) {
         ASSERT_EQ(outBuffer.getData()[i], payload[i]);
     }
+    // Output context carries the VCID from the frame header, other fields untouched
+    ComCfg::FrameContext expectedContext = nullContext;
+    expectedContext.set_vcId(vcId);
+    ASSERT_EQ(this->fromPortHistory_dataOut->at(0).context, expectedContext);
 }
 
 void TcDeframerTester::testInvalidScId() {

--- a/Svc/Ccsds/TcDeframer/test/ut/TcDeframerTester.cpp
+++ b/Svc/Ccsds/TcDeframer/test/ut/TcDeframerTester.cpp
@@ -73,6 +73,60 @@ void TcDeframerTester::testNominalDeframing() {
     ASSERT_EQ(this->fromPortHistory_dataOut->at(0).context, expectedContext);
 }
 
+void TcDeframerTester::testVcIdPropagation() {
+    // Enumerated context fields must hold valid enumerators, so draw them from these sets
+    static const ComCfg::Apid::T APIDS[] = {ComCfg::Apid::FW_PACKET_COMMAND, ComCfg::Apid::FW_PACKET_TELEM,
+                                            ComCfg::Apid::FW_PACKET_FILE,    ComCfg::Apid::FW_PACKET_HAND,
+                                            ComCfg::Apid::FW_PACKET_UNKNOWN, ComCfg::Apid::SPP_IDLE_PACKET};
+    static const ComCfg::Pvn::T PVNS[] = {ComCfg::Pvn::SPACE_PACKET_PROTOCOL,
+                                          ComCfg::Pvn::ENCAPSULATION_PACKET_PROTOCOL,
+                                          ComCfg::Pvn::INVALID_UNINITIALIZED};
+    const U32 frameCount = STest::Random::lowerUpper(2, TcDeframerTester::MAX_HISTORY_SIZE);
+    this->setComponentState(0, 0, 0, true);  // accept all VCIDs
+
+    for (U32 frame = 0; frame < frameCount; frame++) {
+        U8 vcId = static_cast<U8>(STest::Random::lowerUpper(0, 0x3F));  // random 6 bit VCID
+        U8 dataLength = static_cast<U8>(STest::Random::lowerUpper(1, 200));
+        U8 data[dataLength];
+        for (FwIndexType i = 0; i < dataLength; i++) {
+            data[i] = static_cast<U8>(STest::Random::lowerUpper(0, 0xFF));
+        }
+
+        // Randomize every field of the input context so pass-through is checked against non-default values.
+        // The input vcId is forced to differ from the frame VCID to prove the deframer overwrote it.
+        ComCfg::FrameContext inContext;
+        inContext.set_comQueueIndex(static_cast<FwIndexType>(STest::Random::lowerUpper(0, 0x7F)));
+        inContext.set_apid(APIDS[STest::Random::lowerUpper(0, static_cast<U32>(FW_NUM_ARRAY_ELEMENTS(APIDS)) - 1)]);
+        inContext.set_hasSecHdr(STest::Random::lowerUpper(0, 1) == 1);
+        inContext.set_sequenceFlags(static_cast<U8>(STest::Random::lowerUpper(0, 0x3)));
+        inContext.set_sequenceCount(static_cast<U16>(STest::Random::lowerUpper(0, 0x3FFF)));
+        inContext.set_vcId(static_cast<U8>((vcId + STest::Random::lowerUpper(1, 0x3F)) & 0x3F));
+        inContext.set_pvn(PVNS[STest::Random::lowerUpper(0, static_cast<U32>(FW_NUM_ARRAY_ELEMENTS(PVNS)) - 1)]);
+        inContext.set_sendNow(STest::Random::lowerUpper(0, 1) == 1);
+        inContext.set_saIndex(static_cast<U16>(STest::Random::lowerUpper(0, 0xFFFF)));
+        ASSERT_NE(inContext.get_vcId(), vcId);
+
+        Fw::Buffer buffer = this->assembleFrameBuffer(data, dataLength, 0, vcId);
+        this->invoke_to_dataIn(0, buffer, inContext);
+
+        ASSERT_from_dataOut_SIZE(frame + 1);
+        ASSERT_from_dataReturnOut_SIZE(0);
+        ASSERT_from_errorNotify_SIZE(0);
+        ASSERT_EVENTS_SIZE(0);
+        const ComCfg::FrameContext& outContext = this->fromPortHistory_dataOut->at(frame).context;
+        ASSERT_EQ(outContext.get_vcId(), vcId);
+        // Every other field must be passed through unchanged
+        ComCfg::FrameContext expectedContext = inContext;
+        expectedContext.set_vcId(vcId);
+        ASSERT_EQ(outContext, expectedContext);
+        Fw::Buffer outBuffer = this->fromPortHistory_dataOut->at(frame).data;
+        ASSERT_EQ(outBuffer.getSize(), dataLength);
+        for (FwIndexType i = 0; i < dataLength; i++) {
+            ASSERT_EQ(outBuffer.getData()[i], data[i]);
+        }
+    }
+}
+
 void TcDeframerTester::testInvalidScId() {
     // Frame: 5 bytes (header) + 1 byte (data) + 2 bytes (trailer)
     U16 scId = static_cast<U16>(STest::Random::lowerUpper(1, 0x3FF));    // random 10 bit Spacecraft ID

--- a/Svc/Ccsds/TcDeframer/test/ut/TcDeframerTester.hpp
+++ b/Svc/Ccsds/TcDeframer/test/ut/TcDeframerTester.hpp
@@ -44,6 +44,7 @@ class TcDeframerTester final : public TcDeframerGTestBase {
 
     void testDataReturn();
     void testNominalDeframing();
+    void testVcIdPropagation();
     void testInvalidScId();
     void testInvalidVcId();
     void testInvalidLengthToken();

--- a/docs/reference/system-functional/ccsds-protocol.md
+++ b/docs/reference/system-functional/ccsds-protocol.md
@@ -41,7 +41,7 @@ The TM Framer implements the CCSDS Telemetry (TM) Space Data Link Protocol (132.
 
 ### TC Space Data Link Protocol
 
-The TC Deframer implements the CCSDS Telecommand (TC) Space Data Link Protocol (232.0-B-4) for uplink. It extracts payload data from received TC Transfer Frames.
+The TC Deframer implements the CCSDS Telecommand (TC) Space Data Link Protocol (232.0-B-4) for uplink. It extracts payload data from received TC Transfer Frames. The deframer can be configured to accept a single VCID or all VCIDs; the VCID of each received frame is written into the `vcId` field of the `FrameContext` emitted with the payload, so a downstream router can dispatch on it.
 
 ### AOS Space Data Link Protocol
 
@@ -65,7 +65,7 @@ The CCSDS components can be stacked to provide multiple protocol layers. A typic
 
 The current CCSDS implementation does not support:
 
-- Multiple Virtual Channel Identifiers (VCIDs) — only a single VCID is available per TM Framer or TC Deframer instance.
+- Multiple Virtual Channel Identifiers (VCIDs) on downlink — only a single VCID is available per TM Framer instance. The TC Deframer does not route on VCID itself but propagates it in the `FrameContext` for downstream dispatching.
 
 ### Off Nominal
 


### PR DESCRIPTION

| | |
|:---|:---|
|**_Related Issue(s)_**|  https://github.com/nasa/fprime/issues/5926 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**|  |

---
## Change Description

Implements https://github.com/nasa/fprime/issues/5926

This is useful if routing needs to happen based on VCID, with a near-zero cost here.

Follow-up could include doing the port mapping as suggested in #5926 - but this matches the pattern of APID-routing used for Space Packets so I contend this should be enough for now.